### PR TITLE
ref(autofix): Remove impact_assessment and triage from Explorer next steps

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -43,12 +43,7 @@ interface CodingAgentError {
   message: string;
 }
 
-export type AutofixExplorerStep =
-  | 'root_cause'
-  | 'solution'
-  | 'code_changes'
-  | 'impact_assessment'
-  | 'triage';
+export type AutofixExplorerStep = 'root_cause' | 'solution' | 'code_changes' | 'triage';
 
 /**
  * Artifact data types matching the backend Pydantic schemas.

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -43,7 +43,7 @@ interface CodingAgentError {
   message: string;
 }
 
-export type AutofixExplorerStep = 'root_cause' | 'solution' | 'code_changes' | 'triage';
+export type AutofixExplorerStep = 'root_cause' | 'solution' | 'code_changes';
 
 /**
  * Artifact data types matching the backend Pydantic schemas.

--- a/static/app/components/events/autofix/v2/nextSteps.tsx
+++ b/static/app/components/events/autofix/v2/nextSteps.tsx
@@ -27,7 +27,6 @@ const STEP_LABELS: Record<AutofixExplorerStep, string> = {
   root_cause: t('Find Root Cause'),
   solution: t('Plan a Solution'),
   code_changes: t('Write a Code Fix'),
-  impact_assessment: t('Assess the Impact'),
   triage: t('Triage the Issue'),
 };
 
@@ -78,7 +77,6 @@ function getAvailableNextSteps(
 ): AutofixExplorerStep[] {
   const hasRootCause = 'root_cause' in artifacts;
   const hasSolution = 'solution' in artifacts;
-  const hasImpact = 'impact_assessment' in artifacts;
   const hasTriage = 'triage' in artifacts;
 
   if (!hasRootCause) {
@@ -97,10 +95,6 @@ function getAvailableNextSteps(
   // Only show code changes if they don't already exist and no coding agents are launched
   if (!hasCodeChanges && !hasCodingAgents) {
     available.push('code_changes');
-  }
-
-  if (!hasImpact) {
-    available.push('impact_assessment');
   }
 
   if (!hasTriage) {

--- a/static/app/components/events/autofix/v2/nextSteps.tsx
+++ b/static/app/components/events/autofix/v2/nextSteps.tsx
@@ -27,7 +27,6 @@ const STEP_LABELS: Record<AutofixExplorerStep, string> = {
   root_cause: t('Find Root Cause'),
   solution: t('Plan a Solution'),
   code_changes: t('Write a Code Fix'),
-  triage: t('Triage the Issue'),
 };
 
 interface ExplorerNextStepsProps {
@@ -77,7 +76,6 @@ function getAvailableNextSteps(
 ): AutofixExplorerStep[] {
   const hasRootCause = 'root_cause' in artifacts;
   const hasSolution = 'solution' in artifacts;
-  const hasTriage = 'triage' in artifacts;
 
   if (!hasRootCause) {
     // Only root cause is available initially
@@ -95,10 +93,6 @@ function getAvailableNextSteps(
   // Only show code changes if they don't already exist and no coding agents are launched
   if (!hasCodeChanges && !hasCodingAgents) {
     available.push('code_changes');
-  }
-
-  if (!hasTriage) {
-    available.push('triage');
   }
 
   return available;


### PR DESCRIPTION
Drops the impact_assessment and triage steps from the Explorer autofix UI: their "Assess the Impact" / "Triage the Issue" buttons, labels, and availability checks in `getAvailableNextSteps`.

This is the frontend half. Landing the frontend first so the backend can subsequently remove the steps, prompts, agent registrations, sentry_apps webhook events, and analytics without leaving dangling UI affordances. The backend still emits these artifacts today; after this lands they simply will not be surfaced as next-step buttons. A follow-up PR against `src/` will clean up the backend.