### PR TITLE
fix(replay): Add padding to network details to prevent content clipping

### DIFF
--- a/static/app/views/explore/replays/detail/network/details/content.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.tsx
@@ -109,6 +109,7 @@ export function NetworkDetailsContent(props: Props) {
 
 const OverflowFluidHeight = styled(FluidHeight)`
   overflow: auto;
+  padding-bottom: ${p => p.theme.space.md};
 `;
 const SectionList = styled('dl')`
   margin: 0;

--- a/static/app/views/explore/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/explore/replays/detail/network/details/onboarding.tsx
@@ -219,6 +219,7 @@ const StyledTextCopyInput = styled(TextCopyInput)`
 
 const NoMarginAlert = styled(Alert)`
   border-width: 1px 0 0 0;
+  margin-bottom: ${p => p.theme.space.md};
 `;
 
 const StyledInstructions = styled('div')`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the Replay UI, the Network → Details panel was cutting off content at the bottom, specifically the `NoMarginAlert` component displaying the message "You can capture additional headers by adding them to the [requestConfig] and [responseConfig] lists in your SDK config."

## Solution

Added bottom spacing to ensure all content in the scrollable network details panel is fully visible:

1. Added `padding-bottom` to the `OverflowFluidHeight` scrollable container to ensure proper spacing for all content types
2. Added `margin-bottom` to the `NoMarginAlert` component to ensure the specific alert message has adequate spacing at the bottom

## Changes

- Modified `static/app/views/explore/replays/detail/network/details/content.tsx`
  - Added `padding-bottom: ${p => p.theme.space.md}` to `OverflowFluidHeight` styled component
  
- Modified `static/app/views/explore/replays/detail/network/details/onboarding.tsx`
  - Added `margin-bottom: ${p => p.theme.space.md}` to `NoMarginAlert` styled component

## Testing

The fix ensures that when users scroll to the bottom of the Network Details panel, all content including the alert message is fully visible without being clipped.

Fixes REPLAY-866
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [REPLAY-866](https://linear.app/getsentry/issue/REPLAY-866/network-details-message-is-cut-off-at-bottom)

<div><a href="https://cursor.com/agents/bc-b337ba20-f9cc-42cb-947e-9bd1079feb6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b337ba20-f9cc-42cb-947e-9bd1079feb6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

