### PR TITLE
fix(native): Prioritize rendered crash report thread

### DIFF
--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -222,12 +222,6 @@ class AppleCrashReport:
         exceptions = self.exceptions or []
         threads = self.threads or []
 
-        if self.prioritized_thread_id is not None:
-            threads = sorted(
-                threads,
-                key=lambda t: str(t.get("id")) != self.prioritized_thread_id,
-            )
-
         # Process threads first, tracking which ones produced output.
         # When an exception's thread_id matches a thread that produced
         # output, we skip the exception to avoid duplication (the thread
@@ -236,19 +230,23 @@ class AppleCrashReport:
         for thread_info in threads:
             thread_string = self.get_thread_apple_string(thread_info)
             if thread_string is not None:
-                rv.append(thread_string)
                 thread_id = thread_info.get("id")
+                rv.append((thread_id, thread_string))
                 if thread_id is not None:
                     output_thread_ids.add(thread_id)
 
         for exception_info in exceptions:
-            if exception_info.get("thread_id") in output_thread_ids:
+            thread_id = exception_info.get("thread_id")
+            if thread_id in output_thread_ids:
                 continue
             thread_string = self.get_thread_apple_string(exception_info)
             if thread_string is not None:
-                rv.append(thread_string)
+                rv.append((thread_id, thread_string))
 
-        return "\n\n".join(rv)
+        if self.prioritized_thread_id is not None:
+            rv.sort(key=lambda output: str(output[0]) != self.prioritized_thread_id)
+
+        return "\n\n".join(thread_string for _, thread_string in rv)
 
     def get_thread_apple_string(self, thread_info):
         rv = []

--- a/tests/sentry/api/endpoints/test_event_apple_crash_report.py
+++ b/tests/sentry/api/endpoints/test_event_apple_crash_report.py
@@ -1,0 +1,61 @@
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.skips import requires_snuba
+
+pytestmark = [requires_snuba]
+
+
+def _stacktrace(package: str) -> dict:
+    return {
+        "frames": [
+            {
+                "image_addr": "0x2c8000",
+                "instruction_addr": "0x31c3e8",
+                "symbol_addr": "0x31b9f8",
+                "package": package,
+            }
+        ]
+    }
+
+
+class EventAppleCrashReportTest(APITestCase):
+    endpoint = "sentry-api-0-event-apple-crash-report"
+
+    def test_prioritizes_thread_id(self) -> None:
+        self.login_as(self.user)
+        event = self.store_event(
+            data={
+                "platform": "native",
+                "timestamp": before_now(minutes=1).isoformat(),
+                "exception": {
+                    "values": [
+                        {
+                            "type": "EXC_BAD_ACCESS",
+                            "thread_id": 1874743,
+                            "mechanism": {"type": "mach"},
+                            "stacktrace": _stacktrace("/path/to/App.framework/App"),
+                        }
+                    ]
+                },
+                "threads": {
+                    "values": [
+                        {"id": 1874743},
+                        {
+                            "id": 965139,
+                            "stacktrace": _stacktrace("/path/to/Worker.framework/Worker"),
+                        },
+                    ]
+                },
+            },
+            project_id=self.project.id,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            event.event_id,
+            qs_params={"thread_id": "1874743"},
+        )
+        body = response.content.decode()
+
+        assert body.index("Thread 1874743") < body.index("Thread 965139")


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/114231.

That PR added `thread_id`, but it sorted the raw `threads` list before rendering. That missed Apple crash reports where the selected thread is just metadata and the actual stack trace is rendered from the exception, so the visible selected thread still landed after other threads.

This keeps the endpoint behavior, but sorts the rendered thread sections instead. Also adds a small endpoint test for the metadata-only thread shape that the first test missed.