### PR TITLE
fix(tracemetrics): Remove sorting styles from embedded table

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
@@ -120,6 +120,7 @@ function getFieldLabel(field: SampleTableColumnKey): ReactNode {
     [TraceMetricKnownFieldKey.METRIC_VALUE]: () => t('Value'),
     [TraceMetricKnownFieldKey.TIMESTAMP]: () => t('Timestamp'),
     [TraceMetricKnownFieldKey.METRIC_NAME]: () => t('Application Metric'),
+    [TraceMetricKnownFieldKey.METRIC_TYPE]: () => t('Type'),
     [VirtualTableSampleColumnKey.PROJECT_BADGE]: () => t('Project'),
   };
   return fieldLabels[field]?.() ?? null;

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
@@ -72,7 +72,7 @@ function FieldHeaderCellWrapper({
   const columnType = getMetricTableColumnType(field);
   const label = getFieldLabel(field);
   const hasPadding = field !== VirtualTableSampleColumnKey.EXPAND_ROW;
-  const canSort = SORTABLE_SAMPLE_COLUMNS.has(field);
+  const canSort = !embedded && SORTABLE_SAMPLE_COLUMNS.has(field);
 
   function handleSortClick() {
     const kind = sort === 'desc' ? 'asc' : 'desc';


### PR DESCRIPTION
This PR removes the sorting styles from the embedded application metrics table. As well I added in a header value for metric type so now it'll render "Type" for that column rather than being just blank.

Closes LOGS-726