### PR TITLE
fix(ACI): Change the issue stream query filter from detector to monitor

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -911,7 +911,8 @@ SKIP_SNUBA_FIELDS = frozenset(
     (
         "status",
         "substatus",
-        "detector",
+        "detector",  # TODO - delete this once the UI has been updated
+        "monitor",
         "bookmarked_by",
         "assigned_to",
         "for_review",

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -286,7 +286,8 @@ value_converters: Mapping[str, ValueConverter] = {
     "device.class": convert_device_class_value,
     "substatus": convert_substatus_value,
     "issue.seer_actionability": convert_seer_actionability_value,
-    "detector": convert_detector_value,
+    "detector": convert_detector_value,  # TODO - delete this once the UI has been updated
+    "monitor": convert_detector_value,
 }
 
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -587,7 +587,10 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "regressed_in_release": QCallbackCondition(
                 functools.partial(regressed_in_release_filter, projects=projects)
             ),
-            "detector": QCallbackCondition(_make_detector_filter),
+            "detector": QCallbackCondition(
+                _make_detector_filter
+            ),  # TODO - delete this once the UI has been updated
+            "monitor": QCallbackCondition(_make_detector_filter),
             "issue.category": QCallbackCondition(lambda categories: Q(type__in=categories)),
             "issue.type": QCallbackCondition(lambda types: Q(type__in=types)),
             "issue.priority": QCallbackCondition(lambda priorities: Q(priority__in=priorities)),

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -73,7 +73,8 @@ _FIELD_VALUE_TYPES: dict[str, str] = {
     "issue": "issue_short_id",
     "device.class": "device_class",
     "timesSeen": "integer",
-    "detector": "dynamic_id",
+    "detector": "dynamic_id",  # TODO - delete this once the UI has been updated
+    "monitor": "dynamic_id",
 }
 
 # Event context fields available for issue search (from frontend's ISSUE_EVENT_PROPERTY_FIELDS)

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2517,6 +2517,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             == []
         )
 
+    # TODO - Delete this test once the UI has been updated
     def test_query_detector_filter(self) -> None:
         event = self.store_event(
             data={"timestamp": before_now(seconds=500).isoformat(), "fingerprint": ["group-1"]},
@@ -2554,6 +2555,46 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert int(response.data[0]["id"]) == group.id
 
         response_empty = self.get_response(sort_by="date", query="detector:99999")
+        assert response_empty.status_code == 200
+        assert len(response_empty.data) == 0
+
+    def test_query_monitor_filter(self) -> None:
+        event = self.store_event(
+            data={"timestamp": before_now(seconds=500).isoformat(), "fingerprint": ["group-1"]},
+            project_id=self.project.id,
+        )
+        group = event.group
+
+        event2 = self.store_event(
+            data={"timestamp": before_now(seconds=400).isoformat(), "fingerprint": ["group-2"]},
+            project_id=self.project.id,
+        )
+        assert event2.group.id != group.id
+
+        detector_id = 12345  # intentionally multi-digit
+        detector = self.create_detector(
+            id=detector_id,
+            name=f"Test Detector {detector_id}",
+            project=self.project,
+            type="error",
+        )
+
+        self.create_detector_group(
+            detector=detector,
+            group=group,
+        )
+
+        self.login_as(user=self.user)
+
+        # Query for the specific detector ID
+        response = self.get_response(sort_by="date", query=f"monitor:{detector_id}")
+        assert response.status_code == 200
+
+        # Should return only the group associated with the detector
+        assert len(response.data) == 1
+        assert int(response.data[0]["id"]) == group.id
+
+        response_empty = self.get_response(sort_by="date", query="monitor:99999")
         assert response_empty.status_code == 200
         assert len(response_empty.data) == 0
 


### PR DESCRIPTION
# Description
This is part 1 of 3 to migrate the keyword `detector` out of the query filter for the UI. It's broken into 3 parts to ensure the UI / BE fixes are separated, and ensures a seamless cutover to the new filter keyword.

## Remaining Work

- [x] ~This PR adds backend support for the keyword `monitor`.~
- [ ] PR to use `monitor` instead of `detector` in the UI
- [ ] PR to remove `detector` from the backend support