### PR TITLE
feat(webhooks): Add live-run flag to override circuit breaker dry-run

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -525,6 +525,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sentry-app-webhook-hard-timeout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable circuit breaker for webhook endpoint failure detection
     manager.add("organizations:sentry-app-webhook-circuit-breaker", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Override dry-run to enable real blocking per app-owner org during rollout
+    manager.add("organizations:sentry-app-webhook-circuit-breaker-live-run", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     # Enables organization access to the new notification platform
     manager.add("organizations:notification-platform.internal-testing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -139,17 +139,11 @@ def _notify_webhook_disabled(
     if not email or "@" not in email:
         return
 
-    dry_run_option = options.get("sentry-apps.webhook.circuit-breaker.dry-run")
-    live_run_flag = features.has(
+    live_run = features.has(
         "organizations:sentry-app-webhook-circuit-breaker-live-run",
         owner_org,
     )
-    # live-run flag overrides the dry-run option so we can roll out real
-    # blocking/emailing per app-owner org while still collecting dry-run
-    # data from the rest of the population.
-    dry_run = dry_run_option and not live_run_flag
-
-    if dry_run:
+    if not live_run:
         if not set_dedup_key(sentry_app, circuit_breaker):
             return
         logger.info(
@@ -194,16 +188,11 @@ def _circuit_breaker_allows_request(
     if circuit_breaker is None or circuit_breaker.should_allow_request():
         return True
 
-    dry_run_option = options.get("sentry-apps.webhook.circuit-breaker.dry-run")
-    live_run_flag = owner_org is not None and features.has(
+    live_run = owner_org is not None and features.has(
         "organizations:sentry-app-webhook-circuit-breaker-live-run",
         owner_org,
     )
-    # live-run flag overrides the dry-run option so we can roll out real
-    # blocking/emailing per app-owner org while still collecting dry-run
-    # data from the rest of the population.
-    dry_run = dry_run_option and not live_run_flag
-    if dry_run:
+    if not live_run:
         metrics.incr(
             "sentry_app.webhook.circuit_breaker.would_block",
             tags={"slug": sentry_app.slug},

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -25,7 +25,10 @@ from sentry.notifications.platform.types import (
     NotificationProviderKey,
     NotificationTargetResourceType,
 )
-from sentry.organizations.services.organization.model import RpcUserOrganizationContext
+from sentry.organizations.services.organization.model import (
+    RpcOrganization,
+    RpcUserOrganizationContext,
+)
 from sentry.organizations.services.organization.service import organization_service
 from sentry.sentry_apps.metrics import (
     SentryAppEventType,
@@ -130,24 +133,32 @@ def set_dedup_key(sentry_app: SentryApp | RpcSentryApp, circuit_breaker: Circuit
 def _notify_webhook_disabled(
     circuit_breaker: CircuitBreaker,
     sentry_app: SentryApp | RpcSentryApp,
-    owner_context: RpcUserOrganizationContext | None,
+    owner_org: RpcOrganization,
 ) -> None:
     email = sentry_app.creator_label
     if not email or "@" not in email:
         return
 
-    if owner_context is None:
-        return
-    owner_org = owner_context.organization
+    dry_run_option = options.get("sentry-apps.webhook.circuit-breaker.dry-run")
+    live_run_flag = features.has(
+        "organizations:sentry-app-webhook-circuit-breaker-live-run",
+        owner_org,
+    )
+    # live-run flag overrides the dry-run option so we can roll out real
+    # blocking/emailing per app-owner org while still collecting dry-run
+    # data from the rest of the population.
+    dry_run = dry_run_option and not live_run_flag
 
-    if not set_dedup_key(sentry_app, circuit_breaker):
-        return
-
-    if options.get("sentry-apps.webhook.circuit-breaker.dry-run"):
+    if dry_run:
+        if not set_dedup_key(sentry_app, circuit_breaker):
+            return
         logger.info(
             "sentry_app.webhook.circuit_breaker.would_email",
             extra={"slug": sentry_app.slug},
         )
+        return
+
+    if not set_dedup_key(sentry_app, circuit_breaker):
         return
 
     data = SentryAppWebhookDisabled(
@@ -178,11 +189,20 @@ def _circuit_breaker_allows_request(
     sentry_app: SentryApp | RpcSentryApp,
     org_id: int,
     lifecycle: EventLifecycle,
+    owner_org: RpcOrganization | None,
 ) -> bool:
     if circuit_breaker is None or circuit_breaker.should_allow_request():
         return True
 
-    dry_run = options.get("sentry-apps.webhook.circuit-breaker.dry-run")
+    dry_run_option = options.get("sentry-apps.webhook.circuit-breaker.dry-run")
+    live_run_flag = owner_org is not None and features.has(
+        "organizations:sentry-app-webhook-circuit-breaker-live-run",
+        owner_org,
+    )
+    # live-run flag overrides the dry-run option so we can roll out real
+    # blocking/emailing per app-owner org while still collecting dry-run
+    # data from the rest of the population.
+    dry_run = dry_run_option and not live_run_flag
     if dry_run:
         metrics.incr(
             "sentry_app.webhook.circuit_breaker.would_block",
@@ -280,17 +300,20 @@ def send_and_save_webhook_request(
                 include_projects=False,
                 include_teams=False,
             )
+            owner_org = owner_context.organization if owner_context is not None else None
             circuit_breaker = _create_circuit_breaker(sentry_app, owner_context)
-            if not _circuit_breaker_allows_request(circuit_breaker, sentry_app, org_id, lifecycle):
+            if not _circuit_breaker_allows_request(
+                circuit_breaker, sentry_app, org_id, lifecycle, owner_org
+            ):
                 return Response()
 
             with circuit_breaker_tracking(circuit_breaker):
                 response = _send_webhook_request(url, app_platform_event, owner_context)
 
         except WebhookTimeoutError:
-            if circuit_breaker and circuit_breaker.is_open():
+            if circuit_breaker and circuit_breaker.is_open() and owner_org is not None:
                 try:
-                    _notify_webhook_disabled(circuit_breaker, sentry_app, owner_context)
+                    _notify_webhook_disabled(circuit_breaker, sentry_app, owner_org)
                 except Exception as email_error:
                     lifecycle.add_extras(
                         {"reason_str": str(SentryAppWebhookHaltReason.EMAIL_FAILED)}

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -190,15 +190,15 @@ def _circuit_breaker_allows_request(
         "organizations:sentry-app-webhook-circuit-breaker-live-run",
         owner_org,
     )
+    metrics.incr(
+        "sentry_app.webhook.circuit_breaker.would_block",
+        tags={"slug": sentry_app.slug, "live_run": live_run},
+    )
+    logger.warning(
+        "sentry_app.webhook.circuit_breaker.would_block",
+        extra={"slug": sentry_app.slug, "org_id": org_id, "live_run": live_run},
+    )
     if not live_run:
-        metrics.incr(
-            "sentry_app.webhook.circuit_breaker.would_block",
-            tags={"slug": sentry_app.slug},
-        )
-        logger.warning(
-            "sentry_app.webhook.circuit_breaker.would_block",
-            extra={"slug": sentry_app.slug, "org_id": org_id},
-        )
         return True
 
     lifecycle.record_halt(

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -139,20 +139,18 @@ def _notify_webhook_disabled(
     if not email or "@" not in email:
         return
 
+    if not set_dedup_key(sentry_app, circuit_breaker):
+        return
+
     live_run = features.has(
         "organizations:sentry-app-webhook-circuit-breaker-live-run",
         owner_org,
     )
     if not live_run:
-        if not set_dedup_key(sentry_app, circuit_breaker):
-            return
         logger.info(
             "sentry_app.webhook.circuit_breaker.would_email",
             extra={"slug": sentry_app.slug},
         )
-        return
-
-    if not set_dedup_key(sentry_app, circuit_breaker):
         return
 
     data = SentryAppWebhookDisabled(

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -111,6 +111,25 @@ class WebhookCircuitBreakerTest(TestCase):
         # Webhook is blocked — no HTTP call made
         mock_safe_urlopen.assert_not_called()
 
+    @with_feature(
+        [
+            "organizations:sentry-app-webhook-circuit-breaker",
+            "organizations:sentry-app-webhook-circuit-breaker-live-run",
+        ]
+    )
+    @override_options(
+        {**CIRCUIT_BREAKER_OPTIONS, "sentry-apps.webhook.circuit-breaker.dry-run": True}
+    )
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_live_run_flag_overrides_dry_run_and_blocks(self, MockBreaker, mock_safe_urlopen):
+        """Live-run flag takes precedence over dry-run option, blocking the webhook."""
+        mock_breaker_instance = MockBreaker.return_value
+        mock_breaker_instance.should_allow_request.return_value = False
+
+        send_and_save_webhook_request(self.sentry_app, self._make_event())
+        mock_safe_urlopen.assert_not_called()
+
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -271,6 +290,31 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
             send_and_save_webhook_request(self.sentry_app, self._make_event())
 
         MockService.return_value.notify_async.assert_not_called()
+
+    @with_feature(
+        [
+            "organizations:sentry-app-webhook-circuit-breaker",
+            "organizations:sentry-app-webhook-circuit-breaker-live-run",
+        ]
+    )
+    @override_options(
+        {**CIRCUIT_BREAKER_OPTIONS, "sentry-apps.webhook.circuit-breaker.dry-run": True}
+    )
+    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_live_run_flag_sends_email_despite_dry_run_option(
+        self, MockBreaker, mock_safe_urlopen, MockService
+    ):
+        """Live-run flag takes precedence over dry-run option, sending the real email."""
+        self._configure_breaker(MockBreaker, is_open=True)
+        MockService.has_access.return_value = True
+        mock_safe_urlopen.side_effect = WebhookTimeoutError()
+
+        with pytest.raises(WebhookTimeoutError):
+            send_and_save_webhook_request(self.sentry_app, self._make_event())
+
+        MockService.return_value.notify_async.assert_called_once()
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -35,7 +35,6 @@ CIRCUIT_BREAKER_OPTIONS = {
         "threshold": 0.5,
         "floor": 5,  # low floor for testing
     },
-    "sentry-apps.webhook.circuit-breaker.dry-run": False,
     "sentry-apps.webhook.timeout.sec": 1.0,
     "sentry-apps.webhook.restricted-webhook-sending": [],
 }
@@ -77,13 +76,11 @@ class WebhookCircuitBreakerTest(TestCase):
         assert response.status_code == 200
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
-    @override_options(
-        {**CIRCUIT_BREAKER_OPTIONS, "sentry-apps.webhook.circuit-breaker.dry-run": True}
-    )
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_dry_run_emits_metric_but_sends_webhook(self, MockBreaker, mock_safe_urlopen):
-        """In dry-run mode, a broken circuit emits would_block but still sends."""
+    def test_without_live_run_emits_metric_but_sends_webhook(self, MockBreaker, mock_safe_urlopen):
+        """Without live-run flag, a broken circuit emits would_block but still sends."""
         mock_breaker_instance = MockBreaker.return_value
         mock_breaker_instance.should_allow_request.return_value = False
 
@@ -98,36 +95,22 @@ class WebhookCircuitBreakerTest(TestCase):
         assert response.status_code == 200
         mock_safe_urlopen.assert_called_once()
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
-    @override_options(CIRCUIT_BREAKER_OPTIONS)
-    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
-    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_blocking_mode_returns_empty_response(self, MockBreaker, mock_safe_urlopen):
-        """With dry-run OFF, a broken circuit blocks the webhook."""
-        mock_breaker_instance = MockBreaker.return_value
-        mock_breaker_instance.should_allow_request.return_value = False
-
-        send_and_save_webhook_request(self.sentry_app, self._make_event())
-        # Webhook is blocked — no HTTP call made
-        mock_safe_urlopen.assert_not_called()
-
     @with_feature(
         [
             "organizations:sentry-app-webhook-circuit-breaker",
             "organizations:sentry-app-webhook-circuit-breaker-live-run",
         ]
     )
-    @override_options(
-        {**CIRCUIT_BREAKER_OPTIONS, "sentry-apps.webhook.circuit-breaker.dry-run": True}
-    )
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_live_run_flag_overrides_dry_run_and_blocks(self, MockBreaker, mock_safe_urlopen):
-        """Live-run flag takes precedence over dry-run option, blocking the webhook."""
+    def test_blocking_mode_returns_empty_response(self, MockBreaker, mock_safe_urlopen):
+        """With live-run flag enabled, a broken circuit blocks the webhook."""
         mock_breaker_instance = MockBreaker.return_value
         mock_breaker_instance.should_allow_request.return_value = False
 
         send_and_save_webhook_request(self.sentry_app, self._make_event())
+        # Webhook is blocked — no HTTP call made
         mock_safe_urlopen.assert_not_called()
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
@@ -237,7 +220,12 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         mock_breaker_instance.recovery_duration = 600
         return mock_breaker_instance
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @with_feature(
+        [
+            "organizations:sentry-app-webhook-circuit-breaker",
+            "organizations:sentry-app-webhook-circuit-breaker-live-run",
+        ]
+    )
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -245,7 +233,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
     def test_timeout_with_trip_calls_notify_async(
         self, MockBreaker, mock_safe_urlopen, MockService
     ):
-        """When the breaker trips during a timeout, an email is dispatched."""
+        """When the breaker trips during a timeout with live-run, an email is dispatched."""
         self._configure_breaker(MockBreaker, is_open=True)
         MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
@@ -273,16 +261,14 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         MockService.return_value.notify_async.assert_not_called()
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
-    @override_options(
-        {**CIRCUIT_BREAKER_OPTIONS, "sentry-apps.webhook.circuit-breaker.dry-run": True}
-    )
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_dry_run_does_not_dispatch_notify_async(
+    def test_without_live_run_does_not_dispatch_notify_async(
         self, MockBreaker, mock_safe_urlopen, MockService
     ):
-        """Dry-run mode skips delivery even when the breaker trips."""
+        """Without live-run flag, email is skipped even when the breaker trips."""
         self._configure_breaker(MockBreaker, is_open=True)
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
@@ -297,26 +283,6 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
             "organizations:sentry-app-webhook-circuit-breaker-live-run",
         ]
     )
-    @override_options(
-        {**CIRCUIT_BREAKER_OPTIONS, "sentry-apps.webhook.circuit-breaker.dry-run": True}
-    )
-    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
-    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
-    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_live_run_flag_sends_email_despite_dry_run_option(
-        self, MockBreaker, mock_safe_urlopen, MockService
-    ):
-        """Live-run flag takes precedence over dry-run option, sending the real email."""
-        self._configure_breaker(MockBreaker, is_open=True)
-        MockService.has_access.return_value = True
-        mock_safe_urlopen.side_effect = WebhookTimeoutError()
-
-        with pytest.raises(WebhookTimeoutError):
-            send_and_save_webhook_request(self.sentry_app, self._make_event())
-
-        MockService.return_value.notify_async.assert_called_once()
-
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -338,7 +304,12 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         dedup_key = f"sentry-app.webhook.circuit-breaker.notified.{self.sentry_app.slug}"
         assert client.ttl(dedup_key) >= 86400
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @with_feature(
+        [
+            "organizations:sentry-app-webhook-circuit-breaker",
+            "organizations:sentry-app-webhook-circuit-breaker-live-run",
+        ]
+    )
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -357,7 +328,12 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
         MockService.return_value.notify_async.assert_not_called()
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @with_feature(
+        [
+            "organizations:sentry-app-webhook-circuit-breaker",
+            "organizations:sentry-app-webhook-circuit-breaker-live-run",
+        ]
+    )
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -382,7 +358,12 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
         assert MockService.return_value.notify_async.call_count == 2
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @with_feature(
+        [
+            "organizations:sentry-app-webhook-circuit-breaker",
+            "organizations:sentry-app-webhook-circuit-breaker-live-run",
+        ]
+    )
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")


### PR DESCRIPTION
Adds a `organizations:sentry-app-webhook-circuit-breaker-live-run` flag that will override the dry-run option, thus enabling blocking and email notifications for the app owner orgs in the rollout while still collecting dry-run data for everybody else.

Went with this instead of turning off circuit breaker flag + dry run option and then rolling out the cb flag as that would cut off alot of data that I think we would want to monitor to ensure that the system is getting cut over properly.

Refs ISWF-2549
