### PR TITLE
fix(repos): Set minMatchCharLength to 1 for repo search

### DIFF
--- a/static/app/views/settings/organizationRepositories/useRepoSearch.tsx
+++ b/static/app/views/settings/organizationRepositories/useRepoSearch.tsx
@@ -5,7 +5,7 @@ import {useFuzzySearch} from 'sentry/utils/fuzzySearch';
 
 import type {ScmRepoMatches} from './scmRepositoryTable';
 
-const FUSE_OPTIONS = {keys: ['name']};
+const FUSE_OPTIONS = {keys: ['name'], minMatchCharLength: 1};
 
 /**
  * Builds a fuzzy search index over the given repositories and returns a


### PR DESCRIPTION
The global Fuse default of `minMatchCharLength=2` caused a single-character query to activate the filter (returning `{}` instead of `undefined`) while matching nothing, showing "No repositories match your search" immediately on the first keystroke.