### PR TITLE
ref(issues): Fix typo groups_to_transistion -> groups_to_transition

### DIFF
--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -20,17 +20,17 @@ def bulk_transition_group_to_ongoing(
     group_ids: list[int],
     activity_data: Mapping[str, Any] | None = None,
 ) -> None:
-    with sentry_sdk.start_span(name="groups_to_transistion") as span:
+    with sentry_sdk.start_span(name="groups_to_transition") as span:
         # make sure we don't update the Group when its already updated by conditionally updating the Group
-        groups_to_transistion = Group.objects.filter(
+        groups_to_transition = Group.objects.filter(
             id__in=group_ids, status=from_status, substatus=from_substatus
         ).select_related("project")
         span.set_tag("group_ids", group_ids)
-        span.set_tag("groups_to_transistion count", len(groups_to_transistion))
+        span.set_tag("groups_to_transition count", len(groups_to_transition))
 
     with sentry_sdk.start_span(name="update_group_status"):
         Group.objects.update_group_status(
-            groups=groups_to_transistion,
+            groups=groups_to_transition,
             status=GroupStatus.UNRESOLVED,
             substatus=GroupSubStatus.ONGOING,
             activity_type=ActivityType.AUTO_SET_ONGOING,
@@ -39,7 +39,7 @@ def bulk_transition_group_to_ongoing(
             from_substatus=from_substatus,
         )
 
-    for group in groups_to_transistion:
+    for group in groups_to_transition:
         group.status = GroupStatus.UNRESOLVED
         group.substatus = GroupSubStatus.ONGOING
         if from_status != GroupStatus.UNRESOLVED:
@@ -52,11 +52,11 @@ def bulk_transition_group_to_ongoing(
             )
 
     with sentry_sdk.start_span(name="bulk_remove_groups_from_inbox"):
-        bulk_remove_groups_from_inbox(groups_to_transistion)
+        bulk_remove_groups_from_inbox(groups_to_transition)
 
     with sentry_sdk.start_span(name="post_save_send_robust"):
         if not options.get("groups.enable-post-update-signal"):
-            for group in groups_to_transistion:
+            for group in groups_to_transition:
                 post_save.send_robust(
                     sender=Group,
                     instance=group,


### PR DESCRIPTION
Rename the local variable, span name, and span tag in bulk_transition_group_to_ongoing to fix a typo.

No behavior change.