### PR TITLE
feat(oauth): Add age column to application settings

### DIFF
--- a/src/sentry/api/serializers/models/apiapplication.py
+++ b/src/sentry/api/serializers/models/apiapplication.py
@@ -14,6 +14,7 @@ class ApiApplicationSerializer(Serializer):
             "id": obj.client_id,
             "clientID": obj.client_id,
             "clientSecret": obj.client_secret if is_secret_visible else None,
+            "dateCreated": obj.date_added,
             "isPublic": obj.is_public,
             "name": obj.name,
             "homepageUrl": obj.homepage_url,

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -110,6 +110,8 @@ export type ApiApplication = {
   privacyUrl: string | null;
   redirectUris: string[];
   termsUrl: string | null;
+  // Remove the optional marker after June 1, 2026 once the backend field is deployed everywhere.
+  dateCreated?: string;
 };
 
 export type OrgAuthToken = {

--- a/static/app/views/settings/account/apiApplications/index.spec.tsx
+++ b/static/app/views/settings/account/apiApplications/index.spec.tsx
@@ -45,6 +45,28 @@ describe('ApiApplications', () => {
     expect(requestMock).toHaveBeenCalled();
 
     expect(screen.getByText('Adjusted Shrimp')).toBeInTheDocument();
+    expect(screen.getByText('Age')).toBeInTheDocument();
+    expect(screen.getByRole('time')).toHaveAttribute(
+      'dateTime',
+      '2024-01-15T12:00:00.000Z'
+    );
+  });
+
+  it('renders when dateCreated is missing', async () => {
+    const apiApp = ApiApplicationFixture();
+    delete apiApp.dateCreated;
+
+    MockApiClient.addMockResponse({
+      url: '/api-applications/',
+      body: [apiApp],
+    });
+
+    render(<ApiApplications />);
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+
+    expect(screen.getByText('Adjusted Shrimp')).toBeInTheDocument();
+    expect(screen.queryByRole('time')).not.toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
   });
 
   it('renders empty in demo mode even if there are applications', async () => {

--- a/static/app/views/settings/account/apiApplications/index.spec.tsx
+++ b/static/app/views/settings/account/apiApplications/index.spec.tsx
@@ -31,6 +31,7 @@ describe('ApiApplications', () => {
     expect(
       screen.getByText("You haven't created any applications yet.")
     ).toBeInTheDocument();
+    expect(screen.getByTestId('empty-message')).toBeInTheDocument();
   });
 
   it('renders', async () => {

--- a/static/app/views/settings/account/apiApplications/index.tsx
+++ b/static/app/views/settings/account/apiApplications/index.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import styled from '@emotion/styled';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
@@ -10,14 +11,11 @@ import {
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
 import {openModal, type ModalRenderProps} from 'sentry/actionCreators/modal';
-import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {RadioGroup} from 'sentry/components/forms/controls/radioGroup';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {Panel} from 'sentry/components/panels/panel';
-import {PanelBody} from 'sentry/components/panels/panelBody';
-import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {ApiApplication} from 'sentry/types/user';
@@ -122,22 +120,44 @@ export default function ApiApplications() {
         </Flex>
       )}
 
-      <Panel>
-        <PanelHeader>{t('Application Name')}</PanelHeader>
+      <ApplicationsTable>
+        <SimpleTable.Header>
+          <SimpleTable.HeaderCell>{t('Application Name')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell data-column-name="age">
+            {t('Age')}
+          </SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell data-column-name="actions" />
+        </SimpleTable.Header>
 
-        <PanelBody>
-          {isEmpty ? (
-            <EmptyMessage>{t("You haven't created any applications yet.")}</EmptyMessage>
-          ) : (
-            appList.map(app => (
-              <Row key={app.id} app={app} onRemove={handleRemoveApplication} />
-            ))
-          )}
-        </PanelBody>
-      </Panel>
+        {isEmpty ? (
+          <SimpleTable.Empty>
+            {t("You haven't created any applications yet.")}
+          </SimpleTable.Empty>
+        ) : (
+          appList.map(app => (
+            <Row key={app.id} app={app} onRemove={handleRemoveApplication} />
+          ))
+        )}
+      </ApplicationsTable>
     </SentryDocumentTitle>
   );
 }
+
+const ApplicationsTable = styled(SimpleTable)`
+  grid-template-columns: minmax(220px, 1fr) minmax(100px, 160px) max-content;
+
+  [data-column-name='actions'] {
+    padding-left: 0;
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    grid-template-columns: minmax(0, 1fr) max-content;
+
+    [data-column-name='age'] {
+      display: none;
+    }
+  }
+`;
 
 interface CreateApplicationModalProps {
   Body: ModalRenderProps['Body'];

--- a/static/app/views/settings/account/apiApplications/index.tsx
+++ b/static/app/views/settings/account/apiApplications/index.tsx
@@ -130,7 +130,7 @@ export default function ApiApplications() {
         </SimpleTable.Header>
 
         {isEmpty ? (
-          <SimpleTable.Empty>
+          <SimpleTable.Empty data-test-id="empty-message">
             {t("You haven't created any applications yet.")}
           </SimpleTable.Empty>
         ) : (

--- a/static/app/views/settings/account/apiApplications/row.tsx
+++ b/static/app/views/settings/account/apiApplications/row.tsx
@@ -1,9 +1,9 @@
 import {useState} from 'react';
-import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
 
 import {
   addErrorMessage,
@@ -11,7 +11,8 @@ import {
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import {ConfirmDelete} from 'sentry/components/confirmDelete';
-import {PanelItem} from 'sentry/components/panels/panelItem';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {TimeSince} from 'sentry/components/timeSince';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {ApiApplication} from 'sentry/types/user';
@@ -49,39 +50,39 @@ export function Row({app, onRemove}: Props) {
   }
 
   return (
-    <StyledPanelItem>
-      <Stack flex="1" marginRight="md">
-        <ApplicationName to={`${ROUTE_PREFIX}applications/${app.id}/`}>
-          {app.name}
-        </ApplicationName>
-        <ClientId>{app.clientID}</ClientId>
-      </Stack>
+    <SimpleTable.Row>
+      <SimpleTable.RowCell>
+        <Stack flex="1" minWidth="0">
+          <Link to={`${ROUTE_PREFIX}applications/${app.id}/`}>{app.name}</Link>
+          <Text as="span" variant="muted" size="sm" monospace ellipsis>
+            {app.clientID}
+          </Text>
+        </Stack>
+      </SimpleTable.RowCell>
 
-      <ConfirmDelete
-        message={t(
-          'Removing this API Application will break existing usages of the application!'
+      <SimpleTable.RowCell data-column-name="age">
+        {app.dateCreated ? (
+          <TimeSince date={app.dateCreated} suffix="" />
+        ) : (
+          <Text as="span" variant="muted">
+            -
+          </Text>
         )}
-        confirmInput={app.name}
-        onConfirm={handleRemove}
-      >
-        <Button disabled={isLoading} size="sm" icon={<IconDelete />}>
-          {t('Remove')}
-        </Button>
-      </ConfirmDelete>
-    </StyledPanelItem>
+      </SimpleTable.RowCell>
+
+      <SimpleTable.RowCell justify="end" data-column-name="actions">
+        <ConfirmDelete
+          message={t(
+            'Removing this API Application will break existing usages of the application!'
+          )}
+          confirmInput={app.name}
+          onConfirm={handleRemove}
+        >
+          <Button disabled={isLoading} size="sm" icon={<IconDelete />}>
+            {t('Remove')}
+          </Button>
+        </ConfirmDelete>
+      </SimpleTable.RowCell>
+    </SimpleTable.Row>
   );
 }
-
-const StyledPanelItem = styled(PanelItem)`
-  padding: ${p => p.theme.space.xl};
-  align-items: center;
-`;
-
-const ApplicationName = styled(Link)`
-  margin-bottom: ${p => p.theme.space.md};
-`;
-
-const ClientId = styled('div')`
-  color: ${p => p.theme.tokens.content.secondary};
-  font-size: ${p => p.theme.font.size.sm};
-`;

--- a/tests/js/fixtures/apiApplication.ts
+++ b/tests/js/fixtures/apiApplication.ts
@@ -7,6 +7,7 @@ export function ApiApplicationFixture(
     allowedOrigins: [],
     clientID: 'aowekr12903i9i423094i23904j',
     clientSecret: null,
+    dateCreated: '2024-01-15T12:00:00.000Z',
     homepageUrl: null,
     id: '123',
     isPublic: false,

--- a/tests/sentry/api/endpoints/test_api_applications.py
+++ b/tests/sentry/api/endpoints/test_api_applications.py
@@ -18,7 +18,9 @@ class ApiApplicationsListTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
         assert response.data[0]["id"] == app1.client_id
+        assert response.data[0]["dateCreated"] == app1.date_added
         assert response.data[1]["id"] == app2.client_id
+        assert response.data[1]["dateCreated"] == app2.date_added
 
 
 @control_silo_test
@@ -28,7 +30,8 @@ class ApiApplicationsCreateTest(APITestCase):
         url = reverse("sentry-api-0-api-applications")
         response = self.client.post(url, data={})
         assert response.status_code == 201
-        assert ApiApplication.objects.get(client_id=response.data["id"], owner=self.user)
+        app = ApiApplication.objects.get(client_id=response.data["id"], owner=self.user)
+        assert response.data["dateCreated"] == app.date_added
 
     def test_create_confidential_client(self) -> None:
         """Creating an app without isPublic flag creates a confidential client with secret."""


### PR DESCRIPTION
Add an Age column to the OAuth applications list in account settings.

The API now exposes each OAuth application's creation timestamp as dateCreated, and the settings page renders that value with the existing relative TimeSince component. The frontend type keeps dateCreated optional and renders a fallback when it is missing, so older backend responses remain safe during deploy rollout.

This also moves the list from the older panel row layout to SimpleTable for clearer column semantics.