### PR TITLE
ref(attributes): Tidy up attribute getter functions

### DIFF
--- a/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
@@ -1,4 +1,4 @@
-import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {useQueryClient} from '@tanstack/react-query';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {TagCollection} from 'sentry/types/group';
@@ -27,32 +27,28 @@ export function useGetTraceItemAttributeKeys({
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
-  const {mutateAsync: getTraceItemAttributeKeys} = useMutation({
-    mutationFn: async (
-      queryString?: string
-    ): Promise<{
-      booleanAttributes: TagCollection;
-      numberAttributes: TagCollection;
-      stringAttributes: TagCollection;
-    }> => {
-      try {
-        const {json} = await queryClient.fetchQuery({
-          ...traceItemAttributeKeysOptions({
-            organization,
-            selection,
-            traceItemType,
-            projectIds: projectIds ?? selection.projects,
-            search: queryString,
-            query,
-            staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
-          }),
-        });
-        return getTraceItemTagCollection(json);
-      } catch (e) {
-        throw new Error(`Unable to fetch trace item attribute keys: ${e}`);
-      }
-    },
-  });
-
-  return getTraceItemAttributeKeys;
+  return async (
+    queryString?: string
+  ): Promise<{
+    booleanAttributes: TagCollection;
+    numberAttributes: TagCollection;
+    stringAttributes: TagCollection;
+  }> => {
+    try {
+      const {json} = await queryClient.fetchQuery(
+        traceItemAttributeKeysOptions({
+          organization,
+          selection,
+          traceItemType,
+          projectIds: projectIds ?? selection.projects,
+          search: queryString,
+          query,
+          staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+        })
+      );
+      return getTraceItemTagCollection(json);
+    } catch (e) {
+      throw new Error(`Unable to fetch trace item attribute keys: ${e}`);
+    }
+  };
 }

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
@@ -1,3 +1,4 @@
+import {useCallback} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -27,28 +28,31 @@ export function useGetTraceItemAttributeKeys({
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
-  return async (
-    queryString?: string
-  ): Promise<{
-    booleanAttributes: TagCollection;
-    numberAttributes: TagCollection;
-    stringAttributes: TagCollection;
-  }> => {
-    try {
-      const {json} = await queryClient.fetchQuery(
-        traceItemAttributeKeysOptions({
-          organization,
-          selection,
-          traceItemType,
-          projectIds: projectIds ?? selection.projects,
-          search: queryString,
-          query,
-          staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
-        })
-      );
-      return getTraceItemTagCollection(json);
-    } catch (e) {
-      throw new Error(`Unable to fetch trace item attribute keys: ${e}`);
-    }
-  };
+  return useCallback(
+    async (
+      queryString?: string
+    ): Promise<{
+      booleanAttributes: TagCollection;
+      numberAttributes: TagCollection;
+      stringAttributes: TagCollection;
+    }> => {
+      try {
+        const {json} = await queryClient.fetchQuery(
+          traceItemAttributeKeysOptions({
+            organization,
+            selection,
+            traceItemType,
+            projectIds: projectIds ?? selection.projects,
+            search: queryString,
+            query,
+            staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+          })
+        );
+        return getTraceItemTagCollection(json);
+      } catch (e) {
+        throw new Error(`Unable to fetch trace item attribute keys: ${e}`);
+      }
+    },
+    [organization, projectIds, query, queryClient, selection, traceItemType]
+  );
 }

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
@@ -1,6 +1,5 @@
 import {
   queryOptions,
-  useMutation,
   useQueryClient,
   type QueryFunctionContext,
 } from '@tanstack/react-query';
@@ -47,62 +46,58 @@ export function useGetTraceItemAttributeValues({
   const {selection} = usePageFilters();
   const queryClient = useQueryClient();
 
-  const {mutateAsync: getTraceItemAttributeValues} = useMutation({
-    mutationFn: async ({tag, searchQuery}: GetTagValuesParams): Promise<string[]> => {
-      if (tag.kind === FieldKind.FUNCTION || type === 'number' || type === 'boolean') {
-        // We can't really auto suggest values for aggregate functions, numbers, or booleans
-        return Promise.resolve([]);
+  return async ({tag, searchQuery}: GetTagValuesParams): Promise<string[]> => {
+    if (tag.kind === FieldKind.FUNCTION || type === 'number' || type === 'boolean') {
+      // We can't really auto suggest values for aggregate functions, numbers, or booleans
+      return Promise.resolve([]);
+    }
+
+    const project =
+      projectIds && projectIds.length > 0
+        ? projectIds.map(String)
+        : selection.projects.map(String);
+    const datetimeParams = datetime
+      ? normalizeDateTimeParams(datetime)
+      : normalizeDateTimeParams(selection.datetime);
+
+    const options = apiOptions.as<TraceItemAttributeValue[]>()(
+      '/organizations/$organizationIdOrSlug/trace-items/attributes/$key/values/',
+      {
+        path: {organizationIdOrSlug: organization.slug, key: tag.key},
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+        query: {
+          itemType: traceItemType,
+          attributeType: type,
+          query: filterQuery || undefined,
+          substringMatch: searchQuery || undefined,
+          project,
+          ...datetimeParams,
+        },
       }
+    );
+    const originalQueryFn = options.queryFn;
+    const optionsWithPrefixCacheShortcut =
+      typeof originalQueryFn === 'function'
+        ? queryOptions({
+            ...options,
+            queryFn: (ctx: QueryFunctionContext<ApiQueryKey>) => {
+              return (
+                findFreshEmptyPrefixSearchCacheMatch({
+                  client: ctx.client,
+                  currentKey: ctx.queryKey,
+                }) ?? originalQueryFn(ctx)
+              );
+            },
+          })
+        : options;
 
-      const project =
-        projectIds && projectIds.length > 0
-          ? projectIds.map(String)
-          : selection.projects.map(String);
-      const datetimeParams = datetime
-        ? normalizeDateTimeParams(datetime)
-        : normalizeDateTimeParams(selection.datetime);
-
-      const options = apiOptions.as<TraceItemAttributeValue[]>()(
-        '/organizations/$organizationIdOrSlug/trace-items/attributes/$key/values/',
-        {
-          path: {organizationIdOrSlug: organization.slug, key: tag.key},
-          staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
-          query: {
-            itemType: traceItemType,
-            attributeType: type,
-            query: filterQuery || undefined,
-            substringMatch: searchQuery || undefined,
-            project,
-            ...datetimeParams,
-          },
-        }
-      );
-      const originalQueryFn = options.queryFn;
-      const optionsWithPrefixCacheShortcut =
-        typeof originalQueryFn === 'function'
-          ? queryOptions({
-              ...options,
-              queryFn: (ctx: QueryFunctionContext<ApiQueryKey>) => {
-                return (
-                  findFreshEmptyPrefixSearchCacheMatch({
-                    client: ctx.client,
-                    currentKey: ctx.queryKey,
-                  }) ?? originalQueryFn(ctx)
-                );
-              },
-            })
-          : options;
-
-      try {
-        const {json} = await queryClient.fetchQuery(optionsWithPrefixCacheShortcut);
-        return json
-          .filter((item: TraceItemAttributeValue) => defined(item.value))
-          .map((item: TraceItemAttributeValue) => item.value);
-      } catch (e) {
-        throw new Error(`Unable to fetch trace item attribute values: ${e}`);
-      }
-    },
-  });
-
-  return getTraceItemAttributeValues;
+    try {
+      const {json} = await queryClient.fetchQuery(optionsWithPrefixCacheShortcut);
+      return json
+        .filter((item: TraceItemAttributeValue) => defined(item.value))
+        .map((item: TraceItemAttributeValue) => item.value);
+    } catch (e) {
+      throw new Error(`Unable to fetch trace item attribute values: ${e}`);
+    }
+  };
 }

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
@@ -1,3 +1,4 @@
+import {useCallback} from 'react';
 import {
   queryOptions,
   useQueryClient,
@@ -46,58 +47,71 @@ export function useGetTraceItemAttributeValues({
   const {selection} = usePageFilters();
   const queryClient = useQueryClient();
 
-  return async ({tag, searchQuery}: GetTagValuesParams): Promise<string[]> => {
-    if (tag.kind === FieldKind.FUNCTION || type === 'number' || type === 'boolean') {
-      // We can't really auto suggest values for aggregate functions, numbers, or booleans
-      return Promise.resolve([]);
-    }
-
-    const project =
-      projectIds && projectIds.length > 0
-        ? projectIds.map(String)
-        : selection.projects.map(String);
-    const datetimeParams = datetime
-      ? normalizeDateTimeParams(datetime)
-      : normalizeDateTimeParams(selection.datetime);
-
-    const options = apiOptions.as<TraceItemAttributeValue[]>()(
-      '/organizations/$organizationIdOrSlug/trace-items/attributes/$key/values/',
-      {
-        path: {organizationIdOrSlug: organization.slug, key: tag.key},
-        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
-        query: {
-          itemType: traceItemType,
-          attributeType: type,
-          query: filterQuery || undefined,
-          substringMatch: searchQuery || undefined,
-          project,
-          ...datetimeParams,
-        },
+  return useCallback(
+    async ({tag, searchQuery}: GetTagValuesParams): Promise<string[]> => {
+      if (tag.kind === FieldKind.FUNCTION || type === 'number' || type === 'boolean') {
+        // We can't really auto suggest values for aggregate functions, numbers, or booleans
+        return Promise.resolve([]);
       }
-    );
-    const originalQueryFn = options.queryFn;
-    const optionsWithPrefixCacheShortcut =
-      typeof originalQueryFn === 'function'
-        ? queryOptions({
-            ...options,
-            queryFn: (ctx: QueryFunctionContext<ApiQueryKey>) => {
-              return (
-                findFreshEmptyPrefixSearchCacheMatch({
-                  client: ctx.client,
-                  currentKey: ctx.queryKey,
-                }) ?? originalQueryFn(ctx)
-              );
-            },
-          })
-        : options;
 
-    try {
-      const {json} = await queryClient.fetchQuery(optionsWithPrefixCacheShortcut);
-      return json
-        .filter((item: TraceItemAttributeValue) => defined(item.value))
-        .map((item: TraceItemAttributeValue) => item.value);
-    } catch (e) {
-      throw new Error(`Unable to fetch trace item attribute values: ${e}`);
-    }
-  };
+      const project =
+        projectIds && projectIds.length > 0
+          ? projectIds.map(String)
+          : selection.projects.map(String);
+      const datetimeParams = datetime
+        ? normalizeDateTimeParams(datetime)
+        : normalizeDateTimeParams(selection.datetime);
+
+      const options = apiOptions.as<TraceItemAttributeValue[]>()(
+        '/organizations/$organizationIdOrSlug/trace-items/attributes/$key/values/',
+        {
+          path: {organizationIdOrSlug: organization.slug, key: tag.key},
+          staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+          query: {
+            itemType: traceItemType,
+            attributeType: type,
+            query: filterQuery || undefined,
+            substringMatch: searchQuery || undefined,
+            project,
+            ...datetimeParams,
+          },
+        }
+      );
+      const originalQueryFn = options.queryFn;
+      const optionsWithPrefixCacheShortcut =
+        typeof originalQueryFn === 'function'
+          ? queryOptions({
+              ...options,
+              queryFn: (ctx: QueryFunctionContext<ApiQueryKey>) => {
+                return (
+                  findFreshEmptyPrefixSearchCacheMatch({
+                    client: ctx.client,
+                    currentKey: ctx.queryKey,
+                  }) ?? originalQueryFn(ctx)
+                );
+              },
+            })
+          : options;
+
+      try {
+        const {json} = await queryClient.fetchQuery(optionsWithPrefixCacheShortcut);
+        return json
+          .filter((item: TraceItemAttributeValue) => defined(item.value))
+          .map((item: TraceItemAttributeValue) => item.value);
+      } catch (e) {
+        throw new Error(`Unable to fetch trace item attribute values: ${e}`);
+      }
+    },
+    [
+      datetime,
+      filterQuery,
+      organization.slug,
+      projectIds,
+      queryClient,
+      selection.datetime,
+      selection.projects,
+      traceItemType,
+      type,
+    ]
+  );
 }


### PR DESCRIPTION
Tidying up our getter functions to remove the use of `useMutation`. We're not using it anymore than just to wrap the async function, so let's just remove them.

Thanks to @TkDodo for pointing this out 🙌 

Closes EXP-922