### PR TITLE
feat(search): Add userCount filter key to issue search autocomplete

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -123,6 +123,7 @@ export enum FieldKey {
   TIMESTAMP_TO_HOUR = 'timestamp.to_hour',
   TIMES_SEEN = 'timesSeen',
   TITLE = 'title',
+  USER_COUNT = 'userCount',
   TOTAL_COUNT = 'total.count',
   TRACE = 'trace',
   TRACE_PARENT_SPAN = 'trace.parent_span',
@@ -212,6 +213,7 @@ type ErrorFieldKey =
   | FieldKey.STATUS
   | FieldKey.SYMBOLICATED_IN_APP
   | FieldKey.TIMES_SEEN
+  | FieldKey.USER_COUNT
   | FieldKey.TYPE
   | FieldKey.UNREAL_CRASH_TYPE;
 
@@ -2141,6 +2143,12 @@ const ERROR_FIELD_DEFINITION: Record<ErrorFieldKey, FieldDefinition> = {
     valueType: FieldValueType.NUMBER,
     keywords: ['count'],
   },
+  [FieldKey.USER_COUNT]: {
+    desc: t('Number of unique users affected'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.NUMBER,
+    keywords: ['users', 'affected'],
+  },
   [FieldKey.TYPE]: {
     desc: t('Type of event (Errors, transactions, csp and default)'),
     kind: FieldKind.FIELD,
@@ -2761,6 +2769,7 @@ export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.LAST_SEEN,
   FieldKey.RELEASE_STAGE,
   FieldKey.TIMES_SEEN,
+  FieldKey.USER_COUNT,
 ];
 
 // Should match Snuba columns defined in sentry/snuba/events.py

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -377,6 +377,13 @@ function builtInIssuesFields({
       values: [],
       predefined: true,
     },
+    [FieldKey.USER_COUNT]: {
+      ...PREDEFINED_FIELDS[FieldKey.USER_COUNT]!,
+      name: 'User Count',
+      isInput: true,
+      values: [],
+      predefined: true,
+    },
     [FieldKey.ISSUE_PRIORITY]: {
       ...PREDEFINED_FIELDS[FieldKey.ISSUE_PRIORITY]!,
       name: 'Issue Priority',


### PR DESCRIPTION
## Summary
- Registers `USER_COUNT` in the `FieldKey` enum, field definitions, and `ISSUE_PROPERTY_FIELDS` so the search bar recognizes `userCount` as a valid filter key
- Adds `userCount` to `builtInIssuesFields()` so it appears in the issue list search bar autocomplete dropdown
- Follows the same pattern as the existing `timesSeen` filter

Depends on backend PR: https://github.com/getsentry/sentry/pull/114796

## Test plan
- [x] Verified locally that `userCount` appears in the search bar autocomplete
- [ ] CI passes