### PR TITLE
fix(tests): deflake eventsSearchBar function tags test

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
@@ -41,7 +41,7 @@ describe('EventsSearchBar', () => {
     });
   });
 
-  it('does not show function tags in has: dropdown', async () => {
+  it.isKnownFlake('does not show function tags in has: dropdown', async () => {
     render(
       <EventsSearchBar
         onClose={jest.fn()}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
@@ -41,7 +41,7 @@ describe('EventsSearchBar', () => {
     });
   });
 
-  it.isKnownFlake('does not show function tags in has: dropdown', async () => {
+  it('does not show function tags in has: dropdown', async () => {
     render(
       <EventsSearchBar
         onClose={jest.fn()}
@@ -67,14 +67,15 @@ describe('EventsSearchBar', () => {
 
     const input = await screen.findByRole('combobox', {name: 'Add a search term'});
     await userEvent.click(input, {delay: null});
-    await userEvent.paste('has:p', {delay: null});
+    await userEvent.paste('has:', {delay: null});
 
     await userEvent.click(
       await screen.findByRole('button', {name: 'Edit value for filter: has'})
     );
 
-    // Assert we actually have has: dropdown options before checking exclusions.
+    // Wait for the full tag list to render before checking exclusions.
     expect(await screen.findByRole('option', {name: 'environment'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'transaction'})).toBeInTheDocument();
 
     // p50 is a function and should not be suggested as a has: tag.
     expect(screen.queryByRole('option', {name: 'p50'})).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Change paste from `has:p` to `has:` so all tags appear reliably in the dropdown (the "p" filter made results timing-dependent)
- Add assertion for `transaction` tag to confirm full list is rendered before making negative assertion about `p50`

## Test plan
- CI should pass with the previously flaky test now stable