### PR TITLE
fix(breadcrumbs): align severity level label with title

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -187,6 +187,7 @@ const VirtualOffset = styled('div')<{offset: number}>`
 const Header = styled('div')`
   display: grid;
   grid-template-columns: 1fr auto;
+  align-items: end;
 `;
 
 const TextBreak = styled('span')`


### PR DESCRIPTION
Align the 'error', 'info' severity text with the header. I suspect something regressed recently but couldn't find anything — there's also probably a better way to align these, but this seems slightly better than before.

Before:
<img width="262" height="67" alt="Screenshot 2026-05-04 at 10 58 48 AM" src="https://github.com/user-attachments/assets/34ed9263-1695-4fae-8e1f-7d01f66336f8" />

After:
<img width="259" height="65" alt="Screenshot 2026-05-04 at 10 58 58 AM" src="https://github.com/user-attachments/assets/f638aded-070e-4d69-ab53-cc0c29ad763a" />
