### PR TITLE
fix(hotkeys): prevent event.code fallback from matching wrong keys on non-QWERTY layouts

### DIFF
--- a/static/app/components/core/hotkey/keyMappings.tsx
+++ b/static/app/components/core/hotkey/keyMappings.tsx
@@ -123,7 +123,20 @@ export function matchesKey(name: string, event: KeyboardEvent): boolean {
     }
     const code = codeForChar(key);
     if (code && event.code === code) {
-      return true;
+      const eventKey = event.key;
+      // Non-Latin script (e.g. Cyrillic 'к' on KeyK) or no key reported:
+      // trust the physical position.
+      if (eventKey?.length !== 1 || eventKey.charCodeAt(0) > 0x7f) {
+        return true;
+      }
+      // Shift can transform a key into a different symbol on the same layout
+      // (e.g. Shift+1 → '!' on QWERTY). Allow the code fallback in that case.
+      // Without shift, a differing ASCII event.key means a different layout
+      // maps this physical key to another character (e.g. AZERTY '+' on
+      // physical Slash) and we must NOT match.
+      if (event.shiftKey) {
+        return true;
+      }
     }
   }
 

--- a/static/app/components/core/hotkey/useHotkeys.spec.tsx
+++ b/static/app/components/core/hotkey/useHotkeys.spec.tsx
@@ -336,6 +336,32 @@ describe('useHotkeys', () => {
     expect(callback).toHaveBeenCalled();
   });
 
+  it('does not match mod+/ on AZERTY when user presses Cmd++ (physical Slash key)', () => {
+    // On AZERTY, the physical key in the Slash position produces '+'.
+    // event.key is '+', event.code is 'Slash'.
+    // mod+/ should NOT fire because the user typed Cmd++ (zoom in),
+    // not Cmd+/. The event.code fallback must not treat '+' as '/'.
+    isMac.mockReturnValue(true);
+    const callback = jest.fn();
+
+    renderHook(p => useHotkeys(p), {
+      initialProps: [{match: 'mod+/', callback, includeInputs: true}],
+    });
+
+    const evt = {
+      key: '+',
+      code: 'Slash',
+      metaKey: true,
+      preventDefault: jest.fn(),
+    };
+    events.keydown!(evt);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(evt.preventDefault).not.toHaveBeenCalled();
+
+    isMac.mockReturnValue(false);
+  });
+
   describe('mod modifier', () => {
     afterEach(() => {
       isMac.mockReturnValue(false);


### PR DESCRIPTION
On non-QWERTY layouts (e.g. AZERTY), the `event.code` fallback in `matchesKey` matched the physical key position rather than the logical key, causing shortcuts like `Cmd+/` (Ask Seer) to fire when the user pressed `Cmd++` (browser zoom). The physical Slash key produces `+` on AZERTY but still reports `event.code === 'Slash'`, so the fallback incorrectly treated it as `/`.

**Code fallback guard**

The `event.code` fallback now only fires when `event.key` is non-ASCII (non-Latin scripts like Cyrillic) or when Shift is held (shifted symbols on the same layout, e.g. Shift+1 → `!` on QWERTY). When `event.key` is a different printable ASCII character without Shift, the layout intentionally maps that physical key to something else, so the match is rejected.