### PR TITLE
ref(flags): Make organizations:workflow-engine-log-evaluations permanent

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -133,6 +133,14 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "projects:servicehooks": False,
     }
 
+    # Permanent organization features that are controlled via flagpole rather than
+    # subscription plans. Typically backend-only debug/operational toggles
+    # (api_expose=False) that need to stick around long-term.
+    permanent_flagpole_organization_features = {
+        # Opt orgs in to logging workflow evaluations (bypasses sample rate when enabled).
+        "organizations:workflow-engine-log-evaluations": False,
+    }
+
     for org_feature, default in permanent_organization_features.items():
         manager.add(
             org_feature,
@@ -149,6 +157,15 @@ def register_permanent_features(manager: FeatureManager) -> None:
             FeatureHandlerStrategy.INTERNAL,
             default=default,
             api_expose=True,
+        )
+
+    for org_feature, default in permanent_flagpole_organization_features.items():
+        manager.add(
+            org_feature,
+            OrganizationFeature,
+            FeatureHandlerStrategy.FLAGPOLE,
+            default=default,
+            api_expose=False,
         )
 
     # Enable support for multiple regions, and org slug subdomains (customer-domains).

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -133,9 +133,7 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "projects:servicehooks": False,
     }
 
-    # Permanent organization features that are controlled via flagpole rather than
-    # subscription plans. Typically backend-only debug/operational toggles
-    # (api_expose=False) that need to stick around long-term.
+    # Permanent organization features that are controlled via flagpole
     permanent_flagpole_organization_features = {
         # Opt orgs in to logging workflow evaluations (bypasses sample rate when enabled).
         "organizations:workflow-engine-log-evaluations": False,

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -432,8 +432,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:update-action-status", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable logging to debug workflow engine process workflows
     manager.add("organizations:workflow-engine-process-workflows-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable logging workflow evaluations (bypasses sample rate when enabled)
-    manager.add("organizations:workflow-engine-log-evaluations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable logs to debug various metric issue things
     manager.add("organizations:workflow-engine-metric-alert-dual-processing-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine


### PR DESCRIPTION
Move this flag over to be permanent

The flag is an org-level opt-in that forces evaluation logging on, bypassing the global `workflow_engine.evaluation_log_sample_rate`. Keeping it lets us flip on logging for a specific org during debugging without bumping the global sample rate.