### PR TITLE
ref(button-variant): update docs to reference variant

### DIFF
--- a/static/app/components/core/alert/alert.mdx
+++ b/static/app/components/core/alert/alert.mdx
@@ -181,10 +181,10 @@ Add interactive elements like buttons, links or badges to the right side of aler
       variant="danger"
       trailingItems={
         <Flex gap="sm">
-          <Alert.Button priority="danger" icon={<IconDelete />}>
+          <Alert.Button variant="danger" icon={<IconDelete />}>
             Delete
           </Alert.Button>
-          <Alert.Button priority="transparent" icon={<IconEdit />}>
+          <Alert.Button variant="transparent" icon={<IconEdit />}>
             Edit
           </Alert.Button>
         </Flex>
@@ -203,7 +203,7 @@ Add interactive elements like buttons, links or badges to the right side of aler
       trailingItems={
         <Flex gap="sm">
           <Badge variant="warning">Action Required</Badge>
-          <Alert.Button priority="transparent" icon={<IconEdit />}>
+          <Alert.Button variant="transparent" icon={<IconEdit />}>
             Edit
           </Alert.Button>
         </Flex>
@@ -217,7 +217,7 @@ Add interactive elements like buttons, links or badges to the right side of aler
 <Alert.Container>
   <Alert
     variant="info"
-    trailingItems={<Alert.Button priority="primary">Take Action</Alert.Button>}
+    trailingItems={<Alert.Button variant="primary">Take Action</Alert.Button>}
   >
     This alert has a trailing badge
   </Alert>
@@ -225,10 +225,10 @@ Add interactive elements like buttons, links or badges to the right side of aler
     variant="danger"
     trailingItems={
       <Flex gap="sm">
-        <Alert.Button priority="danger" icon={<IconDelete />}>
+        <Alert.Button variant="danger" icon={<IconDelete />}>
           Delete
         </Alert.Button>
-        <Alert.Button priority="muted" icon={<IconEdit />}>
+        <Alert.Button variant="secondary" icon={<IconEdit />}>
           Edit
         </Alert.Button>
       </Flex>

--- a/static/app/components/core/button/button.mdx
+++ b/static/app/components/core/button/button.mdx
@@ -70,25 +70,25 @@ To create a basic button, wrap text in a `<Button>` and pass an `onClick` callba
 
 ## Priorities
 
-Buttons come in a few different styles: `muted`, `primary`, `warning`, `danger`, `transparent` and `link`.
+Buttons come in a few different styles: `primary`, `secondary` (default), `warning`, `danger`, `transparent`, and `link`.
 
 <Storybook.Demo>
-  <Button priority="default">Default</Button>
-  <Button priority="primary">Primary</Button>
-  <Button priority="warning">Warning</Button>
-  <Button priority="danger">Danger</Button>
-  <Button priority="transparent">Transparent</Button>
+  <Button variant="transparent">Default</Button>
+  <Button variant="primary">Primary</Button>
+  <Button variant="warning">Warning</Button>
+  <Button variant="danger">Danger</Button>
+  <Button variant="transparent">Transparent</Button>
   <div style={{alignSelf: 'center'}}>
-    <Button priority="link">Link</Button>
+    <Button variant="link">Link</Button>
   </div>
 </Storybook.Demo>
 ```jsx
-<Button priority="default">Default (default)</Button>
-<Button priority="primary">Primary</Button>
-<Button priority="warning">Warning</Button>
-<Button priority="danger">Danger</Button>
-<Button priority="transparent">Transparent</Button>
-<Button priority="link">Link</Button>
+<Button variant="transparent">Default (default)</Button>
+<Button variant="primary">Primary</Button>
+<Button variant="warning">Warning</Button>
+<Button variant="danger">Danger</Button>
+<Button variant="transparent">Transparent</Button>
+<Button variant="link">Link</Button>
 ```
 
 ## Sizes
@@ -118,12 +118,12 @@ Buttons support an optional leading icon.
 > button size.
 
 <Storybook.Demo>
-  <Button icon={<IconAdd />} priority="primary">
+  <Button icon={<IconAdd />} variant="primary">
     Add
   </Button>
 </Storybook.Demo>
 ```jsx
-<Button icon={<IconAdd />} priority="primary">
+<Button icon={<IconAdd />} variant="primary">
   Add
 </Button>
 ```
@@ -167,13 +167,13 @@ Disabled buttons should be used to indicate that an action is not available.
 
 <Storybook.Demo>
   <Button disabled>Cancel</Button>
-  <Button disabled priority="primary">
+  <Button disabled variant="primary">
     Submit
   </Button>
 </Storybook.Demo>
 ```jsx
 <Button disabled>Cancel</Button>
-<Button disabled priority="primary">
+<Button disabled variant="primary">
   Submit
 </Button>
 ```
@@ -193,10 +193,14 @@ export function BusyDemo() {
   };
   return (
     <Flex gap="md">
-      <Button busy={busy.cancel} priority="default" onClick={() => handleClick('cancel')}>
+      <Button
+        busy={busy.cancel}
+        variant="transparent"
+        onClick={() => handleClick('cancel')}
+      >
         Cancel
       </Button>
-      <Button busy={busy.submit} priority="primary" onClick={() => handleClick('submit')}>
+      <Button busy={busy.submit} variant="primary" onClick={() => handleClick('submit')}>
         Submit
       </Button>
     </Flex>
@@ -209,14 +213,14 @@ export function BusyDemo() {
 ```jsx
 <Flex gap="md">
   <Button
-    priority="secondary"
+    variant="secondary"
     busy={cancelMutation.isPending}
     onClick={cancelMutation.mutateAsync}
   >
     Cancel
   </Button>
   <Button
-    priority="primary"
+    variant="primary"
     busy={submitMutation.isPending}
     onClick={submitMutation.mutateAsync}
   >

--- a/static/app/components/core/button/buttonBar.mdx
+++ b/static/app/components/core/button/buttonBar.mdx
@@ -74,4 +74,4 @@ Use `orientation="vertical"` to stack buttons vertically with joined borders.
 
 ## Notes
 
-ButtonBar is a simple presentational component that handles only the visual layout of buttons. It does not manage any internal state such as which button is active or selected. If you need to track an active button or manage selection state, you should handle that in your parent component and pass the appropriate props (like `priority="primary"`) to the active button.
+ButtonBar is a simple presentational component that handles only the visual layout of buttons. It does not manage any internal state such as which button is active or selected. If you need to track an active button or manage selection state, you should handle that in your parent component and pass the appropriate props (like `variant="primary"`) to the active button.

--- a/static/app/components/core/button/linkButton.mdx
+++ b/static/app/components/core/button/linkButton.mdx
@@ -151,7 +151,7 @@ LinkButtons support an optional leading icon, following the same patterns as reg
 > button size.
 
 <Storybook.Demo>
-  <LinkButton icon={<IconOpen />} priority="primary" to="/dashboard">
+  <LinkButton icon={<IconOpen />} variant="primary" to="/dashboard">
     Open Dashboard
   </LinkButton>
   <LinkButton icon={<IconDocs />} href="https://docs.sentry.io" external>
@@ -159,7 +159,7 @@ LinkButtons support an optional leading icon, following the same patterns as reg
   </LinkButton>
 </Storybook.Demo>
 ```jsx
-<LinkButton icon={<IconOpen />} priority="primary" to="/dashboard">
+<LinkButton icon={<IconOpen />} variant="primary" to="/dashboard">
   Open Dashboard
 </LinkButton>
 <LinkButton icon={<IconDocs />} href="https://docs.sentry.io" external>
@@ -179,7 +179,7 @@ The following table defines standardized call to action copy and icon pairings f
 Disabled LinkButtons prevent navigation and show a non-interactive appearance.
 
 <Storybook.Demo>
-  <LinkButton disabled priority="primary" to="/disabled">
+  <LinkButton disabled variant="primary" to="/disabled">
     Disabled Primary
   </LinkButton>
   <LinkButton disabled to="/disabled">
@@ -187,7 +187,7 @@ Disabled LinkButtons prevent navigation and show a non-interactive appearance.
   </LinkButton>
 </Storybook.Demo>
 ```jsx
-<LinkButton disabled priority="primary" to="/disabled">
+<LinkButton disabled variant="primary" to="/disabled">
   Disabled Primary
 </LinkButton>
 <LinkButton disabled to="/disabled">
@@ -200,12 +200,12 @@ Disabled LinkButtons prevent navigation and show a non-interactive appearance.
 LinkButtons with the `external` prop automatically include security attributes (`target="_blank"`, `rel="noreferrer noopener"`) and always open in a new tab. External links cannot opt out of new-tab behavior.
 
 <Storybook.Demo>
-  <LinkButton href="https://docs.sentry.io" external priority="primary">
+  <LinkButton href="https://docs.sentry.io" external variant="primary">
     Secure External Link
   </LinkButton>
 </Storybook.Demo>
 ```jsx
-<LinkButton href="https://docs.sentry.io" external priority="primary">
+<LinkButton href="https://docs.sentry.io" external variant="primary">
   Secure External Link
 </LinkButton>
 ```

--- a/static/app/components/core/input/inputGroup.mdx
+++ b/static/app/components/core/input/inputGroup.mdx
@@ -196,7 +196,7 @@ export function InteractiveDemo() {
         <InputGroup.Input placeholder="Search" />
         <InputGroup.TrailingItems>
           <Button
-            priority="transparent"
+            variant="transparent"
             icon={<IconSettings />}
             size="zero"
             aria-label="Settings"
@@ -216,7 +216,7 @@ export function InteractiveDemo() {
   <InputGroup.Input placeholder="Search" />
   <InputGroup.TrailingItems>
     <Button
-      priority="transparent"
+      variant="transparent"
       icon={<IconSettings />}
       size="zero"
       aria-label="Settings"
@@ -255,7 +255,7 @@ export function CombinedDemo() {
           <IconAttachment key="trailing-icon" size="sm" />,
           <Button
             key="trailing-button"
-            priority="transparent"
+            variant="transparent"
             icon={<IconSettings />}
             size="zero"
             aria-label="Settings"
@@ -278,7 +278,7 @@ export function CombinedDemo() {
   <InputGroup.Input placeholder="Search" />
   <InputGroup.TrailingItems>
     <Button
-      priority="transparent"
+      variant="transparent"
       icon={<IconSettings />}
       size="zero"
       aria-label="Settings"
@@ -322,7 +322,7 @@ const [value, setValue] = useState('');
   {value && (
     <InputGroup.TrailingItems>
       <Button
-        priority="transparent"
+        variant="transparent"
         icon={<IconClose />}
         size="zero"
         aria-label="Clear"
@@ -368,7 +368,7 @@ Show a loading indicator when fetching results:
   <InputGroup.TextArea placeholder="Enter a description..." rows={4} />
   <InputGroup.TrailingItems>
     <Button
-      priority="transparent"
+      variant="transparent"
       icon={<IconAttachment />}
       size="zero"
       aria-label="Attach file"
@@ -419,7 +419,7 @@ Show a loading indicator when fetching results:
 ```jsx
 <InputGroup.TrailingItems>
   <Button
-    priority="transparent"
+    variant="transparent"
     icon={<IconClose />}
     size="zero"
     aria-label="Clear search"

--- a/static/app/components/core/modal/modal.mdx
+++ b/static/app/components/core/modal/modal.mdx
@@ -38,7 +38,7 @@ function MyPage() {
             <Header closeButton>My Modal</Header>
             <Body>Hello, world!</Body>
             <Footer>
-              <Button priority="primary" onClick={closeModal}>
+              <Button variant="primary" onClick={closeModal}>
                 Done
               </Button>
             </Footer>

--- a/static/app/components/emptyMessage.mdx
+++ b/static/app/components/emptyMessage.mdx
@@ -79,7 +79,7 @@ Add action buttons to guide users toward resolving the empty state.
     <EmptyMessage
       icon={<IconSearch />}
       title="No Results Found"
-      action={<Button priority="primary">Clear Filters</Button>}
+      action={<Button variant="primary">Clear Filters</Button>}
     >
       We couldn't find any results matching your search criteria. Try adjusting your
       filters or search terms.
@@ -90,7 +90,7 @@ Add action buttons to guide users toward resolving the empty state.
 <EmptyMessage
   icon={<IconSearch />}
   title="No Results Found"
-  action={<Button priority="primary">Clear Filters</Button>}
+  action={<Button variant="primary">Clear Filters</Button>}
 >
   We couldn't find any results matching your search criteria. Try adjusting your filters
   or search terms.

--- a/static/app/components/featureShowcase.mdx
+++ b/static/app/components/featureShowcase.mdx
@@ -27,7 +27,7 @@ export function ReadTheDocsFooter() {
         external
         href="https://docs.sentry.io"
         onClick={close}
-        priority="primary"
+        variant="primary"
       >
         Read the Docs
       </LinkButton>
@@ -58,7 +58,7 @@ Each step can include an image, title, content, and navigation actions. The defa
   <Fragment>
     <GlobalModal />
     <Button
-      priority="primary"
+      variant="primary"
       onClick={() => {
         openModal(deps => (
           <FeatureShowcase {...deps}>
@@ -133,7 +133,7 @@ Pass custom children alongside `<FeatureShowcase.StepActions />`, or replace it 
   <Fragment>
     <GlobalModal />
     <Button
-      priority="primary"
+      variant="primary"
       onClick={() => {
         openModal(deps => (
           <FeatureShowcase {...deps}>
@@ -166,7 +166,7 @@ function ReadTheDocsFooter() {
   const {close} = useShowcaseContext();
   return (
     <Flex justify="end">
-      <LinkButton external href="https://docs.sentry.io" onClick={close} priority="primary">
+      <LinkButton external href="https://docs.sentry.io" onClick={close} variant="primary">
         Read the Docs
       </LinkButton>
     </Flex>


### PR DESCRIPTION
Manual pass after the [button-variant codemod](https://github.com/getsentry/design-engineering/tree/main/codemods/button-variant?rgh-link-date=2026-05-01T00%3A40%3A18Z) to normalize on the `variant` prop in our documentation