### PR TITLE
fix(ACI): Update the query filters to show `monitor` instead of `detector`

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -31,7 +31,6 @@ export enum FieldKey {
   BOOKMARKS = 'bookmarks',
   BROWSER_NAME = 'browser.name',
   CULPRIT = 'culprit',
-  DETECTOR = 'detector',
   DEVICE = 'device',
   DEVICE_ARCH = 'device.arch',
   DEVICE_BATTERY_LEVEL = 'device.battery_level',
@@ -87,6 +86,7 @@ export enum FieldKey {
   LEVEL = 'level',
   LOCATION = 'location',
   MESSAGE = 'message',
+  MONITOR = 'monitor',
   OS = 'os',
   OS_BUILD = 'os.build',
   OS_KERNEL_VERSION = 'os.kernel_version',
@@ -178,7 +178,6 @@ type ErrorFieldKey =
   | FieldKey.ASSIGNED_OR_SUGGESTED
   | FieldKey.BOOKMARKS
   | FieldKey.CULPRIT
-  | FieldKey.DETECTOR
   | FieldKey.ERROR_HANDLED
   | FieldKey.ERROR_MECHANISM
   | FieldKey.ERROR_TYPE
@@ -199,6 +198,7 @@ type ErrorFieldKey =
   | FieldKey.LAST_SEEN
   | FieldKey.LEVEL
   | FieldKey.LOCATION
+  | FieldKey.MONITOR
   | FieldKey.STACK_ABS_PATH
   | FieldKey.STACK_COLNO
   | FieldKey.STACK_FILENAME
@@ -1959,12 +1959,6 @@ const ERROR_FIELD_DEFINITION: Record<ErrorFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.DETECTOR]: {
-    desc: t('The detector that triggered the issue'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-    allowWildcard: false,
-  },
   [FieldKey.ERROR_HANDLED]: {
     desc: t('Determines handling status of the error'),
     kind: FieldKind.FIELD,
@@ -2073,6 +2067,12 @@ const ERROR_FIELD_DEFINITION: Record<ErrorFieldKey, FieldDefinition> = {
     desc: t('Location of error'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+  },
+  [FieldKey.MONITOR]: {
+    desc: t('The monitor that triggered the issue'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
   },
   [FieldKey.STACK_ABS_PATH]: {
     desc: t('Absolute path to the source file'),
@@ -2747,7 +2747,6 @@ export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.ASSIGNED_OR_SUGGESTED,
   FieldKey.ASSIGNED,
   FieldKey.BOOKMARKS,
-  FieldKey.DETECTOR,
   FieldKey.FIRST_RELEASE,
   FieldKey.FIRST_SEEN,
   FieldKey.HAS,
@@ -2759,6 +2758,7 @@ export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.ISSUE_TYPE,
   FieldKey.ISSUE,
   FieldKey.LAST_SEEN,
+  FieldKey.MONITOR,
   FieldKey.RELEASE_STAGE,
   FieldKey.TIMES_SEEN,
 ];

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -70,7 +70,7 @@ export const DISCOVER_EXCLUSION_FIELDS: string[] = [
   'issue.type',
   'issue.seer_actionability',
   'issue.seer_last_run',
-  'detector',
+  'monitor',
 ];
 
 export const FOR_REVIEW_QUERIES: string[] = [Query.FOR_REVIEW];


### PR DESCRIPTION
# Description
Update the UI to show `monitor` instead of `detector`.

⚠️⚠️ This PR requires: https://github.com/getsentry/sentry/pull/114796 ⚠️⚠️

### Before
<img width="1181" height="560" alt="Screenshot 2026-05-04 at 3 57 09 PM" src="https://github.com/user-attachments/assets/b47f2c92-efe7-4455-acb9-26f135a589a4" />
<img width="1181" height="506" alt="Screenshot 2026-05-04 at 3 57 16 PM" src="https://github.com/user-attachments/assets/384d7cf5-aa15-417f-abcb-6f9171723d29" />

### After
<img width="981" height="469" alt="Screenshot 2026-05-04 at 3 56 50 PM" src="https://github.com/user-attachments/assets/c0297e23-85c5-4be9-9142-17c89489eab5" />
<img width="988" height="501" alt="Screenshot 2026-05-04 at 3 56 37 PM" src="https://github.com/user-attachments/assets/c21ff4a5-0419-41bb-b36f-d9f2738587b5" />

### Remaining Work
- [x] ~PR to add backend support for the keyword monitor~ [PR](https://github.com/getsentry/sentry/pull/114796)
- [x] ~PR to use monitor instead of detector in the UI~ [PR](https://github.com/getsentry/sentry/pull/114800)
- [ ] PR to remove detector from the backend support