### PR TITLE
chore(issue-detection): Log AI General Issues rather than ingest them

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -163,6 +163,19 @@ def create_issue_occurrence_from_detection(
     Create and produce an IssueOccurrence from an LLM-detected issue.
     """
     group_type = get_group_type_for_title(detected_issue.title)
+
+    if group_type == AIDetectedGeneralGroupType:
+        logger.info(
+            "Detected General AI Issue",
+            extra={
+                "title": detected_issue.title,
+                "explanation": detected_issue.explanation,
+                "impact": detected_issue.impact,
+                "evidence": detected_issue.evidence,
+            },
+        )
+        return None
+
     setting_key = GROUP_TYPE_TO_SETTING.get(group_type)
     if setting_key:
         perf_settings = project.get_option("sentry:performance_issue_settings", default={})

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 from django.db.models import F
 
-from sentry.issues.grouptype import AIDetectedDBGroupType, AIDetectedGeneralGroupType
+from sentry.issues.grouptype import AIDetectedDBGroupType
 from sentry.models.project import Project
 from sentry.tasks.llm_issue_detection import (
     DetectedIssue,
@@ -88,15 +88,15 @@ class LLMIssueDetectionTest(TestCase):
     @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
     def test_create_issue_occurrence_from_detection(self, mock_produce_occurrence):
         detected_issue = DetectedIssue(
-            title="Slow Database Query",
-            explanation="Your application is running out of database connections",
+            title="Inefficient Database Queries",
+            explanation="Multiple sequential queries could be batched",
             impact="High - may cause request failures",
             evidence="Connection pool at 95% capacity",
             offender_span_ids=["span_1", "span_2"],
             trace_id="abc123xyz",
             transaction_name="test_transaction",
             verification_reason="Problem is correctly identified",
-            group_for_fingerprint="Slow Database Query",
+            group_for_fingerprint="Inefficient Database Queries",
         )
 
         create_issue_occurrence_from_detection(
@@ -110,22 +110,20 @@ class LLMIssueDetectionTest(TestCase):
         assert call_kwargs["payload_type"].value == "occurrence"
 
         occurrence = call_kwargs["occurrence"]
-        assert occurrence.type == AIDetectedGeneralGroupType
-        assert occurrence.issue_title == "Slow Database Query"
-        assert occurrence.subtitle == "Your application is running out of database connections"
+        assert occurrence.type == AIDetectedDBGroupType
+        assert occurrence.issue_title == "Inefficient Database Queries"
+        assert occurrence.subtitle == "Multiple sequential queries could be batched"
         assert occurrence.project_id == self.project.id
         assert occurrence.culprit == "test_transaction"
         assert occurrence.level == "warning"
 
-        assert occurrence.fingerprint == [
-            f"1-{AIDetectedGeneralGroupType.type_id}-test_transaction"
-        ]
+        assert occurrence.fingerprint == [f"1-{AIDetectedDBGroupType.type_id}-test_transaction"]
 
         assert occurrence.evidence_data["trace_id"] == "abc123xyz"
         assert occurrence.evidence_data["transaction"] == "test_transaction"
         assert (
             occurrence.evidence_data["explanation"]
-            == "Your application is running out of database connections"
+            == "Multiple sequential queries could be batched"
         )
         assert occurrence.evidence_data["impact"] == "High - may cause request failures"
 
@@ -133,9 +131,7 @@ class LLMIssueDetectionTest(TestCase):
         assert len(evidence_display) == 3
 
         assert evidence_display[0].name == "Explanation"
-        assert (
-            evidence_display[0].value == "Your application is running out of database connections"
-        )
+        assert evidence_display[0].value == "Multiple sequential queries could be batched"
         assert evidence_display[1].name == "Impact"
         assert evidence_display[1].value == "High - may cause request failures"
         assert evidence_display[2].name == "Evidence"
@@ -173,7 +169,7 @@ class LLMIssueDetectionTest(TestCase):
         assert occurrence.type == AIDetectedDBGroupType
 
     @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
-    def test_other_title_uses_fallback_display_title(self, mock_produce_occurrence):
+    def test_general_type_skips_occurrence_creation(self, mock_produce_occurrence):
         detected_issue = DetectedIssue(
             title="Other",
             explanation="Something unusual happening here",
@@ -185,13 +181,12 @@ class LLMIssueDetectionTest(TestCase):
             verification_reason="Verified",
             group_for_fingerprint="Other",
         )
-        create_issue_occurrence_from_detection(
+        result = create_issue_occurrence_from_detection(
             detected_issue=detected_issue,
             project=self.project,
         )
-        occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
-        assert occurrence.issue_title == "AI-Detected Application Issue"
-        assert occurrence.type == AIDetectedGeneralGroupType
+        assert result is None
+        assert not mock_produce_occurrence.called
 
     @with_feature("organizations:gen-ai-features")
     @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -181,11 +181,10 @@ class LLMIssueDetectionTest(TestCase):
             verification_reason="Verified",
             group_for_fingerprint="Other",
         )
-        result = create_issue_occurrence_from_detection(
+        create_issue_occurrence_from_detection(
             detected_issue=detected_issue,
             project=self.project,
         )
-        assert result is None
         assert not mock_produce_occurrence.called
 
     @with_feature("organizations:gen-ai-features")


### PR DESCRIPTION
we are turning off general AI issues for now (issues that don't fit into the categories we have defined). instead of ingesting them we want to log info about them and use that for future improvements.