### PR TITLE
fix(tests): deflake react-native metrics onboarding test

### DIFF
--- a/static/app/gettingStartedDocs/react-native/metrics.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/metrics.spec.tsx
@@ -2,12 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
 
-import {
-  render,
-  screen,
-  userEvent,
-  waitForElementToBeRemoved,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -33,7 +28,7 @@ function renderMockRequests({
 }
 
 describe('getting started with react-native', () => {
-  it.isKnownFlake('shows React Native metrics onboarding content', async () => {
+  it('shows React Native metrics onboarding content', async () => {
     const organization = OrganizationFixture();
     const project = ProjectFixture({platform: 'react-native'});
     renderMockRequests({organization, project});
@@ -45,8 +40,6 @@ describe('getting started with react-native', () => {
         project={project}
       />
     );
-
-    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     expect(
       await screen.findByRole('heading', {name: /install sentry/i})


### PR DESCRIPTION
## Summary
- Remove `waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'))` which causes a race condition: if the mock resolves before the loading indicator mounts, the assertion throws
- The subsequent `findByRole('heading', {name: /install sentry/i})` already serves as the async wait point
- Remove unused `waitForElementToBeRemoved` import
- Change `it.isKnownFlake` back to `it`

## Test plan
- [ ] CI passes on the test file `static/app/gettingStartedDocs/react-native/metrics.spec.tsx`
- [ ] No more flaky failures from the `waitForElementToBeRemoved` race condition