### PR TITLE
ref(spans): clean up enforce-segment-size option

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -29,7 +29,7 @@ ARGS:
 - byte_count -- int -- The total number of bytes in the subsegment.
 - max_segment_bytes -- int -- Maximum allowed ingested bytes for a segment. 0 means no limit.
 - salt -- str -- Unique identifier for this subsegment. When the segment exceeds max_segment_bytes, this subsegment
-                 is detached into its own segment keyed by salt. Empty string disables this behavior.
+                 is detached into its own segment keyed by salt.
 - *span_id -- str[] -- The span ids in the subsegment.
 
 RETURNS:
@@ -127,149 +127,62 @@ redis.call("expire", main_redirect_key, set_timeout)
 local redirect_end_time_ms = get_time_ms()
 table.insert(latency_table, {"redirect_step_latency_ms", redirect_end_time_ms - start_time_ms})
 
-if salt ~= "" then
-    local ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
-    local ingested_byte_count = tonumber(redis.call("get", ingested_byte_count_key) or 0)
+local ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
+local ingested_byte_count = tonumber(redis.call("get", ingested_byte_count_key) or 0)
 
-    for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
-        local span_id = ARGV[i]
-        if span_id ~= parent_span_id then
-            local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
-            local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
-            local child_ibc = tonumber(redis.call("get", child_ibc_key) or 0)
-            byte_count = byte_count + child_ibc
-        end
-    end
-
-    -- If the segment is already too big, make this subsegment its own segment
-    -- with salt as the identifier.
-    if max_segment_bytes > 0 and tonumber(ingested_byte_count) + byte_count > max_segment_bytes then
-        set_span_id = salt
-        set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, salt)
-        ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
-    end
-
-    local ingested_count_key = string.format("span-buf:ic:%s", set_key)
-    local members_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, set_span_id)
-
-    for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
-        local span_id = ARGV[i]
-        if span_id ~= parent_span_id then
-            local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
-
-            local child_ic_key = string.format("span-buf:ic:%s", child_set_key)
-            local child_ic = redis.call("get", child_ic_key)
-            if child_ic then
-                redis.call("incrby", ingested_count_key, child_ic)
-                redis.call("del", child_ic_key)
-            end
-
-            local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
-            local child_ibc = redis.call("get", child_ibc_key)
-            if child_ibc then
-                -- byte_count already holds the child's byte count, so we don't need to add again
-                redis.call("del", child_ibc_key)
-            end
-
-            local child_members_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, span_id)
-            if redis.call("exists", child_members_key) == 1 then
-                merge_set(child_members_key, members_key)
-                redis.call("del", child_members_key)
-            end
-        end
-    end
-
-    local merge_payload_keys_end_time_ms = get_time_ms()
-    table.insert(latency_table, {"merge_payload_keys_step_latency_ms", merge_payload_keys_end_time_ms - redirect_end_time_ms})
-
-    redis.call("sadd", members_key, salt)
-    redis.call("expire", members_key, set_timeout)
-
-    -- Track total number of spans ingested for this segment
-    redis.call("incrby", ingested_count_key, num_spans)
-    redis.call("incrby", ingested_byte_count_key, byte_count)
-    redis.call("expire", ingested_count_key, set_timeout)
-    redis.call("expire", ingested_byte_count_key, set_timeout)
-
-    local counter_merge_end_time_ms = get_time_ms()
-    table.insert(latency_table, {"counter_merge_step_latency_ms", counter_merge_end_time_ms - merge_payload_keys_end_time_ms})
-
-    -- Capture end time and calculate latency in milliseconds
-    local end_time_ms = get_time_ms()
-    local latency_ms = end_time_ms - start_time_ms
-    table.insert(latency_table, {"total_step_latency_ms", latency_ms})
-
-    return {set_key, has_root_span, latency_ms, latency_table, metrics_table}
-end
-
--- Maintain member-keys (span-buf:mk) tracking sets so the flusher
--- knows which payload keys to fetch.
-local member_keys_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, set_span_id)
-redis.call("sadd", member_keys_key, parent_span_id)
-
--- Merge child tracking sets from span_ids that were previously segment roots.
 for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     local span_id = ARGV[i]
     if span_id ~= parent_span_id then
-        local child_mk_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, span_id)
-        if redis.call("exists", child_mk_key) == 1 then
-            merge_set(child_mk_key, member_keys_key)
-            redis.call("del", child_mk_key)
+        local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
+        local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
+        local child_ibc = tonumber(redis.call("get", child_ibc_key) or 0)
+        byte_count = byte_count + child_ibc
+    end
+end
+
+-- If the segment is already too big, make this subsegment its own segment
+-- with salt as the identifier.
+if max_segment_bytes > 0 and tonumber(ingested_byte_count) + byte_count > max_segment_bytes then
+    set_span_id = salt
+    set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, salt)
+    ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
+end
+
+local ingested_count_key = string.format("span-buf:ic:%s", set_key)
+local members_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, set_span_id)
+
+for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
+    local span_id = ARGV[i]
+    if span_id ~= parent_span_id then
+        local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
+
+        local child_ic_key = string.format("span-buf:ic:%s", child_set_key)
+        local child_ic = redis.call("get", child_ic_key)
+        if child_ic then
+            redis.call("incrby", ingested_count_key, child_ic)
+            redis.call("del", child_ic_key)
+        end
+
+        local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
+        local child_ibc = redis.call("get", child_ibc_key)
+        if child_ibc then
+            -- byte_count already holds the child's byte count, so we don't need to add again
+            redis.call("del", child_ibc_key)
+        end
+
+        local child_members_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, span_id)
+        if redis.call("exists", child_members_key) == 1 then
+            merge_set(child_members_key, members_key)
+            redis.call("del", child_members_key)
         end
     end
 end
 
--- Merge parent's tracking set if parent_span_id redirected to a different root.
-if set_span_id ~= parent_span_id then
-    local parent_mk_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, parent_span_id)
-    if redis.call("exists", parent_mk_key) == 1 then
-        merge_set(parent_mk_key, member_keys_key)
-        redis.call("del", parent_mk_key)
-    end
-end
-
-redis.call("expire", member_keys_key, set_timeout)
 local merge_payload_keys_end_time_ms = get_time_ms()
 table.insert(latency_table, {"merge_payload_keys_step_latency_ms", merge_payload_keys_end_time_ms - redirect_end_time_ms})
 
--- Merge ic/ibc counters from child keys into the segment root.
-local ingested_count_key = string.format("span-buf:ic:%s", set_key)
-local ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
-for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
-    local span_id = ARGV[i]
-    if span_id ~= parent_span_id then
-        local child_merged = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
-        local child_ic_key = string.format("span-buf:ic:%s", child_merged)
-        local child_ibc_key = string.format("span-buf:ibc:%s", child_merged)
-        local child_count = redis.call("get", child_ic_key)
-        local child_byte_count = redis.call("get", child_ibc_key)
-        if child_count then
-            redis.call("incrby", ingested_count_key, child_count)
-            redis.call("del", child_ic_key)
-        end
-        if child_byte_count then
-            redis.call("incrby", ingested_byte_count_key, child_byte_count)
-            redis.call("del", child_ibc_key)
-        end
-    end
-end
-if set_span_id ~= parent_span_id then
-    local parent_merged = string.format("span-buf:s:{%s}:%s", project_and_trace, parent_span_id)
-    local parent_ic_key = string.format("span-buf:ic:%s", parent_merged)
-    local parent_ibc_key = string.format("span-buf:ibc:%s", parent_merged)
-    local parent_count = redis.call("get", parent_ic_key)
-    local parent_byte_count = redis.call("get", parent_ibc_key)
-    if parent_count then
-        redis.call("incrby", ingested_count_key, parent_count)
-        redis.call("del", parent_ic_key)
-    end
-    if parent_byte_count then
-        redis.call("incrby", ingested_byte_count_key, parent_byte_count)
-        redis.call("del", parent_ibc_key)
-    end
-end
-local counter_merge_end_time_ms = get_time_ms()
-table.insert(latency_table, {"counter_merge_step_latency_ms", counter_merge_end_time_ms - merge_payload_keys_end_time_ms})
+redis.call("sadd", members_key, salt)
+redis.call("expire", members_key, set_timeout)
 
 -- Track total number of spans ingested for this segment
 redis.call("incrby", ingested_count_key, num_spans)
@@ -277,9 +190,8 @@ redis.call("incrby", ingested_byte_count_key, byte_count)
 redis.call("expire", ingested_count_key, set_timeout)
 redis.call("expire", ingested_byte_count_key, set_timeout)
 
-local ingested_count_end_time_ms = get_time_ms()
-local ingested_count_step_latency_ms = ingested_count_end_time_ms - counter_merge_end_time_ms
-table.insert(latency_table, {"ingested_count_step_latency_ms", ingested_count_step_latency_ms})
+local counter_merge_end_time_ms = get_time_ms()
+table.insert(latency_table, {"counter_merge_step_latency_ms", counter_merge_end_time_ms - merge_payload_keys_end_time_ms})
 
 -- Capture end time and calculate latency in milliseconds
 local end_time_ms = get_time_ms()

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -33,14 +33,9 @@ Segments are flushed out to `buffered-spans` topic under two conditions:
 Now how does that look like in Redis? For each incoming span, we:
 
 1. Store the span payload in a payload key. Each subsegment gets its own key,
-   distributed across Redis cluster nodes.
-   a. When segment size enforcement is disabled, the key uses the parent_span_id to
-   determine where to write span payloads to.
-   Key: `span-buf:s:{project_id:trace_id:parent_span_id}:parent_span_id`
-   b. When segment size enforcement is enabled, the key uses a unique salt per
-   subsegment. This allows us to skip merging the subsegment into the parent segment
-   and not lose any data, since the subsegment will become its own separate segment
-   and be flushed out independently.
+   distributed across Redis cluster nodes. The key uses a unique salt per subsegment
+   so that, if the parent segment is over the byte limit, the subsegment can be
+   detached into its own segment without merging or copying any data.
    Key: `span-buf:s:{project_id:trace_id:salt}:salt`
 2. The Lua script (add-buffer.lua) receives the span IDs and:
    a. Follows redirects from parent_span_id (hashmap at
@@ -49,9 +44,8 @@ Now how does that look like in Redis? For each incoming span, we:
    c. Merges member-keys indexes and counters (ingested count, byte count)
       from span IDs that were previously separate segment roots into the
       current segment root.
-   d. If segment size enforcement is enabled and the segment exceeds
-      max_segment_bytes, detaches the subsegment into its own segment
-      keyed by the salt.
+   d. If the segment exceeds max_segment_bytes, detaches the subsegment
+      into its own segment keyed by the salt.
 3. To a "global queue", we write the segment key, sorted by timeout.
 
 Eventually, flushing cronjob looks at that global queue, and removes all timed
@@ -72,8 +66,7 @@ Segment size enforcement:
 
 Segments can grow unboundedly as spans arrive. To prevent oversized segments from
 consuming excessive memory during flush, the buffer enforces a maximum byte limit
-per segment (controlled by `spans.buffer.max-segment-bytes` and gated behind
-`spans.buffer.enforce-segment-size`).
+per segment (controlled by `spans.buffer.max-segment-bytes`).
 
 Each subsegment is assigned a unique salt (UUID). The Lua script tracks cumulative
 ingested bytes per segment via `span-buf:ibc` keys. If adding a subsegment would
@@ -307,7 +300,6 @@ class SpansBuffer:
         root_timeout = options.get("spans.buffer.root-timeout")
         max_spans_per_evalsha = options.get("spans.buffer.max-spans-per-evalsha")
         max_segment_bytes = options.get("spans.buffer.max-segment-bytes")
-        enforce_segment_size = options.get("spans.buffer.enforce-segment-size")
         result_meta = []
         is_root_span_count = 0
 
@@ -336,9 +328,7 @@ class SpansBuffer:
                 with self.client.pipeline(transaction=False) as p:
                     for (project_and_trace, parent_span_id), salt, subsegment in batch:
                         set_members = self._prepare_payloads(subsegment)
-                        payload_key = self._get_payload_key(project_and_trace, parent_span_id)
-                        if enforce_segment_size:
-                            payload_key = self._get_payload_key(project_and_trace, salt)
+                        payload_key = self._get_payload_key(project_and_trace, salt)
                         p.sadd(payload_key, *set_members)
                         p.expire(payload_key, redis_ttl)
 
@@ -381,7 +371,7 @@ class SpansBuffer:
                             redis_ttl,
                             byte_count,
                             max_segment_bytes,
-                            salt if enforce_segment_size else "",
+                            salt,
                             *span_ids,
                         )
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -39,7 +39,6 @@ DEFAULT_OPTIONS = {
     "spans.buffer.evalsha-latency-threshold": 100,
     "spans.buffer.debug-traces": [],
     "spans.buffer.evalsha-cumulative-logger-enabled": True,
-    "spans.buffer.enforce-segment-size": False,
     "spans.process-segments.schema-validation": 1.0,
 }
 
@@ -823,71 +822,6 @@ def test_compression_functionality(compression_level) -> None:
 
 
 @mock.patch("sentry.spans.buffer.Project")
-def test_max_segment_spans_limit(mock_project_model, buffer: SpansBuffer) -> None:
-    # Mock the project lookup to avoid database access
-    mock_project = mock.Mock()
-    mock_project.id = 1
-    mock_project.organization_id = 100
-    mock_project_model.objects.get_from_cache.return_value = mock_project
-
-    batch1 = [
-        Span(
-            payload=_payload("c" * 16),
-            trace_id="a" * 32,
-            span_id="c" * 16,
-            parent_span_id="b" * 16,
-            segment_id=None,
-            project_id=1,
-        ),
-        Span(
-            payload=_payload("b" * 16),
-            trace_id="a" * 32,
-            span_id="b" * 16,
-            parent_span_id="a" * 16,
-            segment_id=None,
-            project_id=1,
-        ),
-    ]
-    batch2 = [
-        Span(
-            payload=_payload("d" * 16),
-            trace_id="a" * 32,
-            span_id="d" * 16,
-            parent_span_id="a" * 16,
-            segment_id=None,
-            project_id=1,
-        ),
-        Span(
-            payload=_payload("e" * 16),
-            trace_id="a" * 32,
-            span_id="e" * 16,
-            parent_span_id="a" * 16,
-            segment_id=None,
-            project_id=1,
-        ),
-        Span(
-            payload=_payload("a" * 16),
-            trace_id="a" * 32,
-            span_id="a" * 16,
-            parent_span_id=None,
-            project_id=1,
-            segment_id=None,
-            is_segment_span=True,
-        ),
-    ]
-
-    with override_options({"spans.buffer.max-segment-bytes": 100}):
-        buffer.process_spans(batch1, now=0)
-        buffer.process_spans(batch2, now=0)
-        rv = buffer.flush_segments(now=11)
-
-    # The segment is kept even though it exceeds max_segment_bytes,
-    # because oversized segments are chunked at the message level.
-    segment = rv[_segment_id(1, "a" * 32, "a" * 16)]
-    assert len(segment.spans) == 5
-
-
-@mock.patch("sentry.spans.buffer.Project")
 def test_max_segment_bytes_detaches_over_limit(mock_project_model, buffer: SpansBuffer) -> None:
     """When a segment's cumulative ingested bytes exceed max-segment-bytes, subsequent
     subsegments are written to a detached (salted) key so that overflow spans are not lost."""
@@ -931,9 +865,7 @@ def test_max_segment_bytes_detaches_over_limit(mock_project_model, buffer: Spans
         ),
     ]
 
-    with override_options(
-        {"spans.buffer.max-segment-bytes": 70, "spans.buffer.enforce-segment-size": True}
-    ):
+    with override_options({"spans.buffer.max-segment-bytes": 70}):
         buffer.process_spans(batch1, now=0)
         buffer.process_spans(batch2, now=0)
         buffer.process_spans(batch3, now=0)
@@ -989,7 +921,6 @@ def test_max_segment_bytes_under_limit_merges_normally(
     with override_options(
         {
             "spans.buffer.max-segment-bytes": 10 * 1024 * 1024,
-            "spans.buffer.enforce-segment-size": True,
         }
     ):
         buffer.process_spans(batch1, now=0)
@@ -1006,7 +937,8 @@ def test_max_segment_bytes_under_limit_merges_normally(
 
 @mock.patch("sentry.spans.buffer.Project")
 def test_flush_oversized_segments(mock_project_model, buffer: SpansBuffer) -> None:
-    """Test that oversized segments are kept instead of dropped."""
+    """When cumulative bytes exceed max-segment-bytes, spans split across
+    segments but none are dropped."""
     mock_project = mock.Mock()
     mock_project.id = 1
     mock_project.organization_id = 100
@@ -1058,30 +990,18 @@ def test_flush_oversized_segments(mock_project_model, buffer: SpansBuffer) -> No
         ),
     ]
 
+    # `now=61` is past the non-root timeout (60) so the parent segment also flushes.
     with override_options({"spans.buffer.max-segment-bytes": 100}):
         buffer.process_spans(batch1, now=0)
         buffer.process_spans(batch2, now=0)
-        rv = buffer.flush_segments(now=11)
+        rv = buffer.flush_segments(now=61)
 
-    segment = rv[_segment_id(1, "a" * 32, "a" * 16)]
-    assert len(segment.spans) == 5
-    _normalize_output(rv)
-    assert rv == {
-        _segment_id(1, "a" * 32, "a" * 16): FlushedSegment(
-            queue_key=mock.ANY,
-            score=mock.ANY,
-            ingested_count=mock.ANY,
-            payload_keys=mock.ANY,
-            project_id=1,
-            spans=[
-                _output_segment(b"a" * 16, b"a" * 16, True),
-                _output_segment(b"b" * 16, b"a" * 16, False),
-                _output_segment(b"c" * 16, b"a" * 16, False),
-                _output_segment(b"d" * 16, b"a" * 16, False),
-                _output_segment(b"e" * 16, b"a" * 16, False),
-            ],
-        )
-    }
+    all_span_ids = {span.payload["span_id"] for seg in rv.values() for span in seg.spans}
+    assert all_span_ids == {"a" * 16, "b" * 16, "c" * 16, "d" * 16, "e" * 16}
+    assert sum(len(seg.spans) for seg in rv.values()) == 5
+    # Confirms the byte-limit detach actually triggered. Exact count depends on
+    # max-spans-per-evalsha chunking (2 segments for nochunk, 3 for chunk1).
+    assert len(rv) >= 2
 
 
 def test_to_messages_under_limit(buffer: SpansBuffer) -> None:
@@ -1780,10 +1700,15 @@ def test_distributed_payload_keys_populated(distributed_buffer: SpansBuffer) -> 
     buf = distributed_buffer
     process_spans([_dspan("a" * 16, "b" * 16), _dspan("b" * 16, is_root=True)], buf, now=0)
 
-    dist_key = b"span-buf:s:{1:" + b"a" * 32 + b":" + b"b" * 16 + b"}:" + b"b" * 16
     mk_key = b"span-buf:mk:{1:" + b"a" * 32 + b"}:" + b"b" * 16
-    assert buf.client.scard(dist_key) > 0
     assert buf.client.scard(mk_key) > 0
+
+    # Payload keys are salt-keyed (one per subsegment), tracked via mk.
+    salts = buf.client.smembers(mk_key)
+    assert salts
+    for salt in salts:
+        dist_key = b"span-buf:s:{1:" + b"a" * 32 + b":" + salt + b"}:" + salt
+        assert buf.client.scard(dist_key) > 0
 
     rv = buf.flush_segments(now=11)
     set_key = _segment_id(1, "a" * 32, "b" * 16)


### PR DESCRIPTION
We have rolled out the flag in all regions and the spans buffer is stable. We can start cleaning up the flag and default to the new enforce max-segment-bytes subsegment detaching behaviour in the Lua script.