### PR TITLE
ref(snapshots): Rename 'modified' to 'changed' in snapshot UI

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
@@ -10,7 +10,7 @@ from sentry.preprod.url_utils import get_preprod_artifact_comparison_url, get_pr
 _HEADER = "## Sentry Snapshot Testing"
 PROCESSING_STATUS = "⏳ Processing"
 COMPARISON_TABLE_HEADER = (
-    "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |\n"
+    "| Name | Added | Removed | Changed | Renamed | Unchanged | Skipped | Status |\n"
     "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
 )
 

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -72,8 +72,8 @@ def format_snapshot_status_check_messages(
         if total_changed > 0:
             parts.append(
                 ngettext(
-                    "%(count)d modified",
-                    "%(count)d modified",
+                    "%(count)d changed",
+                    "%(count)d changed",
                     total_changed,
                 )
                 % {"count": total_changed}

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -101,7 +101,7 @@ function ChangeCounts({
     parts.push(t('%s removed', removed));
   }
   if (changed > 0) {
-    parts.push(t('%s modified', changed));
+    parts.push(t('%s changed', changed));
   }
   if (unchanged > 0) {
     parts.push(t('%s unchanged', unchanged));

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -320,11 +320,8 @@ const StatusBadge = memo(function StatusBadge({
     case DiffStatus.CHANGED:
       label =
         diffPercent === null || diffPercent === undefined
-          ? t('Modified')
-          : t(
-              'Modified - %s',
-              formatPercentage(diffPercent, diffPercent >= 0.01 ? 1 : 4)
-            );
+          ? t('Changed')
+          : t('Changed - %s', formatPercentage(diffPercent, diffPercent >= 0.01 ? 1 : 4));
       break;
     case DiffStatus.ADDED:
       label = t('Added');

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -151,7 +151,7 @@ describe('SnapshotMainContent', () => {
 
     expect(screen.getByText('Buttons')).toBeInTheDocument();
     expect(screen.getByText('Button / light')).toBeInTheDocument();
-    expect(screen.getByText(/Modified/)).toBeInTheDocument();
+    expect(screen.getByText(/Changed/)).toBeInTheDocument();
     expect(screen.getByText('feature/snapshot-updates')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Pick overlay color'})).toBeInTheDocument();
     expect(screen.getByRole('radio', {name: 'Split'})).toBeChecked();

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -38,7 +38,7 @@ const STATUS_PILLS: ReadonlyArray<{
   label: string;
   status: DiffStatus;
 }> = [
-  {status: DiffStatus.CHANGED, color: 'accent', label: t('modified')},
+  {status: DiffStatus.CHANGED, color: 'accent', label: t('changed')},
   {status: DiffStatus.REMOVED, color: 'danger', label: t('removed')},
   {status: DiffStatus.ADDED, color: 'success', label: t('added')},
   {status: DiffStatus.RENAMED, color: 'warning', label: t('renamed')},
@@ -46,7 +46,7 @@ const STATUS_PILLS: ReadonlyArray<{
 ];
 
 const STATUS_META: Record<DiffStatus, {color: PillColor; label: string}> = {
-  [DiffStatus.CHANGED]: {color: 'accent', label: t('Modified')},
+  [DiffStatus.CHANGED]: {color: 'accent', label: t('Changed')},
   [DiffStatus.ADDED]: {color: 'success', label: t('Added')},
   [DiffStatus.REMOVED]: {color: 'danger', label: t('Removed')},
   [DiffStatus.RENAMED]: {color: 'warning', label: t('Renamed')},

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
@@ -354,7 +354,7 @@ class FormatSnapshotPrCommentSuccessTest(SnapshotPrCommentTestBase):
         )
 
         assert (
-            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |"
+            "| Name | Added | Removed | Changed | Renamed | Unchanged | Skipped | Status |"
             in result
         )
 
@@ -392,7 +392,7 @@ class FormatSnapshotPrCommentNoBaseTest(SnapshotPrCommentTestBase):
         )
 
         assert (
-            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |"
+            "| Name | Added | Removed | Changed | Renamed | Unchanged | Skipped | Status |"
             in result
         )
 

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
@@ -227,7 +227,7 @@ class SnapshotStatusCheckWithSkippedTest(SnapshotTasksTestBase):
             images_changed=2, images_skipped=50, images_unchanged=3
         )
 
-        assert "2 modified" in subtitle
+        assert "2 changed" in subtitle
         assert "50 skipped" in subtitle
         assert "3 unchanged" in subtitle
         assert "Skipped" in summary

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -298,7 +298,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "3 modified, 7 unchanged"
+        assert subtitle == "3 changed, 7 unchanged"
         assert "⏳ Needs approval" in summary
 
     def test_single_image_changed(self) -> None:
@@ -325,7 +325,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             project=self.project,
         )
 
-        assert subtitle == "1 modified, 9 unchanged"
+        assert subtitle == "1 changed, 9 unchanged"
 
     def test_images_added_and_removed(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
@@ -408,7 +408,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             project=self.project,
         )
 
-        assert subtitle == "3 modified, 1 added, 2 removed, 1 renamed, 5 unchanged"
+        assert subtitle == "3 changed, 1 added, 2 removed, 1 renamed, 5 unchanged"
         assert "⏳ Needs approval" in summary
 
 
@@ -554,7 +554,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         assert (
-            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |"
+            "| Name | Added | Removed | Changed | Renamed | Unchanged | Skipped | Status |"
             in summary
         )
         assert "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |" in summary
@@ -671,7 +671,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/snapshots/"
         configure_link = f"[Configure {self.project.name} snapshot settings]({settings_url})"
         expected = (
-            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |\n"
+            "| Name | Added | Removed | Changed | Renamed | Unchanged | Skipped | Status |\n"
             "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app`"
             f" | 0 | 0 | 0 | 0"
@@ -713,12 +713,12 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "3 modified, 1 added, 2 removed, 1 renamed, 4 unchanged"
+        assert subtitle == "3 changed, 1 added, 2 removed, 1 renamed, 4 unchanged"
 
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/snapshots/"
         configure_link = f"[Configure {self.project.name} snapshot settings]({settings_url})"
         expected = (
-            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |\n"
+            "| Name | Added | Removed | Changed | Renamed | Unchanged | Skipped | Status |\n"
             "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app`"
             f" | [{1}]({artifact_url}?selectedTypes=added)"
@@ -1085,12 +1085,12 @@ class SnapshotApprovalFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "3 modified, 1 added, 2 removed, 1 renamed, 4 unchanged"
+        assert subtitle == "3 changed, 1 added, 2 removed, 1 renamed, 4 unchanged"
 
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/snapshots/"
         configure_link = f"[Configure {self.project.name} snapshot settings]({settings_url})"
         expected = (
-            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |\n"
+            "| Name | Added | Removed | Changed | Renamed | Unchanged | Skipped | Status |\n"
             "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app`"
             f" | [{1}]({artifact_url}?selectedTypes=added)"


### PR DESCRIPTION
Standardize snapshot product terminology to use "changed" instead of
"modified" everywhere. We were using the two terms interchangeably
which was inconsistent.

Updated in:
- Sidebar filter pills and status labels
- Snapshot card status badges
- Snapshot list table change counts
- PR comment table headers
- Status check messages
- Related test assertions