### PR TITLE
feat(onboarding): bump SCM replay sample rate to 50%

### DIFF
--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -201,7 +201,7 @@ export function OnboardingWithoutContext() {
   useReplayForCriticalFlow({
     flowName: 'scm_onboarding',
     enabled: hasScmOnboarding,
-    sampleRate: 0.3,
+    sampleRate: 0.5,
   });
 
   const stepObj = onboardingSteps.find(({id}) => stepId === id);


### PR DESCRIPTION
## TL;DR

Bump the forced replay sample rate for SCM onboarding from 30% to 50%, now that replays actually start in this flow.

## Stack

- [PR 1](https://github.com/getsentry/sentry/pull/114774): fix Replay integration not registering during onboarding
- **PR 2 (this):** bump sample rate to 50%

## Details

The prior PR fixes the bug where the Replay integration wasn't registered on `/onboarding/*` routes, so the 30% `sampleRate` we configured was effectively 0%. With registration working, 50% gives a faster signal on the SCM onboarding funnel without doubling baseline replay storage. Easy to dial back if volume is too high.