### PR TITLE
fix(issues): Return 400 for invalid action on group integration details

### DIFF
--- a/src/sentry/issues/endpoints/group_integration_details.py
+++ b/src/sentry/issues/endpoints/group_integration_details.py
@@ -96,7 +96,9 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         # just linking
         action = request.GET.get("action")
         if action not in {"link", "create"}:
-            return Response({"detail": "Action is required and should be either link or create"})
+            return Response(
+                {"detail": "Action is required and should be either link or create"}, status=400
+            )
 
         organization_id = group.project.organization_id
         result = integration_service.organization_context(


### PR DESCRIPTION
GroupIntegrationDetailsEndpoint.get returned an error body without status=400 when the action query parameter was missing or invalid, so clients received HTTP 200 with a detail-shaped error.