### PR TITLE
fix(preprod): Use display_name for snapshot sidebar labels

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -137,12 +137,19 @@ describe('SnapshotMainContent', () => {
       headBranch: 'feature/snapshot-updates',
       isSoloView: false,
       listItems: [
-        {key: 'changed-buttons', name: 'Buttons', pairs: [changedPair], type: 'changed'},
+        {
+          key: 'changed-buttons',
+          name: 'Buttons',
+          displayName: 'Buttons',
+          pairs: [changedPair],
+          type: 'changed',
+        },
       ],
       onNavigateSingleView,
       selectedItem: {
         key: 'changed-buttons',
         name: 'Buttons',
+        displayName: 'Buttons',
         pairs: [changedPair],
         type: 'changed',
       },
@@ -174,6 +181,7 @@ describe('SnapshotMainContent', () => {
       selectedItem: {
         key: 'renamed-buttons',
         name: 'Buttons',
+        displayName: 'Buttons',
         pairs: [renamedPair],
         type: 'renamed',
       },

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
@@ -22,15 +22,19 @@ const sections: SidebarSection[] = [
   {
     type: DiffStatus.CHANGED,
     groups: [
-      {key: 'changed:Button/light', name: 'Button/light', count: 1},
-      {key: 'changed:Alert/dark', name: 'Alert/dark', count: 3},
+      {key: 'changed:Button/light', displayName: 'Button/light', count: 1},
+      {key: 'changed:Alert/dark', displayName: 'Alert/dark', count: 3},
     ],
   },
   {
     type: DiffStatus.UNCHANGED,
     groups: [
-      {key: 'unchanged:Badge/light', name: 'Badge/light', count: 4},
-      {key: 'unchanged:Checkbox/theme-dark', name: 'Checkbox/theme-dark', count: 2},
+      {key: 'unchanged:Badge/light', displayName: 'Badge/light', count: 4},
+      {
+        key: 'unchanged:Checkbox/theme-dark',
+        displayName: 'Checkbox/theme-dark',
+        count: 2,
+      },
     ],
   },
 ];

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.spec.tsx
@@ -1,0 +1,66 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
+
+import {SnapshotSidebarContent, type SidebarSection} from './snapshotSidebarContent';
+
+const noop = () => {};
+
+const statusCounts: Record<DiffStatus, number> = {
+  [DiffStatus.CHANGED]: 1,
+  [DiffStatus.ADDED]: 0,
+  [DiffStatus.REMOVED]: 0,
+  [DiffStatus.RENAMED]: 0,
+  [DiffStatus.UNCHANGED]: 1,
+};
+
+function renderSidebar(sections: SidebarSection[]) {
+  return render(
+    <SnapshotSidebarContent
+      sections={sections}
+      searchQuery=""
+      onSearchChange={noop}
+      onSelectItem={noop}
+      statusCounts={statusCounts}
+      activeStatuses={new Set()}
+      onToggleStatus={noop}
+    />
+  );
+}
+
+describe('SnapshotSidebarContent', () => {
+  it('renders displayName in the sidebar, not the key', () => {
+    renderSidebar([
+      {
+        type: DiffStatus.CHANGED,
+        groups: [
+          {
+            key: 'changed:com.example.MyClass.MyPreview',
+            displayName: 'MyPreview',
+            count: 1,
+          },
+        ],
+      },
+    ]);
+
+    expect(screen.getByText('MyPreview')).toBeInTheDocument();
+    expect(screen.queryByText('com.example.MyClass.MyPreview')).not.toBeInTheDocument();
+  });
+
+  it('shows group name as displayName when group is set', () => {
+    renderSidebar([
+      {
+        type: DiffStatus.UNCHANGED,
+        groups: [
+          {
+            key: 'unchanged:components',
+            displayName: 'components',
+            count: 3,
+          },
+        ],
+      },
+    ]);
+
+    expect(screen.getByText('components')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -12,6 +12,7 @@ import {DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
 
 interface SidebarGroup {
   count: number;
+  displayName: string;
   key: string;
   name: string;
 }
@@ -184,7 +185,7 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
                     ellipsis
                     onPointerEnter={setTitleOnOverflow}
                   >
-                    {group.name}
+                    {group.displayName}
                   </Text>
                 </Flex>
                 <CountBadge>

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -14,7 +14,6 @@ interface SidebarGroup {
   count: number;
   displayName: string;
   key: string;
-  name: string;
 }
 
 export interface SidebarSection {

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -49,7 +49,7 @@ import {
 } from './sidebar/snapshotSidebarContent';
 
 function imageGroupKey(img: SnapshotImage): string {
-  return img.group ?? img.image_file_name;
+  return img.group ?? img.display_name ?? img.image_file_name;
 }
 
 function groupByKey<T>(items: T[], keyOf: (item: T) => string): Map<string, T[]> {

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -344,7 +344,6 @@ export default function SnapshotsPage() {
     function toGroup(item: SidebarItem) {
       return {
         key: item.key,
-        name: item.name,
         displayName: item.displayName,
         count: itemVariantCount(item),
       };
@@ -364,7 +363,7 @@ export default function SnapshotsPage() {
     ];
     const byType = new Map<
       DiffStatus,
-      Array<{count: number; displayName: string; key: string; name: string}>
+      Array<{count: number; displayName: string; key: string}>
     >();
     for (const type of sectionOrder) {
       byType.set(type, []);

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -56,6 +56,10 @@ function imageGroupKey(img: SnapshotImage): string {
   return img.group ?? img.image_file_name;
 }
 
+function imageGroupDisplayName(img: SnapshotImage): string {
+  return img.group ?? getImageName(img);
+}
+
 function groupByKey<T>(items: T[], keyOf: (item: T) => string): Map<string, T[]> {
   const groups = new Map<string, T[]>();
   for (const item of items) {
@@ -249,7 +253,7 @@ export default function SnapshotsPage() {
             type,
             key: `${type}:${groupKey}`,
             name: groupKey,
-            displayName: getImageName(groupedPairs[0]!.head_image),
+            displayName: imageGroupDisplayName(groupedPairs[0]!.head_image),
             pairs: groupedPairs,
           });
         }
@@ -264,7 +268,7 @@ export default function SnapshotsPage() {
             type,
             key: `${type}:${groupKey}`,
             name: groupKey,
-            displayName: getImageName(images[0]!),
+            displayName: imageGroupDisplayName(images[0]!),
             images,
           });
         }
@@ -289,7 +293,7 @@ export default function SnapshotsPage() {
         type: 'solo' as const,
         key: `solo:${groupKey}`,
         name: groupKey,
-        displayName: getImageName(images[0]!),
+        displayName: imageGroupDisplayName(images[0]!),
         images,
       }));
   }, [data, comparisonType]);

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -29,7 +29,11 @@ import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {BuildProcessing} from 'sentry/views/preprod/components/buildProcessing';
-import {ComparisonState, DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
+import {
+  ComparisonState,
+  DiffStatus,
+  getImageName,
+} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
   SidebarItem,
   SnapshotDetailsApiResponse,
@@ -49,7 +53,7 @@ import {
 } from './sidebar/snapshotSidebarContent';
 
 function imageGroupKey(img: SnapshotImage): string {
-  return img.group ?? img.display_name ?? img.image_file_name;
+  return img.group ?? img.image_file_name;
 }
 
 function groupByKey<T>(items: T[], keyOf: (item: T) => string): Map<string, T[]> {
@@ -245,6 +249,7 @@ export default function SnapshotsPage() {
             type,
             key: `${type}:${groupKey}`,
             name: groupKey,
+            displayName: getImageName(groupedPairs[0]!.head_image),
             pairs: groupedPairs,
           });
         }
@@ -255,7 +260,13 @@ export default function SnapshotsPage() {
         type: 'added' | 'removed' | 'unchanged'
       ) => {
         for (const [groupKey, images] of groupByKey(imgs, imageGroupKey)) {
-          items.push({type, key: `${type}:${groupKey}`, name: groupKey, images});
+          items.push({
+            type,
+            key: `${type}:${groupKey}`,
+            name: groupKey,
+            displayName: getImageName(images[0]!),
+            images,
+          });
         }
       };
 
@@ -278,6 +289,7 @@ export default function SnapshotsPage() {
         type: 'solo' as const,
         key: `solo:${groupKey}`,
         name: groupKey,
+        displayName: getImageName(images[0]!),
         images,
       }));
   }, [data, comparisonType]);
@@ -330,7 +342,12 @@ export default function SnapshotsPage() {
 
   const sidebarSections = useMemo<SidebarSection[]>(() => {
     function toGroup(item: SidebarItem) {
-      return {key: item.key, name: item.name, count: itemVariantCount(item)};
+      return {
+        key: item.key,
+        name: item.name,
+        displayName: item.displayName,
+        count: itemVariantCount(item),
+      };
     }
 
     if (comparisonType !== 'diff') {
@@ -347,7 +364,7 @@ export default function SnapshotsPage() {
     ];
     const byType = new Map<
       DiffStatus,
-      Array<{count: number; key: string; name: string}>
+      Array<{count: number; displayName: string; key: string; name: string}>
     >();
     for (const type of sectionOrder) {
       byType.set(type, []);

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -91,6 +91,7 @@ export function getImageName(image: SnapshotImage): string {
 }
 
 interface SidebarItemBase {
+  displayName: string;
   key: string;
   name: string;
 }


### PR DESCRIPTION
## Summary

The snapshot sidebar was showing the full package-qualified `image_file_name` (e.g. `com.example.ui.screens.MyComposableKt.MyPreview`) when no `group` was set, resulting in long unreadable names.

This PR separates the sidebar display name from the grouping key so each can use the right value:

| Field | Value | Used for |
|---|---|---|
| `key` | `${type}:${imageGroupKey(img)}` | Selection/matching |
| `name` | `group ?? image_file_name` | Sorting, search filtering |
| `displayName` | `group ?? display_name ?? image_file_name` | Sidebar label |

When images have an explicit `group`, all three fields use it. When there's no `group`, `name` keeps the full `image_file_name` for unique sorting/search, while `displayName` uses the shorter `display_name` from sidecar metadata for a cleaner sidebar.

Also removes the unused `name` field from `SidebarGroup` since the sidebar only needs `key`, `displayName`, and `count`.