### PR TITLE
fix(charts): Guard echarts.getInstanceByDom against detached DOM nodes

### DIFF
--- a/static/app/views/dashboards/contexts/widgetSyncContext.tsx
+++ b/static/app/views/dashboards/contexts/widgetSyncContext.tsx
@@ -37,6 +37,12 @@ export function WidgetSyncContextProvider({
     if (!observerRef.current) {
       observerRef.current = new IntersectionObserver(entries => {
         for (const entry of entries) {
+          // Skip detached DOM nodes — they can appear in the observer callback
+          // during component unmount/navigation and cause echarts to call
+          // getAttribute on a null element (echarts-for-react race condition).
+          if (!entry.target.isConnected) {
+            continue;
+          }
           const chart = echarts.getInstanceByDom(entry.target as HTMLElement);
           if (!chart) {
             continue;


### PR DESCRIPTION
`TypeError: can't access property "getAttribute", e is null` occurs primarily in Firefox when navigating between pages that display ECharts charts. It looks to be from IntersectionObserver calls firing after the component's been dismounted.

Fixes JAVASCRIPT-337P / fixes LOGS-756.