### PR TITLE
ref(issues): Drop redundant dict() re-cast in materialize_metadata

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -164,7 +164,6 @@ def materialize_metadata(occurrence: IssueOccurrence, event: Event) -> Occurrenc
 
     event_type = get_event_type(event.data)
     event_metadata: dict[str, Any] = dict(event_type.get_metadata(event.data))
-    event_metadata = dict(event_metadata)
     # Don't clobber existing metadata
     event_metadata.update(event.get_event_metadata())
     event_metadata["title"] = occurrence.issue_title


### PR DESCRIPTION
`event_type.get_metadata(...)` is already wrapped in `dict(...)` on the line above, so the second `dict(event_metadata)` produces an identical copy and is immediately discarded.