### PR TITLE
fix(ai): Mirror AI conversation message parsers

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -25,6 +25,11 @@ from sentry.search.events.types import SAMPLING_MODES
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.rpc_dataset_common import TableQuery
 from sentry.snuba.spans_rpc import Spans
+from sentry.utils.ai_message_normalizer import (
+    FILTERED,
+    extract_assistant_output,
+    normalize_to_messages,
+)
 
 logger = logging.getLogger("sentry.api.endpoints.organization_ai_conversations")
 
@@ -62,61 +67,29 @@ def _compute_timestamp_ms(finish_ts: float) -> int:
     return int(finish_ts * 1000) if finish_ts else 0
 
 
-FILTERED = "[Filtered]"
+def _stringify_message_content(content: Any) -> str | None:
+    if isinstance(content, str):
+        return content or None
+
+    try:
+        return json.dumps(content)
+    except TypeError:
+        rendered = str(content)
+        return rendered or None
 
 
-def _parse_messages(messages: str | list | None) -> list | None:
-    if not messages:
-        return None
-    if isinstance(messages, str):
-        try:
-            messages = json.loads(messages)
-        except (json.JSONDecodeError, TypeError):
-            return None
-    if not isinstance(messages, list):
-        return None
-    return messages
-
-
-def _looks_like_json(raw: str) -> bool:
-    """Mirrors the frontend's looksLikeJson: detects values that may parse as JSON."""
-    stripped = raw.strip()
-    if not stripped:
-        return False
-    return stripped[0] in ("[", "{", '"')
-
-
-def _extract_content_from_parts(msg: dict) -> str | None:
-    """Extract text content from a message with parts format, concatenating multiple text parts."""
-    parts = msg.get("parts", [])
-    if not isinstance(parts, list):
-        return None
-
-    text_contents = []
-    for part in parts:
-        if isinstance(part, dict) and part.get("type") == "text":
-            content = part.get("content")
-            if content:
-                text_contents.append(content)
-
-    return "\n".join(text_contents) if text_contents else None
-
-
-def _extract_first_user_message(messages: str | list | None) -> str | None:
+def _extract_first_user_message(messages: Any) -> str | None:
     """Extract first user message, handling both old (content) and new (parts) formats."""
     if isinstance(messages, str) and messages == FILTERED:
         return FILTERED
-    parsed = _parse_messages(messages)
+    parsed = normalize_to_messages(messages, "user")
     if not parsed:
         return None
     for msg in parsed:
-        if isinstance(msg, dict) and msg.get("role") == "user":
-            # Try old format first (content field)
-            content = msg.get("content")
+        if msg.get("role") == "user":
+            content = _stringify_message_content(msg.get("content"))
             if content:
                 return content
-            # Try new parts format
-            return _extract_content_from_parts(msg)
     return None
 
 
@@ -140,43 +113,6 @@ def _get_first_input_message(row: dict) -> str | None:
     return None
 
 
-def _extract_assistant_text(value: Any) -> str | None:
-    """
-    Extracts the assistant text response from a gen_ai.output.messages value.
-
-    Mirrors the frontend's extractAssistantOutput so all shapes the SDKs emit
-    are handled: plain strings, JSON-encoded strings, and arrays of messages
-    in either content or parts format.
-    """
-    # Plain non-JSON string: the entire value is the assistant's response.
-    if isinstance(value, str) and not _looks_like_json(value):
-        return value if value.strip() else None
-
-    parsed: Any = value
-    if isinstance(value, str):
-        try:
-            parsed = json.loads(value)
-        except (json.JSONDecodeError, TypeError):
-            return None
-
-    # JSON-encoded scalar string, e.g. '"Hello"' parses to "Hello".
-    if isinstance(parsed, str):
-        return parsed if parsed.strip() else None
-
-    if not isinstance(parsed, list):
-        return None
-
-    for msg in reversed(parsed):
-        if isinstance(msg, dict) and msg.get("role") == "assistant":
-            content = msg.get("content")
-            if isinstance(content, str) and content:
-                return content
-            parts_content = _extract_content_from_parts(msg)
-            if parts_content:
-                return parts_content
-    return None
-
-
 def _get_last_output(row: dict) -> str | None:
     """
     Gets output text from output attributes, checking in priority order.
@@ -186,7 +122,7 @@ def _get_last_output(row: dict) -> str | None:
     if output_messages:
         if output_messages == FILTERED:
             return FILTERED
-        text = _extract_assistant_text(output_messages)
+        text = extract_assistant_output(output_messages, "assistant")["response_text"]
         if text:
             return text
 

--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -1,4 +1,3 @@
-import json  # noqa: S003
 import logging
 from collections import defaultdict
 from datetime import datetime
@@ -29,6 +28,7 @@ from sentry.utils.ai_message_normalizer import (
     FILTERED,
     extract_assistant_output,
     normalize_to_messages,
+    stringify_message_content,
 )
 
 logger = logging.getLogger("sentry.api.endpoints.organization_ai_conversations")
@@ -67,17 +67,6 @@ def _compute_timestamp_ms(finish_ts: float) -> int:
     return int(finish_ts * 1000) if finish_ts else 0
 
 
-def _stringify_message_content(content: Any) -> str | None:
-    if isinstance(content, str):
-        return content or None
-
-    try:
-        return json.dumps(content)
-    except TypeError:
-        rendered = str(content)
-        return rendered or None
-
-
 def _extract_first_user_message(messages: Any) -> str | None:
     """Extract first user message, handling both old (content) and new (parts) formats."""
     if isinstance(messages, str) and messages == FILTERED:
@@ -87,7 +76,7 @@ def _extract_first_user_message(messages: Any) -> str | None:
         return None
     for msg in parsed:
         if msg.get("role") == "user":
-            content = _stringify_message_content(msg.get("content"))
+            content = stringify_message_content(msg.get("content"))
             if content:
                 return content
     return None

--- a/src/sentry/utils/ai_message_normalizer.py
+++ b/src/sentry/utils/ai_message_normalizer.py
@@ -1,0 +1,304 @@
+import json  # noqa: S003
+from typing import Any, TypedDict
+
+FILTERED = "[Filtered]"
+FILE_CONTENT_PARTS = ("blob", "uri", "file")
+
+
+class AIMessage(TypedDict):
+    role: str
+    content: Any
+
+
+class AIOutputResult(TypedDict):
+    response_text: str | None
+    response_object: str | None
+    tool_calls: str | None
+
+
+class RawMessage(TypedDict, total=False):
+    role: str
+    content: Any
+    parts: list[Any]
+    role_explicit: bool
+
+
+# Keep this parser mirrored with
+# static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts.
+# AI SDKs emit inconsistent shapes and their specs keep changing, so update both
+# parsers together whenever adding or changing a supported format.
+def normalize_to_messages(raw: Any, default_role: str) -> list[AIMessage] | None:
+    raw_messages = _parse_and_detect(raw, default_role)
+
+    normalized: list[AIMessage] = []
+    for msg in raw_messages:
+        role = msg.get("role") or default_role
+        content = _resolve_message_content(msg, role)
+        if content is None or content == "":
+            continue
+        normalized.append({"role": role, "content": content})
+
+    return normalized or None
+
+
+def extract_assistant_output(raw: Any, default_role: str) -> AIOutputResult:
+    raw_messages = _parse_and_detect(raw, default_role)
+    if not raw_messages:
+        return {"response_text": None, "response_object": None, "tool_calls": None}
+
+    selected = _select_assistant_messages(raw_messages)
+
+    text_parts: list[str] = []
+    tool_call_parts: list[Any] = []
+    object_parts: list[Any] = []
+    for msg in selected:
+        _collect_output_extras(
+            msg,
+            text_parts=text_parts,
+            tool_call_parts=tool_call_parts,
+            object_parts=object_parts,
+        )
+
+    response_object = None
+    if object_parts:
+        response_object = json.dumps(object_parts[0] if len(object_parts) == 1 else object_parts)
+
+    return {
+        "response_text": "\n".join(text_parts) if text_parts else None,
+        "response_object": response_object,
+        "tool_calls": json.dumps(tool_call_parts) if tool_call_parts else None,
+    }
+
+
+def _parse_and_detect(raw: Any, default_role: str) -> list[RawMessage]:
+    if isinstance(raw, str):
+        if not _looks_like_json(raw):
+            return [{"role": default_role, "content": raw}] if raw.strip() else []
+
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return []
+        return _detect_shape(parsed, default_role)
+
+    return _detect_shape(raw, default_role)
+
+
+def _detect_shape(value: Any, default_role: str) -> list[RawMessage]:
+    if isinstance(value, str):
+        return [{"role": default_role, "content": value}] if value.strip() else []
+
+    if isinstance(value, list):
+        return _collect_raw_messages(value, default_role)
+
+    if not isinstance(value, dict):
+        return []
+
+    if "messages" in value:
+        return _unwrap_messages_field(value, default_role)
+
+    if "prompt" in value:
+        return _unwrap_system_prompt(value)
+
+    single = _to_raw_message(value, default_role)
+    return [single] if single else []
+
+
+def _collect_raw_messages(items: list[Any], default_role: str) -> list[RawMessage]:
+    out: list[RawMessage] = []
+    for item in items:
+        msg = _to_raw_message(item, default_role)
+        if msg:
+            out.append(msg)
+    return out
+
+
+def _unwrap_messages_field(value: dict[str, Any], default_role: str) -> list[RawMessage]:
+    result: list[RawMessage] = []
+    system = value.get("system")
+    if system:
+        result.append({"role": "system", "role_explicit": True, "content": system})
+
+    inner = value.get("messages")
+    if isinstance(inner, list):
+        result.extend(_collect_raw_messages(inner, default_role))
+        return result
+
+    if isinstance(inner, str):
+        try:
+            result.extend(_detect_shape(json.loads(inner), default_role))
+        except (json.JSONDecodeError, TypeError):
+            if inner.strip():
+                result.append({"role": default_role, "content": inner})
+
+    return result
+
+
+def _unwrap_system_prompt(value: dict[str, Any]) -> list[RawMessage]:
+    result: list[RawMessage] = []
+    system = value.get("system")
+    if system:
+        result.append({"role": "system", "role_explicit": True, "content": system})
+    prompt = value.get("prompt")
+    if prompt:
+        result.append({"role": "user", "role_explicit": True, "content": prompt})
+    return result
+
+
+def _to_raw_message(item: Any, default_role: str) -> RawMessage | None:
+    if isinstance(item, str):
+        return {"role": default_role, "content": item} if item.strip() else None
+
+    if not isinstance(item, dict):
+        return None
+
+    role = item.get("role") if isinstance(item.get("role"), str) and item.get("role") else None
+    if isinstance(item.get("parts"), list):
+        return {
+            "role": role or default_role,
+            "role_explicit": role is not None,
+            "parts": item["parts"],
+        }
+    if "content" in item:
+        return {
+            "role": role or default_role,
+            "role_explicit": role is not None,
+            "content": item.get("content"),
+        }
+    if "completion" in item:
+        return {
+            "role": role or default_role,
+            "role_explicit": role is not None,
+            "content": item.get("completion"),
+        }
+    return None
+
+
+def _resolve_message_content(msg: RawMessage, role: str) -> Any:
+    if "parts" in msg:
+        return _collapse_parts(msg["parts"])
+
+    content = _try_parse_json_recursive(msg.get("content"))
+    return content if role == "tool" else _render_text_content(content)
+
+
+def _render_text_content(content: Any) -> Any:
+    if isinstance(content, list):
+        return _extract_text_from_content_parts(content)
+    return content
+
+
+def _try_parse_json_recursive(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+
+    try:
+        parsed_value = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+
+    if parsed_value is None or isinstance(parsed_value, (bool, int, float)):
+        return value
+    if isinstance(parsed_value, list):
+        return [_try_parse_json_recursive(item) for item in parsed_value]
+    return parsed_value
+
+
+def _collapse_parts(parts: list[Any]) -> Any:
+    has_text = any(isinstance(part, dict) and part.get("type") == "text" for part in parts)
+    has_file = any(
+        isinstance(part, dict) and part.get("type") in FILE_CONTENT_PARTS for part in parts
+    )
+    if has_text or has_file:
+        return _extract_text_from_content_parts(parts)
+
+    object_parts = [
+        part for part in parts if isinstance(part, dict) and part.get("type") == "object"
+    ]
+    if object_parts:
+        return object_parts[0] if len(object_parts) == 1 else object_parts
+
+    tool_calls = [
+        part for part in parts if isinstance(part, dict) and part.get("type") == "tool_call"
+    ]
+    if tool_calls:
+        return tool_calls
+
+    tool_responses = [
+        part
+        for part in parts
+        if isinstance(part, dict) and part.get("type") == "tool_call_response"
+    ]
+    if tool_responses:
+        return "\n".join(str(response.get("result", "")) for response in tool_responses)
+
+    return None
+
+
+def _select_assistant_messages(raw_messages: list[RawMessage]) -> list[RawMessage]:
+    has_role = any(msg.get("role_explicit") is True for msg in raw_messages)
+    if has_role:
+        return [msg for msg in raw_messages if msg.get("role") == "assistant"]
+    return [raw_messages[-1]]
+
+
+def _collect_output_extras(
+    msg: RawMessage,
+    *,
+    text_parts: list[str],
+    tool_call_parts: list[Any],
+    object_parts: list[Any],
+) -> None:
+    if "parts" in msg:
+        for part in msg["parts"]:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") == "text":
+                text = part.get("content") or part.get("text")
+                if isinstance(text, str) and text:
+                    text_parts.append(text)
+            elif part.get("type") == "tool_call":
+                tool_call_parts.append(part)
+            elif part.get("type") == "object":
+                object_parts.append(part)
+            elif part.get("type") in FILE_CONTENT_PARTS:
+                text_parts.append(
+                    f'\n\n[redacted content of type "{part.get("mime_type") or "unknown"}"]\n\n'
+                )
+        return
+
+    content = _try_parse_json_recursive(msg.get("content"))
+    if content is None:
+        return
+    if isinstance(content, str) and content:
+        text_parts.append(content)
+    elif isinstance(content, list):
+        text = _extract_text_from_content_parts(content)
+        if text:
+            text_parts.append(text)
+    elif isinstance(content, dict):
+        object_parts.append(content)
+
+
+def _looks_like_json(raw: str) -> bool:
+    stripped = raw.strip()
+    if not stripped:
+        return False
+    return stripped[0] in ("[", "{", '"')
+
+
+def _extract_text_from_content_parts(parts: list[Any]) -> str:
+    texts: list[str] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") in FILE_CONTENT_PARTS:
+            texts.append(
+                f'\n\n[redacted content of type "{part.get("mime_type") or "unknown"}"]\n\n'
+            )
+            continue
+        if not part.get("type") or part.get("type") == "text":
+            text = part.get("text") or part.get("content")
+            if isinstance(text, str) and text:
+                texts.append(text.strip())
+    return "\n".join(texts)

--- a/src/sentry/utils/ai_message_normalizer.py
+++ b/src/sentry/utils/ai_message_normalizer.py
@@ -24,6 +24,14 @@ class RawMessage(TypedDict, total=False):
     role_explicit: bool
 
 
+class PartBuckets(TypedDict):
+    has_renderable_text_part: bool
+    text_parts: list[str]
+    object_parts: list[Any]
+    tool_calls: list[Any]
+    tool_responses: list[dict[str, Any]]
+
+
 # Keep this parser mirrored with
 # static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts.
 # AI SDKs emit inconsistent shapes and their specs keep changing, so update both
@@ -218,34 +226,63 @@ def _try_parse_json_recursive(value: Any) -> Any:
 
 
 def _collapse_parts(parts: list[Any]) -> Any:
-    has_text = any(isinstance(part, dict) and part.get("type") == "text" for part in parts)
-    has_file = any(
-        isinstance(part, dict) and part.get("type") in FILE_CONTENT_PARTS for part in parts
-    )
-    if has_text or has_file:
-        return _extract_text_from_content_parts(parts)
+    buckets = _bucket_parts(parts)
 
-    object_parts = [
-        part for part in parts if isinstance(part, dict) and part.get("type") == "object"
-    ]
-    if object_parts:
-        return object_parts[0] if len(object_parts) == 1 else object_parts
-
-    tool_calls = [
-        part for part in parts if isinstance(part, dict) and part.get("type") == "tool_call"
-    ]
-    if tool_calls:
-        return tool_calls
-
-    tool_responses = [
-        part
-        for part in parts
-        if isinstance(part, dict) and part.get("type") == "tool_call_response"
-    ]
-    if tool_responses:
-        return "\n".join(str(response.get("result", "")) for response in tool_responses)
+    if buckets["has_renderable_text_part"]:
+        return "\n".join(buckets["text_parts"])
+    if buckets["object_parts"]:
+        return (
+            buckets["object_parts"][0]
+            if len(buckets["object_parts"]) == 1
+            else buckets["object_parts"]
+        )
+    if buckets["tool_calls"]:
+        return buckets["tool_calls"]
+    if buckets["tool_responses"]:
+        return "\n".join(str(response.get("result", "")) for response in buckets["tool_responses"])
 
     return None
+
+
+def _bucket_parts(parts: list[Any]) -> PartBuckets:
+    buckets: PartBuckets = {
+        "has_renderable_text_part": False,
+        "text_parts": [],
+        "object_parts": [],
+        "tool_calls": [],
+        "tool_responses": [],
+    }
+
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+
+        part_type = part.get("type")
+        if part_type in FILE_CONTENT_PARTS:
+            buckets["has_renderable_text_part"] = True
+            buckets["text_parts"].append(_redacted_file_content(part))
+            continue
+        if part_type == "text":
+            buckets["has_renderable_text_part"] = True
+            text = _text_from_part(part, strip=True)
+            if text:
+                buckets["text_parts"].append(text)
+            continue
+        if not part_type:
+            text = _text_from_part(part, strip=True)
+            if text:
+                buckets["text_parts"].append(text)
+            continue
+        if part_type == "object":
+            buckets["object_parts"].append(part)
+            continue
+        if part_type == "tool_call":
+            buckets["tool_calls"].append(part)
+            continue
+        if part_type == "tool_call_response":
+            buckets["tool_responses"].append(part)
+
+    return buckets
 
 
 def _select_assistant_messages(raw_messages: list[RawMessage]) -> list[RawMessage]:
@@ -334,10 +371,17 @@ def _extract_text_from_content_parts(parts: list[Any]) -> str:
             texts.append(_redacted_file_content(part))
             continue
         if not part.get("type") or part.get("type") == "text":
-            text = part.get("text") or part.get("content")
-            if isinstance(text, str) and text:
-                texts.append(text.strip())
+            text = _text_from_part(part, strip=True)
+            if text:
+                texts.append(text)
     return "\n".join(texts)
+
+
+def _text_from_part(part: dict[str, Any], *, strip: bool = False) -> str | None:
+    text = part.get("text") or part.get("content")
+    if not isinstance(text, str) or not text:
+        return None
+    return text.strip() if strip else text
 
 
 def _redacted_file_content(part: dict[str, Any]) -> str:

--- a/src/sentry/utils/ai_message_normalizer.py
+++ b/src/sentry/utils/ai_message_normalizer.py
@@ -3,6 +3,7 @@ from typing import Any, TypedDict
 
 FILTERED = "[Filtered]"
 FILE_CONTENT_PARTS = ("blob", "uri", "file")
+_INVALID_JSON = object()
 
 
 class AIMessage(TypedDict):
@@ -28,8 +29,26 @@ class RawMessage(TypedDict, total=False):
 # AI SDKs emit inconsistent shapes and their specs keep changing, so update both
 # parsers together whenever adding or changing a supported format.
 def normalize_to_messages(raw: Any, default_role: str) -> list[AIMessage] | None:
-    raw_messages = _parse_and_detect(raw, default_role)
+    messages = _normalize_raw_messages(
+        _raw_messages_from_attribute(raw, default_role), default_role
+    )
+    return messages or None
 
+
+def extract_assistant_output(raw: Any, default_role: str) -> AIOutputResult:
+    raw_messages = _raw_messages_from_attribute(raw, default_role)
+    if not raw_messages:
+        return _empty_output()
+
+    selected = _select_assistant_messages(raw_messages)
+    return _output_from_messages(selected)
+
+
+def _empty_output() -> AIOutputResult:
+    return {"response_text": None, "response_object": None, "tool_calls": None}
+
+
+def _normalize_raw_messages(raw_messages: list[RawMessage], default_role: str) -> list[AIMessage]:
     normalized: list[AIMessage] = []
     for msg in raw_messages:
         role = msg.get("role") or default_role
@@ -37,22 +56,15 @@ def normalize_to_messages(raw: Any, default_role: str) -> list[AIMessage] | None
         if content is None or content == "":
             continue
         normalized.append({"role": role, "content": content})
+    return normalized
 
-    return normalized or None
 
-
-def extract_assistant_output(raw: Any, default_role: str) -> AIOutputResult:
-    raw_messages = _parse_and_detect(raw, default_role)
-    if not raw_messages:
-        return {"response_text": None, "response_object": None, "tool_calls": None}
-
-    selected = _select_assistant_messages(raw_messages)
-
+def _output_from_messages(messages: list[RawMessage]) -> AIOutputResult:
     text_parts: list[str] = []
     tool_call_parts: list[Any] = []
     object_parts: list[Any] = []
-    for msg in selected:
-        _collect_output_extras(
+    for msg in messages:
+        _append_output_from_message(
             msg,
             text_parts=text_parts,
             tool_call_parts=tool_call_parts,
@@ -70,21 +82,22 @@ def extract_assistant_output(raw: Any, default_role: str) -> AIOutputResult:
     }
 
 
-def _parse_and_detect(raw: Any, default_role: str) -> list[RawMessage]:
-    if isinstance(raw, str):
-        if not _looks_like_json(raw):
-            return [{"role": default_role, "content": raw}] if raw.strip() else []
-
-        try:
-            parsed = json.loads(raw)
-        except (json.JSONDecodeError, TypeError):
-            return []
-        return _detect_shape(parsed, default_role)
-
-    return _detect_shape(raw, default_role)
+def _raw_messages_from_attribute(raw: Any, default_role: str) -> list[RawMessage]:
+    parsed = _parse_attribute(raw)
+    if parsed is _INVALID_JSON:
+        return []
+    return _raw_messages_from_value(parsed, default_role)
 
 
-def _detect_shape(value: Any, default_role: str) -> list[RawMessage]:
+def _parse_attribute(raw: Any) -> Any:
+    if not isinstance(raw, str):
+        return raw
+    if not _looks_like_json(raw):
+        return raw
+    return _parse_json_string(raw, fallback=_INVALID_JSON)
+
+
+def _raw_messages_from_value(value: Any, default_role: str) -> list[RawMessage]:
     if isinstance(value, str):
         return [{"role": default_role, "content": value}] if value.strip() else []
 
@@ -125,11 +138,12 @@ def _unwrap_messages_field(value: dict[str, Any], default_role: str) -> list[Raw
         return result
 
     if isinstance(inner, str):
-        try:
-            result.extend(_detect_shape(json.loads(inner), default_role))
-        except (json.JSONDecodeError, TypeError):
+        parsed_inner = _parse_json_string(inner, fallback=_INVALID_JSON)
+        if parsed_inner is _INVALID_JSON:
             if inner.strip():
                 result.append({"role": default_role, "content": inner})
+            return result
+        result.extend(_raw_messages_from_value(parsed_inner, default_role))
 
     return result
 
@@ -192,9 +206,8 @@ def _try_parse_json_recursive(value: Any) -> Any:
     if not isinstance(value, str):
         return value
 
-    try:
-        parsed_value = json.loads(value)
-    except (json.JSONDecodeError, TypeError):
+    parsed_value = _parse_json_string(value, fallback=_INVALID_JSON)
+    if parsed_value is _INVALID_JSON:
         return value
 
     if parsed_value is None or isinstance(parsed_value, (bool, int, float)):
@@ -242,7 +255,7 @@ def _select_assistant_messages(raw_messages: list[RawMessage]) -> list[RawMessag
     return [raw_messages[-1]]
 
 
-def _collect_output_extras(
+def _append_output_from_message(
     msg: RawMessage,
     *,
     text_parts: list[str],
@@ -250,21 +263,12 @@ def _collect_output_extras(
     object_parts: list[Any],
 ) -> None:
     if "parts" in msg:
-        for part in msg["parts"]:
-            if not isinstance(part, dict):
-                continue
-            if part.get("type") == "text":
-                text = part.get("content") or part.get("text")
-                if isinstance(text, str) and text:
-                    text_parts.append(text)
-            elif part.get("type") == "tool_call":
-                tool_call_parts.append(part)
-            elif part.get("type") == "object":
-                object_parts.append(part)
-            elif part.get("type") in FILE_CONTENT_PARTS:
-                text_parts.append(
-                    f'\n\n[redacted content of type "{part.get("mime_type") or "unknown"}"]\n\n'
-                )
+        _append_output_from_parts(
+            msg["parts"],
+            text_parts=text_parts,
+            tool_call_parts=tool_call_parts,
+            object_parts=object_parts,
+        )
         return
 
     content = _try_parse_json_recursive(msg.get("content"))
@@ -280,6 +284,40 @@ def _collect_output_extras(
         object_parts.append(content)
 
 
+def _append_output_from_parts(
+    parts: list[Any],
+    *,
+    text_parts: list[str],
+    tool_call_parts: list[Any],
+    object_parts: list[Any],
+) -> None:
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+
+        part_type = part.get("type")
+        if part_type == "text":
+            text = part.get("content") or part.get("text")
+            if isinstance(text, str) and text:
+                text_parts.append(text)
+            continue
+        if part_type == "tool_call":
+            tool_call_parts.append(part)
+            continue
+        if part_type == "object":
+            object_parts.append(part)
+            continue
+        if part_type in FILE_CONTENT_PARTS:
+            text_parts.append(_redacted_file_content(part))
+
+
+def _parse_json_string(value: str, *, fallback: Any) -> Any:
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return fallback
+
+
 def _looks_like_json(raw: str) -> bool:
     stripped = raw.strip()
     if not stripped:
@@ -293,12 +331,14 @@ def _extract_text_from_content_parts(parts: list[Any]) -> str:
         if not isinstance(part, dict):
             continue
         if part.get("type") in FILE_CONTENT_PARTS:
-            texts.append(
-                f'\n\n[redacted content of type "{part.get("mime_type") or "unknown"}"]\n\n'
-            )
+            texts.append(_redacted_file_content(part))
             continue
         if not part.get("type") or part.get("type") == "text":
             text = part.get("text") or part.get("content")
             if isinstance(text, str) and text:
                 texts.append(text.strip())
     return "\n".join(texts)
+
+
+def _redacted_file_content(part: dict[str, Any]) -> str:
+    return f'\n\n[redacted content of type "{part.get("mime_type") or "unknown"}"]\n\n'

--- a/src/sentry/utils/ai_message_normalizer.py
+++ b/src/sentry/utils/ai_message_normalizer.py
@@ -52,6 +52,17 @@ def extract_assistant_output(raw: Any, default_role: str) -> AIOutputResult:
     return _output_from_messages(selected)
 
 
+def stringify_message_content(content: Any) -> str | None:
+    if isinstance(content, str):
+        return content or None
+
+    try:
+        return json.dumps(content)
+    except TypeError:
+        rendered = str(content)
+        return rendered or None
+
+
 def _empty_output() -> AIOutputResult:
     return {"response_text": None, "response_object": None, "tool_calls": None}
 
@@ -174,7 +185,8 @@ def _to_raw_message(item: Any, default_role: str) -> RawMessage | None:
     if not isinstance(item, dict):
         return None
 
-    role = item.get("role") if isinstance(item.get("role"), str) and item.get("role") else None
+    raw_role = item.get("role")
+    role = raw_role if isinstance(raw_role, str) and raw_role else None
     if isinstance(item.get("parts"), list):
         return {
             "role": role or default_role,
@@ -363,18 +375,7 @@ def _looks_like_json(raw: str) -> bool:
 
 
 def _extract_text_from_content_parts(parts: list[Any]) -> str:
-    texts: list[str] = []
-    for part in parts:
-        if not isinstance(part, dict):
-            continue
-        if part.get("type") in FILE_CONTENT_PARTS:
-            texts.append(_redacted_file_content(part))
-            continue
-        if not part.get("type") or part.get("type") == "text":
-            text = _text_from_part(part, strip=True)
-            if text:
-                texts.append(text)
-    return "\n".join(texts)
+    return "\n".join(_bucket_parts(parts)["text_parts"])
 
 
 def _text_from_part(part: dict[str, Any], *, strip: bool = False) -> str | None:

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.spec.ts
@@ -407,6 +407,61 @@ describe('extractAssistantOutput', () => {
       expect(responseText).toBe('the answer');
     });
 
+    it('parses JSON-encoded string content from assistant messages', () => {
+      const input = JSON.stringify([
+        {role: 'assistant', content: JSON.stringify('the answer')},
+      ]);
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe('the answer');
+    });
+
+    it('parses JSON-encoded content parts from assistant messages', () => {
+      const input = JSON.stringify([
+        {
+          role: 'assistant',
+          content: JSON.stringify([{type: 'text', text: 'the answer'}]),
+        },
+      ]);
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe('the answer');
+    });
+
+    it('ignores empty string content from assistant messages', () => {
+      const input = JSON.stringify([
+        {role: 'assistant', content: ''},
+        {role: 'assistant', content: 'the answer'},
+      ]);
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe('the answer');
+    });
+
+    it('preserves JSON primitive content strings from assistant messages', () => {
+      const numeric = extractAssistantOutput(
+        JSON.stringify([{role: 'assistant', content: '42'}]),
+        {
+          defaultRole: 'assistant',
+        }
+      );
+      const boolean = extractAssistantOutput(
+        JSON.stringify([{role: 'assistant', content: 'true'}]),
+        {defaultRole: 'assistant'}
+      );
+      const nullable = extractAssistantOutput(
+        JSON.stringify([{role: 'assistant', content: 'null'}]),
+        {defaultRole: 'assistant'}
+      );
+
+      expect(numeric.responseText).toBe('42');
+      expect(boolean.responseText).toBe('true');
+      expect(nullable.responseText).toBe('null');
+    });
+
     it('treats object content as a response object', () => {
       const input = JSON.stringify([
         {role: 'assistant', content: {schema: 's', data: {k: 1}}},
@@ -466,6 +521,17 @@ describe('extractAssistantOutput', () => {
 
       expect(responseText).toBe('A\nB');
     });
+
+    it('treats declared completion roles as explicit roles', () => {
+      const input = JSON.stringify([
+        {role: 'assistant', completion: 'A'},
+        {role: 'assistant', completion: 'B'},
+      ]);
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe('A\nB');
+    });
   });
 
   describe('plain strings and non-array inputs', () => {
@@ -485,6 +551,22 @@ describe('extractAssistantOutput', () => {
       const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
 
       expect(responseText).toBe('direct');
+    });
+
+    it('extracts content from a single {content} object', () => {
+      const input = JSON.stringify({content: 'direct without role'});
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe('direct without role');
+    });
+
+    it('extracts content from a single {completion} object', () => {
+      const input = JSON.stringify({completion: 'completion text'});
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe('completion text');
     });
 
     it('returns all null fields for empty input', () => {

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
@@ -1,6 +1,6 @@
 import {
   parseJsonWithFix,
-  tryParseJsonRecursive,
+  tryParseJsonRecursive as parseJsonRecursive,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 
 export interface AIMessage {
@@ -26,6 +26,10 @@ type RawMessage = {
   role?: string;
   roleExplicit?: boolean;
 };
+
+// Keep this parser mirrored with src/sentry/utils/ai_message_normalizer.py.
+// AI SDKs emit inconsistent shapes and their specs keep changing, so update both
+// parsers together whenever adding or changing a supported format.
 
 /**
  * Normalizes AI attribute values into a list of messages.
@@ -233,6 +237,13 @@ function toRawMessage(item: unknown, defaultRole: string): RawMessage | null {
       content: item.content,
     };
   }
+  if (item.completion !== undefined) {
+    return {
+      role: role ?? defaultRole,
+      roleExplicit: role !== undefined,
+      content: item.completion,
+    };
+  }
   return null;
 }
 
@@ -240,7 +251,7 @@ function resolveMessageContent(msg: RawMessage, role: string): unknown {
   if (msg.parts) {
     return collapseParts(msg.parts);
   }
-  const parsed = tryParseJsonRecursive(msg.content);
+  const parsed = tryParseJsonContent(msg.content);
   return role === 'tool' ? parsed : renderTextContent(parsed);
 }
 
@@ -313,11 +324,11 @@ function collectOutputExtras(
     return;
   }
 
-  const content = msg.content;
+  const content = tryParseJsonContent(msg.content);
   if (content === undefined || content === null) {
     return;
   }
-  if (typeof content === 'string') {
+  if (typeof content === 'string' && content) {
     textParts.push(content);
   } else if (Array.isArray(content)) {
     const extracted = extractTextFromContentParts(content);
@@ -333,6 +344,17 @@ const FILE_CONTENT_PARTS = ['blob', 'uri', 'file'] as const;
 const FILE_CONTENT_PART_TYPES = new Set<string>(FILE_CONTENT_PARTS);
 type FileContentPartType = (typeof FILE_CONTENT_PARTS)[number];
 type UnknownRecord = Record<string, unknown>;
+
+function tryParseJsonContent(value: unknown): unknown {
+  const parsed = parseJsonRecursive(value);
+  if (
+    typeof value === 'string' &&
+    (parsed === null || typeof parsed === 'number' || typeof parsed === 'boolean')
+  ) {
+    return value;
+  }
+  return parsed;
+}
 
 function looksLikeJson(raw: string): boolean {
   const trimmed = raw.trim();

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
@@ -1,6 +1,6 @@
 import {
   parseJsonWithFix,
-  tryParseJsonRecursive as parseJsonRecursive,
+  tryParseJsonRecursive,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 
 export interface AIMessage {
@@ -26,6 +26,8 @@ type RawMessage = {
   role?: string;
   roleExplicit?: boolean;
 };
+
+type UnknownRecord = Record<string, unknown>;
 
 type PartBuckets = {
   hasRenderableTextPart: boolean;
@@ -285,7 +287,7 @@ function resolveMessageContent(msg: RawMessage, role: string): unknown {
   if (msg.parts) {
     return collapseParts(msg.parts);
   }
-  const parsed = tryParseJsonContent(msg.content);
+  const parsed = parseJsonContentPreservingPrimitives(msg.content);
   return role === 'tool' ? parsed : renderTextContent(parsed);
 }
 
@@ -388,7 +390,7 @@ function appendOutputFromMessage(
     return;
   }
 
-  const content = tryParseJsonContent(msg.content);
+  const content = parseJsonContentPreservingPrimitives(msg.content);
   if (content === undefined || content === null) {
     return;
   }
@@ -435,10 +437,9 @@ function appendOutputFromParts(
 const FILE_CONTENT_PARTS = ['blob', 'uri', 'file'] as const;
 const FILE_CONTENT_PART_TYPES = new Set<string>(FILE_CONTENT_PARTS);
 type FileContentPartType = (typeof FILE_CONTENT_PARTS)[number];
-type UnknownRecord = Record<string, unknown>;
 
-function tryParseJsonContent(value: unknown): unknown {
-  const parsed = parseJsonRecursive(value);
+function parseJsonContentPreservingPrimitives(value: unknown): unknown {
+  const parsed = tryParseJsonRecursive(value);
   if (
     typeof value === 'string' &&
     (parsed === null || typeof parsed === 'number' || typeof parsed === 'boolean')
@@ -466,27 +467,7 @@ function looksLikeJson(raw: string): boolean {
 }
 
 function extractTextFromContentParts(parts: unknown[]): string {
-  const texts: string[] = [];
-  for (const part of parts) {
-    if (!isRecord(part)) {
-      continue;
-    }
-
-    const partType = getPartType(part);
-    if (isFileContentPartType(partType)) {
-      texts.push(redactedFileContent(part));
-      continue;
-    }
-    // Accept untyped items with `text` or `content` (older Anthropic-style
-    // [{text: '...'}] arrays) as well as explicit `type: 'text'` parts.
-    if (!partType || partType === 'text') {
-      const text = getTextPartContent(part, {trim: true});
-      if (text) {
-        texts.push(text);
-      }
-    }
-  }
-  return texts.join('\n');
+  return bucketParts(parts).textParts.join('\n');
 }
 
 function isRecord(value: unknown): value is UnknownRecord {

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
@@ -49,21 +49,15 @@ export function normalizeToMessages(
   raw: string,
   {defaultRole}: {defaultRole: string}
 ): NormalizedResult {
-  const {fixedInvalidJson, messages: rawMessages} = parseAndDetect(raw, defaultRole);
-
-  const normalized: AIMessage[] = [];
-  for (const msg of rawMessages) {
-    const role = msg.role ?? defaultRole;
-    const content = resolveMessageContent(msg, role);
-    if (content === undefined || content === null || content === '') {
-      continue;
-    }
-    normalized.push({role, content});
-  }
+  const {fixedInvalidJson, messages: rawMessages} = rawMessagesFromAttribute(
+    raw,
+    defaultRole
+  );
+  const messages = normalizeRawMessages(rawMessages, defaultRole);
 
   return {
     fixedInvalidJson,
-    messages: normalized.length > 0 ? normalized : null,
+    messages: messages.length > 0 ? messages : null,
   };
 }
 
@@ -79,25 +73,53 @@ export function extractAssistantOutput(
   raw: string,
   {defaultRole}: {defaultRole: string}
 ): AIOutputResult {
-  const {fixedInvalidJson, messages: rawMessages} = parseAndDetect(raw, defaultRole);
+  const {fixedInvalidJson, messages: rawMessages} = rawMessagesFromAttribute(
+    raw,
+    defaultRole
+  );
 
-  const empty: AIOutputResult = {
+  if (rawMessages.length === 0) {
+    return emptyOutput(fixedInvalidJson);
+  }
+
+  const selected = selectAssistantMessages(rawMessages);
+  return outputFromMessages(selected, fixedInvalidJson);
+}
+
+function emptyOutput(fixedInvalidJson: boolean): AIOutputResult {
+  return {
     fixedInvalidJson,
     responseText: null,
     responseObject: null,
     toolCalls: null,
   };
-  if (rawMessages.length === 0) {
-    return empty;
+}
+
+function normalizeRawMessages(
+  rawMessages: RawMessage[],
+  defaultRole: string
+): AIMessage[] {
+  const normalized: AIMessage[] = [];
+  for (const msg of rawMessages) {
+    const role = msg.role ?? defaultRole;
+    const content = resolveMessageContent(msg, role);
+    if (content === undefined || content === null || content === '') {
+      continue;
+    }
+    normalized.push({role, content});
   }
+  return normalized;
+}
 
-  const selected = selectAssistantMessages(rawMessages);
-
+function outputFromMessages(
+  messages: RawMessage[],
+  fixedInvalidJson: boolean
+): AIOutputResult {
   const textParts: string[] = [];
   const toolCallParts: unknown[] = [];
   const objectParts: unknown[] = [];
-  for (const msg of selected) {
-    collectOutputExtras(msg, {textParts, toolCallParts, objectParts});
+  for (const msg of messages) {
+    appendOutputFromMessage(msg, {textParts, toolCallParts, objectParts});
   }
 
   return {
@@ -111,30 +133,34 @@ export function extractAssistantOutput(
   };
 }
 
-function parseAndDetect(
+function rawMessagesFromAttribute(
   raw: string,
   defaultRole: string
 ): {fixedInvalidJson: boolean; messages: RawMessage[]} {
-  if (!looksLikeJson(raw)) {
-    return {
-      fixedInvalidJson: false,
-      messages: raw.trim() ? [{role: defaultRole, content: raw}] : [],
-    };
-  }
-
-  const {parsed, fixedInvalidJson}: {fixedInvalidJson: boolean; parsed: unknown} =
-    parseJsonWithFix(raw);
-  if (parsed === null) {
+  const {fixedInvalidJson, parsed} = parseAttribute(raw);
+  if (parsed === undefined) {
     return {fixedInvalidJson, messages: []};
   }
 
-  return {fixedInvalidJson, messages: detectShape(parsed, defaultRole)};
+  return {
+    fixedInvalidJson,
+    messages: rawMessagesFromValue(parsed, defaultRole),
+  };
+}
+
+function parseAttribute(raw: string): {fixedInvalidJson: boolean; parsed: unknown} {
+  if (!looksLikeJson(raw)) {
+    return {fixedInvalidJson: false, parsed: raw};
+  }
+  const {parsed, fixedInvalidJson}: {fixedInvalidJson: boolean; parsed: unknown} =
+    parseJsonWithFix(raw);
+  return {fixedInvalidJson, parsed: parsed ?? undefined};
 }
 
 /**
  * Maps an already-parsed value onto a list of raw messages.
  */
-function detectShape(value: unknown, defaultRole: string): RawMessage[] {
+function rawMessagesFromValue(value: unknown, defaultRole: string): RawMessage[] {
   if (typeof value === 'string') {
     return value.trim() ? [{role: defaultRole, content: value}] : [];
   }
@@ -187,14 +213,14 @@ function unwrapMessagesField(value: UnknownRecord, defaultRole: string): RawMess
     return result;
   }
   if (typeof inner === 'string') {
-    try {
-      const innerParsed: unknown = JSON.parse(inner);
-      result.push(...detectShape(innerParsed, defaultRole));
-    } catch {
+    const innerParsed = parseJsonString(inner);
+    if (innerParsed === undefined) {
       if (inner.trim()) {
         result.push({role: defaultRole, content: inner});
       }
+      return result;
     }
+    result.push(...rawMessagesFromValue(innerParsed, defaultRole));
   }
   return result;
 }
@@ -299,28 +325,14 @@ function selectAssistantMessages(rawMessages: RawMessage[]): RawMessage[] {
   return [rawMessages[rawMessages.length - 1]!];
 }
 
-function collectOutputExtras(
+function appendOutputFromMessage(
   msg: RawMessage,
   buckets: {objectParts: unknown[]; textParts: string[]; toolCallParts: unknown[]}
 ): void {
-  const {textParts, toolCallParts, objectParts} = buckets;
+  const {textParts, objectParts} = buckets;
 
   if (msg.parts) {
-    for (const part of msg.parts) {
-      const partType = getPartType(part);
-      if (partType === 'text' && isRecord(part)) {
-        const text = getStringField(part, 'content') ?? getStringField(part, 'text');
-        if (text) {
-          textParts.push(text);
-        }
-      } else if (partType === 'tool_call') {
-        toolCallParts.push(part);
-      } else if (partType === 'object') {
-        objectParts.push(part);
-      } else if (isFileContentPartType(partType) && isRecord(part)) {
-        textParts.push(`\n\n[redacted content of type "${getMimeType(part)}"]\n\n`);
-      }
-    }
+    appendOutputFromParts(msg.parts, buckets);
     return;
   }
 
@@ -340,6 +352,34 @@ function collectOutputExtras(
   }
 }
 
+function appendOutputFromParts(
+  parts: unknown[],
+  buckets: {objectParts: unknown[]; textParts: string[]; toolCallParts: unknown[]}
+): void {
+  const {textParts, toolCallParts, objectParts} = buckets;
+  for (const part of parts) {
+    const partType = getPartType(part);
+    if (partType === 'text' && isRecord(part)) {
+      const text = getStringField(part, 'content') ?? getStringField(part, 'text');
+      if (text) {
+        textParts.push(text);
+      }
+      continue;
+    }
+    if (partType === 'tool_call') {
+      toolCallParts.push(part);
+      continue;
+    }
+    if (partType === 'object') {
+      objectParts.push(part);
+      continue;
+    }
+    if (isFileContentPartType(partType) && isRecord(part)) {
+      textParts.push(redactedFileContent(part));
+    }
+  }
+}
+
 const FILE_CONTENT_PARTS = ['blob', 'uri', 'file'] as const;
 const FILE_CONTENT_PART_TYPES = new Set<string>(FILE_CONTENT_PARTS);
 type FileContentPartType = (typeof FILE_CONTENT_PARTS)[number];
@@ -354,6 +394,14 @@ function tryParseJsonContent(value: unknown): unknown {
     return value;
   }
   return parsed;
+}
+
+function parseJsonString(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
 }
 
 function looksLikeJson(raw: string): boolean {
@@ -374,7 +422,7 @@ function extractTextFromContentParts(parts: unknown[]): string {
 
     const partType = getPartType(part);
     if (isFileContentPartType(partType)) {
-      texts.push(`\n\n[redacted content of type "${getMimeType(part)}"]\n\n`);
+      texts.push(redactedFileContent(part));
       continue;
     }
     // Accept untyped items with `text` or `content` (older Anthropic-style
@@ -408,4 +456,8 @@ function isFileContentPartType(value: unknown): value is FileContentPartType {
 
 function getMimeType(record: UnknownRecord): string {
   return getStringField(record, 'mime_type') ?? 'unknown';
+}
+
+function redactedFileContent(record: UnknownRecord): string {
+  return `\n\n[redacted content of type "${getMimeType(record)}"]\n\n`;
 }

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
@@ -27,6 +27,14 @@ type RawMessage = {
   roleExplicit?: boolean;
 };
 
+type PartBuckets = {
+  hasRenderableTextPart: boolean;
+  objectParts: unknown[];
+  textParts: string[];
+  toolCalls: unknown[];
+  toolResponses: UnknownRecord[];
+};
+
 // Keep this parser mirrored with src/sentry/utils/ai_message_normalizer.py.
 // AI SDKs emit inconsistent shapes and their specs keep changing, so update both
 // parsers together whenever adding or changing a supported format.
@@ -291,30 +299,74 @@ function renderTextContent(content: unknown): unknown {
  * structured objects, then tool_calls, then tool_call_responses.
  */
 function collapseParts(parts: unknown[]): unknown {
-  const hasText = parts.some(part => getPartType(part) === 'text');
-  const hasFile = parts.some(part => isFileContentPartType(getPartType(part)));
-  if (hasText || hasFile) {
-    return extractTextFromContentParts(parts);
-  }
+  const buckets = bucketParts(parts);
 
-  const objectParts = parts.filter(part => getPartType(part) === 'object');
-  if (objectParts.length > 0) {
-    return objectParts.length === 1 ? objectParts[0] : objectParts;
+  if (buckets.hasRenderableTextPart) {
+    return buckets.textParts.join('\n');
   }
-
-  const toolCalls = parts.filter(part => getPartType(part) === 'tool_call');
-  if (toolCalls.length > 0) {
-    return toolCalls;
+  if (buckets.objectParts.length > 0) {
+    return buckets.objectParts.length === 1
+      ? buckets.objectParts[0]
+      : buckets.objectParts;
   }
-
-  const toolResponses = parts.filter(part => getPartType(part) === 'tool_call_response');
-  if (toolResponses.length > 0) {
-    return toolResponses
-      .map(response => (isRecord(response) ? response.result : undefined))
-      .join('\n');
+  if (buckets.toolCalls.length > 0) {
+    return buckets.toolCalls;
+  }
+  if (buckets.toolResponses.length > 0) {
+    return buckets.toolResponses.map(response => response.result).join('\n');
   }
 
   return undefined;
+}
+
+function bucketParts(parts: unknown[]): PartBuckets {
+  const buckets: PartBuckets = {
+    hasRenderableTextPart: false,
+    textParts: [],
+    objectParts: [],
+    toolCalls: [],
+    toolResponses: [],
+  };
+  for (const part of parts) {
+    if (!isRecord(part)) {
+      continue;
+    }
+
+    const partType = getPartType(part);
+    if (isFileContentPartType(partType)) {
+      buckets.hasRenderableTextPart = true;
+      buckets.textParts.push(redactedFileContent(part));
+      continue;
+    }
+    if (partType === 'text') {
+      buckets.hasRenderableTextPart = true;
+      const text = getTextPartContent(part, {trim: true});
+      if (text) {
+        buckets.textParts.push(text);
+      }
+      continue;
+    }
+    if (!partType) {
+      const text = getTextPartContent(part, {trim: true});
+      if (text) {
+        buckets.textParts.push(text);
+      }
+      continue;
+    }
+    if (partType === 'object') {
+      buckets.objectParts.push(part);
+      continue;
+    }
+    if (partType === 'tool_call') {
+      buckets.toolCalls.push(part);
+      continue;
+    }
+    if (partType === 'tool_call_response') {
+      buckets.toolResponses.push(part);
+    }
+  }
+
+  return buckets;
 }
 
 function selectAssistantMessages(rawMessages: RawMessage[]): RawMessage[] {
@@ -428,9 +480,9 @@ function extractTextFromContentParts(parts: unknown[]): string {
     // Accept untyped items with `text` or `content` (older Anthropic-style
     // [{text: '...'}] arrays) as well as explicit `type: 'text'` parts.
     if (!partType || partType === 'text') {
-      const text = getStringField(part, 'text') ?? getStringField(part, 'content');
+      const text = getTextPartContent(part, {trim: true});
       if (text) {
-        texts.push(text.trim());
+        texts.push(text);
       }
     }
   }
@@ -456,6 +508,14 @@ function isFileContentPartType(value: unknown): value is FileContentPartType {
 
 function getMimeType(record: UnknownRecord): string {
   return getStringField(record, 'mime_type') ?? 'unknown';
+}
+
+function getTextPartContent(
+  record: UnknownRecord,
+  options: {trim?: boolean} = {}
+): string | undefined {
+  const text = getStringField(record, 'text') ?? getStringField(record, 'content');
+  return options.trim ? text?.trim() : text;
 }
 
 function redactedFileContent(record: UnknownRecord): string {

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -4,12 +4,6 @@ from uuid import uuid4
 
 from django.urls import reverse
 
-from sentry.api.endpoints.organization_ai_conversations import (
-    _extract_content_from_parts,
-    _extract_first_user_message,
-    _get_first_input_message,
-    _get_last_output,
-)
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
 
@@ -18,184 +12,6 @@ from .test_organization_ai_conversations_base import (
     LLM_TOKENS,
     BaseAIConversationsTestCase,
 )
-
-
-class TestExtractContentFromParts:
-    """Unit tests for _extract_content_from_parts helper function"""
-
-    def test_single_text_part(self) -> None:
-        msg = {"parts": [{"type": "text", "content": "Hello, world!"}]}
-        assert _extract_content_from_parts(msg) == "Hello, world!"
-
-    def test_multiple_text_parts(self) -> None:
-        msg = {
-            "parts": [
-                {"type": "text", "content": "First part."},
-                {"type": "text", "content": "Second part."},
-            ]
-        }
-        assert _extract_content_from_parts(msg) == "First part.\nSecond part."
-
-    def test_mixed_part_types(self) -> None:
-        msg = {
-            "parts": [
-                {"type": "text", "content": "User question"},
-                {"type": "tool_call", "id": "123", "name": "weather"},
-                {"type": "text", "content": "More text"},
-            ]
-        }
-        # Should only extract text parts
-        assert _extract_content_from_parts(msg) == "User question\nMore text"
-
-    def test_empty_parts(self) -> None:
-        msg: dict[str, Any] = {"parts": []}
-        assert _extract_content_from_parts(msg) is None
-
-    def test_no_parts_key(self) -> None:
-        msg = {"content": "old format"}
-        assert _extract_content_from_parts(msg) is None
-
-    def test_parts_not_list(self) -> None:
-        msg = {"parts": "invalid"}
-        assert _extract_content_from_parts(msg) is None
-
-    def test_empty_content(self) -> None:
-        msg = {"parts": [{"type": "text", "content": ""}]}
-        assert _extract_content_from_parts(msg) is None
-
-    def test_missing_content(self) -> None:
-        msg = {"parts": [{"type": "text"}]}
-        assert _extract_content_from_parts(msg) is None
-
-
-class TestExtractFirstUserMessage:
-    """Unit tests for _extract_first_user_message helper function"""
-
-    def test_old_format_content(self) -> None:
-        messages = '[{"role": "user", "content": "Hello"}]'
-        assert _extract_first_user_message(messages) == "Hello"
-
-    def test_new_format_parts(self) -> None:
-        messages = '[{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]'
-        assert _extract_first_user_message(messages) == "Hello"
-
-    def test_prefers_old_format_when_both_exist(self) -> None:
-        messages = (
-            '[{"role": "user", "content": "Old", "parts": [{"type": "text", "content": "New"}]}]'
-        )
-        assert _extract_first_user_message(messages) == "Old"
-
-    def test_finds_first_user_message(self) -> None:
-        messages = '[{"role": "system", "content": "System"}, {"role": "user", "content": "First"}, {"role": "user", "content": "Second"}]'
-        assert _extract_first_user_message(messages) == "First"
-
-    def test_returns_none_for_no_user_messages(self) -> None:
-        messages = (
-            '[{"role": "system", "content": "System"}, {"role": "assistant", "content": "Hi"}]'
-        )
-        assert _extract_first_user_message(messages) is None
-
-    def test_returns_none_for_invalid_json(self) -> None:
-        messages = "invalid json"
-        assert _extract_first_user_message(messages) is None
-
-    def test_returns_none_for_none_input(self) -> None:
-        assert _extract_first_user_message(None) is None
-
-    def test_returns_none_for_empty_list(self) -> None:
-        messages = "[]"
-        assert _extract_first_user_message(messages) is None
-
-    def test_returns_filtered(self) -> None:
-        assert _extract_first_user_message("[Filtered]") == "[Filtered]"
-
-
-class TestGetFirstInputMessage:
-    """Unit tests for _get_first_input_message helper function"""
-
-    def test_prefers_new_format(self) -> None:
-        row = {
-            "gen_ai.input.messages": '[{"role": "user", "parts": [{"type": "text", "content": "New"}]}]',
-            "gen_ai.request.messages": '[{"role": "user", "content": "Old"}]',
-        }
-        assert _get_first_input_message(row) == "New"
-
-    def test_falls_back_to_old_format(self) -> None:
-        row = {"gen_ai.request.messages": '[{"role": "user", "content": "Old"}]'}
-        assert _get_first_input_message(row) == "Old"
-
-    def test_returns_none_when_both_empty(self) -> None:
-        row: dict[str, Any] = {}
-        assert _get_first_input_message(row) is None
-
-    def test_skips_invalid_new_format(self) -> None:
-        row = {
-            "gen_ai.input.messages": "invalid",
-            "gen_ai.request.messages": '[{"role": "user", "content": "Old"}]',
-        }
-        assert _get_first_input_message(row) == "Old"
-
-    def test_returns_filtered_for_new_format(self) -> None:
-        row = {"gen_ai.input.messages": "[Filtered]"}
-        assert _get_first_input_message(row) == "[Filtered]"
-
-    def test_returns_filtered_for_old_format(self) -> None:
-        row = {"gen_ai.request.messages": "[Filtered]"}
-        assert _get_first_input_message(row) == "[Filtered]"
-
-
-class TestGetLastOutput:
-    """Unit tests for _get_last_output helper function"""
-
-    def test_prefers_new_format_text_part(self) -> None:
-        row = {
-            "gen_ai.output.messages": '[{"role": "assistant", "parts": [{"type": "text", "content": "New"}]}]',
-            "gen_ai.response.text": "Old",
-        }
-        assert _get_last_output(row) == "New"
-
-    def test_prefers_new_format_content(self) -> None:
-        row = {
-            "gen_ai.output.messages": '[{"role": "assistant", "content": "New content"}]',
-            "gen_ai.response.text": "Old",
-        }
-        assert _get_last_output(row) == "New content"
-
-    def test_falls_back_to_old_format(self) -> None:
-        row = {"gen_ai.response.text": "Old response"}
-        assert _get_last_output(row) == "Old response"
-
-    def test_returns_none_when_empty(self) -> None:
-        row: dict[str, Any] = {}
-        assert _get_last_output(row) is None
-
-    def test_finds_last_assistant_message(self) -> None:
-        row = {
-            "gen_ai.output.messages": '[{"role": "assistant", "content": "First"}, {"role": "user", "content": "Question"}, {"role": "assistant", "content": "Last"}]'
-        }
-        assert _get_last_output(row) == "Last"
-
-    def test_uses_plain_string_as_assistant_text(self) -> None:
-        row = {
-            "gen_ai.output.messages": "Plain text response",
-            "gen_ai.response.text": "Fallback",
-        }
-        assert _get_last_output(row) == "Plain text response"
-
-    def test_extracts_json_encoded_string(self) -> None:
-        row = {"gen_ai.output.messages": '"Hello, world!"'}
-        assert _get_last_output(row) == "Hello, world!"
-
-    def test_falls_back_on_invalid_json(self) -> None:
-        row = {
-            "gen_ai.output.messages": "[broken json",
-            "gen_ai.response.text": "Fallback",
-        }
-        assert _get_last_output(row) == "Fallback"
-
-    def test_returns_filtered(self) -> None:
-        row = {"gen_ai.output.messages": "[Filtered]"}
-        assert _get_last_output(row) == "[Filtered]"
 
 
 class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
@@ -1078,6 +894,45 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
         assert response.data[0]["firstInput"] == user_content
         assert response.data[0]["lastOutput"] == response_content
+
+    def test_structured_user_part_populates_first_input(self) -> None:
+        now = before_now(days=19).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        trace_id = uuid4().hex
+
+        input_messages = [
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "type": "object",
+                        "data": {"question": "Weather in Paris?"},
+                    }
+                ],
+            }
+        ]
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            trace_id=trace_id,
+            input_messages=input_messages,
+            output_messages=[{"role": "assistant", "content": "It's rainy"}],
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200
+        assert response.data[0]["firstInput"] == (
+            '{"type": "object", "data": {"question": "Weather in Paris?"}}'
+        )
 
     def test_tool_names_populated(self) -> None:
         """Test that toolNames is populated with distinct tool names from tool spans"""

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -1,9 +1,14 @@
+import json  # noqa: S003
 from datetime import timedelta
 from typing import Any
 from uuid import uuid4
 
 from django.urls import reverse
 
+from sentry.api.endpoints.organization_ai_conversations import (
+    _get_first_input_message,
+    _get_last_output,
+)
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
 
@@ -12,6 +17,83 @@ from .test_organization_ai_conversations_base import (
     LLM_TOKENS,
     BaseAIConversationsTestCase,
 )
+
+
+def json_string(value: Any) -> str:
+    return json.dumps(value)
+
+
+class TestGetFirstInputMessage:
+    def test_prefers_input_messages(self) -> None:
+        row = {
+            "gen_ai.input.messages": json_string(
+                [{"role": "user", "parts": [{"type": "text", "content": "New"}]}]
+            ),
+            "gen_ai.request.messages": json_string([{"role": "user", "content": "Old"}]),
+        }
+        assert _get_first_input_message(row) == "New"
+
+    def test_falls_back_to_request_messages(self) -> None:
+        row = {"gen_ai.request.messages": json_string([{"role": "user", "content": "Old"}])}
+        assert _get_first_input_message(row) == "Old"
+
+    def test_returns_none_when_both_empty(self) -> None:
+        row: dict[str, Any] = {}
+        assert _get_first_input_message(row) is None
+
+    def test_skips_invalid_input_messages(self) -> None:
+        row = {
+            "gen_ai.input.messages": "[broken json",
+            "gen_ai.request.messages": json_string([{"role": "user", "content": "Old"}]),
+        }
+        assert _get_first_input_message(row) == "Old"
+
+    def test_returns_filtered_for_input_messages(self) -> None:
+        row = {"gen_ai.input.messages": "[Filtered]"}
+        assert _get_first_input_message(row) == "[Filtered]"
+
+    def test_returns_filtered_for_request_messages(self) -> None:
+        row = {"gen_ai.request.messages": "[Filtered]"}
+        assert _get_first_input_message(row) == "[Filtered]"
+
+
+class TestGetLastOutput:
+    def test_prefers_output_messages_text_part(self) -> None:
+        row = {
+            "gen_ai.output.messages": json_string(
+                [{"role": "assistant", "parts": [{"type": "text", "content": "New"}]}]
+            ),
+            "gen_ai.response.text": "Old",
+        }
+        assert _get_last_output(row) == "New"
+
+    def test_prefers_output_messages_content(self) -> None:
+        row = {
+            "gen_ai.output.messages": json_string(
+                [{"role": "assistant", "content": "New content"}]
+            ),
+            "gen_ai.response.text": "Old",
+        }
+        assert _get_last_output(row) == "New content"
+
+    def test_falls_back_to_response_text(self) -> None:
+        row = {"gen_ai.response.text": "Old response"}
+        assert _get_last_output(row) == "Old response"
+
+    def test_returns_none_when_empty(self) -> None:
+        row: dict[str, Any] = {}
+        assert _get_last_output(row) is None
+
+    def test_falls_back_on_invalid_output_messages(self) -> None:
+        row = {
+            "gen_ai.output.messages": "[broken json",
+            "gen_ai.response.text": "Fallback",
+        }
+        assert _get_last_output(row) == "Fallback"
+
+    def test_returns_filtered(self) -> None:
+        row = {"gen_ai.output.messages": "[Filtered]"}
+        assert _get_last_output(row) == "[Filtered]"
 
 
 class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):

--- a/tests/sentry/utils/test_ai_message_normalizer.py
+++ b/tests/sentry/utils/test_ai_message_normalizer.py
@@ -1,0 +1,185 @@
+from sentry.utils.ai_message_normalizer import (
+    extract_assistant_output,
+    normalize_to_messages,
+)
+
+
+class TestNormalizeContentParts:
+    def test_single_text_part(self) -> None:
+        messages = '[{"role": "user", "parts": [{"type": "text", "content": "Hello, world!"}]}]'
+        assert normalize_to_messages(messages, "user") == [
+            {"role": "user", "content": "Hello, world!"}
+        ]
+
+    def test_multiple_text_parts(self) -> None:
+        messages = '[{"role": "user", "parts": [{"type": "text", "content": "First part."}, {"type": "text", "content": "Second part."}]}]'
+        assert normalize_to_messages(messages, "user") == [
+            {"role": "user", "content": "First part.\nSecond part."}
+        ]
+
+    def test_mixed_part_types(self) -> None:
+        messages = '[{"role": "user", "parts": [{"type": "text", "content": "User question"}, {"type": "tool_call", "id": "123", "name": "weather"}, {"type": "text", "content": "More text"}]}]'
+        assert normalize_to_messages(messages, "user") == [
+            {"role": "user", "content": "User question\nMore text"}
+        ]
+
+    def test_empty_parts(self) -> None:
+        messages = '[{"role": "user", "parts": []}]'
+        assert normalize_to_messages(messages, "user") is None
+
+    def test_content_without_parts(self) -> None:
+        messages = '[{"role": "user", "content": "old format"}]'
+        assert normalize_to_messages(messages, "user") == [
+            {"role": "user", "content": "old format"}
+        ]
+
+    def test_parts_not_list(self) -> None:
+        messages = '[{"role": "user", "parts": "invalid"}]'
+        assert normalize_to_messages(messages, "user") is None
+
+    def test_empty_content(self) -> None:
+        messages = '[{"role": "user", "parts": [{"type": "text", "content": ""}]}]'
+        assert normalize_to_messages(messages, "user") is None
+
+    def test_missing_content(self) -> None:
+        messages = '[{"role": "user", "parts": [{"type": "text"}]}]'
+        assert normalize_to_messages(messages, "user") is None
+
+
+class TestNormalizeToMessages:
+    def test_old_format_content(self) -> None:
+        messages = '[{"role": "user", "content": "Hello"}]'
+        assert normalize_to_messages(messages, "user") == [{"role": "user", "content": "Hello"}]
+
+    def test_new_format_parts(self) -> None:
+        messages = '[{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]'
+        assert normalize_to_messages(messages, "user") == [{"role": "user", "content": "Hello"}]
+
+    def test_prefers_parts_format_when_both_exist(self) -> None:
+        messages = (
+            '[{"role": "user", "content": "Old", "parts": [{"type": "text", "content": "New"}]}]'
+        )
+        assert normalize_to_messages(messages, "user") == [{"role": "user", "content": "New"}]
+
+    def test_finds_user_messages(self) -> None:
+        messages = '[{"role": "system", "content": "System"}, {"role": "user", "content": "First"}, {"role": "user", "content": "Second"}]'
+        assert normalize_to_messages(messages, "user") == [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "First"},
+            {"role": "user", "content": "Second"},
+        ]
+
+    def test_returns_none_for_malformed_json(self) -> None:
+        assert normalize_to_messages("[broken json", "user") is None
+
+    def test_returns_none_for_none_input(self) -> None:
+        assert normalize_to_messages(None, "user") is None
+
+    def test_returns_none_for_empty_list(self) -> None:
+        assert normalize_to_messages("[]", "user") is None
+
+    def test_uses_plain_string_as_user_text(self) -> None:
+        assert normalize_to_messages("Plain user input", "user") == [
+            {"role": "user", "content": "Plain user input"}
+        ]
+
+
+class TestExtractAssistantOutput:
+    def test_prefers_new_format_text_part(self) -> None:
+        result = extract_assistant_output(
+            '[{"role": "assistant", "parts": [{"type": "text", "content": "New"}]}]',
+            "assistant",
+        )
+        assert result["response_text"] == "New"
+
+    def test_prefers_new_format_content(self) -> None:
+        result = extract_assistant_output(
+            '[{"role": "assistant", "content": "New content"}]',
+            "assistant",
+        )
+        assert result["response_text"] == "New content"
+
+    def test_parses_json_encoded_content_string(self) -> None:
+        result = extract_assistant_output(
+            '[{"role": "assistant", "content": "\\"New content\\""}]',
+            "assistant",
+        )
+        assert result["response_text"] == "New content"
+
+    def test_parses_json_encoded_content_parts(self) -> None:
+        result = extract_assistant_output(
+            '[{"role": "assistant", "content": "[{\\"type\\": \\"text\\", \\"text\\": \\"New content\\"}]"}]',
+            "assistant",
+        )
+        assert result["response_text"] == "New content"
+
+    def test_ignores_empty_string_content(self) -> None:
+        result = extract_assistant_output(
+            '[{"role": "assistant", "content": ""}, {"role": "assistant", "content": "New content"}]',
+            "assistant",
+        )
+        assert result["response_text"] == "New content"
+
+    def test_preserves_json_primitive_content_strings(self) -> None:
+        numeric = extract_assistant_output('[{"role": "assistant", "content": "42"}]', "assistant")
+        boolean = extract_assistant_output(
+            '[{"role": "assistant", "content": "true"}]', "assistant"
+        )
+        null = extract_assistant_output('[{"role": "assistant", "content": "null"}]', "assistant")
+        assert numeric["response_text"] == "42"
+        assert boolean["response_text"] == "true"
+        assert null["response_text"] == "null"
+
+    def test_returns_none_when_empty(self) -> None:
+        result = extract_assistant_output("", "assistant")
+        assert result["response_text"] is None
+        assert result["response_object"] is None
+        assert result["tool_calls"] is None
+
+    def test_joins_assistant_messages(self) -> None:
+        result = extract_assistant_output(
+            '[{"role": "assistant", "content": "First"}, {"role": "user", "content": "Question"}, {"role": "assistant", "content": "Last"}]',
+            "assistant",
+        )
+        assert result["response_text"] == "First\nLast"
+
+    def test_treats_default_role_only_messages_as_roleless(self) -> None:
+        result = extract_assistant_output(
+            '[{"content": "A"}, {"content": "B"}]',
+            "assistant",
+        )
+        assert result["response_text"] == "B"
+
+    def test_treats_declared_default_role_values_as_explicit_roles(self) -> None:
+        result = extract_assistant_output(
+            '[{"role": "assistant", "content": "A"}, {"role": "assistant", "content": "B"}]',
+            "assistant",
+        )
+        assert result["response_text"] == "A\nB"
+
+    def test_treats_declared_completion_roles_as_explicit_roles(self) -> None:
+        result = extract_assistant_output(
+            '[{"role": "assistant", "completion": "A"}, {"role": "assistant", "completion": "B"}]',
+            "assistant",
+        )
+        assert result["response_text"] == "A\nB"
+
+    def test_uses_plain_string_as_assistant_text(self) -> None:
+        result = extract_assistant_output("Plain text response", "assistant")
+        assert result["response_text"] == "Plain text response"
+
+    def test_extracts_json_encoded_string(self) -> None:
+        result = extract_assistant_output('"Hello, world!"', "assistant")
+        assert result["response_text"] == "Hello, world!"
+
+    def test_returns_none_on_malformed_json(self) -> None:
+        result = extract_assistant_output("[broken json", "assistant")
+        assert result["response_text"] is None
+
+    def test_extracts_single_object_content(self) -> None:
+        result = extract_assistant_output('{"content": "Object content"}', "assistant")
+        assert result["response_text"] == "Object content"
+
+    def test_extracts_single_object_completion(self) -> None:
+        result = extract_assistant_output('{"completion": "Completion text"}', "assistant")
+        assert result["response_text"] == "Completion text"

--- a/tests/sentry/utils/test_ai_message_normalizer.py
+++ b/tests/sentry/utils/test_ai_message_normalizer.py
@@ -1,72 +1,146 @@
+import json  # noqa: S003
+from typing import Any
+
 from sentry.utils.ai_message_normalizer import (
     extract_assistant_output,
     normalize_to_messages,
+    stringify_message_content,
 )
+
+
+def json_string(value: Any) -> str:
+    return json.dumps(value)
 
 
 class TestNormalizeContentParts:
     def test_single_text_part(self) -> None:
-        messages = '[{"role": "user", "parts": [{"type": "text", "content": "Hello, world!"}]}]'
+        messages = json_string(
+            [{"role": "user", "parts": [{"type": "text", "content": "Hello, world!"}]}]
+        )
         assert normalize_to_messages(messages, "user") == [
             {"role": "user", "content": "Hello, world!"}
         ]
 
     def test_multiple_text_parts(self) -> None:
-        messages = '[{"role": "user", "parts": [{"type": "text", "content": "First part."}, {"type": "text", "content": "Second part."}]}]'
+        messages = json_string(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"type": "text", "content": "First part."},
+                        {"type": "text", "content": "Second part."},
+                    ],
+                }
+            ]
+        )
         assert normalize_to_messages(messages, "user") == [
             {"role": "user", "content": "First part.\nSecond part."}
         ]
 
     def test_mixed_part_types(self) -> None:
-        messages = '[{"role": "user", "parts": [{"type": "text", "content": "User question"}, {"type": "tool_call", "id": "123", "name": "weather"}, {"type": "text", "content": "More text"}]}]'
+        messages = json_string(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"type": "text", "content": "User question"},
+                        {"type": "tool_call", "id": "123", "name": "weather"},
+                        {"type": "text", "content": "More text"},
+                    ],
+                }
+            ]
+        )
         assert normalize_to_messages(messages, "user") == [
             {"role": "user", "content": "User question\nMore text"}
         ]
 
     def test_empty_parts(self) -> None:
-        messages = '[{"role": "user", "parts": []}]'
+        messages = json_string([{"role": "user", "parts": []}])
         assert normalize_to_messages(messages, "user") is None
 
     def test_content_without_parts(self) -> None:
-        messages = '[{"role": "user", "content": "old format"}]'
+        messages = json_string([{"role": "user", "content": "old format"}])
         assert normalize_to_messages(messages, "user") == [
             {"role": "user", "content": "old format"}
         ]
 
     def test_parts_not_list(self) -> None:
-        messages = '[{"role": "user", "parts": "invalid"}]'
+        messages = json_string([{"role": "user", "parts": "invalid"}])
         assert normalize_to_messages(messages, "user") is None
 
     def test_empty_content(self) -> None:
-        messages = '[{"role": "user", "parts": [{"type": "text", "content": ""}]}]'
+        messages = json_string([{"role": "user", "parts": [{"type": "text", "content": ""}]}])
         assert normalize_to_messages(messages, "user") is None
 
     def test_missing_content(self) -> None:
-        messages = '[{"role": "user", "parts": [{"type": "text"}]}]'
+        messages = json_string([{"role": "user", "parts": [{"type": "text"}]}])
         assert normalize_to_messages(messages, "user") is None
 
 
 class TestNormalizeToMessages:
     def test_old_format_content(self) -> None:
-        messages = '[{"role": "user", "content": "Hello"}]'
+        messages = json_string([{"role": "user", "content": "Hello"}])
         assert normalize_to_messages(messages, "user") == [{"role": "user", "content": "Hello"}]
 
     def test_new_format_parts(self) -> None:
-        messages = '[{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]'
+        messages = json_string([{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}])
         assert normalize_to_messages(messages, "user") == [{"role": "user", "content": "Hello"}]
 
     def test_prefers_parts_format_when_both_exist(self) -> None:
-        messages = (
-            '[{"role": "user", "content": "Old", "parts": [{"type": "text", "content": "New"}]}]'
+        messages = json_string(
+            [
+                {
+                    "role": "user",
+                    "content": "Old",
+                    "parts": [{"type": "text", "content": "New"}],
+                }
+            ]
         )
         assert normalize_to_messages(messages, "user") == [{"role": "user", "content": "New"}]
 
     def test_finds_user_messages(self) -> None:
-        messages = '[{"role": "system", "content": "System"}, {"role": "user", "content": "First"}, {"role": "user", "content": "Second"}]'
+        messages = json_string(
+            [
+                {"role": "system", "content": "System"},
+                {"role": "user", "content": "First"},
+                {"role": "user", "content": "Second"},
+            ]
+        )
         assert normalize_to_messages(messages, "user") == [
             {"role": "system", "content": "System"},
             {"role": "user", "content": "First"},
             {"role": "user", "content": "Second"},
+        ]
+
+    def test_unwraps_messages_array(self) -> None:
+        messages = json_string(
+            {
+                "system": "System",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+        )
+        assert normalize_to_messages(messages, "user") == [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def test_unwraps_messages_json_string(self) -> None:
+        messages = json_string(
+            {
+                "system": "System",
+                "messages": json_string([{"role": "user", "content": "Hello"}]),
+            }
+        )
+        assert normalize_to_messages(messages, "user") == [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def test_unwraps_system_prompt(self) -> None:
+        messages = json_string({"system": "System", "prompt": "Question"})
+        assert normalize_to_messages(messages, "user") == [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "Question"},
         ]
 
     def test_returns_none_for_malformed_json(self) -> None:
@@ -87,45 +161,61 @@ class TestNormalizeToMessages:
 class TestExtractAssistantOutput:
     def test_prefers_new_format_text_part(self) -> None:
         result = extract_assistant_output(
-            '[{"role": "assistant", "parts": [{"type": "text", "content": "New"}]}]',
+            json_string([{"role": "assistant", "parts": [{"type": "text", "content": "New"}]}]),
             "assistant",
         )
         assert result["response_text"] == "New"
 
     def test_prefers_new_format_content(self) -> None:
         result = extract_assistant_output(
-            '[{"role": "assistant", "content": "New content"}]',
+            json_string([{"role": "assistant", "content": "New content"}]),
             "assistant",
         )
         assert result["response_text"] == "New content"
 
     def test_parses_json_encoded_content_string(self) -> None:
         result = extract_assistant_output(
-            '[{"role": "assistant", "content": "\\"New content\\""}]',
+            json_string([{"role": "assistant", "content": json_string("New content")}]),
             "assistant",
         )
         assert result["response_text"] == "New content"
 
     def test_parses_json_encoded_content_parts(self) -> None:
         result = extract_assistant_output(
-            '[{"role": "assistant", "content": "[{\\"type\\": \\"text\\", \\"text\\": \\"New content\\"}]"}]',
+            json_string(
+                [
+                    {
+                        "role": "assistant",
+                        "content": json_string([{"type": "text", "text": "New content"}]),
+                    }
+                ]
+            ),
             "assistant",
         )
         assert result["response_text"] == "New content"
 
     def test_ignores_empty_string_content(self) -> None:
         result = extract_assistant_output(
-            '[{"role": "assistant", "content": ""}, {"role": "assistant", "content": "New content"}]',
+            json_string(
+                [
+                    {"role": "assistant", "content": ""},
+                    {"role": "assistant", "content": "New content"},
+                ]
+            ),
             "assistant",
         )
         assert result["response_text"] == "New content"
 
     def test_preserves_json_primitive_content_strings(self) -> None:
-        numeric = extract_assistant_output('[{"role": "assistant", "content": "42"}]', "assistant")
-        boolean = extract_assistant_output(
-            '[{"role": "assistant", "content": "true"}]', "assistant"
+        numeric = extract_assistant_output(
+            json_string([{"role": "assistant", "content": "42"}]), "assistant"
         )
-        null = extract_assistant_output('[{"role": "assistant", "content": "null"}]', "assistant")
+        boolean = extract_assistant_output(
+            json_string([{"role": "assistant", "content": "true"}]), "assistant"
+        )
+        null = extract_assistant_output(
+            json_string([{"role": "assistant", "content": "null"}]), "assistant"
+        )
         assert numeric["response_text"] == "42"
         assert boolean["response_text"] == "true"
         assert null["response_text"] == "null"
@@ -138,28 +228,51 @@ class TestExtractAssistantOutput:
 
     def test_joins_assistant_messages(self) -> None:
         result = extract_assistant_output(
-            '[{"role": "assistant", "content": "First"}, {"role": "user", "content": "Question"}, {"role": "assistant", "content": "Last"}]',
+            json_string(
+                [
+                    {"role": "assistant", "content": "First"},
+                    {"role": "user", "content": "Question"},
+                    {"role": "assistant", "content": "Last"},
+                ]
+            ),
             "assistant",
         )
         assert result["response_text"] == "First\nLast"
 
+    def test_unwraps_messages_json_string(self) -> None:
+        result = extract_assistant_output(
+            json_string({"messages": json_string([{"role": "assistant", "content": "Wrapped"}])}),
+            "assistant",
+        )
+        assert result["response_text"] == "Wrapped"
+
     def test_treats_default_role_only_messages_as_roleless(self) -> None:
         result = extract_assistant_output(
-            '[{"content": "A"}, {"content": "B"}]',
+            json_string([{"content": "A"}, {"content": "B"}]),
             "assistant",
         )
         assert result["response_text"] == "B"
 
     def test_treats_declared_default_role_values_as_explicit_roles(self) -> None:
         result = extract_assistant_output(
-            '[{"role": "assistant", "content": "A"}, {"role": "assistant", "content": "B"}]',
+            json_string(
+                [
+                    {"role": "assistant", "content": "A"},
+                    {"role": "assistant", "content": "B"},
+                ]
+            ),
             "assistant",
         )
         assert result["response_text"] == "A\nB"
 
     def test_treats_declared_completion_roles_as_explicit_roles(self) -> None:
         result = extract_assistant_output(
-            '[{"role": "assistant", "completion": "A"}, {"role": "assistant", "completion": "B"}]',
+            json_string(
+                [
+                    {"role": "assistant", "completion": "A"},
+                    {"role": "assistant", "completion": "B"},
+                ]
+            ),
             "assistant",
         )
         assert result["response_text"] == "A\nB"
@@ -169,7 +282,7 @@ class TestExtractAssistantOutput:
         assert result["response_text"] == "Plain text response"
 
     def test_extracts_json_encoded_string(self) -> None:
-        result = extract_assistant_output('"Hello, world!"', "assistant")
+        result = extract_assistant_output(json_string("Hello, world!"), "assistant")
         assert result["response_text"] == "Hello, world!"
 
     def test_returns_none_on_malformed_json(self) -> None:
@@ -177,9 +290,20 @@ class TestExtractAssistantOutput:
         assert result["response_text"] is None
 
     def test_extracts_single_object_content(self) -> None:
-        result = extract_assistant_output('{"content": "Object content"}', "assistant")
+        result = extract_assistant_output(json_string({"content": "Object content"}), "assistant")
         assert result["response_text"] == "Object content"
 
     def test_extracts_single_object_completion(self) -> None:
-        result = extract_assistant_output('{"completion": "Completion text"}', "assistant")
+        result = extract_assistant_output(
+            json_string({"completion": "Completion text"}), "assistant"
+        )
         assert result["response_text"] == "Completion text"
+
+
+class TestStringifyMessageContent:
+    def test_returns_strings_unchanged(self) -> None:
+        assert stringify_message_content("Hello") == "Hello"
+        assert stringify_message_content("") is None
+
+    def test_json_encodes_structured_content(self) -> None:
+        assert stringify_message_content({"question": "Weather?"}) == '{"question": "Weather?"}'


### PR DESCRIPTION
Keep the conversation overview parser aligned with the frontend AI message normalizer so both views understand the same evolving SDK payload shapes. The overview now extracts output text from single-object `{content: ...}` and `{completion: ...}` payloads instead of falling back to raw or empty output.

**Parser alignment**

Move backend AI message parsing into `sentry.utils.ai_message_normalizer` and add cross-references in the backend and frontend parsers. The comments call out that new formats need to be added on both sides because provider payloads are inconsistent and the specs keep changing.

Frontend and backend changes can be safely deployed independently. 

Fixes TET-2273
Fixes TET-2281