### PR TITLE
fix(dashboards): Include threshold changes in revision diffs

### DIFF
--- a/static/app/views/dashboards/dashboardRevisionsDiff.spec.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.spec.ts
@@ -209,6 +209,90 @@ describe('diffWidgets', () => {
     });
   });
 
+  it('distinguishes widgets with identical queries but different thresholds in fingerprint matching', () => {
+    const q = {
+      conditions: '',
+      aggregates: ['count()'],
+      columns: [],
+      orderby: '',
+      name: '',
+    } as any;
+    const base1 = makeWidget({
+      id: '1',
+      title: 'Custom Widget',
+      queries: [q],
+      thresholds: {max_values: {max1: 100}, unit: 'ms'},
+    });
+    const base2 = makeWidget({
+      id: '2',
+      title: 'Custom Widget',
+      queries: [q],
+      thresholds: {max_values: {max1: 200}, unit: 'ms'},
+    });
+    const snap1 = makeWidget({
+      id: '10',
+      title: 'Custom Widget',
+      queries: [q],
+      thresholds: {max_values: {max1: 100}, unit: 'ms'},
+    });
+    const snap2 = makeWidget({
+      id: '20',
+      title: 'Custom Widget',
+      queries: [q],
+      thresholds: {max_values: {max1: 200}, unit: 'ms'},
+    });
+    const result = diffWidgets(
+      makeDashboard([base1, base2]),
+      makeDashboard([snap1, snap2])
+    );
+    expect(result.find(r => r.status === 'added')).toBeUndefined();
+    expect(result.find(r => r.status === 'removed')).toBeUndefined();
+  });
+
+  it('detects a threshold change', () => {
+    const base = makeWidget({
+      id: '1',
+      thresholds: {max_values: {max1: 100}, unit: 'ms'},
+    });
+    const snap = makeWidget({
+      id: '1',
+      thresholds: {max_values: {max1: 200}, unit: 'ms'},
+    });
+    const result = diffWidgets(makeDashboard([base]), makeDashboard([snap]));
+    expect(result[0]).toMatchObject({
+      status: 'modified',
+      fields: [{field: 'thresholds'}],
+    });
+  });
+
+  it('detects a threshold being added', () => {
+    const base = makeWidget({id: '1'});
+    const snap = makeWidget({id: '1', thresholds: {max_values: {max1: 100}, unit: 'ms'}});
+    const result = diffWidgets(makeDashboard([base]), makeDashboard([snap]));
+    expect(result[0]).toMatchObject({
+      status: 'modified',
+      fields: [{field: 'thresholds', before: '(none)'}],
+    });
+  });
+
+  it('detects a threshold being removed', () => {
+    const base = makeWidget({id: '1', thresholds: {max_values: {max1: 100}, unit: 'ms'}});
+    const snap = makeWidget({id: '1'});
+    const result = diffWidgets(makeDashboard([base]), makeDashboard([snap]));
+    expect(result[0]).toMatchObject({
+      status: 'modified',
+      fields: [{field: 'thresholds', after: '(none)'}],
+    });
+  });
+
+  it('does not flag a change when thresholds are identical', () => {
+    const thresholds = {max_values: {max1: 100}, unit: 'ms'};
+    const base = makeWidget({id: '1', thresholds});
+    const snap = makeWidget({id: '1', thresholds});
+    const result = diffWidgets(makeDashboard([base]), makeDashboard([snap]));
+    expect(result).toEqual([]);
+  });
+
   it('does not flag a change when one widget has null description and the other has empty string', () => {
     const base = makeWidget({
       id: '1',

--- a/static/app/views/dashboards/dashboardRevisionsDiff.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.ts
@@ -110,7 +110,7 @@ function makeWidgetFingerprint(w: Widget): string {
   const layoutPart = w.layout
     ? `${w.layout.x},${w.layout.y},${w.layout.w},${w.layout.h}`
     : '';
-  return `${w.title}::${w.displayType}::${w.interval ?? ''}::${w.description ?? ''}::${queryPart}::${layoutPart}`;
+  return `${w.title}::${w.displayType}::${w.interval ?? ''}::${w.description ?? ''}::${queryPart}::${layoutPart}::${JSON.stringify(w.thresholds ?? null)}`;
 }
 
 function diffQueryFields(
@@ -247,6 +247,18 @@ export function diffWidgets(
         field: isTextWidget ? t('content') : t('description'),
         before: truncateDescription(baseDescription),
         after: truncateDescription(snapshotDescription),
+      });
+    }
+
+    const baseThresholds = JSON.stringify(match.thresholds ?? null);
+    const snapshotThresholds = JSON.stringify(snapshotWidget.thresholds ?? null);
+    if (baseThresholds !== snapshotThresholds) {
+      fields.push({
+        field: 'thresholds',
+        before: match.thresholds ? JSON.stringify(match.thresholds) : t('(none)'),
+        after: snapshotWidget.thresholds
+          ? JSON.stringify(snapshotWidget.thresholds)
+          : t('(none)'),
       });
     }
 


### PR DESCRIPTION
Widget threshold changes were not being checked in dashboard revision diffs, so editing thresholds appeared as a no-op in the revision history.

Threshold changes also incorrectly showed that new widgets were being added when a revert happened with threshold changes.

Before
<img width="744" height="847" alt="Screenshot 2026-05-01 at 3 47 23 PM" src="https://github.com/user-attachments/assets/09846323-fbc3-4115-acbb-63a428312d30" />

After
<img width="744" height="847" alt="Screenshot 2026-05-01 at 3 47 34 PM" src="https://github.com/user-attachments/assets/8538278f-f6cb-49f2-a943-e45ae52f1645" />

Fixes DAIN-1614