### PR TITLE
fix(repositories): Silence bitbucket errors when performing auto-sync

### DIFF
--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -283,10 +283,11 @@ class BitbucketServerIntegration(RepositoryIntegration[BitbucketServerClient]):
         return data.get("error", {}).get("message", "unknown error")
 
     def is_broken_integration_error(self, exc: Exception) -> HaltReason | None:
-        if isinstance(exc, ApiError) and exc.code in (403, 404):
+        if isinstance(exc, ApiError):
+            if exc.code == 403:
+               return "unauthorized"
             if exc.code == 404:
                 return "configuration_error"
-            return "unauthorized"
         return super().is_broken_integration_error(exc)
 
     # RepositoryIntegration methods

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -28,6 +28,7 @@ from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.repository import repository_service
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.repository import (
+    HaltReason,
     RepositoryInfo,
     RepositoryIntegration,
 )
@@ -280,6 +281,13 @@ class BitbucketServerIntegration(RepositoryIntegration[BitbucketServerClient]):
 
     def error_message_from_json(self, data):
         return data.get("error", {}).get("message", "unknown error")
+
+    def is_broken_integration_error(self, exc: Exception) -> HaltReason | None:
+        if isinstance(exc, ApiError) and exc.code in (403, 404):
+            if exc.code == 404:
+                return "configuration_error"
+            return "unauthorized"
+        return super().is_broken_integration_error(exc)
 
     # RepositoryIntegration methods
 

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -285,7 +285,7 @@ class BitbucketServerIntegration(RepositoryIntegration[BitbucketServerClient]):
     def is_broken_integration_error(self, exc: Exception) -> HaltReason | None:
         if isinstance(exc, ApiError):
             if exc.code == 403:
-               return "unauthorized"
+                return "unauthorized"
             if exc.code == 404:
                 return "configuration_error"
         return super().is_broken_integration_error(exc)

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -844,6 +844,57 @@ class SyncReposLockTestCase(IntegrationTestCase):
 
 
 @control_silo_test
+class BitbucketServerIsBrokenIntegrationErrorTestCase(TestCase):
+    """Tests for the BitbucketServerIntegration.is_broken_integration_error override."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration = self.create_provider_integration(
+            provider="bitbucket_server",
+            name="Example Bitbucket",
+            metadata={"verify_ssl": False, "base_url": "https://bitbucket.example.com"},
+        )
+        identity = Identity.objects.create(
+            idp=self.create_identity_provider(
+                external_id="bitbucket.example.com:sentry-test", type="bitbucket_server"
+            ),
+            user=self.user,
+            external_id="bitbucket-server-123",
+            data={
+                "consumer_key": "sentry-test",
+                "private_key": "fake-key",
+                "access_token": "access-token",
+                "access_token_secret": "access-token-secret",
+            },
+        )
+        self.integration.add_organization(self.organization, self.user, identity.id)
+        self.installation = self.integration.get_installation(organization_id=self.organization.id)
+
+    def test_api_error_403_returns_unauthorized(self) -> None:
+        exc = ApiError("forbidden", code=403)
+        assert self.installation.is_broken_integration_error(exc) == "unauthorized"
+
+    def test_api_error_404_returns_configuration_error(self) -> None:
+        exc = ApiError("not found", code=404)
+        assert self.installation.is_broken_integration_error(exc) == "configuration_error"
+
+    def test_api_error_500_not_terminal(self) -> None:
+        exc = ApiError("server error", code=500)
+        assert self.installation.is_broken_integration_error(exc) is None
+
+    def test_base_class_cases_still_work(self) -> None:
+        assert (
+            self.installation.is_broken_integration_error(ApiUnauthorized("bad token"))
+            == "unauthorized"
+        )
+        assert (
+            self.installation.is_broken_integration_error(IdentityNotValid())
+            == "identity_not_valid"
+        )
+        assert self.installation.is_broken_integration_error(RuntimeError("boom")) is None
+
+
+@control_silo_test
 class IsBrokenIntegrationErrorTestCase(TestCase):
     """Tests for the RepositoryIntegration.is_broken_integration_error base implementation."""
 


### PR DESCRIPTION
This more explicitly handles from bitbucket errors and allows us to silence them

Fixes SENTRY-5NNQ
