### PR TITLE
fix(csp): Allow browser.sentry-cdn.com in connect-src

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -543,6 +543,7 @@ CSP_CONNECT_SRC = [
     "*.algolia.net",
     "*.algolianet.com",
     "*.algolia.io",
+    "browser.sentry-cdn.com",
 ]
 CSP_FRAME_ANCESTORS = [
     "'none'",


### PR DESCRIPTION
## Summary
- Add `browser.sentry-cdn.com` to the CSP `connect-src` allowlist in `src/sentry/conf/server.py`
- Fixes CSP violation blocking the sentry toolbar source map (`sentry-toolbar/1.0.0-beta.23/toolbar.min.js.map`)

Related to https://sentry.slack.com/archives/C078M6CS36K/p1777492327359559

## Test plan
- [ ] Verify the sentry toolbar loads without CSP `connect-src` violations in the browser console
- [ ] Confirm no other CSP directives are affected