### PR TITLE
fix(api-docs): widen dataset enum on /events/ to include discover, errors, transactions

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -22,7 +22,12 @@ from sentry.api.paginator import EAPPageTokenPaginator, GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
 from sentry.apidocs import constants as api_constants
 from sentry.apidocs.examples.discover_performance_examples import DiscoverAndPerformanceExamples
-from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, OrganizationParams, VisibilityParams
+from sentry.apidocs.parameters import (
+    CursorQueryParam,
+    GlobalParams,
+    OrganizationParams,
+    VisibilityParams,
+)
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -22,7 +22,7 @@ from sentry.api.paginator import EAPPageTokenPaginator, GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
 from sentry.apidocs import constants as api_constants
 from sentry.apidocs.examples.discover_performance_examples import DiscoverAndPerformanceExamples
-from sentry.apidocs.parameters import GlobalParams, OrganizationParams, VisibilityParams
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, OrganizationParams, VisibilityParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
@@ -149,6 +149,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             VisibilityParams.QUERY,
             VisibilityParams.SORT,
             VisibilityParams.DATASET,
+            CursorQueryParam,
         ],
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -651,9 +651,19 @@ When TopEvents is passed, both sort and groupBy are required parameters""",
         required=True,
         type=str,
         description="Which dataset to query, changing datasets changes the available fields that can be queried",
-        # Hardcoding this since our full list of datasets includes some that probably will get deprecated as more stuff
-        # moves to EAP
-        enum=["profile_functions", "logs", "spans", "uptime_results"],
+        # Not every key in DATASET_OPTIONS is listed here — internal,
+        # metrics-layer, and deprecated aliases (e.g. "ourlogs",
+        # "metricsEnhanced", "spansIndexed") are intentionally omitted so
+        # the public API surface stays stable as backends migrate to EAP.
+        enum=[
+            "discover",
+            "errors",
+            "logs",
+            "profile_functions",
+            "spans",
+            "transactions",
+            "uptime_results",
+        ],
     )
     INTERVAL = OpenApiParameter(
         name="interval",


### PR DESCRIPTION
The OpenAPI spec for `GET /organizations/{org}/events/` declares `dataset` as `["logs", "profile_functions", "spans", "uptime_results"]` only. The runtime (`DATASET_OPTIONS` in `snuba/utils.py`) accepts many more values including `"discover"`, `"errors"`, and `"transactions"`.

This mismatch causes the generated `@sentry/api` TypeScript SDK to reject these dataset values at the type level, forcing consumers (e.g. `getsentry/cli`) to bypass the SDK and use raw HTTP requests for any query targeting these datasets.

## Changes

- Add `"discover"`, `"errors"`, and `"transactions"` to the `VisibilityParams.DATASET` enum in `src/sentry/apidocs/parameters.py`
- Internal, metrics-layer, and deprecated aliases (e.g. `"ourlogs"`, `"metricsEnhanced"`, `"spansIndexed"`) are intentionally omitted to keep the public API surface stable

## Testing

No behavior change — this only affects OpenAPI spec generation. The runtime already accepts all three values via `DATASET_OPTIONS`.

## Context

In `getsentry/cli`, 4 paginated call sites in `src/lib/api/` (`fetchTransactionsPage`, `fetchSpansPage`, `fetchEventsPage`, `queryWidgetTable`) use raw `apiRequestToRegion` instead of the SDK's `queryExploreEventsInTableFormat` solely because the generated types reject their `dataset` values. Fixing the enum here unblocks migration to the typed SDK function.

Related: `getsentry/sentry-api-schema#69` (pagination wrappers — blocked on this enum for full CLI adoption).

<!--
## Plan
1. Widen the `dataset` enum on `VisibilityParams.DATASET` in `src/sentry/apidocs/parameters.py`
   from `["profile_functions", "logs", "spans", "uptime_results"]`
   to `["discover", "errors", "logs", "profile_functions", "spans", "transactions", "uptime_results"]`
2. Keep internal/deprecated/metrics-layer dataset aliases out of the public enum
3. No runtime changes needed — the server already accepts these values
4. Affects both `/events/` (table) and `/events-stats/` (timeseries) endpoints
   since both reference `VisibilityParams.DATASET`
-->