### PR TITLE
feat(repos): Always show uninstall button, disabled without access in repos v2

### DIFF
--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Button, LinkButton} from '@sentry/scraps/button';
+import {Button, type ButtonProps, LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {StatusIndicator} from '@sentry/scraps/statusIndicator';
@@ -96,6 +96,11 @@ export interface ScmInstallation {
    * `repositories` is still empty.
    */
   reposLoading?: boolean;
+  /**
+   * Props forwarded to the uninstall button. Use to disable or annotate it
+   * when the viewer lacks the required access.
+   */
+  uninstallButtonProps?: Omit<ButtonProps, 'onClick'>;
 }
 
 interface ScmRepositoryTableProps {
@@ -396,7 +401,7 @@ function InstallationActions({
   onUninstall,
   onSettings,
 }: InstallationActionsProps) {
-  const {manageUrl, overflowMenuItems} = installation;
+  const {manageUrl, overflowMenuItems, uninstallButtonProps} = installation;
   return (
     <Fragment>
       {manageUrl && (
@@ -421,6 +426,7 @@ function InstallationActions({
               size="xs"
               variant="transparent"
               icon={<IconDelete />}
+              {...uninstallButtonProps}
               onClick={() => onUninstall(installation)}
             />
           )}

--- a/static/app/views/settings/organizationRepositoriesV2/index.spec.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/index.spec.tsx
@@ -187,14 +187,13 @@ describe('OrganizationRepositoriesV2', () => {
     await waitFor(() => expect(refetchRequest).toHaveBeenCalledTimes(1));
   });
 
-  it('hides the uninstall button when the user lacks org:integrations access', async () => {
+  it('shows the uninstall button as disabled when the user lacks org:integrations access', async () => {
     setupDefaultMocks();
 
     render(<OrganizationRepositoriesV2 />, {
       organization: OrganizationFixture({access: []}),
     });
 
-    await screen.findByText('my-org');
-    expect(screen.queryByRole('button', {name: 'Uninstall'})).not.toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'Uninstall'})).toBeDisabled();
   });
 });

--- a/static/app/views/settings/organizationRepositoriesV2/index.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/index.tsx
@@ -133,6 +133,16 @@ export function OrganizationRepositoriesV2() {
       manageUrl: getProviderConfigUrl(integration) ?? undefined,
       mappedProjectSlugsByRepoId,
       mappingsLoading,
+      uninstallButtonProps: hasAccess
+        ? undefined
+        : {
+            disabled: true,
+            tooltipProps: {
+              title: t(
+                'You must be an organization owner, manager or admin to uninstall this provider'
+              ),
+            },
+          },
     }));
     return groupBy(installations, i => i.integration.provider.key);
   }, [
@@ -141,6 +151,7 @@ export function OrganizationRepositoriesV2() {
     reposLoading,
     mappedProjectSlugsByRepoId,
     mappingsLoading,
+    hasAccess,
   ]);
 
   const handleAddIntegration = (_data: Integration) => {
@@ -226,11 +237,7 @@ export function OrganizationRepositoriesV2() {
                   provider={provider}
                   installations={installationsByProviderKey[provider.key]!}
                   repoMatches={repoMatches}
-                  onUninstall={
-                    hasAccess
-                      ? inst => handleDeleteIntegration(inst.integration)
-                      : undefined
-                  }
+                  onUninstall={inst => handleDeleteIntegration(inst.integration)}
                 />
               ))
           )}


### PR DESCRIPTION
The uninstall button is now always rendered — disabled with a tooltip when
the viewer lacks org:integrations access rather than hidden entirely.

Forwarded via uninstallButtonProps on ScmInstallation, keeping the table
component generic.