### PR TITLE
fix(issues): Use Heading in sentry app external issue modal title

### DIFF
--- a/static/app/components/group/sentryAppExternalIssueModal.tsx
+++ b/static/app/components/group/sentryAppExternalIssueModal.tsx
@@ -2,6 +2,7 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {TabList, Tabs} from '@sentry/scraps/tabs';
+import {Heading} from '@sentry/scraps/text';
 
 import {openModal, type ModalRenderProps} from 'sentry/actionCreators/modal';
 import {SentryAppExternalIssueForm} from 'sentry/components/group/sentryAppExternalIssueForm';
@@ -78,7 +79,9 @@ function SentryAppExternalIssueModal(props: Props) {
 
   return (
     <Fragment>
-      <Header closeButton>{tct('[name] Issue', {name})}</Header>
+      <Header closeButton>
+        <Heading as="h4">{tct('[name] Issue', {name})}</Heading>
+      </Header>
       <TabsContainer>
         <Tabs value={action} onChange={setAction}>
           <TabList>


### PR DESCRIPTION
The sentry-app external issue modal (used for Linear and other internal-integration "issue link" components) rendered the modal title as plain text, while the first-party external issue modal used for Jira/GitHub/etc. wraps its title in `<Heading as="h4">`. The modal `Header` CSS only applies the 20px title size to `h1`-`h6` elements, so the sentry-app variant rendered noticeably smaller than its first-party siblings.

Wrap the title in `<Heading as="h4">` so all integration modals share the same title size.