### PR TITLE
chore(ACI): Move metric issues into generic post processing pipeline

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -649,11 +649,7 @@ def run_post_process_job(job: PostProcessJob) -> None:
         )
         return
 
-    issue_type_id = group_event.group.issue_type.type_id if group_event.group else None
-    if (
-        issue_category in GROUP_CATEGORY_POST_PROCESS_PIPELINE
-        and issue_type_id not in _REGRESSION_TYPE_IDS_USE_GENERIC_PIPELINE
-    ):
+    if issue_category in GROUP_CATEGORY_POST_PROCESS_PIPELINE:
         pipeline = GROUP_CATEGORY_POST_PROCESS_PIPELINE[issue_category]
     else:
         pipeline = GENERIC_POST_PROCESS_PIPELINE
@@ -970,20 +966,9 @@ def process_workflow_engine(job: PostProcessJob) -> None:
         return
 
 
-def process_workflow_engine_issue_alerts(job: PostProcessJob) -> None:
+def process_workflow_engine_alerts(job: PostProcessJob) -> None:
     """
-    Call for process_workflow_engine with the issue alert feature flag
-    """
-    if job["is_reprocessed"]:
-        return
-
-    # process workflow engine if we are single processing or dual processing for a specific org
-    process_workflow_engine(job)
-
-
-def process_workflow_engine_metric_issues(job: PostProcessJob) -> None:
-    """
-    Call for process_workflow_engine for metric alerts
+    Call for process_workflow_engine
     """
     if job["is_reprocessed"]:
         return
@@ -1618,7 +1603,7 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE: dict[
         handle_auto_assignment,
         kick_off_seer_automation,
         kick_off_lightweight_rca_cluster,
-        process_workflow_engine_issue_alerts,
+        process_workflow_engine_alerts,
         process_resource_change_bounds,
         process_data_forwarding,
         process_plugins,
@@ -1637,11 +1622,8 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE: dict[
     GroupCategory.FEEDBACK: [
         feedback_filter_decorator(process_snoozes),
         feedback_filter_decorator(process_inbox_adds),
-        feedback_filter_decorator(process_workflow_engine_issue_alerts),
+        feedback_filter_decorator(process_workflow_engine_alerts),
         feedback_filter_decorator(process_resource_change_bounds),
-    ],
-    GroupCategory.METRIC: [
-        process_workflow_engine_metric_issues,
     ],
     GroupCategory.INSTRUMENTATION: [
         process_snoozes,
@@ -1654,18 +1636,7 @@ GENERIC_POST_PROCESS_PIPELINE: list[Callable[[PostProcessJob], None]] = [
     process_snoozes,
     process_inbox_adds,
     kick_off_seer_automation,
-    process_workflow_engine_issue_alerts,
+    process_workflow_engine_alerts,
     process_resource_change_bounds,
     process_data_forwarding,
 ]
-
-# These regression group types were migrated from GroupCategory.PERFORMANCE to
-# GroupCategory.METRIC but should still use the generic pipeline rather than the
-# metric-alert-specific one.
-_REGRESSION_TYPE_IDS_USE_GENERIC_PIPELINE: frozenset[int] = frozenset(
-    {
-        1018,  # PerformanceP95EndpointRegressionGroupType
-        1019,  # PerformanceStreamedSpansGroupTypeExperimental
-        2011,  # ProfileFunctionRegressionType
-    }
-)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -931,12 +931,10 @@ def process_replay_link(job: PostProcessJob) -> None:
 def process_workflow_engine(job: PostProcessJob) -> None:
     """
     Invoke the workflow_engine to process workflows given the job.
-
-    Currently, we do not want to add this to an event in post processing,
-    instead wrap this with a check for a feature flag before invoking.
-
-    Eventually, we'll want to replace `process_rule` with this method.
     """
+    if job["is_reprocessed"]:
+        return
+
     metrics.incr("workflow_engine.issue_platform.payload.received.occurrence")
 
     from sentry.workflow_engine.tasks.workflows import process_workflows_event
@@ -964,16 +962,6 @@ def process_workflow_engine(job: PostProcessJob) -> None:
     except Exception:
         logger.exception("Could not process workflow task", extra={"job": job})
         return
-
-
-def process_workflow_engine_alerts(job: PostProcessJob) -> None:
-    """
-    Call for process_workflow_engine
-    """
-    if job["is_reprocessed"]:
-        return
-
-    process_workflow_engine(job)
 
 
 def process_code_mappings(job: PostProcessJob) -> None:
@@ -1603,7 +1591,7 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE: dict[
         handle_auto_assignment,
         kick_off_seer_automation,
         kick_off_lightweight_rca_cluster,
-        process_workflow_engine_alerts,
+        process_workflow_engine,
         process_resource_change_bounds,
         process_data_forwarding,
         process_plugins,
@@ -1622,7 +1610,7 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE: dict[
     GroupCategory.FEEDBACK: [
         feedback_filter_decorator(process_snoozes),
         feedback_filter_decorator(process_inbox_adds),
-        feedback_filter_decorator(process_workflow_engine_alerts),
+        feedback_filter_decorator(process_workflow_engine),
         feedback_filter_decorator(process_resource_change_bounds),
     ],
     GroupCategory.INSTRUMENTATION: [
@@ -1636,7 +1624,7 @@ GENERIC_POST_PROCESS_PIPELINE: list[Callable[[PostProcessJob], None]] = [
     process_snoozes,
     process_inbox_adds,
     kick_off_seer_automation,
-    process_workflow_engine_alerts,
+    process_workflow_engine,
     process_resource_change_bounds,
     process_data_forwarding,
 ]

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -3624,7 +3624,7 @@ class PostProcessGroupPerformanceTest(
 
     @patch("sentry.tasks.post_process.handle_owner_assignment")
     @patch("sentry.tasks.post_process.handle_auto_assignment")
-    @patch("sentry.tasks.post_process.process_workflow_engine_issue_alerts")
+    @patch("sentry.tasks.post_process.process_workflow_engine_alerts")
     @patch("sentry.tasks.post_process.run_post_process_job")
     @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
     @patch("sentry.signals.transaction_processed.send_robust")
@@ -3635,7 +3635,7 @@ class PostProcessGroupPerformanceTest(
         transaction_processed_signal_mock,
         mock_process_workflows_event,
         run_post_process_job_mock,
-        mock_process_workflow_engine_issue_alerts,
+        mock_process_workflow_engine_alerts,
         mock_handle_auto_assignment,
         mock_handle_owner_assignment,
     ):
@@ -3648,11 +3648,11 @@ class PostProcessGroupPerformanceTest(
         call_order = [
             mock_handle_owner_assignment,
             mock_handle_auto_assignment,
-            mock_process_workflow_engine_issue_alerts,
+            mock_process_workflow_engine_alerts,
         ]
         mock_handle_owner_assignment.side_effect = None
         mock_handle_auto_assignment.side_effect = None
-        mock_process_workflow_engine_issue_alerts.side_effect = None
+        mock_process_workflow_engine_alerts.side_effect = None
 
         post_process_group(
             is_new=True,
@@ -3671,7 +3671,7 @@ class PostProcessGroupPerformanceTest(
         assert call_order == [
             mock_handle_owner_assignment,
             mock_handle_auto_assignment,
-            mock_process_workflow_engine_issue_alerts,
+            mock_process_workflow_engine_alerts,
         ]
 
 
@@ -3786,7 +3786,7 @@ class PostProcessGroupGenericTest(
 
     @patch("sentry.tasks.post_process.handle_owner_assignment")
     @patch("sentry.tasks.post_process.handle_auto_assignment")
-    @patch("sentry.tasks.post_process.process_workflow_engine_issue_alerts")
+    @patch("sentry.tasks.post_process.process_workflow_engine_alerts")
     @patch("sentry.tasks.post_process.run_post_process_job")
     @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
     @patch("sentry.signals.event_processed.send_robust")
@@ -3797,7 +3797,7 @@ class PostProcessGroupGenericTest(
         event_processed_signal_mock,
         mock_process_workflows_event,
         run_post_process_job_mock,
-        mock_process_workflow_engine_issue_alerts,
+        mock_process_workflow_engine_alerts,
         mock_handle_auto_assignment,
         mock_handle_owner_assignment,
     ):
@@ -3805,11 +3805,11 @@ class PostProcessGroupGenericTest(
         call_order = [
             mock_handle_owner_assignment,
             mock_handle_auto_assignment,
-            mock_process_workflow_engine_issue_alerts,
+            mock_process_workflow_engine_alerts,
         ]
         mock_handle_owner_assignment.side_effect = None
         mock_handle_auto_assignment.side_effect = None
-        mock_process_workflow_engine_issue_alerts.side_effect = None
+        mock_process_workflow_engine_alerts.side_effect = None
         self.call_post_process_group(
             is_new=False,
             is_regression=True,
@@ -3822,7 +3822,7 @@ class PostProcessGroupGenericTest(
         assert call_order == [
             mock_handle_owner_assignment,
             mock_handle_auto_assignment,
-            mock_process_workflow_engine_issue_alerts,
+            mock_process_workflow_engine_alerts,
         ]
         assert snuba_raw_query_mock.call_count == 0
 
@@ -4420,12 +4420,12 @@ class PostProcessGroupInstrumentationIssueTest(
                 eventstream_type=EventStreamEventType.Generic.value,
             )
 
-    @patch("sentry.tasks.post_process.process_workflow_engine_issue_alerts")
+    @patch("sentry.tasks.post_process.process_workflow_engine_alerts")
     def test_instrumentation_issues_do_not_trigger_alerts(
         self,
-        mock_process_workflow_engine_issue_alerts,
+        mock_process_workflow_engine_alerts,
     ):
-        """Instrumentation issues should not trigger process_rules or process_workflow_engine_issue_alerts."""
+        """Instrumentation issues should not trigger process_rules or process_workflow_engine_alerts."""
         event = self.create_event(
             data={},
             project_id=self.project.id,
@@ -4438,4 +4438,4 @@ class PostProcessGroupInstrumentationIssueTest(
             event=event,
         )
 
-        mock_process_workflow_engine_issue_alerts.assert_not_called()
+        mock_process_workflow_engine_alerts.assert_not_called()

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -3624,7 +3624,7 @@ class PostProcessGroupPerformanceTest(
 
     @patch("sentry.tasks.post_process.handle_owner_assignment")
     @patch("sentry.tasks.post_process.handle_auto_assignment")
-    @patch("sentry.tasks.post_process.process_workflow_engine_alerts")
+    @patch("sentry.tasks.post_process.process_workflow_engine")
     @patch("sentry.tasks.post_process.run_post_process_job")
     @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
     @patch("sentry.signals.transaction_processed.send_robust")
@@ -3635,7 +3635,7 @@ class PostProcessGroupPerformanceTest(
         transaction_processed_signal_mock,
         mock_process_workflows_event,
         run_post_process_job_mock,
-        mock_process_workflow_engine_alerts,
+        mock_process_workflow_engine,
         mock_handle_auto_assignment,
         mock_handle_owner_assignment,
     ):
@@ -3648,11 +3648,11 @@ class PostProcessGroupPerformanceTest(
         call_order = [
             mock_handle_owner_assignment,
             mock_handle_auto_assignment,
-            mock_process_workflow_engine_alerts,
+            mock_process_workflow_engine,
         ]
         mock_handle_owner_assignment.side_effect = None
         mock_handle_auto_assignment.side_effect = None
-        mock_process_workflow_engine_alerts.side_effect = None
+        mock_process_workflow_engine.side_effect = None
 
         post_process_group(
             is_new=True,
@@ -3671,7 +3671,7 @@ class PostProcessGroupPerformanceTest(
         assert call_order == [
             mock_handle_owner_assignment,
             mock_handle_auto_assignment,
-            mock_process_workflow_engine_alerts,
+            mock_process_workflow_engine,
         ]
 
 
@@ -3786,7 +3786,7 @@ class PostProcessGroupGenericTest(
 
     @patch("sentry.tasks.post_process.handle_owner_assignment")
     @patch("sentry.tasks.post_process.handle_auto_assignment")
-    @patch("sentry.tasks.post_process.process_workflow_engine_alerts")
+    @patch("sentry.tasks.post_process.process_workflow_engine")
     @patch("sentry.tasks.post_process.run_post_process_job")
     @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event")
     @patch("sentry.signals.event_processed.send_robust")
@@ -3797,7 +3797,7 @@ class PostProcessGroupGenericTest(
         event_processed_signal_mock,
         mock_process_workflows_event,
         run_post_process_job_mock,
-        mock_process_workflow_engine_alerts,
+        mock_process_workflow_engine,
         mock_handle_auto_assignment,
         mock_handle_owner_assignment,
     ):
@@ -3805,11 +3805,11 @@ class PostProcessGroupGenericTest(
         call_order = [
             mock_handle_owner_assignment,
             mock_handle_auto_assignment,
-            mock_process_workflow_engine_alerts,
+            mock_process_workflow_engine,
         ]
         mock_handle_owner_assignment.side_effect = None
         mock_handle_auto_assignment.side_effect = None
-        mock_process_workflow_engine_alerts.side_effect = None
+        mock_process_workflow_engine.side_effect = None
         self.call_post_process_group(
             is_new=False,
             is_regression=True,
@@ -3822,7 +3822,7 @@ class PostProcessGroupGenericTest(
         assert call_order == [
             mock_handle_owner_assignment,
             mock_handle_auto_assignment,
-            mock_process_workflow_engine_alerts,
+            mock_process_workflow_engine,
         ]
         assert snuba_raw_query_mock.call_count == 0
 
@@ -4420,12 +4420,12 @@ class PostProcessGroupInstrumentationIssueTest(
                 eventstream_type=EventStreamEventType.Generic.value,
             )
 
-    @patch("sentry.tasks.post_process.process_workflow_engine_alerts")
+    @patch("sentry.tasks.post_process.process_workflow_engine")
     def test_instrumentation_issues_do_not_trigger_alerts(
         self,
-        mock_process_workflow_engine_alerts,
+        mock_process_workflow_engine,
     ):
-        """Instrumentation issues should not trigger process_rules or process_workflow_engine_alerts."""
+        """Instrumentation issues should not trigger process_rules or process_workflow_engine."""
         event = self.create_event(
             data={},
             project_id=self.project.id,
@@ -4438,4 +4438,4 @@ class PostProcessGroupInstrumentationIssueTest(
             event=event,
         )
 
-        mock_process_workflow_engine_alerts.assert_not_called()
+        mock_process_workflow_engine.assert_not_called()

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -97,7 +97,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             type_id = 1
             slug = "no_handler"
             description = "no handler"
-            category = GroupCategory.METRIC_ALERT.value
+            category = GroupCategory.METRIC.value
 
         class MockDetectorHandler(BaseDetectorHandler[dict[str, Any], int]):
             def evaluate_impl(


### PR DESCRIPTION
Moves metric issues in the generic post processing pipeline and cleans up some related code around it. Previously metric issues only hit `process_workflow_engine_metric_issues` but now they will be integrated into more steps:

* `process_snoozes` - no changes because metric issues have enable_escalation_detection disabled
* `process_inbox_adds` - will start adding metric issues to group inbox, allowing users to mark them as reviewed
* `kick_off_seer_automation` - will add seer summaries and autofix stuff to them
* `process_resource_change_bounds` - will add them to the sentry app `error.created` webhook
* `process_data_forwarding` -  will as the name implies, send them along to data forwarding providers