### PR TITLE
fix(issues): When navigating issue groups, reset stack trace

### DIFF
--- a/static/app/components/stackTrace/issueStackTrace/index.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/index.tsx
@@ -143,6 +143,8 @@ export function IssueStackTrace(props: IssueStackTraceProps) {
           <PersistDisplayOptions setPersistedOptions={setPersistedOptions} />
         )}
         <IssueStackTraceContent
+          // Reset internal state when switching events
+          key={event.id}
           event={event}
           values={values}
           group={group}


### PR DESCRIPTION
resets the collapse state when navigating between events in an issue

fixes #68097