### PR TITLE
ref(issues): Remove redundant Fragment in EventCreatedTooltip

### DIFF
--- a/static/app/views/issueDetails/eventCreatedTooltip.tsx
+++ b/static/app/views/issueDetails/eventCreatedTooltip.tsx
@@ -44,11 +44,9 @@ export function EventCreatedTooltip({event}: Props) {
       <dt>{t('Occurred')}</dt>
       <dd>
         {dateCreated ? (
-          <Fragment>
-            <AutoSelectText>
-              {dateCreated.format('ll')} {dateCreated.format(format)}
-            </AutoSelectText>
-          </Fragment>
+          <AutoSelectText>
+            {dateCreated.format('ll')} {dateCreated.format(format)}
+          </AutoSelectText>
         ) : (
           <NotApplicableText>{t('n/a')}</NotApplicableText>
         )}


### PR DESCRIPTION
The Fragment wrapping a single AutoSelectText child has no effect.