### PR TITLE
chore(autofix): Add analytic when users click on autofix evidence

### DIFF
--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -111,6 +111,7 @@ describe('ArtifactCard', () => {
       render(
         <RootCauseCard
           autofix={mockAutofix}
+          groupId="1"
           section={makeSection('root_cause', 'completed', [artifact])}
         />
       );
@@ -128,6 +129,7 @@ describe('ArtifactCard', () => {
       render(
         <RootCauseCard
           autofix={mockAutofix}
+          groupId="1"
           section={makeSection('root_cause', 'completed', [artifact])}
         />
       );
@@ -148,6 +150,7 @@ describe('ArtifactCard', () => {
       render(
         <RootCauseCard
           autofix={mockAutofix}
+          groupId="1"
           section={makeSection('root_cause', 'completed', [artifact])}
         />
       );
@@ -163,6 +166,7 @@ describe('ArtifactCard', () => {
       render(
         <RootCauseCard
           autofix={mockAutofix}
+          groupId="1"
           section={makeSection('root_cause', 'completed', [artifact])}
         />
       );
@@ -185,6 +189,7 @@ describe('ArtifactCard', () => {
       render(
         <RootCauseCard
           autofix={mockAutofix}
+          groupId="1"
           section={makeSection('root_cause', 'completed', [artifact])}
         />
       );
@@ -203,6 +208,7 @@ describe('ArtifactCard', () => {
       render(
         <RootCauseCard
           autofix={mockAutofix}
+          groupId="1"
           section={makeSection('root_cause', 'completed', [artifact])}
         />
       );
@@ -220,6 +226,7 @@ describe('ArtifactCard', () => {
       render(
         <RootCauseCard
           autofix={mockAutofix}
+          groupId="1"
           section={makeSection('root_cause', 'completed', [artifact])}
         />
       );
@@ -615,6 +622,7 @@ describe('ArtifactCard', () => {
       render(
         <RootCauseCard
           autofix={mockAutofix}
+          groupId="1"
           section={makeSection('root_cause', 'completed', [artifact])}
         />
       );
@@ -631,6 +639,7 @@ describe('ArtifactCard', () => {
       render(
         <RootCauseCard
           autofix={mockAutofix}
+          groupId="1"
           section={makeSection('root_cause', 'completed', [artifact])}
         />
       );
@@ -650,6 +659,7 @@ describe('ArtifactCard', () => {
       render(
         <RootCauseCard
           autofix={mockAutofix}
+          groupId="1"
           section={makeSection('root_cause', 'completed', [artifact])}
         />
       );

--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -74,122 +74,202 @@ describe('AutofixEvidence', () => {
 
   describe('EvidenceTelemetry', () => {
     it('renders "Query: Spans" for spans dataset', () => {
-      const props = resolveProps(
-        makeToolCall('telemetry_live_search'),
-        makeToolLink('telemetry_live_search', {dataset: 'spans', query: 'test'})
+      const toolCall = makeToolCall('telemetry_live_search');
+      const toolLink = makeToolLink('telemetry_live_search', {
+        dataset: 'spans',
+        query: 'test',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Query: Spans')).toBeInTheDocument();
     });
 
     it('renders "Query: Issues" for issues dataset', () => {
-      const props = resolveProps(
-        makeToolCall('telemetry_live_search'),
-        makeToolLink('telemetry_live_search', {dataset: 'issues', query: 'test'})
+      const toolCall = makeToolCall('telemetry_live_search');
+      const toolLink = makeToolLink('telemetry_live_search', {
+        dataset: 'issues',
+        query: 'test',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Query: Issues')).toBeInTheDocument();
     });
 
     it('renders "Query: Errors" for errors dataset', () => {
-      const props = resolveProps(
-        makeToolCall('telemetry_live_search'),
-        makeToolLink('telemetry_live_search', {dataset: 'errors', query: 'test'})
+      const toolCall = makeToolCall('telemetry_live_search');
+      const toolLink = makeToolLink('telemetry_live_search', {
+        dataset: 'errors',
+        query: 'test',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Query: Errors')).toBeInTheDocument();
     });
 
     it('renders "Query: Logs" for logs dataset', () => {
-      const props = resolveProps(
-        makeToolCall('telemetry_live_search'),
-        makeToolLink('telemetry_live_search', {dataset: 'logs', query: 'test'})
+      const toolCall = makeToolCall('telemetry_live_search');
+      const toolLink = makeToolLink('telemetry_live_search', {
+        dataset: 'logs',
+        query: 'test',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Query: Logs')).toBeInTheDocument();
     });
 
     it('renders "Query: Metrics" for metrics dataset', () => {
-      const props = resolveProps(
-        makeToolCall('telemetry_live_search'),
-        makeToolLink('telemetry_live_search', {
-          dataset: 'metrics',
-          query: 'test',
-          trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
-        })
+      const toolCall = makeToolCall('telemetry_live_search');
+      const toolLink = makeToolLink('telemetry_live_search', {
+        dataset: 'metrics',
+        query: 'test',
+        trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Query: Metrics')).toBeInTheDocument();
     });
 
     it('renders "Query: Metrics" for tracemetrics dataset', () => {
-      const props = resolveProps(
-        makeToolCall('telemetry_live_search'),
-        makeToolLink('telemetry_live_search', {
-          dataset: 'tracemetrics',
-          query: 'test',
-          trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
-        })
+      const toolCall = makeToolCall('telemetry_live_search');
+      const toolLink = makeToolLink('telemetry_live_search', {
+        dataset: 'tracemetrics',
+        query: 'test',
+        trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Query: Metrics')).toBeInTheDocument();
     });
 
     it('defaults to "Query: Spans" when dataset is undefined', () => {
-      const props = resolveProps(
-        makeToolCall('telemetry_live_search'),
-        makeToolLink('telemetry_live_search', {query: 'test'})
+      const toolCall = makeToolCall('telemetry_live_search');
+      const toolLink = makeToolLink('telemetry_live_search', {query: 'test'});
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Query: Spans')).toBeInTheDocument();
     });
   });
 
   describe('EvidenceTrace', () => {
     it('renders span label when span_id is provided', () => {
-      const props = resolveProps(
-        makeToolCall('get_trace_waterfall'),
-        makeToolLink('get_trace_waterfall', {
-          trace_id: 'abc123def4567890',
-          span_id: '11223344aabbccdd',
-        })
+      const toolCall = makeToolCall('get_trace_waterfall');
+      const toolLink = makeToolLink('get_trace_waterfall', {
+        trace_id: 'abc123def4567890',
+        span_id: '11223344aabbccdd',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Span: 11223344')).toBeInTheDocument();
     });
 
     it('renders trace label when only trace_id is provided', () => {
-      const props = resolveProps(
-        makeToolCall('get_trace_waterfall'),
-        makeToolLink('get_trace_waterfall', {trace_id: 'abc123def4567890'})
+      const toolCall = makeToolCall('get_trace_waterfall');
+      const toolLink = makeToolLink('get_trace_waterfall', {
+        trace_id: 'abc123def4567890',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Trace: abc123de')).toBeInTheDocument();
     });
   });
 
   describe('EvidenceIssue', () => {
     it('renders error label with event_id via get_event_details', () => {
-      const props = resolveProps(
-        makeToolCall('get_event_details'),
-        makeToolLink('get_event_details', {
-          event_id: 'abcd1234efgh5678',
-          issue_id: '12345',
-        })
+      const toolCall = makeToolCall('get_event_details');
+      const toolLink = makeToolLink('get_event_details', {
+        event_id: 'abcd1234efgh5678',
+        issue_id: '12345',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Error: abcd1234')).toBeInTheDocument();
     });
 
     it('renders error label with event_id via get_issue_details', () => {
-      const props = resolveProps(
-        makeToolCall('get_issue_details'),
-        makeToolLink('get_issue_details', {
-          issue_id: '12345',
-          event_id: 'abcd1234efgh5678',
-        })
+      const toolCall = makeToolCall('get_issue_details');
+      const toolLink = makeToolLink('get_issue_details', {
+        issue_id: '12345',
+        event_id: 'abcd1234efgh5678',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Error: abcd1234')).toBeInTheDocument();
     });
 
@@ -205,38 +285,61 @@ describe('AutofixEvidence', () => {
 
   describe('EvidenceReplay', () => {
     it('renders replay label', () => {
-      const props = resolveProps(
-        makeToolCall('get_replay_details'),
-        makeToolLink('get_replay_details', {replay_id: 'aabbccdd11223344'})
+      const toolCall = makeToolCall('get_replay_details');
+      const toolLink = makeToolLink('get_replay_details', {
+        replay_id: 'aabbccdd11223344',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Replay: aabbccdd')).toBeInTheDocument();
     });
   });
 
   describe('EvidenceProfile', () => {
     it('renders profile label', () => {
-      const props = resolveProps(
-        makeToolCall('get_profile_flamegraph'),
-        makeToolLink('get_profile_flamegraph', {
-          profile_id: 'prof1234abcd5678',
-          project_id: '1',
-        })
+      const toolCall = makeToolCall('get_profile_flamegraph');
+      const toolLink = makeToolLink('get_profile_flamegraph', {
+        profile_id: 'prof1234abcd5678',
+        project_id: '1',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Profile: prof1234')).toBeInTheDocument();
     });
   });
 
   describe('EvidenceCodeSearch', () => {
     it('renders filename for read_file mode', () => {
-      const props = resolveProps(
-        makeToolCall('code_search', {mode: 'read_file', path: 'src/foo/bar.py'}),
-        makeToolLink('code_search', {
-          code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
-        })
+      const toolCall = makeToolCall('code_search', {
+        mode: 'read_file',
+        path: 'src/foo/bar.py',
+      });
+      const toolLink = makeToolLink('code_search', {
+        code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('File: bar.py')).toBeInTheDocument();
       expect(screen.getByText('File: bar.py').closest('a')).toHaveAttribute(
         'href',
@@ -245,17 +348,22 @@ describe('AutofixEvidence', () => {
     });
 
     it('renders truncated filename for read_file mode', () => {
-      const props = resolveProps(
-        makeToolCall('code_search', {
-          mode: 'read_file',
-          path: 'src/foo/thisisalongfilename.py',
-        }),
-        makeToolLink('code_search', {
-          code_url:
-            'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py',
-        })
+      const toolCall = makeToolCall('code_search', {
+        mode: 'read_file',
+        path: 'src/foo/thisisalongfilename.py',
+      });
+      const toolLink = makeToolLink('code_search', {
+        code_url: 'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('File: thisisal\u2026ename.py')).toBeInTheDocument();
       expect(
         screen.getByText('File: thisisal\u2026ename.py').closest('a')
@@ -335,14 +443,20 @@ describe('AutofixEvidence', () => {
     const END_DATE = '2024-01-31';
 
     it('renders commit label with short hash for single commit', () => {
-      const props = resolveProps(
-        makeToolCall('git_search'),
-        makeToolLink('git_search', {
-          commit_url: COMMIT_URL,
-          sha: FULL_SHA,
-        })
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {
+        commit_url: COMMIT_URL,
+        sha: FULL_SHA,
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Commit: a1b2c3d')).toBeInTheDocument();
       expect(screen.getByText('Commit: a1b2c3d').closest('a')).toHaveAttribute(
         'href',
@@ -352,28 +466,40 @@ describe('AutofixEvidence', () => {
 
     it('renders full sha when sha is not a 40-char hex hash', () => {
       const shortSha = 'abc1234';
-      const props = resolveProps(
-        makeToolCall('git_search'),
-        makeToolLink('git_search', {
-          commit_url: COMMIT_URL,
-          sha: shortSha,
-        })
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {
+        commit_url: COMMIT_URL,
+        sha: shortSha,
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Commit: abc1234')).toBeInTheDocument();
     });
 
     it('renders commits label with repo name when file_path is absent', () => {
-      const props = resolveProps(
-        makeToolCall('git_search'),
-        makeToolLink('git_search', {
-          commits_url: COMMITS_URL,
-          repo_name: REPO_NAME,
-          start_date: START_DATE,
-          end_date: END_DATE,
-        })
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {
+        commits_url: COMMITS_URL,
+        repo_name: REPO_NAME,
+        start_date: START_DATE,
+        end_date: END_DATE,
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText(`Commits: ${REPO_NAME}`)).toBeInTheDocument();
       expect(screen.getByText(`Commits: ${REPO_NAME}`).closest('a')).toHaveAttribute(
         'href',
@@ -382,48 +508,66 @@ describe('AutofixEvidence', () => {
     });
 
     it('renders commits label with short file_path without truncation', () => {
-      const props = resolveProps(
-        makeToolCall('git_search'),
-        makeToolLink('git_search', {
-          commits_url: COMMITS_URL,
-          repo_name: REPO_NAME,
-          start_date: START_DATE,
-          end_date: END_DATE,
-          file_path: 'src/foo/bar.py',
-        })
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {
+        commits_url: COMMITS_URL,
+        repo_name: REPO_NAME,
+        start_date: START_DATE,
+        end_date: END_DATE,
+        file_path: 'src/foo/bar.py',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Commits: bar.py')).toBeInTheDocument();
     });
 
     it('renders commits label with truncated file_path when file_path is long', () => {
-      const props = resolveProps(
-        makeToolCall('git_search'),
-        makeToolLink('git_search', {
-          commits_url: COMMITS_URL,
-          repo_name: REPO_NAME,
-          start_date: START_DATE,
-          end_date: END_DATE,
-          file_path: 'src/components/thisisalongfilename.tsx',
-        })
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {
+        commits_url: COMMITS_URL,
+        repo_name: REPO_NAME,
+        start_date: START_DATE,
+        end_date: END_DATE,
+        file_path: 'src/components/thisisalongfilename.tsx',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Commits: thisisal\u2026name.tsx')).toBeInTheDocument();
     });
 
     it('prefers single commit path when both param sets are present', () => {
-      const props = resolveProps(
-        makeToolCall('git_search'),
-        makeToolLink('git_search', {
-          commit_url: COMMIT_URL,
-          sha: FULL_SHA,
-          commits_url: COMMITS_URL,
-          repo_name: REPO_NAME,
-          start_date: START_DATE,
-          end_date: END_DATE,
-        })
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {
+        commit_url: COMMIT_URL,
+        sha: FULL_SHA,
+        commits_url: COMMITS_URL,
+        repo_name: REPO_NAME,
+        start_date: START_DATE,
+        end_date: END_DATE,
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
       );
-      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Commit: a1b2c3d')).toBeInTheDocument();
     });
 

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -14,17 +14,34 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getShortEventId} from 'sentry/utils/events';
 import {getShortCommitHash} from 'sentry/utils/git/getShortCommitHash';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import type {ToolCall, ToolLink} from 'sentry/views/seerExplorer/types';
 import {buildToolLinkUrl} from 'sentry/views/seerExplorer/utils';
 
 interface AutofixEvidenceProps {
   evidenceButtonProps: EvidenceButtonProps;
+  groupId: string;
+  toolCall: ToolCall;
 }
 
-export function AutofixEvidence({evidenceButtonProps}: AutofixEvidenceProps) {
+export function AutofixEvidence({
+  evidenceButtonProps,
+  groupId,
+  toolCall,
+}: AutofixEvidenceProps) {
+  const organization = useOrganization();
   const {label, icon, tooltip, ...rest} = evidenceButtonProps;
+
+  const handleClick = () => {
+    trackAnalytics('autofix.evidence.clicked', {
+      organization,
+      group_id: groupId,
+      tool_name: toolCall.function,
+    });
+  };
 
   if ('to' in rest && defined(rest.to)) {
     return (
@@ -33,6 +50,7 @@ export function AutofixEvidence({evidenceButtonProps}: AutofixEvidenceProps) {
         size="zero"
         to={rest.to}
         openInNewTab
+        onClick={handleClick}
         tooltipProps={tooltip ? {title: tooltip} : undefined}
       >
         {label}
@@ -47,6 +65,7 @@ export function AutofixEvidence({evidenceButtonProps}: AutofixEvidenceProps) {
         size="zero"
         href={rest.href}
         external
+        onClick={handleClick}
         tooltipProps={tooltip ? {title: tooltip} : undefined}
       >
         {label}

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -57,7 +57,7 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
 
   return (
     <Flex direction="column" gap="lg">
-      <SeerDrawerArtifacts autofix={autofix} sections={sections} />
+      <SeerDrawerArtifacts autofix={autofix} sections={sections} groupId={group.id} />
       {autofix.runState?.status === 'completed' && (
         <SeerDrawerNextStep group={group} autofix={autofix} sections={sections} />
       )}
@@ -84,17 +84,25 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
 
 interface SeerDrawerArtifactsProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
+  groupId: string;
   sections: AutofixSection[];
 }
 
-function SeerDrawerArtifacts({autofix, sections}: SeerDrawerArtifactsProps) {
+function SeerDrawerArtifacts({autofix, groupId, sections}: SeerDrawerArtifactsProps) {
   return (
     <Fragment>
       {sections.map(section => {
         const key = `${section.step}-${section.blocks[0]?.id ?? null}`;
 
         if (isRootCauseSection(section)) {
-          return <RootCauseCard key={key} autofix={autofix} section={section} />;
+          return (
+            <RootCauseCard
+              key={key}
+              autofix={autofix}
+              section={section}
+              groupId={groupId}
+            />
+          );
         }
 
         if (isSolutionSection(section)) {

--- a/static/app/components/events/autofix/v3/rootCauseCard.tsx
+++ b/static/app/components/events/autofix/v3/rootCauseCard.tsx
@@ -26,10 +26,11 @@ import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 
 interface RootCauseCardProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
+  groupId: string;
   section: AutofixSection;
 }
 
-export function RootCauseCard({autofix, section}: RootCauseCardProps) {
+export function RootCauseCard({autofix, groupId, section}: RootCauseCardProps) {
   const artifact = useMemo(() => {
     const sectionArtifact = getAutofixArtifactFromSection(section);
     return isRootCauseArtifact(sectionArtifact) ? sectionArtifact : null;
@@ -114,6 +115,8 @@ export function RootCauseCard({autofix, section}: RootCauseCardProps) {
                   <AutofixEvidence
                     key={e.toolCall.id}
                     evidenceButtonProps={e.evidenceButtonProps}
+                    groupId={groupId}
+                    toolCall={e.toolCall}
                   />
                 ))}
               </Flex>

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -52,6 +52,11 @@ export type SeerAnalyticsEventsParameters = {
     mode?: 'explorer' | 'legacy';
     referrer?: string;
   };
+  'autofix.evidence.clicked': {
+    group_id: string;
+    organization: Organization;
+    tool_name: string;
+  };
   'autofix.root_cause.find_solution': {
     group_id: string;
     organization: Organization;
@@ -155,6 +160,7 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'autofix.coding_agent.launch': 'Autofix: Coding Agent Launch',
   'autofix.code_changes.re_run': 'Autofix: Code Changes Re-run',
   'autofix.create_pr_clicked': 'Autofix: Create PR Setup Clicked',
+  'autofix.evidence.clicked': 'Autofix: Evidence Clicked',
   'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',
   'autofix.root_cause.re_run': 'Autofix: Root Cause Re-run',
   'autofix.solution.code': 'Autofix: Code It Up',


### PR DESCRIPTION
Emit analytic event to understand what evidence users click on most.