### PR TITLE
fix(dashboards): Show current version when no revisions exist

### DIFF
--- a/static/app/views/dashboards/dashboardRevisions.spec.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.spec.tsx
@@ -150,14 +150,16 @@ describe('DashboardRevisionsButton', () => {
     expect(screen.getAllByText('Edit')).toHaveLength(2);
   });
 
-  it('shows the empty state when no revisions exist', async () => {
+  it('shows Current Version and no-previous-revisions message when no revisions exist', async () => {
     MockApiClient.addMockResponse({url: REVISIONS_URL, body: []});
 
     renderButton();
     renderGlobalModal();
     await userEvent.click(screen.getByRole('button', {name: 'Dashboard Revisions'}));
 
-    expect(await screen.findByText('No revisions found.')).toBeInTheDocument();
+    expect(await screen.findByText('Current Version')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(1);
+    expect(screen.getByText('Dashboard Owner')).toBeInTheDocument();
   });
 
   it('shows an error state when the revisions API request fails', async () => {

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -5,7 +5,7 @@ import {useMutation} from '@tanstack/react-query';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Heading} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -107,7 +107,7 @@ function DashboardRevisionsModal({
           <LoadingIndicator />
         ) : isError ? (
           <Alert variant="danger">{t('Failed to load dashboard revisions.')}</Alert>
-        ) : displayedRevisions.length ? (
+        ) : (
           <Flex direction="column" gap="md">
             {isRestoreError && (
               <Alert variant="danger">{t('Failed to restore this revision.')}</Alert>
@@ -122,7 +122,7 @@ function DashboardRevisionsModal({
                 isSelected={isNewestVersionSelected}
                 onSelect={() => setSelectedRevisionId(NEWEST_VERSION_ID)}
                 revisionSource={revisions?.[0]?.source ?? 'edit'}
-                createdBy={revisions?.[0]?.createdBy ?? null}
+                createdBy={revisions?.[0]?.createdBy ?? dashboard.createdBy ?? null}
                 dateCreated={null}
                 dashboardId={dashboardId}
                 baseRevisionId={displayedRevisions[0]?.id ?? null}
@@ -144,10 +144,6 @@ function DashboardRevisionsModal({
                 />
               ))}
             </Flex>
-          </Flex>
-        ) : (
-          <Flex align="center" justify="center" padding="xl">
-            <Text variant="muted">{t('No revisions found.')}</Text>
           </Flex>
         )}
       </Body>


### PR DESCRIPTION
## Changes

When a dashboard has no revision history, the Edit History modal previously showed an empty "No revisions found" state. Now it always shows the **Current Version** entry, using the dashboard creator as the author attribution. 

The `RevisionListItem` already renders "This is the oldest revision — no previous state to compare against" when there's nothing to diff against, so no additional messaging is needed.

Before

<img width="688" height="234" alt="image" src="https://github.com/user-attachments/assets/fef52ff7-f229-417e-8caa-6a92fcfde4e8" />



After

<img width="688" height="234" alt="image" src="https://github.com/user-attachments/assets/3c870181-e57a-4eae-af12-a7f67c1bbab9" />
