### PR TITLE
fix(supergroups): Close drawer on click outside, but not modals

### DIFF
--- a/static/app/components/core/backdrop/backdrop.tsx
+++ b/static/app/components/core/backdrop/backdrop.tsx
@@ -6,6 +6,7 @@ interface BackdropProps extends Omit<
   'style' | 'className' | `on${string}`
 > {
   zIndex: 'widgetBuilderDrawer' | 'drawer' | 'modal';
+  'data-drawer-backdrop'?: string;
   'data-test-id'?: string;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }

--- a/static/app/components/core/drawer/index.tsx
+++ b/static/app/components/core/drawer/index.tsx
@@ -206,7 +206,7 @@ export function GlobalDrawer({children}: any) {
       >
         <AnimatePresence>
           {isDrawerOpen && currentDrawerConfig.options.mode !== 'passive' ? (
-            <Backdrop zIndex="drawer" key="backdrop" />
+            <Backdrop zIndex="drawer" key="backdrop" data-drawer-backdrop="" />
           ) : null}
           {isDrawerOpen && (
             <DrawerComponents.DrawerPanel

--- a/static/app/components/core/drawer/index.tsx
+++ b/static/app/components/core/drawer/index.tsx
@@ -103,6 +103,15 @@ const DrawerContext = createContext<DrawerContextType>({
   panelRef: {current: null},
 });
 
+function shouldCloseOnInteractOutsideByDefault(element: Element) {
+  if (document.getElementById('modal-portal')?.contains(element)) {
+    return false;
+  }
+
+  const overlay = element.closest('[data-overlay]');
+  return !overlay || overlay.hasAttribute('data-drawer-backdrop');
+}
+
 export function GlobalDrawer({children}: any) {
   const location = useLocation();
   const [currentDrawerConfig, overwriteDrawerConfig] = useState<
@@ -170,11 +179,16 @@ export function GlobalDrawer({children}: any) {
   }, [currentDrawerConfig, handleClose]);
   const {shouldCloseOnInteractOutside} = currentDrawerConfig?.options ?? {};
   useOnClickOutside(panelRef, e => {
-    if (
-      defined(shouldCloseOnInteractOutside) &&
-      defined(e?.target) &&
-      !shouldCloseOnInteractOutside(e.target as Element)
-    ) {
+    if (!defined(e?.target)) {
+      handleClickOutside();
+      return;
+    }
+
+    const shouldClose = shouldCloseOnInteractOutside
+      ? shouldCloseOnInteractOutside(e.target as Element)
+      : shouldCloseOnInteractOutsideByDefault(e.target as Element);
+
+    if (!shouldClose) {
       return;
     }
     handleClickOutside();

--- a/static/app/views/issueDetails/streamline/sidebar/supergroupSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/supergroupSection.tsx
@@ -38,9 +38,14 @@ export function SupergroupSection({group}: SupergroupSectionProps) {
     openDrawer(() => <SupergroupDetailDrawer supergroup={supergroup} />, {
       ariaLabel: t('Issue group details'),
       drawerKey: 'supergroup-drawer',
-      shouldCloseOnInteractOutside: el =>
-        !document.getElementById('modal-portal')?.contains(el) &&
-        !el.closest('[data-overlay]'),
+      shouldCloseOnInteractOutside: el => {
+        if (document.getElementById('modal-portal')?.contains(el)) {
+          return false;
+        }
+
+        const overlay = el.closest('[data-overlay]');
+        return !overlay || overlay.hasAttribute('data-drawer-backdrop');
+      },
     });
   };
 

--- a/static/app/views/issueDetails/streamline/sidebar/supergroupSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/supergroupSection.tsx
@@ -38,14 +38,6 @@ export function SupergroupSection({group}: SupergroupSectionProps) {
     openDrawer(() => <SupergroupDetailDrawer supergroup={supergroup} />, {
       ariaLabel: t('Issue group details'),
       drawerKey: 'supergroup-drawer',
-      shouldCloseOnInteractOutside: el => {
-        if (document.getElementById('modal-portal')?.contains(el)) {
-          return false;
-        }
-
-        const overlay = el.closest('[data-overlay]');
-        return !overlay || overlay.hasAttribute('data-drawer-backdrop');
-      },
     });
   };
 

--- a/static/app/views/issueList/supergroups/useSupergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/useSupergroupDrawer.tsx
@@ -112,14 +112,6 @@ export function useSupergroupDrawer({lookup, memberList}: UseSupergroupDrawerOpt
       {
         ariaLabel: t('Issue group details'),
         drawerKey: 'supergroup-drawer',
-        shouldCloseOnInteractOutside: el => {
-          if (document.getElementById('modal-portal')?.contains(el)) {
-            return false;
-          }
-
-          const overlay = el.closest('[data-overlay]');
-          return !overlay || overlay.hasAttribute('data-drawer-backdrop');
-        },
         shouldCloseOnLocationChange: nextLocation =>
           !nextLocation.query[SUPERGROUP_DRAWER_QUERY_PARAM],
         onClose: () => stripDrawerParam(),

--- a/static/app/views/issueList/supergroups/useSupergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/useSupergroupDrawer.tsx
@@ -112,9 +112,14 @@ export function useSupergroupDrawer({lookup, memberList}: UseSupergroupDrawerOpt
       {
         ariaLabel: t('Issue group details'),
         drawerKey: 'supergroup-drawer',
-        shouldCloseOnInteractOutside: el =>
-          !document.getElementById('modal-portal')?.contains(el) &&
-          !el.closest('[data-overlay]'),
+        shouldCloseOnInteractOutside: el => {
+          if (document.getElementById('modal-portal')?.contains(el)) {
+            return false;
+          }
+
+          const overlay = el.closest('[data-overlay]');
+          return !overlay || overlay.hasAttribute('data-drawer-backdrop');
+        },
         shouldCloseOnLocationChange: nextLocation =>
           !nextLocation.query[SUPERGROUP_DRAWER_QUERY_PARAM],
         onClose: () => stripDrawerParam(),


### PR DESCRIPTION
allows closing the supergroup drawer on click outside but not when interacting with modals or the modal backdrop
