### PR TITLE
docs(agents): Add repo policy docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,7 @@ Workflow steering (commit, pre-commit, hybrid cloud, etc.) lives in **skills** (
 
 - `policies/README.md` explains when a short repo policy doc should exist.
 - `policies/code-comments.md` is the repo default for comments, docstrings, and JSDoc.
+- `policies/TEMPLATE.md` is the template for adding new policy docs.
 
 ## Viewer/Organization Context
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,11 @@ Use the right AGENTS.md for the area you're working in:
 
 Workflow steering (commit, pre-commit, hybrid cloud, etc.) lives in **skills** (`.agents/skills/`). Attach or read the area `AGENTS.md` when working in that tree. Add or update guidance in the appropriate AGENTS.md or skill—do not duplicate long guidance in editor-specific rule files.
 
+### Policies
+
+- `policies/README.md` explains when a short repo policy doc should exist.
+- `policies/code-comments.md` is the repo default for comments, docstrings, and JSDoc.
+
 ## Viewer/Organization Context
 
 - Viewer identity is wired through the app via the `ViewerContext` contextvar; use `sentry.viewer_context.get_viewer_context()` instead of explicitly threading org/user identity when the current viewer is in scope.

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,21 @@
+# Policies
+
+Policies are short repo-wide defaults.
+
+Use a policy doc when we want to say "this is how we normally do this here"
+without turning it into a full architecture document or feature spec.
+
+Good policy topics:
+
+- API design and migration shape
+- code comments, docstrings, and JSDoc
+- testing expectations
+- naming conventions
+- migration hygiene
+- automation safety boundaries
+
+Keep policy docs small:
+
+- explain the intent briefly
+- state the default rule clearly
+- call out only the meaningful exceptions

--- a/policies/README.md
+++ b/policies/README.md
@@ -19,3 +19,5 @@ Keep policy docs small:
 - explain the intent briefly
 - state the default rule clearly
 - call out only the meaningful exceptions
+
+Use `policies/TEMPLATE.md` for new policies.

--- a/policies/TEMPLATE.md
+++ b/policies/TEMPLATE.md
@@ -1,0 +1,14 @@
+# Policy Name
+
+## Intent
+
+One short paragraph on why this policy exists.
+
+## Policy
+
+- Default rule
+- Second rule if needed
+
+## Exceptions
+
+- Only list real exceptions

--- a/policies/code-comments.md
+++ b/policies/code-comments.md
@@ -1,0 +1,27 @@
+# Code Comments
+
+## Intent
+
+Comments, docstrings, and JSDoc are for non-obvious intent, invariants, safety
+boundaries, and tradeoffs.
+
+They are not there to narrate obvious code.
+
+## Policy
+
+- Add comments when behavior is easy to misread, policy-driven, or coupled to
+  a non-obvious invariant.
+- Use brief docstrings or JSDoc for shared/public helpers, endpoints, hooks,
+  components, or exported functions when future readers need intent, contract,
+  or safety context to change them safely.
+- Call out Sentry-specific boundaries when relevant: organization/project
+  scoping, silo or cell behavior, customer-data constraints, retention/date
+  assumptions, feature-flag rollout, and migration compatibility.
+- Keep comments short and concrete. Explain why the code exists or what boundary it is protecting.
+- Delete or rewrite stale comments immediately when behavior changes.
+
+## Exceptions
+
+- Do not comment obvious transformations, test setup, or control flow.
+- Do not add comments that simply restate names or code in English.
+- Do not preserve comments about removed or obsolete code paths.


### PR DESCRIPTION
Adopt the repo policy pattern for agent guidance by adding a small `/policies` directory and linking it from the root `AGENTS.md`. The initial code-comments policy centralizes comment, docstring, and JSDoc guidance without adding area-specific agent-guide prose. `policies/TEMPLATE.md` gives future policy docs a small standard structure.