### PR TITLE
ref(flags): Remove organizations:on-demand-gen-metrics-deprecation-prefill

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -517,7 +517,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:traces-overlay-charts-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Conversation focused views in AI Insights
     manager.add("organizations:gen-ai-conversations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:on-demand-gen-metrics-deprecation-prefill", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:on-demand-gen-metrics-deprecation-query-prefill", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables Conduit demo endpoint and UI
     manager.add("organizations:conduit-demo", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -333,14 +333,11 @@ class OrganizationOnDemandRuleStatsEndpoint(OrganizationEndpoint):
         project = projects[0]
         enabled_features = on_demand_metrics_feature_flags(organization)
         prefilling = "organizations:on-demand-metrics-prefill" in enabled_features
-        prefilling_for_deprecation = (
-            "organizations:on-demand-gen-metrics-deprecation-prefill" in enabled_features
-        )
         alert_specs = get_default_version_alert_metric_specs(
             project,
             enabled_features,
             prefilling,
-            prefilling_for_deprecation=prefilling_for_deprecation,
+            prefilling_for_deprecation=False,
         )
 
         return Response(

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -2067,14 +2067,10 @@ def schedule_update_project_config(
     """
     enabled_features = on_demand_metrics_feature_flags(_unpack_organization(alert_rule))
     prefilling = "organizations:on-demand-metrics-prefill" in enabled_features
-    prefilling_for_deprecation = (
-        "organizations:on-demand-gen-metrics-deprecation-prefill" in enabled_features
-    )
     if (
         not projects
         or "organizations:on-demand-metrics-extraction" not in enabled_features
         and not prefilling
-        and not prefilling_for_deprecation
     ):
         return
 
@@ -2085,7 +2081,7 @@ def schedule_update_project_config(
         alert_snuba_query.query,
         None,
         prefilling,
-        prefilling_for_deprecation=prefilling_for_deprecation,
+        prefilling_for_deprecation=False,
     )
     if should_use_on_demand:
         for project in projects:

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -70,14 +70,7 @@ def schedule_update_project_config(detector: Detector) -> None:
     """
     enabled_features = on_demand_metrics_feature_flags(detector.project.organization)
     prefilling = "organizations:on-demand-metrics-prefill" in enabled_features
-    prefilling_for_deprecation = (
-        "organizations:on-demand-gen-metrics-deprecation-prefill" in enabled_features
-    )
-    if (
-        "organizations:on-demand-metrics-extraction" not in enabled_features
-        and not prefilling
-        and not prefilling_for_deprecation
-    ):
+    if "organizations:on-demand-metrics-extraction" not in enabled_features and not prefilling:
         return
 
     snuba_query = fetch_snuba_query(detector)
@@ -90,7 +83,7 @@ def schedule_update_project_config(detector: Detector) -> None:
         snuba_query.query,
         None,
         prefilling,
-        prefilling_for_deprecation=prefilling_for_deprecation,
+        prefilling_for_deprecation=False,
     )
     if should_use_on_demand:
         schedule_invalidate_project_config(

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -139,16 +139,13 @@ def get_on_demand_metric_specs(
     timeout.check()
 
     prefilling = "organizations:on-demand-metrics-prefill" in enabled_features
-    prefilling_for_deprecation = (
-        "organizations:on-demand-gen-metrics-deprecation-prefill" in enabled_features
-    )
 
     with sentry_sdk.start_span(op="get_alert_metric_specs"):
         alert_specs = _get_alert_metric_specs(
             project,
             enabled_features,
             prefilling,
-            prefilling_for_deprecation=prefilling_for_deprecation,
+            prefilling_for_deprecation=False,
         )
     timeout.check()
     with sentry_sdk.start_span(op="get_widget_metric_specs"):
@@ -164,7 +161,6 @@ def on_demand_metrics_feature_flags(organization: Organization) -> set[str]:
         "organizations:on-demand-metrics-extraction-widgets",  # Controls extraction for widgets
         "organizations:on-demand-metrics-extraction-experimental",
         "organizations:on-demand-metrics-prefill",
-        "organizations:on-demand-gen-metrics-deprecation-prefill",
     ]
 
     enabled_features = set()

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -43,9 +43,6 @@ from sentry.testutils.pytest.fixtures import django_db_all
 ON_DEMAND_METRICS = "organizations:on-demand-metrics-extraction"
 ON_DEMAND_METRICS_WIDGETS = "organizations:on-demand-metrics-extraction-widgets"
 ON_DEMAND_METRICS_PREFILL = "organizations:on-demand-metrics-prefill"
-ON_DEMAND_METRICS_PREFILL_FOR_DEPRECATION = (
-    "organizations:on-demand-gen-metrics-deprecation-prefill"
-)
 
 
 def create_alert(
@@ -1952,7 +1949,6 @@ def test_get_metric_extraction_config_epm_eps(
         ([ON_DEMAND_METRICS], 1),  # Alerts.
         ([ON_DEMAND_METRICS_PREFILL], 1),  # Alerts.
         ([ON_DEMAND_METRICS, ON_DEMAND_METRICS_PREFILL], 1),  # Alerts.
-        ([ON_DEMAND_METRICS, ON_DEMAND_METRICS_PREFILL_FOR_DEPRECATION], 2),  # Alerts.
         # Revert to 2 after {"include_environment_tag"} becomes the default
         ([ON_DEMAND_METRICS, ON_DEMAND_METRICS_WIDGETS], 3),  # Alerts and widgets.
         # Revert to 1 after {"include_environment_tag"} becomes the default


### PR DESCRIPTION
The flag scanner classified this as flagpole-disabled. The flag fed into prefilling_for_deprecation at four call sites; with it always False those sites just pass False through. The parameter on downstream functions is preserved for now.

<!-- Describe your PR here. -->