### PR TITLE
fix(ourlogs): only constrain page for Logs (samples) mode

### DIFF
--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -425,7 +425,10 @@ export function LogsTabContent({datePageFilterProps, tableExpando}: LogsTabProps
         datePageFilterProps={datePageFilterProps}
         searchBarWidthOffset={columnEditorButtonRef.current?.clientWidth}
       />
-      <ViewportConstrainedPage constrained={tableExpando} hideFooter={tableExpando}>
+      <ViewportConstrainedPage
+        constrained={tableExpando && mode === Mode.SAMPLES}
+        hideFooter={tableExpando}
+      >
         <ViewportConstrainedBody>
           <LogsControlSection expanded={sidebarOpen}>
             {sidebarOpen ? <LogsToolbar /> : null}


### PR DESCRIPTION
Logs (`Mode.SAMPLES`) use infinite scrolling in their table with a sticky header. Aggregates (`Mode.AGGREGATE`) uses a paginated table with next/previous controls, no sticky header. Unifying aggregates to the logs-style scroll behavior would be a bigger & more-discussion-necessary change, so for now I just limited the page height constraint to logs mode.

Fixes LOGS-758