### PR TITLE
fix(preprod): Stabilize scroll position in Split mode snapshot list

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -17,6 +17,20 @@ import {computeMaskSize} from './computeMaskSize';
 
 export const MAX_IMAGE_HEIGHT = 480;
 
+function aspectRatio(
+  width: number | undefined,
+  height: number | undefined
+): string | undefined {
+  return width && height ? `${width} / ${height}` : undefined;
+}
+
+function imageSizerProps(image: SnapshotImage) {
+  return {
+    $naturalWidth: image.width || undefined,
+    $aspectRatio: aspectRatio(image.width || undefined, image.height || undefined),
+  };
+}
+
 export const SplitPairBody = memo(function SplitPairBody({
   baseUrl,
   headUrl,
@@ -54,14 +68,16 @@ export const SplitPairBody = memo(function SplitPairBody({
             </Text>
           </Container>
           <ZoomViewport ref={zoom1.containerRef}>
-            <ZoomTransformLayer style={zoomTransformStyle(zoom1.transform)}>
-              <LazyImage
-                src={baseUrl}
-                alt={`${altPrefix} (base)`}
-                width={baseImage.width || undefined}
-                height={baseImage.height || undefined}
-              />
-            </ZoomTransformLayer>
+            <ImageSizer {...imageSizerProps(baseImage)}>
+              <ZoomTransformLayer style={zoomTransformStyle(zoom1.transform)}>
+                <LazyImage
+                  src={baseUrl}
+                  alt={`${altPrefix} (base)`}
+                  width={baseImage.width || undefined}
+                  height={baseImage.height || undefined}
+                />
+              </ZoomTransformLayer>
+            </ImageSizer>
           </ZoomViewport>
         </Stack>
         <Stack minWidth="0" borderLeft="secondary">
@@ -71,22 +87,24 @@ export const SplitPairBody = memo(function SplitPairBody({
             </Text>
           </Container>
           <ZoomViewport ref={zoom2.containerRef}>
-            <ZoomTransformLayer style={zoomTransformStyle(zoom2.transform)}>
-              <LazyImage
-                src={headUrl}
-                alt={`${altPrefix} (head)`}
-                width={headImage.width || undefined}
-                height={headImage.height || undefined}
-              >
-                {diffMaskUrl && (
-                  <DiffOverlay
-                    $overlayColor={overlayColor!}
-                    $maskUrl={diffMaskUrl}
-                    $maskSize={computeMaskSize(baseImage, headImage)}
-                  />
-                )}
-              </LazyImage>
-            </ZoomTransformLayer>
+            <ImageSizer {...imageSizerProps(headImage)}>
+              <ZoomTransformLayer style={zoomTransformStyle(zoom2.transform)}>
+                <LazyImage
+                  src={headUrl}
+                  alt={`${altPrefix} (head)`}
+                  width={headImage.width || undefined}
+                  height={headImage.height || undefined}
+                >
+                  {diffMaskUrl && (
+                    <DiffOverlay
+                      $overlayColor={overlayColor!}
+                      $maskUrl={diffMaskUrl}
+                      $maskSize={computeMaskSize(baseImage, headImage)}
+                    />
+                  )}
+                </LazyImage>
+              </ZoomTransformLayer>
+            </ImageSizer>
           </ZoomViewport>
         </Stack>
       </Grid>
@@ -288,15 +306,17 @@ function LazyImage({
       setLoaded(true);
     }
   }, []);
-  const displayHeight =
-    width && height ? `${Math.min(height, MAX_IMAGE_HEIGHT)}px` : `${MAX_IMAGE_HEIGHT}px`;
   return (
     <Container position="relative" display="inline-block" maxWidth="100%">
       {!loaded && (
         <Placeholder
           width={width ? `${width}px` : '100%'}
-          height={displayHeight}
-          style={{maxWidth: '100%', maxHeight: `${MAX_IMAGE_HEIGHT}px`}}
+          height={width && height ? 'auto' : `${MAX_IMAGE_HEIGHT}px`}
+          style={{
+            maxWidth: '100%',
+            maxHeight: `${MAX_IMAGE_HEIGHT}px`,
+            aspectRatio: aspectRatio(width, height),
+          }}
         />
       )}
       <HiddenUntilLoaded
@@ -354,6 +374,16 @@ const ZoomViewport = styled('div')`
   &:active {
     cursor: grabbing;
   }
+`;
+
+const ImageSizer = styled('div')<{$aspectRatio?: string; $naturalWidth?: number}>`
+  width: ${p => (p.$naturalWidth ? `${p.$naturalWidth}px` : '100%')};
+  max-width: 100%;
+  max-height: ${MAX_IMAGE_HEIGHT}px;
+  ${p => (p.$aspectRatio ? `aspect-ratio: ${p.$aspectRatio};` : '')}
+  display: flex;
+  justify-content: center;
+  overflow: visible;
 `;
 
 const ZoomTransformLayer = styled('div')`


### PR DESCRIPTION
Split mode "changed" cards caused rapid scroll position oscillation because
the ZoomViewport containers had no intrinsic height. When LazyImage
placeholders transitioned to loaded images, card heights changed, triggering
virtualizer re-measurement and a scroll correction feedback loop.

**Fix:** Add an `ImageSizer` wrapper inside each ZoomViewport that uses CSS
`aspect-ratio` derived from image metadata to lock the container height from
first paint. Placeholders also use `aspect-ratio` so they match the final
image dimensions, eliminating the resize that triggered the loop.

Only affects Split mode (`SplitPairBody`) — other diff modes (wipe, onion)
were not affected.