### PR TITLE
feat(preprod): Configure higher rate limits for image endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
@@ -13,6 +13,8 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.models.project import Project
 from sentry.objectstore import get_preprod_session
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +25,19 @@ class ProjectPreprodArtifactImageEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
+    # Higher limits than default (40 rps, 25 concurrent) since this proxies images from Objectstore (2.5k rps, 1k concurrent capacity).
+    # Snapshot pages load many images in parallel, so per-user is 200 rps/100 concurrent and per-org is 2k rps/100 concurrent.
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=200, window=1, concurrent_limit=100),
+                RateLimitCategory.USER: RateLimit(limit=200, window=1, concurrent_limit=100),
+                RateLimitCategory.ORGANIZATION: RateLimit(
+                    limit=2000, window=1, concurrent_limit=100
+                ),
+            }
+        }
+    )
 
     def get(
         self,


### PR DESCRIPTION
Configures custom rate limits on `ProjectPreprodArtifactImageEndpoint` to avoid 429 errors when snapshot pages load many images in parallel.

The default Django rate limits (40 rps, 25 concurrent) are too low for this endpoint, which proxies images from Objectstore (capacity: 2.5k rps, 1k concurrent). Snapshot pages can trigger dozens of parallel image requests, easily exceeding the defaults.

New limits:
| Category | Before (default) | After |
|---|---|---|
| IP | 40 rps, 25 concurrent | 200 rps, 100 concurrent |
| User | 40 rps, 25 concurrent | 200 rps, 100 concurrent |
| Organization | 40 rps, 25 concurrent | 2000 rps, 100 concurrent |