### PR TITLE
fix(ACI): Rename detector -> monitor in the search UI query

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -911,7 +911,7 @@ SKIP_SNUBA_FIELDS = frozenset(
     (
         "status",
         "substatus",
-        "detector",
+        "monitor",
         "bookmarked_by",
         "assigned_to",
         "for_review",

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -286,7 +286,7 @@ value_converters: Mapping[str, ValueConverter] = {
     "device.class": convert_device_class_value,
     "substatus": convert_substatus_value,
     "issue.seer_actionability": convert_seer_actionability_value,
-    "detector": convert_detector_value,
+    "monitor": convert_detector_value,
 }
 
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -587,7 +587,7 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "regressed_in_release": QCallbackCondition(
                 functools.partial(regressed_in_release_filter, projects=projects)
             ),
-            "detector": QCallbackCondition(_make_detector_filter),
+            "monitor": QCallbackCondition(_make_detector_filter),
             "issue.category": QCallbackCondition(lambda categories: Q(type__in=categories)),
             "issue.type": QCallbackCondition(lambda types: Q(type__in=types)),
             "issue.priority": QCallbackCondition(lambda priorities: Q(priority__in=priorities)),

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -73,7 +73,7 @@ _FIELD_VALUE_TYPES: dict[str, str] = {
     "issue": "issue_short_id",
     "device.class": "device_class",
     "timesSeen": "integer",
-    "detector": "dynamic_id",
+    "monitor": "dynamic_id",
 }
 
 # Event context fields available for issue search (from frontend's ISSUE_EVENT_PROPERTY_FIELDS)

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -31,7 +31,7 @@ export enum FieldKey {
   BOOKMARKS = 'bookmarks',
   BROWSER_NAME = 'browser.name',
   CULPRIT = 'culprit',
-  DETECTOR = 'detector',
+  MONITOR = 'monitor',
   DEVICE = 'device',
   DEVICE_ARCH = 'device.arch',
   DEVICE_BATTERY_LEVEL = 'device.battery_level',
@@ -178,7 +178,7 @@ type ErrorFieldKey =
   | FieldKey.ASSIGNED_OR_SUGGESTED
   | FieldKey.BOOKMARKS
   | FieldKey.CULPRIT
-  | FieldKey.DETECTOR
+  | FieldKey.MONITOR
   | FieldKey.ERROR_HANDLED
   | FieldKey.ERROR_MECHANISM
   | FieldKey.ERROR_TYPE
@@ -1959,8 +1959,8 @@ const ERROR_FIELD_DEFINITION: Record<ErrorFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.DETECTOR]: {
-    desc: t('The detector that triggered the issue'),
+  [FieldKey.MONITOR]: {
+    desc: t('The monitor that triggered the issue'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
     allowWildcard: false,
@@ -2747,7 +2747,7 @@ export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.ASSIGNED_OR_SUGGESTED,
   FieldKey.ASSIGNED,
   FieldKey.BOOKMARKS,
-  FieldKey.DETECTOR,
+  FieldKey.MONITOR,
   FieldKey.FIRST_RELEASE,
   FieldKey.FIRST_SEEN,
   FieldKey.HAS,

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -70,7 +70,7 @@ export const DISCOVER_EXCLUSION_FIELDS: string[] = [
   'issue.type',
   'issue.seer_actionability',
   'issue.seer_last_run',
-  'detector',
+  'monitor',
 ];
 
 export const FOR_REVIEW_QUERIES: string[] = [Query.FOR_REVIEW];

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2546,14 +2546,14 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         self.login_as(user=self.user)
 
         # Query for the specific detector ID
-        response = self.get_response(sort_by="date", query=f"detector:{detector_id}")
+        response = self.get_response(sort_by="date", query=f"monitor:{detector_id}")
         assert response.status_code == 200
 
         # Should return only the group associated with the detector
         assert len(response.data) == 1
         assert int(response.data[0]["id"]) == group.id
 
-        response_empty = self.get_response(sort_by="date", query="detector:99999")
+        response_empty = self.get_response(sort_by="date", query="monitor:99999")
         assert response_empty.status_code == 200
         assert len(response_empty.data) == 0
 


### PR DESCRIPTION
DRAFT PR -- DO NOT MERGE

TODO - Break this down into multiple PRs; 1 to add `monitor` support in the query, another to update the UI, and a final to remove `detector`, rather than doing all 3 in this PR.