### PR TITLE
feat(issues): Allow event-only activities via StatusChangeMessage

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -22,7 +22,7 @@ from sentry.models.groupinbox import (
 )
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.types.activity import ActivityType
+from sentry.types.activity import AUTOFIX_ACTIVITY_TYPES, ActivityType
 from sentry.types.group import IGNORED_SUBSTATUS_CHOICES, GroupSubStatus
 from sentry.utils import metrics
 from sentry.utils.registry import Registry
@@ -30,10 +30,79 @@ from sentry.utils.registry import Registry
 logger = logging.getLogger(__name__)
 
 
+def _record_event_activity(
+    group: Group,
+    activity_type: ActivityType,
+    status_change: StatusChangeMessageData,
+) -> None:
+    """
+    Record an Activity row tied to ``group`` for an event-only
+    StatusChangeMessage (one that carries an explicit ``activity_type`` and
+    does not actually change the group's status).
+
+    Mirrors the activity-creation + handler-dispatch tail of ``update_status``
+    so the workflow engine and other registered handlers see these activities.
+    """
+    activity = Activity.objects.create_group_activity(
+        group=group,
+        type=activity_type,
+        data=status_change.get("activity_data"),
+    )
+
+    metrics.incr(
+        "workflow_engine.issue_platform.status_change_handler",
+        amount=len(group_status_update_registry.registrations.keys()),
+        tags={"activity_type": activity_type.value, "event_only": "true"},
+        sample_rate=1.0,
+    )
+    for handler in group_status_update_registry.registrations.values():
+        logger.info(
+            "group.status_change.activity_created.handler",
+            extra={
+                "group_id": group.id,
+                "activity_type": activity_type,
+                "event_only": True,
+            },
+        )
+        handler(group, status_change, activity)
+
+
 def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
     activity_type: ActivityType | None = None
     new_status = status_change["new_status"]
     new_substatus = status_change["new_substatus"]
+
+    # Event-only path: a StatusChangeMessage may carry an explicit
+    # `activity_type` to record an activity on the group without changing
+    # its status (used for autofix/Seer state transitions). Handle that
+    # branch before the status-equality early return below.
+    requested_activity_type_value = status_change.get("activity_type")
+    if requested_activity_type_value is not None:
+        is_int = isinstance(requested_activity_type_value, int)
+        is_bool = isinstance(requested_activity_type_value, bool)
+        if not is_int or is_bool:
+            logger.error(
+                "group.update_status.invalid_activity_type",
+                extra={
+                    "group_id": group.id,
+                    "activity_type": repr(requested_activity_type_value),
+                },
+            )
+            return
+        try:
+            requested_activity_type = ActivityType(requested_activity_type_value)
+        except ValueError:
+            logger.error(
+                "group.update_status.unknown_activity_type",
+                extra={
+                    "group_id": group.id,
+                    "activity_type": requested_activity_type_value,
+                },
+            )
+            return
+        if requested_activity_type in AUTOFIX_ACTIVITY_TYPES:
+            _record_event_activity(group, requested_activity_type, status_change)
+            return
 
     if group.status == new_status and group.substatus == new_substatus:
         return
@@ -247,6 +316,7 @@ def _get_status_change_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
         "detector_id": payload.get("detector_id", None),
         "activity_data": payload.get("activity_data", None),
         "update_date": payload.get("update_date", None),
+        "activity_type": payload.get("activity_type", None),
     }
 
     process_occurrence_data(data)

--- a/src/sentry/issues/status_change_message.py
+++ b/src/sentry/issues/status_change_message.py
@@ -16,6 +16,11 @@ class StatusChangeMessageData(TypedDict):
     detector_id: int | None
     activity_data: dict[str, Any] | None
     update_date: NotRequired[datetime | None]
+    # Optional ActivityType.value for callers that want to record an Activity
+    # entry on the group without a real status change (e.g. autofix events).
+    # When set and matching the group's current status, the consumer creates
+    # an Activity of this type and dispatches workflow handlers.
+    activity_type: NotRequired[int | None]
 
 
 @dataclass(frozen=True)
@@ -27,6 +32,7 @@ class StatusChangeMessage:
     detector_id: int | None = None
     activity_data: dict[str, Any] | None = None
     update_date: datetime | None = None
+    activity_type: int | None = None
     id: str = field(default_factory=lambda: uuid4().hex)
 
     def to_dict(
@@ -40,5 +46,6 @@ class StatusChangeMessage:
             "detector_id": self.detector_id,
             "activity_data": self.activity_data,
             "update_date": self.update_date,
+            "activity_type": self.activity_type,
             "id": self.id,
         }

--- a/src/sentry/types/activity.py
+++ b/src/sentry/types/activity.py
@@ -34,6 +34,9 @@ class ActivityType(Enum):
     DELETED_ATTACHMENT = 27
     REFERENCED_IN_COMMIT = 28
 
+    AUTOFIX_PR_CREATED = 29
+    AUTOFIX_PR_MERGED = 30
+
 
 # Warning: This must remain in this EXACT order.
 CHOICES = tuple(
@@ -67,6 +70,8 @@ CHOICES = tuple(
         ActivityType.SET_PRIORITY,  # 26
         ActivityType.DELETED_ATTACHMENT,  # 27
         ActivityType.REFERENCED_IN_COMMIT,  # 28
+        ActivityType.AUTOFIX_PR_CREATED,  # 29
+        ActivityType.AUTOFIX_PR_MERGED,  # 30
     ]
 )
 
@@ -81,4 +86,13 @@ STATUS_CHANGE_ACTIVITY_TYPES = (
     ActivityType.SET_RESOLVED_IN_COMMIT,
     ActivityType.SET_RESOLVED_IN_PULL_REQUEST,
     ActivityType.SET_ESCALATING,
+)
+
+
+# Activity types that record autofix/Seer state transitions on an issue.
+# These do NOT change the group's status — they exist purely to drive the
+# activity timeline, workflow engine, and notification platform.
+AUTOFIX_ACTIVITY_TYPES = (
+    ActivityType.AUTOFIX_PR_CREATED,
+    ActivityType.AUTOFIX_PR_MERGED,
 )

--- a/tests/sentry/issues/test_status_change_consumer.py
+++ b/tests/sentry/issues/test_status_change_consumer.py
@@ -527,6 +527,117 @@ class TestStatusChangeRegistry(IssueOccurrenceTestBase):
 
             mock_handler.assert_called_once_with(self.group, self.message, latest_activity)
 
+    def test_event_only_activity_type_creates_activity_without_status_change(self) -> None:
+        self.message["new_status"] = self.group.status
+        self.message["new_substatus"] = self.group.substatus
+        self.message["activity_type"] = ActivityType.AUTOFIX_PR_MERGED.value
+        self.message["activity_data"] = {"run_id": 42, "pr_url": "https://example.invalid/pr/1"}
+
+        previous_status = self.group.status
+        previous_substatus = self.group.substatus
+
+        with patch(
+            "sentry.issues.status_change_consumer.group_status_update_registry",
+        ) as mock_registry:
+            mock_handler = MagicMock()
+            mock_registry.registrations = {"test_event_only": mock_handler}
+
+            update_status(self.group, self.message)
+
+            latest_activity = self.get_latest_activity(ActivityType.AUTOFIX_PR_MERGED)
+            assert latest_activity.data == {
+                "run_id": 42,
+                "pr_url": "https://example.invalid/pr/1",
+            }
+            mock_handler.assert_called_once_with(self.group, self.message, latest_activity)
+
+        self.group.refresh_from_db()
+        assert self.group.status == previous_status
+        assert self.group.substatus == previous_substatus
+
+    def test_event_only_unknown_activity_type_is_dropped(self) -> None:
+        self.message["new_status"] = self.group.status
+        self.message["new_substatus"] = self.group.substatus
+        self.message["activity_type"] = 99999  # not a real ActivityType value
+
+        with patch(
+            "sentry.issues.status_change_consumer.group_status_update_registry",
+        ) as mock_registry:
+            mock_handler = MagicMock()
+            mock_registry.registrations = {"test_event_only": mock_handler}
+
+            update_status(self.group, self.message)
+            assert mock_handler.call_count == 0
+
+        assert not Activity.objects.filter(
+            group_id=self.group.id, type=ActivityType.AUTOFIX_PR_MERGED.value
+        ).exists()
+
+    def test_event_only_malformed_dict_activity_type_is_dropped(self) -> None:
+        # Non-int payloads (dict, list, string, etc.) would raise TypeError
+        # from ActivityType(...). Validate they're rejected without
+        # propagating an exception that would crash the consumer.
+        self.message["new_status"] = self.group.status
+        self.message["new_substatus"] = self.group.substatus
+        self.message["activity_type"] = {}  # type: ignore[typeddict-item]
+
+        with patch(
+            "sentry.issues.status_change_consumer.group_status_update_registry",
+        ) as mock_registry:
+            mock_handler = MagicMock()
+            mock_registry.registrations = {"test_event_only": mock_handler}
+
+            update_status(self.group, self.message)
+            assert mock_handler.call_count == 0
+
+    def test_event_only_malformed_list_activity_type_is_dropped(self) -> None:
+        self.message["new_status"] = self.group.status
+        self.message["new_substatus"] = self.group.substatus
+        self.message["activity_type"] = []  # type: ignore[typeddict-item]
+
+        with patch(
+            "sentry.issues.status_change_consumer.group_status_update_registry",
+        ) as mock_registry:
+            mock_handler = MagicMock()
+            mock_registry.registrations = {"test_event_only": mock_handler}
+
+            update_status(self.group, self.message)
+            assert mock_handler.call_count == 0
+
+    def test_event_only_malformed_string_activity_type_is_dropped(self) -> None:
+        self.message["new_status"] = self.group.status
+        self.message["new_substatus"] = self.group.substatus
+        self.message["activity_type"] = "30"  # type: ignore[typeddict-item]
+
+        with patch(
+            "sentry.issues.status_change_consumer.group_status_update_registry",
+        ) as mock_registry:
+            mock_handler = MagicMock()
+            mock_registry.registrations = {"test_event_only": mock_handler}
+
+            update_status(self.group, self.message)
+            assert mock_handler.call_count == 0
+
+    def test_event_only_bool_activity_type_is_dropped(self) -> None:
+        # bool is a subclass of int and would otherwise coerce to 1/0 and
+        # match real ActivityType values.
+        self.message["new_status"] = self.group.status
+        self.message["new_substatus"] = self.group.substatus
+        self.message["activity_type"] = True  # type: ignore[typeddict-item]
+
+        with patch(
+            "sentry.issues.status_change_consumer.group_status_update_registry",
+        ) as mock_registry:
+            mock_handler = MagicMock()
+            mock_registry.registrations = {"test_event_only": mock_handler}
+
+            update_status(self.group, self.message)
+            assert mock_handler.call_count == 0
+
+        assert not Activity.objects.filter(
+            group_id=self.group.id, type=ActivityType.SET_RESOLVED.value
+        ).exists()
+
     def test_update_status_with_custom_update_date(self) -> None:
         self.message["new_status"] = GroupStatus.RESOLVED
         self.message["new_substatus"] = None


### PR DESCRIPTION
Add an optional `activity_type` field to StatusChangeMessage so callers
can record an Activity row on a group without changing its status. The
consumer dispatches the registered group_status_update_registry handlers
for these activities, giving them the same workflow-engine reach as real
status changes.

This is the foundation for plumbing autofix/Seer state transitions
(PR created, PR merged, root cause / solution / coding completed)
through the issue platform: emit a StatusChangeMessage from the autofix
completion paths, land it as an Activity timeline entry, and let the
workflow engine route it to the notification platform.

Two new ActivityType values are reserved up front:
AUTOFIX_PR_CREATED and AUTOFIX_PR_MERGED. They are intentionally not
added to STATUS_CHANGE_ACTIVITY_TYPES — they are events, not status
changes. The new consumer branch only fires for types listed in
AUTOFIX_ACTIVITY_TYPES, so existing callers are unaffected.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Agent transcript: https://claudescope.sentry.dev/share/Ou4DMaZM14XBCqsLG8l0exCpEu1wRaCgA0CLUvqftE0