### PR TITLE
ref(flags): Remove organizations:sentry-app-webhook-requests

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -391,7 +391,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Organizations on the new seat-based Seer plan
     manager.add("organizations:seat-based-seer-enabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable new SentryApp webhook request endpoint
-    manager.add("organizations:sentry-app-webhook-requests", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable mobile starfish ui module view
     manager.add("organizations:starfish-mobile-ui-module", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Allow organizations to configure all symbol sources.

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_webhook_requests.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_webhook_requests.py
@@ -6,7 +6,6 @@ from requests.models import Response
 
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test, create_test_cells
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
@@ -54,7 +53,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         self.mock_request.body = "mock request body"
         self.mock_response.request = self.mock_request
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_superuser_sees_unowned_published_requests(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
 
@@ -82,7 +80,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert response.data[0]["sentryAppSlug"] == self.unowned_published_app.slug
         assert response.data[0]["responseCode"] == 200
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_superuser_sees_unpublished_stats(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
 
@@ -102,7 +99,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert len(response.data) == 1
         assert response.data[0]["sentryAppSlug"] == self.unowned_unpublished_app.slug
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_user_sees_owned_published_requests(self) -> None:
         self.login_as(user=self.user)
 
@@ -122,7 +118,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert response.data[0]["sentryAppSlug"] == self.published_app.slug
         assert response.data[0]["responseCode"] == 200
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_user_does_not_see_unowned_published_requests(self) -> None:
         self.login_as(user=self.user)
 
@@ -141,7 +136,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert response.status_code == 403
         assert response.data["detail"] == "You do not have permission to perform this action."
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_user_sees_owned_unpublished_requests(self) -> None:
         self.login_as(user=self.user)
 
@@ -158,7 +152,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert response.status_code == 200
         assert len(response.data) == 1
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_internal_app_requests_does_not_have_organization_field(self) -> None:
         self.login_as(user=self.user)
         buffer = SentryAppWebhookRequestsBuffer(self.internal_app)
@@ -177,7 +170,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert response.data[0]["sentryAppSlug"] == self.internal_app.slug
         assert response.data[0]["responseCode"] == 200
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_event_type_filter(self) -> None:
         self.login_as(user=self.user)
         buffer = SentryAppWebhookRequestsBuffer(self.published_app)
@@ -211,7 +203,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert response3.data[0]["sentryAppSlug"] == self.published_app.slug
         assert response3.data[0]["responseCode"] == 400
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_invalid_event_type(self) -> None:
         self.login_as(user=self.user)
 
@@ -220,7 +211,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
 
         assert response.status_code == 400
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_errors_only_filter(self) -> None:
         self.login_as(user=self.user)
         buffer = SentryAppWebhookRequestsBuffer(self.published_app)
@@ -267,7 +257,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert response.status_code == 200
         assert len(response.data) == 2
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_linked_error_not_returned_if_project_does_not_exist(self) -> None:
         self.login_as(user=self.user)
 
@@ -294,7 +283,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert response.data[0]["sentryAppSlug"] == self.published_app.slug
         assert "errorUrl" not in response.data[0]
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_org_slug_filter(self) -> None:
         """Test that filtering by the qparam organizationSlug properly filters results"""
         self.login_as(user=self.user)
@@ -325,7 +313,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert response.status_code == 200
         assert len(response.data) == 2
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_date_filter(self) -> None:
         """Test that filtering by the qparams start and end properly filters results"""
         self.login_as(user=self.user)
@@ -390,7 +377,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         )
         assert start_after_end_response.status_code == 400
 
-    @with_feature("organizations:sentry-app-webhook-requests")
     def test_get_includes_installation_requests(self) -> None:
         self.login_as(user=self.user)
         buffer = SentryAppWebhookRequestsBuffer(self.published_app)


### PR DESCRIPTION
The flag scanner classified this as flagpole-disabled. The flag was never actually checked anywhere in code — the scanner saw the URL route name sentry-api-0-sentry-app-webhook-requests but that is not a feature gate. Only the registration and the @with_feature test decorators existed; dropping both.
