### PR TITLE
ref(seer): Move /seer/workflows to /issues/autofix

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1647,12 +1647,6 @@ function buildRoutes(): RouteObject[] {
     children: replayChildren,
   };
 
-  const seerRoutes: SentryRouteObject = {
-    path: '/seer/workflows/',
-    component: make(() => import('sentry/views/seerWorkflows')),
-    withOrgPath: true,
-  };
-
   const releaseChildren: SentryRouteObject[] = [
     {
       index: true,
@@ -2543,6 +2537,10 @@ function buildRoutes(): RouteObject[] {
       ),
     },
     {
+      path: 'autofix/',
+      component: make(() => import('sentry/views/seerWorkflows')),
+    },
+    {
       path: 'autofix/recent/',
       component: make(() => import('sentry/views/issueList/pages/autofix/recentlyRun')),
     },
@@ -2797,7 +2795,6 @@ function buildRoutes(): RouteObject[] {
       preprodRoutes,
       pullRequestRoutes,
       replayRoutes,
-      seerRoutes,
       releasesRoutes,
       statsRoutes,
       discoverRoutes,

--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -117,7 +117,7 @@ describe('SeerWorkflows', () => {
     const link = await screen.findByRole('button', {name: 'Explorer'});
     expect(link).toHaveAttribute(
       'href',
-      `/organizations/${organization.slug}/seer/workflows/?explorerRunId=42`
+      `/organizations/${organization.slug}/issues/autofix/?explorerRunId=42`
     );
   });
 

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -128,7 +128,7 @@ function SeerWorkflows() {
                               size="xs"
                               icon={<IconOpen />}
                               to={{
-                                pathname: `/organizations/${organization.slug}/seer/workflows/`,
+                                pathname: `/organizations/${organization.slug}/issues/autofix/`,
                                 query: {explorerRunId},
                               }}
                             >
@@ -282,7 +282,7 @@ function RunDetail({
                   size="xs"
                   icon={<IconOpen />}
                   to={{
-                    pathname: `/organizations/${organizationSlug}/seer/workflows/`,
+                    pathname: `/organizations/${organizationSlug}/issues/autofix/`,
                     query: {explorerRunId: issue.seerRunId},
                   }}
                 >

--- a/static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx
@@ -245,7 +245,7 @@ export function NightShift({canWrite, project}: Props) {
         label={t('Runs')}
         hintText={t('View past Night Shift runs for this organization.')}
       >
-        <Link to={`/organizations/${organization.slug}/seer/workflows/`}>
+        <Link to={`/organizations/${organization.slug}/issues/autofix/`}>
           {t('View organization runs')}
         </Link>
       </Row>


### PR DESCRIPTION
Relocate the Night Shift runs view from the standalone `/seer/workflows/` route into `/issues/autofix/`, alongside the existing `/issues/autofix/recent/` page. Frontend-only change — the backend API endpoint `/organizations/<slug>/seer/workflows/` is unchanged.


Agent transcript: https://claudescope.sentry.dev/share/CS7guNmwzYkPDfj4gcCnPxJqvQw2KKV1P4HCVaP_Gcc