### PR TITLE
ref(flags): Remove organizations:revoke-org-auth-on-slug-rename

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -250,8 +250,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:events-sql-grammar-api", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Add build code and build number to semver ordering
     manager.add("organizations:semver-ordering-with-build-code", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable revocation of org auth keys when a user renames an org slug
-    manager.add("organizations:revoke-org-auth-on-slug-rename", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable detecting SDK crashes during event processing
     manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Seer PR code review for GitHub Enterprise Server organizations

--- a/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
@@ -2,9 +2,8 @@ import logging
 from copy import deepcopy
 
 from django.db import IntegrityError, router, transaction
-from django.utils import timezone as django_timezone
 
-from sentry import features, roles
+from sentry import roles
 from sentry.constants import RESERVED_ORGANIZATION_SLUGS
 from sentry.db.models.utils import slugify_instance
 from sentry.hybridcloud.models.outbox import CellOutbox, ControlOutbox, outbox_context
@@ -15,7 +14,6 @@ from sentry.hybridcloud.services.control_organization_provisioning import (
     RpcOrganizationSlugReservation,
     serialize_slug_reservation,
 )
-from sentry.hybridcloud.services.organization_mapping.serial import serialize_organization_mapping
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
@@ -24,7 +22,6 @@ from sentry.models.organizationslugreservation import (
     OrganizationSlugReservation,
     OrganizationSlugReservationType,
 )
-from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.services.organization import OrganizationProvisioningOptions
 from sentry.utils import json
@@ -226,18 +223,6 @@ class DatabaseBackedControlOrganizationProvisioningService(
                     reservation_type=OrganizationSlugReservationType.TEMPORARY_RENAME_ALIAS.value,
                 ).save(unsafe_write=True)
 
-                org_mapping = OrganizationMapping.objects.filter(
-                    organization_id=organization_id
-                ).first()
-                org = (
-                    serialize_organization_mapping(org_mapping) if org_mapping is not None else None
-                )
-                if org and features.has("organizations:revoke-org-auth-on-slug-rename", org):
-                    # Changing a slug invalidates all org tokens, so revoke them all.
-                    auth_tokens = OrgAuthToken.objects.filter(
-                        organization_id=organization_id, date_deactivated__isnull=True
-                    )
-                    auth_tokens.update(date_deactivated=django_timezone.now())
         except IntegrityError as e:
             # Check if this is a unique constraint violation on the slug
             if "sentry_organizationslugreservation_slug_key" in str(e):

--- a/tests/sentry/hybridcloud/services/test_control_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/services/test_control_organization_provisioning.py
@@ -27,7 +27,6 @@ from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, create_t
 from sentry.types.cell import get_local_cell
 from sentry.users.models.user import User
 from sentry.users.services.user.serial import serialize_generic_user
-from sentry.utils.security.orgauthtoken_token import hash_token
 
 
 class TestControlOrganizationProvisioningBase(TestCase):
@@ -382,27 +381,3 @@ class TestControlOrganizationProvisioningSlugUpdates(TestControlOrganizationProv
         with assume_test_silo_mode(SiloMode.CELL):
             org.refresh_from_db()
             assert org.slug == desired_slug
-
-    def test_update_slug_revokes_auth_tokens(self) -> None:
-        self.organization = self.create_organization(
-            slug="old-slug", name="org", owner=self.create_user()
-        )
-        token_str = "sntrys_abc123_xyz"
-        token = self.create_org_auth_token(
-            organization_id=self.organization.id,
-            scope_list=[],
-            name="test_token",
-            token_hashed=hash_token(token_str),
-            date_last_used=None,
-        )
-        assert token.date_deactivated is None
-        with self.feature("organizations:revoke-org-auth-on-slug-rename"):
-            control_organization_provisioning_rpc_service.update_organization_slug(
-                organization_id=self.organization.id,
-                desired_slug="new-slug",
-                require_exact=True,
-                cell_name=self.cell_name,
-            )
-
-            token.refresh_from_db()
-            assert token.date_deactivated is not None


### PR DESCRIPTION
The flag scanner classified this as flagpole-disabled. The flag gated revoking OrgAuthTokens when a slug is renamed; with it always False the revocation block never ran. Removes the dead block, now-unused imports, and the corresponding test.

<!-- Describe your PR here. -->