### PR TITLE
fix(slack-seer): Ensure organization context is present for handoff storage + block kit fix

### DIFF
--- a/src/sentry/seer/agent/coding_agent_handoff.py
+++ b/src/sentry/seer/agent/coding_agent_handoff.py
@@ -191,7 +191,11 @@ def launch_coding_agents(
 
     # Store the coding agent states to Seer
     try:
-        store_coding_agent_states_to_seer(run_id=run_id, coding_agent_states=states_to_store)
+        store_coding_agent_states_to_seer(
+            run_id=run_id,
+            coding_agent_states=states_to_store,
+            organization_id=organization.id,
+        )
     except SeerApiError:
         logger.exception(
             "explorer.coding_agent.seer_storage_error",

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -62,6 +62,7 @@ from sentry.seer.autofix.utils import (
     update_coding_agent_state,
 )
 from sentry.seer.models import SeerApiError
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.imports import import_string
 
@@ -105,7 +106,9 @@ def sanitize_branch_name(branch_name: str) -> str:
 
 
 def store_coding_agent_states_to_seer(
-    run_id: int, coding_agent_states: list[CodingAgentState]
+    run_id: int,
+    coding_agent_states: list[CodingAgentState],
+    organization_id: int | None = None,
 ) -> None:
     """Store multiple coding agent states via Seer batch API."""
     if not coding_agent_states:
@@ -114,7 +117,12 @@ def store_coding_agent_states_to_seer(
         run_id=run_id,
         coding_agent_states=[state.dict() for state in coding_agent_states],
     )
-    response = make_store_coding_agent_states_request(body, timeout=30)
+    viewer_context: SeerViewerContext | None = None
+    if organization_id is not None:
+        viewer_context = SeerViewerContext(organization_id=organization_id)
+    response = make_store_coding_agent_states_request(
+        body, timeout=30, viewer_context=viewer_context
+    )
 
     if response.status >= 400:
         raise SeerApiError(response.data.decode("utf-8"), response.status)
@@ -403,7 +411,11 @@ def _launch_agents_for_repos(
         )
 
     try:
-        store_coding_agent_states_to_seer(run_id=run_id, coding_agent_states=states_to_store)
+        store_coding_agent_states_to_seer(
+            run_id=run_id,
+            coding_agent_states=states_to_store,
+            organization_id=organization.id,
+        )
     except SeerApiError:
         logger.exception(
             "coding_agent.seer_storage_error",

--- a/src/sentry/seer/entrypoints/slack/messaging.py
+++ b/src/sentry/seer/entrypoints/slack/messaging.py
@@ -234,14 +234,14 @@ def update_existing_message(
             }
         )
 
+        transformer: Callable[[dict[str, Any]], dict[str, Any] | None]
         # The RCA button is on an issue alert, so we just remove the button from the list of actions.
         # Later updates only have autofix buttons (View, Start), so we remove the whole actions block.
         # This is because we add the View button back to the footer, along with some status text.
-        transformer = (
-            remove_autofix_button_transformer
-            if data.current_point == AutofixStoppingPoint.ROOT_CAUSE
-            else remove_all_buttons_transformer
-        )
+        transformer = remove_all_buttons_transformer
+        if data.current_point == AutofixStoppingPoint.ROOT_CAUSE and data.handoff_target is None:
+            transformer = remove_autofix_button_transformer
+
         try:
             message_data = request.data["message"]
             original_blocks = message_data["blocks"]

--- a/tests/sentry/seer/agent/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/agent/test_coding_agent_handoff.py
@@ -52,7 +52,11 @@ class TestLaunchCodingAgents(TestCase):
         assert len(result["failures"]) == 0
         assert result["successes"][0]["repo_name"] == "owner/repo"
         mock_installation.launch.assert_called_once()
-        mock_store.assert_called_once()
+        mock_store.assert_called_once_with(
+            run_id=self.run_id,
+            coding_agent_states=[mock_installation.launch.return_value],
+            organization_id=self.organization.id,
+        )
 
     @patch("sentry.seer.agent.coding_agent_handoff.store_coding_agent_states_to_seer")
     @patch("sentry.seer.agent.coding_agent_handoff._validate_and_get_integration")
@@ -105,6 +109,7 @@ class TestLaunchCodingAgents(TestCase):
         assert len(result["failures"]) == 1
         assert result["successes"][0]["repo_name"] == "owner/repo1"
         assert result["failures"][0]["repo_name"] == "owner/repo2"
+        assert mock_store.call_args.kwargs["organization_id"] == self.organization.id
 
     @patch("sentry.seer.agent.coding_agent_handoff.store_coding_agent_states_to_seer")
     @patch("sentry.seer.agent.coding_agent_handoff._validate_and_get_integration")
@@ -127,6 +132,7 @@ class TestLaunchCodingAgents(TestCase):
         # Verify launch was called with a sanitized branch name
         launch_request = mock_installation.launch.call_args[0][0]
         assert launch_request.branch_name.startswith("my-fix-")
+        assert mock_store.call_args.kwargs["organization_id"] == self.organization.id
 
     @patch("sentry.seer.agent.coding_agent_handoff.store_coding_agent_states_to_seer")
     @patch("sentry.seer.agent.coding_agent_handoff.GithubCopilotAgentClient")

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -115,6 +115,7 @@ class TestLaunchAgentsForRepos(TestCase):
         assert mock_installation.launch.called
         launch_request = mock_installation.launch.call_args[0][0]
         assert launch_request.auto_create_pr is False
+        assert mock_store_states.call_args.kwargs["organization_id"] == self.organization.id
 
     @patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer")
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_prompt")
@@ -143,6 +144,7 @@ class TestLaunchAgentsForRepos(TestCase):
         assert mock_installation.launch.called
         launch_request = mock_installation.launch.call_args[0][0]
         assert launch_request.auto_create_pr is True
+        assert mock_store_states.call_args.kwargs["organization_id"] == self.organization.id
 
     @patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer")
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_prompt")
@@ -172,6 +174,7 @@ class TestLaunchAgentsForRepos(TestCase):
         assert mock_installation.launch.called
         launch_request = mock_installation.launch.call_args[0][0]
         assert launch_request.auto_create_pr is False
+        assert mock_store_states.call_args.kwargs["organization_id"] == self.organization.id
 
     @patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer")
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_prompt")
@@ -282,6 +285,7 @@ class TestLaunchAgentsForRepos(TestCase):
         mock_get_prompt.assert_called_once()
         call_args = mock_get_prompt.call_args
         assert call_args[0][3] == "AIML-2301"
+        assert mock_store_states.call_args.kwargs["organization_id"] == self.organization.id
 
 
 class TestPollGithubCopilotAgents(TestCase):


### PR DESCRIPTION
Two fixes, one is actually important:

### the important one

- when triggering agent hand-off from slack, it would not attach to the run displayed in the UI
- It'd still trigger the agent and create the pull request though, this turned out the be a Seer error
- locally i could not repro, but I _**believe**_ the error is because the browser uses middleware to attach the organization to the request to save the agent details to Seer's run state, but since we're triggering from slack that middleware didn't have an organization to default to. Adding it explicitly _**should**_ mitigate this
<img width="310" height="479" alt="image" src="https://github.com/user-attachments/assets/46ed31ab-83cb-47c2-8a49-b2bf09062ea8" />

### less important
- remove the duplicate block kit buttons when starting handoff

Before
<img width="575" height="122" alt="image" src="https://github.com/user-attachments/assets/08140ffc-644a-41fe-9036-78fe87541539" />
After
<img width="603" height="125" alt="image" src="https://github.com/user-attachments/assets/d928462d-1158-45ac-8b51-89100612baaf" />
