### PR TITLE
feat(preprod): Add Amplitude analytics to snapshot detail page

### DIFF
--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -78,6 +78,36 @@ export type PreprodBuildEventParameters = {
     metric: string;
     value: number;
   };
+  'preprod.snapshots.details.approve_clicked': {
+    build_id: string;
+    organization: Organization;
+  };
+  'preprod.snapshots.details.diff_mode_changed': {
+    diff_mode: string;
+    organization: Organization;
+  };
+  'preprod.snapshots.details.image_link_copied': {
+    diff_status: string | null;
+    image_file_name: string;
+    organization: Organization;
+  };
+  'preprod.snapshots.details.image_metadata_copied': {
+    diff_status: string | null;
+    image_file_name: string;
+    organization: Organization;
+  };
+  'preprod.snapshots.details.view_mode_changed': {
+    organization: Organization;
+    view_mode: string;
+  };
+  'preprod.snapshots.details.viewed': {
+    approval_status: string | null;
+    comparison_type: string;
+    has_base_build: boolean;
+    image_count: number;
+    organization: Organization;
+    project_id: string;
+  };
   'preprod.snapshots.list.row_clicked': BasePreprodBuildEvent & {
     approval_status?: string | null;
     comparison_state?: string | null;
@@ -114,6 +144,13 @@ export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | nul
     'Preprod Releases: Mobile Builds Tab Clicked',
   'preprod.releases.snapshots.tab-clicked': 'Preprod Releases: Snapshots Tab Clicked',
   'preprod.snapshots.list.row_clicked': 'Preprod Snapshots: List Row Clicked',
+  'preprod.snapshots.details.viewed': 'Preprod Snapshots: Details Viewed',
+  'preprod.snapshots.details.approve_clicked': 'Preprod Snapshots: Approve Clicked',
+  'preprod.snapshots.details.image_link_copied': 'Preprod Snapshots: Image Link Copied',
+  'preprod.snapshots.details.image_metadata_copied':
+    'Preprod Snapshots: Image Metadata Copied',
+  'preprod.snapshots.details.view_mode_changed': 'Preprod Snapshots: View Mode Changed',
+  'preprod.snapshots.details.diff_mode_changed': 'Preprod Snapshots: Diff Mode Changed',
   'preprod.settings.status_check_rule_created':
     'Preprod Settings: Status Check Rule Created',
   'preprod.settings.status_check_rule_deleted':

--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -88,12 +88,10 @@ export type PreprodBuildEventParameters = {
   };
   'preprod.snapshots.details.image_link_copied': {
     diff_status: string | null;
-    image_file_name: string;
     organization: Organization;
   };
   'preprod.snapshots.details.image_metadata_copied': {
     diff_status: string | null;
-    image_file_name: string;
     organization: Organization;
   };
   'preprod.snapshots.details.view_mode_changed': {

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -26,8 +26,10 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {AvatarUser} from 'sentry/types/user';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {openBuildDebugInfoModal} from 'sentry/views/preprod/snapshots/header/buildDebugInfoModal';
 import type {SnapshotDetailsApiResponse} from 'sentry/views/preprod/types/snapshotTypes';
 import {getSnapshotPath} from 'sentry/views/preprod/utils/buildLinkUtils';
@@ -48,6 +50,7 @@ export function SnapshotHeaderActions({
   const clientRef = useRef(new Client());
   useEffect(() => () => clientRef.current.clear(), []);
   const navigate = useNavigate();
+  const organization = useOrganization();
   const isSentryEmployee = useIsSentryEmployee();
   const [isApproving, setIsApproving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -70,6 +73,10 @@ export function SnapshotHeaderActions({
   }));
 
   const handleApprove = () => {
+    trackAnalytics('preprod.snapshots.details.approve_clicked', {
+      organization,
+      build_id: data.head_artifact_id,
+    });
     setIsApproving(true);
     clientRef.current.request(
       `/organizations/${organizationSlug}/preprodartifacts/${data.head_artifact_id}/approve/`,

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -58,6 +58,8 @@ export const PairCard = memo(function PairCard({
   snapshotKey,
   onSelectSnapshot,
   onOpenSnapshot,
+  onCopyLink,
+  onCopyMetadata,
 }: {
   copyUrl: string;
   diffMode: DiffMode;
@@ -67,6 +69,8 @@ export const PairCard = memo(function PairCard({
   snapshotKey: string;
   diffImageBaseUrl?: string;
   headBranch?: string | null;
+  onCopyLink?: () => void;
+  onCopyMetadata?: () => void;
   onOpenSnapshot?: (key: string) => void;
   onSelectSnapshot?: (key: string | null) => void;
   overlayColor?: string;
@@ -139,6 +143,8 @@ export const PairCard = memo(function PairCard({
           copyUrl={copyUrl}
           onDoubleClick={handleOpen}
           showBottomBorder={false}
+          onCopyLink={onCopyLink}
+          onCopyMetadata={onCopyMetadata}
         />
         <Container padding="0 xl xl">{body}</Container>
       </SnapshotVariantFrame>
@@ -156,6 +162,8 @@ export const ImageCard = memo(function ImageCard({
   snapshotKey,
   onSelectSnapshot,
   onOpenSnapshot,
+  onCopyLink,
+  onCopyMetadata,
 }: {
   cardType: 'added' | 'removed' | 'renamed' | 'solo' | 'unchanged';
   copyUrl: string;
@@ -164,6 +172,8 @@ export const ImageCard = memo(function ImageCard({
   isSelected: boolean;
   snapshotKey: string;
   copyData?: unknown;
+  onCopyLink?: () => void;
+  onCopyMetadata?: () => void;
   onOpenSnapshot?: (key: string) => void;
   onSelectSnapshot?: (key: string | null) => void;
 }) {
@@ -207,6 +217,8 @@ export const ImageCard = memo(function ImageCard({
           copyUrl={copyUrl}
           onDoubleClick={handleOpen}
           showBottomBorder={false}
+          onCopyLink={onCopyLink}
+          onCopyMetadata={onCopyMetadata}
         />
         <Container padding="0 xl xl">
           <ImageColumn src={imageUrl} alt={getImageName(image)} image={image} />
@@ -227,6 +239,8 @@ export const CardHeader = memo(function CardHeader({
   copyUrl,
   onDoubleClick,
   showBottomBorder = true,
+  onCopyLink,
+  onCopyMetadata,
 }: {
   copyData: unknown;
   copyUrl: string;
@@ -235,6 +249,8 @@ export const CardHeader = memo(function CardHeader({
   onToggleDark: () => void;
   diffPercent?: number | null;
   displayName?: string | null;
+  onCopyLink?: () => void;
+  onCopyMetadata?: () => void;
   onDoubleClick?: () => void;
   showBottomBorder?: boolean;
   status?: DiffStatus | null;
@@ -270,11 +286,12 @@ export const CardHeader = memo(function CardHeader({
           aria-label={t('Copy link to this snapshot')}
           tooltip={t('Copy link')}
           icon={<IconLink size="sm" />}
-          onClick={() =>
-            copy(copyUrl, {successMessage: t('Copied link to this snapshot')})
-          }
+          onClick={() => {
+            copy(copyUrl, {successMessage: t('Copied link to this snapshot')});
+            onCopyLink?.();
+          }}
         />
-        <MetadataInfoButton copyData={copyData} />
+        <MetadataInfoButton copyData={copyData} onCopy={onCopyMetadata} />
       </Flex>
     </CardHeaderRow>
   );
@@ -291,7 +308,13 @@ function MetadataTooltip({json}: {json: string}) {
   );
 }
 
-function MetadataInfoButton({copyData}: {copyData: unknown}) {
+function MetadataInfoButton({
+  copyData,
+  onCopy,
+}: {
+  copyData: unknown;
+  onCopy?: () => void;
+}) {
   const {copy} = useCopyToClipboard();
   const json = JSON.stringify(copyData, null, 2);
 
@@ -300,7 +323,10 @@ function MetadataInfoButton({copyData}: {copyData: unknown}) {
       <InfoIconButton
         type="button"
         aria-label={t('Copy metadata as JSON')}
-        onClick={() => copy(json, {successMessage: t('Copied metadata as JSON')})}
+        onClick={() => {
+          copy(json, {successMessage: t('Copied metadata as JSON')});
+          onCopy?.();
+        }}
       >
         <IconInfo size="sm" />
       </InfoIconButton>

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -15,6 +15,8 @@ import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import type {
   SidebarItem,
   SnapshotDiffPair,
@@ -573,10 +575,28 @@ const GroupContainer = memo(function GroupContainer({
   onSelectSnapshot?: (key: string | null) => void;
   overlayColor?: string;
 }) {
+  const organization = useOrganization();
   const cards = group.cards.map(card => {
     const snapshotKey = snapshotKeyFor(card);
     const isSelected = snapshotKey === selectedSnapshotKey;
     const copyUrl = buildSnapshotLink(snapshotKey);
+    const fileName =
+      card.type === 'pair-card'
+        ? card.pair.head_image.image_file_name
+        : card.image.image_file_name;
+    const diffStatus = card.type === 'pair-card' ? 'changed' : card.cardType;
+    const onCopyLink = () =>
+      trackAnalytics('preprod.snapshots.details.image_link_copied', {
+        organization,
+        image_file_name: fileName,
+        diff_status: diffStatus === 'solo' ? null : diffStatus,
+      });
+    const onCopyMetadata = () =>
+      trackAnalytics('preprod.snapshots.details.image_metadata_copied', {
+        organization,
+        image_file_name: fileName,
+        diff_status: diffStatus === 'solo' ? null : diffStatus,
+      });
     return card.type === 'pair-card' ? (
       <PairCard
         key={card.id}
@@ -591,6 +611,8 @@ const GroupContainer = memo(function GroupContainer({
         snapshotKey={snapshotKey}
         onSelectSnapshot={onSelectSnapshot}
         onOpenSnapshot={onOpenSnapshot}
+        onCopyLink={onCopyLink}
+        onCopyMetadata={onCopyMetadata}
       />
     ) : (
       <ImageCard
@@ -604,6 +626,8 @@ const GroupContainer = memo(function GroupContainer({
         snapshotKey={snapshotKey}
         onSelectSnapshot={onSelectSnapshot}
         onOpenSnapshot={onOpenSnapshot}
+        onCopyLink={onCopyLink}
+        onCopyMetadata={onCopyMetadata}
       />
     );
   });

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -580,21 +580,15 @@ const GroupContainer = memo(function GroupContainer({
     const snapshotKey = snapshotKeyFor(card);
     const isSelected = snapshotKey === selectedSnapshotKey;
     const copyUrl = buildSnapshotLink(snapshotKey);
-    const fileName =
-      card.type === 'pair-card'
-        ? card.pair.head_image.image_file_name
-        : card.image.image_file_name;
     const diffStatus = card.type === 'pair-card' ? 'changed' : card.cardType;
     const onCopyLink = () =>
       trackAnalytics('preprod.snapshots.details.image_link_copied', {
         organization,
-        image_file_name: fileName,
         diff_status: diffStatus === 'solo' ? null : diffStatus,
       });
     const onCopyMetadata = () =>
       trackAnalytics('preprod.snapshots.details.image_metadata_copied', {
         organization,
-        image_file_name: fileName,
         diff_status: diffStatus === 'solo' ? null : diffStatus,
       });
     return card.type === 'pair-card' ? (

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -22,6 +22,8 @@ import {
   IconStack,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {DiffStatus, getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
@@ -105,6 +107,7 @@ export function SnapshotMainContent({
   canNavigateNext,
   navButtonRefs,
 }: SnapshotMainContentProps) {
+  const organization = useOrganization();
   const [isDark, setIsDark] = useState(false);
   const toggleDark = useCallback(() => setIsDark(v => !v), []);
   const [scrollProgress, setScrollProgress] = useState(0);
@@ -269,6 +272,18 @@ export function SnapshotMainContent({
           diffPercent: currentPair.diff,
           copyData: currentPair,
           copyUrl: buildSnapshotLink(image.image_file_name),
+          onCopyLink: () =>
+            trackAnalytics('preprod.snapshots.details.image_link_copied', {
+              organization,
+              image_file_name: image.image_file_name,
+              diff_status: 'changed',
+            }),
+          onCopyMetadata: () =>
+            trackAnalytics('preprod.snapshots.details.image_metadata_copied', {
+              organization,
+              image_file_name: image.image_file_name,
+              diff_status: 'changed',
+            }),
         }}
         diffControls={diffControls}
         body={
@@ -311,6 +326,18 @@ export function SnapshotMainContent({
           status: DiffStatus.RENAMED,
           copyData: currentPair,
           copyUrl: buildSnapshotLink(image.image_file_name),
+          onCopyLink: () =>
+            trackAnalytics('preprod.snapshots.details.image_link_copied', {
+              organization,
+              image_file_name: image.image_file_name,
+              diff_status: 'renamed',
+            }),
+          onCopyMetadata: () =>
+            trackAnalytics('preprod.snapshots.details.image_metadata_copied', {
+              organization,
+              image_file_name: image.image_file_name,
+              diff_status: 'renamed',
+            }),
         }}
         body={<SingleImageDisplay imageUrl={imageUrl} alt={getImageName(image)} />}
       />
@@ -352,6 +379,18 @@ export function SnapshotMainContent({
         status,
         copyData: currentImage,
         copyUrl: buildSnapshotLink(currentImage.image_file_name),
+        onCopyLink: () =>
+          trackAnalytics('preprod.snapshots.details.image_link_copied', {
+            organization,
+            image_file_name: currentImage.image_file_name,
+            diff_status: status ? selectedItem.type : null,
+          }),
+        onCopyMetadata: () =>
+          trackAnalytics('preprod.snapshots.details.image_metadata_copied', {
+            organization,
+            image_file_name: currentImage.image_file_name,
+            diff_status: status ? selectedItem.type : null,
+          }),
       }}
       body={<SingleImageDisplay imageUrl={imageUrl} alt={getImageName(currentImage)} />}
     />
@@ -551,11 +590,18 @@ function ViewModeToggle({
   onViewModeChange: (mode: ViewMode) => void;
   viewMode: ViewMode;
 }) {
+  const organization = useOrganization();
   return (
     <SegmentedControl
       size="xs"
       value={viewMode}
-      onChange={onViewModeChange}
+      onChange={(value: ViewMode) => {
+        onViewModeChange(value);
+        trackAnalytics('preprod.snapshots.details.view_mode_changed', {
+          organization,
+          view_mode: value,
+        });
+      }}
       aria-label={t('View mode')}
     >
       <SegmentedControl.Item
@@ -657,8 +703,19 @@ function DiffModeToggle({
   diffMode: DiffMode;
   onDiffModeChange: (mode: DiffMode) => void;
 }) {
+  const organization = useOrganization();
   return (
-    <SegmentedControl size="xs" value={diffMode} onChange={onDiffModeChange}>
+    <SegmentedControl
+      size="xs"
+      value={diffMode}
+      onChange={(value: DiffMode) => {
+        onDiffModeChange(value);
+        trackAnalytics('preprod.snapshots.details.diff_mode_changed', {
+          organization,
+          diff_mode: value,
+        });
+      }}
+    >
       <SegmentedControl.Item
         key="split"
         icon={<IconPause />}

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -275,13 +275,11 @@ export function SnapshotMainContent({
           onCopyLink: () =>
             trackAnalytics('preprod.snapshots.details.image_link_copied', {
               organization,
-              image_file_name: image.image_file_name,
               diff_status: 'changed',
             }),
           onCopyMetadata: () =>
             trackAnalytics('preprod.snapshots.details.image_metadata_copied', {
               organization,
-              image_file_name: image.image_file_name,
               diff_status: 'changed',
             }),
         }}
@@ -329,13 +327,11 @@ export function SnapshotMainContent({
           onCopyLink: () =>
             trackAnalytics('preprod.snapshots.details.image_link_copied', {
               organization,
-              image_file_name: image.image_file_name,
               diff_status: 'renamed',
             }),
           onCopyMetadata: () =>
             trackAnalytics('preprod.snapshots.details.image_metadata_copied', {
               organization,
-              image_file_name: image.image_file_name,
               diff_status: 'renamed',
             }),
         }}
@@ -382,13 +378,11 @@ export function SnapshotMainContent({
         onCopyLink: () =>
           trackAnalytics('preprod.snapshots.details.image_link_copied', {
             organization,
-            image_file_name: currentImage.image_file_name,
             diff_status: status ? selectedItem.type : null,
           }),
         onCopyMetadata: () =>
           trackAnalytics('preprod.snapshots.details.image_metadata_copied', {
             organization,
-            image_file_name: currentImage.image_file_name,
             diff_status: status ? selectedItem.type : null,
           }),
       }}

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -17,6 +17,7 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
@@ -142,6 +143,22 @@ export default function SnapshotsPage() {
       },
     }
   );
+
+  const viewedArtifactRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (isPending || !data || viewedArtifactRef.current === data.head_artifact_id) {
+      return;
+    }
+    viewedArtifactRef.current = data.head_artifact_id;
+    trackAnalytics('preprod.snapshots.details.viewed', {
+      organization,
+      comparison_type: data.comparison_type,
+      image_count: data.image_count,
+      approval_status: data.approval_info?.status ?? null,
+      has_base_build: !!data.base_artifact_id,
+      project_id: data.project_id,
+    });
+  }, [isPending, data, organization]);
 
   const [searchQuery, setSearchQuery] = useState('');
   const pushHistory = {history: 'push' as const};


### PR DESCRIPTION
Adds frontend analytics instrumentation to the snapshot detail page, which previously had zero tracking. This covers the core user flows needed to understand snapshot adoption and usage patterns.

**6 new Amplitude events**

- `preprod.snapshots.details.viewed` — fires once per snapshot page load with metadata (comparison type, image count, approval status, whether a base build exists, project ID)
- `preprod.snapshots.details.approve_clicked` — tracks approval button clicks
- `preprod.snapshots.details.image_link_copied` / `image_metadata_copied` — per-image tracking with filename and diff status
- `preprod.snapshots.details.view_mode_changed` — list vs single view toggle
- `preprod.snapshots.details.diff_mode_changed` — split/wipe/onion diff mode toggle

**Implementation approach**

The page view event uses a ref guard to dedupe against refetch polling (the snapshot API re-polls while comparisons are processing). Image copy events use callback props on `CardHeader` to keep the component analytics-agnostic — parents wire up the tracking.

Refs EME-1006