### PR TITLE
feat(seer): Add ui_tools pass-through for client-side tool definitions

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -321,6 +321,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the thinking blocks toggle in the Seer Agent top bar
     manager.add("organizations:seer-explorer-thinking-blocks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable client-side UI tools for Seer Agent
+    manager.add("organizations:seer-explorer-ui-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable structured LLM context (JSON snapshot) instead of ASCII DOM snapshot
     manager.add("organizations:context-engine-structured-page-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Allow root_cause as a valid automated run stopping point and org-level default

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -253,6 +253,7 @@ class SeerAgentClient:
         metadata: dict[str, Any] | None = None,
         request: Request | None = None,
         override_ce_enable: bool = True,
+        ui_tools: str | None = None,
     ) -> int:
         """
         Start a new Seer Agent session.
@@ -327,6 +328,9 @@ class SeerAgentClient:
 
         if metadata:
             chat_body["metadata"] = metadata
+
+        if ui_tools:
+            chat_body["ui_tools"] = ui_tools
 
         if features.has(
             "organizations:seer-explorer-context-engine", self.organization, actor=self.user
@@ -406,6 +410,7 @@ class SeerAgentClient:
         page_name: str | None = None,
         artifact_key: str | None = None,
         artifact_schema: type[BaseModel] | None = None,
+        ui_tools: str | None = None,
         request: Request | None = None,
     ) -> int:
         """
@@ -449,6 +454,9 @@ class SeerAgentClient:
         if artifact_key and artifact_schema:
             chat_body["artifact_key"] = artifact_key
             chat_body["artifact_schema"] = artifact_schema.schema()
+
+        if ui_tools:
+            chat_body["ui_tools"] = ui_tools
 
         # No random rollout here — Seer ANDs this with the persisted value from start_run,
         # so the start_run coin flip is the single source of truth.

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -73,6 +73,7 @@ class AgentChatRequest(TypedDict):
     is_context_engine_enabled: NotRequired[bool]
     max_iterations: NotRequired[int]
     proxy_headers: NotRequired[dict[str, str] | None]
+    ui_tools: NotRequired[str | None]
 
 
 class AgentRunsRequest(TypedDict):

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -97,6 +97,13 @@ class SeerAgentChatSerializer(serializers.Serializer):
         allow_null=True,
         help_text="Override code mode tools: 'off', 'on', 'only', or boolean for backwards compat.",
     )
+    ui_tools = serializers.CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        default=None,
+        help_text="JSON-encoded tool definitions for client-side UI tools.",
+    )
 
 
 class OrganizationSeerAgentChatPermission(OrganizationPermission):
@@ -207,6 +214,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         page_name = validated_data.get("page_name")
         override_ce_enable = validated_data["override_ce_enable"]
         override_code_mode_enable = validated_data.get("override_code_mode_enable")
+        ui_tools = validated_data.get("ui_tools")
 
         # If the frontend sent a structured LLMContext JSON snapshot, convert to markdown.
         if on_page_context:
@@ -248,6 +256,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                     insert_index=insert_index,
                     on_page_context=on_page_context,
                     page_name=page_name,
+                    ui_tools=ui_tools,
                     request=request,
                 )
             else:
@@ -256,6 +265,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                     prompt=query,
                     on_page_context=on_page_context,
                     page_name=page_name,
+                    ui_tools=ui_tools,
                     override_ce_enable=override_ce_enable,
                     request=request,
                 )

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -214,7 +214,13 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         page_name = validated_data.get("page_name")
         override_ce_enable = validated_data["override_ce_enable"]
         override_code_mode_enable = validated_data.get("override_code_mode_enable")
-        ui_tools = validated_data.get("ui_tools")
+        ui_tools = (
+            validated_data.get("ui_tools")
+            if features.has(
+                "organizations:seer-explorer-ui-tools", organization, actor=request.user
+            )
+            else None
+        )
 
         # If the frontend sent a structured LLMContext JSON snapshot, convert to markdown.
         if on_page_context:

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -123,6 +123,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             prompt="What is this error about?",
             on_page_context=None,
             page_name=None,
+            ui_tools=None,
             override_ce_enable=True,
             request=ANY,
         )
@@ -185,6 +186,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             insert_index=2,
             on_page_context=None,
             page_name=None,
+            ui_tools=None,
             request=ANY,
         )
 


### PR DESCRIPTION
Passthrough a reserved ui_tools field through seer that will contain serialized action schema that the frontend can attempt to parse and invoke the correct action