### PR TITLE
ref(grouping): Correctly parameterize dotted ints

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -257,6 +257,9 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             (::[fF]{4}:)? # Optional prefix mapping the IPv4 address which follows to IPv6 format
             (
                 \b
+                # Negative lookbehind to ensure this isn't part of a longer set of dot-delimited
+                # ints (so, prevent 1.2.3.4.5 from matching as 1.<ip>)
+                (?<!\d\.)
                 # Three numbers from 0-255, each followed by a literal dot, no leading zeros allowed
                 (
                     (
@@ -270,6 +273,9 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
                 # Final number from 0-255 (same pattern alternatives as above)
                 (\d | [1-9]\d | 1\d{2} | 2[0-4]\d | 25[0-5])
                 (/\d{1,2})? # Optional CIDR suffix
+                # Negative lookahead to ensure this isn't part of a longer set of dot-delimited
+                # ints (so, prevent 1.2.3.4.5 from matching as <ip>.5)
+                (?!\.\d)
                 \b
             )
             |
@@ -402,7 +408,29 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             \b
         """,
     ),
-    ParameterizationRegex(name="float", raw_pattern=r"""-\d+\.\d+\b | \b\d+\.\d+\b"""),
+    ParameterizationRegex(
+        name="float",
+        raw_pattern=r"""
+            (
+                # For positive values, in addition to the wordbreak, a negative lookbehind to ensure
+                # this isn't part of a longer set of dot-delimited ints (IOW, to prevent `1.2.3`
+                # from matching as `1.<float>`)
+                (
+                    \b
+                    (?<!\d\.)
+                ) |
+                # For negative values, no wordbreak or lookbehind needed, since the minus sign
+                # itself both creates a wordbreak and prevents the `1.2.3` case matching on `2.3`
+                -
+            )
+            # The value itself
+            \d+\.\d+
+            # Negative lookahead to ensure this isn't part of a longer set of dot-delimited ints
+            # (IOW, to prevent 1.2.3 from matching as <float>.3)
+            (?!\.\d)
+            \b
+        """,
+    ),
     ParameterizationRegex(
         name="int",
         raw_pattern=r"""

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -71,6 +71,9 @@ standard_cases = [
     ("ip - v6 final compressed segment", "2012:d157::", "<ip>"),
     ("ip - v4 mapped to v6", "::ffff:192.168.1.1", "<ip>"),
     ("ip - v6 full", "1121:0c03:1231:130d:0000:16da:0908:da07", "<ip>"),
+    ("ip - v4 too many segments", "11.21.12.31.12", "<int>.<int>.<int>.<int>.<int>"),
+    ("ip - v4 segment > 255", "12.31.12.908", "<int>.<int>.<int>.<int>"),
+    ("ip - v4 leading zeros", "11.21.12.001", "<int>.<int>.<int>.<int>"),
     ("ip - double colon object property", "Option::unwrap()", "Option::unwrap()"),
     ("ip - double colon object property including hex", "Bee::buzz()", "Bee::buzz()"),
     (
@@ -232,6 +235,8 @@ standard_cases = [
     ("random id - no numbers", "kMtdgDcgG", "kMtdgDcgG"),
     ("random id - no numbers until later", "kMtdgDcgG 1121", "kMtdgDcgG <int>"),
     ("float", "0.23", "<float>"),
+    ("float - postive, too many segments", "1.2.3", "<int>.<int>.<int>"),
+    ("float - negative, too many segments", "-1.2.3", "<int>.<int>.<int>"),
     ("int", "23", "<int>"),
     ("int - negative", "-23", "<int>"),
     ("int - separator", "0:17502", "<int>:<int>"),
@@ -323,18 +328,6 @@ incorrect_cases = [
         "<int>/Nov/<int>:<date>",
     ),
     (
-        "float - postive, too many segments",
-        "1.2.3",
-        "<int>.<int>.<int>",
-        "<float>.<int>",
-    ),
-    (
-        "float - negative, too many segments",
-        "-1.2.3",
-        "<int>.<int>.<int>",
-        "<float>.<int>",
-    ),
-    (
         "int - number in word",
         "Encoding: utf-8",
         "Encoding: utf-8",
@@ -345,24 +338,6 @@ incorrect_cases = [
         "4,150,908",
         "<int>",
         "<int>,<int>,<int>",
-    ),
-    (
-        "ip - v4, leading zeros",
-        "11.21.12.001",
-        "<int>.<int>.<int>.<int>",
-        "<float>.<float>",
-    ),
-    (
-        "ip - v4, segment > 255",
-        "12.31.12.908",
-        "<int>.<int>.<int>.<int>",
-        "<float>.<float>",
-    ),
-    (
-        "ip - v4, too many segments",
-        "11.21.12.31.12",
-        "<int>.<int>.<int>.<int>.<int>",
-        "<ip>.<int>",
     ),
     (
         "ip - short double colon object property including only hex",
@@ -806,7 +781,7 @@ ip_false_positive_cases = [
     ("ip - too few segments", "12:31:99", True),
     ("ip - v4 leading zeros", "11.21.12.001", False),
     ("ip - v4 segment > 255", "12.31.12.908", False),
-    ("ip - v4 too many segments", "11.21.12.31.12", True),
+    ("ip - v4 too many segments", "11.21.12.31.12", False),
     ("date - colon btwn date and time", "21/Nov/2012:12:31:12", True),
 ]
 


### PR DESCRIPTION
This fixes our IPv4 and float parameterization regexes so that IPv4 values must have exactly 4 dotted segments, and floats must have exactly 2. (Currently, `1.2.3.4.5` matches as `<ip>.<int>` and `1.2.3` matches as `<float>.<int>`.) 