### PR TITLE
fix(preprod): Derive sidebar highlight from selection state in list view

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -296,20 +296,15 @@ export const SnapshotListView = memo(function SnapshotListView({
 
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el) {
+    if (!el || groups.length === 0) {
       return;
     }
     el.addEventListener('scroll', handleScroll, {passive: true});
+    handleScroll();
     return () => {
       el.removeEventListener('scroll', handleScroll);
       cancelAnimationFrame(rafId.current);
     };
-  }, [handleScroll]);
-
-  useEffect(() => {
-    if (groups.length > 0) {
-      handleScroll();
-    }
   }, [groups, handleScroll]);
 
   const initialSnapshotKey = useRef(selectedSnapshotKey ?? null).current;

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -573,8 +573,22 @@ export default function SnapshotsPage() {
       : deferredItem;
   const singleViewVariantIndex = singleViewPosition?.variantIdx ?? 0;
 
-  const activeItemKey =
-    viewMode === 'list' ? visibleItemKey : (singleViewItem?.key ?? null);
+  const activeItemKey = useMemo(() => {
+    if (viewMode !== 'list') {
+      return singleViewItem?.key ?? null;
+    }
+    if (selectedSnapshotKey && singleViewPosition) {
+      return listItems[singleViewPosition.itemIdx]?.key ?? visibleItemKey;
+    }
+    return visibleItemKey;
+  }, [
+    viewMode,
+    singleViewItem,
+    selectedSnapshotKey,
+    singleViewPosition,
+    listItems,
+    visibleItemKey,
+  ]);
 
   const isComparisonProcessing =
     !!comparisonRunInfo?.state &&


### PR DESCRIPTION
Two fixes for the snapshot list view:

**Sidebar highlighting race condition** — `activeItemKey` (which drives
sidebar highlighting) was derived solely from `visibleItemKey`, a
scroll-tracked value updated via `requestAnimationFrame`. When clicking
a sidebar item, the rAF callback could overwrite the state before React
re-rendered. Fix: derive `activeItemKey` from `selectedSnapshotKey` via
`singleViewPosition` when a snapshot is selected, falling back to
`visibleItemKey` only when nothing is selected.

**Progress bar not updating on initial scroll** — The scroll listener
effect depended only on `handleScroll` (a stable `useCallback`), so it
ran exactly once on mount. When `useDeferredValue` caused the initial
render to have empty items, the `ScrollContainer` didn't exist yet and
the listener was never attached. Fix: merge the scroll listener and
initial-scroll effects into a single effect that depends on `groups`,
so the listener is attached when the scroll container first mounts.