### PR TITLE
fix(preprod): Show total image count in snapshot status pills

### DIFF
--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -374,7 +374,7 @@ export default function SnapshotsPage() {
       : searchFilteredItems;
     for (const item of source) {
       if (item.type in counts) {
-        counts[item.type as DiffStatus]++;
+        counts[item.type as DiffStatus] += itemVariantCount(item);
       }
     }
     return counts;


### PR DESCRIPTION
The status pills in the snapshot sidebar (e.g. "20 unchanged") were counting
the number of snapshot *groups* rather than the total number of individual
images. A group with 5 image variants was counted as 1.

Uses the existing `itemVariantCount` helper to sum `pairs.length` (for
changed/renamed) or `images.length` (for added/removed/unchanged) per group,
so the pills now reflect the actual image totals.