### PR TITLE
chore(integrations): log Jira issue.updated webhook payloads behind a flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -169,6 +169,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-github-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github_enterprise-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-gitlab-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Temporary: log full Jira Cloud `issue.updated` webhook payloads so we can design project-change link rewriting.
+    manager.add("organizations:jira-issue-updated-payload-logging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable inviting billing members to organizations at the member limit.
     manager.add("organizations:invite-billing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
     # Enable inviting members to organizations.

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -104,29 +104,39 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
         # webhook payload so we can see exactly what Jira sends us (especially
         # for `project` changes, which we want to use to update the linked
         # Jira issue link in Sentry).
-        if _payload_logging_enabled(rpc_integration.id):
-            issue = data.get("issue") or {}
-            fields = issue.get("fields") or {}
-            changelog_items = (data.get("changelog") or {}).get("items") or []
-            payload_extra = {
-                "integration_id": rpc_integration.id,
-                "issue_key": issue.get("key"),
-                "issue_id": issue.get("id"),
-                "webhook_event": data.get("webhookEvent"),
-                "changed_fields": [item.get("field") for item in changelog_items],
-                "project": fields.get("project"),
-                "payload": data,
-            }
-            logger.info("jira.issue-updated.payload", extra=payload_extra)
-            project_change = next(
-                (item for item in changelog_items if item.get("field") == "project"),
-                None,
-            )
-            if project_change is not None:
-                logger.info(
-                    "jira.issue-updated.project-changed",
-                    extra={**payload_extra, "project_change": project_change},
+        #
+        # This is purely diagnostic, so swallow any failure (including transient
+        # RPC errors from the feature-flag check) rather than letting it skip
+        # the real `handle_assignee_change` / `handle_status_change` calls below.
+        try:
+            if _payload_logging_enabled(rpc_integration.id):
+                issue = data.get("issue") or {}
+                fields = issue.get("fields") or {}
+                changelog_items = (data.get("changelog") or {}).get("items") or []
+                payload_extra = {
+                    "integration_id": rpc_integration.id,
+                    "issue_key": issue.get("key"),
+                    "issue_id": issue.get("id"),
+                    "webhook_event": data.get("webhookEvent"),
+                    "changed_fields": [item.get("field") for item in changelog_items],
+                    "project": fields.get("project"),
+                    "payload": data,
+                }
+                logger.info("jira.issue-updated.payload", extra=payload_extra)
+                project_change = next(
+                    (item for item in changelog_items if item.get("field") == "project"),
+                    None,
                 )
+                if project_change is not None:
+                    logger.info(
+                        "jira.issue-updated.project-changed",
+                        extra={**payload_extra, "project_change": project_change},
+                    )
+        except Exception:
+            logger.exception(
+                "jira.issue-updated.payload-logging-failed",
+                extra={"integration_id": rpc_integration.id},
+            )
 
         if not data.get("changelog"):
             logger.info("jira.missing-changelog", extra={"integration_id": rpc_integration.id})

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -14,10 +14,12 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.integrations.services.integration import integration_service
 from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
-from sentry.integrations.utils.scope import bind_org_context_from_integration
-from sentry.organizations.services.organization import organization_service
+from sentry.integrations.utils.scope import (
+    bind_org_context_from_integration,
+    get_org_integrations,
+)
+from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -35,17 +37,17 @@ def _payload_logging_enabled(integration_id: int) -> bool:
     `jira-issue-updated-payload-logging` feature enabled.
 
     A Jira integration can be shared by multiple Sentry orgs, and
-    `features.has` needs an `Organization`, so we have to walk the linked
-    `OrganizationIntegration` rows and look each org up.
+    `features.has` needs an `Organization`, so we walk the linked
+    `OrganizationIntegration` rows and batch the org lookup through the
+    region-silo cache (the endpoint is `@cell_silo_endpoint`, so the
+    region-cache path is always available) to avoid issuing N RPCs on every
+    webhook.
     """
-    contexts = integration_service.organization_contexts(integration_id=integration_id)
-    for oi in contexts.organization_integrations:
-        org = organization_service.get_organization_by_id(
-            id=oi.organization_id, include_teams=False, include_projects=False
-        )
-        if org and features.has(PAYLOAD_LOGGING_FEATURE, org.organization):
-            return True
-    return False
+    org_ids = [oi.organization_id for oi in get_org_integrations(integration_id)]
+    if not org_ids:
+        return False
+    organizations = Organization.objects.get_many_from_cache(org_ids)
+    return any(features.has(PAYLOAD_LOGGING_FEATURE, org) for org in organizations)
 
 
 @cell_silo_endpoint

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -16,7 +16,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
 from sentry.integrations.utils.scope import bind_org_context_from_integration
-from sentry.organizations.services.organization import RpcOrganization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -27,20 +26,6 @@ from .base import JiraWebhookBase
 logger = logging.getLogger(__name__)
 
 PAYLOAD_LOGGING_FEATURE = "organizations:jira-issue-updated-payload-logging"
-
-
-def _payload_logging_enabled(org: RpcOrganization | None) -> bool:
-    """True if `org` is non-None and has the
-    `jira-issue-updated-payload-logging` feature enabled.
-
-    `org` is the org `bind_org_context_from_integration` resolved this Jira
-    integration to. It is `None` when the integration is linked to zero orgs
-    or to multiple orgs; we deliberately skip payload logging in the
-    multi-org (ambiguous) case rather than dumping one tenant's webhook
-    payload into our logs because a different tenant on the same Jira
-    workspace flipped the flag.
-    """
-    return org is not None and features.has(PAYLOAD_LOGGING_FEATURE, org)
 
 
 @cell_silo_endpoint
@@ -96,17 +81,18 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
 
         data = request.data
 
-        # Temporary: when a linked org has the
+        # Temporary: when the linked org has the
         # `jira-issue-updated-payload-logging` feature enabled, log the full
         # webhook payload so we can see exactly what Jira sends us (especially
         # for `project` changes, which we want to use to update the linked
-        # Jira issue link in Sentry).
+        # Jira issue link in Sentry). Skip the check (and the log) for ambiguous
+        # multi-tenant Jira installations, where `org is None`.
         #
         # This is purely diagnostic, so swallow any failure (including transient
         # RPC errors from the feature-flag check) rather than letting it skip
         # the real `handle_assignee_change` / `handle_status_change` calls below.
         try:
-            if _payload_logging_enabled(org):
+            if org is not None and features.has(PAYLOAD_LOGGING_FEATURE, org):
                 issue = data.get("issue") or {}
                 fields = issue.get("fields") or {}
                 changelog_items = (data.get("changelog") or {}).get("items") or []

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -15,11 +15,8 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
-from sentry.integrations.utils.scope import (
-    bind_org_context_from_integration,
-    get_org_integrations,
-)
-from sentry.models.organization import Organization
+from sentry.integrations.utils.scope import bind_org_context_from_integration
+from sentry.organizations.services.organization import RpcOrganization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -32,22 +29,18 @@ logger = logging.getLogger(__name__)
 PAYLOAD_LOGGING_FEATURE = "organizations:jira-issue-updated-payload-logging"
 
 
-def _payload_logging_enabled(integration_id: int) -> bool:
-    """True if any org linked to this Jira integration has the
+def _payload_logging_enabled(org: RpcOrganization | None) -> bool:
+    """True if `org` is non-None and has the
     `jira-issue-updated-payload-logging` feature enabled.
 
-    A Jira integration can be shared by multiple Sentry orgs, and
-    `features.has` needs an `Organization`, so we walk the linked
-    `OrganizationIntegration` rows and batch the org lookup through the
-    region-silo cache (the endpoint is `@cell_silo_endpoint`, so the
-    region-cache path is always available) to avoid issuing N RPCs on every
-    webhook.
+    `org` is the org `bind_org_context_from_integration` resolved this Jira
+    integration to. It is `None` when the integration is linked to zero orgs
+    or to multiple orgs; we deliberately skip payload logging in the
+    multi-org (ambiguous) case rather than dumping one tenant's webhook
+    payload into our logs because a different tenant on the same Jira
+    workspace flipped the flag.
     """
-    org_ids = [oi.organization_id for oi in get_org_integrations(integration_id)]
-    if not org_ids:
-        return False
-    organizations = Organization.objects.get_many_from_cache(org_ids)
-    return any(features.has(PAYLOAD_LOGGING_FEATURE, org) for org in organizations)
+    return org is not None and features.has(PAYLOAD_LOGGING_FEATURE, org)
 
 
 @cell_silo_endpoint
@@ -95,8 +88,10 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
             method="POST",
         )
         # Integrations and their corresponding RpcIntegrations share the same id,
-        # so we don't need to first convert this to a full Integration object
-        bind_org_context_from_integration(rpc_integration.id, {"webhook": "issue_updated"})
+        # so we don't need to first convert this to a full Integration object.
+        # Capture the bound org so the payload-logging feature check below can
+        # reuse it instead of re-resolving the integration.
+        org = bind_org_context_from_integration(rpc_integration.id, {"webhook": "issue_updated"})
         sentry_sdk.set_tag("integration_id", rpc_integration.id)
 
         data = request.data
@@ -111,7 +106,7 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
         # RPC errors from the feature-flag check) rather than letting it skip
         # the real `handle_assignee_change` / `handle_status_change` calls below.
         try:
-            if _payload_logging_enabled(rpc_integration.id):
+            if _payload_logging_enabled(org):
                 issue = data.get("issue") or {}
                 fields = issue.get("fields") or {}
                 changelog_items = (data.get("changelog") or {}).get("items") or []

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -134,11 +134,8 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
                         "jira.issue-updated.project-changed",
                         extra={**payload_extra, "project_change": project_change},
                     )
-        except Exception:
-            logger.exception(
-                "jira.issue-updated.payload-logging-failed",
-                extra={"integration_id": rpc_integration.id},
-            )
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
 
         if not data.get("changelog"):
             logger.info("jira.missing-changelog", extra={"integration_id": rpc_integration.id})

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -10,11 +10,14 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import Scope
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
 from sentry.integrations.utils.scope import bind_org_context_from_integration
+from sentry.organizations.services.organization import organization_service
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -23,6 +26,26 @@ from ..utils import handle_assignee_change, handle_jira_api_error, handle_status
 from .base import JiraWebhookBase
 
 logger = logging.getLogger(__name__)
+
+PAYLOAD_LOGGING_FEATURE = "organizations:jira-issue-updated-payload-logging"
+
+
+def _payload_logging_enabled(integration_id: int) -> bool:
+    """True if any org linked to this Jira integration has the
+    `jira-issue-updated-payload-logging` feature enabled.
+
+    A Jira integration can be shared by multiple Sentry orgs, and
+    `features.has` needs an `Organization`, so we have to walk the linked
+    `OrganizationIntegration` rows and look each org up.
+    """
+    contexts = integration_service.organization_contexts(integration_id=integration_id)
+    for oi in contexts.organization_integrations:
+        org = organization_service.get_organization_by_id(
+            id=oi.organization_id, include_teams=False, include_projects=False
+        )
+        if org and features.has(PAYLOAD_LOGGING_FEATURE, org.organization):
+            return True
+    return False
 
 
 @cell_silo_endpoint
@@ -75,6 +98,36 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
         sentry_sdk.set_tag("integration_id", rpc_integration.id)
 
         data = request.data
+
+        # Temporary: when a linked org has the
+        # `jira-issue-updated-payload-logging` feature enabled, log the full
+        # webhook payload so we can see exactly what Jira sends us (especially
+        # for `project` changes, which we want to use to update the linked
+        # Jira issue link in Sentry).
+        if _payload_logging_enabled(rpc_integration.id):
+            issue = data.get("issue") or {}
+            fields = issue.get("fields") or {}
+            changelog_items = (data.get("changelog") or {}).get("items") or []
+            payload_extra = {
+                "integration_id": rpc_integration.id,
+                "issue_key": issue.get("key"),
+                "issue_id": issue.get("id"),
+                "webhook_event": data.get("webhookEvent"),
+                "changed_fields": [item.get("field") for item in changelog_items],
+                "project": fields.get("project"),
+                "payload": data,
+            }
+            logger.info("jira.issue-updated.payload", extra=payload_extra)
+            project_change = next(
+                (item for item in changelog_items if item.get("field") == "project"),
+                None,
+            )
+            if project_change is not None:
+                logger.info(
+                    "jira.issue-updated.project-changed",
+                    extra={**payload_extra, "project_change": project_change},
+                )
+
         if not data.get("changelog"):
             logger.info("jira.missing-changelog", extra={"integration_id": rpc_integration.id})
             return self.respond()

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -10,7 +10,7 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcOrganizationIntegration
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
-from sentry.organizations.services.organization import organization_service
+from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.silo.base import SiloMode
 from sentry.utils.sdk import (
     bind_ambiguous_org_context,
@@ -58,7 +58,7 @@ def get_org_integrations(
 
 def bind_org_context_from_integration(
     integration_id: int, extra: Mapping[str, Any] | None = None
-) -> None:
+) -> RpcOrganization | None:
     """
     Given the id of an Integration or an RpcIntegration, get the associated org(s) and bind that
     data to the scope.
@@ -68,6 +68,12 @@ def bind_org_context_from_integration(
     GitHub org, or an instance of the Slack integration tied to a particular Slack workspace), which
     can be shared by multiple orgs. Also, it doesn't matter whether the passed id comes from an
     Integration or an RpcIntegration object, because corresponding ones share the same id.
+
+    Returns the bound `RpcOrganization` when exactly one Sentry org is linked to this integration,
+    so callers that need the org for follow-up work (e.g. a feature-flag check) don't have to
+    re-fetch it. Returns `None` for unlinked integrations and for installations shared across
+    multiple orgs, since attributing the integration to a single tenant in those cases would be
+    ambiguous.
     """
 
     org_integrations = get_org_integrations(integration_id)
@@ -86,6 +92,7 @@ def bind_org_context_from_integration(
         # (With `add_to_scope=False`, we still log a warning - separate from the one above - on data
         # mismatch.)
         check_tag_for_scope_bleed("integration_id", integration_id, add_to_scope=False)
+        return None
     elif len(org_integrations) == 1:
         org_integration = org_integrations[0]
         org = organization_service.get_organization_by_id(
@@ -93,12 +100,13 @@ def bind_org_context_from_integration(
         )
         if org is not None:
             bind_organization_context(org.organization)
-        else:
-            logger.warning(
-                "Unable to call organization_service.get_organization_by_id with organization id=%s.",
-                org_integration.organization_id,
-                extra=extra,
-            )
+            return org.organization
+        logger.warning(
+            "Unable to call organization_service.get_organization_by_id with organization id=%s.",
+            org_integration.organization_id,
+            extra=extra,
+        )
+        return None
     else:
         org_ids = [org_integration.organization_id for org_integration in org_integrations]
         org_slugs = []
@@ -115,3 +123,4 @@ def bind_org_context_from_integration(
             org_slugs = [org.slug for org in orgs]
 
         bind_ambiguous_org_context(org_slugs, f"integration (id={integration_id})")
+        return None

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -216,6 +216,34 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
             data = StubService.get_stub_data("jira", "changelog_missing.json")
             self.get_success_response(**data, extra_headers=dict(HTTP_AUTHORIZATION=TOKEN))
 
+    @patch("sentry.integrations.jira.webhooks.issue_updated.logger")
+    @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
+    @patch("sentry.integrations.jira.webhooks.issue_updated._payload_logging_enabled")
+    def test_payload_logging_failure_does_not_skip_handlers(
+        self,
+        mock_payload_logging_enabled: MagicMock,
+        mock_sync_group_assignee_inbound: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        # The diagnostic payload-logging path makes RPC calls that could fail
+        # transiently. Those failures must not prevent the real webhook
+        # handlers from running.
+        mock_payload_logging_enabled.side_effect = RuntimeError("transient RPC failure")
+
+        with patch(
+            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            return_value=self.integration,
+        ):
+            data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
+            self.get_success_response(**data, extra_headers=dict(HTTP_AUTHORIZATION=TOKEN))
+
+        mock_sync_group_assignee_inbound.assert_called_with(
+            self.integration, "jess@sentry.io", "APP-123", assign=True
+        )
+        assert (
+            mock_logger.exception.call_args.args[0] == "jira.issue-updated.payload-logging-failed"
+        )
+
 
 class MockErroringJiraEndpoint(JiraWebhookBase):
     permission_classes = ()

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -217,20 +217,26 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
             data = StubService.get_stub_data("jira", "changelog_missing.json")
             self.get_success_response(**data, extra_headers=dict(HTTP_AUTHORIZATION=TOKEN))
 
+    @with_feature("organizations:jira-issue-updated-payload-logging")
     @patch("sentry.integrations.jira.webhooks.issue_updated.sentry_sdk.capture_exception")
     @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
-    @patch("sentry.integrations.jira.webhooks.issue_updated._payload_logging_enabled")
+    @patch("sentry.integrations.jira.webhooks.issue_updated.logger")
     def test_payload_logging_failure_does_not_skip_handlers(
         self,
-        mock_payload_logging_enabled: MagicMock,
+        mock_logger: MagicMock,
         mock_sync_group_assignee_inbound: MagicMock,
         mock_capture_exception: MagicMock,
     ) -> None:
-        # The diagnostic payload-logging path makes RPC calls that could fail
-        # transiently. Those failures must not prevent the real webhook
-        # handlers from running.
-        error = RuntimeError("transient RPC failure")
-        mock_payload_logging_enabled.side_effect = error
+        # The diagnostic payload-logging path can fail transiently (e.g. a
+        # broken `extra=` payload, or a flaky logging backend). Those failures
+        # must not prevent the real webhook handlers from running.
+        error = RuntimeError("simulated payload logging failure")
+
+        def raising_info(event_name: str, *args: object, **kwargs: object) -> None:
+            if event_name == "jira.issue-updated.payload":
+                raise error
+
+        mock_logger.info.side_effect = raising_info
 
         with patch(
             "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -16,6 +16,7 @@ from sentry.integrations.utils.atlassian_connect import AtlassianConnectValidati
 from sentry.organizations.services.organization.serial import serialize_rpc_organization
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.viewer_context import ActorType, get_viewer_context
 
@@ -243,6 +244,24 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
         assert (
             mock_logger.exception.call_args.args[0] == "jira.issue-updated.payload-logging-failed"
         )
+
+    @with_feature("organizations:jira-issue-updated-payload-logging")
+    @patch("sentry.integrations.jira.webhooks.issue_updated.logger")
+    @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
+    def test_payload_logging_logs_when_feature_enabled(
+        self,
+        mock_sync_group_assignee_inbound: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        with patch(
+            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            return_value=self.integration,
+        ):
+            data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
+            self.get_success_response(**data, extra_headers=dict(HTTP_AUTHORIZATION=TOKEN))
+
+        info_event_names = [call.args[0] for call in mock_logger.info.call_args_list]
+        assert "jira.issue-updated.payload" in info_event_names
 
 
 class MockErroringJiraEndpoint(JiraWebhookBase):

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -217,19 +217,20 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
             data = StubService.get_stub_data("jira", "changelog_missing.json")
             self.get_success_response(**data, extra_headers=dict(HTTP_AUTHORIZATION=TOKEN))
 
-    @patch("sentry.integrations.jira.webhooks.issue_updated.logger")
+    @patch("sentry.integrations.jira.webhooks.issue_updated.sentry_sdk.capture_exception")
     @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
     @patch("sentry.integrations.jira.webhooks.issue_updated._payload_logging_enabled")
     def test_payload_logging_failure_does_not_skip_handlers(
         self,
         mock_payload_logging_enabled: MagicMock,
         mock_sync_group_assignee_inbound: MagicMock,
-        mock_logger: MagicMock,
+        mock_capture_exception: MagicMock,
     ) -> None:
         # The diagnostic payload-logging path makes RPC calls that could fail
         # transiently. Those failures must not prevent the real webhook
         # handlers from running.
-        mock_payload_logging_enabled.side_effect = RuntimeError("transient RPC failure")
+        error = RuntimeError("transient RPC failure")
+        mock_payload_logging_enabled.side_effect = error
 
         with patch(
             "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
@@ -241,9 +242,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
         mock_sync_group_assignee_inbound.assert_called_with(
             self.integration, "jess@sentry.io", "APP-123", assign=True
         )
-        assert (
-            mock_logger.exception.call_args.args[0] == "jira.issue-updated.payload-logging-failed"
-        )
+        mock_capture_exception.assert_called_once_with(error)
 
     @with_feature("organizations:jira-issue-updated-payload-logging")
     @patch("sentry.integrations.jira.webhooks.issue_updated.logger")


### PR DESCRIPTION


Adds a temporary `organizations:jira-issue-updated-payload-logging` Flagpole feature that, when enabled for a linked org, causes the Jira Cloud `issue.updated` webhook handler to log the full webhook payload plus a focused log line whenever the changelog contains a `project` change. We need this data to design issue-link rewriting when a Jira issue is moved between projects.

Resolves ISWF-1512