### PR TITLE
ref(cells): Remove platform filter and project sort from org listing

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -184,7 +184,6 @@ Valid query fields include:
 - `slug`: The organization slug
 - `status`: The organization's current status (one of `active`, `pending_deletion`, or `deletion_in_progress`)
 - `email` or `member_id`: Filter your organizations by the emails or [organization member IDs](/api/organizations/list-an-organizations-members/) of specific members included
-- `platform`: Filter your organizations to those with at least one project using this platform
 - `query`: Filter your organizations by name, slug, and members that contain this substring
 
 Example: `query=(slug:foo AND status:active) OR (email:[thing-one@example.com,thing-two@example.com] AND query:bar)`
@@ -199,7 +198,6 @@ Example: `query=(slug:foo AND status:active) OR (email:[thing-one@example.com,th
 
 Valid fields include:
 - `members`: By number of members
-- `projects`: By number of projects
 - `events`: By number of events in the past 24 hours
 """,
     )

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -38,7 +38,6 @@ from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
-from sentry.models.projectplatform import ProjectPlatform
 from sentry.search.utils import tokenize_query
 from sentry.services.organization import (
     OrganizationOptions,
@@ -174,16 +173,6 @@ class OrganizationIndexEndpoint(Endpoint):
                         for u in user_service.get_many_by_email(emails=value, is_verified=False)
                     }
                     queryset = queryset.filter(Q(member_set__user_id__in=user_ids))
-                elif key == "platform":
-                    # Note: platform filtering is kept here but is not present in the control version
-                    # of this endpoint, since the data is not in control and our UI isn't
-                    # passing this anymore.
-                    sentry_sdk.capture_message("organization_index.platform_filter_used")
-                    queryset = queryset.filter(
-                        project__in=ProjectPlatform.objects.filter(platform__in=value).values(
-                            "project_id"
-                        )
-                    )
                 elif key == "id":
                     queryset = queryset.filter(id__in=value)
                 elif key == "status":
@@ -207,11 +196,6 @@ class OrganizationIndexEndpoint(Endpoint):
         if sort_by == "members":
             queryset = queryset.annotate(member_count=Count("member_set"))
             order_by = "-member_count"
-            paginator_cls = OffsetPaginator
-        elif sort_by == "projects":
-            sentry_sdk.capture_message("organization_index.sort_by_projects_used")
-            queryset = queryset.annotate(project_count=Count("project"))
-            order_by = "-project_count"
             paginator_cls = OffsetPaginator
         else:
             order_by = "-date_added"
@@ -317,10 +301,6 @@ class OrganizationIndexEndpoint(Endpoint):
             )
             queryset = queryset.annotate(member_count=Coalesce(Subquery(member_count_subquery), 0))
             order_by = "-member_count"
-            paginator_cls = OffsetPaginator
-        elif sort_by == "projects":
-            queryset = queryset.none()
-            order_by = "-date_created"
             paginator_cls = OffsetPaginator
         else:
             order_by = "-date_created"


### PR DESCRIPTION
Both `platform` query filtering and `sortBy=projects` depend on project data that is not available in the control silo, so they cannot be supported as the organizations index endpoint migrates from cell to control.

Neither has been logged once in weeks, confirming they are not being used by any customers. Remove them from the cell path to keep it aligned with the future control silo path.
