### PR TITLE
fix(tests): deflake eventReplay upsell test

### DIFF
--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -145,7 +145,7 @@ describe('EventReplay', () => {
     });
   });
 
-  it('should render the replay inline onboarding component when replays are enabled and the project supports replay', async () => {
+  it.isKnownFlake('should render the replay inline onboarding component when replays are enabled and the project supports replay', async () => {
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({
       activateSidebar: jest.fn(),
     });

--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -145,19 +145,22 @@ describe('EventReplay', () => {
     });
   });
 
-  it.isKnownFlake('should render the replay inline onboarding component when replays are enabled and the project supports replay', async () => {
-    MockUseReplayOnboardingSidebarPanel.mockReturnValue({
-      activateSidebar: jest.fn(),
-    });
-    jest.mocked(useEventCanShowReplayUpsell).mockReturnValue({
-      canShowUpsell: true,
-      upsellPlatform: 'javascript',
-      upsellProjectId: '1',
-    });
-    render(<EventReplay {...defaultProps} />, {organization});
+  it.isKnownFlake(
+    'should render the replay inline onboarding component when replays are enabled and the project supports replay',
+    async () => {
+      MockUseReplayOnboardingSidebarPanel.mockReturnValue({
+        activateSidebar: jest.fn(),
+      });
+      jest.mocked(useEventCanShowReplayUpsell).mockReturnValue({
+        canShowUpsell: true,
+        upsellPlatform: 'javascript',
+        upsellProjectId: '1',
+      });
+      render(<EventReplay {...defaultProps} />, {organization});
 
-    expect(await screen.findByTestId('replay-inline-onboarding')).toBeInTheDocument();
-  });
+      expect(await screen.findByTestId('replay-inline-onboarding')).toBeInTheDocument();
+    }
+  );
 
   it('should render a replay when there is a replayId from tags', async () => {
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({

--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -11,6 +11,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {EventReplay} from 'sentry/components/events/eventReplay';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {useEventCanShowReplayUpsell} from 'sentry/utils/event/useEventCanShowReplayUpsell';
 import {useLoadReplayReader} from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import {
   useHaveSelectedProjectsSentAnyReplayEvents,
@@ -21,6 +22,7 @@ import type {RawReplayError} from 'sentry/utils/replays/types';
 
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
 jest.mock('sentry/utils/replays/hooks/useLoadReplayReader');
+jest.mock('sentry/utils/event/useEventCanShowReplayUpsell');
 // Replay clip preview is very heavy, mock it out
 jest.mock(
   'sentry/components/events/eventReplay/replayClipPreview',
@@ -135,19 +137,27 @@ describe('EventReplay', () => {
       hasSentOneReplay: false,
       fetching: false,
     });
+
+    jest.mocked(useEventCanShowReplayUpsell).mockReturnValue({
+      canShowUpsell: false,
+      upsellPlatform: undefined,
+      upsellProjectId: undefined,
+    });
   });
 
-  it.isKnownFlake(
-    'should render the replay inline onboarding component when replays are enabled and the project supports replay',
-    async () => {
-      MockUseReplayOnboardingSidebarPanel.mockReturnValue({
-        activateSidebar: jest.fn(),
-      });
-      render(<EventReplay {...defaultProps} />, {organization});
+  it('should render the replay inline onboarding component when replays are enabled and the project supports replay', async () => {
+    MockUseReplayOnboardingSidebarPanel.mockReturnValue({
+      activateSidebar: jest.fn(),
+    });
+    jest.mocked(useEventCanShowReplayUpsell).mockReturnValue({
+      canShowUpsell: true,
+      upsellPlatform: 'javascript',
+      upsellProjectId: '1',
+    });
+    render(<EventReplay {...defaultProps} />, {organization});
 
-      expect(await screen.findByTestId('replay-inline-onboarding')).toBeInTheDocument();
-    }
-  );
+    expect(await screen.findByTestId('replay-inline-onboarding')).toBeInTheDocument();
+  });
 
   it('should render a replay when there is a replayId from tags', async () => {
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({


### PR DESCRIPTION
## Summary
- Remove `it.isKnownFlake` marker from the eventReplay upsell test
- Mock `useEventCanShowReplayUpsell` hook to eliminate flakiness caused by `ProjectsStore` loading state and `useProjects()` race conditions
- Set a default mock returning `canShowUpsell: false` in `beforeEach`, and override to `canShowUpsell: true` in the specific upsell test

## Test plan
- [ ] CI passes on the previously flaky test
- [ ] Other tests in the file remain green