### PR TITLE
fix(tests): deflake versionHoverCard render test

### DIFF
--- a/static/app/components/versionHoverCard.spec.tsx
+++ b/static/app/components/versionHoverCard.spec.tsx
@@ -4,7 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {ReleaseFixture} from 'sentry-fixture/release';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {VersionHoverCard} from './versionHoverCard';
 
@@ -31,19 +31,19 @@ describe('VersionHoverCard', () => {
     });
   });
 
-  it.isKnownFlake('renders', async () => {
+  it('renders', async () => {
     render(
       <VersionHoverCard
         organization={organization}
         projectSlug={project.slug}
         releaseVersion={release.version}
+        forceVisible
       >
         <div>{release.version}</div>
       </VersionHoverCard>
     );
 
     expect(await screen.findByText(release.version)).toBeInTheDocument();
-    await userEvent.hover(screen.getByText(release.version));
 
     expect(await screen.findByText(deploy.environment)).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Package'})).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Remove `isKnownFlake` marker from the `renders` test in `versionHoverCard.spec.tsx`
- Use `forceVisible` prop on `VersionHoverCard` to bypass hovercard show delay, eliminating the race condition where `userEvent.hover` could resolve before the hovercard and its 3 async API calls completed
- Remove now-unnecessary `userEvent.hover` call and unused `userEvent` import

## Test plan
- [ ] CI passes the previously flaky test reliably