### PR TITLE
ref(snapshots): Move card selection from header to card frame

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -246,24 +246,6 @@ describe('SnapshotCards', () => {
     snapshotCardHeaderStatus({state: 'no-status', status: null});
 
     it.snapshot(
-      'card-header-interactive-selected',
-      () => (
-        <Wrapper>
-          <CardHeader
-            {...headerProps}
-            displayName="Button / light"
-            status={DiffStatus.CHANGED}
-            diffPercent={0.042}
-            isSelected
-            onSelect={noop}
-            onDoubleClick={noop}
-          />
-        </Wrapper>
-      ),
-      {theme: themeName, state: 'card-header-interactive-selected'}
-    );
-
-    it.snapshot(
       'card-header-static',
       () => (
         <Wrapper>

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -123,7 +123,7 @@ export const PairCard = memo(function PairCard({
       <SnapshotVariantFrame
         isSelected={isSelected}
         data-snapshot-key={snapshotKey}
-        onClick={e => e.stopPropagation()}
+        onClick={handleSelect}
       >
         <CardHeader
           displayName={image.display_name}
@@ -134,9 +134,7 @@ export const PairCard = memo(function PairCard({
           onToggleDark={() => setIsDark(v => !v)}
           copyData={pair}
           copyUrl={copyUrl}
-          onSelect={handleSelect}
           onDoubleClick={handleOpen}
-          isSelected={isSelected}
           showBottomBorder={false}
         />
         <Container padding="0 xl xl">{body}</Container>
@@ -191,7 +189,7 @@ export const ImageCard = memo(function ImageCard({
       <SnapshotVariantFrame
         isSelected={isSelected}
         data-snapshot-key={snapshotKey}
-        onClick={e => e.stopPropagation()}
+        onClick={handleSelect}
       >
         <CardHeader
           displayName={image.display_name}
@@ -201,9 +199,7 @@ export const ImageCard = memo(function ImageCard({
           onToggleDark={() => setIsDark(v => !v)}
           copyData={copyData ?? image}
           copyUrl={copyUrl}
-          onSelect={handleSelect}
           onDoubleClick={handleOpen}
-          isSelected={isSelected}
           showBottomBorder={false}
         />
         <Container padding="0 xl xl">
@@ -223,9 +219,7 @@ export const CardHeader = memo(function CardHeader({
   onToggleDark,
   copyData,
   copyUrl,
-  onSelect,
   onDoubleClick,
-  isSelected,
   showBottomBorder = true,
 }: {
   copyData: unknown;
@@ -235,34 +229,13 @@ export const CardHeader = memo(function CardHeader({
   onToggleDark: () => void;
   diffPercent?: number | null;
   displayName?: string | null;
-  isSelected?: boolean;
   onDoubleClick?: () => void;
-  onSelect?: () => void;
   showBottomBorder?: boolean;
   status?: DiffStatus | null;
 }) {
   const {copy} = useCopyToClipboard();
-  const handleRowKeyDown = onSelect
-    ? (e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (e.key === 'Enter') {
-          e.preventDefault();
-          onSelect();
-        } else if (e.key === ' ') {
-          e.preventDefault();
-        }
-      }
-    : undefined;
   return (
-    <CardHeaderRow
-      onClick={onSelect}
-      onDoubleClick={onDoubleClick}
-      onKeyDown={handleRowKeyDown}
-      role={onSelect ? 'button' : undefined}
-      tabIndex={onSelect ? 0 : undefined}
-      aria-pressed={onSelect ? isSelected : undefined}
-      isInteractive={!!onSelect}
-      $showBottomBorder={showBottomBorder}
-    >
+    <CardHeaderRow onDoubleClick={onDoubleClick} $showBottomBorder={showBottomBorder}>
       <Stack gap="xs" minWidth="0" flex="1">
         {displayName ? (
           <Fragment>
@@ -395,7 +368,6 @@ function IconButton({
 
 const CardHeaderRow = styled('div')<{
   $showBottomBorder?: boolean;
-  isInteractive?: boolean;
 }>`
   display: flex;
   align-items: flex-start;
@@ -404,20 +376,6 @@ const CardHeaderRow = styled('div')<{
   padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
   border-bottom: ${p =>
     p.$showBottomBorder ? `1px solid ${p.theme.tokens.border.secondary}` : 0};
-  ${p =>
-    p.isInteractive &&
-    `
-      cursor: pointer;
-      user-select: none;
-
-      &:hover {
-        background: ${p.theme.tokens.background.secondary};
-      }
-
-      &:focus {
-        outline: none;
-      }
-    `}
 `;
 
 const InfoIconButton = styled('button')`

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -77,7 +77,10 @@ export const PairCard = memo(function PairCard({
   const headUrl = `${imageBaseUrl}${image.key}/`;
 
   const handleSelect = onSelectSnapshot
-    ? () => onSelectSnapshot(isSelected ? null : snapshotKey)
+    ? (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onSelectSnapshot(isSelected ? null : snapshotKey);
+      }
     : undefined;
   const handleOpen = onOpenSnapshot ? () => onOpenSnapshot(snapshotKey) : undefined;
 
@@ -180,7 +183,10 @@ export const ImageCard = memo(function ImageCard({
   }
 
   const handleSelect = onSelectSnapshot
-    ? () => onSelectSnapshot(isSelected ? null : snapshotKey)
+    ? (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onSelectSnapshot(isSelected ? null : snapshotKey);
+      }
     : undefined;
   const handleOpen = onOpenSnapshot ? () => onOpenSnapshot(snapshotKey) : undefined;
 

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -426,14 +426,9 @@ function SingleViewLayout({
       height="100%"
       width="100%"
       background="secondary"
+      onClick={e => e.stopPropagation()}
     >
-      <Flex
-        align="center"
-        justify="between"
-        gap="md"
-        padding="md xl md 0"
-        onClick={e => e.stopPropagation()}
-      >
+      <Flex align="center" justify="between" gap="md" padding="md xl md 0">
         <Flex align="center" gap="md">
           {toggle}
           {sortDropdown}


### PR DESCRIPTION
Move the click-to-select handler from `CardHeader` to `SnapshotVariantFrame` so clicking anywhere on the card body selects it, while removing the unintended behavior where clicking the header text navigated to the first card in the list.

Also broadens the `stopPropagation` scope in `SingleViewLayout` from just the toolbar to the entire single-view wrapper, preventing clicks inside the single view from bubbling up to the parent `handleDeselectSnapshot` handler (which was causing the single view to jump to the first image on click).

Changes:
- `snapshotCards.tsx`: Remove `onSelect`, `isSelected`, keyboard/ARIA interaction from `CardHeader`; move `onClick={handleSelect}` to `SnapshotVariantFrame` in both `PairCard` and `ImageCard`; remove interactive styles from `CardHeaderRow`
- `snapshotMainContent.tsx`: Move `stopPropagation` from inner toolbar `Flex` to outer `SingleViewLayout` wrapper
- `snapshotCards.snapshots.tsx`: Remove snapshot test for interactive-selected header state (props no longer exist)