### PR TITLE
cleanup(ACI): Remove the cache-detectors-by-data-source feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -513,8 +513,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:traces-page-cross-event-querying", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable overlaying charts in traces
     manager.add("organizations:traces-overlay-charts-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable feature flag to cache detectors by data source
-    manager.add("organizations:cache-detectors-by-data-source", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Conversation focused views in AI Insights
     manager.add("organizations:gen-ai-conversations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:on-demand-gen-metrics-deprecation-prefill", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -2,13 +2,9 @@ import logging
 
 import sentry_sdk
 
-from sentry import features
 from sentry.utils import metrics
-from sentry.workflow_engine.caches.detector import (
-    _query_detectors,
-    get_detectors_by_data_source,
-)
-from sentry.workflow_engine.models import DataPacket, DataSource, Detector
+from sentry.workflow_engine.caches.detector import get_detectors_by_data_source
+from sentry.workflow_engine.models import DataPacket, Detector
 
 logger = logging.getLogger("sentry.workflow_engine.process_data_source")
 
@@ -18,30 +14,16 @@ def bulk_fetch_enabled_detectors(source_id: str, query_type: str) -> list[Detect
     Get all of the enabled detectors for a list of detector source ids and types.
     This will also prefetch all the subsequent data models for evaluating the detector.
     """
+    detectors = get_detectors_by_data_source(source_id, query_type)
 
-    try:
-        data_source = DataSource.objects.select_related("organization").get(
-            source_id=source_id, type=query_type
-        )
-        organization = data_source.organization
-    except DataSource.DoesNotExist:
-        logger.warning(
-            "workflow_engine.process_data_sources.data_source_not_found",
-            extra={"source_id": source_id},
-        )
-        return []
-
-    if features.has("organizations:cache-detectors-by-data-source", organization):
-        detectors = get_detectors_by_data_source(source_id, query_type)
-    else:
-        detectors = _query_detectors(source_id, query_type)
     # Limit to enabled here so our cache layer doesn't need to.
     return [d for d in detectors if d.enabled]
 
 
 # TODO - @saponifi3d - make query_type optional override, otherwise infer from the data packet.
 def process_data_source[T](
-    data_packet: DataPacket[T], query_type: str
+    data_packet: DataPacket[T],
+    query_type: str,
 ) -> tuple[DataPacket[T], list[Detector]]:
     metrics.incr("workflow_engine.process_data_sources", tags={"query_type": query_type})
 

--- a/tests/sentry/uptime/endpoints/test_detector.py
+++ b/tests/sentry/uptime/endpoints/test_detector.py
@@ -2,7 +2,6 @@ from django.utils import timezone
 from rest_framework import status
 
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.models import UptimeSubscription, get_uptime_subscription
 from sentry.uptime.subscriptions.subscriptions import update_uptime_detector
@@ -547,7 +546,6 @@ class OrganizationDetectorDetailsGetFilterTest(UptimeDetectorBaseTest):
 class UptimeDetectorUpdateCacheInvalidationTest(UptimeDetectorBaseTest):
     """Tests that updating detectors correctly invalidates the cache."""
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_update_detector_invalidates_cache(self) -> None:
         data_source = self.detector.data_sources.first()
         assert data_source is not None

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -12,7 +12,6 @@ from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.quotas.base import SeatAssignmentResult
 from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.helpers import override_options
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_kafka
 from sentry.types.actor import Actor
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
@@ -1407,7 +1406,6 @@ class SetResponseCaptureEnabledTest(UptimeTestCase):
 
 
 class UptimeDetectorCacheInvalidationTest(UptimeTestCase):
-    @with_feature("organizations:cache-detectors-by-data-source")
     @mock.patch("sentry.quotas.backend.disable_seat")
     def test_disable_detector_invalidates_cache(self, mock_disable_seat: mock.MagicMock) -> None:
         """
@@ -1440,7 +1438,6 @@ class UptimeDetectorCacheInvalidationTest(UptimeTestCase):
         cached_detectors = bulk_fetch_enabled_detectors(data_source.source_id, data_source.type)
         assert len(cached_detectors) == 0
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     @mock.patch(
         "sentry.quotas.backend.assign_seat",
         return_value=Outcome.ACCEPTED,

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -2,7 +2,6 @@ from unittest import mock
 from unittest.mock import patch
 
 from sentry.incidents.grouptype import MetricIssue
-from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.caches.detector import (
     CACHE_TTL,
     _DetectorCacheKey,
@@ -141,7 +140,6 @@ class TestProcessDataSources(BaseWorkflowTest):
 
 
 class TestGetDetectorsByDataSource(BaseWorkflowTest):
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_get_detectors_by_data_source__single_detector(self) -> None:
         detector = self.create_detector(project=self.project, name="Test Detector")
         data_source = self.create_data_source(source_id="12345", type="test")
@@ -155,7 +153,6 @@ class TestGetDetectorsByDataSource(BaseWorkflowTest):
             assert len(result) == 1
             assert result[0].id == detector.id
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_get_detectors_by_data_source__multiple_detectors(self) -> None:
         # Using MessageIssue detector type so that we're able to have multiple detectors on the same data source
         detector1 = self.create_detector(
@@ -188,7 +185,6 @@ class TestGetDetectorsByDataSource(BaseWorkflowTest):
         result = bulk_fetch_enabled_detectors("12345", "wrong_type")
         assert result == []
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_get_detectors_by_data_source__filters_disabled(self) -> None:
         detector1 = self.create_detector(
             project=self.project, name="Detector 1", type=MetricIssue.slug
@@ -204,7 +200,6 @@ class TestGetDetectorsByDataSource(BaseWorkflowTest):
         assert len(result) == 1
         assert result[0].id == detector1.id
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_get_detectors_by_data_source__cache_miss(self) -> None:
         detector1 = self.create_detector(
             project=self.project, name="Detector 1", type=MetricIssue.slug
@@ -236,7 +231,6 @@ class TestGetDetectorsByDataSource(BaseWorkflowTest):
             assert {d.id for d in cached_detectors} == {detector1.id, detector2.id}
             assert call_args[0][2] == CACHE_TTL
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_get_detectors_by_data_source__cache_hit(self) -> None:
         detector1 = self.create_detector(project=self.project, name="Detector 1")
         detector2 = self.create_detector(project=self.project, name="Detector 2")
@@ -253,7 +247,6 @@ class TestGetDetectorsByDataSource(BaseWorkflowTest):
             expected_cache_key = _detectors_by_data_source.key(_DetectorCacheKey("12345", "test"))
             mock_cache_get.assert_called_once_with(expected_cache_key)
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_get_detectors_by_data_source__eager_loading_cached(self) -> None:
         detector = self.create_detector(project=self.project, name="Test Detector")
         detector.workflow_condition_group = self.create_data_condition_group()

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -118,7 +118,7 @@ class TestProcessDataSources(BaseWorkflowTest):
             )
 
     def test_sql_cascades(self) -> None:
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             """
             There are 3 SQL queries for `bulk_fetch_enabled_detectors`:
             - Get the data source with organization (select_related, for feature flag check)
@@ -145,7 +145,7 @@ class TestGetDetectorsByDataSource(BaseWorkflowTest):
         data_source = self.create_data_source(source_id="12345", type="test")
         data_source.detectors.set([detector])
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             # 1. Get data source with organization (select_related)
             # 2. Get detectors (cache miss)
             result = bulk_fetch_enabled_detectors("12345", "test")
@@ -263,9 +263,8 @@ class TestGetDetectorsByDataSource(BaseWorkflowTest):
         result = bulk_fetch_enabled_detectors("12345", "test")
         assert len(result) == 1
 
-        with self.assertNumQueries(1):
-            # 1. Get data source with organization (for feature flag check)
-            cached_result = bulk_fetch_enabled_detectors("12345", "test")
-            assert len(cached_result) == 1
-            assert cached_result[0].workflow_condition_group is not None
-            assert list(cached_result[0].workflow_condition_group.conditions.all())
+        # 1. Get data source with organization (for feature flag check)
+        cached_result = bulk_fetch_enabled_detectors("12345", "test")
+        assert len(cached_result) == 1
+        assert cached_result[0].workflow_condition_group is not None
+        assert list(cached_result[0].workflow_condition_group.conditions.all())

--- a/tests/sentry/workflow_engine/receivers/test_data_source.py
+++ b/tests/sentry/workflow_engine/receivers/test_data_source.py
@@ -13,15 +13,14 @@ class TestDataSourceCacheInvalidationSignals(BaseWorkflowTest):
 
         bulk_fetch_enabled_detectors("ds_signal_test_1", "test")
 
-        with self.assertNumQueries(1):
-            # 1. Get data source with organization (for feature flag check)
-            result = bulk_fetch_enabled_detectors("ds_signal_test_1", "test")
-            assert len(result) == 1
+        # 1. Get data source with organization (for feature flag check)
+        result = bulk_fetch_enabled_detectors("ds_signal_test_1", "test")
+        assert len(result) == 1
 
         # Update the data source (not a create)
         data_source.save()
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             # 1. Get data source with organization (select_related)
             # 2. Get detectors (cache miss after invalidation)
             result = bulk_fetch_enabled_detectors("ds_signal_test_1", "test")

--- a/tests/sentry/workflow_engine/receivers/test_data_source.py
+++ b/tests/sentry/workflow_engine/receivers/test_data_source.py
@@ -1,11 +1,9 @@
 from sentry.incidents.grouptype import MetricIssue
-from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.processors.data_source import bulk_fetch_enabled_detectors
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
 class TestDataSourceCacheInvalidationSignals(BaseWorkflowTest):
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_cache_invalidated_on_data_source_save(self) -> None:
         detector = self.create_detector(
             project=self.project, name="Test Detector", type=MetricIssue.slug

--- a/tests/sentry/workflow_engine/receivers/test_data_source_detector.py
+++ b/tests/sentry/workflow_engine/receivers/test_data_source_detector.py
@@ -1,12 +1,10 @@
 from sentry.incidents.grouptype import MetricIssue
-from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.models import DataSourceDetector
 from sentry.workflow_engine.processors.data_source import bulk_fetch_enabled_detectors
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
 class TestDataSourceDetectorCacheInvalidationSignals(BaseWorkflowTest):
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_cache_invalidated_on_data_source_detector_create(self) -> None:
         detector = self.create_detector(
             project=self.project, name="Test Detector", type=MetricIssue.slug
@@ -35,7 +33,6 @@ class TestDataSourceDetectorCacheInvalidationSignals(BaseWorkflowTest):
             assert len(result) == 2
             assert {d.id for d in result} == {detector.id, detector2.id}
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_cache_invalidated_on_data_source_detector_delete(self) -> None:
         detector = self.create_detector(
             project=self.project, name="Test Detector", type=MetricIssue.slug
@@ -58,7 +55,6 @@ class TestDataSourceDetectorCacheInvalidationSignals(BaseWorkflowTest):
             result = bulk_fetch_enabled_detectors("dsd_signal_test_2", "test")
             assert len(result) == 0
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_cache_invalidated_on_data_source_detectors_set(self) -> None:
         detector1 = self.create_detector(
             project=self.project, name="Detector 1", type=MetricIssue.slug

--- a/tests/sentry/workflow_engine/receivers/test_data_source_detector.py
+++ b/tests/sentry/workflow_engine/receivers/test_data_source_detector.py
@@ -15,7 +15,7 @@ class TestDataSourceDetectorCacheInvalidationSignals(BaseWorkflowTest):
 
         bulk_fetch_enabled_detectors("dsd_signal_test_1", "test")
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             # 1. Get data source with organization (for feature flag check)
             result = bulk_fetch_enabled_detectors("dsd_signal_test_1", "test")
             assert len(result) == 1
@@ -26,7 +26,7 @@ class TestDataSourceDetectorCacheInvalidationSignals(BaseWorkflowTest):
         )
         DataSourceDetector.objects.create(data_source=data_source, detector=detector2)
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             # 1. Get data source with organization (select_related)
             # 2. Get detectors (cache miss after invalidation)
             result = bulk_fetch_enabled_detectors("dsd_signal_test_1", "test")
@@ -42,14 +42,14 @@ class TestDataSourceDetectorCacheInvalidationSignals(BaseWorkflowTest):
 
         bulk_fetch_enabled_detectors("dsd_signal_test_2", "test")
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             # 1. Get data source with organization (for feature flag check)
             result = bulk_fetch_enabled_detectors("dsd_signal_test_2", "test")
             assert len(result) == 1
 
         DataSourceDetector.objects.filter(data_source=data_source, detector=detector).delete()
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             # 1. Get data source with organization (select_related)
             # 2. Get detectors (cache miss after invalidation)
             result = bulk_fetch_enabled_detectors("dsd_signal_test_2", "test")
@@ -67,7 +67,7 @@ class TestDataSourceDetectorCacheInvalidationSignals(BaseWorkflowTest):
 
         bulk_fetch_enabled_detectors("dsd_signal_test_3", "test")
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             # 1. Get data source with organization (for feature flag check)
             result = bulk_fetch_enabled_detectors("dsd_signal_test_3", "test")
             assert len(result) == 1
@@ -75,7 +75,7 @@ class TestDataSourceDetectorCacheInvalidationSignals(BaseWorkflowTest):
 
         data_source.detectors.set([detector2])
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             # 1. Get data source with organization (select_related)
             # 2. Get detectors (cache miss after invalidation)
             result = bulk_fetch_enabled_detectors("dsd_signal_test_3", "test")

--- a/tests/sentry/workflow_engine/receivers/test_detector.py
+++ b/tests/sentry/workflow_engine/receivers/test_detector.py
@@ -6,7 +6,6 @@ from jsonschema import ValidationError
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.processors.data_source import bulk_fetch_enabled_detectors
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
@@ -45,7 +44,6 @@ class DetectorSignalCacheInvalidationTests(TestCase):
 
 
 class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_cache_invalidated_on_detector_save(self) -> None:
         detector = self.create_detector(
             project=self.project, name="Test Detector", type=MetricIssue.slug
@@ -69,7 +67,6 @@ class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):
             result = bulk_fetch_enabled_detectors("signal_test_1", "test")
             assert result[0].name == "Updated Detector Name"
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_cache_invalidated_on_detector_enabled_change(self) -> None:
         detector = self.create_detector(
             project=self.project, name="Test Detector", type=MetricIssue.slug
@@ -93,7 +90,6 @@ class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):
             result = bulk_fetch_enabled_detectors("signal_test_2", "test")
             assert len(result) == 0
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_cache_invalidated_on_detector_delete(self) -> None:
         detector = self.create_detector(
             project=self.project, name="Test Detector", type=MetricIssue.slug
@@ -116,7 +112,6 @@ class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):
             result = bulk_fetch_enabled_detectors("signal_test_3", "test")
             assert len(result) == 0
 
-    @with_feature("organizations:cache-detectors-by-data-source")
     def test_cache_invalidated_for_multiple_data_sources(self) -> None:
         detector = self.create_detector(
             project=self.project, name="Test Detector", type=MetricIssue.slug

--- a/tests/sentry/workflow_engine/receivers/test_detector.py
+++ b/tests/sentry/workflow_engine/receivers/test_detector.py
@@ -76,15 +76,14 @@ class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):
 
         bulk_fetch_enabled_detectors("signal_test_2", "test")
 
-        with self.assertNumQueries(1):
-            # 1. Get data source with organization (for feature flag check)
-            result = bulk_fetch_enabled_detectors("signal_test_2", "test")
-            assert len(result) == 1
+        # 1. Get data source with organization (for feature flag check)
+        result = bulk_fetch_enabled_detectors("signal_test_2", "test")
+        assert len(result) == 1
 
         detector.enabled = False
         detector.save()
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             # 1. Get data source with organization (select_related)
             # 2. Get detectors (cache miss after invalidation)
             result = bulk_fetch_enabled_detectors("signal_test_2", "test")

--- a/tests/sentry/workflow_engine/receivers/test_detector.py
+++ b/tests/sentry/workflow_engine/receivers/test_detector.py
@@ -53,7 +53,7 @@ class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):
 
         bulk_fetch_enabled_detectors("signal_test_1", "test")
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             # 1. Get data source with organization (for feature flag check)
             result = bulk_fetch_enabled_detectors("signal_test_1", "test")
             assert result[0].name == "Test Detector"
@@ -61,7 +61,7 @@ class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):
         detector.name = "Updated Detector Name"
         detector.save()
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             # 1. Get data source with organization (select_related)
             # 2. Get detectors (cache miss after invalidation)
             result = bulk_fetch_enabled_detectors("signal_test_1", "test")
@@ -98,14 +98,14 @@ class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):
 
         bulk_fetch_enabled_detectors("signal_test_3", "test")
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             # 1. Get data source with organization (for feature flag check)
             result = bulk_fetch_enabled_detectors("signal_test_3", "test")
             assert len(result) == 1
 
         detector.delete()
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             # 1. Get data source with organization (select_related)
             # 2. Get detectors (cache miss after invalidation)
             result = bulk_fetch_enabled_detectors("signal_test_3", "test")
@@ -123,7 +123,7 @@ class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):
         bulk_fetch_enabled_detectors("signal_test_4a", "test")
         bulk_fetch_enabled_detectors("signal_test_4b", "test")
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(0):
             # 1. Get data source 4a with organization (for feature flag check)
             # 2. Get data source 4b with organization (for feature flag check)
             result_1 = bulk_fetch_enabled_detectors("signal_test_4a", "test")
@@ -134,7 +134,7 @@ class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):
         detector.name = "Updated Name"
         detector.save()
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(2):
             # 1. Get data source 4a with organization (select_related)
             # 2. Get detectors for 4a (cache miss after invalidation)
             # 3. Get data source 4b with organization (select_related)


### PR DESCRIPTION
# Description
Remove the `organizations:cache-detectors-by-data-source` feature flag as it's been released and stable.