### PR TITLE
feat(repos): Add SCM repositories v2 page behind feature flag

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -27,6 +27,7 @@ const productionEntryPoints = [
   'static/app/views/settings/organizationRepositories/noIntegrationsEmptyState.tsx',
   'static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx',
   'static/app/views/settings/organizationRepositories/useRepoSearch.tsx',
+  'static/app/views/settings/organizationRepositoriesV2/index.tsx',
 ];
 
 const testingEntryPoints = [

--- a/static/app/views/settings/organizationRepositories/index.tsx
+++ b/static/app/views/settings/organizationRepositories/index.tsx
@@ -9,10 +9,15 @@ import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
+import {OrganizationRepositoriesV2} from 'sentry/views/settings/organizationRepositoriesV2';
 
 export default function OrganizationRepositories() {
   const organization = useOrganization();
   const {repoFilter, setRepoFilter, searchTerm, setSearchTerm} = useScmTreeFilters();
+
+  if (organization.features.includes('scm-repositories-v2')) {
+    return <OrganizationRepositoriesV2 />;
+  }
 
   return (
     <AnalyticsArea name="repositories">

--- a/static/app/views/settings/organizationRepositoriesV2/index.spec.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/index.spec.tsx
@@ -1,0 +1,200 @@
+import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
+import {GitLabIntegrationProviderFixture} from 'sentry-fixture/gitlabIntegrationProvider';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {OrganizationRepositoriesV2} from 'sentry/views/settings/organizationRepositoriesV2';
+
+// ScmRepositoryTable uses @tanstack/react-virtual, which only renders rows
+// whose bounding rect overlaps the scroll container. Without this stub it
+// sees a 0×0 viewport and renders nothing.
+function stubBoundingClientRect() {
+  jest
+    .spyOn(window.Element.prototype, 'getBoundingClientRect')
+    .mockImplementation(() => ({
+      x: 0,
+      y: 0,
+      width: 600,
+      height: 400,
+      left: 0,
+      top: 0,
+      right: 600,
+      bottom: 400,
+      toJSON: jest.fn(),
+    }));
+}
+
+const GITHUB_PROVIDER = GitHubIntegrationProviderFixture();
+const GITHUB_INTEGRATION = OrganizationIntegrationsFixture({
+  id: '1',
+  name: 'my-org',
+  provider: {
+    key: 'github',
+    slug: 'github',
+    name: 'GitHub',
+    canAdd: true,
+    canDisable: false,
+    features: [],
+    aspects: {},
+  },
+});
+
+function setupDefaultMocks() {
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/config/integrations/',
+    body: {providers: [GITHUB_PROVIDER]},
+  });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/integrations/',
+    body: [GITHUB_INTEGRATION],
+  });
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/integrations/${GITHUB_INTEGRATION.id}/`,
+    body: GITHUB_INTEGRATION,
+  });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/repos/',
+    body: [],
+  });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/code-mappings/',
+    body: [],
+  });
+}
+
+describe('OrganizationRepositoriesV2', () => {
+  beforeEach(() => {
+    stubBoundingClientRect();
+  });
+
+  it('shows a loading indicator while queries are pending', async () => {
+    setupDefaultMocks();
+    render(<OrganizationRepositoriesV2 />);
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    await screen.findByRole('searchbox');
+  });
+
+  it('shows empty state with a Connect button per provider when no integrations are installed', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/config/integrations/',
+      body: {providers: [GITHUB_PROVIDER, GitLabIntegrationProviderFixture()]},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/repos/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/code-mappings/',
+      body: [],
+    });
+
+    render(<OrganizationRepositoriesV2 />);
+
+    expect(await screen.findByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText('GitLab')).toBeInTheDocument();
+
+    const connectButtons = screen.getAllByRole('button', {name: 'Add integration'});
+    expect(connectButtons).toHaveLength(2);
+  });
+
+  it('shows the connect provider button in the header when integrations are installed', async () => {
+    setupDefaultMocks();
+    render(<OrganizationRepositoriesV2 />);
+
+    expect(
+      await screen.findByRole('button', {name: 'Connect new provider'})
+    ).toBeInTheDocument();
+  });
+
+  it('renders a table for each provider that has an installation', async () => {
+    setupDefaultMocks();
+    render(<OrganizationRepositoriesV2 />);
+
+    expect(await screen.findByText('my-org')).toBeInTheDocument();
+  });
+
+  it('shows repos loading state in the table while the repos query is pending', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/config/integrations/',
+      body: {providers: [GITHUB_PROVIDER]},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/',
+      body: [GITHUB_INTEGRATION],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/integrations/${GITHUB_INTEGRATION.id}/`,
+      body: GITHUB_INTEGRATION,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/code-mappings/',
+      body: [],
+    });
+    // Use a large delay to simulate a slow/pending repos query. The
+    // providers and integrations responses arrive first, so the table
+    // renders, but reposLoading stays true until repos resolves.
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/repos/',
+      body: [],
+      asyncDelay: 10000,
+    });
+
+    render(<OrganizationRepositoriesV2 />);
+
+    expect(await screen.findByText('Loading repositories')).toBeInTheDocument();
+  });
+
+  it('clicking uninstall prompts for confirmation then refetches integrations', async () => {
+    setupDefaultMocks();
+
+    const deleteRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/integrations/${GITHUB_INTEGRATION.id}/`,
+      method: 'DELETE',
+      body: {},
+    });
+
+    render(<OrganizationRepositoriesV2 />);
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Uninstall'}));
+
+    // The confirmation modal must appear before any DELETE is fired.
+    expect(deleteRequest).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', {name: "I'm sure, uninstall"})).toBeInTheDocument();
+
+    // Override the integrations mock before the refetch happens.
+    const refetchRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/',
+      body: [],
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: "I'm sure, uninstall"}));
+
+    await waitFor(() => expect(deleteRequest).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(refetchRequest).toHaveBeenCalledTimes(1));
+  });
+
+  it('hides the uninstall button when the user lacks org:integrations access', async () => {
+    setupDefaultMocks();
+
+    render(<OrganizationRepositoriesV2 />, {
+      organization: OrganizationFixture({access: []}),
+    });
+
+    await screen.findByText('my-org');
+    expect(screen.queryByRole('button', {name: 'Uninstall'})).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/settings/organizationRepositoriesV2/index.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/index.tsx
@@ -1,0 +1,241 @@
+import {useMemo, useState} from 'react';
+import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
+import groupBy from 'lodash/groupBy';
+import mapValues from 'lodash/mapValues';
+import sortBy from 'lodash/sortBy';
+import uniq from 'lodash/uniq';
+
+import {Input} from '@sentry/scraps/input';
+import {Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+
+import {hasEveryAccess} from 'sentry/components/acl/access';
+import {AnalyticsArea} from 'sentry/components/analyticsArea';
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {organizationConfigIntegrationsQueryOptions} from 'sentry/components/repositories/scmIntegrationTree/organizationConfigIntegrationsQueryOptions';
+import {getProviderConfigUrl} from 'sentry/components/repositories/scmIntegrationTree/providerConfigLink';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {t, tct} from 'sentry/locale';
+import type {
+  Integration,
+  Repository,
+  RepositoryProjectPathConfig,
+} from 'sentry/types/integrations';
+import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {isScmProvider} from 'sentry/utils/integrationUtil';
+import {organizationRepositoriesInfiniteOptions} from 'sentry/utils/repositories/repoQueryOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
+import {ConnectProviderDropdown} from 'sentry/views/settings/organizationRepositories/connectProviderDropdown';
+import {NoIntegrationsEmptyState} from 'sentry/views/settings/organizationRepositories/noIntegrationsEmptyState';
+import type {ScmInstallation} from 'sentry/views/settings/organizationRepositories/scmRepositoryTable';
+import {ScmRepositoryTable} from 'sentry/views/settings/organizationRepositories/scmRepositoryTable';
+import {useRepoSearch} from 'sentry/views/settings/organizationRepositories/useRepoSearch';
+import {organizationIntegrationsQueryOptions} from 'sentry/views/settings/seer/overview/utils/organizationIntegrationsQueryOptions';
+
+import {useDeleteIntegration} from './useDeleteIntegration';
+
+const SCM_PROVIDER_ORDER = [
+  'github',
+  'github_enterprise',
+  'gitlab',
+  'bitbucket',
+  'bitbucket_server',
+  'vsts',
+];
+
+export function OrganizationRepositoriesV2() {
+  const organization = useOrganization();
+  const hasAccess = hasEveryAccess(['org:integrations'], {organization});
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const providersQuery = useQuery(
+    organizationConfigIntegrationsQueryOptions({organization})
+  );
+
+  const scmProviders = useMemo(() => {
+    const providers = (providersQuery.data?.providers ?? []).filter(isScmProvider);
+    return sortBy(providers, [
+      p => {
+        const idx = SCM_PROVIDER_ORDER.indexOf(p.key);
+        return idx === -1 ? SCM_PROVIDER_ORDER.length : idx;
+      },
+      p => p.name,
+    ]);
+  }, [providersQuery.data]);
+
+  const scmProviderKeys = useMemo(() => scmProviders.map(p => p.key), [scmProviders]);
+
+  const integrationsQuery = useQuery(
+    organizationIntegrationsQueryOptions({organization})
+  );
+
+  const scmIntegrations = useMemo(() => {
+    if (integrationsQuery.data === undefined) {
+      return [];
+    }
+    return integrationsQuery.data.filter(
+      i => i !== null && scmProviderKeys.includes(i.provider.key)
+    );
+  }, [integrationsQuery.data, scmProviderKeys]);
+
+  const reposQueryOptions = organizationRepositoriesInfiniteOptions({
+    organization,
+    staleTime: 0,
+  });
+  const reposQuery = useInfiniteQuery(reposQueryOptions);
+  useFetchAllPages({result: reposQuery});
+
+  const allRepos = useMemo<Repository[]>(
+    () => reposQuery.data?.pages.flatMap(page => page.json) ?? [],
+    [reposQuery.data]
+  );
+  const reposLoading =
+    !reposQuery.data || reposQuery.hasNextPage || reposQuery.isFetchingNextPage;
+
+  const reposByIntegrationId = useMemo(
+    () => groupBy(allRepos, r => r.integrationId),
+    [allRepos]
+  );
+
+  const codeMappingsQuery = useInfiniteQuery(
+    apiOptions.asInfinite<RepositoryProjectPathConfig[]>()(
+      '/organizations/$organizationIdOrSlug/code-mappings/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        query: {per_page: 100},
+        staleTime: 10_000,
+      }
+    )
+  );
+  useFetchAllPages({result: codeMappingsQuery});
+
+  const mappedProjectSlugsByRepoId = useMemo(() => {
+    const mappings = codeMappingsQuery.data?.pages.flatMap(p => p.json) ?? [];
+    return mapValues(
+      groupBy(mappings, m => m.repoId),
+      ms => uniq(ms.map(m => m.projectSlug))
+    );
+  }, [codeMappingsQuery.data]);
+
+  const mappingsLoading =
+    codeMappingsQuery.isPending ||
+    codeMappingsQuery.hasNextPage ||
+    codeMappingsQuery.isFetchingNextPage;
+
+  const installationsByProviderKey = useMemo(() => {
+    const installations = scmIntegrations.map<ScmInstallation>(integration => ({
+      integration,
+      repositories: reposByIntegrationId[integration.id] ?? [],
+      reposLoading,
+      manageUrl: getProviderConfigUrl(integration) ?? undefined,
+      mappedProjectSlugsByRepoId,
+      mappingsLoading,
+    }));
+    return groupBy(installations, i => i.integration.provider.key);
+  }, [
+    scmIntegrations,
+    reposByIntegrationId,
+    reposLoading,
+    mappedProjectSlugsByRepoId,
+    mappingsLoading,
+  ]);
+
+  const handleAddIntegration = (_data: Integration) => {
+    integrationsQuery.refetch();
+    reposQuery.refetch();
+  };
+
+  const handleDeleteIntegration = useDeleteIntegration({
+    onSuccess: () => {
+      integrationsQuery.refetch();
+      reposQuery.refetch();
+    },
+  });
+
+  const repoMatches = useRepoSearch(allRepos, searchTerm);
+
+  const isLoading = providersQuery.isPending || integrationsQuery.isPending;
+  const isError =
+    providersQuery.isError || integrationsQuery.isError || reposQuery.isError;
+
+  const pageDescription = tct(
+    'Connecting a repo to a project enables [suspectCommits:Suspect Commits] on issues, [suggestedAssignees:Suggested Assignees] based on code owners, the ability to mark an issue [resolvedViaCommit:Resolved via Commit or PR], and is a requirement for [seer:Seer].',
+    {
+      suspectCommits: (
+        <ExternalLink href="https://docs.sentry.io/product/issues/suspect-commits/" />
+      ),
+      suggestedAssignees: (
+        <ExternalLink href="https://docs.sentry.io/product/issues/ownership-rules/#code-owners" />
+      ),
+      resolvedViaCommit: (
+        <ExternalLink href="https://docs.sentry.io/product/releases/associate-commits/#associate-commits-with-a-release" />
+      ),
+      seer: (
+        <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities" />
+      ),
+    }
+  );
+
+  return (
+    <AnalyticsArea name="repositories-v2">
+      <SentryDocumentTitle title={t('Repositories')} orgSlug={organization.slug} />
+      <SettingsPageHeader
+        title={t('Repositories')}
+        subtitle={pageDescription}
+        action={
+          scmIntegrations.length > 0 ? (
+            <ConnectProviderDropdown
+              providers={scmProviders.filter(p => p.canAdd)}
+              onAddIntegration={handleAddIntegration}
+            />
+          ) : null
+        }
+      />
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : isError ? (
+        <LoadingError
+          onRetry={() => {
+            providersQuery.refetch();
+            integrationsQuery.refetch();
+            reposQuery.refetch();
+          }}
+        />
+      ) : (
+        <Stack gap="lg">
+          <Input
+            type="search"
+            placeholder={t('Search repositories')}
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.target.value)}
+          />
+          {!integrationsQuery.isPending && scmIntegrations.length === 0 ? (
+            <NoIntegrationsEmptyState
+              providers={scmProviders}
+              onAddIntegration={handleAddIntegration}
+            />
+          ) : (
+            scmProviders
+              .filter(p => installationsByProviderKey[p.key])
+              .map(provider => (
+                <ScmRepositoryTable
+                  key={provider.key}
+                  provider={provider}
+                  installations={installationsByProviderKey[provider.key]!}
+                  repoMatches={repoMatches}
+                  onUninstall={
+                    hasAccess
+                      ? inst => handleDeleteIntegration(inst.integration)
+                      : undefined
+                  }
+                />
+              ))
+          )}
+        </Stack>
+      )}
+    </AnalyticsArea>
+  );
+}

--- a/static/app/views/settings/organizationRepositoriesV2/useDeleteIntegration.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/useDeleteIntegration.tsx
@@ -1,0 +1,53 @@
+import {useMutation} from '@tanstack/react-query';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {openConfirmModal} from 'sentry/components/confirm';
+import {t} from 'sentry/locale';
+import type {Integration} from 'sentry/types/integrations';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+interface UseDeleteIntegrationOptions {
+  onSuccess?: (integration: Integration) => void;
+}
+
+export function useDeleteIntegration({onSuccess}: UseDeleteIntegrationOptions = {}) {
+  const organization = useOrganization();
+
+  const mutation = useMutation({
+    mutationFn: (integration: Integration) =>
+      fetchMutation({
+        method: 'DELETE',
+        url: getApiUrl(
+          '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
+          {
+            path: {
+              organizationIdOrSlug: organization.slug,
+              integrationId: integration.id,
+            },
+          }
+        ),
+      }),
+    onSuccess: (_data, integration) => {
+      addSuccessMessage(t('%s has been removed.', integration.name));
+      onSuccess?.(integration);
+    },
+    onError: () => {
+      addErrorMessage(t('Failed to remove integration'));
+    },
+  });
+
+  return (integration: Integration) => {
+    openConfirmModal({
+      header: t('Uninstall integration'),
+      message: t(
+        "Sentry will lose access to linked repositories, external issues, team mappings, and notifications from this integration will stop. Your data in %s isn't affected. You can reinstall anytime.",
+        integration.provider.name
+      ),
+      confirmText: t("I'm sure, uninstall"),
+      priority: 'danger',
+      onConfirm: () => mutation.mutate(integration),
+    });
+  };
+}


### PR DESCRIPTION
Adds the new repositories settings page gated behind `organizations:scm-repositories-v2`.

The v2 page replaces the tree-based layout with per-provider `ScmRepositoryTable` sections showing installations, repos, and code mappings inline. The legacy view stays active for orgs without the flag.

Part of [VDY-116: Create unified repository list and install flow UX](https://linear.app/getsentry/issue/VDY-116/create-unified-repository-list-and-install-flow-ux)