### PR TITLE
ref(settings): use SettingsPageHeader subtitle on dynamic sampling

### DIFF
--- a/static/app/views/settings/dynamicSampling/index.tsx
+++ b/static/app/views/settings/dynamicSampling/index.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {FeatureBadge} from '@sentry/scraps/badge';
@@ -80,6 +79,9 @@ export default function DynamicSamplingSettings() {
             </Fragment>
           )
         }
+        subtitle={t(
+          'Dynamic Sampling lets you manage span storage in Sentry. This prioritizes important events and increases visibility into lower-volume projects, keeping the most relevant data while minimizing redundancy. You can customize sample rates and priorities in the settings to control which data is retained.'
+        )}
         action={
           <LinkButton
             external
@@ -91,18 +93,11 @@ export default function DynamicSamplingSettings() {
       />
       <OrganizationPermissionAlert />
       {hasReadAccess ? (
-        <Fragment>
-          <Paragraph>
-            {t(
-              'Dynamic Sampling lets you manage span storage in Sentry. This prioritizes important events and increases visibility into lower-volume projects, keeping the most relevant data while minimizing redundancy. You can customize sample rates and priorities in the settings to control which data is retained.'
-            )}
-          </Paragraph>
-          {organization.samplingMode === 'organization' ? (
-            <OrganizationSampling />
-          ) : (
-            <ProjectSampling />
-          )}
-        </Fragment>
+        organization.samplingMode === 'organization' ? (
+          <OrganizationSampling />
+        ) : (
+          <ProjectSampling />
+        )
       ) : (
         <Alert.Container>
           <Alert variant="warning" showIcon={false}>
@@ -113,7 +108,3 @@ export default function DynamicSamplingSettings() {
     </Fragment>
   );
 }
-
-const Paragraph = styled('p')`
-  margin-bottom: ${p => p.theme.space.lg};
-`;


### PR DESCRIPTION
Move the page description into the `SettingsPageHeader` subtitle slot instead of rendering it as a separate styled paragraph below the header. The description now also renders for users without read access, which is consistent with the title.