### PR TITLE
feat(dashboards): Add Copy Widget URL icon to the widget card header

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -31,6 +31,7 @@ import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/featu
 import {useExtractionStatus} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -260,6 +261,18 @@ function WidgetCard(props: Props) {
     };
   }, [timeoutRef]);
 
+  const onCopyUrlClick =
+    currentDashboardId && props.index !== undefined
+      ? () => {
+          const widgetUrl = `${window.location.origin}${normalizeUrl(
+            `/organizations/${organization.slug}/dashboard/${currentDashboardId}/widget/${props.index}/`
+          )}`;
+          copyToClipboard(widgetUrl, {
+            successMessage: t('Widget URL copied to clipboard'),
+          });
+        }
+      : undefined;
+
   const onFullScreenViewClick = () => {
     if (isWidgetViewerPath(location.pathname)) {
       return;
@@ -335,9 +348,7 @@ function WidgetCard(props: Props) {
         props.onDelete,
         props.onDuplicate,
         props.onEdit,
-        data?.timeseriesResults,
-        currentDashboardId,
-        props.index
+        data?.timeseriesResults
       )
     : [];
 
@@ -393,6 +404,7 @@ function WidgetCard(props: Props) {
             actionsMessage={actionsMessage}
             actions={actions}
             noVisualizationPadding={canUseTimeseriesVisualization}
+            onCopyUrlClick={onCopyUrlClick}
             onFullScreenViewClick={disableFullscreen ? undefined : onFullScreenViewClick}
             borderless={props.borderless}
             revealTooltip={props.forceDescriptionTooltip ? 'always' : undefined}
@@ -437,6 +449,7 @@ function WidgetCard(props: Props) {
           error={widgetQueryError}
           actionsMessage={actionsMessage}
           actions={actions}
+          onCopyUrlClick={onCopyUrlClick}
           onFullScreenViewClick={disableFullscreen ? undefined : onFullScreenViewClick}
           borderless={props.borderless}
           revealTooltip={props.forceDescriptionTooltip ? 'always' : undefined}

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import type {LegendComponentOption} from 'echarts';
 import type {Location} from 'history';
 import omit from 'lodash/omit';
+import qs from 'query-string';
 
 import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
@@ -264,9 +265,17 @@ function WidgetCard(props: Props) {
   const onCopyUrlClick =
     currentDashboardId && props.index !== undefined
       ? () => {
-          const widgetUrl = `${window.location.origin}${normalizeUrl(
+          const pathname = normalizeUrl(
             `/organizations/${organization.slug}/dashboard/${currentDashboardId}/widget/${props.index}/`
-          )}`;
+          );
+          const params = qs.parse(location.search);
+          if (!params.interval && widgetInterval) {
+            params.interval = widgetInterval;
+          }
+          const query = qs.stringify(params);
+          const widgetUrl = `${window.location.origin}${pathname}${
+            query ? `?${query}` : ''
+          }`;
           copyToClipboard(widgetUrl, {
             successMessage: t('Widget URL copied to clipboard'),
           });

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -335,7 +335,9 @@ function WidgetCard(props: Props) {
         props.onDelete,
         props.onDuplicate,
         props.onEdit,
-        data?.timeseriesResults
+        data?.timeseriesResults,
+        currentDashboardId,
+        props.index
       )
     : [];
 

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -19,9 +19,7 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isEquation, stripEquationPrefix} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {safeURL} from 'sentry/utils/url/safeURL';
-import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -178,9 +176,7 @@ export function getMenuOptions(
   onDelete?: () => void,
   onDuplicate?: () => void,
   onEdit?: () => void,
-  timeseriesResults?: Series[],
-  dashboardId?: string,
-  widgetIndex?: string
+  timeseriesResults?: Series[]
 ) {
   const menuOptions: MenuItemProps[] = [];
 
@@ -398,21 +394,6 @@ export function getMenuOptions(
         : undefined,
       disabled: widgetLimitReached || !hasEditAccess || disableTransactionEdit,
     });
-
-    if (dashboardId && widgetIndex !== undefined) {
-      menuOptions.push({
-        key: 'copy-widget-url',
-        label: t('Copy Widget URL'),
-        onAction: () => {
-          const widgetUrl = `${window.location.origin}${normalizeUrl(
-            `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/${widgetIndex}/`
-          )}`;
-          copyToClipboard(widgetUrl, {
-            successMessage: t('Widget URL copied to clipboard'),
-          });
-        },
-      });
-    }
 
     menuOptions.push({
       key: 'edit-widget',

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -19,7 +19,9 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isEquation, stripEquationPrefix} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {safeURL} from 'sentry/utils/url/safeURL';
+import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -176,7 +178,9 @@ export function getMenuOptions(
   onDelete?: () => void,
   onDuplicate?: () => void,
   onEdit?: () => void,
-  timeseriesResults?: Series[]
+  timeseriesResults?: Series[],
+  dashboardId?: string,
+  widgetIndex?: string
 ) {
   const menuOptions: MenuItemProps[] = [];
 
@@ -394,6 +398,21 @@ export function getMenuOptions(
         : undefined,
       disabled: widgetLimitReached || !hasEditAccess || disableTransactionEdit,
     });
+
+    if (dashboardId && widgetIndex !== undefined) {
+      menuOptions.push({
+        key: 'copy-widget-url',
+        label: t('Copy Widget URL'),
+        onAction: () => {
+          const widgetUrl = `${window.location.origin}${normalizeUrl(
+            `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/${widgetIndex}/`
+          )}`;
+          copyToClipboard(widgetUrl, {
+            successMessage: t('Widget URL copied to clipboard'),
+          });
+        },
+      });
+    }
 
     menuOptions.push({
       key: 'edit-widget',

--- a/static/app/views/dashboards/widgetCard/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetFrame.tsx
@@ -7,7 +7,7 @@ import {Container} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
-import {IconEllipsis, IconExpand, IconWarning} from 'sentry/icons';
+import {IconCopy, IconEllipsis, IconExpand, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {StateProps} from 'sentry/views/dashboards/widgets/common/types';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -24,6 +24,7 @@ interface WidgetFrameProps extends StateProps, WidgetDescriptionProps {
   borderless?: boolean;
   children?: React.ReactNode;
   noVisualizationPadding?: boolean;
+  onCopyUrlClick?: () => void;
   onFullScreenViewClick?: () => void | Promise<void>;
   revealActions?: 'always' | 'hover';
   revealTooltip?: 'always' | 'hover';
@@ -51,6 +52,8 @@ export function WidgetFrame(props: WidgetFrameProps) {
 
   const shouldShowFullScreenViewButton =
     Boolean(props.onFullScreenViewClick) && !props.error;
+
+  const shouldShowCopyUrlButton = Boolean(props.onCopyUrlClick) && !props.error;
 
   const shouldShowActions = actions && actions.length > 0;
 
@@ -136,6 +139,20 @@ export function WidgetFrame(props: WidgetFrameProps) {
                 />
               ) : null}
             </TitleActionsWrapper>
+          )}
+
+          {shouldShowCopyUrlButton && (
+            <Tooltip title={t('Copy Widget URL')}>
+              <Button
+                size="xs"
+                aria-label={t('Copy Widget URL')}
+                variant="transparent"
+                icon={<IconCopy />}
+                onClick={() => {
+                  props.onCopyUrlClick?.();
+                }}
+              />
+            </Tooltip>
           )}
 
           {shouldShowFullScreenViewButton && (


### PR DESCRIPTION
Adds a copy icon button to the widget card header between the actions dropdown and the full-screen button so users can grab a shareable widget link without opening the full-screen viewer.

<img width="729" height="492" alt="image" src="https://github.com/user-attachments/assets/877f559e-4a31-40fb-ba62-c7f12bb5dfc7" />


Refs DAIN-1608