### PR TITLE
fix(replays): Ignore issue stream sort on issue replays

### DIFF
--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -7,7 +7,6 @@ import {DEFAULT_REPLAY_LIST_SORT} from 'sentry/components/replays/table/useRepla
 import {IssueCategory, type Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {EventView} from 'sentry/utils/discover/eventView';
-import {decodeScalar} from 'sentry/utils/queryString';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
 import {useCleanQueryParamsOnRouteLeave} from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
@@ -66,9 +65,9 @@ export function useReplaysFromIssue({
       query: replayIds.length ? `id:[${String(replayIds)}]` : 'id:1',
       range: '90d',
       projects: [],
-      orderby: decodeScalar(location.query.sort, DEFAULT_REPLAY_LIST_SORT),
+      orderby: DEFAULT_REPLAY_LIST_SORT,
     });
-  }, [location.query.sort, replayIds]);
+  }, [replayIds]);
 
   useCleanQueryParamsOnRouteLeave({
     fieldsToClean: ['cursor'],


### PR DESCRIPTION
Issue details can inherit issue stream sort params like `user`, but the replays endpoint does not understand those fields.

Always use the replay list default sort for issue replays instead.