### PR TITLE
feat(sentry-apps): Skip webhook dispatch for disabled sentry apps

### DIFF
--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -99,17 +99,19 @@ def _check_sentry_app_disabled(
     request: Request,
     sentry_app: SentryApp | RpcSentryApp,
 ) -> None:
+    if not options.get("sentry-apps.disabled-enforcement"):
+        return
+
     if not sentry_app.is_disabled:
         return
 
     if request.method in endpoint.allow_disabled_sentry_app_for_methods:
         return
 
-    if options.get("sentry-apps.disabled-enforcement"):
-        raise SentryAppError(
-            message="This Sentry App has been disabled",
-            status_code=403,
-        )
+    raise SentryAppError(
+        message="This Sentry App has been disabled",
+        status_code=403,
+    )
 
 
 class IntegrationPlatformEndpoint(Endpoint):

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -74,6 +74,7 @@ class SentryAppWebhookHaltReason(StrEnum):
     HARD_TIMEOUT = "hard_timeout"
     CIRCUIT_BROKEN = "circuit_broken"
     EMAIL_FAILED = "email_failed"
+    APP_DISABLED = "app_disabled"
 
 
 class SentryAppExternalRequestFailureReason(StrEnum):

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -13,7 +13,7 @@ from requests.exceptions import ChunkedEncodingError, ConnectionError, RequestEx
 from taskbroker_client.constants import CompressionType
 from taskbroker_client.retry import NoRetriesRemainingError, Retry, retry_task
 
-from sentry import analytics, nodestore
+from sentry import analytics, features, nodestore
 from sentry.analytics.events.alert_rule_ui_component_webhook_sent import (
     AlertRuleUiComponentWebhookSentEvent,
 )
@@ -45,6 +45,7 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.project import Project
 from sentry.notifications.utils.rules import get_rule_or_workflow_id
+from sentry.organizations.services.organization import organization_service
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.metrics import (
     SentryAppEventType,
@@ -56,7 +57,7 @@ from sentry.sentry_apps.metrics import (
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
-from sentry.sentry_apps.services.app.model import RpcSentryAppInstallation
+from sentry.sentry_apps.services.app.model import RpcSentryApp, RpcSentryAppInstallation
 from sentry.sentry_apps.services.app.service import (
     app_service,
     get_by_application_id,
@@ -213,6 +214,10 @@ def send_alert_webhook_v2(
         sentry_app = app_service.get_sentry_app_by_id(id=sentry_app_id)
         if sentry_app is None:
             raise SentryAppSentryError(message=SentryAppWebhookFailureReason.MISSING_SENTRY_APP)
+
+        if _is_sentry_app_disabled_for_webhooks(sentry_app):
+            lifecycle.record_halt(halt_reason=SentryAppWebhookHaltReason.APP_DISABLED)
+            return
 
         installations = app_service.get_many(
             filter=dict(
@@ -740,11 +745,29 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
         )
 
 
+def _is_sentry_app_disabled_for_webhooks(sentry_app: RpcSentryApp) -> bool:
+    if not sentry_app.is_disabled:
+        return False
+    owner_context = organization_service.get_organization_by_id(
+        id=sentry_app.owner_id, user_id=None, include_projects=False, include_teams=False
+    )
+    if owner_context and features.has(
+        "organizations:sentry-app-disabled-enforcement",
+        owner_context.organization,
+    ):
+        return True
+    return False
+
+
 def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: Any) -> None:
     with SentryAppInteractionEvent(
         operation_type=SentryAppInteractionType.SEND_WEBHOOK,
         event_type=SentryAppEventType(event),
     ).capture() as lifecycle:
+        if _is_sentry_app_disabled_for_webhooks(installation.sentry_app):
+            lifecycle.record_halt(halt_reason=SentryAppWebhookHaltReason.APP_DISABLED)
+            return
+
         servicehook: ServiceHook | None = _load_service_hook(
             installation.organization_id, installation.id
         )
@@ -962,6 +985,10 @@ def send_metric_alert_webhook(
         sentry_app = app_service.get_sentry_app_by_id(id=sentry_app_id)
         if sentry_app is None:
             lifecycle.record_failure(SentryAppWebhookFailureReason.MISSING_SENTRY_APP)
+            return
+
+        if _is_sentry_app_disabled_for_webhooks(sentry_app):
+            lifecycle.record_halt(halt_reason=SentryAppWebhookHaltReason.APP_DISABLED)
             return
 
         installations = app_service.get_many(

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -13,7 +13,7 @@ from requests.exceptions import ChunkedEncodingError, ConnectionError, RequestEx
 from taskbroker_client.constants import CompressionType
 from taskbroker_client.retry import NoRetriesRemainingError, Retry, retry_task
 
-from sentry import analytics, features, nodestore
+from sentry import analytics, nodestore, options
 from sentry.analytics.events.alert_rule_ui_component_webhook_sent import (
     AlertRuleUiComponentWebhookSentEvent,
 )
@@ -45,7 +45,6 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.project import Project
 from sentry.notifications.utils.rules import get_rule_or_workflow_id
-from sentry.organizations.services.organization import organization_service
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.metrics import (
     SentryAppEventType,
@@ -748,15 +747,7 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
 def _is_sentry_app_disabled_for_webhooks(sentry_app: RpcSentryApp) -> bool:
     if not sentry_app.is_disabled:
         return False
-    owner_context = organization_service.get_organization_by_id(
-        id=sentry_app.owner_id, user_id=None, include_projects=False, include_teams=False
-    )
-    if owner_context and features.has(
-        "organizations:sentry-app-disabled-enforcement",
-        owner_context.organization,
-    ):
-        return True
-    return False
+    return options.get("sentry-apps.disabled-enforcement")
 
 
 def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: Any) -> None:

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -745,9 +745,9 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
 
 
 def _is_sentry_app_disabled_for_webhooks(sentry_app: RpcSentryApp) -> bool:
-    if not sentry_app.is_disabled:
+    if not options.get("sentry-apps.disabled-enforcement"):
         return False
-    return options.get("sentry-apps.disabled-enforcement")
+    return sentry_app.is_disabled
 
 
 def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: Any) -> None:

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -51,6 +51,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -2111,7 +2112,7 @@ class TestSendMetricAlertWebhook(TestCase):
         assert len(ui_component_calls) == 0
 
 
-FEATURE_FLAG = "organizations:sentry-app-disabled-enforcement"
+DISABLED_OPTION = {"sentry-apps.disabled-enforcement": True}
 
 
 def disable_app(app: SentryApp) -> None:
@@ -2132,7 +2133,7 @@ class TestDisabledSentryAppWebhooks(TestCase):
         )
         self.issue = self.create_group(project=self.project)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(DISABLED_OPTION)
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_workflow_notification_blocked_for_disabled_app(
@@ -2145,7 +2146,7 @@ class TestDisabledSentryAppWebhooks(TestCase):
             mock_record=mock_record, error_msg=SentryAppWebhookHaltReason.APP_DISABLED
         )
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(DISABLED_OPTION)
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_send_alert_webhook_v2_blocked_for_disabled_app(
@@ -2166,7 +2167,7 @@ class TestDisabledSentryAppWebhooks(TestCase):
             mock_record=mock_record, error_msg=SentryAppWebhookHaltReason.APP_DISABLED
         )
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(DISABLED_OPTION)
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_send_metric_alert_webhook_blocked_for_disabled_app(

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -2109,3 +2109,94 @@ class TestSendMetricAlertWebhook(TestCase):
             if isinstance(call.args[0], AlertRuleUiComponentWebhookSentEvent)
         ]
         assert len(ui_component_calls) == 0
+
+
+FEATURE_FLAG = "organizations:sentry-app-disabled-enforcement"
+
+
+def disable_app(app: SentryApp) -> None:
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        app.update(is_disabled=True)
+
+
+class TestDisabledSentryAppWebhooks(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project()
+        self.user = self.create_user()
+        self.sentry_app = self.create_sentry_app(
+            organization=self.project.organization,
+            events=["issue.resolved", "issue.ignored", "issue.assigned"],
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.project.organization, slug=self.sentry_app.slug
+        )
+        self.issue = self.create_group(project=self.project)
+
+    @with_feature(FEATURE_FLAG)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_workflow_notification_blocked_for_disabled_app(
+        self, mock_record: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
+        disable_app(self.sentry_app)
+        workflow_notification(self.install.id, self.issue.id, "resolved", self.user.id)
+        assert not safe_urlopen.called
+        assert_halt_metric(
+            mock_record=mock_record, error_msg=SentryAppWebhookHaltReason.APP_DISABLED
+        )
+
+    @with_feature(FEATURE_FLAG)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_send_alert_webhook_v2_blocked_for_disabled_app(
+        self, mock_record: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+        disable_app(self.sentry_app)
+        send_alert_webhook_v2(
+            instance_id=event.event_id,
+            group_id=event.group.id,
+            occurrence_id=None,
+            rule_label="Test Rule",
+            sentry_app_id=self.sentry_app.id,
+        )
+        assert not safe_urlopen.called
+        assert_halt_metric(
+            mock_record=mock_record, error_msg=SentryAppWebhookHaltReason.APP_DISABLED
+        )
+
+    @with_feature(FEATURE_FLAG)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_send_metric_alert_webhook_blocked_for_disabled_app(
+        self, mock_record: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
+        disable_app(self.sentry_app)
+        send_metric_alert_webhook(
+            sentry_app_id=self.sentry_app.id,
+            new_status=IncidentStatus.CRITICAL.value,
+            incident_attachment_json=json.dumps(
+                {
+                    "metric_alert": {"alert_rule": {"triggers": []}},
+                    "description_text": "Something went wrong",
+                    "description_title": "Test Alert",
+                    "web_url": "http://example.com/alert/1",
+                }
+            ),
+            organization_id=self.project.organization.id,
+            project_id=self.project.id,
+            alert_id=42,
+        )
+        assert not safe_urlopen.called
+        assert_halt_metric(
+            mock_record=mock_record, error_msg=SentryAppWebhookHaltReason.APP_DISABLED
+        )
+
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    def test_workflow_notification_still_sends_without_feature_flag(
+        self, safe_urlopen: MagicMock
+    ) -> None:
+        disable_app(self.sentry_app)
+        workflow_notification(self.install.id, self.issue.id, "resolved", self.user.id)
+        assert safe_urlopen.called


### PR DESCRIPTION
Skip webhook delivery when a sentry app has `is_disabled=True` and the `sentry-apps.disabled-enforcement` option is enabled. Adds early-return checks in `send_webhooks`, `send_alert_webhook_v2`, and `send_metric_alert_webhook`.

Installation lifecycle webhooks (install/uninstall) are intentionally not blocked — those are needed for cleanup flows.

Depends on #114263 (merged) and #114469.

Refs ISWF-1234