### PR TITLE
fix(tests): deflake trace details summary tab test

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -988,17 +988,16 @@ describe('trace view', () => {
     ).toBeInTheDocument();
   });
 
-  it.isKnownFlake(
-    'does not render the summary tab even when the legacy feature flag is enabled',
-    async () => {
-      const organization = OrganizationFixture({features: ['single-trace-summary']});
+  it('does not render the summary tab even when the legacy feature flag is enabled', async () => {
+    const organization = OrganizationFixture({features: ['single-trace-summary']});
 
-      await completeTestSetup({organization});
+    await completeTestSetup({organization});
 
-      expect(await screen.findByRole('tab', {name: 'Waterfall'})).toBeInTheDocument();
+    expect(await screen.findByRole('tab', {name: 'Waterfall'})).toBeInTheDocument();
+    await waitFor(() => {
       expect(screen.queryByRole('tab', {name: 'Summary'})).not.toBeInTheDocument();
-    }
-  );
+    });
+  });
 
   describe('pageload', () => {
     it('scrolls to trace root', async () => {

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -988,16 +988,19 @@ describe('trace view', () => {
     ).toBeInTheDocument();
   });
 
-  it.isKnownFlake('does not render the summary tab even when the legacy feature flag is enabled', async () => {
-    const organization = OrganizationFixture({features: ['single-trace-summary']});
+  it.isKnownFlake(
+    'does not render the summary tab even when the legacy feature flag is enabled',
+    async () => {
+      const organization = OrganizationFixture({features: ['single-trace-summary']});
 
-    await completeTestSetup({organization});
+      await completeTestSetup({organization});
 
-    expect(await screen.findByRole('tab', {name: 'Waterfall'})).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.queryByRole('tab', {name: 'Summary'})).not.toBeInTheDocument();
-    });
-  });
+      expect(await screen.findByRole('tab', {name: 'Waterfall'})).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByRole('tab', {name: 'Summary'})).not.toBeInTheDocument();
+      });
+    }
+  );
 
   describe('pageload', () => {
     it('scrolls to trace root', async () => {

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -988,7 +988,7 @@ describe('trace view', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not render the summary tab even when the legacy feature flag is enabled', async () => {
+  it.isKnownFlake('does not render the summary tab even when the legacy feature flag is enabled', async () => {
     const organization = OrganizationFixture({features: ['single-trace-summary']});
 
     await completeTestSetup({organization});


### PR DESCRIPTION
## Summary
- Remove `isKnownFlake` marker from the "does not render the summary tab even when the legacy feature flag is enabled" test
- Wrap the negative `queryByRole` assertion in `waitFor` to prevent a race condition where the assertion fires before the component finishes rendering after the Waterfall tab appears

## Test plan
- [ ] CI passes on this branch
- [ ] The previously flaky test now passes reliably