### PR TITLE
feat(ai-agents): Show estimated cost on AI agents overview

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -45,6 +45,7 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
     {
       id: 'ai-agents-overview-agent-runs',
       title: t('Agent Runs'),
+      description: t('Number of agent runs captured over time.'),
       displayType: DisplayType.BAR,
       widgetType: WidgetType.SPANS,
       interval: '1h',
@@ -61,26 +62,28 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       ],
     },
     {
-      id: 'ai-agents-overview-llm-calls-traffic',
-      title: t('LLM Calls'),
+      id: 'ai-agents-overview-estimated-cost',
+      title: t('Estimated Cost'),
+      description: t('Estimated cost of LLM calls with token and model data.'),
       displayType: DisplayType.BAR,
       widgetType: WidgetType.SPANS,
       interval: '1h',
       queries: [
         {
-          name: t('Count'),
+          name: t('Cost'),
           conditions: AI_CLIENT_FILTER,
-          fields: [`count(${SpanFields.SPAN_DURATION})`],
-          aggregates: [`count(${SpanFields.SPAN_DURATION})`],
+          fields: [`sum(${SpanFields.GEN_AI_COST_TOTAL_TOKENS})`],
+          aggregates: [`sum(${SpanFields.GEN_AI_COST_TOTAL_TOKENS})`],
           columns: [],
-          fieldAliases: [WIDGET_COLUMN_LABELS.count],
-          orderby: `-count(${SpanFields.SPAN_DURATION})`,
+          fieldAliases: [t('Estimated Cost')],
+          orderby: `-sum(${SpanFields.GEN_AI_COST_TOTAL_TOKENS})`,
         },
       ],
     },
     {
       id: 'ai-agents-overview-duration',
       title: t('Duration'),
+      description: t('Average and p95 duration for agent runs and LLM calls.'),
       displayType: DisplayType.LINE,
       widgetType: WidgetType.SPANS,
       interval: '1h',
@@ -111,6 +114,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
     {
       id: 'ai-agents-overview-llm-calls-by-model',
       title: t('LLM Calls by Model'),
+      description: t('Number of LLM calls grouped by response model.'),
       displayType: DisplayType.BAR,
       widgetType: WidgetType.SPANS,
       interval: '1h',
@@ -141,6 +145,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
     {
       id: 'ai-agents-overview-tokens-used',
       title: t('Tokens Used'),
+      description: t('Total tokens used by LLM calls, grouped by response model.'),
       displayType: DisplayType.BAR,
       widgetType: WidgetType.SPANS,
       interval: '1h',
@@ -171,6 +176,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
     {
       id: 'ai-agents-overview-tool-calls',
       title: t('Tool Calls'),
+      description: t('Tool call volume grouped by tool name.'),
       displayType: DisplayType.BAR,
       widgetType: WidgetType.SPANS,
       interval: '1h',
@@ -203,6 +209,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
 const AGENTS_TRACES_TABLE = {
   id: 'ai-agents-traces-table',
   title: t('Traces'),
+  description: t('Agent traces with duration, token, cost, and tool usage.'),
   displayType: DisplayType.AGENTS_TRACES_TABLE,
   interval: '1h',
   tableWidths: DEFAULT_TRACES_TABLE_WIDTHS,


### PR DESCRIPTION
Replace the redundant LLM Calls traffic chart in the AI Agents Overview prebuilt dashboard with Estimated Cost, based on summed `gen_ai.cost.total_tokens` for LLM calls. The overview widgets now include descriptions so their tooltips explain what each chart and table represents.

Refs TET-2292