### PR TITLE
feat(autofix): Open autofix evidence in new tab

### DIFF
--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -32,6 +32,7 @@ export function AutofixEvidence({evidenceButtonProps}: AutofixEvidenceProps) {
         icon={icon}
         size="zero"
         to={rest.to}
+        openInNewTab
         tooltipProps={tooltip ? {title: tooltip} : undefined}
       >
         {label}


### PR DESCRIPTION
When viewing autofix evidence, it should always be opening in a new tab to avoid closing the autofix drawer.