### PR TITLE
ref(issues): Simplify get_highlight_preset_for_project branches

### DIFF
--- a/src/sentry/issues/highlights.py
+++ b/src/sentry/issues/highlights.py
@@ -49,8 +49,6 @@ FALLBACK_HIGHLIGHTS: HighlightPreset = {
 
 
 def get_highlight_preset_for_project(project: Project) -> HighlightPreset:
-    if not project.platform or project.platform == "other":
-        return FALLBACK_HIGHLIGHTS
-    elif project.platform in MOBILE:
+    if project.platform in MOBILE:
         return MOBILE_HIGHLIGHTS
     return FALLBACK_HIGHLIGHTS


### PR DESCRIPTION
Drop the redundant `not project.platform or project.platform == "other"` branch. MOBILE is a set of concrete platform strings that contains neither None nor `other`, so `project.platform in MOBILE` already returns False for those cases and falls through to FALLBACK_HIGHLIGHTS.

No behavior change.