### PR TITLE
ref(ai-spans): Tighten AI message normalizer types

### DIFF
--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.spec.ts
@@ -427,6 +427,17 @@ describe('extractAssistantOutput', () => {
 
       expect(responseText).toBe('B');
     });
+
+    it('treats declared defaultRole values as explicit roles', () => {
+      const input = JSON.stringify([
+        {role: 'assistant', content: 'A'},
+        {role: 'assistant', content: 'B'},
+      ]);
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe('A\nB');
+    });
   });
 
   describe('plain strings and non-array inputs', () => {

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
@@ -4,7 +4,7 @@ import {
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 
 export interface AIMessage {
-  content: any;
+  content: unknown;
   role: string;
 }
 
@@ -21,15 +21,16 @@ interface AIOutputResult {
 }
 
 type RawMessage = {
-  content?: any;
-  parts?: any[];
+  content?: unknown;
+  parts?: unknown[];
   role?: string;
+  roleExplicit?: boolean;
 };
 
 /**
- * Normalizes any AI attribute value into a list of messages.
+ * Normalizes AI attribute values into a list of messages.
  *
- * Accepts every shape the codebase supports on any attribute:
+ * Accepts every shape the codebase supports on supported attributes:
  * - parts-format array:     [{role, parts: [{type, text|content}, ...]}]
  * - content-format array:   [{role, content}]
  * - messages wrapper:       {messages: [...] | "[...]"}, optional `system`
@@ -63,11 +64,11 @@ export function normalizeToMessages(
 }
 
 /**
- * Extracts assistant output from any AI attribute value, splitting it into
+ * Extracts assistant output from AI attribute values, splitting it into
  * response text, structured objects, and tool calls.
  *
  * Role selection rule:
- * - If any message declares a role, select all with `role === 'assistant'`.
+ * - If at least one message declares a role, select all with `role === 'assistant'`.
  * - Otherwise, take the last message.
  */
 export function extractAssistantOutput(
@@ -86,11 +87,11 @@ export function extractAssistantOutput(
     return empty;
   }
 
-  const selected = selectAssistantMessages(rawMessages, defaultRole);
+  const selected = selectAssistantMessages(rawMessages);
 
   const textParts: string[] = [];
-  const toolCallParts: any[] = [];
-  const objectParts: any[] = [];
+  const toolCallParts: unknown[] = [];
+  const objectParts: unknown[] = [];
   for (const msg of selected) {
     collectOutputExtras(msg, {textParts, toolCallParts, objectParts});
   }
@@ -117,7 +118,8 @@ function parseAndDetect(
     };
   }
 
-  const {parsed, fixedInvalidJson} = parseJsonWithFix(raw);
+  const {parsed, fixedInvalidJson}: {fixedInvalidJson: boolean; parsed: unknown} =
+    parseJsonWithFix(raw);
   if (parsed === null) {
     return {fixedInvalidJson, messages: []};
   }
@@ -128,7 +130,7 @@ function parseAndDetect(
 /**
  * Maps an already-parsed value onto a list of raw messages.
  */
-function detectShape(value: any, defaultRole: string): RawMessage[] {
+function detectShape(value: unknown, defaultRole: string): RawMessage[] {
   if (typeof value === 'string') {
     return value.trim() ? [{role: defaultRole, content: value}] : [];
   }
@@ -137,7 +139,7 @@ function detectShape(value: any, defaultRole: string): RawMessage[] {
     return collectRawMessages(value, defaultRole);
   }
 
-  if (!value || typeof value !== 'object') {
+  if (!isRecord(value)) {
     return [];
   }
 
@@ -153,7 +155,7 @@ function detectShape(value: any, defaultRole: string): RawMessage[] {
   return single ? [single] : [];
 }
 
-function collectRawMessages(items: any[], defaultRole: string): RawMessage[] {
+function collectRawMessages(items: unknown[], defaultRole: string): RawMessage[] {
   const out: RawMessage[] = [];
   for (const item of items) {
     const msg = toRawMessage(item, defaultRole);
@@ -168,10 +170,11 @@ function collectRawMessages(items: any[], defaultRole: string): RawMessage[] {
  * OpenRouter-style wrapper: `{messages: [...] | "[...]"}`.
  * Also supports an optional `system` prepended.
  */
-function unwrapMessagesField(value: any, defaultRole: string): RawMessage[] {
+function unwrapMessagesField(value: UnknownRecord, defaultRole: string): RawMessage[] {
   const result: RawMessage[] = [];
-  if (typeof value.system === 'string' && value.system.length > 0) {
-    result.push({role: 'system', content: value.system});
+  const system = getStringField(value, 'system');
+  if (system) {
+    result.push({role: 'system', roleExplicit: true, content: system});
   }
 
   const inner = value.messages;
@@ -181,7 +184,7 @@ function unwrapMessagesField(value: any, defaultRole: string): RawMessage[] {
   }
   if (typeof inner === 'string') {
     try {
-      const innerParsed = JSON.parse(inner);
+      const innerParsed: unknown = JSON.parse(inner);
       result.push(...detectShape(innerParsed, defaultRole));
     } catch {
       if (inner.trim()) {
@@ -195,37 +198,45 @@ function unwrapMessagesField(value: any, defaultRole: string): RawMessage[] {
 /**
  * Legacy Vercel/AI SDK shape: `{system?, prompt}`.
  */
-function unwrapSystemPrompt(value: any): RawMessage[] {
+function unwrapSystemPrompt(value: UnknownRecord): RawMessage[] {
   const result: RawMessage[] = [];
-  if (typeof value.system === 'string' && value.system.length > 0) {
-    result.push({role: 'system', content: value.system});
+  const system = getStringField(value, 'system');
+  if (system) {
+    result.push({role: 'system', roleExplicit: true, content: system});
   }
   if (value.prompt) {
-    result.push({role: 'user', content: value.prompt});
+    result.push({role: 'user', roleExplicit: true, content: value.prompt});
   }
   return result;
 }
 
-function toRawMessage(item: any, defaultRole: string): RawMessage | null {
+function toRawMessage(item: unknown, defaultRole: string): RawMessage | null {
   if (typeof item === 'string') {
     return item.trim() ? {role: defaultRole, content: item} : null;
   }
-  if (!item || typeof item !== 'object') {
+  if (!isRecord(item)) {
     return null;
   }
 
-  const role =
-    typeof item.role === 'string' && item.role.length > 0 ? item.role : undefined;
+  const role = getStringField(item, 'role');
   if (Array.isArray(item.parts)) {
-    return {role: role ?? defaultRole, parts: item.parts};
+    return {
+      role: role ?? defaultRole,
+      roleExplicit: role !== undefined,
+      parts: item.parts,
+    };
   }
   if (item.content !== undefined) {
-    return {role: role ?? defaultRole, content: item.content};
+    return {
+      role: role ?? defaultRole,
+      roleExplicit: role !== undefined,
+      content: item.content,
+    };
   }
   return null;
 }
 
-function resolveMessageContent(msg: RawMessage, role: string): any {
+function resolveMessageContent(msg: RawMessage, role: string): unknown {
   if (msg.parts) {
     return collapseParts(msg.parts);
   }
@@ -233,7 +244,7 @@ function resolveMessageContent(msg: RawMessage, role: string): any {
   return role === 'tool' ? parsed : renderTextContent(parsed);
 }
 
-function renderTextContent(content: any): any {
+function renderTextContent(content: unknown): unknown {
   return Array.isArray(content) ? extractTextFromContentParts(content) : content;
 }
 
@@ -242,38 +253,35 @@ function renderTextContent(content: any): any {
  * render. Prefers text (plus file redaction placeholders); falls back to
  * structured objects, then tool_calls, then tool_call_responses.
  */
-function collapseParts(parts: any[]): any {
-  const hasText = parts.some((p: any) => p?.type === 'text');
-  const hasFile = parts.some((p: any) => p?.type && FILE_CONTENT_PARTS.includes(p.type));
+function collapseParts(parts: unknown[]): unknown {
+  const hasText = parts.some(part => getPartType(part) === 'text');
+  const hasFile = parts.some(part => isFileContentPartType(getPartType(part)));
   if (hasText || hasFile) {
     return extractTextFromContentParts(parts);
   }
 
-  const objectParts = parts.filter((p: any) => p?.type === 'object');
+  const objectParts = parts.filter(part => getPartType(part) === 'object');
   if (objectParts.length > 0) {
     return objectParts.length === 1 ? objectParts[0] : objectParts;
   }
 
-  const toolCalls = parts.filter((p: any) => p?.type === 'tool_call');
+  const toolCalls = parts.filter(part => getPartType(part) === 'tool_call');
   if (toolCalls.length > 0) {
     return toolCalls;
   }
 
-  const toolResponses = parts.filter((p: any) => p?.type === 'tool_call_response');
+  const toolResponses = parts.filter(part => getPartType(part) === 'tool_call_response');
   if (toolResponses.length > 0) {
-    return toolResponses.map((r: any) => r.result).join('\n');
+    return toolResponses
+      .map(response => (isRecord(response) ? response.result : undefined))
+      .join('\n');
   }
 
   return undefined;
 }
 
-function selectAssistantMessages(
-  rawMessages: RawMessage[],
-  defaultRole: string
-): RawMessage[] {
-  const hasRole = rawMessages.some(
-    m => typeof m.role === 'string' && m.role.length > 0 && m.role !== defaultRole
-  );
+function selectAssistantMessages(rawMessages: RawMessage[]): RawMessage[] {
+  const hasRole = rawMessages.some(m => m.roleExplicit === true);
   if (hasRole) {
     return rawMessages.filter(m => m.role === 'assistant');
   }
@@ -282,25 +290,24 @@ function selectAssistantMessages(
 
 function collectOutputExtras(
   msg: RawMessage,
-  buckets: {objectParts: any[]; textParts: string[]; toolCallParts: any[]}
+  buckets: {objectParts: unknown[]; textParts: string[]; toolCallParts: unknown[]}
 ): void {
   const {textParts, toolCallParts, objectParts} = buckets;
 
   if (msg.parts) {
     for (const part of msg.parts) {
-      if (part?.type === 'text') {
-        const text = part.content ?? part.text;
-        if (typeof text === 'string' && text) {
+      const partType = getPartType(part);
+      if (partType === 'text' && isRecord(part)) {
+        const text = getStringField(part, 'content') ?? getStringField(part, 'text');
+        if (text) {
           textParts.push(text);
         }
-      } else if (part?.type === 'tool_call') {
+      } else if (partType === 'tool_call') {
         toolCallParts.push(part);
-      } else if (part?.type === 'object') {
+      } else if (partType === 'object') {
         objectParts.push(part);
-      } else if (part?.type && FILE_CONTENT_PARTS.includes(part.type)) {
-        textParts.push(
-          `\n\n[redacted content of type "${part.mime_type ?? 'unknown'}"]\n\n`
-        );
+      } else if (isFileContentPartType(partType) && isRecord(part)) {
+        textParts.push(`\n\n[redacted content of type "${getMimeType(part)}"]\n\n`);
       }
     }
     return;
@@ -317,12 +324,15 @@ function collectOutputExtras(
     if (extracted) {
       textParts.push(extracted);
     }
-  } else if (typeof content === 'object') {
+  } else if (content !== null && typeof content === 'object') {
     objectParts.push(content);
   }
 }
 
 const FILE_CONTENT_PARTS = ['blob', 'uri', 'file'] as const;
+const FILE_CONTENT_PART_TYPES = new Set<string>(FILE_CONTENT_PARTS);
+type FileContentPartType = (typeof FILE_CONTENT_PARTS)[number];
+type UnknownRecord = Record<string, unknown>;
 
 function looksLikeJson(raw: string): boolean {
   const trimmed = raw.trim();
@@ -333,24 +343,47 @@ function looksLikeJson(raw: string): boolean {
   return first === '[' || first === '{' || first === '"';
 }
 
-function extractTextFromContentParts(parts: any[]): string {
+function extractTextFromContentParts(parts: unknown[]): string {
   const texts: string[] = [];
   for (const part of parts) {
-    if (!part || typeof part !== 'object') {
+    if (!isRecord(part)) {
       continue;
     }
-    if (part.type && FILE_CONTENT_PARTS.includes(part.type)) {
-      texts.push(`\n\n[redacted content of type "${part.mime_type ?? 'unknown'}"]\n\n`);
+
+    const partType = getPartType(part);
+    if (isFileContentPartType(partType)) {
+      texts.push(`\n\n[redacted content of type "${getMimeType(part)}"]\n\n`);
       continue;
     }
     // Accept untyped items with `text` or `content` (older Anthropic-style
     // [{text: '...'}] arrays) as well as explicit `type: 'text'` parts.
-    if (!part.type || part.type === 'text') {
-      const text = part.text ?? part.content;
-      if (typeof text === 'string' && text) {
+    if (!partType || partType === 'text') {
+      const text = getStringField(part, 'text') ?? getStringField(part, 'content');
+      if (text) {
         texts.push(text.trim());
       }
     }
   }
   return texts.join('\n');
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getStringField(record: UnknownRecord, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getPartType(value: unknown): string | undefined {
+  return isRecord(value) ? getStringField(value, 'type') : undefined;
+}
+
+function isFileContentPartType(value: unknown): value is FileContentPartType {
+  return typeof value === 'string' && FILE_CONTENT_PART_TYPES.has(value);
+}
+
+function getMimeType(record: UnknownRecord): string {
+  return getStringField(record, 'mime_type') ?? 'unknown';
 }

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
@@ -172,7 +172,7 @@ function collectRawMessages(items: unknown[], defaultRole: string): RawMessage[]
  */
 function unwrapMessagesField(value: UnknownRecord, defaultRole: string): RawMessage[] {
   const result: RawMessage[] = [];
-  const system = getStringField(value, 'system');
+  const system = value.system;
   if (system) {
     result.push({role: 'system', roleExplicit: true, content: system});
   }
@@ -200,7 +200,7 @@ function unwrapMessagesField(value: UnknownRecord, defaultRole: string): RawMess
  */
 function unwrapSystemPrompt(value: UnknownRecord): RawMessage[] {
   const result: RawMessage[] = [];
-  const system = getStringField(value, 'system');
+  const system = value.system;
   if (system) {
     result.push({role: 'system', roleExplicit: true, content: system});
   }


### PR DESCRIPTION
Keep `aiMessageNormalizer` parsed payloads as `unknown` until local guards narrow their shape. This removes local `any` usage while preserving the flexible message formats the normalizer accepts.

**Type Coverage Diff**

`pnpm run type-coverage-diff --commit` reported no new `any` symbols for `aiMessageNormalizer` and 25 removed `any`-typed symbols:

```text
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:92   toolCallParts
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:93   objectParts
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:120  parsed
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:131  value
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:156  items
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:171  value
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:184  innerParsed
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:198  value
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:209  item
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:217  role
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:236  content
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:245  parts
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:246  part
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:247  part
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:252  objectParts
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:252  part
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:257  toolCalls
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:257  part
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:262  toolResponses
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:262  part
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:264  response
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:285  buckets
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:292  text
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:336  parts
static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts:349  text
```

Closes TET-2295