### PR TITLE
perf(issues): Use generator instead of list comp in handle_merge any()

### DIFF
--- a/src/sentry/issues/merge.py
+++ b/src/sentry/issues/merge.py
@@ -32,7 +32,7 @@ def handle_merge(
 
     Returns a dict with the primary group id and a list of the merged group ids.
     """
-    if any([group.issue_category != GroupCategory.ERROR for group in group_list]):
+    if any(group.issue_category != GroupCategory.ERROR for group in group_list):
         raise rest_framework.exceptions.ValidationError(detail="Only error issues can be merged.")
 
     # Sort by:


### PR DESCRIPTION
any() can short-circuit on the first match, but wrapping the comprehension in brackets builds the entire list before any() runs. Drop the brackets to let any() iterate lazily.