### PR TITLE
ref(onboarding): Enforce display order for SCM provider pills

### DIFF
--- a/static/app/views/onboarding/components/scmProviderPills.spec.tsx
+++ b/static/app/views/onboarding/components/scmProviderPills.spec.tsx
@@ -45,6 +45,21 @@ describe('ScmProviderPills', () => {
     expect(screen.queryByText('More')).not.toBeInTheDocument();
   });
 
+  it('renders primary providers in GitHub, GitLab, Bitbucket order regardless of API order', () => {
+    const providers = [
+      bitbucketProvider,
+      GitLabIntegrationProviderFixture(),
+      GitHubIntegrationProviderFixture(),
+    ];
+
+    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[0]).toHaveTextContent('GitHub');
+    expect(buttons[1]).toHaveTextContent('GitLab');
+    expect(buttons[2]).toHaveTextContent('Bitbucket');
+  });
+
   it('shows secondary providers in a "More" dropdown', async () => {
     const providers = [
       GitHubIntegrationProviderFixture(),

--- a/static/app/views/onboarding/components/scmProviderPills.tsx
+++ b/static/app/views/onboarding/components/scmProviderPills.tsx
@@ -10,10 +10,10 @@ import {IntegrationButton} from 'sentry/views/settings/organizationIntegrations/
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
 /**
- * Provider keys shown as top-level pill buttons. Everything else is grouped
- * into the "More" dropdown to reduce visual clutter.
+ * Provider keys shown as top-level pill buttons, in display order.
+ * Everything else is grouped into the "More" dropdown.
  */
-const PRIMARY_PROVIDER_KEYS = new Set(['github', 'gitlab', 'bitbucket']);
+const PRIMARY_PROVIDER_KEYS: readonly string[] = ['github', 'gitlab', 'bitbucket'];
 
 interface ScmProviderPillsProps {
   onInstall: (data: Integration) => void;
@@ -23,8 +23,10 @@ interface ScmProviderPillsProps {
 export function ScmProviderPills({providers, onInstall}: ScmProviderPillsProps) {
   const organization = useOrganization();
   const {startFlow} = useAddIntegration();
-  const primaryProviders = providers.filter(p => PRIMARY_PROVIDER_KEYS.has(p.key));
-  const moreProviders = providers.filter(p => !PRIMARY_PROVIDER_KEYS.has(p.key));
+  const primaryProviders = PRIMARY_PROVIDER_KEYS.map(key =>
+    providers.find(p => p.key === key)
+  ).filter((p): p is IntegrationProvider => p !== undefined);
+  const moreProviders = providers.filter(p => !PRIMARY_PROVIDER_KEYS.includes(p.key));
   const gridItemCount = primaryProviders.length + (moreProviders.length > 0 ? 1 : 0);
 
   const columnsXs = `repeat(${Math.min(gridItemCount, 2)}, 1fr)`;


### PR DESCRIPTION
## Summary

The `/organizations/{slug}/integrations/` endpoint orders providers alphabetically by name, which renders the primary onboarding pills as Bitbucket, GitHub, GitLab. Drive the pill order from the `PRIMARY_PROVIDER_KEYS` array instead so the SCM connect step always shows GitHub, GitLab, Bitbucket.

The "More" dropdown is unaffected and continues to display in the order returned by the API.

## Test plan

- [ ] `CI=true pnpm test static/app/views/onboarding/components/scmProviderPills.spec.tsx` passes (5 tests, including a new ordering test)
- [ ] Visit the onboarding SCM connect step locally and confirm pill order is GitHub, GitLab, Bitbucket