### PR TITLE
feat(projects): Remove Project Details removal banners

### DIFF
--- a/static/app/views/projectDetail/index.tsx
+++ b/static/app/views/projectDetail/index.tsx
@@ -1,4 +1,3 @@
-import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -19,9 +18,5 @@ export default function ProjectDetailContainer() {
       : {}
   );
 
-  return (
-    <PageAlertProvider>
-      <ProjectDetail />
-    </PageAlertProvider>
-  );
+  return <ProjectDetail />;
 }

--- a/static/app/views/projectDetail/projectDetail.spec.tsx
+++ b/static/app/views/projectDetail/projectDetail.spec.tsx
@@ -14,7 +14,6 @@ import * as pageFilters from 'sentry/components/pageFilters/actions';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 
 import {ProjectDetail} from './projectDetail';
-import ProjectDetailContainer from './';
 
 jest.mock('sentry/actionCreators/organization');
 
@@ -112,18 +111,6 @@ describe('ProjectDetail', () => {
 
     expect(await screen.findByText(/project details/i)).toBeInTheDocument();
     expect(screen.getByText(project.slug)).toBeInTheDocument();
-  });
-
-  it('Render deprecation dialog', async () => {
-    ProjectsStore.loadInitialData([project]);
-    setupMockResponses();
-
-    render(<ProjectDetailContainer />, {
-      organization,
-      initialRouterConfig,
-    });
-
-    expect(await screen.findByText(/similar charts are available/i)).toBeInTheDocument();
   });
 
   it('Sync project with slug', async () => {

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -4,7 +4,6 @@ import pick from 'lodash/pick';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
-import {Link} from '@sentry/scraps/link';
 
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organization';
 import {fetchTagValues} from 'sentry/actionCreators/tags';
@@ -24,9 +23,8 @@ import {MissingProjectMembership} from 'sentry/components/projects/missingProjec
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {IconSettings} from 'sentry/icons';
-import {t, tctCode} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
-import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {routeTitleGen} from 'sentry/utils/routeTitle';
 import {useApi} from 'sentry/utils/useApi';
@@ -82,28 +80,6 @@ export function ProjectDetail() {
     }
     return ['chart1'];
   }, [hasTransactions, hasSessions]);
-
-  const {setPageInfo, pageAlert} = usePageAlert();
-  const {orgId, projectId: projectSlug} = params;
-  const msg = useMemo(
-    () =>
-      tctCode(
-        'Project Details will be removed soon. Find this project’s settings under [settingsLink:Settings]. Similar charts are available on the [sessionHealth:Session Health] and [backendOverview:Backend Overview] dashboards.',
-        {
-          settingsLink: <Link to={`/settings/${orgId}/projects/${projectSlug}/`} />,
-          sessionHealth: (
-            <Link to={`/organizations/${orgId}/insights/mobile/sessions/`} />
-          ),
-          backendOverview: <Link to={`/organizations/${orgId}/insights/backend/`} />,
-        }
-      ),
-    [orgId, projectSlug]
-  );
-  useEffect(() => {
-    if (pageAlert?.message !== msg) {
-      setPageInfo(msg);
-    }
-  }, [msg, pageAlert, setPageInfo]);
 
   const onRetryProjects = useCallback(() => {
     fetchOrganizationDetails(api, params.orgId);
@@ -280,7 +256,6 @@ export function ProjectDetail() {
 
             <Layout.Body noRowGap>
               <Layout.Main>
-                <PageAlert />
                 <ProjectFiltersWrapper>
                   <ProjectFilters
                     query={query}

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -7,7 +7,6 @@ import uniqBy from 'lodash/uniqBy';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Grid, Stack} from '@sentry/scraps/layout';
-import {Link} from '@sentry/scraps/link';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -18,15 +17,10 @@ import {SearchBar} from 'sentry/components/searchBar';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconAdd, IconUser} from 'sentry/icons';
-import {t, tctCode} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {ProjectsStatsStore} from 'sentry/stores/projectsStatsStore';
 import type {Team} from 'sentry/types/organization';
 import type {Project, TeamWithProjects} from 'sentry/types/project';
-import {
-  PageAlert,
-  PageAlertProvider,
-  usePageAlert,
-} from 'sentry/utils/performance/contexts/pageAlert';
 import {
   onRenderCallback,
   Profiler,
@@ -150,25 +144,6 @@ function Dashboard() {
   const {teams: userTeams, isLoading: loadingTeams, isError} = useUserTeams();
   const isAllTeams = location.query.team === '';
   const selectedTeams = getTeamParams(location.query.team ?? 'myteams');
-  const {setPageInfo, pageAlert} = usePageAlert();
-
-  const msg = useMemo(
-    () =>
-      tctCode(
-        'Project Details pages will be removed soon. You can edit project settings and create new projects in [settingsLink:Settings].',
-        {
-          settingsLink: <Link to={`/settings/${organization.slug}/projects/`} />,
-        }
-      ),
-    [organization.slug]
-  );
-
-  useEffect(() => {
-    if (pageAlert?.message !== msg) {
-      setPageInfo(msg);
-    }
-  }, [setPageInfo, pageAlert, msg]);
-
   const {teams: allTeams} = useTeamsById({
     ids: selectedTeams.filter(team => team !== 'myteams'),
   });
@@ -316,7 +291,6 @@ function Dashboard() {
       </Layout.Header>
       <Layout.Body>
         <Layout.Main width="full">
-          <PageAlert />
           <SearchAndSelectorWrapper>
             <TeamFilter
               selectedTeams={selectedTeams}
@@ -347,9 +321,7 @@ function OrganizationDashboard() {
   return (
     <Stack flex={1}>
       <NoProjectMessage organization={organization}>
-        <PageAlertProvider>
-          <Dashboard />
-        </PageAlertProvider>
+        <Dashboard />
       </NoProjectMessage>
     </Stack>
   );


### PR DESCRIPTION
Remove the deprecation banners from the Project Details and Projects Dashboard pages. The banners were added in #105617 to warn users that these pages would be removed soon but we decided that we're going to hold off until we have a better answer for people who use the pages, so the banners can go away. Essentially just a full revert of the original PR.

Closes DAIN-1596