### PR TITLE
fix(dashboards): dashboard card preview misalignment

### DIFF
--- a/static/app/views/dashboards/manage/gridPreview/index.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/index.tsx
@@ -5,7 +5,6 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {defined} from 'sentry/utils';
-import {uniqueId} from 'sentry/utils/guid';
 import {
   assignDefaultLayout,
   calculateColumnDepths,
@@ -58,12 +57,11 @@ export function GridPreview({widgetPreview}: Props) {
       isResizable={false}
       isDraggable={false}
       useCSSTransforms={false}
-      measureBeforeMount
     >
       {renderPreview.map(({displayType, layout}, index) => {
         const color = chartPalette[index % chartPalette.length]!;
         return (
-          <Chart key={uniqueId()} data-grid={{...layout}}>
+          <Chart key={index} data-grid={{...layout}}>
             <PreviewWrapper>
               <MiniWidget displayType={displayType} color={color} />
             </PreviewWrapper>


### PR DESCRIPTION
Closes DAIN-1580

fixes the widget previews in a dashboard card on the All Dashboards page. I think the grid layout better utilizes indexes instead of the unique ids and measuring before mount produces the incorrect positions

| Before | After |
|--------|--------|
| <img width="1216" height="714" alt="image" src="https://github.com/user-attachments/assets/d8708c27-d4e0-4cf8-b0b0-4ae149f003e6" />| <img width="1256" height="697" alt="image" src="https://github.com/user-attachments/assets/689ed1f2-0e94-4f1c-ac47-fe346ac82d9e" /> |
