### PR TITLE
feat(minidump): Add feature for uploading minidumps to object store

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -568,6 +568,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:relay-upload-endpoint", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables the uploading of minidump attachments to the objectstore.
     manager.add("projects:relay-minidump-attachment-uploads", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enables the uploading of minidumps to the objectstore.
+    manager.add("projects:relay-minidump-uploads", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     # Enable lightweight RCA clustering write path (generate embeddings on new issues)
     manager.add("organizations:supergroups-lightweight-rca-clustering-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -73,6 +73,7 @@ EXPOSABLE_FEATURES = [
     "projects:trace-attachment-processing",
     "projects:relay-upload-endpoint",
     "projects:relay-minidump-attachment-uploads",
+    "projects:relay-minidump-uploads",
 ]
 
 EXTRACT_METRICS_VERSION = 1


### PR DESCRIPTION
Relay PR that this is gonna be used in: https://github.com/getsentry/relay/pull/5909