### PR TITLE
chore(ui): Use `test-ci` instead of `CI=true` to run tests w/ agents

### DIFF
--- a/.agents/skills/lint-new/SKILL.md
+++ b/.agents/skills/lint-new/SKILL.md
@@ -97,7 +97,7 @@ ruleTester.run('$ARGUMENTS', $RULE_NAME, {
 Run tests:
 
 ```bash
-pnpm run test-ci "static/eslint/eslintPluginScraps/src/rules/$ARGUMENTS.spec.ts"
+pnpm test-ci "static/eslint/eslintPluginScraps/src/rules/$ARGUMENTS.spec.ts"
 ```
 
 ## Autofix Guidance
@@ -165,7 +165,7 @@ Add to `eslint.config.ts` inside the `name: 'plugin/@sentry/scraps'` block:
 ### 3. Verify
 
 ```bash
-pnpm run test-ci "static/eslint/eslintPluginScraps/src/rules/$ARGUMENTS.spec.ts"
+pnpm test-ci "static/eslint/eslintPluginScraps/src/rules/$ARGUMENTS.spec.ts"
 ```
 
 ## Extending an Existing Rule

--- a/.agents/skills/lint-new/SKILL.md
+++ b/.agents/skills/lint-new/SKILL.md
@@ -97,7 +97,7 @@ ruleTester.run('$ARGUMENTS', $RULE_NAME, {
 Run tests:
 
 ```bash
-CI=true pnpm test "static/eslint/eslintPluginScraps/src/rules/$ARGUMENTS.spec.ts"
+pnpm run test-ci "static/eslint/eslintPluginScraps/src/rules/$ARGUMENTS.spec.ts"
 ```
 
 ## Autofix Guidance
@@ -165,7 +165,7 @@ Add to `eslint.config.ts` inside the `name: 'plugin/@sentry/scraps'` block:
 ### 3. Verify
 
 ```bash
-CI=true pnpm test "static/eslint/eslintPluginScraps/src/rules/$ARGUMENTS.spec.ts"
+pnpm run test-ci "static/eslint/eslintPluginScraps/src/rules/$ARGUMENTS.spec.ts"
 ```
 
 ## Extending an Existing Rule

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,11 +165,11 @@ pnpm run fix
 #### Testing
 
 ```bash
-# Run JavaScript tests (always use CI flag)
-CI=true pnpm test <file_path>
+# Run JavaScript tests
+pnpm run test-ci <file_path>
 
 # Run specific test file(s)
-CI=true pnpm test components/avatar.spec.tsx
+pnpm run test-ci components/avatar.spec.tsx
 ```
 
 ### Git worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,10 +166,10 @@ pnpm run fix
 
 ```bash
 # Run JavaScript tests
-pnpm run test-ci <file_path>
+pnpm test-ci <file_path>
 
 # Run specific test file(s)
-pnpm run test-ci components/avatar.spec.tsx
+pnpm test-ci components/avatar.spec.tsx
 ```
 
 ### Git worktrees


### PR DESCRIPTION
Avoids an issue with codex where it asks for permission on every test run because of the environment variable.

`test-ci` no longer spits out coverage and is pretty much the same as `test` but with watch mode disabled.