### PR TITLE
fix(search-query-builder): cmd del not clearing free text

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -374,6 +374,26 @@ describe('SearchQueryBuilder', () => {
       }
     );
 
+    it('clears uncommitted free text repeatedly with Cmd+Delete', async () => {
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />);
+
+      const input = screen.getByRole('combobox', {name: 'Add a search term'});
+
+      await userEvent.type(input, 'first');
+      await userEvent.keyboard('{Control>}{Delete}{/Control}');
+
+      await waitFor(() => {
+        expect(input).toHaveValue('');
+      });
+
+      await userEvent.type(input, 'second');
+      await userEvent.keyboard('{Control>}{Delete}{/Control}');
+
+      await waitFor(() => {
+        expect(input).toHaveValue('');
+      });
+    });
+
     it('is hidden at small sizes', async () => {
       Object.defineProperty(Element.prototype, 'clientWidth', {value: 100});
       const mockOnChange = jest.fn();

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -99,6 +99,7 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
   onKeyUp?: (e: KeyboardEvent) => void;
   onOpenChange?: (newOpenState: boolean) => void;
   onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
+  onSearchQueryClear?: () => void;
   openOnFocus?: boolean;
   placeholder?: string;
   ref?: React.Ref<HTMLInputElement>;
@@ -364,6 +365,7 @@ export function SearchQueryBuilderCombobox<
   onKeyUp,
   onInputChange,
   onOpenChange,
+  onSearchQueryClear,
   autoFocus,
   openOnFocus,
   onFocus,
@@ -622,6 +624,7 @@ export function SearchQueryBuilderCombobox<
           if (isCtrlKeyPressed(e) && (e.key === 'Backspace' || e.key === 'Delete')) {
             e.preventDefault();
             e.stopPropagation();
+            onSearchQueryClear?.();
             state.close();
             clearSearchQuery({reopenDropdown: true});
             return;

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -671,6 +671,7 @@ function SearchQueryBuilderInputInternal({
         onKeyDown={onKeyDown}
         onKeyDownCapture={onKeyDownCapture}
         onOpenChange={setIsOpen}
+        onSearchQueryClear={() => setInputValue('')}
         openOnFocus={shouldReopenDropdownOnFocus}
         onFocus={() => {
           if (shouldReopenDropdownOnFocus) {


### PR DESCRIPTION
Small bug leftover from the cmd + del improvements, where free text inputs weren't being cleared properly.