### PR TITLE
ref(dashboards): Inline top_n -> area conversion into widget library templates

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -70,7 +70,7 @@ import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
 import {WidgetLegendNameEncoderDecoder} from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
-import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
+import {getDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
 import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
 
@@ -139,7 +139,7 @@ function AddToDashboardModal({
   const hasMultipleWidgets = widgets.length > 1;
 
   // Check if the widget is a static widget from a widget template
-  const widgetTemplates = getTopNConvertedDefaultWidgets(organization);
+  const widgetTemplates = getDefaultWidgets(organization);
   const widgetTemplate = widgetTemplates.find(w => w.displayType === widget.displayType);
   const shouldOpenWidgetLibrary =
     !isWidgetEditable(widget.displayType) || widgetTemplate?.isCustomizable === false;

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -78,7 +78,7 @@ import {
 } from 'sentry/views/dashboards/widgetBuilder/utils';
 import {convertWidgetToQueryParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import {getDefaultWidget} from 'sentry/views/dashboards/widgetBuilder/utils/getDefaultWidget';
-import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
+import {getDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
 import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {generatePerformanceEventView} from 'sentry/views/performance/data';
@@ -650,7 +650,7 @@ class DashboardDetail extends Component<Props, State> {
           pathname = `/organizations/${organization.slug}/dashboards/new/widget-builder/widget/new/`;
         }
 
-        const defaultLibraryWidget = getTopNConvertedDefaultWidgets(organization)[0];
+        const defaultLibraryWidget = getDefaultWidgets(organization)[0];
         navigate(
           normalizeUrl({
             // TODO: Replace with the old widget builder path when swapping over

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -71,7 +71,7 @@ import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder
 import {convertWidgetToBuilderState} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
 import {readableConditions} from 'sentry/views/dashboards/widgetCard/widgetLLMContext';
-import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
+import {getDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
 import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
@@ -234,7 +234,7 @@ function WidgetBuilderSlideoutInner({
     [observer]
   );
 
-  const widgetLibraryWidgets = getTopNConvertedDefaultWidgets(organization);
+  const widgetLibraryWidgets = getDefaultWidgets(organization);
 
   const widgetLibraryElement = (
     <SlideoutBreadcrumb

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
@@ -7,7 +7,7 @@ import {testableDebounce} from 'sentry/utils/url/testUtils';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {WidgetTemplatesList} from 'sentry/views/dashboards/widgetBuilder/components/widgetTemplatesList';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
+import {getDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
 import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
 
 jest.mock('sentry/utils/useNavigate', () => ({
@@ -16,7 +16,7 @@ jest.mock('sentry/utils/useNavigate', () => ({
 jest.mock('lodash/debounce');
 
 jest.mock('sentry/views/dashboards/widgetLibrary/data', () => ({
-  getTopNConvertedDefaultWidgets: jest.fn(() => [
+  getDefaultWidgets: jest.fn(() => [
     {
       id: 'duration-distribution',
       title: 'Duration Distribution',
@@ -30,7 +30,7 @@ jest.mock('sentry/views/dashboards/widgetLibrary/data', () => ({
 }));
 
 const mockUseNavigate = jest.mocked(useNavigate);
-const mockGetTopNConvertedDefaultWidgets = jest.mocked(getTopNConvertedDefaultWidgets);
+const mockGetDefaultWidgets = jest.mocked(getDefaultWidgets);
 
 jest.mock('sentry/actionCreators/indicator');
 
@@ -163,7 +163,7 @@ describe('WidgetTemplatesList', () => {
   });
 
   it('should pre-select widget based on widgetTemplateId query parameter', async () => {
-    mockGetTopNConvertedDefaultWidgets.mockReturnValue([
+    mockGetDefaultWidgets.mockReturnValue([
       {
         id: 'duration-distribution',
         title: 'Duration Distribution',

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
@@ -18,7 +18,7 @@ import type {Widget} from 'sentry/views/dashboards/types';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {convertWidgetToBuilderState} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
-import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
+import {getDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
 import {getWidgetIcon} from 'sentry/views/dashboards/widgetLibrary/widgetCard';
 
 interface WidgetTemplatesListProps {
@@ -37,7 +37,7 @@ export function WidgetTemplatesList({
   const theme = useTheme();
   const organization = useOrganization();
   const location = useLocation();
-  const widgets = getTopNConvertedDefaultWidgets(organization);
+  const widgets = getDefaultWidgets(organization);
 
   const widgetTemplateId = decodeScalar(location.query?.widgetTemplateId);
   const initialSelectedIndex = widgetTemplateId

--- a/static/app/views/dashboards/widgetLibrary/data.tsx
+++ b/static/app/views/dashboards/widgetLibrary/data.tsx
@@ -10,7 +10,7 @@ import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
 import {SCORE_BREAKDOWN_WHEEL_WIDGET} from 'sentry/views/dashboards/widgetLibrary/webVitalsWidgets';
 import {hasPlatformizedInsights} from 'sentry/views/insights/common/utils/useHasPlatformizedInsights';
 
-const getDefaultWidgets = (organization: Organization) => {
+export const getDefaultWidgets = (organization: Organization) => {
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
   const transactionsWidgets: WidgetTemplate[] = [
     {
@@ -44,9 +44,10 @@ const getDefaultWidgets = (organization: Organization) => {
       id: 'high-throughput-transactions',
       title: t('High Throughput Transactions'),
       description: t('Top 5 transactions with the largest volume.'),
-      displayType: DisplayType.TOP_N,
+      displayType: DisplayType.AREA,
       widgetType: WidgetType.TRANSACTIONS,
       interval: '5m',
+      limit: TOP_N,
       isCustomizable: true,
       queries: [
         {
@@ -188,9 +189,10 @@ const getDefaultWidgets = (organization: Organization) => {
       id: 'high-throughput-transactions',
       title: t('High Throughput Transactions'),
       description: t('Top 5 transactions with the largest volume.'),
-      displayType: DisplayType.TOP_N,
+      displayType: DisplayType.AREA,
       widgetType: WidgetType.SPANS,
       interval: '5m',
+      limit: TOP_N,
       isCustomizable: true,
       queries: [
         {
@@ -322,9 +324,10 @@ const getDefaultWidgets = (organization: Organization) => {
       id: 'top-unhandled',
       title: t('Top Unhandled Error Types'),
       description: t('Most frequently encountered unhandled errors.'),
-      displayType: DisplayType.TOP_N,
+      displayType: DisplayType.AREA,
       widgetType: WidgetType.ERRORS,
       interval: '5m',
+      limit: TOP_N,
       isCustomizable: true,
       queries: [
         {
@@ -384,18 +387,3 @@ const getDefaultWidgets = (organization: Organization) => {
       ? [...spanWidgets, ...errorsWidgets]
       : [...transactionsWidgets, ...errorsWidgets];
 };
-
-export function getTopNConvertedDefaultWidgets(
-  organization: Organization
-): readonly WidgetTemplate[] {
-  return getDefaultWidgets(organization).map(widget => {
-    if (widget.displayType === DisplayType.TOP_N) {
-      return {
-        ...widget,
-        displayType: DisplayType.AREA,
-        limit: TOP_N,
-      };
-    }
-    return widget;
-  });
-}


### PR DESCRIPTION
The three `top_n` widget library templates (`high-throughput-transactions` x2 and `top-unhandled`) are now defined as `area` with `limit: 5` directly, instead of `top_n` plus a runtime converter. Users already saw the converted form via `getTopNConvertedDefaultWidgets`, so this is a no-op for them; it removes an indirection now that the builder no longer creates `top_n` widgets at all.

Pairs with the data backfill in #114560, but doesn't depend on it — both can land in either order.