### PR TITLE
fix(tests): deflake metricsTab max metrics limit test

### DIFF
--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -682,67 +682,66 @@ describe('MetricsTabContent', () => {
     expect(within(equationSection).getAllByTestId('metric-panel')).toHaveLength(1);
   });
 
-  it.isKnownFlake(
-    'disables both Add Metric and Add Equation buttons when the maximum number of metric queries is reached',
-    async () => {
-      const metricQueryWithGroupBy = JSON.stringify({
-        metric: {name: 'bar', type: 'distribution'},
-        query: '',
-        aggregateFields: [
-          {groupBy: 'environment'},
-          {yAxes: ['per_second(bar)'], displayType: 'line'},
-        ],
-        aggregateSortBys: [],
-        mode: 'aggregate',
-      });
-      const orgWithFeature = OrganizationFixture({
-        features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
-      });
-      render(
-        <ProviderWrapper>
-          <MetricsTabContent datePageFilterProps={datePageFilterProps} />
-        </ProviderWrapper>,
-        {
-          organization: orgWithFeature,
-          initialRouterConfig: {
-            location: {
-              pathname: '/organizations/:orgId/explore/metrics/',
-              query: {
-                start: '2025-04-10T14%3A37%3A55',
-                end: '2025-04-10T20%3A04%3A51',
-                metric: [metricQueryWithGroupBy, metricQueryWithGroupBy],
-                title: 'Test Title',
-              },
+  it('disables both Add Metric and Add Equation buttons when the maximum number of metric queries is reached', async () => {
+    const metricQueryWithGroupBy = JSON.stringify({
+      metric: {name: 'bar', type: 'distribution'},
+      query: '',
+      aggregateFields: [
+        {groupBy: 'environment'},
+        {yAxes: ['per_second(bar)'], displayType: 'line'},
+      ],
+      aggregateSortBys: [],
+      mode: 'aggregate',
+    });
+    const orgWithFeature = OrganizationFixture({
+      features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+    });
+    render(
+      <ProviderWrapper>
+        <MetricsTabContent datePageFilterProps={datePageFilterProps} />
+      </ProviderWrapper>,
+      {
+        organization: orgWithFeature,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/:orgId/explore/metrics/',
+            query: {
+              start: '2025-04-10T14%3A37%3A55',
+              end: '2025-04-10T20%3A04%3A51',
+              metric: [metricQueryWithGroupBy, metricQueryWithGroupBy],
+              title: 'Test Title',
             },
-            route: '/organizations/:orgId/explore/metrics/',
           },
-        }
-      );
-      expect(await screen.findAllByText('Add Metric')).not.toHaveLength(0);
-      expect(screen.getAllByText('Add Equation').length).toBeGreaterThan(0);
+          route: '/organizations/:orgId/explore/metrics/',
+        },
+      }
+    );
+    expect(await screen.findAllByText('Add Metric')).not.toHaveLength(0);
+    expect(screen.getAllByText('Add Equation').length).toBeGreaterThan(0);
 
-      // Only 2 entries (cap is 3) -> both buttons are enabled
-      for (const button of screen.getAllByRole('button', {
-        name: 'Add Metric',
-      })) {
-        expect(button).toBeEnabled();
-      }
-      for (const button of screen.getAllByRole('button', {name: 'Add Equation'})) {
-        expect(button).toBeEnabled();
-      }
-
-      // Add an entry, 3 entries (at cap) -> both buttons are disabled
-      await userEvent.click(screen.getAllByRole('button', {name: 'Add Metric'})[0]!);
-      for (const button of screen.getAllByRole('button', {
-        name: 'Add Metric',
-      })) {
-        expect(button).toBeDisabled();
-      }
-      for (const button of screen.getAllByRole('button', {name: 'Add Equation'})) {
-        expect(button).toBeDisabled();
-      }
+    // Only 2 entries (cap is 3) -> both buttons are enabled
+    for (const button of screen.getAllByRole('button', {
+      name: 'Add Metric',
+    })) {
+      expect(button).toBeEnabled();
     }
-  );
+    for (const button of screen.getAllByRole('button', {name: 'Add Equation'})) {
+      expect(button).toBeEnabled();
+    }
+
+    // Add an entry, 3 entries (at cap) -> both buttons are disabled
+    await userEvent.click(screen.getAllByRole('button', {name: 'Add Metric'})[0]!);
+    await waitFor(() => {
+      for (const button of screen.getAllByRole('button', {
+        name: 'Add Metric',
+      })) {
+        expect(button).toBeDisabled();
+      }
+    });
+    for (const button of screen.getAllByRole('button', {name: 'Add Equation'})) {
+      expect(button).toBeDisabled();
+    }
+  });
 
   it('disables delete button for metrics referenced by an equation', async () => {
     const orgWithEquations = OrganizationFixture({


### PR DESCRIPTION
## Summary
- Removed `it.isKnownFlake` marker from the "max metrics limit" test in `metricsTab.spec.tsx`
- Wrapped post-click disabled button assertions in `await waitFor()` to wait for React to re-render with updated state before checking button disabled attributes

## Root Cause
After clicking "Add Metric", synchronous `getAllByRole` + disabled checks ran before React re-rendered with the new metric count, causing intermittent failures.

## Test plan
- [ ] CI passes the previously flaky test reliably