### PR TITLE
feat(supergroups): track total supergroups viewed

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -498,6 +498,11 @@ function IssueListOverview({
     num_issues: groups.length,
     group_ids: groups.map(group => group.id),
     total_issues_count: queryCount,
+    total_issue_group_count: new Set(
+      Object.values(supergroupLookup)
+        .filter(sg => sg !== null)
+        .map(sg => sg.id)
+    ).size,
     sort,
     realtime_active: realtimeActive,
     is_view: urlParams.viewId ? true : false,


### PR DESCRIPTION
Track how many supergroups were viewed so we can identify users who see supergroups in their issue stream.
