### PR TITLE
fix(tests): deflake stackTrace tooltip URL test

### DIFF
--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -961,8 +961,8 @@ describe('Core StackTrace', () => {
     ).toBeInTheDocument();
   });
 
-  it.isKnownFlake('shows URL link in tooltip when absPath is an http URL', async () => {
-    jest.useFakeTimers();
+  it('shows URL link in tooltip when absPath is an http URL', async () => {
+    jest.useFakeTimers({advanceTimers: true});
     const {event, stacktrace} = makeStackTraceData();
     const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
 


### PR DESCRIPTION
## Summary
- Remove `it.isKnownFlake` marker from the "shows URL link in tooltip when absPath is an http URL" test
- Change `jest.useFakeTimers()` to `jest.useFakeTimers({advanceTimers: true})` so that `findByRole`'s internal retry `setTimeout` calls are not frozen by fake timers, which was causing a deadlock and making the test flaky

## Test plan
- [ ] CI passes the previously flaky test reliably