### PR TITLE
feat(preprod): Add per-category controls for snapshot PR comments UI

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -97,6 +97,10 @@ export type Project = {
   preprodSizeStatusChecksEnabled?: boolean;
   preprodSizeStatusChecksRules?: unknown[];
   preprodSnapshotPrCommentsEnabled?: boolean;
+  preprodSnapshotPrCommentsPostOnAdded?: boolean;
+  preprodSnapshotPrCommentsPostOnChanged?: boolean;
+  preprodSnapshotPrCommentsPostOnRemoved?: boolean;
+  preprodSnapshotPrCommentsPostOnRenamed?: boolean;
   preprodSnapshotStatusChecksEnabled?: boolean;
   preprodSnapshotStatusChecksFailOnAdded?: boolean;
   preprodSnapshotStatusChecksFailOnChanged?: boolean;

--- a/static/app/views/settings/project/preprod/getSnapshotPrComments.ts
+++ b/static/app/views/settings/project/preprod/getSnapshotPrComments.ts
@@ -6,7 +6,7 @@ const POST_ON_REMOVED_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_removed
 const POST_ON_CHANGED_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_changed';
 const POST_ON_RENAMED_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_renamed';
 
-export function useSnapshotPrComments(project: Project) {
+export function getSnapshotPrComments(project: Project) {
   const enabled =
     project.preprodSnapshotPrCommentsEnabled ?? project.options?.[ENABLED_KEY] === true;
 

--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.spec.tsx
@@ -3,6 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {SnapshotPrCommentsToggle} from 'sentry/views/settings/project/preprod/snapshotPrCommentsToggle';
 
 describe('SnapshotPrCommentsToggle', () => {
@@ -162,6 +163,7 @@ describe('SnapshotPrCommentsToggle', () => {
       options: {},
       preprodSnapshotPrCommentsEnabled: true,
     });
+    ProjectsStore.loadInitialData([project]);
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
     const mock = MockApiClient.addMockResponse({
       url: projectEndpoint,
@@ -180,7 +182,7 @@ describe('SnapshotPrCommentsToggle', () => {
     );
 
     expect(
-      screen.getByText('Enable PR comments to configure post conditions')
+      await screen.findByText('Enable PR comments to configure post conditions')
     ).toBeInTheDocument();
     expect(
       screen.queryByRole('checkbox', {name: 'Post on Changed Snapshots'})

--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.spec.tsx
@@ -1,0 +1,229 @@
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {SnapshotPrCommentsToggle} from 'sentry/views/settings/project/preprod/snapshotPrCommentsToggle';
+
+describe('SnapshotPrCommentsToggle', () => {
+  const {organization} = initializeOrg();
+  const initialRouterConfig = {
+    location: {
+      pathname: `/settings/projects/test-project/snapshots/`,
+    },
+    route: '/settings/projects/:projectId/snapshots/',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders default values when the project has no preprod options', async () => {
+    const project = ProjectFixture({options: {}});
+    render(<SnapshotPrCommentsToggle />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    expect(
+      await screen.findByRole('checkbox', {name: 'Enable Snapshot PR Comments'})
+    ).not.toBeChecked();
+    expect(
+      screen.getByText('Enable PR comments to configure post conditions')
+    ).toBeInTheDocument();
+  });
+
+  it('shows per-category toggles when enabled with correct defaults', async () => {
+    const project = ProjectFixture({
+      options: {},
+      preprodSnapshotPrCommentsEnabled: true,
+    });
+    render(<SnapshotPrCommentsToggle />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    expect(
+      await screen.findByRole('checkbox', {name: 'Enable Snapshot PR Comments'})
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Post on Changed Snapshots'})
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Post on Removed Snapshots'})
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Post on Added Snapshots'})
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Post on Renamed Snapshots'})
+    ).not.toBeChecked();
+  });
+
+  it('reflects project values from explicit fields', async () => {
+    const project = ProjectFixture({
+      options: {},
+      preprodSnapshotPrCommentsEnabled: true,
+      preprodSnapshotPrCommentsPostOnAdded: true,
+      preprodSnapshotPrCommentsPostOnRemoved: false,
+      preprodSnapshotPrCommentsPostOnChanged: false,
+      preprodSnapshotPrCommentsPostOnRenamed: true,
+    });
+    render(<SnapshotPrCommentsToggle />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    expect(
+      await screen.findByRole('checkbox', {name: 'Post on Added Snapshots'})
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Post on Removed Snapshots'})
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Post on Changed Snapshots'})
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Post on Renamed Snapshots'})
+    ).toBeChecked();
+  });
+
+  it('saves post_on_changed when toggled off', async () => {
+    const project = ProjectFixture({
+      options: {},
+      preprodSnapshotPrCommentsEnabled: true,
+    });
+    const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    const mock = MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      method: 'PUT',
+      body: {},
+    });
+
+    render(<SnapshotPrCommentsToggle />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    await userEvent.click(
+      await screen.findByRole('checkbox', {name: 'Post on Changed Snapshots'})
+    );
+
+    await waitFor(() =>
+      expect(mock).toHaveBeenCalledWith(
+        projectEndpoint,
+        expect.objectContaining({
+          method: 'PUT',
+          data: {preprodSnapshotPrCommentsPostOnChanged: false},
+        })
+      )
+    );
+  });
+
+  it('saves post_on_renamed when toggled on', async () => {
+    const project = ProjectFixture({
+      options: {},
+      preprodSnapshotPrCommentsEnabled: true,
+    });
+    const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    const mock = MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      method: 'PUT',
+      body: {},
+    });
+
+    render(<SnapshotPrCommentsToggle />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    await userEvent.click(
+      await screen.findByRole('checkbox', {name: 'Post on Renamed Snapshots'})
+    );
+
+    await waitFor(() =>
+      expect(mock).toHaveBeenCalledWith(
+        projectEndpoint,
+        expect.objectContaining({
+          method: 'PUT',
+          data: {preprodSnapshotPrCommentsPostOnRenamed: true},
+        })
+      )
+    );
+  });
+
+  it('immediately hides post condition toggles when PR comments are disabled', async () => {
+    const project = ProjectFixture({
+      options: {},
+      preprodSnapshotPrCommentsEnabled: true,
+    });
+    const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    const mock = MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      method: 'PUT',
+      body: {},
+    });
+
+    render(<SnapshotPrCommentsToggle />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    await userEvent.click(
+      await screen.findByRole('checkbox', {name: 'Enable Snapshot PR Comments'})
+    );
+
+    expect(
+      screen.getByText('Enable PR comments to configure post conditions')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Post on Changed Snapshots'})
+    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(mock).toHaveBeenCalledWith(
+        projectEndpoint,
+        expect.objectContaining({
+          method: 'PUT',
+          data: {preprodSnapshotPrCommentsEnabled: false},
+        })
+      )
+    );
+  });
+
+  it('hides per-category toggles and shows a hint when PR comments are disabled', async () => {
+    const project = ProjectFixture({
+      options: {},
+      preprodSnapshotPrCommentsEnabled: false,
+    });
+    render(<SnapshotPrCommentsToggle />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    expect(
+      await screen.findByText('Enable PR comments to configure post conditions')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Post on Added Snapshots'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Post on Removed Snapshots'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Post on Changed Snapshots'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Post on Renamed Snapshots'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', {name: 'Enable Snapshot PR Comments'})
+    ).toBeEnabled();
+  });
+});

--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment} from 'react';
 import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
@@ -10,9 +10,10 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
-import {useSnapshotPrComments} from './useSnapshotPrComments';
+import {getSnapshotPrComments} from './getSnapshotPrComments';
 
 const schema = z.object({
   preprodSnapshotPrCommentsEnabled: z.boolean(),
@@ -32,16 +33,12 @@ type PrCommentField = {
 
 export function SnapshotPrCommentsToggle() {
   const organization = useOrganization();
-  const {project} = useProjectSettingsOutlet();
+  const {project: outletProject} = useProjectSettingsOutlet();
+  const project = useProjectFromId({project_id: outletProject.id}) ?? outletProject;
   const {enabled, postOnAdded, postOnRemoved, postOnChanged, postOnRenamed} =
-    useSnapshotPrComments(project);
-  const [prCommentsEnabled, setPrCommentsEnabled] = useState(enabled);
+    getSnapshotPrComments(project);
 
   const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
-
-  useEffect(() => {
-    setPrCommentsEnabled(enabled);
-  }, [enabled]);
 
   const mutationOptions = {
     mutationFn: (data: Partial<Schema>) =>
@@ -50,12 +47,19 @@ export function SnapshotPrCommentsToggle() {
         method: 'PUT',
         data,
       }),
+    onMutate: (data: Partial<Schema>) => {
+      const previous = ProjectsStore.getById(project.id);
+      ProjectsStore.onUpdateSuccess({id: project.id, ...data});
+      return () => {
+        if (previous) {
+          ProjectsStore.onUpdateSuccess(previous);
+        }
+      };
+    },
     onSuccess: (response: Project) => ProjectsStore.onUpdateSuccess(response),
-  };
-
-  const enabledMutationOptions = {
-    ...mutationOptions,
-    onError: () => setPrCommentsEnabled(enabled),
+    onError: (_error: unknown, _variables: Partial<Schema>, rollback?: () => void) => {
+      rollback?.();
+    },
   };
 
   const postConditionFields = [
@@ -91,7 +95,7 @@ export function SnapshotPrCommentsToggle() {
         name="preprodSnapshotPrCommentsEnabled"
         schema={schema}
         initialValue={enabled}
-        mutationOptions={enabledMutationOptions}
+        mutationOptions={mutationOptions}
       >
         {field => (
           <field.Layout.Row
@@ -100,18 +104,12 @@ export function SnapshotPrCommentsToggle() {
               'Sentry will post snapshot comparison results as comments on pull requests.'
             )}
           >
-            <field.Switch
-              checked={field.state.value}
-              onChange={value => {
-                setPrCommentsEnabled(value);
-                field.handleChange(value);
-              }}
-            />
+            <field.Switch checked={field.state.value} onChange={field.handleChange} />
           </field.Layout.Row>
         )}
       </AutoSaveForm>
 
-      {prCommentsEnabled ? (
+      {enabled ? (
         <Fragment>
           {postConditionFields.map(({name, initialValue, label, hintText}) => (
             <AutoSaveForm

--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {mutationOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
@@ -40,14 +41,14 @@ export function SnapshotPrCommentsToggle() {
 
   const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
 
-  const mutationOptions = {
+  const projectMutationOptions = mutationOptions({
     mutationFn: (data: Partial<Schema>) =>
       fetchMutation<Project>({
         url: projectEndpoint,
         method: 'PUT',
         data,
       }),
-    onMutate: (data: Partial<Schema>) => {
+    onMutate: data => {
       const previous = ProjectsStore.getById(project.id);
       ProjectsStore.onUpdateSuccess({id: project.id, ...data});
       return () => {
@@ -56,11 +57,11 @@ export function SnapshotPrCommentsToggle() {
         }
       };
     },
-    onSuccess: (response: Project) => ProjectsStore.onUpdateSuccess(response),
-    onError: (_error: unknown, _variables: Partial<Schema>, rollback?: () => void) => {
+    onSuccess: response => ProjectsStore.onUpdateSuccess(response),
+    onError: (_error, _variables, rollback) => {
       rollback?.();
     },
-  };
+  });
 
   const postConditionFields = [
     {
@@ -95,7 +96,7 @@ export function SnapshotPrCommentsToggle() {
         name="preprodSnapshotPrCommentsEnabled"
         schema={schema}
         initialValue={enabled}
-        mutationOptions={mutationOptions}
+        mutationOptions={projectMutationOptions}
       >
         {field => (
           <field.Layout.Row
@@ -117,7 +118,7 @@ export function SnapshotPrCommentsToggle() {
               name={name}
               schema={schema}
               initialValue={initialValue}
-              mutationOptions={mutationOptions}
+              mutationOptions={projectMutationOptions}
             >
               {field => (
                 <field.Layout.Row label={label} hintText={hintText}>

--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
@@ -1,64 +1,144 @@
-import {Flex, Stack} from '@sentry/scraps/layout';
-import {Switch} from '@sentry/scraps/switch';
+import {Fragment, useEffect, useState} from 'react';
+import {z} from 'zod';
+
+import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
+import {Container} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  addSuccessMessage,
-} from 'sentry/actionCreators/indicator';
-import {Panel} from 'sentry/components/panels/panel';
-import {PanelBody} from 'sentry/components/panels/panelBody';
-import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {t} from 'sentry/locale';
-import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {Project} from 'sentry/types/project';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
-const READ_KEY = 'sentry:preprod_snapshot_pr_comments_enabled';
-const WRITE_KEY = 'preprodSnapshotPrCommentsEnabled';
+import {useSnapshotPrComments} from './useSnapshotPrComments';
+
+const schema = z.object({
+  preprodSnapshotPrCommentsEnabled: z.boolean(),
+  preprodSnapshotPrCommentsPostOnAdded: z.boolean(),
+  preprodSnapshotPrCommentsPostOnRemoved: z.boolean(),
+  preprodSnapshotPrCommentsPostOnChanged: z.boolean(),
+  preprodSnapshotPrCommentsPostOnRenamed: z.boolean(),
+});
+
+type Schema = z.infer<typeof schema>;
+type PrCommentField = {
+  hintText: string;
+  initialValue: boolean;
+  label: string;
+  name: keyof Schema;
+};
 
 export function SnapshotPrCommentsToggle() {
+  const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
-  const {mutate: updateProject} = useUpdateProject(project);
+  const {enabled, postOnAdded, postOnRemoved, postOnChanged, postOnRenamed} =
+    useSnapshotPrComments(project);
+  const [prCommentsEnabled, setPrCommentsEnabled] = useState(enabled);
 
-  const enabled = (project[WRITE_KEY] ?? project.options?.[READ_KEY]) !== false;
+  const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
 
-  function handleToggle() {
-    addLoadingMessage(t('Saving...'));
-    updateProject(
-      {[WRITE_KEY]: !enabled},
-      {
-        onSuccess: () => {
-          addSuccessMessage(t('PR comment settings updated'));
-        },
-        onError: () => {
-          addErrorMessage(t('Failed to save changes. Please try again.'));
-        },
-      }
-    );
-  }
+  useEffect(() => {
+    setPrCommentsEnabled(enabled);
+  }, [enabled]);
+
+  const mutationOptions = {
+    mutationFn: (data: Partial<Schema>) =>
+      fetchMutation<Project>({
+        url: projectEndpoint,
+        method: 'PUT',
+        data,
+      }),
+    onSuccess: (response: Project) => ProjectsStore.onUpdateSuccess(response),
+  };
+
+  const enabledMutationOptions = {
+    ...mutationOptions,
+    onError: () => setPrCommentsEnabled(enabled),
+  };
+
+  const postConditionFields = [
+    {
+      name: 'preprodSnapshotPrCommentsPostOnChanged',
+      initialValue: postOnChanged,
+      label: t('Post on Changed Snapshots'),
+      hintText: t('Include snapshots with pixel content changes in the PR comment.'),
+    },
+    {
+      name: 'preprodSnapshotPrCommentsPostOnRemoved',
+      initialValue: postOnRemoved,
+      label: t('Post on Removed Snapshots'),
+      hintText: t('Include removed snapshots in the PR comment.'),
+    },
+    {
+      name: 'preprodSnapshotPrCommentsPostOnAdded',
+      initialValue: postOnAdded,
+      label: t('Post on Added Snapshots'),
+      hintText: t('Include newly added snapshots in the PR comment.'),
+    },
+    {
+      name: 'preprodSnapshotPrCommentsPostOnRenamed',
+      initialValue: postOnRenamed,
+      label: t('Post on Renamed Snapshots'),
+      hintText: t('Include renamed snapshots in the PR comment.'),
+    },
+  ] satisfies PrCommentField[];
 
   return (
-    <Panel>
-      <PanelHeader>{t('Snapshots - Pull Request Comments')}</PanelHeader>
-      <PanelBody>
-        <Flex align="center" justify="between" padding="xl">
-          <Stack gap="xs">
-            <Text size="lg" bold>
-              {t('Snapshot Pull Request Comments')}
-            </Text>
-            <Text size="sm" variant="muted">
-              {t('Post snapshot comparison results as comments on pull requests.')}
-            </Text>
-          </Stack>
-          <Switch
-            size="lg"
-            checked={enabled}
-            onChange={handleToggle}
-            aria-label={t('Toggle snapshot PR comments')}
-          />
-        </Flex>
-      </PanelBody>
-    </Panel>
+    <FieldGroup title={t('Snapshots - Pull Request Comments')}>
+      <AutoSaveForm
+        name="preprodSnapshotPrCommentsEnabled"
+        schema={schema}
+        initialValue={enabled}
+        mutationOptions={enabledMutationOptions}
+      >
+        {field => (
+          <field.Layout.Row
+            label={t('Enable Snapshot PR Comments')}
+            hintText={t(
+              'Sentry will post snapshot comparison results as comments on pull requests.'
+            )}
+          >
+            <field.Switch
+              checked={field.state.value}
+              onChange={value => {
+                setPrCommentsEnabled(value);
+                field.handleChange(value);
+              }}
+            />
+          </field.Layout.Row>
+        )}
+      </AutoSaveForm>
+
+      {prCommentsEnabled ? (
+        <Fragment>
+          {postConditionFields.map(({name, initialValue, label, hintText}) => (
+            <AutoSaveForm
+              key={name}
+              name={name}
+              schema={schema}
+              initialValue={initialValue}
+              mutationOptions={mutationOptions}
+            >
+              {field => (
+                <field.Layout.Row label={label} hintText={hintText}>
+                  <field.Switch
+                    checked={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                </field.Layout.Row>
+              )}
+            </AutoSaveForm>
+          ))}
+        </Fragment>
+      ) : (
+        <Container padding="md">
+          <Text align="center" variant="muted" italic>
+            {t('Enable PR comments to configure post conditions')}
+          </Text>
+        </Container>
+      )}
+    </FieldGroup>
   );
 }

--- a/static/app/views/settings/project/preprod/useSnapshotPrComments.ts
+++ b/static/app/views/settings/project/preprod/useSnapshotPrComments.ts
@@ -1,0 +1,36 @@
+import type {Project} from 'sentry/types/project';
+
+const ENABLED_KEY = 'sentry:preprod_snapshot_pr_comments_enabled';
+const POST_ON_ADDED_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_added';
+const POST_ON_REMOVED_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_removed';
+const POST_ON_CHANGED_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_changed';
+const POST_ON_RENAMED_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_renamed';
+
+export function useSnapshotPrComments(project: Project) {
+  const enabled =
+    project.preprodSnapshotPrCommentsEnabled ?? project.options?.[ENABLED_KEY] === true;
+
+  const postOnAdded =
+    project.preprodSnapshotPrCommentsPostOnAdded ??
+    project.options?.[POST_ON_ADDED_KEY] === true;
+
+  const postOnRemoved =
+    project.preprodSnapshotPrCommentsPostOnRemoved ??
+    project.options?.[POST_ON_REMOVED_KEY] !== false;
+
+  const postOnChanged =
+    project.preprodSnapshotPrCommentsPostOnChanged ??
+    project.options?.[POST_ON_CHANGED_KEY] !== false;
+
+  const postOnRenamed =
+    project.preprodSnapshotPrCommentsPostOnRenamed ??
+    project.options?.[POST_ON_RENAMED_KEY] === true;
+
+  return {
+    enabled,
+    postOnAdded,
+    postOnRemoved,
+    postOnChanged,
+    postOnRenamed,
+  };
+}


### PR DESCRIPTION
## Summary

Adds frontend per-category toggles for snapshot PR comments, matching the existing status checks UI pattern. This is the frontend counterpart to #114302 which added the backend support.

- Converts the simple on/off PR comments toggle into a `FieldGroup` with per-category `AutoSaveForm` switches
- Adds controls for: changed, removed, added, and renamed snapshot categories
- Creates `useSnapshotPrComments` hook mirroring `useSnapshotStatusChecks`
- Adds TypeScript types for the new project fields

EME-1046