### PR TITLE
feat(aci): Add a warning banner for no connections on an Alert

### DIFF
--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -221,6 +221,52 @@ describe('AutomationDetail', () => {
     });
   });
 
+  it('displays no connections warning when detectorIds is empty', async () => {
+    const automationWithNoConnections = AutomationFixture({
+      ...automation,
+      detectorIds: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/123/',
+      body: automationWithNoConnections,
+    });
+
+    render(<AutomationDetail />, {
+      organization,
+      initialRouterConfig: {
+        route: '/alerts/:automationId/',
+        location: {pathname: '/alerts/123/'},
+      },
+    });
+
+    await screen.findByRole('heading', {name: 'Test Automation'});
+
+    expect(
+      screen.getByText(
+        'Warning, the alert is not connected to a project or monitor. Alert will not trigger.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('does not display no connections warning when detectorIds exist', async () => {
+    render(<AutomationDetail />, {
+      organization,
+      initialRouterConfig: {
+        route: '/alerts/:automationId/',
+        location: {pathname: '/alerts/123/'},
+      },
+    });
+
+    await screen.findByRole('heading', {name: 'Test Automation'});
+
+    expect(
+      screen.queryByText(
+        'Warning, the alert is not connected to a project or monitor. Alert will not trigger.'
+      )
+    ).not.toBeInTheDocument();
+  });
+
   it('displays connected projects and monitors', async () => {
     const project = ProjectFixture({id: '10', slug: 'my-project', name: 'My Project'});
     ProjectsStore.loadInitialData([project]);

--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -244,7 +244,7 @@ describe('AutomationDetail', () => {
 
     expect(
       screen.getByText(
-        'Warning, the alert is not connected to a project or monitor. Alert will not trigger.'
+        'This alert is not connected to a project or monitor. Alert will not trigger.'
       )
     ).toBeInTheDocument();
   });
@@ -262,7 +262,7 @@ describe('AutomationDetail', () => {
 
     expect(
       screen.queryByText(
-        'Warning, the alert is not connected to a project or monitor. Alert will not trigger.'
+        'This alert is not connected to a project or monitor. Alert will not trigger.'
       )
     ).not.toBeInTheDocument();
   });

--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -244,7 +244,7 @@ describe('AutomationDetail', () => {
 
     expect(
       screen.getByText(
-        'This alert is not connected to a project or monitor. Alert will not trigger.'
+        'This alert is not connected to a project or monitor and will not trigger.'
       )
     ).toBeInTheDocument();
   });
@@ -262,7 +262,7 @@ describe('AutomationDetail', () => {
 
     expect(
       screen.queryByText(
-        'This alert is not connected to a project or monitor. Alert will not trigger.'
+        'This alert is not connected to a project or monitor and will not trigger.'
       )
     ).not.toBeInTheDocument();
   });

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -67,6 +67,8 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
     />
   );
 
+  const hasConnections = !!automation.detectorIds.length;
+
   return (
     <SentryDocumentTitle title={automation.name}>
       <DetailLayout>
@@ -90,11 +92,21 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
         <DetailLayout.Body>
           <DetailLayout.Main>
             <DisabledAlert automation={automation} />
+
             {automation.enabled && warning && (
               <Alert variant={warning.color === 'warning' ? 'warning' : 'danger'}>
                 {warning.message}
               </Alert>
             )}
+
+            {!hasConnections && (
+              <Alert variant="warning">
+                {t(
+                  'Warning, the alert is not connected to a project or monitor. Alert will not trigger.'
+                )}
+              </Alert>
+            )}
+
             <PageFiltersContainer>
               {hasPageFrameFeature ? (
                 <Flex align="center" justify="between" gap="md">
@@ -106,6 +118,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
               ) : (
                 <DatePageFilter />
               )}
+
               <ErrorBoundary>
                 <AutomationStatsChart
                   automationId={automation.id}
@@ -115,6 +128,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
                   utc={utc ?? null}
                 />
               </ErrorBoundary>
+
               <DetailSection title={t('History')}>
                 <ErrorBoundary mini>
                   <AutomationHistoryList
@@ -128,6 +142,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
                   />
                 </ErrorBoundary>
               </DetailSection>
+
               <DetailSection
                 title={t('Connected Projects')}
                 description={t(
@@ -138,6 +153,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
                   <ConnectedProjectsList automationId={automation.id} />
                 </ErrorBoundary>
               </DetailSection>
+
               <DetailSection
                 title={t('Connected Monitors')}
                 description={t(
@@ -155,6 +171,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
               </DetailSection>
             </PageFiltersContainer>
           </DetailLayout.Main>
+
           <DetailLayout.Sidebar>
             <DetailSection title={t('Last Triggered')}>
               {automation.lastTriggered ? (

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -102,7 +102,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
             {!hasConnections && (
               <Alert variant="warning">
                 {t(
-                  'Warning, the alert is not connected to a project or monitor. Alert will not trigger.'
+                  'This alert is not connected to a project or monitor and will not trigger.'
                 )}
               </Alert>
             )}


### PR DESCRIPTION
# Description
It's possible to create an alert w/o a connection to a project or a detector, this is fine but it means the alert won't trigger.

This PR will introduce a banner to warn the user that this isn't connected to anything an won't alert on any issue.

## Before
<img width="1552" height="1377" alt="Screenshot 2026-05-04 at 12 52 27 PM" src="https://github.com/user-attachments/assets/2917b478-8bf3-4f9e-b35f-e2fa838f7dfc" />

## After
<img width="1392" height="1522" alt="Screenshot 2026-05-04 at 1 30 51 PM" src="https://github.com/user-attachments/assets/83630ebc-6660-4400-8db9-8be00d639eac" />
