### PR TITLE
feat(cells): Replicate OrganizationAvatar to OrganizationAvatarReplica via outbox

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -156,6 +156,13 @@ register(
 )
 
 register(
+    "outbox_replication.sentry_organizationavatar.replication_version",
+    type=Int,
+    default=0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "hybrid_cloud.authentication.disabled_organization_shards",
     type=Sequence,
     default=[],

--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -67,6 +67,7 @@ class OutboxCategory(IntEnum):
     SENTRY_APP_NORMALIZE_ACTIONS = 44
     PROJECT_KEY_UPDATE = 45
     SCM_INTEGRATION_CONFIG_BACKFILL = 46
+    ORGANIZATION_AVATAR_UPDATE = 47
 
     @classmethod
     def as_choices(cls) -> Sequence[tuple[int, int]]:
@@ -283,6 +284,7 @@ class OutboxScope(IntEnum):
             OutboxCategory.FTC_CONSENT,
             OutboxCategory.PROJECT_KEY_UPDATE,
             OutboxCategory.SCM_INTEGRATION_CONFIG_BACKFILL,
+            OutboxCategory.ORGANIZATION_AVATAR_UPDATE,
         },
     )
     USER_SCOPE = scope_categories(

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -32,6 +32,7 @@ from sentry.models.authidentityreplica import AuthIdentityReplica
 from sentry.models.authprovider import AuthProvider
 from sentry.models.authproviderreplica import AuthProviderReplica
 from sentry.models.organization import Organization
+from sentry.models.organizationavatarreplica import OrganizationAvatarReplica
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
 from sentry.models.organizationslugreservationreplica import OrganizationSlugReservationReplica
@@ -397,3 +398,15 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
         ProjectKeyMapping.objects.filter(
             project_key_id=project_key_id, cell_name=cell_name
         ).delete()
+
+    def upsert_organization_avatar_replica(
+        self, *, organization_id: int, avatar_type: int, avatar_ident: str
+    ) -> None:
+        with transaction.atomic(router.db_for_write(OrganizationAvatarReplica)):
+            OrganizationAvatarReplica.objects.update_or_create(
+                organization_id=organization_id,
+                defaults={"avatar_type": avatar_type, "avatar_ident": avatar_ident},
+            )
+
+    def delete_organization_avatar_replica(self, *, organization_id: int) -> None:
+        OrganizationAvatarReplica.objects.filter(organization_id=organization_id).delete()

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -53,6 +53,18 @@ class ControlReplicaService(RpcService):
     def delete_project_key_mapping(self, *, project_key_id: int, cell_name: str) -> None:
         pass
 
+    @rpc_method
+    @abc.abstractmethod
+    def upsert_organization_avatar_replica(
+        self, *, organization_id: int, avatar_type: int, avatar_ident: str
+    ) -> None:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
+    def delete_organization_avatar_replica(self, *, organization_id: int) -> None:
+        pass
+
     @classmethod
     def get_local_implementation(cls) -> RpcService:
         from .impl import DatabaseBackedControlReplicaService

--- a/src/sentry/models/avatars/organization_avatar.py
+++ b/src/sentry/models/avatars/organization_avatar.py
@@ -1,19 +1,26 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 from django.db import models
 
 from sentry.db.models import FlexibleForeignKey, cell_silo_model
 from sentry.db.models.fields.bounded import BoundedBigIntegerField
+from sentry.hybridcloud.outbox.base import ReplicatedCellModel
+from sentry.hybridcloud.outbox.category import OutboxCategory
 
 from . import AvatarBase
 
 
 @cell_silo_model
-class OrganizationAvatar(AvatarBase):
+class OrganizationAvatar(AvatarBase, ReplicatedCellModel):
     """
     An OrganizationAvatar associates an Organization with their avatar photo File
     and contains their preferences for avatar type.
     """
+
+    category = OutboxCategory.ORGANIZATION_AVATAR_UPDATE
 
     AVATAR_TYPES = ((0, "letter_avatar"), (1, "upload"))
 
@@ -32,3 +39,22 @@ class OrganizationAvatar(AvatarBase):
 
     def get_cache_key(self, size) -> str:
         return f"org_avatar:{self.organization_id}:{size}"
+
+    def handle_async_replication(self, shard_identifier: int) -> None:
+        from sentry.hybridcloud.services.replica import control_replica_service
+
+        control_replica_service.upsert_organization_avatar_replica(
+            organization_id=self.organization_id,
+            avatar_type=self.avatar_type,
+            avatar_ident=self.ident,
+        )
+
+    @classmethod
+    def handle_async_deletion(
+        cls, identifier: int, shard_identifier: int, payload: Mapping[str, Any] | None
+    ) -> None:
+        from sentry.hybridcloud.services.replica import control_replica_service
+
+        control_replica_service.delete_organization_avatar_replica(
+            organization_id=shard_identifier,
+        )

--- a/src/sentry/models/avatars/organization_avatar.py
+++ b/src/sentry/models/avatars/organization_avatar.py
@@ -7,14 +7,14 @@ from django.db import models
 
 from sentry.db.models import FlexibleForeignKey, cell_silo_model
 from sentry.db.models.fields.bounded import BoundedBigIntegerField
-from sentry.hybridcloud.outbox.base import ReplicatedCellModel
 from sentry.hybridcloud.outbox.category import OutboxCategory
 
 from . import AvatarBase
 
 
+# TODO(cells): Inherit from ReplicatedCellModel once RPC methods deployed
 @cell_silo_model
-class OrganizationAvatar(AvatarBase, ReplicatedCellModel):
+class OrganizationAvatar(AvatarBase):
     """
     An OrganizationAvatar associates an Organization with their avatar photo File
     and contains their preferences for avatar type.

--- a/src/sentry/models/avatars/organization_avatar.py
+++ b/src/sentry/models/avatars/organization_avatar.py
@@ -41,20 +41,26 @@ class OrganizationAvatar(AvatarBase, ReplicatedCellModel):
         return f"org_avatar:{self.organization_id}:{size}"
 
     def handle_async_replication(self, shard_identifier: int) -> None:
-        from sentry.hybridcloud.services.replica import control_replica_service
+        # TODO(cells): Uncomment implementation once RPC methods deployed
+        pass
 
-        control_replica_service.upsert_organization_avatar_replica(
-            organization_id=self.organization_id,
-            avatar_type=self.avatar_type,
-            avatar_ident=self.ident,
-        )
+        # from sentry.hybridcloud.services.replica import control_replica_service
+
+        # control_replica_service.upsert_organization_avatar_replica(
+        #     organization_id=self.organization_id,
+        #     avatar_type=self.avatar_type,
+        #     avatar_ident=self.ident,
+        # )
 
     @classmethod
     def handle_async_deletion(
         cls, identifier: int, shard_identifier: int, payload: Mapping[str, Any] | None
     ) -> None:
-        from sentry.hybridcloud.services.replica import control_replica_service
+        # TODO(cells): Uncomment implementation once RPC methods deployed
+        pass
 
-        control_replica_service.delete_organization_avatar_replica(
-            organization_id=shard_identifier,
-        )
+        # from sentry.hybridcloud.services.replica import control_replica_service
+
+        # control_replica_service.delete_organization_avatar_replica(
+        #     organization_id=shard_identifier,
+        # )

--- a/tests/sentry/models/test_organization_avatar.py
+++ b/tests/sentry/models/test_organization_avatar.py
@@ -1,6 +1,12 @@
 from sentry.models.avatars.organization_avatar import OrganizationAvatar
 from sentry.models.files.file import File
+from sentry.models.organizationavatarreplica import OrganizationAvatarReplica
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.factories import Factories
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test, create_test_cells
 
 
 class OrganizationAvatarTestCase(TestCase):
@@ -15,3 +21,29 @@ class OrganizationAvatarTestCase(TestCase):
         assert avatar.get_file() is None
         assert OrganizationAvatar.objects.get(id=avatar.id).file_id is None
         assert OrganizationAvatar.objects.get(id=avatar.id).get_file() is None
+
+
+@django_db_all(transaction=True)
+@cell_silo_test(cells=create_test_cells("us"), include_monolith_run=True)
+def test_organization_avatar_replica_created_on_save() -> None:
+    org = Factories.create_organization()
+    avatar = OrganizationAvatar.objects.create(organization=org, avatar_type=0)
+
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        replica = OrganizationAvatarReplica.objects.get(organization_id=org.id)
+        assert replica.avatar_type == avatar.avatar_type
+        assert replica.avatar_ident == avatar.ident
+
+
+@django_db_all(transaction=True)
+@cell_silo_test(cells=create_test_cells("us"), include_monolith_run=True)
+def test_organization_avatar_replica_deleted_on_avatar_delete() -> None:
+    org = Factories.create_organization()
+    avatar = OrganizationAvatar.objects.create(organization=org, avatar_type=0)
+    org_id = org.id
+
+    with outbox_runner():
+        avatar.delete()
+
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        assert not OrganizationAvatarReplica.objects.filter(organization_id=org_id).exists()

--- a/tests/sentry/models/test_organization_avatar.py
+++ b/tests/sentry/models/test_organization_avatar.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.models.avatars.organization_avatar import OrganizationAvatar
 from sentry.models.files.file import File
 from sentry.models.organizationavatarreplica import OrganizationAvatarReplica
@@ -23,6 +25,8 @@ class OrganizationAvatarTestCase(TestCase):
         assert OrganizationAvatar.objects.get(id=avatar.id).get_file() is None
 
 
+# TODO(cells): Unskip when implemented
+@pytest.mark.skip(reason="Requires implementation of avatar replication in control")
 @django_db_all(transaction=True)
 @cell_silo_test(cells=create_test_cells("us"), include_monolith_run=True)
 def test_organization_avatar_replica_created_on_save() -> None:
@@ -35,6 +39,8 @@ def test_organization_avatar_replica_created_on_save() -> None:
         assert replica.avatar_ident == avatar.ident
 
 
+# TODO(cells): Unskip when implemented
+@pytest.mark.skip(reason="Requires implementation of avatar deletion in control")
 @django_db_all(transaction=True)
 @cell_silo_test(cells=create_test_cells("us"), include_monolith_run=True)
 def test_organization_avatar_replica_deleted_on_avatar_delete() -> None:


### PR DESCRIPTION
Wire OrganizationAvatar as a ReplicatedCellModel using a new ORGANIZATION_AVATAR_UPDATE outbox category. On save, handle_async_replication upserts avatar_type and ident into OrganizationAvatarReplica via control_replica_service. On delete, handle_async_deletion removes the replica row by organization_id.

This change enables the organization listing endpoint to move from cells to control, enabling the cellular architecture, and removing the need for UI fan out in order to get all of a user's organizations.

This change only writes new avatar records. The backfill of existing rows will be added as a follow up via a replication_version bump.
