### PR TITLE
fix(tests): deflake discover resultsSearchQueryBuilder tests

### DIFF
--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -40,7 +40,7 @@ describe('ResultsSearchQueryBuilder', () => {
     ]);
   });
 
-  it('does not show function tags in has: dropdown', async () => {
+  it.isKnownFlake('does not show function tags in has: dropdown', async () => {
     render(
       <ResultsSearchQueryBuilder
         query=""
@@ -77,7 +77,7 @@ describe('ResultsSearchQueryBuilder', () => {
     });
   });
 
-  it('shows normal tags, e.g. transaction, in the dropdown', async () => {
+  it.isKnownFlake('shows normal tags, e.g. transaction, in the dropdown', async () => {
     render(
       <ResultsSearchQueryBuilder
         query=""

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -8,6 +8,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import TagStore from 'sentry/stores/tagStore';
 import {SavedSearchType} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {FieldKind} from 'sentry/utils/fields';
@@ -31,9 +32,15 @@ describe('ResultsSearchQueryBuilder', () => {
       url: '/organizations/org-slug/tags/',
       body: [{key: 'transaction', name: 'transaction', kind: FieldKind.FIELD}],
     });
+    // Pre-populate TagStore to eliminate race between async API response and user interaction
+    TagStore.loadTagsSuccess([
+      {key: 'transaction', name: 'transaction'},
+      {key: 'environment', name: 'environment'},
+      {key: 'user', name: 'user'},
+    ]);
   });
 
-  it.isKnownFlake('does not show function tags in has: dropdown', async () => {
+  it('does not show function tags in has: dropdown', async () => {
     render(
       <ResultsSearchQueryBuilder
         query=""
@@ -70,7 +77,7 @@ describe('ResultsSearchQueryBuilder', () => {
     });
   });
 
-  it.isKnownFlake('shows normal tags, e.g. transaction, in the dropdown', async () => {
+  it('shows normal tags, e.g. transaction, in the dropdown', async () => {
     render(
       <ResultsSearchQueryBuilder
         query=""

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -8,7 +8,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
-import TagStore from 'sentry/stores/tagStore';
+import {TagStore} from 'sentry/stores/tagStore';
 import {SavedSearchType} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {FieldKind} from 'sentry/utils/fields';


### PR DESCRIPTION
## Summary
- Pre-populate `TagStore` before render in `resultsSearchQueryBuilder.spec.tsx` to eliminate the race condition between async API response and user interaction
- Remove `isKnownFlake` markers from both tests now that the root cause is fixed
- The `supportedTags` prop was declared but never read by the component — tags came from `TagStore` populated asynchronously via the `/organizations/org-slug/tags/` API

## Test plan
- [ ] CI passes on both previously-flaky tests: "does not show function tags in has: dropdown" and "shows normal tags, e.g. transaction, in the dropdown"