### PR TITLE
fix(tests): deflake registerForm tests

### DIFF
--- a/static/app/views/auth/registerForm.spec.tsx
+++ b/static/app/views/auth/registerForm.spec.tsx
@@ -20,17 +20,19 @@ describe('Register', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
-    expect(apiRequest).toHaveBeenCalledWith(
-      '/auth/register/',
-      expect.objectContaining({
-        data: {
-          name: 'joe',
-          username: 'test@test.com',
-          password: '12345pass',
-          subscribe: true,
-        },
-      })
-    );
+    await waitFor(() => {
+      expect(apiRequest).toHaveBeenCalledWith(
+        '/auth/register/',
+        expect.objectContaining({
+          data: {
+            name: 'joe',
+            username: 'test@test.com',
+            password: '12345pass',
+            subscribe: true,
+          },
+        })
+      );
+    });
   }
 
   it('handles errors', async () => {


### PR DESCRIPTION
## Summary
- Wraps the API call assertion in the `doLogin` helper with `waitFor` to handle async form submission timing
- The form's submit handler runs validation and fires the API request asynchronously, but the assertion was previously running synchronously after `userEvent.click`

## Test plan
- CI should pass with the previously flaky tests now stable