### PR TITLE
fix(ai-trace): Minimize system prompts in trace input

### DIFF
--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.spec.ts
@@ -190,6 +190,20 @@ describe('normalizeToMessages', () => {
         {role: 'user', content: 'Hi!'},
       ]);
     });
+
+    it('prepends a structured system field when present', () => {
+      const input = JSON.stringify({
+        system: {instructions: ['Be concise'], priority: 'high'},
+        messages: [{role: 'user', content: 'Hi!'}],
+      });
+
+      const {messages} = normalizeToMessages(input, {defaultRole: 'user'});
+
+      expect(messages).toEqual([
+        {role: 'system', content: {instructions: ['Be concise'], priority: 'high'}},
+        {role: 'user', content: 'Hi!'},
+      ]);
+    });
   });
 
   describe('legacy shapes', () => {
@@ -200,6 +214,20 @@ describe('normalizeToMessages', () => {
 
       expect(messages).toEqual([
         {role: 'system', content: 'sys'},
+        {role: 'user', content: 'do the thing'},
+      ]);
+    });
+
+    it('expands structured {system, prompt} into two messages', () => {
+      const input = JSON.stringify({
+        system: {instructions: ['Be concise'], priority: 'high'},
+        prompt: 'do the thing',
+      });
+
+      const {messages} = normalizeToMessages(input, {defaultRole: 'user'});
+
+      expect(messages).toEqual([
+        {role: 'system', content: {instructions: ['Be concise'], priority: 'high'}},
         {role: 'user', content: 'do the thing'},
       ]);
     });

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
@@ -170,7 +170,7 @@ function collectRawMessages(items: any[], defaultRole: string): RawMessage[] {
  */
 function unwrapMessagesField(value: any, defaultRole: string): RawMessage[] {
   const result: RawMessage[] = [];
-  if (typeof value.system === 'string' && value.system.length > 0) {
+  if (value.system !== undefined && value.system !== null && value.system !== '') {
     result.push({role: 'system', content: value.system});
   }
 
@@ -197,7 +197,7 @@ function unwrapMessagesField(value: any, defaultRole: string): RawMessage[] {
  */
 function unwrapSystemPrompt(value: any): RawMessage[] {
   const result: RawMessage[] = [];
-  if (typeof value.system === 'string' && value.system.length > 0) {
+  if (value.system !== undefined && value.system !== null && value.system !== '') {
     result.push({role: 'system', content: value.system});
   }
   if (value.prompt) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.spec.tsx
@@ -1,0 +1,38 @@
+import type {ComponentProps} from 'react';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {AIInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
+
+function makeAiNode(
+  messages: Array<{content: string; role: string}>
+): ComponentProps<typeof AIInputSection>['node'] {
+  return {
+    id: 'span-id',
+    attributes: {
+      'gen_ai.operation.type': 'chat',
+      'gen_ai.input.messages': JSON.stringify(messages),
+    },
+    value: {},
+  } as ComponentProps<typeof AIInputSection>['node'];
+}
+
+describe('AIInputSection', () => {
+  it('minimizes system prompt by default while keeping user messages visible', async () => {
+    render(
+      <AIInputSection
+        node={makeAiNode([
+          {role: 'system', content: 'System prompt'},
+          {role: 'user', content: 'User message'},
+        ])}
+      />
+    );
+
+    expect(screen.getByText('User message')).toBeVisible();
+    expect(screen.getByText('System prompt')).not.toBeVisible();
+
+    await userEvent.click(screen.getByRole('button', {name: 'System'}));
+
+    expect(screen.getByText('System prompt')).toBeVisible();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {AIInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
 
 function makeAiNode(
-  messages: Array<{content: string; role: string}>
+  messages: Array<{content: unknown; role: string}> | Record<string, unknown>
 ): ComponentProps<typeof AIInputSection>['node'] {
   return {
     id: 'span-id',
@@ -34,5 +34,23 @@ describe('AIInputSection', () => {
     await userEvent.click(screen.getByRole('button', {name: 'System'}));
 
     expect(screen.getByText('System prompt')).toBeVisible();
+  });
+
+  it('minimizes structured system prompts by default', async () => {
+    render(
+      <AIInputSection
+        node={makeAiNode({
+          system: {instructions: ['Be concise'], priority: 'high'},
+          prompt: 'User message',
+        })}
+      />
+    );
+
+    expect(screen.getByText('User message')).toBeVisible();
+    expect(screen.getByText('instructions')).not.toBeVisible();
+
+    await userEvent.click(screen.getByRole('button', {name: 'System'}));
+
+    expect(screen.getByText('instructions')).toBeVisible();
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.spec.tsx
@@ -14,7 +14,7 @@ function makeAiNode(
       'gen_ai.input.messages': JSON.stringify(messages),
     },
     value: {},
-  } as ComponentProps<typeof AIInputSection>['node'];
+  } as unknown as ComponentProps<typeof AIInputSection>['node'];
 }
 
 describe('AIInputSection', () => {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.spec.tsx
@@ -9,11 +9,19 @@ const originalResizeObserver = window.ResizeObserver;
 function makeAiNode(
   messages: Array<{content: unknown; role: string}> | Record<string, unknown>
 ): ComponentProps<typeof AIInputSection>['node'] {
+  return makeAiNodeWithAttributes({
+    'gen_ai.input.messages': JSON.stringify(messages),
+  });
+}
+
+function makeAiNodeWithAttributes(
+  attributes: Record<string, unknown>
+): ComponentProps<typeof AIInputSection>['node'] {
   return {
     id: 'span-id',
     attributes: {
       'gen_ai.operation.type': 'chat',
-      'gen_ai.input.messages': JSON.stringify(messages),
+      ...attributes,
     },
     value: {},
   } as unknown as ComponentProps<typeof AIInputSection>['node'];
@@ -78,6 +86,24 @@ describe('AIInputSection', () => {
     );
 
     expect(screen.getByText('instructions')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Show More'})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'System'})).not.toBeInTheDocument();
+  });
+
+  it('clips JSON system instructions with show more', () => {
+    window.ResizeObserver = MockResizeObserver;
+
+    render(
+      <AIInputSection
+        node={makeAiNodeWithAttributes({
+          'gen_ai.system_instructions': JSON.stringify([
+            {content: 'You are Seer, a powerful AI assistant built by Sentry.'},
+          ]),
+        })}
+      />
+    );
+
+    expect(screen.getByText('content')).toBeVisible();
     expect(screen.getByRole('button', {name: 'Show More'})).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'System'})).not.toBeInTheDocument();
   });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.spec.tsx
@@ -1,8 +1,10 @@
 import type {ComponentProps} from 'react';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {AIInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
+
+const originalResizeObserver = window.ResizeObserver;
 
 function makeAiNode(
   messages: Array<{content: unknown; role: string}> | Record<string, unknown>
@@ -17,8 +19,36 @@ function makeAiNode(
   } as unknown as ComponentProps<typeof AIInputSection>['node'];
 }
 
+class MockResizeObserver {
+  callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(element: Element) {
+    this.callback(
+      [
+        {
+          target: element,
+          contentBoxSize: [{blockSize: 300, inlineSize: 0}],
+        } as unknown as ResizeObserverEntry,
+      ],
+      this
+    );
+  }
+
+  disconnect() {}
+
+  unobserve() {}
+}
+
 describe('AIInputSection', () => {
-  it('minimizes system prompt by default while keeping user messages visible', async () => {
+  afterEach(() => {
+    window.ResizeObserver = originalResizeObserver;
+  });
+
+  it('renders system prompt without a nested disclosure while keeping user messages visible', () => {
     render(
       <AIInputSection
         node={makeAiNode([
@@ -29,28 +59,26 @@ describe('AIInputSection', () => {
     );
 
     expect(screen.getByText('User message')).toBeVisible();
-    expect(screen.getByText('System prompt')).not.toBeVisible();
-
-    await userEvent.click(screen.getByRole('button', {name: 'System'}));
-
     expect(screen.getByText('System prompt')).toBeVisible();
+    expect(screen.queryByRole('button', {name: 'System'})).not.toBeInTheDocument();
   });
 
-  it('minimizes structured system prompts by default', async () => {
+  it('clips structured system prompts with show more', () => {
+    window.ResizeObserver = MockResizeObserver;
+
     render(
       <AIInputSection
-        node={makeAiNode({
-          system: {instructions: ['Be concise'], priority: 'high'},
-          prompt: 'User message',
-        })}
+        node={makeAiNode([
+          {
+            role: 'system',
+            content: {instructions: ['Be concise'], priority: 'high'},
+          },
+        ])}
       />
     );
 
-    expect(screen.getByText('User message')).toBeVisible();
-    expect(screen.getByText('instructions')).not.toBeVisible();
-
-    await userEvent.click(screen.getByRole('button', {name: 'System'}));
-
     expect(screen.getByText('instructions')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Show More'})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'System'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -253,20 +253,14 @@ function MessagesArrayRenderer({
       <TraceDrawerComponents.MultilineJSON value={message.content} maxDefaultDepth={2} />
     );
 
-  const renderSystemMessageContent = (message: AIMessage) =>
-    typeof message.content === 'string' ? (
-      <AIContentRenderer text={message.content} />
-    ) : (
-      <SystemMessageClippedBox
-        clipHeight={150}
-        buttonProps={{priority: 'default', size: 'xs'}}
-      >
-        <TraceDrawerComponents.MultilineJSON
-          value={message.content}
-          maxDefaultDepth={2}
-        />
-      </SystemMessageClippedBox>
-    );
+  const renderSystemMessageContent = (message: AIMessage) => (
+    <SystemMessageClippedBox
+      clipHeight={150}
+      buttonProps={{priority: 'default', size: 'xs'}}
+    >
+      {renderMessageContent(message)}
+    </SystemMessageClippedBox>
+  );
 
   const renderMessage = (message: AIMessage, index: number) => {
     if (message.role === 'system') {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -4,10 +4,10 @@ import * as Sentry from '@sentry/react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
+import {ClippedBox} from 'sentry/components/clippedBox';
 import {t, tct} from 'sentry/locale';
 import type {EventTransaction} from 'sentry/types/event';
 import {usePrevious} from 'sentry/utils/usePrevious';
@@ -253,13 +253,28 @@ function MessagesArrayRenderer({
       <TraceDrawerComponents.MultilineJSON value={message.content} maxDefaultDepth={2} />
     );
 
+  const renderSystemMessageContent = (message: AIMessage) =>
+    typeof message.content === 'string' ? (
+      <AIContentRenderer text={message.content} />
+    ) : (
+      <SystemMessageClippedBox
+        clipHeight={150}
+        buttonProps={{priority: 'default', size: 'xs'}}
+      >
+        <TraceDrawerComponents.MultilineJSON
+          value={message.content}
+          maxDefaultDepth={2}
+        />
+      </SystemMessageClippedBox>
+    );
+
   const renderMessage = (message: AIMessage, index: number) => {
     if (message.role === 'system') {
       return (
-        <SystemMessageDisclosure key={index} defaultExpanded={false} size="xs">
-          <Disclosure.Title>{t('System')}</Disclosure.Title>
-          <Disclosure.Content>{renderMessageContent(message)}</Disclosure.Content>
-        </SystemMessageDisclosure>
+        <Fragment key={index}>
+          <RoleLabel>{message.role}</RoleLabel>
+          {renderSystemMessageContent(message)}
+        </Fragment>
       );
     }
 
@@ -336,7 +351,8 @@ const RoleLabel = styled(TraceDrawerComponents.MultilineTextLabel)`
   }
 `;
 
-const SystemMessageDisclosure = styled(Disclosure)`
+const SystemMessageClippedBox = styled(ClippedBox)`
+  padding: 0;
   margin-bottom: ${p => p.theme.space.lg};
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
+import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
@@ -245,18 +246,27 @@ function MessagesArrayRenderer({
     }
   }, [messages.length, previousMessagesLength]);
 
+  const renderMessageContent = (message: AIMessage) =>
+    typeof message.content === 'string' ? (
+      <AIContentRenderer text={message.content} />
+    ) : (
+      <TraceDrawerComponents.MultilineJSON value={message.content} maxDefaultDepth={2} />
+    );
+
   const renderMessage = (message: AIMessage, index: number) => {
+    if (message.role === 'system') {
+      return (
+        <SystemMessageDisclosure key={index} defaultExpanded={false} size="xs">
+          <Disclosure.Title>{t('System')}</Disclosure.Title>
+          <Disclosure.Content>{renderMessageContent(message)}</Disclosure.Content>
+        </SystemMessageDisclosure>
+      );
+    }
+
     return (
       <Fragment key={index}>
         <RoleLabel>{message.role}</RoleLabel>
-        {typeof message.content === 'string' ? (
-          <AIContentRenderer text={message.content} />
-        ) : (
-          <TraceDrawerComponents.MultilineJSON
-            value={message.content}
-            maxDefaultDepth={2}
-          />
-        )}
+        {renderMessageContent(message)}
       </Fragment>
     );
   };
@@ -324,6 +334,10 @@ const RoleLabel = styled(TraceDrawerComponents.MultilineTextLabel)`
   &::first-letter {
     text-transform: capitalize;
   }
+`;
+
+const SystemMessageDisclosure = styled(Disclosure)`
+  margin-bottom: ${p => p.theme.space.lg};
 `;
 
 const ButtonDivider = styled('div')`


### PR DESCRIPTION
Render system prompt messages in the AI input section behind a collapsed disclosure by default. User messages remain visible, so trace details still show the active prompt context without forcing users to expand the whole Input section.

Structured `system` fields now normalize as system messages too, so object-shaped system prompts use the same collapsed rendering path as string prompts.

Before:
<img width="587" height="449" alt="CleanShot 2026-05-04 at 13 54 57" src="https://github.com/user-attachments/assets/b5ea1bef-effd-4c84-a28d-2a54e0b4263e" />

After:
<img width="587" height="497" alt="CleanShot 2026-05-04 at 13 56 52" src="https://github.com/user-attachments/assets/11d86bae-bcc4-4542-b66f-7b58e3600650" />

Fixes TET-2282