### PR TITLE
ref(snapshots): Update sidebar UI to be collapsible again

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -74,6 +74,7 @@ interface GroupRow {
   estimatedHeight: number;
   id: string;
   isUngrouped: boolean;
+  itemKey: string;
   name: string;
 }
 
@@ -157,6 +158,7 @@ function buildGroups(items: SidebarItem[]): GroupRow[] {
     groups.push({
       id: `g:${item.key}`,
       name: item.name,
+      itemKey: item.key,
       cards,
       isUngrouped: ungrouped,
       estimatedHeight:
@@ -170,7 +172,7 @@ function buildGroups(items: SidebarItem[]): GroupRow[] {
 }
 
 export interface SnapshotListViewHandle {
-  scrollToGroup: (name: string) => void;
+  scrollToGroup: (itemKey: string) => void;
 }
 
 export const SnapshotListView = memo(function SnapshotListView({
@@ -222,8 +224,8 @@ export const SnapshotListView = memo(function SnapshotListView({
   useImperativeHandle(
     ref,
     () => ({
-      scrollToGroup(name: string) {
-        const groupIdx = groups.findIndex(g => g.name === name);
+      scrollToGroup(itemKey: string) {
+        const groupIdx = groups.findIndex(g => g.itemKey === itemKey);
         if (groupIdx === -1) {
           return;
         }
@@ -254,7 +256,7 @@ export const SnapshotListView = memo(function SnapshotListView({
 
       const rows = el.querySelectorAll<HTMLElement>('[data-index]');
       const ROW_THRESHOLD = 100;
-      let visibleGroupName = groupsRef.current[0]?.name ?? null;
+      let visibleItemKey = groupsRef.current[0]?.itemKey ?? null;
       for (const row of rows) {
         const idx = parseInt(row.dataset.index ?? '', 10);
         if (isNaN(idx)) {
@@ -262,10 +264,10 @@ export const SnapshotListView = memo(function SnapshotListView({
         }
         const rowTop = row.getBoundingClientRect().top - containerTop;
         if (rowTop <= ROW_THRESHOLD) {
-          visibleGroupName = groupsRef.current[idx]?.name ?? null;
+          visibleItemKey = groupsRef.current[idx]?.itemKey ?? null;
         }
       }
-      onVisibleGroupChangeRef.current?.(visibleGroupName);
+      onVisibleGroupChangeRef.current?.(visibleItemKey);
 
       if (onScrollProgressRef.current) {
         const maxScroll = el.scrollHeight - el.clientHeight;

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -201,7 +201,13 @@ export function SnapshotMainContent({
         width="100%"
         background="secondary"
       >
-        <Flex align="center" justify="between" gap="md" padding="md xl md 0">
+        <Flex
+          align="center"
+          justify="between"
+          gap="md"
+          padding="md xl md 0"
+          background="primary"
+        >
           <Flex align="center" gap="md" onClick={e => e.stopPropagation()}>
             {toggle}
             {sortDropdown}
@@ -234,7 +240,13 @@ export function SnapshotMainContent({
   if (!selectedItem) {
     return (
       <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-        <Flex align="center" justify="between" gap="md" padding="md xl md 0">
+        <Flex
+          align="center"
+          justify="between"
+          gap="md"
+          padding="md xl md 0"
+          background="primary"
+        >
           <Flex align="center" gap="md">
             {toggle}
             {sortDropdown}

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
@@ -4,7 +4,7 @@ import {ThemeProvider} from '@emotion/react';
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 import {DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
 
-import {SnapshotSidebarContent, type SidebarGroup} from './snapshotSidebarContent';
+import {SnapshotSidebarContent, type SidebarSection} from './snapshotSidebarContent';
 
 jest.mock('@sentry/scraps/layout', () => {
   const actual = jest.requireActual('@sentry/scraps/layout');
@@ -18,11 +18,21 @@ const themes = {light: lightTheme, dark: darkTheme};
 
 const noop = () => {};
 
-const groups: SidebarGroup[] = [
-  {key: 'Button/light', name: 'Button/light', count: 1},
-  {key: 'Alert/dark', name: 'Alert/dark', count: 3},
-  {key: 'Badge/light', name: 'Badge/light', count: 4},
-  {key: 'Checkbox/theme-dark', name: 'Checkbox/theme-dark', count: 2},
+const sections: SidebarSection[] = [
+  {
+    type: DiffStatus.CHANGED,
+    groups: [
+      {key: 'changed:Button/light', name: 'Button/light', count: 1},
+      {key: 'changed:Alert/dark', name: 'Alert/dark', count: 3},
+    ],
+  },
+  {
+    type: DiffStatus.UNCHANGED,
+    groups: [
+      {key: 'unchanged:Badge/light', name: 'Badge/light', count: 4},
+      {key: 'unchanged:Checkbox/theme-dark', name: 'Checkbox/theme-dark', count: 2},
+    ],
+  },
 ];
 
 const statusCounts: Record<DiffStatus, number> = {
@@ -48,7 +58,7 @@ describe('SnapshotSidebarContent', () => {
       () => (
         <Wrapper>
           <SnapshotSidebarContent
-            groups={groups}
+            sections={sections}
             searchQuery=""
             onSearchChange={noop}
             onSelectItem={noop}
@@ -66,8 +76,8 @@ describe('SnapshotSidebarContent', () => {
       () => (
         <Wrapper>
           <SnapshotSidebarContent
-            groups={groups}
-            activeGroupName="Badge/light"
+            sections={sections}
+            activeItemKey="unchanged:Badge/light"
             searchQuery=""
             onSearchChange={noop}
             onSelectItem={noop}
@@ -85,7 +95,7 @@ describe('SnapshotSidebarContent', () => {
       () => (
         <Wrapper>
           <SnapshotSidebarContent
-            groups={groups}
+            sections={sections}
             searchQuery=""
             onSearchChange={noop}
             onSelectItem={noop}
@@ -103,7 +113,7 @@ describe('SnapshotSidebarContent', () => {
       () => (
         <Wrapper>
           <SnapshotSidebarContent
-            groups={[]}
+            sections={[]}
             searchQuery="missing"
             onSearchChange={noop}
             onSelectItem={noop}

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -1,11 +1,12 @@
 import {memo, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Disclosure} from '@sentry/scraps/disclosure';
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {IconChevron, IconSearch} from 'sentry/icons';
+import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
 
@@ -38,8 +39,8 @@ const STATUS_PILLS: ReadonlyArray<{
   status: DiffStatus;
 }> = [
   {status: DiffStatus.CHANGED, color: 'accent', label: t('modified')},
-  {status: DiffStatus.ADDED, color: 'success', label: t('added')},
   {status: DiffStatus.REMOVED, color: 'danger', label: t('removed')},
+  {status: DiffStatus.ADDED, color: 'success', label: t('added')},
   {status: DiffStatus.RENAMED, color: 'warning', label: t('renamed')},
   {status: DiffStatus.UNCHANGED, color: 'muted', label: t('unchanged')},
 ];
@@ -99,10 +100,10 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
   }, [activeItemKey]);
 
   const [collapsed, setCollapsed] = useState<Set<DiffStatus>>(() => new Set());
-  const toggleCollapsed = (type: DiffStatus) => {
+  const toggleSection = (type: DiffStatus, expanded: boolean) => {
     setCollapsed(prev => {
       const next = new Set(prev);
-      if (next.has(type)) {
+      if (expanded) {
         next.delete(type);
       } else {
         next.add(type);
@@ -162,53 +163,58 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
           const meta = sectionType ? STATUS_META[sectionType] : null;
           const isCollapsed = !!sectionType && collapsed.has(sectionType);
           const showHeader = !!meta && !!sectionType && sections.length > 1;
+          const items = section.groups.map(group => {
+            const isActive = group.key === activeItemKey;
+            return (
+              <SidebarItemRow
+                key={group.key}
+                data-item-key={group.key}
+                isSelected={isActive}
+                indented={showHeader}
+                onClick={e => {
+                  e.stopPropagation();
+                  onSelectItem(group.key);
+                }}
+              >
+                <Flex align="center" gap="sm" flex="1" minWidth="0">
+                  <Text
+                    size="md"
+                    variant={isActive ? 'accent' : 'muted'}
+                    bold={isActive}
+                    ellipsis
+                    onPointerEnter={setTitleOnOverflow}
+                  >
+                    {group.name}
+                  </Text>
+                </Flex>
+                <CountBadge>
+                  <Text variant="muted" size="xs">
+                    {group.count}
+                  </Text>
+                </CountBadge>
+              </SidebarItemRow>
+            );
+          });
+          if (!showHeader) {
+            return <Stack key={sectionType ?? 'solo'}>{items}</Stack>;
+          }
           return (
-            <Stack key={sectionType ?? 'solo'}>
-              {showHeader && meta && sectionType && (
-                <SectionHeader onClick={() => toggleCollapsed(sectionType)}>
-                  <ChevronWrapper isCollapsed={isCollapsed}>
-                    <IconChevron size="xs" direction="down" />
-                  </ChevronWrapper>
+            <SectionDisclosure
+              key={sectionType}
+              size="xs"
+              expanded={!isCollapsed}
+              onExpandedChange={expanded => toggleSection(sectionType, expanded)}
+            >
+              <Disclosure.Title>
+                <Flex align="center" gap="sm">
                   <Dot pillColor={meta.color} active />
                   <Text size="sm" bold>
                     {meta.label}
                   </Text>
-                </SectionHeader>
-              )}
-              {!isCollapsed &&
-                section.groups.map(group => {
-                  const isActive = group.key === activeItemKey;
-                  return (
-                    <SidebarItemRow
-                      key={group.key}
-                      data-item-key={group.key}
-                      isSelected={isActive}
-                      indented={showHeader}
-                      onClick={e => {
-                        e.stopPropagation();
-                        onSelectItem(group.key);
-                      }}
-                    >
-                      <Flex align="center" gap="sm" flex="1" minWidth="0">
-                        <Text
-                          size="md"
-                          variant={isActive ? 'accent' : 'muted'}
-                          bold={isActive}
-                          ellipsis
-                          onPointerEnter={setTitleOnOverflow}
-                        >
-                          {group.name}
-                        </Text>
-                      </Flex>
-                      <CountBadge>
-                        <Text variant="muted" size="xs">
-                          {group.count}
-                        </Text>
-                      </CountBadge>
-                    </SidebarItemRow>
-                  );
-                })}
-            </Stack>
+                </Flex>
+              </Disclosure.Title>
+              {!isCollapsed && items}
+            </SectionDisclosure>
           );
         })}
         {!hasGroups && (
@@ -301,27 +307,18 @@ const CountBadge = styled('div')`
   background: ${p => p.theme.tokens.background.secondary};
 `;
 
-const SectionHeader = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.sm};
-  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
-  cursor: pointer;
-  user-select: none;
+const SectionDisclosure = styled(Disclosure)`
+  width: 100%;
+  align-items: stretch;
 
-  &:hover {
-    background: ${p => p.theme.tokens.background.secondary};
+  > :first-child {
+    padding-right: 0;
+    border-radius: 0;
+
+    > button {
+      border-radius: 0;
+    }
   }
-`;
-
-const ChevronWrapper = styled('span')<{isCollapsed: boolean}>`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 8px;
-  overflow: hidden;
-  transition: transform 100ms ease;
-  transform: rotate(${p => (p.isCollapsed ? '-90deg' : '0deg')});
 `;
 
 const SidebarItemRow = styled('div')<{indented: boolean; isSelected: boolean}>`

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -1,24 +1,29 @@
-import {useEffect, useRef} from 'react';
+import {memo, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {IconSearch} from 'sentry/icons';
+import {IconChevron, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
 
-export interface SidebarGroup {
+interface SidebarGroup {
   count: number;
   key: string;
   name: string;
 }
 
+export interface SidebarSection {
+  groups: SidebarGroup[];
+  type?: DiffStatus;
+}
+
 export const DIFF_TYPE_ORDER: Record<string, number> = {
   [DiffStatus.CHANGED]: 0,
-  [DiffStatus.ADDED]: 1,
-  [DiffStatus.REMOVED]: 2,
+  [DiffStatus.REMOVED]: 1,
+  [DiffStatus.ADDED]: 2,
   [DiffStatus.RENAMED]: 3,
   [DiffStatus.UNCHANGED]: 4,
 };
@@ -39,20 +44,28 @@ const STATUS_PILLS: ReadonlyArray<{
   {status: DiffStatus.UNCHANGED, color: 'muted', label: t('unchanged')},
 ];
 
+const STATUS_META: Record<DiffStatus, {color: PillColor; label: string}> = {
+  [DiffStatus.CHANGED]: {color: 'accent', label: t('Modified')},
+  [DiffStatus.ADDED]: {color: 'success', label: t('Added')},
+  [DiffStatus.REMOVED]: {color: 'danger', label: t('Removed')},
+  [DiffStatus.RENAMED]: {color: 'warning', label: t('Renamed')},
+  [DiffStatus.UNCHANGED]: {color: 'muted', label: t('Unchanged')},
+};
+
 interface SnapshotSidebarContentProps {
   activeStatuses: Set<DiffStatus>;
-  groups: SidebarGroup[];
   onSearchChange: (query: string) => void;
-  onSelectItem: (key: string) => void;
+  onSelectItem: (itemKey: string) => void;
   onToggleStatus: (status: DiffStatus) => void;
   searchQuery: string;
-  activeGroupName?: string | null;
+  sections: SidebarSection[];
+  activeItemKey?: string | null;
   statusCounts?: StatusCounts | null;
 }
 
-export function SnapshotSidebarContent({
-  groups,
-  activeGroupName,
+export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
+  sections,
+  activeItemKey,
   searchQuery,
   onSearchChange,
   onSelectItem,
@@ -67,11 +80,11 @@ export function SnapshotSidebarContent({
 
   useEffect(() => {
     const container = listRef.current;
-    if (!container || !activeGroupName) {
+    if (!container || !activeItemKey) {
       return;
     }
     const el = container.querySelector<HTMLElement>(
-      `[data-item-name="${CSS.escape(activeGroupName)}"]`
+      `[data-item-key="${CSS.escape(activeItemKey)}"]`
     );
     if (!el) {
       return;
@@ -83,39 +96,22 @@ export function SnapshotSidebarContent({
     } else if (eRect.bottom > cRect.bottom) {
       container.scrollTop += eRect.bottom - cRect.bottom;
     }
-  }, [activeGroupName]);
+  }, [activeItemKey]);
 
-  const renderGroup = (group: SidebarGroup) => {
-    const isActive = group.key === activeGroupName;
-    return (
-      <SidebarItemRow
-        key={group.key}
-        data-item-name={group.key}
-        isSelected={isActive}
-        onClick={e => {
-          e.stopPropagation();
-          onSelectItem(group.key);
-        }}
-      >
-        <Flex align="center" gap="sm" flex="1" minWidth="0">
-          <Text
-            size="md"
-            variant={isActive ? 'accent' : 'muted'}
-            bold={isActive}
-            ellipsis
-            onPointerEnter={setTitleOnOverflow}
-          >
-            {group.name}
-          </Text>
-        </Flex>
-        <CountBadge>
-          <Text variant="muted" size="xs">
-            {group.count}
-          </Text>
-        </CountBadge>
-      </SidebarItemRow>
-    );
+  const [collapsed, setCollapsed] = useState<Set<DiffStatus>>(() => new Set());
+  const toggleCollapsed = (type: DiffStatus) => {
+    setCollapsed(prev => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
   };
+
+  const hasGroups = sections.some(s => s.groups.length > 0);
 
   return (
     <Stack height="100%" width="100%">
@@ -158,8 +154,64 @@ export function SnapshotSidebarContent({
         )}
       </Stack>
       <Stack ref={listRef} overflow="auto" flex="1" paddingRight="0">
-        {groups.map(renderGroup)}
-        {groups.length === 0 && (
+        {sections.map(section => {
+          if (section.groups.length === 0) {
+            return null;
+          }
+          const sectionType = section.type;
+          const meta = sectionType ? STATUS_META[sectionType] : null;
+          const isCollapsed = !!sectionType && collapsed.has(sectionType);
+          const showHeader = !!meta && !!sectionType && sections.length > 1;
+          return (
+            <Stack key={sectionType ?? 'solo'}>
+              {showHeader && meta && sectionType && (
+                <SectionHeader onClick={() => toggleCollapsed(sectionType)}>
+                  <ChevronWrapper isCollapsed={isCollapsed}>
+                    <IconChevron size="xs" direction="down" />
+                  </ChevronWrapper>
+                  <Dot pillColor={meta.color} active />
+                  <Text size="sm" bold>
+                    {meta.label}
+                  </Text>
+                </SectionHeader>
+              )}
+              {!isCollapsed &&
+                section.groups.map(group => {
+                  const isActive = group.key === activeItemKey;
+                  return (
+                    <SidebarItemRow
+                      key={group.key}
+                      data-item-key={group.key}
+                      isSelected={isActive}
+                      indented={showHeader}
+                      onClick={e => {
+                        e.stopPropagation();
+                        onSelectItem(group.key);
+                      }}
+                    >
+                      <Flex align="center" gap="sm" flex="1" minWidth="0">
+                        <Text
+                          size="md"
+                          variant={isActive ? 'accent' : 'muted'}
+                          bold={isActive}
+                          ellipsis
+                          onPointerEnter={setTitleOnOverflow}
+                        >
+                          {group.name}
+                        </Text>
+                      </Flex>
+                      <CountBadge>
+                        <Text variant="muted" size="xs">
+                          {group.count}
+                        </Text>
+                      </CountBadge>
+                    </SidebarItemRow>
+                  );
+                })}
+            </Stack>
+          );
+        })}
+        {!hasGroups && (
           <Flex align="center" justify="center" padding="lg">
             <Text variant="muted" size="sm">
               {t('No components found.')}
@@ -169,7 +221,7 @@ export function SnapshotSidebarContent({
       </Stack>
     </Stack>
   );
-}
+});
 
 function StatusPill({
   color,
@@ -214,10 +266,10 @@ const PillButton = styled('button')<{active: boolean}>`
   }
 `;
 
-const Dot = styled('span')<{active: boolean; pillColor: PillColor}>`
+const Dot = styled('span')<{active: boolean; pillColor: PillColor; dotSize?: number}>`
   display: inline-block;
-  width: 8px;
-  height: 8px;
+  width: ${p => p.dotSize ?? 6}px;
+  height: ${p => p.dotSize ?? 6}px;
   border-radius: 50%;
   background: ${p => {
     if (!p.active) {
@@ -249,10 +301,37 @@ const CountBadge = styled('div')`
   background: ${p => p.theme.tokens.background.secondary};
 `;
 
-const SidebarItemRow = styled('div')<{isSelected: boolean}>`
+const SectionHeader = styled('div')`
   display: flex;
   align-items: center;
-  padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
+  gap: ${p => p.theme.space.sm};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
+  cursor: pointer;
+  user-select: none;
+
+  &:hover {
+    background: ${p => p.theme.tokens.background.secondary};
+  }
+`;
+
+const ChevronWrapper = styled('span')<{isCollapsed: boolean}>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 8px;
+  overflow: hidden;
+  transition: transform 100ms ease;
+  transform: rotate(${p => (p.isCollapsed ? '-90deg' : '0deg')});
+`;
+
+const SidebarItemRow = styled('div')<{indented: boolean; isSelected: boolean}>`
+  display: flex;
+  align-items: center;
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
+  padding-left: ${p =>
+    p.indented
+      ? `calc(${p.theme.space.xl} + 8px + ${p.theme.space.sm})`
+      : p.theme.space.xl};
   gap: ${p => p.theme.space.sm};
   cursor: pointer;
   border-right: 3px solid

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -709,14 +709,30 @@ export default function SnapshotsPage() {
   );
 }
 
+const TOOLBAR_HEIGHT = '45px';
+
 const DragHandle = styled('div')`
+  position: relative;
   display: grid;
   place-items: center;
   width: ${p => p.theme.space.xl};
   height: 100%;
   cursor: ew-resize;
   user-select: inherit;
-  background: ${p => p.theme.tokens.background.secondary};
+  background: linear-gradient(
+    to bottom,
+    ${p => p.theme.tokens.background.primary} ${TOOLBAR_HEIGHT},
+    ${p => p.theme.tokens.background.secondary} ${TOOLBAR_HEIGHT}
+  );
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: ${TOOLBAR_HEIGHT};
+    left: 0;
+    right: 0;
+    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  }
 
   &:hover {
     background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -1,4 +1,12 @@
-import {startTransition, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from 'react';
+import {
+  startTransition,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {parseAsArrayOf, parseAsString, parseAsStringLiteral, useQueryState} from 'nuqs';
@@ -302,14 +310,11 @@ export default function SnapshotsPage() {
   const filteredItems = useMemo(() => {
     const hasStatusFilter = activeStatuses.size > 0;
     const base = hasStatusFilter
-      ? searchFilteredItems.filter(item =>
-          activeStatuses.has(item.type as DiffStatus)
-        )
+      ? searchFilteredItems.filter(item => activeStatuses.has(item.type as DiffStatus))
       : searchFilteredItems;
 
     return [...base].sort((a, b) => {
-      const typeOrder =
-        (DIFF_TYPE_ORDER[a.type] ?? 99) - (DIFF_TYPE_ORDER[b.type] ?? 99);
+      const typeOrder = (DIFF_TYPE_ORDER[a.type] ?? 99) - (DIFF_TYPE_ORDER[b.type] ?? 99);
       if (typeOrder !== 0) {
         return typeOrder;
       }
@@ -340,7 +345,10 @@ export default function SnapshotsPage() {
       DiffStatus.RENAMED,
       DiffStatus.UNCHANGED,
     ];
-    const byType = new Map<DiffStatus, Array<{count: number; key: string; name: string}>>();
+    const byType = new Map<
+      DiffStatus,
+      Array<{count: number; key: string; name: string}>
+    >();
     for (const type of sectionOrder) {
       byType.set(type, []);
     }

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from 'react';
+import {startTransition, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {parseAsArrayOf, parseAsString, parseAsStringLiteral, useQueryState} from 'nuqs';
@@ -36,7 +36,7 @@ import type {SnapshotListViewHandle} from './main/snapshotListView';
 import {type NavButtonRefs, SnapshotMainContent} from './main/snapshotMainContent';
 import {
   DIFF_TYPE_ORDER,
-  type SidebarGroup,
+  type SidebarSection,
   SnapshotSidebarContent,
 } from './sidebar/snapshotSidebarContent';
 
@@ -152,11 +152,12 @@ export default function SnapshotsPage() {
       .withDefault('list')
       .withOptions(pushHistory)
   );
+  const replaceHistory = {history: 'replace' as const};
   const [activeStatusList, setActiveStatusList] = useQueryState(
     'selectedTypes',
     parseAsArrayOf(parseAsStringLiteral(Object.values(DiffStatus)))
       .withDefault([])
-      .withOptions(pushHistory)
+      .withOptions(replaceHistory)
   );
   const [selectedSnapshotKey, setSelectedSnapshotKey] = useQueryState(
     'selectedSnapshot',
@@ -172,14 +173,18 @@ export default function SnapshotsPage() {
 
   const handleToggleStatus = useCallback(
     (status: DiffStatus) => {
-      setActiveStatusList(prev => {
-        if (prev.length === 0) {
-          return [status];
-        }
-        if (prev.length === 1 && prev[0] === status) {
-          return [];
-        }
-        return prev.includes(status) ? prev.filter(s => s !== status) : [...prev, status];
+      startTransition(() => {
+        setActiveStatusList(prev => {
+          if (prev.length === 0) {
+            return [status];
+          }
+          if (prev.length === 1 && prev[0] === status) {
+            return [];
+          }
+          return prev.includes(status)
+            ? prev.filter(s => s !== status)
+            : [...prev, status];
+        });
       });
     },
     [setActiveStatusList]
@@ -275,11 +280,8 @@ export default function SnapshotsPage() {
     [sidebarItems]
   );
 
-  const deferredSearchQuery = useDeferredValue(searchQuery);
-  const deferredActiveStatuses = useDeferredValue(activeStatuses);
-
   const searchFilteredItems = useMemo(() => {
-    const trimmedQuery = deferredSearchQuery.trim().toLowerCase();
+    const trimmedQuery = searchQuery.trim().toLowerCase();
     if (!trimmedQuery) {
       return sidebarItems;
     }
@@ -295,48 +297,64 @@ export default function SnapshotsPage() {
       }
     }
     return result;
-  }, [sidebarItems, memberSearchKeys, deferredSearchQuery]);
+  }, [sidebarItems, memberSearchKeys, searchQuery]);
 
   const filteredItems = useMemo(() => {
-    const hasStatusFilter = deferredActiveStatuses.size > 0;
+    const hasStatusFilter = activeStatuses.size > 0;
     const base = hasStatusFilter
       ? searchFilteredItems.filter(item =>
-          deferredActiveStatuses.has(item.type as DiffStatus)
+          activeStatuses.has(item.type as DiffStatus)
         )
       : searchFilteredItems;
 
-    if (sortBy === 'alpha') {
-      return [...base].sort((a, b) => a.name.localeCompare(b.name));
-    }
     return [...base].sort((a, b) => {
-      const diffA = itemMaxDiff(a);
-      const diffB = itemMaxDiff(b);
-      if (diffA !== diffB) {
-        return diffB - diffA;
+      const typeOrder =
+        (DIFF_TYPE_ORDER[a.type] ?? 99) - (DIFF_TYPE_ORDER[b.type] ?? 99);
+      if (typeOrder !== 0) {
+        return typeOrder;
       }
-      return (DIFF_TYPE_ORDER[a.type] ?? 99) - (DIFF_TYPE_ORDER[b.type] ?? 99);
+      if (sortBy === 'diff') {
+        const diffDelta = itemMaxDiff(b) - itemMaxDiff(a);
+        if (diffDelta !== 0) {
+          return diffDelta;
+        }
+      }
+      return a.name.localeCompare(b.name);
     });
-  }, [searchFilteredItems, deferredActiveStatuses, sortBy]);
+  }, [searchFilteredItems, activeStatuses, sortBy]);
 
-  const sidebarGroups = useMemo<SidebarGroup[]>(() => {
-    const merged = new Map<string, SidebarGroup>();
-    for (const item of filteredItems) {
-      const existing = merged.get(item.name);
-      const count =
-        item.type === 'changed' || item.type === 'renamed'
-          ? item.pairs.length
-          : item.images.length;
-      if (existing) {
-        existing.count += count;
-      } else {
-        merged.set(item.name, {key: item.name, name: item.name, count});
-      }
+  const sidebarSections = useMemo<SidebarSection[]>(() => {
+    function toGroup(item: SidebarItem) {
+      return {key: item.key, name: item.name, count: itemVariantCount(item)};
     }
-    return [...merged.values()];
-  }, [filteredItems]);
 
+    if (comparisonType !== 'diff') {
+      const groups = filteredItems.map(toGroup);
+      return groups.length > 0 ? [{groups}] : [];
+    }
+
+    const sectionOrder = [
+      DiffStatus.CHANGED,
+      DiffStatus.REMOVED,
+      DiffStatus.ADDED,
+      DiffStatus.RENAMED,
+      DiffStatus.UNCHANGED,
+    ];
+    const byType = new Map<DiffStatus, Array<{count: number; key: string; name: string}>>();
+    for (const type of sectionOrder) {
+      byType.set(type, []);
+    }
+    for (const item of filteredItems) {
+      byType.get(item.type as DiffStatus)?.push(toGroup(item));
+    }
+    return sectionOrder
+      .filter(type => byType.get(type)!.length > 0)
+      .map(type => ({type, groups: byType.get(type)!}));
+  }, [filteredItems, comparisonType]);
+
+  const deferredFilteredItems = useDeferredValue(filteredItems);
   const currentItem = filteredItems[0] ?? null;
-  const listItems = filteredItems;
+  const listItems = deferredFilteredItems;
 
   const statusCounts = useMemo<Record<DiffStatus, number> | null>(() => {
     if (comparisonType !== 'diff') {
@@ -358,11 +376,11 @@ export default function SnapshotsPage() {
   }, [searchFilteredItems, comparisonType]);
 
   const listViewRef = useRef<SnapshotListViewHandle>(null);
-  const [visibleGroupName, setVisibleGroupName] = useState<string | null>(null);
+  const [visibleItemKey, setVisibleItemKey] = useState<string | null>(null);
 
   const handleSelectItem = useCallback(
-    (name: string) => {
-      const item = filteredItems.find(i => i.name === name);
+    (itemKey: string) => {
+      const item = filteredItems.find(i => i.key === itemKey);
       if (!item) {
         return;
       }
@@ -370,7 +388,7 @@ export default function SnapshotsPage() {
       if (key) {
         setSelectedSnapshotKey(key);
       }
-      listViewRef.current?.scrollToGroup(name);
+      listViewRef.current?.scrollToGroup(itemKey);
     },
     [filteredItems, setSelectedSnapshotKey]
   );
@@ -547,8 +565,8 @@ export default function SnapshotsPage() {
       : deferredItem;
   const singleViewVariantIndex = singleViewPosition?.variantIdx ?? 0;
 
-  const activeGroupName =
-    viewMode === 'list' ? visibleGroupName : (singleViewItem?.name ?? null);
+  const activeItemKey =
+    viewMode === 'list' ? visibleItemKey : (singleViewItem?.key ?? null);
 
   const isComparisonProcessing =
     !!comparisonRunInfo?.state &&
@@ -588,8 +606,8 @@ export default function SnapshotsPage() {
         }}
       >
         <SnapshotSidebarContent
-          groups={sidebarGroups}
-          activeGroupName={activeGroupName}
+          sections={sidebarSections}
+          activeItemKey={activeItemKey}
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
           onSelectItem={handleSelectItem}
@@ -626,7 +644,7 @@ export default function SnapshotsPage() {
           headBranch={data?.vcs_info?.head_ref}
           selectedSnapshotKey={selectedSnapshotKey}
           onSelectSnapshot={setSelectedSnapshotKey}
-          onVisibleGroupChange={setVisibleGroupName}
+          onVisibleGroupChange={setVisibleItemKey}
           sortBy={sortBy}
           onSortByChange={setSortBy}
           onNavigateSingleView={navigateSingleView}


### PR DESCRIPTION
## Summary

Refactors the snapshot sidebar from a flat list with an "All" toggle into collapsible sections grouped by diff status (Modified, Removed, Added, Renamed, Unchanged). The sidebar now tracks scroll position in the main list view bidirectionally — scrolling the list highlights the active group in the sidebar, and clicking a sidebar group scrolls the list to that group.

### Changes

- **Collapsible sidebar sections**: Groups are organized by diff status with section headers that can be collapsed/expanded. Removes the "All" / single-group selection model in favor of always showing the full list
- **Bidirectional scroll sync**: The sidebar highlights whichever group is currently visible in the list view, and clicking a sidebar item scrolls the list to that group via `useImperativeHandle` + `scrollToGroup`
- **Scroll progress indicator**: Adds a progress bar + counter (e.g. "3/42") to the list toolbar showing current position in the snapshot list
- **Sort stability**: Items are now always sorted by diff type first, then by the selected sort (diff % or alpha), so status sections stay grouped
- **Scroll handling**: Replaces React `onScroll` with a native `addEventListener` + `requestAnimationFrame` for better performance; increases virtualizer overscan from 2 to 5
- **Misc UI polish**: Fixes placeholder aspect ratio in lazy images, adds border-radius matching for selected overlay on first/last cards, simplifies search placeholder text

## Test plan

- [ ] Sidebar sections collapse and expand correctly
- [ ] Clicking a sidebar group scrolls the list view to that group
- [ ] Scrolling the list view updates the active sidebar highlight
- [ ] Progress bar and counter update while scrolling
- [ ] Status filter pills still filter correctly
- [ ] Single view mode still navigates correctly with keyboard
- [ ] Snapshot tests updated for new sidebar structure