### PR TITLE
ci: run getsentry acceptance on gsApp changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -108,6 +108,12 @@ acceptance: &acceptance
   - '.github/workflows/acceptance.yml'
   - '.github/actions/collect-test-data/**'
 
+# Used in `getsentry-dispatch.js` to decide whether to run getsentry's
+# acceptance suite against a sentry PR. Scoped to gsApp and gsAdmin
+# frontend changes (both have acceptance tests in getsentry).
+gsapp: &gsapp
+  - added|deleted|modified: 'static/{gsApp,gsAdmin}/**/*.{ts,tsx}'
+
 api_docs: &api_docs
   - *backend_all
   - 'api-docs/**'

--- a/.github/workflows/scripts/getsentry-dispatch.js
+++ b/.github/workflows/scripts/getsentry-dispatch.js
@@ -10,6 +10,11 @@ const DISPATCHES = [
   {
     workflow: 'backend.yml',
     pathFilterName: 'backend_all',
+    selectiveTesting: true,
+  },
+  {
+    workflow: 'acceptance.yml',
+    pathFilterName: 'gsapp',
   },
 ];
 
@@ -27,11 +32,17 @@ export async function dispatch({
 
   const dispatches =
     targetWorkflow !== undefined
-      ? [{workflow: targetWorkflow, pathFilterName: 'backend_all'}]
+      ? [
+          DISPATCHES.find(d => d.workflow === targetWorkflow) ?? {
+            workflow: targetWorkflow,
+            pathFilterName: 'backend_all',
+            selectiveTesting: true,
+          },
+        ]
       : DISPATCHES;
 
   await Promise.all(
-    dispatches.map(({workflow, pathFilterName}) => {
+    dispatches.map(({workflow, pathFilterName, selectiveTesting}) => {
       const inputs = {
         pull_request_number: `${context.payload.pull_request.number}`, // needs to be string
         skip: `${fileChanges[pathFilterName] !== 'true'}`, // even though this is a boolean, it must be cast to a string
@@ -41,9 +52,12 @@ export async function dispatch({
         // prSHA is the sha actions should post commit statuses too.
         'sentry-pr-sha': context.payload.pull_request.head.sha,
 
-        // Changed files for selective testing. Empty string means full suite.
-        'sentry-changed-files': sentryChangedFiles || '',
-        'sentry-previous-filenames': sentryPreviousFilenames || '',
+        // Only forward to workflows that declare these inputs; dispatching
+        // a workflow with undeclared inputs returns a 422.
+        ...(selectiveTesting && {
+          'sentry-changed-files': sentryChangedFiles || '',
+          'sentry-previous-filenames': sentryPreviousFilenames || '',
+        }),
       };
 
       core.info(


### PR DESCRIPTION
Re-applies #113890 with a fix.

The original PR added `acceptance.yml` to the `DISPATCHES` list in `getsentry-dispatch.js`, but the script forwards `sentry-changed-files` and `sentry-previous-filenames` to every dispatched workflow. `getsentry/acceptance.yml` doesn't declare those inputs, so every dispatch returned `422 Unexpected inputs provided` (failing run: https://github.com/getsentry/sentry/actions/runs/25313202628/job/74204688223).

This branch:

- Adds the `gsapp` path filter in `.github/file-filters.yml` (unchanged from #113890).
- Adds `acceptance.yml` to `DISPATCHES`, with a new `selectiveTesting` flag set only on `backend.yml`.
- Forwards `sentry-changed-files` / `sentry-previous-filenames` only when `selectiveTesting` is true, so dispatch payloads only contain inputs each target workflow declares.

Sequencing: rebase on `master` after the revert of #113890 lands, then merge.

closes #113890 (re-do)