### PR TITLE
fix(tests): deflake customerDetails disabled permission test

### DIFF
--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1261,7 +1261,7 @@ describe('Customer Details', () => {
       permissions: new Set(['billing.admin']),
     });
 
-    it.isKnownFlake('renders disabled without billing.admin permissions', async () => {
+    it('renders disabled without billing.admin permissions', async () => {
       ConfigStore.set('user', mockUser);
 
       setUpMocks(organization, {isBillingAdmin: false});
@@ -1280,7 +1280,7 @@ describe('Customer Details', () => {
         screen.getAllByRole('button', {name: 'Customers Actions'})[0]!
       );
 
-      expect(screen.getByTestId('changeSoftCap')).toHaveAttribute(
+      expect(await screen.findByTestId('changeSoftCap')).toHaveAttribute(
         'aria-disabled',
         'true'
       );


### PR DESCRIPTION
## Summary
- Replace `it.isKnownFlake` with `it` for the "renders disabled without billing.admin permissions" test
- Change synchronous `screen.getByTestId('changeSoftCap')` to `await screen.findByTestId('changeSoftCap')` so the test waits for the dropdown menu items to render asynchronously after clicking the "Customers Actions" button

## Test plan
- [ ] CI passes for `static/gsAdmin/views/customerDetails.spec.tsx`
- [ ] The previously flaky test now passes reliably