### PR TITLE
feat(dynamic-sampling): use config in per-org pipeline

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/tasks/configuration.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/configuration.py
@@ -16,11 +16,16 @@ TargetSampleRate = float | None
 ProjectTargetSampleRates = Mapping[ProjectId, TargetSampleRate]
 
 
-def get_configuration(organization: Organization) -> BaseDynamicSamplingConfiguration:
+def get_configuration(organization_id: int) -> BaseDynamicSamplingConfiguration:
+    try:
+        organization = Organization.objects.get_from_cache(id=organization_id)
+    except Organization.DoesNotExist:
+        return NoDynamicSamplingConfiguration()
+
     if not has_custom_dynamic_sampling(organization):
         configuration = AutomaticDynamicSamplingConfiguration(organization)
         if not configuration.is_enabled:
-            return NoDynamicSamplingConfiguration(organization)
+            return NoDynamicSamplingConfiguration()
         return configuration
 
     if (
@@ -60,6 +65,9 @@ class BaseDynamicSamplingConfiguration(ABC):
 
 
 class NoDynamicSamplingConfiguration(BaseDynamicSamplingConfiguration):
+    def __init__(self) -> None:
+        pass
+
     @property
     def is_enabled(self) -> bool:
         return False

--- a/src/sentry/dynamic_sampling/per_org/tasks/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/queries.py
@@ -7,11 +7,11 @@ from typing import Any
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
 
 from sentry.constants import ObjectStatus
+from sentry.dynamic_sampling.per_org.tasks.configuration import BaseDynamicSamplingConfiguration
 from sentry.dynamic_sampling.tasks.common import (
     ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
     OrganizationDataVolume,
 )
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.eap.constants import SAMPLING_MODE_HIGHEST_ACCURACY
 from sentry.search.eap.types import SearchResolverConfig
@@ -25,11 +25,11 @@ def _get_aggregate_int(row: Mapping[str, Any], column: str) -> int:
 
 
 def get_eap_organization_volume(
-    organization: Organization,
+    config: BaseDynamicSamplingConfiguration,
     time_interval: timedelta = ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
 ) -> OrganizationDataVolume | None:
     projects = list(
-        Project.objects.filter(organization_id=organization.id, status=ObjectStatus.ACTIVE)
+        Project.objects.filter(organization_id=config.organization.id, status=ObjectStatus.ACTIVE)
     )
     if not projects:
         return None
@@ -41,7 +41,7 @@ def get_eap_organization_volume(
             start=start_time,
             end=end_time,
             projects=projects,
-            organization=organization,
+            organization=config.organization,
         ),
         query_string="is_transaction:true",
         selected_columns=["count()", "count_sample()"],
@@ -66,4 +66,4 @@ def get_eap_organization_volume(
         return None
     indexed = _get_aggregate_int(row, "count_sample()")
 
-    return OrganizationDataVolume(org_id=organization.id, total=total, indexed=indexed)
+    return OrganizationDataVolume(org_id=config.organization.id, total=total, indexed=indexed)

--- a/src/sentry/dynamic_sampling/per_org/tasks/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/scheduler.py
@@ -8,6 +8,7 @@ from django.db.models import F
 from django.db.models.functions import Mod
 from taskbroker_client.retry import Retry
 
+from sentry.dynamic_sampling.per_org.tasks.configuration import get_configuration
 from sentry.dynamic_sampling.per_org.tasks.gate import is_org_in_rollout
 from sentry.dynamic_sampling.per_org.tasks.queries import get_eap_organization_volume
 from sentry.dynamic_sampling.per_org.tasks.telemetry import (
@@ -17,7 +18,6 @@ from sentry.dynamic_sampling.per_org.tasks.telemetry import (
     track_dynamic_sampling,
 )
 from sentry.dynamic_sampling.rules.utils import OrganizationId, get_redis_client_for_ds
-from sentry.dynamic_sampling.utils import has_dynamic_sampling
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -97,15 +97,11 @@ def schedule_per_org_calculations() -> None:
 )
 @track_dynamic_sampling
 def run_calculations_per_org_task(org_id: OrganizationId) -> TelemetryStatus | None:
-    try:
-        organization = Organization.objects.get_from_cache(id=org_id)
-    except Organization.DoesNotExist:
-        return TelemetryStatus.ORG_NOT_FOUND
-
-    if not has_dynamic_sampling(organization):
+    config = get_configuration(org_id)
+    if not config.is_enabled:
         return TelemetryStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
 
-    org_volume = get_eap_organization_volume(organization)
+    org_volume = get_eap_organization_volume(config)
     if org_volume is None:
         return TelemetryStatus.NO_VOLUME
 

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_configuration.py
@@ -50,7 +50,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
             "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
             return_value=0.5,
         ) as get_blended_sample_rate:
-            configuration = get_configuration(org)
+            configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
         assert configuration.is_enabled
@@ -69,7 +69,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
             "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
             return_value=None,
         ):
-            configuration = get_configuration(org)
+            configuration = get_configuration(org.id)
 
         assert isinstance(configuration, NoDynamicSamplingConfiguration)
         assert not configuration.is_enabled
@@ -86,7 +86,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
             "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
             return_value=0.5,
         ):
-            configuration = get_configuration(org)
+            configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
         assert configuration.sample_rate == 0.5
@@ -111,7 +111,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                         "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate"
                     ) as get_blended_sample_rate,
                 ):
-                    configuration = get_configuration(org)
+                    configuration = get_configuration(org.id)
 
                 assert isinstance(configuration, CustomDynamicSamplingOrganizationConfiguration)
                 assert configuration.is_enabled
@@ -148,7 +148,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                         "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate"
                     ) as get_blended_sample_rate,
                 ):
-                    configuration = get_configuration(org)
+                    configuration = get_configuration(org.id)
 
                 assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
                 assert configuration.is_enabled
@@ -185,7 +185,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                         }
                     ),
                 ):
-                    configuration = get_configuration(org)
+                    configuration = get_configuration(org.id)
 
                 assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
                 assert not configuration.is_enabled
@@ -209,7 +209,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                         }
                     ),
                 ):
-                    configuration = get_configuration(org)
+                    configuration = get_configuration(org.id)
 
                 assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
                 assert not configuration.is_enabled
@@ -235,7 +235,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                         return_value=1.0,
                     ),
                 ):
-                    configuration = get_configuration(org)
+                    configuration = get_configuration(org.id)
 
                 assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
                 assert configuration.is_enabled

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
@@ -1,14 +1,27 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from unittest.mock import patch
 
+from sentry.dynamic_sampling.per_org.tasks.configuration import (
+    BaseDynamicSamplingConfiguration,
+    get_configuration,
+)
 from sentry.dynamic_sampling.per_org.tasks.queries import get_eap_organization_volume
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
+from sentry.models.organization import Organization
 from sentry.testutils.cases import SnubaTestCase, SpanTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 
 
 class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
+    def get_config(self, organization: Organization) -> BaseDynamicSamplingConfiguration:
+        with patch(
+            "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
+            return_value=1.0,
+        ):
+            return get_configuration(organization.id)
+
     def test_get_eap_organization_volume_existing_org(self) -> None:
         organization = self.create_organization()
         project = self.create_project(organization=organization)
@@ -45,7 +58,9 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
             ]
         )
 
-        org_volume = get_eap_organization_volume(organization, time_interval=timedelta(hours=1))
+        org_volume = get_eap_organization_volume(
+            self.get_config(organization), time_interval=timedelta(hours=1)
+        )
 
         assert org_volume == OrganizationDataVolume(org_id=organization.id, total=2, indexed=2)
 
@@ -68,7 +83,9 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
             ]
         )
 
-        org_volume = get_eap_organization_volume(organization, time_interval=timedelta(hours=1))
+        org_volume = get_eap_organization_volume(
+            self.get_config(organization), time_interval=timedelta(hours=1)
+        )
 
         assert org_volume == OrganizationDataVolume(org_id=organization.id, total=10, indexed=1)
 
@@ -76,13 +93,17 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         organization = self.create_organization()
         self.create_project(organization=organization)
 
-        org_volume = get_eap_organization_volume(organization, time_interval=timedelta(hours=1))
+        org_volume = get_eap_organization_volume(
+            self.get_config(organization), time_interval=timedelta(hours=1)
+        )
 
         assert org_volume is None
 
     def test_get_eap_organization_volume_without_projects(self) -> None:
         organization = self.create_organization()
 
-        org_volume = get_eap_organization_volume(organization, time_interval=timedelta(hours=1))
+        org_volume = get_eap_organization_volume(
+            self.get_config(organization), time_interval=timedelta(hours=1)
+        )
 
         assert org_volume is None

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from sentry.dynamic_sampling.per_org.tasks.configuration import BaseDynamicSamplingConfiguration
 from sentry.dynamic_sampling.per_org.tasks.scheduler import (
     BUCKET_COUNT,
     BUCKET_CURSOR_KEY,
@@ -16,6 +17,13 @@ from sentry.models.organization import OrganizationStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
+
+
+def _assert_called_once_with_config(mock, organization_id: int) -> None:
+    mock.assert_called_once()
+    config = mock.call_args.args[0]
+    assert isinstance(config, BaseDynamicSamplingConfiguration)
+    assert config.organization.id == organization_id
 
 
 def _drain_dispatched_org_ids(burst) -> list[int]:
@@ -118,7 +126,10 @@ class SchedulePerOrgCalculationsTest(TestCase):
         org = self.create_organization()
 
         with (
-            self.feature("organizations:dynamic-sampling"),
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
+                return_value=1.0,
+            ),
             patch(
                 "sentry.dynamic_sampling.per_org.tasks.scheduler.get_eap_organization_volume",
                 return_value=None,
@@ -127,7 +138,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
             result = run_calculations_per_org_task(org.id)
 
         assert result == TelemetryStatus.NO_VOLUME
-        get_volume.assert_called_once_with(org)
+        _assert_called_once_with_config(get_volume, org.id)
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_continues_with_traffic(self) -> None:
@@ -135,7 +146,10 @@ class SchedulePerOrgCalculationsTest(TestCase):
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
 
         with (
-            self.feature("organizations:dynamic-sampling"),
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
+                return_value=1.0,
+            ),
             patch(
                 "sentry.dynamic_sampling.per_org.tasks.scheduler.get_eap_organization_volume",
                 return_value=org_volume,
@@ -144,15 +158,21 @@ class SchedulePerOrgCalculationsTest(TestCase):
             result = run_calculations_per_org_task(org.id)
 
         assert result is None
-        get_volume.assert_called_once_with(org)
+        _assert_called_once_with_config(get_volume, org.id)
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_skips_org_without_dynamic_sampling(self) -> None:
         org = self.create_organization()
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.tasks.scheduler.get_eap_organization_volume"
-        ) as get_volume:
+        with (
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
+                return_value=None,
+            ),
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.scheduler.get_eap_organization_volume"
+            ) as get_volume,
+        ):
             result = run_calculations_per_org_task(org.id)
 
         assert result == TelemetryStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
@@ -165,7 +185,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         ) as get_volume:
             result = run_calculations_per_org_task(99999999)
 
-        assert result == TelemetryStatus.ORG_NOT_FOUND
+        assert result == TelemetryStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
         get_volume.assert_not_called()
 
 


### PR DESCRIPTION
- Use the config added in https://github.com/getsentry/sentry/pull/114837 in the per-org pipeline scheduler
- This will cause the logic to (hopefully) work as expected, meaning that we will see queries to quotas for information about the sample rates and queries to EAP about organization volumes


Contributes to TET-2230