### PR TITLE
feat(seer): Add structured LLM context for issue detail page

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -684,10 +684,7 @@ function GroupDetailsContentInner({
   );
 }
 
-const GroupDetailsContent = registerLLMContext(
-  'issue-detail',
-  GroupDetailsContentInner as unknown as React.ComponentType<Record<string, unknown>>
-) as unknown as React.ComponentType<GroupDetailsContentProps>;
+const GroupDetailsContent = registerLLMContext('issue-detail', GroupDetailsContentInner);
 
 interface GroupDetailsPageContentProps extends FetchGroupDetailsState {
   children: React.ReactNode;

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -81,6 +81,8 @@ import {
   useEnvironmentsFromUrl,
   useIsSampleEvent,
 } from 'sentry/views/issueDetails/utils';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
+import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
 type Error = (typeof ERROR_TYPES)[keyof typeof ERROR_TYPES] | null;
 
@@ -564,7 +566,7 @@ function GroupDetailsContentError({
   }
 }
 
-function GroupDetailsContent({
+function GroupDetailsContentInner({
   children,
   group,
   project,
@@ -640,6 +642,27 @@ function GroupDetailsContent({
 
   useEngagedViewTracking({group, project});
 
+  useLLMContext({
+    contextHint:
+      'Sentry issue detail page. Shows a single grouped issue with its latest event. ' +
+      'shortId is the human-readable issue identifier (e.g. PROJ-123). ' +
+      'Tools: get_issue_details(issue_id) for issue aggregate stats and stack trace; ' +
+      'get_event_details(event_id?, issue_id?) for a specific error event; ' +
+      'telemetry_live_search(dataset, question, project_slugs) for querying spans/errors/logs/metrics.',
+    shortId: group.shortId,
+    title: group.title,
+    level: group.level,
+    status: group.status,
+    priority: group.priority,
+    issueType: group.issueType,
+    count: group.count,
+    userCount: group.userCount,
+    firstSeen: group.firstSeen,
+    lastSeen: group.lastSeen,
+    projectSlug: project.slug,
+    eventId: event?.id,
+  });
+
   const isDisplayingEventDetails = [
     Tab.DETAILS,
     Tab.DISTRIBUTIONS,
@@ -660,6 +683,11 @@ function GroupDetailsContent({
     </GroupDetailsLayout>
   );
 }
+
+const GroupDetailsContent = registerLLMContext(
+  'issue-detail',
+  GroupDetailsContentInner as unknown as React.ComponentType<Record<string, unknown>>
+) as unknown as React.ComponentType<GroupDetailsContentProps>;
 
 interface GroupDetailsPageContentProps extends FetchGroupDetailsState {
   children: React.ReactNode;

--- a/static/app/views/seerExplorer/contexts/llmContextTypes.ts
+++ b/static/app/views/seerExplorer/contexts/llmContextTypes.ts
@@ -20,6 +20,7 @@
 export type LLMContextNodeType =
   | 'chart'
   | 'dashboard'
+  | 'issue-detail'
   | 'issue-list'
   | 'trace'
   | 'traces-explorer'

--- a/static/app/views/seerExplorer/contexts/registerLLMContext.tsx
+++ b/static/app/views/seerExplorer/contexts/registerLLMContext.tsx
@@ -22,7 +22,7 @@ import type {LLMContextNodeType} from './llmContextTypes';
  *   // Widget rendered inside Dashboard will nest correctly:
  *   // { nodeType: 'dashboard', children: [{ nodeType: 'widget', ... }] }
  */
-export function registerLLMContext<P extends Record<string, unknown>>(
+export function registerLLMContext<P>(
   nodeType: LLMContextNodeType,
   WrappedComponent: ComponentType<P>
 ): ComponentType<P> {

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -55,7 +55,7 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/explore/traces/trace/:traceSlug/',
 ]);
 /** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>(['/issues/']);
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>(['/issues/', '/issues/:groupId/']);
 
 function supportsStructuredContext(
   referrer: string,


### PR DESCRIPTION
+ Register the issue detail page (/issues/:groupId/) as a structured LLM context node so Seer Explorer receives typed issue metadata instead of an ASCII DOM snapshot. Follows the same pattern used for dashboards, traces, and the issue list page.

+ Wraps GroupDetailsContent with registerLLMContext('issue-detail', ...) and pushes 12 fields (shortId, title, level, status, priority, issueType, count, userCount, firstSeen, lastSeen, projectSlug, eventId) plus tool-call hints via useLLMContext.
