### PR TITLE
ref(flags): Remove organizations:continuous-profiling-beta-ui (frontend)

### DIFF
--- a/static/app/components/profiling/billing/alerts.tsx
+++ b/static/app/components/profiling/billing/alerts.tsx
@@ -4,14 +4,6 @@ export const ProfilingBetaAlertBanner = HookOrDefault({
   hookName: 'component:profiling-billing-banner',
 });
 
-export const ContinuousProfilingBetaAlertBanner = HookOrDefault({
-  hookName: 'component:continuous-profiling-beta-banner',
-});
-
-export const ContinuousProfilingBetaSDKAlertBanner = HookOrDefault({
-  hookName: 'component:continuous-profiling-beta-sdk-banner',
-});
-
 export const ContinuousProfilingBillingRequirementBanner = HookOrDefault({
   hookName: 'component:continuous-profiling-billing-requirement-banner',
 });

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -110,10 +110,6 @@ type ProfilingBetaAlertBannerProps = {
   organization: Organization;
 };
 
-type ContinuousProfilingBetaAlertBannerProps = {
-  organization: Organization;
-};
-
 type ContinuousProfilingBillingRequirementBannerProps = {
   project: Project;
 };
@@ -200,8 +196,6 @@ type ComponentHooks = {
   'component:ai-setup-data-consent': () => React.ComponentType<AiSetupDataConsentProps> | null;
   'component:codecov-integration-settings-link': () => React.ComponentType<CodecovLinkProps>;
   'component:confirm-account-close': () => React.ComponentType<AttemptCloseAttemptProps>;
-  'component:continuous-profiling-beta-banner': () => React.ComponentType<ContinuousProfilingBetaAlertBannerProps>;
-  'component:continuous-profiling-beta-sdk-banner': () => React.ComponentType;
   'component:continuous-profiling-billing-requirement-banner': () => React.ComponentType<ContinuousProfilingBillingRequirementBannerProps>;
   'component:crons-list-page-header': () => React.ComponentType<CronsBillingBannerProps>;
   'component:crons-onboarding-panel': () => React.ComponentType<CronsOnboardingPanelProps>;

--- a/static/app/views/explore/profiling/content.tsx
+++ b/static/app/views/explore/profiling/content.tsx
@@ -8,7 +8,6 @@ import {Stack} from '@sentry/scraps/layout';
 import {Pagination} from '@sentry/scraps/pagination';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
-import Feature from 'sentry/components/acl/feature';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
@@ -20,11 +19,7 @@ import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPa
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {TransactionSearchQueryBuilder} from 'sentry/components/performance/transactionSearchQueryBuilder';
-import {
-  ContinuousProfilingBetaAlertBanner,
-  ContinuousProfilingBetaSDKAlertBanner,
-  ProfilingBetaAlertBanner,
-} from 'sentry/components/profiling/billing/alerts';
+import {ProfilingBetaAlertBanner} from 'sentry/components/profiling/billing/alerts';
 import {ProfileEventsTable} from 'sentry/components/profiling/profileEventsTable';
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -165,10 +160,6 @@ export default function ProfilingContent() {
       >
         <Stack flex={1}>
           <ProfilingBetaAlertBanner organization={organization} />
-          <Feature features="continuous-profiling-beta-ui">
-            <ContinuousProfilingBetaAlertBanner organization={organization} />
-            <ContinuousProfilingBetaSDKAlertBanner />
-          </Feature>
           <ProfilingContentPageHeader />
           <ExploreBodySearch>
             <Layout.Main width="full">

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -1,21 +1,17 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconClose, IconInfo, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {getDaysSinceDate} from 'sentry/utils/getDaysSinceDate';
 import {getProfileDurationCategoryForPlatform} from 'sentry/utils/profiling/platforms';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import {useDismissAlert} from 'sentry/utils/useDismissAlert';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -271,52 +267,6 @@ export const ProfilingBetaAlertBanner = withSubscription(
   {noLoader: true}
 );
 
-export function ContinuousProfilingBetaSDKAlertBanner() {
-  const sdkDeprecationResults = useSDKDeprecations();
-
-  const sdkDeprecations = useMemo(() => {
-    const sdks = new Map<string, SDKDeprecation>();
-
-    for (const sdk of sdkDeprecationResults.data?.data ?? []) {
-      const key = `${sdk.sdkName}:${sdk.sdkVersion}`;
-      sdks.set(key, sdk);
-    }
-
-    return sdks;
-  }, [sdkDeprecationResults.data?.data]);
-
-  if (sdkDeprecations.size <= 0) {
-    return null;
-  }
-
-  return (
-    <Alert.Container>
-      <Alert system variant="warning">
-        {tct(
-          '[bold:Action Needed: Profiling beta period ends May 19, 2025.] Your SDK is out of date. To continue using profiling without interruption, upgrade to the latest version:',
-          {
-            bold: <b />,
-          }
-        )}
-        <SDKDeprecationsContainer>
-          {sdkDeprecations.values().map(sdk => {
-            const key = `${sdk.projectId}-${sdk.sdkName}-${sdk.sdkVersion}`;
-            return (
-              <Flex as="li" align="baseline" key={key}>
-                <Dot />
-                {tct('[name] minimum version [version]', {
-                  name: <code>{sdk.sdkName}</code>,
-                  version: <code>{sdk.minimumVersion}</code>,
-                })}
-              </Flex>
-            );
-          })}
-        </SDKDeprecationsContainer>
-      </Alert>
-    </Alert.Container>
-  );
-}
-
 interface ContinuousProfilingBillingRequirementBanner {
   project: Project;
 }
@@ -535,49 +485,6 @@ function OnDemandOrPaygBanner({
     </Alert>
   );
 }
-
-interface SDKDeprecation {
-  minimumVersion: string;
-  projectId: string;
-  sdkName: string;
-  sdkVersion: string;
-}
-
-function useSDKDeprecations() {
-  const organization = useOrganization();
-  const {selection} = usePageFilters();
-
-  const path = getApiUrl('/organizations/$organizationIdOrSlug/sdk-deprecations/', {
-    path: {organizationIdOrSlug: organization.slug},
-  });
-  const options = {
-    query: {
-      project: selection.projects,
-      event_type: 'profile',
-    },
-  };
-
-  return useApiQuery<{data: SDKDeprecation[]}>([path, options], {
-    staleTime: 0,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-    retry: false,
-  });
-}
-
-const SDKDeprecationsContainer = styled('ul')`
-  margin: 0;
-`;
-
-const Dot = styled('span')`
-  display: inline-block;
-  margin-right: ${p => p.theme.space.md};
-  border-radius: ${p => p.theme.radius.md};
-  width: ${p => p.theme.space.xs};
-  height: ${p => p.theme.space.xs};
-  /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
-  background-color: ${p => p.theme.tokens.content.primary};
-`;
 
 const AlertBody = styled('div')`
   margin-bottom: ${p => p.theme.space.md};

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -82,7 +82,6 @@ import {GsBillingCommandPaletteActions} from './components/gsBillingCommandPalet
 import {PrimaryNavigationQuotaExceeded} from './components/navBillingStatus';
 import {OpenInDiscoverBtn} from './components/openInDiscoverBtn';
 import {
-  ContinuousProfilingBetaSDKAlertBanner,
   ContinuousProfilingBillingRequirementBanner,
   ProfilingBetaAlertBanner,
 } from './components/profiling/alerts';
@@ -229,8 +228,6 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:ai-setup-configuration': () => AiSetupConfiguration,
   'component:ai-setup-data-consent': () => AiSetupDataConsent,
   'component:codecov-integration-settings-link': () => CodecovSettingsLink,
-  'component:continuous-profiling-beta-sdk-banner': () =>
-    ContinuousProfilingBetaSDKAlertBanner,
   'component:continuous-profiling-billing-requirement-banner': () =>
     ContinuousProfilingBillingRequirementBanner,
   'component:header-date-page-filter-upsell-footer': () => DateRangeQueryLimitFooter,


### PR DESCRIPTION
The flag scanner classified this as flagpole-disabled. The flag gated a pair of beta banners on the Profiling page; with it always False the banners never render.

Removes the Feature wrapper and unused banner components (ContinuousProfilingBetaAlertBanner, ContinuousProfilingBetaSDKAlertBanner), their hook type declarations, the gsApp implementation + hook registration, and the SDKDeprecation helpers that only supported the SDK banner.

The backend registration removal will follow in a separate PR.

<!-- Describe your PR here. -->