### PR TITLE
cleanup(ACI): Remove a feature flag for action-filter-cache

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -436,8 +436,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:workflow-engine-metric-alert-dual-processing-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine
     manager.add("organizations:workflow-engine-metric-alert-group-by-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable caching for workflow action filters
-    manager.add("organizations:workflow-engine-action-filters-cache", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable ingestion through trusted relays only
     manager.add("organizations:ingest-through-trusted-relays-only", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Disable issue stream detector notifications for metric issues

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -16,7 +16,6 @@ from sentry.workflow_engine.caches.action_filters import get_action_filters_by_w
 from sentry.workflow_engine.caches.workflow import get_workflows_by_detectors
 from sentry.workflow_engine.models import DataConditionGroup, Detector, DetectorWorkflow, Workflow
 from sentry.workflow_engine.models.data_condition import DataCondition
-from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
 from sentry.workflow_engine.processors.contexts.workflow_event_context import (
     WorkflowEventContext,
     WorkflowEventContextData,
@@ -270,24 +269,13 @@ def evaluate_workflows_action_filters(
         queue_items_by_workflow.keys()
     )
 
-    organization = event_data.event.project.organization
-
     action_conditions_to_workflow: dict[DataConditionGroup, Workflow] = {}
+    all_workflows_lookup: dict[int, Workflow] = {w.id: w for w in all_workflows}
+    action_filters_by_workflows = get_action_filters_by_workflows(all_workflows)
 
-    if features.has("organizations:workflow-engine-action-filters-cache", organization):
-        all_workflows_lookup: dict[int, Workflow] = {w.id: w for w in all_workflows}
-        action_filters_by_workflows = get_action_filters_by_workflows(all_workflows)
-
-        for workflow_id, dcgs in action_filters_by_workflows.items():
-            for dcg in dcgs:
-                action_conditions_to_workflow[dcg] = all_workflows_lookup[workflow_id]
-    else:
-        action_conditions_to_workflow = {
-            wdcg.condition_group: wdcg.workflow
-            for wdcg in WorkflowDataConditionGroup.objects.select_related(
-                "workflow", "condition_group"
-            ).filter(workflow__in=all_workflows)
-        }
+    for workflow_id, dcgs in action_filters_by_workflows.items():
+        for dcg in dcgs:
+            action_conditions_to_workflow[dcg] = all_workflows_lookup[workflow_id]
 
     filtered_action_groups: set[DataConditionGroup] = set()
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -738,16 +738,6 @@ class TestTaintTracking(BaseWorkflowTest):
         b = EvaluationStats(tainted=3, untainted=4)
         assert a + b == EvaluationStats(tainted=4, untainted=6)
 
-    # Temporary test to exercise all evaluate_workflows_action_filters paths
-    # with caching enabled
-    def test_action_filter_stats_excludes_delayed_workflows__with_cache(self) -> None:
-        with self.feature("organizations:workflow-engine-action-filters-cache"):
-            self.test_action_filter_stats_excludes_delayed_workflows()
-
-    def test_action_filter_stats_from_trigger_result__with_cache(self) -> None:
-        with self.feature("organizations:workflow-engine-action-filters-cache"):
-            self.test_action_filter_stats_from_trigger_result()
-
 
 @freeze_time(FROZEN_TIME)
 class TestWorkflowEnqueuing(BaseWorkflowTest):
@@ -1132,32 +1122,6 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             max=timezone.now().timestamp(),
         )
         assert list(project_ids.keys()) == [self.project.id]
-
-    # Temporary tests to exercise all evaluate_workflows_action_filters paths
-    # with caching enabled
-    def test_activity__with_slow_conditions__with_cache(self) -> None:
-        with self.feature("organizations:workflow-engine-action-filters-cache"):
-            self.test_activity__with_slow_conditions()
-
-    def test_enqueues_when_slow_conditions__with_cache(self) -> None:
-        with self.feature("organizations:workflow-engine-action-filters-cache"):
-            self.test_enqueues_when_slow_conditions()
-
-    def test_with_slow_conditions__with_cache(self) -> None:
-        with self.feature("organizations:workflow-engine-action-filters-cache"):
-            self.test_with_slow_conditions()
-
-    def test_basic__with_filter__filtered__with_cache(self) -> None:
-        with self.feature("organizations:workflow-engine-action-filters-cache"):
-            self.test_basic__with_filter__filtered()
-
-    def test_basic__with_filter__passes__with_cache(self) -> None:
-        with self.feature("organizations:workflow-engine-action-filters-cache"):
-            self.test_basic__with_filter__passes()
-
-    def test_basic__no_filter__with_cache(self) -> None:
-        with self.feature("organizations:workflow-engine-action-filters-cache"):
-            self.test_basic__no_filter()
 
 
 class TestEnqueueWorkflows(BaseWorkflowTest):


### PR DESCRIPTION
# Description
Remove the flag checks for `workflow-engine-action-filters-cache` as the cache has successfully rolled out.