### PR TITLE
fix(seer): Honor project stopping point preference in night shift runs

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -10,7 +10,11 @@ from typing import Any, Literal, TypedDict
 import sentry_sdk
 
 from sentry import features, options, quotas
-from sentry.constants import DataCategory, ObjectStatus
+from sentry.constants import (
+    SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
+    DataCategory,
+    ObjectStatus,
+)
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
 from sentry.seer.autofix.autofix_agent import AutofixStep, trigger_autofix_agent
@@ -325,10 +329,12 @@ def run_night_shift_execution(
         for c in candidates:
             c.group.project = projects_by_id[c.group.project_id]
 
+        stopping_point_by_project_id = {ep.project.id: ep.stopping_point for ep in eligible}
         issues = _run_autofix_for_candidates(
             run=run,
             candidates=candidates,
             options=resolved_options,
+            stopping_point_by_project_id=stopping_point_by_project_id,
             log_extra=log_extra,
         )
         seer_run_id_by_group = {i.group_id: i.seer_run_id for i in issues}
@@ -422,6 +428,7 @@ def _fail_run(
 class EligibleProject:
     project: Project
     tweaks: NightShiftTweaks
+    stopping_point: AutofixStoppingPoint
 
 
 def _get_eligible_projects(
@@ -454,7 +461,15 @@ def _get_eligible_projects(
         return []
 
     eligible = [
-        EligibleProject(project=p, tweaks=get_night_shift_tweaks(p)) for p in with_automation
+        EligibleProject(
+            project=p,
+            tweaks=get_night_shift_tweaks(p),
+            stopping_point=AutofixStoppingPoint(
+                preferences[p.id].automated_run_stopping_point
+                or SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
+            ),
+        )
+        for p in with_automation
     ]
     if source == "cron":
         eligible = [ep for ep in eligible if ep.tweaks.enabled]
@@ -465,6 +480,7 @@ def _run_autofix_for_candidates(
     run: SeerNightShiftRun,
     candidates: Sequence[TriageResult],
     options: SeerNightShiftRunOptions,
+    stopping_point_by_project_id: Mapping[int, AutofixStoppingPoint],
     log_extra: dict[str, object],
 ) -> list[SeerNightShiftRunIssue]:
     """
@@ -486,11 +502,10 @@ def _run_autofix_for_candidates(
 
     issues = []
     for c in fixable_candidates:
-        # Ignore automated_run_stopping_point preference — its default blocks PR creation.
         stopping_point = (
             AutofixStoppingPoint.ROOT_CAUSE
             if c.action == TriageAction.ROOT_CAUSE_ONLY
-            else AutofixStoppingPoint.OPEN_PR
+            else stopping_point_by_project_id[c.group.project_id]
         )
 
         user_context = (

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -404,6 +404,9 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         org = self.create_organization()
         project = self.create_project(organization=org)
         self._make_eligible(project)
+        project.update_option(
+            "sentry:seer_automated_run_stopping_point", AutofixStoppingPoint.OPEN_PR.value
+        )
 
         autofix_group = self._store_event_and_update_group(
             project, "autofix", seer_fixability_score=0.9, times_seen=5
@@ -431,6 +434,23 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
             SeerNightShiftRunIssue.objects.filter(run=run).values_list("group_id", "seer_run_id")
         )
         assert issue_run_ids == {autofix_group.id: "42", root_cause_group.id: "99"}
+
+    def test_autofix_stopping_point_honors_project_preference(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+        project.update_option(
+            "sentry:seer_automated_run_stopping_point", AutofixStoppingPoint.SOLUTION.value
+        )
+
+        group = self._store_event_and_update_group(
+            project, "autofix", seer_fixability_score=0.9, times_seen=5
+        )
+
+        with self._patched_night_shift([(group.id, "autofix")]) as (mock_trigger, _):
+            run_night_shift_for_org(org.id)
+
+        assert mock_trigger.call_args.kwargs["stopping_point"] == AutofixStoppingPoint.SOLUTION
 
     def test_forwards_reasoning_effort_to_trigger(self) -> None:
         org = self.create_organization()


### PR DESCRIPTION
Night shift previously hardcoded `AutofixStoppingPoint.OPEN_PR` for every candidate, overriding each project's configured `automated_run_stopping_point`. After user feedback that this ignored their settings, eligible projects now carry their preference through to `trigger_autofix_agent`.

**Per-project stopping point**

`EligibleProject` now carries the project's `automated_run_stopping_point` (resolved from `bulk_read_preferences_from_sentry_db`, falling back to `SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT`). `_run_autofix_for_candidates` looks up the stopping point per candidate via a `project_id` map.

**Triage interaction unchanged**

`ROOT_CAUSE_ONLY` triages still pin to `AutofixStoppingPoint.ROOT_CAUSE` — that's the agent's decision about a specific issue, not a project-wide preference.