### PR TITLE
fix(repositories): Convert repository sync api to be a control endpoint

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integration_repo_sync.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_repo_sync.py
@@ -5,9 +5,9 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import cell_silo_endpoint
+from sentry.api.base import control_silo_endpoint
 from sentry.integrations.api.bases.organization_integrations import (
-    CellOrganizationIntegrationBaseEndpoint,
+    OrganizationIntegrationBaseEndpoint,
 )
 from sentry.integrations.source_code_management.sync_repos import (
     SCM_SYNC_PROVIDERS,
@@ -16,8 +16,8 @@ from sentry.integrations.source_code_management.sync_repos import (
 from sentry.models.organization import Organization
 
 
-@cell_silo_endpoint
-class OrganizationIntegrationRepoSyncEndpoint(CellOrganizationIntegrationBaseEndpoint):
+@control_silo_endpoint
+class OrganizationIntegrationRepoSyncEndpoint(OrganizationIntegrationBaseEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repo_sync.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repo_sync.py
@@ -1,8 +1,10 @@
 from unittest.mock import MagicMock, patch
 
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import control_silo_test
 
 
+@control_silo_test
 class OrganizationIntegrationRepoSyncTest(APITestCase):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
This accesses a control task directly, so it has to be a control endpoint itsef.

Fixes SENTRY-5PB1

<!-- Describe your PR here. -->