### PR TITLE
fix,ref(tracemetrics): Resolve styling issues for side panel

### DIFF
--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -11,11 +11,10 @@ import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
-import {OPTIONS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
+import {NONE_UNIT, OPTIONS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
 import {useHasMetricUnitsUI} from 'sentry/views/explore/metrics/hooks/useHasMetricUnitsUI';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
-import {NONE_UNIT} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {
   TraceMetricKnownFieldKey,

--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -20,7 +20,11 @@ import {
   TraceMetricKnownFieldKey,
   type TraceMetricTypeValue,
 } from 'sentry/views/explore/metrics/types';
-import {makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
+import {
+  hasDisplayMetricUnit,
+  makeMetricSelectValue,
+  makeMetricsAggregate,
+} from 'sentry/views/explore/metrics/utils';
 
 interface Props {
   aggregate: string;
@@ -37,10 +41,6 @@ interface MetricSelectOption {
   trailingItems: ReactNode;
   value: string;
   metricUnit?: string;
-}
-
-function makeMetricSelectValue(metric: TraceMetric): string {
-  return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
 }
 
 export function EAPMetricsField({
@@ -81,12 +81,9 @@ export function EAPMetricsField({
       trailingItems: (
         <Fragment>
           <MetricTypeBadge metricType={traceMetric.type as TraceMetricTypeValue} />
-          {hasMetricUnitsUI &&
-            traceMetric.unit &&
-            traceMetric.unit !== '-' &&
-            traceMetric.unit !== NONE_UNIT && (
-              <Tag variant="promotion">{traceMetric.unit}</Tag>
-            )}
+          {hasDisplayMetricUnit(hasMetricUnitsUI, traceMetric.unit) ? (
+            <Tag variant="promotion">{traceMetric.unit}</Tag>
+          ) : null}
         </Fragment>
       ),
     }),
@@ -124,13 +121,14 @@ export function EAPMetricsField({
         trailingItems: (
           <Fragment>
             <MetricTypeBadge metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]} />
-            {hasMetricUnitsUI &&
-              option[TraceMetricKnownFieldKey.METRIC_UNIT] &&
-              option[TraceMetricKnownFieldKey.METRIC_UNIT] !== NONE_UNIT && (
-                <Tag variant="promotion">
-                  {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
-                </Tag>
-              )}
+            {hasDisplayMetricUnit(
+              hasMetricUnitsUI,
+              option[TraceMetricKnownFieldKey.METRIC_UNIT]
+            ) ? (
+              <Tag variant="promotion">
+                {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
+              </Tag>
+            ) : null}
           </Fragment>
         ),
       })) ?? []),
@@ -180,10 +178,7 @@ export function EAPMetricsField({
     onChange(newAggregate, {});
   };
 
-  const traceMetricSelectValue = makeMetricSelectValue(
-    hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
-  );
-  const previousOptions = usePrevious(metricOptions ?? []);
+  const previousOptions = usePrevious(metricOptions);
 
   // Auto-select the first metric when API resolves and no metric is selected
   useEffect(() => {
@@ -212,8 +207,8 @@ export function EAPMetricsField({
       <FlexWrapper>
         <StyledSelectControl
           searchable
-          options={isFetching ? previousOptions : (metricOptions ?? [])}
-          value={traceMetricSelectValue}
+          options={isFetching ? previousOptions : metricOptions}
+          value={metricSelectValue}
           isLoading={isFetching}
           onInputChange={debouncedSetSearch}
           placeholder={t('Select an application metric')}

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
@@ -21,7 +21,7 @@ import {
   OPTIONS_BY_TYPE,
 } from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
+import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricSelector';
 
 function getUpdatedAggregatesMultiMetric(
   aggregateSource: Column[],

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -31,7 +31,7 @@ import {
 import {AggregateDropdown} from 'sentry/views/explore/metrics/metricToolbar/aggregateDropdown';
 import {DeleteMetricButton} from 'sentry/views/explore/metrics/metricToolbar/deleteMetricButton';
 import {Filter} from 'sentry/views/explore/metrics/metricToolbar/filter';
-import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
+import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricSelector';
 import {VisualizeLabel} from 'sentry/views/explore/metrics/metricToolbar/visualizeLabel';
 import {
   LocalMultiMetricsQueryParamsProvider,

--- a/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
@@ -32,17 +32,17 @@ import {
   TraceMetricKnownFieldKey,
   type TraceMetricTypeValue,
 } from 'sentry/views/explore/metrics/types';
-import {makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
+import {
+  hasDisplayMetricUnit,
+  makeMetricSelectValue,
+  makeMetricsAggregate,
+} from 'sentry/views/explore/metrics/utils';
 
 interface MetricSelectOption extends SelectOption<string> {
   metricName: string;
   metricType: TraceMetricTypeValue;
   trailingItems: ReactNode;
   metricUnit?: string;
-}
-
-function makeMetricSelectValue(metric: TraceMetric): string {
-  return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
 }
 
 /**
@@ -85,12 +85,9 @@ export function MetricsVisualize() {
       trailingItems: (
         <Fragment>
           <MetricTypeBadge metricType={traceMetric.type as TraceMetricTypeValue} />
-          {hasMetricUnitsUI &&
-            traceMetric.unit &&
-            traceMetric.unit !== '-' &&
-            traceMetric.unit !== NONE_UNIT && (
-              <Tag variant="promotion">{traceMetric.unit}</Tag>
-            )}
+          {hasDisplayMetricUnit(hasMetricUnitsUI, traceMetric.unit) ? (
+            <Tag variant="promotion">{traceMetric.unit}</Tag>
+          ) : null}
         </Fragment>
       ),
     }),
@@ -128,13 +125,14 @@ export function MetricsVisualize() {
         trailingItems: (
           <Fragment>
             <MetricTypeBadge metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]} />
-            {hasMetricUnitsUI &&
-              option[TraceMetricKnownFieldKey.METRIC_UNIT] &&
-              option[TraceMetricKnownFieldKey.METRIC_UNIT] !== NONE_UNIT && (
-                <Tag variant="promotion">
-                  {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
-                </Tag>
-              )}
+            {hasDisplayMetricUnit(
+              hasMetricUnitsUI,
+              option[TraceMetricKnownFieldKey.METRIC_UNIT]
+            ) ? (
+              <Tag variant="promotion">
+                {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
+              </Tag>
+            ) : null}
           </Fragment>
         ),
       })) ?? []),
@@ -213,10 +211,7 @@ export function MetricsVisualize() {
     }
   }, [metricOptions, updateFormAggregate, traceMetric.name, hasMetricUnitsUI]);
 
-  const traceMetricSelectValue = makeMetricSelectValue(
-    hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
-  );
-  const previousOptions = usePrevious(metricOptions ?? []);
+  const previousOptions = usePrevious(metricOptions);
   const hasNoMetrics = isMetricOptionsEmpty && !search;
 
   return (
@@ -238,8 +233,8 @@ export function MetricsVisualize() {
             <div>
               <StyledSelect
                 search={{onChange: debouncedSetSearch, filter: false}}
-                options={isFetching ? previousOptions : (metricOptions ?? [])}
-                value={traceMetricSelectValue}
+                options={isFetching ? previousOptions : metricOptions}
+                value={metricSelectValue}
                 loading={isFetching}
                 menuTitle={t('Application Metrics')}
                 onChange={(option: SelectOption<SelectKey>) => {

--- a/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
@@ -23,11 +23,10 @@ import {
 } from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
-import {OPTIONS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
+import {NONE_UNIT, OPTIONS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
 import {useHasMetricUnitsUI} from 'sentry/views/explore/metrics/hooks/useHasMetricUnitsUI';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
-import {NONE_UNIT} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {
   TraceMetricKnownFieldKey,

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -14,6 +14,8 @@ import {
   type TraceMetricFieldKey,
 } from 'sentry/views/explore/metrics/types';
 
+export const NONE_UNIT = 'none';
+
 const AlwaysHiddenTraceMetricFields: TraceMetricFieldKey[] = [
   TraceMetricKnownFieldKey.ID,
   TraceMetricKnownFieldKey.ORGANIZATION_ID,

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -65,6 +65,10 @@ export const HiddenTraceMetricGroupByFields: TraceMetricFieldKey[] = [
   TraceMetricKnownFieldKey.TIMESTAMP,
 ];
 
+export const HIDDEN_TRACEMETRIC_GROUP_BY_FIELDS_SET = new Set(
+  HiddenTraceMetricGroupByFields
+);
+
 const TRACEMETRICS_FILTERS: FilterKeySection = {
   value: 'tracemetrics_filters',
   label: t('Application Metrics'),

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
@@ -15,13 +15,15 @@ import {
   SAMPLING_MODE,
   useProgressiveQuery,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {AlwaysPresentTraceMetricFields} from 'sentry/views/explore/metrics/constants';
+import {
+  AlwaysPresentTraceMetricFields,
+  NONE_UNIT,
+} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
   useMetricsFrozenSearch,
   useMetricsFrozenTracePeriod,
 } from 'sentry/views/explore/metrics/metricsFrozenContext';
-import {NONE_UNIT} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
 import {
   TraceMetricKnownFieldKey,
   type TraceMetricEventsResponseItem,

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -20,7 +20,7 @@ import {AggregateDropdown} from 'sentry/views/explore/metrics/metricToolbar/aggr
 import {DeleteMetricButton} from 'sentry/views/explore/metrics/metricToolbar/deleteMetricButton';
 import {Filter} from 'sentry/views/explore/metrics/metricToolbar/filter';
 import {GroupBySelector} from 'sentry/views/explore/metrics/metricToolbar/groupBySelector';
-import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
+import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricSelector';
 import {VisualizeLabel} from 'sentry/views/explore/metrics/metricToolbar/visualizeLabel';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricDetailPanel.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricDetailPanel.tsx
@@ -10,24 +10,15 @@ import {t} from 'sentry/locale';
 import {prettifyTagKey} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useTraceMetricItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
-import {
-  HiddenTraceMetricGroupByFields,
-  NONE_UNIT,
-} from 'sentry/views/explore/metrics/constants';
+import {HIDDEN_TRACEMETRIC_GROUP_BY_FIELDS_SET} from 'sentry/views/explore/metrics/constants';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
 import type {MetricSelectOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
-import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
+import {
+  createTraceMetricFilter,
+  hasDisplayMetricUnit,
+} from 'sentry/views/explore/metrics/utils';
 
 const METRIC_ATTRIBUTES_DEBOUNCE_DURATION = 200;
-
-function hasDisplayMetricUnit(
-  hasMetricUnitsUI: boolean,
-  metricUnit?: string
-): metricUnit is string {
-  return (
-    hasMetricUnitsUI && !!metricUnit && metricUnit !== '-' && metricUnit !== NONE_UNIT
-  );
-}
 
 export function MetricDetailPanel({
   metric,
@@ -118,15 +109,16 @@ function MetricAttributesSection({
   const {attributes: booleanAttrs, isLoading: booleanLoading} =
     useTraceMetricItemAttributes(metricAttributeQuery, 'boolean');
 
-  const attributeKeys = useMemo(() => {
+  const attributeLabels = useMemo(() => {
     const keys = new Set([
       ...Object.keys(stringAttrs ?? {}),
       ...Object.keys(numberAttrs ?? {}),
       ...Object.keys(booleanAttrs ?? {}),
-    ]);
-    return [...keys]
-      .filter(key => !HiddenTraceMetricGroupByFields.includes(key))
-      .sort((a, b) => prettifyTagKey(a).localeCompare(prettifyTagKey(b)));
+    ]).difference(HIDDEN_TRACEMETRIC_GROUP_BY_FIELDS_SET);
+
+    return Array.from(keys)
+      .map(prettifyTagKey)
+      .toSorted((a, b) => a.localeCompare(b));
   }, [stringAttrs, numberAttrs, booleanAttrs]);
 
   if (isDebouncingAttributes || stringLoading || numberLoading || booleanLoading) {
@@ -140,7 +132,7 @@ function MetricAttributesSection({
     );
   }
 
-  if (attributeKeys.length === 0) {
+  if (attributeLabels.length === 0) {
     return (
       <Stack gap="xs">
         <Text size="md">{t('Attributes')}:</Text>
@@ -155,9 +147,9 @@ function MetricAttributesSection({
     <Stack gap="xs">
       <Text size="md">{t('Attributes')}:</Text>
       <Flex wrap="wrap" gap="xs">
-        {attributeKeys.map(key => (
-          <Tag key={key} variant="muted">
-            {prettifyTagKey(key)}
+        {attributeLabels.map(label => (
+          <Tag key={label} variant="muted">
+            {label}
           </Tag>
         ))}
       </Flex>

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricDetailPanel.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricDetailPanel.tsx
@@ -12,7 +12,7 @@ import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useTraceMetricItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {HIDDEN_TRACEMETRIC_GROUP_BY_FIELDS_SET} from 'sentry/views/explore/metrics/constants';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
-import type {MetricSelectOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
+import type {MetricSelectorOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
 import {
   createTraceMetricFilter,
   hasDisplayMetricUnit,
@@ -25,7 +25,7 @@ export function MetricDetailPanel({
   hasMetricUnitsUI,
 }: {
   hasMetricUnitsUI: boolean;
-  metric: MetricSelectOption | null;
+  metric: MetricSelectorOption | null;
 }) {
   if (!metric) {
     return (

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricDetailPanel.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricDetailPanel.tsx
@@ -1,0 +1,166 @@
+import {useMemo} from 'react';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {DateTime} from 'sentry/components/dateTime';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import {prettifyTagKey} from 'sentry/utils/fields';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useTraceMetricItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {
+  HiddenTraceMetricGroupByFields,
+  NONE_UNIT,
+} from 'sentry/views/explore/metrics/constants';
+import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
+import type {MetricSelectOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
+import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
+
+const METRIC_ATTRIBUTES_DEBOUNCE_DURATION = 200;
+
+function hasDisplayMetricUnit(
+  hasMetricUnitsUI: boolean,
+  metricUnit?: string
+): metricUnit is string {
+  return (
+    hasMetricUnitsUI && !!metricUnit && metricUnit !== '-' && metricUnit !== NONE_UNIT
+  );
+}
+
+export function MetricDetailPanel({
+  metric,
+  hasMetricUnitsUI,
+}: {
+  hasMetricUnitsUI: boolean;
+  metric: MetricSelectOption | null;
+}) {
+  if (!metric) {
+    return (
+      <Flex align="center" justify="center" flex="1">
+        <Text variant="muted">{t('Select an application metric to see details')}</Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      <Text bold wordBreak="break-all">
+        {metric.metricName}
+      </Text>
+      <Flex gap="xs" align="center">
+        <Text variant="muted" size="md">
+          {t('Type')}
+        </Text>
+        <MetricTypeBadge metricType={metric.metricType} />
+      </Flex>
+      {hasDisplayMetricUnit(hasMetricUnitsUI, metric.metricUnit) ? (
+        <Flex gap="xs" align="center">
+          <Text variant="muted" size="md">
+            {t('Unit')}
+          </Text>
+          <Tag variant="promotion">{metric.metricUnit}</Tag>
+        </Flex>
+      ) : null}
+      {metric.lastSeen ? (
+        <Flex gap="xs" align="center">
+          <Text variant="muted" size="md">
+            {t('Last seen')}
+          </Text>
+          <DateTime date={metric.lastSeen} timeZone />
+        </Flex>
+      ) : null}
+      {metric.count === undefined ? null : (
+        <Flex gap="xs" align="center">
+          <Text variant="muted" size="md">
+            {t('Times seen')}
+          </Text>
+          <Text size="md">{metric.count.toLocaleString()}</Text>
+        </Flex>
+      )}
+      <MetricAttributesSection
+        metricName={metric.metricName}
+        metricType={metric.metricType}
+      />
+    </Stack>
+  );
+}
+
+function MetricAttributesSection({
+  metricName,
+  metricType,
+}: {
+  metricName: string;
+  metricType: string;
+}) {
+  const traceMetricFilter = createTraceMetricFilter({
+    name: metricName,
+    type: metricType,
+  });
+
+  const debouncedTraceMetricFilter = useDebouncedValue(
+    traceMetricFilter,
+    METRIC_ATTRIBUTES_DEBOUNCE_DURATION
+  );
+
+  const isDebouncingAttributes = debouncedTraceMetricFilter !== traceMetricFilter;
+  const metricAttributeQuery = {
+    enabled: Boolean(debouncedTraceMetricFilter),
+    query: debouncedTraceMetricFilter,
+    staleTime: Infinity,
+  };
+
+  const {attributes: stringAttrs, isLoading: stringLoading} =
+    useTraceMetricItemAttributes(metricAttributeQuery, 'string');
+  const {attributes: numberAttrs, isLoading: numberLoading} =
+    useTraceMetricItemAttributes(metricAttributeQuery, 'number');
+  const {attributes: booleanAttrs, isLoading: booleanLoading} =
+    useTraceMetricItemAttributes(metricAttributeQuery, 'boolean');
+
+  const attributeKeys = useMemo(() => {
+    const keys = new Set([
+      ...Object.keys(stringAttrs ?? {}),
+      ...Object.keys(numberAttrs ?? {}),
+      ...Object.keys(booleanAttrs ?? {}),
+    ]);
+    return [...keys]
+      .filter(key => !HiddenTraceMetricGroupByFields.includes(key))
+      .sort((a, b) => prettifyTagKey(a).localeCompare(prettifyTagKey(b)));
+  }, [stringAttrs, numberAttrs, booleanAttrs]);
+
+  if (isDebouncingAttributes || stringLoading || numberLoading || booleanLoading) {
+    return (
+      <Stack gap="xs">
+        <Text size="md">{t('Attributes')}:</Text>
+        <Flex gap="xs">
+          <LoadingIndicator size={16} style={{margin: 0}} />
+        </Flex>
+      </Stack>
+    );
+  }
+
+  if (attributeKeys.length === 0) {
+    return (
+      <Stack gap="xs">
+        <Text size="md">{t('Attributes')}:</Text>
+        <Flex gap="xs">
+          <Text size="md">{t('No attributes found')}</Text>
+        </Flex>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap="xs">
+      <Text size="md">{t('Attributes')}:</Text>
+      <Flex wrap="wrap" gap="xs">
+        {attributeKeys.map(key => (
+          <Tag key={key} variant="muted">
+            {prettifyTagKey(key)}
+          </Tag>
+        ))}
+      </Flex>
+    </Stack>
+  );
+}

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricListBoxOption.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricListBoxOption.tsx
@@ -8,12 +8,12 @@ import {LeadWrap} from '@sentry/scraps/compactSelect';
 import {MenuListItem, type MenuListItemProps} from '@sentry/scraps/menuListItem';
 
 import {IconCheckmark} from 'sentry/icons';
-import type {MetricSelectOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
+import type {MetricSelectorOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
 
 interface MetricListBoxOptionProps {
   dataIndex: number;
-  item: Node<MetricSelectOption>;
-  listState: ComboBoxState<MetricSelectOption>;
+  item: Node<MetricSelectorOption>;
+  listState: ComboBoxState<MetricSelectorOption>;
   size: MenuListItemProps['size'];
   measureRef?: React.Ref<HTMLLIElement>;
   updateSidePanelAnchorOffset?: (activeOptionElement?: HTMLElement | null) => void;

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricListBoxOption.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricListBoxOption.tsx
@@ -1,0 +1,79 @@
+import {useCallback, useRef} from 'react';
+import {useOption} from '@react-aria/listbox';
+import {mergeProps, mergeRefs} from '@react-aria/utils';
+import {type ComboBoxState} from '@react-stately/combobox';
+import type {Node} from '@react-types/shared';
+
+import {LeadWrap} from '@sentry/scraps/compactSelect';
+import {MenuListItem, type MenuListItemProps} from '@sentry/scraps/menuListItem';
+
+import {IconCheckmark} from 'sentry/icons';
+import type {MetricSelectOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
+
+interface MetricListBoxOptionProps {
+  dataIndex: number;
+  item: Node<MetricSelectOption>;
+  listState: ComboBoxState<MetricSelectOption>;
+  size: MenuListItemProps['size'];
+  measureRef?: React.Ref<HTMLLIElement>;
+  updateSidePanelAnchorOffset?: (activeOptionElement?: HTMLElement | null) => void;
+}
+
+export function MetricListBoxOption({
+  item,
+  listState,
+  size,
+  dataIndex,
+  measureRef,
+  updateSidePanelAnchorOffset,
+}: MetricListBoxOptionProps) {
+  const ref = useRef<HTMLLIElement>(null);
+  const option = item.value!;
+  const {optionProps, isFocused, isSelected, isDisabled, isPressed} = useOption(
+    {
+      key: item.key,
+      'aria-label': option.label,
+      shouldUseVirtualFocus: true,
+      shouldSelectOnPressUp: true,
+    },
+    listState,
+    ref
+  );
+  const optionPropsMerged = mergeProps(optionProps, {
+    onMouseEnter: () => {
+      listState.selectionManager.setFocused(true);
+      listState.selectionManager.setFocusedKey(item.key);
+      updateSidePanelAnchorOffset?.(ref.current);
+    },
+  });
+  const activeOptionRef = useCallback(
+    (element: HTMLLIElement | null) => {
+      if (element && isFocused) {
+        updateSidePanelAnchorOffset?.(element);
+      }
+    },
+    [isFocused, updateSidePanelAnchorOffset]
+  );
+
+  return (
+    <MenuListItem
+      {...optionPropsMerged}
+      as="li"
+      data-index={dataIndex}
+      ref={mergeRefs(ref, measureRef, activeOptionRef)}
+      size={size}
+      label={option.label}
+      isFocused={isFocused}
+      isSelected={isSelected}
+      isPressed={isPressed}
+      disabled={isDisabled}
+      priority={isSelected ? 'primary' : 'default'}
+      leadingItems={
+        <LeadWrap aria-hidden="true">
+          {isSelected ? <IconCheckmark size="sm" /> : null}
+        </LeadWrap>
+      }
+      trailingItems={option.trailingItems}
+    />
+  );
+}

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricListBoxOption.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricListBoxOption.tsx
@@ -32,7 +32,7 @@ export function MetricListBoxOption({
   const {optionProps, isFocused, isSelected, isDisabled, isPressed} = useOption(
     {
       key: item.key,
-      'aria-label': option.label,
+      'aria-label': option.metricName,
       shouldUseVirtualFocus: true,
       shouldSelectOnPressUp: true,
     },

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.spec.tsx
@@ -11,7 +11,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
-import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
+import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricSelector';
 
 const SORTED_METRIC_NAMES = [
   'bar',

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.spec.tsx
@@ -516,6 +516,19 @@ describe('MetricSelector', () => {
       expect((await screen.findAllByText('bar')).length).toBeGreaterThan(0);
     });
 
+    it('does not render side panel when no metric is selected', async () => {
+      render(<MetricSelector traceMetric={{name: '', type: ''}} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(await screen.findByRole('button', {name: 'None'}));
+      await userEvent.hover(await screen.findByRole('option', {name: 'bar'}));
+
+      expect(screen.queryByText('Type')).not.toBeInTheDocument();
+      expect(screen.queryByText('Last seen')).not.toBeInTheDocument();
+      expect(screen.queryByText('Times seen')).not.toBeInTheDocument();
+    });
+
     it('shows attributes section in side panel', async () => {
       render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
         organization,

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -1,47 +1,45 @@
-import {Fragment, useEffect, useId, useMemo, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useId, useMemo, useRef, useState} from 'react';
+import styled from '@emotion/styled';
 import {useComboBox} from '@react-aria/combobox';
 import {FocusScope} from '@react-aria/focus';
 import {useKeyboard} from '@react-aria/interactions';
-import {useOption} from '@react-aria/listbox';
-import {mergeProps, mergeRefs} from '@react-aria/utils';
+import {mergeProps} from '@react-aria/utils';
 import {Item} from '@react-stately/collections';
-import {useComboBoxState, type ComboBoxState} from '@react-stately/combobox';
-import type {Node} from '@react-types/shared';
+import {useComboBoxState} from '@react-stately/combobox';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {Tag} from '@sentry/scraps/badge';
 import {LeadWrap, ListWrap} from '@sentry/scraps/compactSelect';
 import {InputGroup} from '@sentry/scraps/input';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {MenuListItem, type MenuListItemProps} from '@sentry/scraps/menuListItem';
+import {MenuListItem} from '@sentry/scraps/menuListItem';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
-import {DateTime} from 'sentry/components/dateTime';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconCheckmark, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {prettifyTagKey} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useOverlay} from 'sentry/utils/useOverlay';
 import {usePrevious} from 'sentry/utils/usePrevious';
-import {useTraceMetricItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
-import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
+import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import {useHasMetricUnitsUI} from 'sentry/views/explore/metrics/hooks/useHasMetricUnitsUI';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
+import {MetricDetailPanel} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricDetailPanel';
+import {MetricListBoxOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricListBoxOption';
+import type {MetricSelectOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
 import {
   TraceMetricKnownFieldKey,
   type TraceMetricTypeValue,
 } from 'sentry/views/explore/metrics/types';
-import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 
-export const NONE_UNIT = 'none';
-const METRIC_ATTRIBUTES_DEBOUNCE_DURATION = 200;
 const METRIC_SELECTOR_OPTION_HEIGHT = 42;
+const METRIC_SELECTOR_DROPDOWN_MAX_HEIGHT = 400;
+const METRIC_SELECTOR_DROPDOWN_MIN_HEIGHT = 200;
 
 function nextFrameCallback(cb: () => void) {
   if ('requestAnimationFrame' in window) {
@@ -60,6 +58,10 @@ function hasDisplayMetricUnit(
   return (
     hasMetricUnitsUI && !!metricUnit && metricUnit !== '-' && metricUnit !== NONE_UNIT
   );
+}
+
+function makeMetricSelectValue(metric: TraceMetric): string {
+  return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
 }
 
 function MetricOptionTrailingItems({
@@ -81,17 +83,6 @@ function MetricOptionTrailingItems({
   );
 }
 
-interface MetricSelectOption {
-  label: string;
-  metricName: string;
-  metricType: TraceMetricTypeValue;
-  value: string;
-  count?: number;
-  lastSeen?: number;
-  metricUnit?: string;
-  trailingItems?: MenuListItemProps['trailingItems'];
-}
-
 export function MetricSelector({
   traceMetric,
   onChange,
@@ -111,8 +102,10 @@ export function MetricSelector({
   const listElementRef = useRef<HTMLUListElement>(null);
   const scrollElementRef = useRef<HTMLDivElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const sidePanelRef = useRef<HTMLDivElement>(null);
 
   const [searchInputValue, setSearchInputValue] = useState('');
+  const [sidePanelAnchorOffset, setSidePanelAnchorOffset] = useState<number | null>(null);
   const debouncedSearch = useDebouncedValue(searchInputValue, DEFAULT_DEBOUNCE_DURATION);
   const {data: metricOptionsData, isFetching} = useMetricOptions({
     search: debouncedSearch,
@@ -311,6 +304,7 @@ export function MetricSelector({
     state: overlayState,
     triggerProps,
     overlayProps,
+    arrowProps: overlayArrowProps,
     triggerRef,
     update: updateOverlay,
   } = useOverlay({
@@ -380,6 +374,55 @@ export function MetricSelector({
     id: triggerId,
   });
 
+  const isOverlayAboveTrigger = overlayArrowProps.placement?.startsWith('top') ?? false;
+  const activeOptionIndex = focusedKey
+    ? collectionItems.findIndex(item => item.key === focusedKey)
+    : -1;
+
+  const updateSidePanelAnchorOffset = useCallback(
+    (activeOptionElement?: HTMLElement | null) => {
+      if (!isOpen || (!activeOptionElement && activeOptionIndex < 0)) {
+        setSidePanelAnchorOffset(null);
+        return;
+      }
+
+      const optionElement =
+        activeOptionElement ??
+        listElementRef.current?.querySelector<HTMLElement>(
+          `[data-index="${activeOptionIndex}"]`
+        );
+      const popoverElement = popoverRef.current;
+
+      if (!optionElement || !popoverElement) {
+        setSidePanelAnchorOffset(null);
+        return;
+      }
+
+      const optionRect = optionElement.getBoundingClientRect();
+      const popoverRect = popoverElement.getBoundingClientRect();
+      const sidePanelRect = sidePanelRef.current?.getBoundingClientRect();
+      const optionCenter = optionRect.top + optionRect.height / 2;
+      const sidePanelHeight = sidePanelRect?.height ?? 0;
+      const offset = isOverlayAboveTrigger
+        ? popoverRect.bottom - optionCenter - sidePanelHeight / 2
+        : optionCenter - popoverRect.top - sidePanelHeight / 2;
+      const maxOffset = Math.max(0, popoverRect.height - sidePanelHeight);
+
+      setSidePanelAnchorOffset(Math.min(Math.max(0, offset), maxOffset));
+    },
+    [activeOptionIndex, isOpen, isOverlayAboveTrigger]
+  );
+
+  const setSidePanelRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      sidePanelRef.current = element;
+      if (element) {
+        updateSidePanelAnchorOffset();
+      }
+    },
+    [updateSidePanelAnchorOffset]
+  );
+
   const virtualItems = virtualizer.getVirtualItems();
 
   // Fall back to rendering all items when the virtualizer can't measure
@@ -395,6 +438,9 @@ export function MetricSelector({
           size: METRIC_SELECTOR_OPTION_HEIGHT,
           lane: 0,
         }));
+
+  const sidePanelAnchorPosition =
+    sidePanelAnchorOffset === null ? undefined : {md: `${sidePanelAnchorOffset}px`};
 
   return (
     <Container width="100%" position="relative">
@@ -412,21 +458,28 @@ export function MetricSelector({
         style={{...overlayProps.style, display: isOpen ? 'block' : 'none'}}
       >
         {isOpen ? (
-          <Overlay
+          <MetricSelectorOverlay
             ref={popoverRef}
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-            }}
+            style={{display: 'flex', flexDirection: 'column'}}
           >
             <FocusScope contain>
-              <Flex direction={{xs: 'column', sm: 'row'}}>
+              <Flex
+                minHeight="0"
+                direction={{
+                  xs: isOverlayAboveTrigger ? 'column-reverse' : 'column',
+                  md: 'row',
+                }}
+              >
                 <Stack
                   minWidth="400px"
-                  minHeight="0"
-                  borderRight={{sm: 'primary'}}
-                  borderBottom={{xs: 'primary', sm: undefined}}
+                  minHeight={`${METRIC_SELECTOR_DROPDOWN_MIN_HEIGHT}px`}
+                  maxHeight={`${METRIC_SELECTOR_DROPDOWN_MAX_HEIGHT}px`}
+                  borderBottom={
+                    isOverlayAboveTrigger ? undefined : {xs: 'primary', md: undefined}
+                  }
+                  borderTop={
+                    isOverlayAboveTrigger ? {xs: 'primary', md: undefined} : undefined
+                  }
                 >
                   <Flex align="center" justify="between" padding="sm lg">
                     <Text size="sm" bold wrap="nowrap">
@@ -463,8 +516,8 @@ export function MetricSelector({
                     overflowY="auto"
                     flex="1"
                     minHeight="0"
-                    maxHeight="400px"
                     padding="xs 0"
+                    onScroll={() => updateSidePanelAnchorOffset()}
                   >
                     {/* Hidden element that reserves width based on the longest option label */}
                     {longestOption ? (
@@ -532,6 +585,9 @@ export function MetricSelector({
                                   size="md"
                                   dataIndex={virtualRow.index}
                                   measureRef={virtualizer.measureElement}
+                                  updateSidePanelAnchorOffset={
+                                    updateSidePanelAnchorOffset
+                                  }
                                 />
                               );
                             })}
@@ -541,214 +597,50 @@ export function MetricSelector({
                     )}
                   </Container>
                 </Stack>
-                <Container width={{sm: '280px'}} padding="lg" minHeight={{sm: '260px'}}>
+                <SidePanel
+                  ref={setSidePanelRef}
+                  top={
+                    isOverlayAboveTrigger
+                      ? undefined
+                      : (sidePanelAnchorPosition ?? {md: 0})
+                  }
+                  bottom={
+                    isOverlayAboveTrigger
+                      ? (sidePanelAnchorPosition ?? {md: 0})
+                      : undefined
+                  }
+                  width={{xs: '100%', md: '280px'}}
+                  padding="lg"
+                  minHeight="0"
+                >
                   <MetricDetailPanel
                     metric={highlightedOption ?? optionFromTraceMetric}
                     hasMetricUnitsUI={hasMetricUnitsUI}
                   />
-                </Container>
+                </SidePanel>
               </Flex>
             </FocusScope>
-          </Overlay>
+          </MetricSelectorOverlay>
         ) : null}
       </PositionWrapper>
     </Container>
   );
 }
 
-interface MetricListBoxOptionProps {
-  dataIndex: number;
-  item: Node<MetricSelectOption>;
-  listState: ComboBoxState<MetricSelectOption>;
-  size: MenuListItemProps['size'];
-  measureRef?: React.Ref<HTMLLIElement>;
-}
-
-function MetricListBoxOption({
-  item,
-  listState,
-  size,
-  dataIndex,
-  measureRef,
-}: MetricListBoxOptionProps) {
-  const ref = useRef<HTMLLIElement>(null);
-  const option = item.value!;
-  const {optionProps, isFocused, isSelected, isDisabled, isPressed} = useOption(
-    {
-      key: item.key,
-      'aria-label': option.label,
-      shouldUseVirtualFocus: true,
-      shouldSelectOnPressUp: true,
-    },
-    listState,
-    ref
-  );
-  const optionPropsMerged = mergeProps(optionProps, {
-    onMouseEnter: () => {
-      listState.selectionManager.setFocused(true);
-      listState.selectionManager.setFocusedKey(item.key);
-    },
-  });
-
-  return (
-    <MenuListItem
-      {...optionPropsMerged}
-      as="li"
-      data-index={dataIndex}
-      ref={mergeRefs(ref, measureRef)}
-      size={size}
-      label={option.label}
-      isFocused={isFocused}
-      isSelected={isSelected}
-      isPressed={isPressed}
-      disabled={isDisabled}
-      priority={isSelected ? 'primary' : 'default'}
-      leadingItems={
-        <LeadWrap aria-hidden="true">
-          {isSelected ? <IconCheckmark size="sm" /> : null}
-        </LeadWrap>
-      }
-      trailingItems={option.trailingItems}
-    />
-  );
-}
-
-function MetricDetailPanel({
-  metric,
-  hasMetricUnitsUI,
-}: {
-  hasMetricUnitsUI: boolean;
-  metric: MetricSelectOption | null;
-}) {
-  if (!metric) {
-    return (
-      <Flex align="center" justify="center" flex="1">
-        <Text variant="muted">{t('Select an application metric to see details')}</Text>
-      </Flex>
-    );
+const MetricSelectorOverlay = styled(Overlay)`
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    overflow: visible;
   }
+`;
 
-  return (
-    <Stack gap="md">
-      <Text bold wordBreak="break-all">
-        {metric.metricName}
-      </Text>
-      <Flex gap="xs" align="center">
-        <Text variant="muted" size="md">
-          {t('Type')}
-        </Text>
-        <MetricTypeBadge metricType={metric.metricType} />
-      </Flex>
-      {hasDisplayMetricUnit(hasMetricUnitsUI, metric.metricUnit) ? (
-        <Flex gap="xs" align="center">
-          <Text variant="muted" size="md">
-            {t('Unit')}
-          </Text>
-          <Tag variant="promotion">{metric.metricUnit}</Tag>
-        </Flex>
-      ) : null}
-      {metric.lastSeen ? (
-        <Flex gap="xs" align="center">
-          <Text variant="muted" size="md">
-            {t('Last seen')}
-          </Text>
-          <DateTime date={metric.lastSeen} timeZone />
-        </Flex>
-      ) : null}
-      {metric.count === undefined ? null : (
-        <Flex gap="xs" align="center">
-          <Text variant="muted" size="md">
-            {t('Times seen')}
-          </Text>
-          <Text size="md">{metric.count.toLocaleString()}</Text>
-        </Flex>
-      )}
-      <MetricAttributesSection
-        metricName={metric.metricName}
-        metricType={metric.metricType}
-      />
-    </Stack>
-  );
-}
-
-function makeMetricSelectValue(metric: TraceMetric): string {
-  return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
-}
-
-function MetricAttributesSection({
-  metricName,
-  metricType,
-}: {
-  metricName: string;
-  metricType: string;
-}) {
-  const traceMetricFilter = createTraceMetricFilter({
-    name: metricName,
-    type: metricType,
-  });
-
-  const debouncedTraceMetricFilter = useDebouncedValue(
-    traceMetricFilter,
-    METRIC_ATTRIBUTES_DEBOUNCE_DURATION
-  );
-
-  const isDebouncingAttributes = debouncedTraceMetricFilter !== traceMetricFilter;
-  const metricAttributeQuery = {
-    enabled: Boolean(debouncedTraceMetricFilter),
-    query: debouncedTraceMetricFilter,
-    staleTime: Infinity,
-  };
-
-  const {attributes: stringAttrs, isLoading: stringLoading} =
-    useTraceMetricItemAttributes(metricAttributeQuery, 'string');
-  const {attributes: numberAttrs, isLoading: numberLoading} =
-    useTraceMetricItemAttributes(metricAttributeQuery, 'number');
-  const {attributes: booleanAttrs, isLoading: booleanLoading} =
-    useTraceMetricItemAttributes(metricAttributeQuery, 'boolean');
-
-  const attributeKeys = useMemo(() => {
-    const keys = new Set([
-      ...Object.keys(stringAttrs ?? {}),
-      ...Object.keys(numberAttrs ?? {}),
-      ...Object.keys(booleanAttrs ?? {}),
-    ]);
-    return [...keys]
-      .filter(key => !HiddenTraceMetricGroupByFields.includes(key))
-      .sort((a, b) => prettifyTagKey(a).localeCompare(prettifyTagKey(b)));
-  }, [stringAttrs, numberAttrs, booleanAttrs]);
-
-  if (isDebouncingAttributes || stringLoading || numberLoading || booleanLoading) {
-    return (
-      <Stack gap="xs">
-        <Text size="md">{t('Attributes')}:</Text>
-        <Flex gap="xs">
-          <LoadingIndicator size={16} style={{margin: 0}} />
-        </Flex>
-      </Stack>
-    );
+const SidePanel = styled(Container)`
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    position: absolute;
+    left: 100%;
+    max-height: calc(100vh - 32px);
+    overflow-y: auto;
+    background: ${p => p.theme.tokens.background.primary};
+    border: 1px solid ${p => p.theme.tokens.border.primary};
+    border-radius: ${p => p.theme.radius.md};
   }
-
-  if (attributeKeys.length === 0) {
-    return (
-      <Stack gap="xs">
-        <Text size="md">{t('Attributes')}:</Text>
-        <Flex gap="xs">
-          <Text size="md">{t('No attributes found')}</Text>
-        </Flex>
-      </Stack>
-    );
-  }
-
-  return (
-    <Stack gap="xs">
-      <Text size="md">{t('Attributes')}:</Text>
-      <Flex wrap="wrap" gap="xs">
-        {attributeKeys.map(key => (
-          <Tag key={key} variant="muted">
-            {prettifyTagKey(key)}
-          </Tag>
-        ))}
-      </Flex>
-    </Stack>
-  );
-}
+`;

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -43,7 +43,7 @@ import {
 
 const METRIC_SELECTOR_OPTION_HEIGHT = 42;
 const METRIC_SELECTOR_DROPDOWN_MAX_HEIGHT = 400;
-const METRIC_SELECTOR_DROPDOWN_MIN_HEIGHT = 200;
+const METRIC_SELECTOR_DROPDOWN_MIN_HEIGHT = 0;
 
 function nextFrameCallback(cb: () => void) {
   if ('requestAnimationFrame' in window) {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -36,6 +36,10 @@ import {
   TraceMetricKnownFieldKey,
   type TraceMetricTypeValue,
 } from 'sentry/views/explore/metrics/types';
+import {
+  hasDisplayMetricUnit,
+  makeMetricSelectValue,
+} from 'sentry/views/explore/metrics/utils';
 
 const METRIC_SELECTOR_OPTION_HEIGHT = 42;
 const METRIC_SELECTOR_DROPDOWN_MAX_HEIGHT = 400;
@@ -49,19 +53,6 @@ function nextFrameCallback(cb: () => void) {
       cb();
     }, 1);
   }
-}
-
-function hasDisplayMetricUnit(
-  hasMetricUnitsUI: boolean,
-  metricUnit?: string
-): metricUnit is string {
-  return (
-    hasMetricUnitsUI && !!metricUnit && metricUnit !== '-' && metricUnit !== NONE_UNIT
-  );
-}
-
-function makeMetricSelectValue(metric: TraceMetric): string {
-  return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
 }
 
 function MetricOptionTrailingItems({
@@ -113,7 +104,7 @@ export function MetricSelector({
     environments,
   });
 
-  const metricSelectValue = makeMetricSelectValue(
+  const traceMetricSelectValue = makeMetricSelectValue(
     hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
   );
 
@@ -123,7 +114,7 @@ export function MetricSelector({
   const optionFromTraceMetric: MetricSelectOption = useMemo(
     () => ({
       label: traceMetric.name,
-      value: metricSelectValue,
+      value: traceMetricSelectValue,
       metricType: traceMetric.type as TraceMetricTypeValue,
       metricUnit: hasMetricUnitsUI ? (traceMetric.unit ?? '-') : undefined,
       metricName: traceMetric.name,
@@ -136,7 +127,7 @@ export function MetricSelector({
       ),
     }),
     [
-      metricSelectValue,
+      traceMetricSelectValue,
       traceMetric.name,
       traceMetric.type,
       traceMetric.unit,
@@ -148,13 +139,7 @@ export function MetricSelector({
   // find when the dropdown is reopened. Filter it out of the API results to
   // avoid duplication.
   const metricOptions = useMemo((): MetricSelectOption[] => {
-    const selectedMetricValue = traceMetric.name
-      ? makeMetricSelectValue(
-          hasMetricUnitsUI
-            ? traceMetric
-            : {name: traceMetric.name, type: traceMetric.type}
-        )
-      : null;
+    const selectedMetricValue = traceMetric.name ? traceMetricSelectValue : null;
 
     const apiOptions =
       metricOptionsData?.data?.map(option => ({
@@ -197,7 +182,13 @@ export function MetricSelector({
       ...(selectedOption ? [selectedOption] : []),
       ...apiOptions.filter(o => o.value !== selectedMetricValue),
     ];
-  }, [metricOptionsData, optionFromTraceMetric, traceMetric, hasMetricUnitsUI]);
+  }, [
+    metricOptionsData,
+    optionFromTraceMetric,
+    traceMetric.name,
+    traceMetricSelectValue,
+    hasMetricUnitsUI,
+  ]);
 
   // Auto-select the first metric when no metric is currently selected.
   // This handles the initial load case where the URL has no metric param.
@@ -211,15 +202,11 @@ export function MetricSelector({
     }
   }, [metricOptions, onChange, traceMetric.name, hasMetricUnitsUI]);
 
-  const traceMetricSelectValue = makeMetricSelectValue(
-    hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
-  );
-
   // Show the previous options while a new search is loading so the list
   // doesn't flash empty during debounced re-fetches.
-  const previousOptions = usePrevious(metricOptions ?? []);
+  const previousOptions = usePrevious(metricOptions);
   const displayedOptions = useMemo(
-    () => (isFetching ? previousOptions : (metricOptions ?? [])),
+    () => (isFetching ? previousOptions : metricOptions),
     [isFetching, previousOptions, metricOptions]
   );
 

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -31,7 +31,7 @@ import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
 import {MetricDetailPanel} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricDetailPanel';
 import {MetricListBoxOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricListBoxOption';
-import type {MetricSelectOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
+import type {MetricSelectorOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
 import {
   TraceMetricKnownFieldKey,
   type TraceMetricTypeValue,
@@ -111,7 +111,7 @@ export function MetricSelector({
   // Build an option object from the currently selected trace metric so it
   // can be shown in the list even if the API response hasn't loaded yet or
   // doesn't include it (e.g. it was filtered out by search).
-  const optionFromTraceMetric: MetricSelectOption = useMemo(
+  const optionFromTraceMetric: MetricSelectorOption = useMemo(
     () => ({
       label: traceMetric.name,
       value: traceMetricSelectValue,
@@ -138,7 +138,7 @@ export function MetricSelector({
   // Always show the selected metric at the top of the list so it's easy to
   // find when the dropdown is reopened. Filter it out of the API results to
   // avoid duplication.
-  const metricOptions = useMemo((): MetricSelectOption[] => {
+  const metricOptions = useMemo((): MetricSelectorOption[] => {
     const selectedMetricValue = traceMetric.name ? traceMetricSelectValue : null;
 
     const apiOptions =
@@ -213,15 +213,19 @@ export function MetricSelector({
   // Find the option with the longest label to render as a hidden element.
   // This reserves enough width for the overlay so it doesn't resize as
   // the user scrolls through the virtualized list.
-  const longestOption = useMemo(
-    () =>
-      displayedOptions.reduce<MetricSelectOption | null>(
-        (longest, option) =>
-          !longest || option.label.length > longest.label.length ? option : longest,
-        null
-      ),
-    [displayedOptions]
-  );
+  const longestOption = useMemo(() => {
+    return displayedOptions.reduce<MetricSelectorOption | null>((longest, option) => {
+      if (typeof option.label !== 'string' || option.label.length === 0) {
+        return longest;
+      }
+
+      if (typeof longest?.label !== 'string') {
+        return option;
+      }
+
+      return option.label.length > longest?.label.length ? option : longest;
+    }, null);
+  }, [displayedOptions]);
 
   const displayedOptionsMap = useMemo(
     () => new Map(displayedOptions.map(option => [option.value, option])),
@@ -256,8 +260,8 @@ export function MetricSelector({
     });
   }
 
-  const comboBoxState = useComboBoxState<MetricSelectOption>({
-    children: (item: MetricSelectOption) => <Item key={item.value}>{item.label}</Item>,
+  const comboBoxState = useComboBoxState<MetricSelectorOption>({
+    children: (item: MetricSelectorOption) => <Item key={item.value}>{item.label}</Item>,
     items: displayedOptions,
     allowsEmptyCollection: true,
     shouldCloseOnBlur: false,
@@ -318,16 +322,17 @@ export function MetricSelector({
     },
   });
 
-  const {inputProps: comboBoxInputProps, listBoxProps} = useComboBox<MetricSelectOption>(
-    {
-      'aria-labelledby': triggerId,
-      listBoxRef: listElementRef,
-      inputRef: searchRef,
-      popoverRef,
-      shouldFocusWrap: true,
-    },
-    comboBoxState
-  );
+  const {inputProps: comboBoxInputProps, listBoxProps} =
+    useComboBox<MetricSelectorOption>(
+      {
+        'aria-labelledby': triggerId,
+        listBoxRef: listElementRef,
+        inputRef: searchRef,
+        popoverRef,
+        shouldFocusWrap: true,
+      },
+      comboBoxState
+    );
 
   const collectionItems = useMemo(
     () => [...comboBoxState.collection],

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -428,6 +428,7 @@ export function MetricSelector({
 
   const sidePanelAnchorPosition =
     sidePanelAnchorOffset === null ? undefined : {md: `${sidePanelAnchorOffset}px`};
+  const hasSelectedMetric = Boolean(traceMetric.name);
 
   return (
     <Container width="100%" position="relative">
@@ -584,27 +585,29 @@ export function MetricSelector({
                     )}
                   </Container>
                 </Stack>
-                <SidePanel
-                  ref={setSidePanelRef}
-                  top={
-                    isOverlayAboveTrigger
-                      ? undefined
-                      : (sidePanelAnchorPosition ?? {md: 0})
-                  }
-                  bottom={
-                    isOverlayAboveTrigger
-                      ? (sidePanelAnchorPosition ?? {md: 0})
-                      : undefined
-                  }
-                  width={{xs: '100%', md: '280px'}}
-                  padding="lg"
-                  minHeight="0"
-                >
-                  <MetricDetailPanel
-                    metric={highlightedOption ?? optionFromTraceMetric}
-                    hasMetricUnitsUI={hasMetricUnitsUI}
-                  />
-                </SidePanel>
+                {hasSelectedMetric ? (
+                  <SidePanel
+                    ref={setSidePanelRef}
+                    top={
+                      isOverlayAboveTrigger
+                        ? undefined
+                        : (sidePanelAnchorPosition ?? {md: 0})
+                    }
+                    bottom={
+                      isOverlayAboveTrigger
+                        ? (sidePanelAnchorPosition ?? {md: 0})
+                        : undefined
+                    }
+                    width={{xs: '100%', md: '280px'}}
+                    padding="lg"
+                    minHeight="0"
+                  >
+                    <MetricDetailPanel
+                      metric={highlightedOption ?? optionFromTraceMetric}
+                      hasMetricUnitsUI={hasMetricUnitsUI}
+                    />
+                  </SidePanel>
+                ) : null}
               </Flex>
             </FocusScope>
           </MetricSelectorOverlay>

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/types.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/types.tsx
@@ -1,0 +1,14 @@
+import type {MenuListItemProps} from '@sentry/scraps/menuListItem';
+
+import type {TraceMetricTypeValue} from 'sentry/views/explore/metrics/types';
+
+export interface MetricSelectOption {
+  label: string;
+  metricName: string;
+  metricType: TraceMetricTypeValue;
+  value: string;
+  count?: number;
+  lastSeen?: number;
+  metricUnit?: string;
+  trailingItems?: MenuListItemProps['trailingItems'];
+}

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/types.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/types.tsx
@@ -1,14 +1,11 @@
-import type {MenuListItemProps} from '@sentry/scraps/menuListItem';
+import type {SelectOption} from '@sentry/scraps/compactSelect';
 
 import type {TraceMetricTypeValue} from 'sentry/views/explore/metrics/types';
 
-export interface MetricSelectOption {
-  label: string;
+export interface MetricSelectOption extends SelectOption<string> {
   metricName: string;
   metricType: TraceMetricTypeValue;
-  value: string;
   count?: number;
   lastSeen?: number;
   metricUnit?: string;
-  trailingItems?: MenuListItemProps['trailingItems'];
 }

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/types.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/types.tsx
@@ -2,7 +2,7 @@ import type {SelectOption} from '@sentry/scraps/compactSelect';
 
 import type {TraceMetricTypeValue} from 'sentry/views/explore/metrics/types';
 
-export interface MetricSelectOption extends SelectOption<string> {
+export interface MetricSelectorOption extends SelectOption<string> {
   metricName: string;
   metricType: TraceMetricTypeValue;
   count?: number;

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -21,13 +21,13 @@ import type {
   SavedQuery,
 } from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {isRawVisualize} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
   defaultMetricQuery,
   encodeMetricQueryParams,
   type BaseMetricQuery,
 } from 'sentry/views/explore/metrics/metricQuery';
-import {NONE_UNIT} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
 import {normalizeFunctionToken} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -95,6 +95,19 @@ export function createTraceMetricFilter(traceMetric: TraceMetric): string | unde
     : undefined;
 }
 
+export function hasDisplayMetricUnit(
+  hasMetricUnitsUI: boolean,
+  metricUnit?: string
+): metricUnit is string {
+  return (
+    hasMetricUnitsUI && !!metricUnit && metricUnit !== '-' && metricUnit !== NONE_UNIT
+  );
+}
+
+export function makeMetricSelectValue(metric: TraceMetric): string {
+  return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
+}
+
 export function getMetricsUnit(
   meta: MetaType | EventsMetaType,
   field: string

--- a/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
@@ -16,7 +16,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceMetricItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
+import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricSelector';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsCrossEvents,


### PR DESCRIPTION
This PR fixes a styling issue with the metrics selector that stems from the side panel. This PR also brings in some refactors around the metrics selector to split things up, and tidy up a few other things.

Closes LOGS-753

**Examples:**

| | |
|-|-|
|Wide screen, bottom dropdown | <img width="726" height="455" alt="Screenshot 2026-05-01 at 10 02 10" src="https://github.com/user-attachments/assets/160d8cb6-cb66-4545-9ede-d7e22dcc7f84" /> |
|Wide screen, top dropdown | <img width="699" height="416" alt="Screenshot 2026-05-01 at 10 02 18" src="https://github.com/user-attachments/assets/c5ea9b80-0e13-4632-9bf8-3ef1f9972184" /> |
|Wide screen, bottom dropdown, small selector | <img width="733" height="340" alt="Screenshot 2026-05-01 at 10 07 37" src="https://github.com/user-attachments/assets/d6e88341-6452-48d1-97cf-883f3e97028d" /> |
|Wide screen, top dropdown, small selector | <img width="734" height="337" alt="Screenshot 2026-05-01 at 10 07 46" src="https://github.com/user-attachments/assets/ae92bab5-6f60-49a8-a9dc-2ef5ff78ee32" /> |
|Narrow screen, bottom dropdown | <img width="455" height="683" alt="Screenshot 2026-05-01 at 10 02 53" src="https://github.com/user-attachments/assets/48778837-7fd5-4c00-bc50-9c33de2c2f76" /> |
|Narrow screen, top dropdown | <img width="419" height="574" alt="Screenshot 2026-05-01 at 10 03 04" src="https://github.com/user-attachments/assets/4fab96a6-9ea0-412e-b31b-c67b89c2e9ce" /> |
|Narrow screen, bottom dropdown, small selector | <img width="464" height="400" alt="Screenshot 2026-05-01 at 10 08 49" src="https://github.com/user-attachments/assets/79f7d756-0efc-4a74-aeec-b219bdcfb26c" /> |
|Narrow screen, top dropdown, small selector | <img width="454" height="447" alt="Screenshot 2026-05-01 at 10 09 02" src="https://github.com/user-attachments/assets/e57c0f7f-bfcb-4621-8e47-29c9bac1125f" /> |
