### PR TITLE
ref(settings): use SettingsPageHeader subtitle on console SDK invites

### DIFF
--- a/static/app/views/settings/organizationConsoleSdkInvites/index.tsx
+++ b/static/app/views/settings/organizationConsoleSdkInvites/index.tsx
@@ -20,7 +20,6 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
 import {useConsoleSdkInvites, useRevokeConsoleSdkPlatformInvite} from './hooks';
 
@@ -63,11 +62,11 @@ export default function ConsoleSDKInvitesSettings() {
       <SentryDocumentTitle title={t('Console SDK Invites')} orgSlug={organization.slug} />
       <SettingsPageHeader
         title={t('Console SDK Invites')}
+        subtitle={t(
+          'Manage invitations to our private gaming console SDK GitHub repositories.'
+        )}
         action={hasPageFrame ? undefined : action}
       />
-      <TextBlock>
-        {t('Manage invitations to our private gaming console SDK GitHub repositories.')}
-      </TextBlock>
       {!userHasConsoleAccess && <NoAccessAlert />}
       {!isPending && !isError && userHasConsoleAccess && !userHasQuotaRemaining && (
         <NoQuotaRemaining organization={organization} />


### PR DESCRIPTION
Move the page description into the `SettingsPageHeader` subtitle slot instead of rendering it as a separate `TextBlock` below the header.