### PR TITLE
Additional logging and metrics for suspended user activity

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -49,6 +49,7 @@ from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.utils import jwt, metrics
+from sentry.utils.auth import record_suspended_user_rejection
 from sentry.utils.linksign import process_signature
 from sentry.utils.security.orgauthtoken_token import SENTRY_ORG_AUTH_TOKEN_PREFIX, hash_token
 
@@ -541,6 +542,15 @@ class UserAuthTokenAuthentication(StandardAuthentication):
             raise AuthenticationFailed("User inactive or deleted")
 
         if not isinstance(token, SystemToken) and user and getattr(user, "is_suspended", False):
+            logger.info(
+                "api.token.suspended-user",
+                extra={
+                    "user_id": user.id,
+                    "token_id": getattr(token, "id", None),
+                    "ip_address": request.META.get("REMOTE_ADDR"),
+                },
+            )
+            record_suspended_user_rejection("token_auth")
             raise AuthenticationFailed("User account is suspended")
 
         if application_is_inactive:
@@ -850,6 +860,8 @@ class ViewerContextAuthentication(BaseAuthentication):
                     "path": request.path,
                 },
             )
+            if user is not None and getattr(user, "is_suspended", False):
+                record_suspended_user_rejection("viewer_context_auth")
             return None
 
         sentry_sdk.get_isolation_scope().set_tag("viewer_context_auth", True)

--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -62,6 +62,7 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
 
         if getattr(user, "is_suspended", False):
             metrics.incr("login.attempt", instance="failure", skip_internal=True, sample_rate=1.0)
+            auth.record_suspended_user_rejection("api_login")
             return self.respond_with_error({"__all__": ["Your account has been suspended."]})
 
         auth.login(request, user, organization_id=organization.id if organization else None)

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -984,8 +984,10 @@ class AuthHelper(Pipeline[AuthProvider, AuthHelperSessionStore]):
                         "auth_identity_id": auth_identity.id,
                         "user_id": auth_identity.user_id,
                         "organization_id": self.organization.id,
+                        "ip_address": self.request.META.get("REMOTE_ADDR"),
                     },
                 )
+                auth.record_suspended_user_rejection("sso_finish")
                 return self.error(ERR_USER_SUSPENDED)
 
             try:

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -221,6 +221,10 @@ class SuperuserUserSerializer(BaseUserSerializer):
     def update(self, instance: User, validated_data: dict[str, Any]) -> User:
         request = self.context.get("request")
         should_audit = False
+        suspension_changed = (
+            "is_suspended" in validated_data
+            and instance.is_suspended != validated_data["is_suspended"]
+        )
 
         if request:
             privileged_fields = {"is_active", "is_staff", "is_superuser", "is_suspended"}
@@ -231,7 +235,7 @@ class SuperuserUserSerializer(BaseUserSerializer):
             }
             should_audit = bool(changed_fields)
 
-        if validated_data.get("is_suspended") and not instance.is_suspended:
+        if suspension_changed and validated_data["is_suspended"]:
             instance.refresh_session_nonce()
 
         user = super().update(instance, validated_data)
@@ -242,9 +246,20 @@ class SuperuserUserSerializer(BaseUserSerializer):
                 extra={
                     "user_id": user.id,
                     "actor_id": getattr(request.user, "id", None),
+                    "ip_address": request.META.get("REMOTE_ADDR"),
                     "form_data": getattr(request, "data", None),
                     "changed_fields": changed_fields,
                 },
+            )
+
+        if suspension_changed and request:
+            capture_security_activity(
+                account=user,
+                type="user.suspended" if user.is_suspended else "user.unsuspended",
+                actor=request.user,
+                ip_address=request.META.get("REMOTE_ADDR", ""),
+                context={"actor_id": getattr(request.user, "id", None)},
+                send_email=False,
             )
 
         return user

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -37,6 +37,18 @@ _LOGIN_URL: str | None = None
 
 MFA_SESSION_KEY = "mfa"
 
+SUSPENDED_USER_REJECTED_METRIC = "auth.suspended_user.rejected"
+
+
+def record_suspended_user_rejection(path: str) -> None:
+    metrics.incr(
+        SUSPENDED_USER_REJECTED_METRIC,
+        tags={"path": path},
+        skip_internal=True,
+        sample_rate=1.0,
+    )
+
+
 DISABLE_SSO_CHECK_FOR_LOCAL_DEV = getattr(settings, "DISABLE_SSO_CHECK_FOR_LOCAL_DEV", False)
 
 
@@ -315,6 +327,7 @@ def login(
     Returns boolean indicating if the user was logged in.
     """
     if getattr(user, "is_suspended", False):
+        record_suspended_user_rejection("session_login")
         return False
 
     if passed_2fa is None:
@@ -457,6 +470,7 @@ class EmailAuthBackend(ModelBackend):
     def get_user(self, user_id: int) -> RpcUser | None:  # type: ignore[override]  # XXX: HC "pretends" to be the user model
         user = user_service.get_user(user_id=user_id)
         if user is not None and user.is_suspended:
+            record_suspended_user_rejection("session_get_user")
             return None
         return user
 

--- a/src/sentry/utils/linksign.py
+++ b/src/sentry/utils/linksign.py
@@ -13,6 +13,7 @@ from sentry.models.organization import Organization
 from sentry.types.cell import get_local_locality
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
+from sentry.utils.auth import record_suspended_user_rejection
 from sentry.utils.numbers import base36_decode, base36_encode
 
 
@@ -108,5 +109,6 @@ def process_signature(request: HttpRequest, max_age: int = 60 * 60 * 24 * 10) ->
     except ValueError:
         return None
     if user is not None and getattr(user, "is_suspended", False):
+        record_suspended_user_rejection("link_sign")
         return None
     return user

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -16,7 +16,7 @@ from sentry import ratelimits as ratelimiter
 from sentry.auth import password_validation
 from sentry.users.models.user import User
 from sentry.users.models.user_option import UserOption
-from sentry.utils.auth import logger
+from sentry.utils.auth import logger, record_suspended_user_rejection
 from sentry.utils.dates import get_timezone_choices
 from sentry.web.forms.fields import AllowedEmailField, CustomTypedChoiceField
 
@@ -127,6 +127,7 @@ class AuthenticationForm(forms.Form):
             )
 
         if getattr(self.user_cache, "is_suspended", False):
+            record_suspended_user_rejection("web_login")
             raise forms.ValidationError(self.error_messages["suspended"])
 
         self.check_for_test_cookie()

--- a/src/sentry/web/frontend/reactivate_account.py
+++ b/src/sentry/web/frontend/reactivate_account.py
@@ -19,6 +19,7 @@ class ReactivateAccountView(BaseView):
             return self.handle_auth_required(request)
 
         if getattr(request.user, "is_suspended", False):
+            auth.record_suspended_user_rejection("reactivate_view")
             return self.respond("sentry/account-suspended.html")
 
         if request.POST.get("op") == "confirm":

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -27,6 +27,7 @@ from requests_oauthlib import OAuth1
 
 from sentry.users.services.user.service import user_service
 from sentry.utils import json
+from sentry.utils.auth import record_suspended_user_rejection
 from sentry.utils.http import absolute_uri
 from social_auth.exceptions import (
     AuthCanceled,
@@ -192,6 +193,8 @@ class SocialAuthBackend:
         user = user_service.get_user(user_id=user_id)
         if user and user.is_active and not user.is_suspended:
             return user
+        if user and user.is_suspended:
+            record_suspended_user_rejection("social_get_user")
         return None
 
 

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import UTC, datetime, timedelta
+from unittest import mock
 
 import orjson
 import pytest
@@ -365,10 +366,26 @@ class TestTokenAuthentication(TestCase):
 
         request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
+        request.META["REMOTE_ADDR"] = "10.0.0.1"
 
-        with pytest.raises(AuthenticationFailed) as exc_info:
-            self.auth.authenticate(request)
+        with (
+            mock.patch("sentry.api.authentication.logger") as mock_logger,
+            mock.patch("sentry.api.authentication.record_suspended_user_rejection") as mock_metric,
+        ):
+            with pytest.raises(AuthenticationFailed) as exc_info:
+                self.auth.authenticate(request)
+
         assert exc_info.value.detail == "User account is suspended"
+
+        mock_logger.info.assert_any_call(
+            "api.token.suspended-user",
+            extra={
+                "user_id": self.user.id,
+                "token_id": self.api_token.id,
+                "ip_address": "10.0.0.1",
+            },
+        )
+        mock_metric.assert_called_once_with("token_auth")
 
 
 @control_silo_test

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -485,6 +485,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
             extra={
                 "user_id": self.user.id,
                 "actor_id": self.superuser.id,
+                "ip_address": "127.0.0.1",
                 "form_data": {"isActive": "false"},
                 "changed_fields": {"is_active"},
             },
@@ -506,6 +507,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
             extra={
                 "user_id": self.user.id,
                 "actor_id": self.superuser.id,
+                "ip_address": "127.0.0.1",
                 "form_data": {"isStaff": "true"},
                 "changed_fields": {"is_staff"},
             },
@@ -529,6 +531,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
             extra={
                 "user_id": self.user.id,
                 "actor_id": self.superuser.id,
+                "ip_address": "127.0.0.1",
                 "form_data": {"isSuperuser": "true"},
                 "changed_fields": {"is_superuser"},
             },
@@ -586,6 +589,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
             extra={
                 "user_id": self.user.id,
                 "actor_id": self.superuser.id,
+                "ip_address": "127.0.0.1",
                 "form_data": {"isActive": "false", "isStaff": "true"},
                 "changed_fields": {"is_active", "is_staff"},
             },
@@ -886,6 +890,7 @@ class UserDetailsStaffUpdateTest(UserDetailsTest):
             extra={
                 "user_id": self.user.id,
                 "actor_id": self.staff_user.id,
+                "ip_address": "127.0.0.1",
                 "form_data": {"isActive": "false"},
                 "changed_fields": {"is_active"},
             },
@@ -909,6 +914,7 @@ class UserDetailsStaffUpdateTest(UserDetailsTest):
             extra={
                 "user_id": self.user.id,
                 "actor_id": self.staff_user.id,
+                "ip_address": "127.0.0.1",
                 "form_data": {"isStaff": "true"},
                 "changed_fields": {"is_staff"},
             },
@@ -932,6 +938,7 @@ class UserDetailsStaffUpdateTest(UserDetailsTest):
             extra={
                 "user_id": self.user.id,
                 "actor_id": self.staff_user.id,
+                "ip_address": "127.0.0.1",
                 "form_data": {"isSuperuser": "true"},
                 "changed_fields": {"is_superuser"},
             },

--- a/tests/sentry/users/api/endpoints/test_user_details_analytics.py
+++ b/tests/sentry/users/api/endpoints/test_user_details_analytics.py
@@ -12,6 +12,60 @@ from sentry.users.models.userpermission import UserPermission
 
 
 @control_silo_test
+class UserDetailsSuspendSecurityActivityTest(APITestCase):
+    endpoint = "sentry-api-0-user-details"
+    method = "put"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.target_user = self.create_user(email="target@example.com")
+        self.superuser = self.create_user(email="su@example.com", is_superuser=True)
+        self.login_as(user=self.superuser, superuser=True)
+
+    @mock.patch("sentry.users.api.endpoints.user_details.capture_security_activity")
+    def test_suspend_emits_security_activity(self, mock_security_activity: mock.MagicMock) -> None:
+        self.get_success_response(self.target_user.id, isSuspended="true")
+
+        assert mock_security_activity.called
+        kwargs = mock_security_activity.call_args.kwargs
+        assert kwargs["type"] == "user.suspended"
+        assert kwargs["account"].id == self.target_user.id
+        assert kwargs["actor"].id == self.superuser.id
+        assert kwargs["send_email"] is False
+        assert kwargs["context"] == {"actor_id": self.superuser.id}
+
+    @mock.patch("sentry.users.api.endpoints.user_details.capture_security_activity")
+    def test_unsuspend_emits_security_activity(
+        self, mock_security_activity: mock.MagicMock
+    ) -> None:
+        self.target_user.update(is_suspended=True)
+
+        self.get_success_response(self.target_user.id, isSuspended="false")
+
+        assert mock_security_activity.called
+        kwargs = mock_security_activity.call_args.kwargs
+        assert kwargs["type"] == "user.unsuspended"
+        assert kwargs["account"].id == self.target_user.id
+        assert kwargs["send_email"] is False
+
+    @mock.patch("sentry.users.api.endpoints.user_details.capture_security_activity")
+    def test_idempotent_suspend_does_not_emit(self, mock_security_activity: mock.MagicMock) -> None:
+        self.target_user.update(is_suspended=True)
+
+        self.get_success_response(self.target_user.id, isSuspended="true")
+
+        assert not mock_security_activity.called
+
+    @mock.patch("sentry.users.api.endpoints.user_details.capture_security_activity")
+    def test_unrelated_update_does_not_emit_suspension_activity(
+        self, mock_security_activity: mock.MagicMock
+    ) -> None:
+        self.get_success_response(self.target_user.id, name="Renamed User")
+
+        assert not mock_security_activity.called
+
+
+@control_silo_test
 class UserDetailsDeleteAnalyticsTest(APITestCase):
     endpoint = "sentry-api-0-user-details"
     method = "delete"

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest import mock
 
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.backends.base import SessionBase
@@ -61,8 +62,10 @@ class EmailAuthBackendTest(TestCase):
 
     def test_get_user_returns_none_for_suspended_user(self) -> None:
         self.user.update(is_suspended=True)
-        result = self.backend.get_user(self.user.id)
+        with mock.patch("sentry.utils.auth.record_suspended_user_rejection") as mock_metric:
+            result = self.backend.get_user(self.user.id)
         assert result is None
+        mock_metric.assert_called_once_with("session_get_user")
 
     def test_get_user_returns_user_for_active_user(self) -> None:
         result = self.backend.get_user(self.user.id)
@@ -186,7 +189,9 @@ class LoginTest(TestCase):
     def test_suspended_user_cannot_login(self) -> None:
         self.user.update(is_suspended=True)
         request = self._make_request()
-        assert not login(request, self.user)
+        with mock.patch("sentry.utils.auth.record_suspended_user_rejection") as mock_metric:
+            assert not login(request, self.user)
+        mock_metric.assert_called_once_with("session_login")
 
 
 def test_sso_expiry_default() -> None:


### PR DESCRIPTION
Adding some QOL improvements for auditing and metrics around suspended user accounts. 
- `record_suspended_user_rejection(path)` as a new helper for metrics recording
- Added a `api.token.suspended-user` info log
- `SuperuserUserSerializer.update()` now triggers a `capture_security_activity(type="user.suspended" | "user.unsuspended")`
- Capturing IPs in new log type, suspended user log, and during user.edit
- Bunch of tests