### PR TITLE
feat(preprod): Add scroll wheel navigation in single snapshot view

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
@@ -405,6 +405,62 @@ function SingleViewLayout({
   toggle: React.ReactNode;
   rightControls?: React.ReactNode;
 }) {
+  const wheelCooldownRef = useRef(false);
+  const pressTimeoutRef = useRef<number | undefined>(undefined);
+  const cooldownTimeoutRef = useRef<number | undefined>(undefined);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const navStateRef = useRef({onNavigateSingleView, canNavigateNext, canNavigatePrev});
+  navStateRef.current = {onNavigateSingleView, canNavigateNext, canNavigatePrev};
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+    const handler = (e: WheelEvent) => {
+      if (e.deltaY === 0) {
+        return;
+      }
+      e.preventDefault();
+      if (wheelCooldownRef.current) {
+        return;
+      }
+      const {
+        onNavigateSingleView: navigate,
+        canNavigateNext: canNext,
+        canNavigatePrev: canPrev,
+      } = navStateRef.current;
+      const isNext = e.deltaY > 0;
+      if (isNext ? !canNext : !canPrev) {
+        return;
+      }
+      wheelCooldownRef.current = true;
+      navigate(isNext ? 'next' : 'prev');
+
+      const btn = isNext ? navButtonRefs.next.current : navButtonRefs.prev.current;
+      if (btn) {
+        btn.setAttribute('aria-pressed', 'true');
+        clearTimeout(pressTimeoutRef.current);
+        pressTimeoutRef.current = window.setTimeout(
+          () => btn.removeAttribute('aria-pressed'),
+          150
+        );
+      }
+
+      clearTimeout(cooldownTimeoutRef.current);
+      cooldownTimeoutRef.current = window.setTimeout(() => {
+        wheelCooldownRef.current = false;
+      }, 120);
+    };
+    el.addEventListener('wheel', handler, {passive: false});
+    return () => {
+      el.removeEventListener('wheel', handler);
+      clearTimeout(pressTimeoutRef.current);
+      clearTimeout(cooldownTimeoutRef.current);
+    };
+  }, [navButtonRefs]);
+
   const card = (
     <SnapshotVariantFrame fillHeight>
       <CardHeader
@@ -445,7 +501,7 @@ function SingleViewLayout({
         </Flex>
       </Flex>
       <Separator orientation="horizontal" />
-      <SingleViewScroll>
+      <SingleViewScroll ref={scrollRef}>
         <Flex direction="row" gap="xl" flex="1" minHeight="0" align="stretch">
           <Flex direction="column" flex="1" minWidth="0">
             <DarkAware isDark={isDark}>
@@ -454,28 +510,30 @@ function SingleViewLayout({
               </SnapshotCardFrame>
             </DarkAware>
           </Flex>
-          <NavGutter onClick={e => e.stopPropagation()}>
-            <Tooltip title={t('Previous (↑)')} skipWrapper>
-              <Button
-                ref={navButtonRefs.prev}
-                size="sm"
-                icon={<IconArrow direction="up" />}
-                aria-label={t('Previous snapshot')}
-                disabled={!canNavigatePrev}
-                onClick={() => onNavigateSingleView('prev')}
-              />
-            </Tooltip>
-            <Tooltip title={t('Next (↓)')} skipWrapper>
-              <Button
-                ref={navButtonRefs.next}
-                size="sm"
-                icon={<IconArrow direction="down" />}
-                aria-label={t('Next snapshot')}
-                disabled={!canNavigateNext}
-                onClick={() => onNavigateSingleView('next')}
-              />
-            </Tooltip>
-          </NavGutter>
+          <Container flexShrink={0} onClick={e => e.stopPropagation()}>
+            <NavGutter>
+              <Tooltip title={t('Previous (↑)')} skipWrapper>
+                <Button
+                  ref={navButtonRefs.prev}
+                  size="sm"
+                  icon={<IconArrow direction="up" />}
+                  aria-label={t('Previous snapshot')}
+                  disabled={!canNavigatePrev}
+                  onClick={() => onNavigateSingleView('prev')}
+                />
+              </Tooltip>
+              <Tooltip title={t('Next (↓)')} skipWrapper>
+                <Button
+                  ref={navButtonRefs.next}
+                  size="sm"
+                  icon={<IconArrow direction="down" />}
+                  aria-label={t('Next snapshot')}
+                  disabled={!canNavigateNext}
+                  onClick={() => onNavigateSingleView('next')}
+                />
+              </Tooltip>
+            </NavGutter>
+          </Container>
         </Flex>
       </SingleViewScroll>
     </Flex>
@@ -658,17 +716,37 @@ const SingleViewScroll = styled('div')`
   flex-direction: column;
 `;
 
-// Sticky + vertically centered so the nav arrows sit at the viewport's
-// vertical center and stay reachable as the user scrolls tall images.
 const NavGutter = styled('div')`
   position: sticky;
   top: 50%;
   transform: translateY(-50%);
-  align-self: flex-start;
   display: flex;
   flex-direction: column;
   gap: ${p => p.theme.space.sm};
   flex-shrink: 0;
+
+  button[aria-pressed='true'] {
+    &::after {
+      transform: translateY(0px);
+    }
+    > span:last-child {
+      transform: translateY(0px);
+    }
+  }
+`;
+
+const SingleViewCard = styled(Card)`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-height: 0;
+`;
+
+const SingleViewBody = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-height: 0;
 `;
 
 const ColorPickerWrapper = styled('div')`

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
@@ -439,9 +439,11 @@ function SingleViewLayout({
       navigate(isNext ? 'next' : 'prev');
 
       const btn = isNext ? navButtonRefs.next.current : navButtonRefs.prev.current;
+      const otherBtn = isNext ? navButtonRefs.prev.current : navButtonRefs.next.current;
       if (btn) {
-        btn.setAttribute('aria-pressed', 'true');
         clearTimeout(pressTimeoutRef.current);
+        otherBtn?.removeAttribute('aria-pressed');
+        btn.setAttribute('aria-pressed', 'true');
         pressTimeoutRef.current = window.setTimeout(
           () => btn.removeAttribute('aria-pressed'),
           150
@@ -733,20 +735,6 @@ const NavGutter = styled('div')`
       transform: translateY(0px);
     }
   }
-`;
-
-const SingleViewCard = styled(Card)`
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 0;
-  min-height: 0;
-`;
-
-const SingleViewBody = styled('div')`
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 0;
-  min-height: 0;
 `;
 
 const ColorPickerWrapper = styled('div')`

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -445,10 +445,12 @@ export default function SnapshotsPage() {
     };
   }, [listItems, singleViewPosition]);
 
-  const navButtonRefs: NavButtonRefs = {
-    prev: useRef<HTMLButtonElement>(null),
-    next: useRef<HTMLButtonElement>(null),
-  };
+  const prevButtonRef = useRef<HTMLButtonElement>(null);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
+  const navButtonRefs = useMemo<NavButtonRefs>(
+    () => ({prev: prevButtonRef, next: nextButtonRef}),
+    []
+  );
 
   const pressTimeoutRef = useRef<number>(undefined);
   // Ref so the keydown handler reads latest state without re-registering.


### PR DESCRIPTION
Adds mouse wheel navigation to the single snapshot view mode. Scrolling
anywhere in the content area (the space around the image card) navigates
between snapshots — scroll down for next, scroll up for previous.

This makes browsing through snapshots much faster than clicking the
up/down arrow buttons individually.

Implementation uses an imperative wheel event listener with `passive: false`
to ensure `preventDefault()` works correctly in React 19 (React registers
synthetic wheel handlers as passive by default). A 250ms ref-based cooldown
ensures each scroll tick maps to exactly one navigation step.

Also splits `NavGutter` into `NavGutterColumn` (flex layout) + `NavGutter`
(sticky positioning) to cleanly separate layout concerns.