### PR TITLE
ref(issues): Replace redundant elif with else in update_inbox

### DIFF
--- a/src/sentry/issues/update_inbox.py
+++ b/src/sentry/issues/update_inbox.py
@@ -36,7 +36,7 @@ def update_inbox(
     if in_inbox:
         for group in group_list:
             add_group_to_inbox(group, GroupInboxReason.MANUAL)
-    elif not in_inbox:
+    else:
         for group in group_list:
             # Remove from inbox first to insert the mark reviewed activity
             remove_group_from_inbox(


### PR DESCRIPTION
The elif not in_inbox branch is only reachable when in_inbox is false, so the condition is redundant. Replace with a plain else.

No behavior change.