### PR TITLE
chore(aci): Add callout on inline alert form

### DIFF
--- a/static/app/views/automations/components/automationBuilderDrawerForm.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.tsx
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react';
 import {useQueryClient} from '@tanstack/react-query';
 import {Observer} from 'mobx-react-lite';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {DrawerBody, DrawerHeader} from '@sentry/scraps/drawer';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -64,6 +65,9 @@ function FormBody({closeDrawer, model}: {closeDrawer: () => void; model: FormMod
   return (
     <DrawerBody>
       <Stack direction="column" gap="xl">
+        <Alert variant="info">
+          {t('This alert will only trigger on issues created by this monitor.')}
+        </Alert>
         <Flex direction="column" gap="lg">
           <Stack gap="md">
             <AutomationBuilder />


### PR DESCRIPTION
Explains that the inline alert form only connects to the current viewed monitor. This addresses some user feedback.

<img width="1278" height="750" alt="CleanShot 2026-05-01 at 10 21 23@2x" src="https://github.com/user-attachments/assets/521a721b-6292-4d0d-9f63-a8bc55f8acd0" />
