### PR TITLE
fix(ui): Disable links in project selector avatars

### DIFF
--- a/static/app/components/forms/fields/sentryProjectSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryProjectSelectorField.tsx
@@ -53,6 +53,7 @@ function SelectedProjectMultiValueLabel({
             project={data.project}
             avatarSize={14}
             avatarProps={{consistentWidth: true}}
+            disableLink
             hideName
           />
         ) : null}
@@ -81,6 +82,7 @@ export function SentryProjectSelectorField({
           project={project}
           avatarSize={avatarSize}
           avatarProps={{consistentWidth: true}}
+          disableLink
           hideName
         />
       ),


### PR DESCRIPTION
Project selector chips and dropdown rows use project badges just for the avatar, but those badges still wrapped the avatar in a project details link.

Pass `disableLink` for both the selected multi-value chips and the dropdown options so the selector does not hide links inside its UI.