### PR TITLE
fix(ACI): Update `detector` to be `monitor` for the UI in issue search

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -911,7 +911,6 @@ SKIP_SNUBA_FIELDS = frozenset(
     (
         "status",
         "substatus",
-        "detector",  # TODO - delete this once the UI has been updated
         "monitor",
         "bookmarked_by",
         "assigned_to",

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -286,7 +286,6 @@ value_converters: Mapping[str, ValueConverter] = {
     "device.class": convert_device_class_value,
     "substatus": convert_substatus_value,
     "issue.seer_actionability": convert_seer_actionability_value,
-    "detector": convert_detector_value,  # TODO - delete this once the UI has been updated
     "monitor": convert_detector_value,
 }
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -587,9 +587,6 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "regressed_in_release": QCallbackCondition(
                 functools.partial(regressed_in_release_filter, projects=projects)
             ),
-            "detector": QCallbackCondition(
-                _make_detector_filter
-            ),  # TODO - delete this once the UI has been updated
             "monitor": QCallbackCondition(_make_detector_filter),
             "issue.category": QCallbackCondition(lambda categories: Q(type__in=categories)),
             "issue.type": QCallbackCondition(lambda types: Q(type__in=types)),

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -73,7 +73,6 @@ _FIELD_VALUE_TYPES: dict[str, str] = {
     "issue": "issue_short_id",
     "device.class": "device_class",
     "timesSeen": "integer",
-    "detector": "dynamic_id",  # TODO - delete this once the UI has been updated
     "monitor": "dynamic_id",
 }
 

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -31,7 +31,6 @@ export enum FieldKey {
   BOOKMARKS = 'bookmarks',
   BROWSER_NAME = 'browser.name',
   CULPRIT = 'culprit',
-  DETECTOR = 'detector',
   DEVICE = 'device',
   DEVICE_ARCH = 'device.arch',
   DEVICE_BATTERY_LEVEL = 'device.battery_level',
@@ -87,6 +86,7 @@ export enum FieldKey {
   LEVEL = 'level',
   LOCATION = 'location',
   MESSAGE = 'message',
+  MONITOR = 'monitor',
   OS = 'os',
   OS_BUILD = 'os.build',
   OS_KERNEL_VERSION = 'os.kernel_version',
@@ -178,7 +178,6 @@ type ErrorFieldKey =
   | FieldKey.ASSIGNED_OR_SUGGESTED
   | FieldKey.BOOKMARKS
   | FieldKey.CULPRIT
-  | FieldKey.DETECTOR
   | FieldKey.ERROR_HANDLED
   | FieldKey.ERROR_MECHANISM
   | FieldKey.ERROR_TYPE
@@ -199,6 +198,7 @@ type ErrorFieldKey =
   | FieldKey.LAST_SEEN
   | FieldKey.LEVEL
   | FieldKey.LOCATION
+  | FieldKey.MONITOR
   | FieldKey.STACK_ABS_PATH
   | FieldKey.STACK_COLNO
   | FieldKey.STACK_FILENAME
@@ -1959,12 +1959,6 @@ const ERROR_FIELD_DEFINITION: Record<ErrorFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.DETECTOR]: {
-    desc: t('The detector that triggered the issue'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-    allowWildcard: false,
-  },
   [FieldKey.ERROR_HANDLED]: {
     desc: t('Determines handling status of the error'),
     kind: FieldKind.FIELD,
@@ -2073,6 +2067,12 @@ const ERROR_FIELD_DEFINITION: Record<ErrorFieldKey, FieldDefinition> = {
     desc: t('Location of error'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+  },
+  [FieldKey.MONITOR]: {
+    desc: t('The monitor that triggered the issue'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
   },
   [FieldKey.STACK_ABS_PATH]: {
     desc: t('Absolute path to the source file'),
@@ -2747,7 +2747,6 @@ export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.ASSIGNED_OR_SUGGESTED,
   FieldKey.ASSIGNED,
   FieldKey.BOOKMARKS,
-  FieldKey.DETECTOR,
   FieldKey.FIRST_RELEASE,
   FieldKey.FIRST_SEEN,
   FieldKey.HAS,
@@ -2759,6 +2758,7 @@ export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.ISSUE_TYPE,
   FieldKey.ISSUE,
   FieldKey.LAST_SEEN,
+  FieldKey.MONITOR,
   FieldKey.RELEASE_STAGE,
   FieldKey.TIMES_SEEN,
 ];

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -70,7 +70,7 @@ export const DISCOVER_EXCLUSION_FIELDS: string[] = [
   'issue.type',
   'issue.seer_actionability',
   'issue.seer_last_run',
-  'detector',
+  'monitor',
 ];
 
 export const FOR_REVIEW_QUERIES: string[] = [Query.FOR_REVIEW];

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2517,47 +2517,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             == []
         )
 
-    # TODO - Delete this test once the UI has been updated
-    def test_query_detector_filter(self) -> None:
-        event = self.store_event(
-            data={"timestamp": before_now(seconds=500).isoformat(), "fingerprint": ["group-1"]},
-            project_id=self.project.id,
-        )
-        group = event.group
-
-        event2 = self.store_event(
-            data={"timestamp": before_now(seconds=400).isoformat(), "fingerprint": ["group-2"]},
-            project_id=self.project.id,
-        )
-        assert event2.group.id != group.id
-
-        detector_id = 12345  # intentionally multi-digit
-        detector = self.create_detector(
-            id=detector_id,
-            name=f"Test Detector {detector_id}",
-            project=self.project,
-            type="error",
-        )
-
-        self.create_detector_group(
-            detector=detector,
-            group=group,
-        )
-
-        self.login_as(user=self.user)
-
-        # Query for the specific detector ID
-        response = self.get_response(sort_by="date", query=f"detector:{detector_id}")
-        assert response.status_code == 200
-
-        # Should return only the group associated with the detector
-        assert len(response.data) == 1
-        assert int(response.data[0]["id"]) == group.id
-
-        response_empty = self.get_response(sort_by="date", query="detector:99999")
-        assert response_empty.status_code == 200
-        assert len(response_empty.data) == 0
-
     def test_query_monitor_filter(self) -> None:
         event = self.store_event(
             data={"timestamp": before_now(seconds=500).isoformat(), "fingerprint": ["group-1"]},


### PR DESCRIPTION
# Description
Last phase of the rename / cleanup; this will remove the legacy references to detector and only support monitor.

1. Update the BE to support both monitor and detector [[PR](https://github.com/getsentry/sentry/pull/114796)]
2. Update the UI [[PR](https://github.com/getsentry/sentry/pull/114800)]
3. This PR! 🎉 Cleans up the remnants.