### PR TITLE
chore(cross-events): Temp disable traces tab and add new checks

### DIFF
--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -17,7 +17,6 @@ import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logs
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {getTitleFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/title';
-import {useCrossEventQueries} from 'sentry/views/explore/hooks/useCrossEventQueries';
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTracesTable';
@@ -38,6 +37,7 @@ import {
   useQueryParamsTitle,
   useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
+import type {CrossEventQueryExtras} from 'sentry/views/explore/queryParams/crossEvent';
 import type {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {
   isVisualizeEquation,
@@ -69,7 +69,7 @@ interface UseTrackAnalyticsProps {
   timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
   visualizes: readonly Visualize[];
   attributeBreakdownsMode?: 'breakdowns' | 'cohort_comparison';
-  crossEventQueries?: ReturnType<typeof useCrossEventQueries>;
+  crossEventQueries?: CrossEventQueryExtras;
   title?: string;
   tracesTableResult?: TracesTableResult;
 }
@@ -481,6 +481,7 @@ export function useAnalytics({
   tracesTableResult,
   timeseriesResult,
   interval,
+  crossEventQueries,
 }: Pick<
   UseTrackAnalyticsProps,
   | 'queryType'
@@ -489,6 +490,7 @@ export function useAnalytics({
   | 'tracesTableResult'
   | 'timeseriesResult'
   | 'interval'
+  | 'crossEventQueries'
 >) {
   const dataset = useSpansDataset();
   const title = useQueryParamsTitle();
@@ -498,7 +500,6 @@ export function useAnalytics({
   const topEvents = useTopEvents();
   const isTopN = topEvents ? topEvents > 0 : false;
   const {chartSelection} = useChartSelection();
-  const crossEventQueries = useCrossEventQueries();
 
   const attributeBreakdownsMode =
     queryType === 'attribute_breakdowns'

--- a/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
@@ -152,6 +152,22 @@ describe('useCrossEventQueries', () => {
     });
   });
 
+  it('returns undefined when all cross event queries are for unavailable datasets', () => {
+    const {result} = renderHookWithProviders(useCrossEventQueries, {
+      additionalWrapper: wrapper([
+        {type: 'logs', query: 'test:a'},
+        {
+          type: 'metrics',
+          query: 'env:prod',
+          metric: {name: 'my_metric', type: 'counter'},
+        },
+      ]),
+      initialProps: {spans: true, logs: false, metrics: false},
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
   it('prepends metric identity fields to metric queries', () => {
     const {result} = renderHookWithProviders(useCrossEventQueries, {
       additionalWrapper: wrapper([

--- a/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
@@ -16,8 +16,14 @@ import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
 import {defaultCursor} from 'sentry/views/explore/queryParams/cursor';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import type {CrossEventDatasetAvailability} from 'sentry/views/explore/spans/crossEvents/useCrossEventDatasetAvailability';
 
 const mockSetQueryParams = jest.fn();
+const ALL_CROSS_EVENT_DATASETS_AVAILABLE: CrossEventDatasetAvailability = {
+  spans: true,
+  logs: true,
+  metrics: true,
+};
 
 function wrapper(crossEvents?: CrossEvent[]) {
   return function Wrapped({children}: {children: ReactNode}) {
@@ -57,6 +63,7 @@ describe('useCrossEventQueries', () => {
   it('returns undefined if there are no cross event queries', () => {
     const {result} = renderHookWithProviders(useCrossEventQueries, {
       additionalWrapper: wrapper(),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
     expect(result.current).toBeUndefined();
@@ -65,6 +72,7 @@ describe('useCrossEventQueries', () => {
   it('returns undefined if cross event queries array is empty', () => {
     const {result} = renderHookWithProviders(useCrossEventQueries, {
       additionalWrapper: wrapper([]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
     expect(result.current).toBeUndefined();
@@ -77,6 +85,7 @@ describe('useCrossEventQueries', () => {
         {type: 'spans', query: 'test:b'},
         {type: 'spans', query: 'test:c'},
       ]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
     // Since MAX_CROSS_EVENT_QUERIES is 2, the third query ('spans') will be dropped.
@@ -94,6 +103,7 @@ describe('useCrossEventQueries', () => {
         {type: 'spans', query: 'test:b'},
         {type: 'spans', query: 'test:c'},
       ]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
     // Only first 2 are kept
@@ -111,6 +121,7 @@ describe('useCrossEventQueries', () => {
         {type: 'invalid' as any, query: 'test:b'},
         {type: 'spans', query: 'test:c'},
       ]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
     expect(result.current).toStrictEqual({
@@ -121,20 +132,18 @@ describe('useCrossEventQueries', () => {
   });
 
   it('ignores queries for unavailable datasets', () => {
-    const {result} = renderHookWithProviders(
-      () => useCrossEventQueries({spans: true, logs: false, metrics: false}),
-      {
-        additionalWrapper: wrapper([
-          {type: 'logs', query: 'test:a'},
-          {type: 'spans', query: 'test:b'},
-          {
-            type: 'metrics',
-            query: 'env:prod',
-            metric: {name: 'my_metric', type: 'counter'},
-          },
-        ]),
-      }
-    );
+    const {result} = renderHookWithProviders(useCrossEventQueries, {
+      additionalWrapper: wrapper([
+        {type: 'logs', query: 'test:a'},
+        {type: 'spans', query: 'test:b'},
+        {
+          type: 'metrics',
+          query: 'env:prod',
+          metric: {name: 'my_metric', type: 'counter'},
+        },
+      ]),
+      initialProps: {spans: true, logs: false, metrics: false},
+    });
 
     expect(result.current).toStrictEqual({
       logQuery: [],
@@ -152,6 +161,7 @@ describe('useCrossEventQueries', () => {
           metric: {name: 'my_metric', type: 'distribution', unit: 'ms'},
         },
       ]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
     expect(result.current).toStrictEqual({
@@ -172,6 +182,7 @@ describe('useCrossEventQueries', () => {
           metric: {name: 'my_metric', type: 'counter'},
         },
       ]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
     expect(result.current).toStrictEqual({
@@ -190,6 +201,7 @@ describe('useCrossEventQueries', () => {
           metric: {name: 'my_metric', type: 'counter', unit: 'none'},
         },
       ]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
     expect(result.current).toStrictEqual({
@@ -210,6 +222,7 @@ describe('useCrossEventQueries', () => {
           metric: {name: 'my_metric', type: 'distribution', unit: 'ms'},
         },
       ]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
     expect(result.current).toStrictEqual({
@@ -226,6 +239,7 @@ describe('useCrossEventQueries', () => {
       additionalWrapper: wrapper([
         {type: 'metrics', query: 'env:prod', metric: {name: '', type: ''}},
       ]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
     expect(result.current).toStrictEqual({

--- a/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
@@ -120,6 +120,29 @@ describe('useCrossEventQueries', () => {
     });
   });
 
+  it('ignores queries for unavailable datasets', () => {
+    const {result} = renderHookWithProviders(
+      () => useCrossEventQueries({spans: true, logs: false, metrics: false}),
+      {
+        additionalWrapper: wrapper([
+          {type: 'logs', query: 'test:a'},
+          {type: 'spans', query: 'test:b'},
+          {
+            type: 'metrics',
+            query: 'env:prod',
+            metric: {name: 'my_metric', type: 'counter'},
+          },
+        ]),
+      }
+    );
+
+    expect(result.current).toStrictEqual({
+      logQuery: [],
+      spanQuery: ['test:b'],
+      metricQuery: [],
+    });
+  });
+
   it('prepends metric identity fields to metric queries', () => {
     const {result} = renderHookWithProviders(useCrossEventQueries, {
       additionalWrapper: wrapper([

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -8,8 +8,15 @@ import {
 } from 'sentry/views/explore/metrics/utils';
 import {useQueryParamsCrossEvents} from 'sentry/views/explore/queryParams/context';
 import {isCrossEventType} from 'sentry/views/explore/queryParams/crossEvent';
+import type {CrossEventDatasetAvailability} from 'sentry/views/explore/spans/crossEvents/useCrossEventDatasetAvailability';
 
-export function useCrossEventQueries() {
+const ALL_CROSS_EVENT_DATASETS_AVAILABLE: CrossEventDatasetAvailability = {
+  spans: true,
+  logs: true,
+  metrics: true,
+};
+
+export function useCrossEventQueries(availability = ALL_CROSS_EVENT_DATASETS_AVAILABLE) {
   const crossEvents = useQueryParamsCrossEvents();
 
   return useMemo(() => {
@@ -20,7 +27,9 @@ export function useCrossEventQueries() {
     // We only want to include the first MAX_CROSS_EVENT_QUERIES cross events in the
     // actual API request to avoid overwhelming the backend.
     const slicedCrossEvents = crossEvents
-      .filter(crossEvent => isCrossEventType(crossEvent.type))
+      .filter(
+        crossEvent => isCrossEventType(crossEvent.type) && availability[crossEvent.type]
+      )
       .slice(0, MAX_CROSS_EVENT_QUERIES);
 
     const logQuery: string[] = [];
@@ -48,5 +57,5 @@ export function useCrossEventQueries() {
     }
 
     return {spanQuery, logQuery, metricQuery};
-  }, [crossEvents]);
+  }, [availability, crossEvents]);
 }

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -31,6 +31,10 @@ export function useCrossEventQueries(
       )
       .slice(0, MAX_CROSS_EVENT_QUERIES);
 
+    if (slicedCrossEvents.length === 0) {
+      return;
+    }
+
     const logQuery: string[] = [];
     const spanQuery: string[] = [];
     const metricQuery: string[] = [];

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -7,16 +7,15 @@ import {
   isCompleteTraceMetric,
 } from 'sentry/views/explore/metrics/utils';
 import {useQueryParamsCrossEvents} from 'sentry/views/explore/queryParams/context';
-import {isCrossEventType} from 'sentry/views/explore/queryParams/crossEvent';
+import {
+  isCrossEventType,
+  type CrossEventQueryExtras,
+} from 'sentry/views/explore/queryParams/crossEvent';
 import type {CrossEventDatasetAvailability} from 'sentry/views/explore/spans/crossEvents/useCrossEventDatasetAvailability';
 
-const ALL_CROSS_EVENT_DATASETS_AVAILABLE: CrossEventDatasetAvailability = {
-  spans: true,
-  logs: true,
-  metrics: true,
-};
-
-export function useCrossEventQueries(availability = ALL_CROSS_EVENT_DATASETS_AVAILABLE) {
+export function useCrossEventQueries(
+  availability: CrossEventDatasetAvailability
+): CrossEventQueryExtras | undefined {
   const crossEvents = useQueryParamsCrossEvents();
 
   return useMemo(() => {

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -1,4 +1,5 @@
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
+import type {CrossEventQueryExtras} from 'sentry/views/explore/queryParams/crossEvent';
 
 export const SAMPLING_MODE = {
   NORMAL: 'NORMAL',
@@ -20,13 +21,10 @@ const NON_EXTRAPOLATED_SAMPLING_MODE_QUERY_EXTRAS = {
 } as const;
 
 export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
-export type RPCQueryExtras = {
+export type RPCQueryExtras = Partial<CrossEventQueryExtras> & {
   caseInsensitive?: CaseInsensitive;
   disableAggregateExtrapolation?: string;
-  logQuery?: string[];
-  metricQuery?: string[];
   samplingMode?: SamplingMode;
-  spanQuery?: string[];
 };
 
 interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {

--- a/static/app/views/explore/queryParams/context.spec.tsx
+++ b/static/app/views/explore/queryParams/context.spec.tsx
@@ -81,6 +81,19 @@ describe('QueryParamsContext', () => {
           crossEvents: [{query: 'bar', type: 'logs'}],
         });
       });
+
+      it('should clear the crossEvents when setting an empty array', () => {
+        renderHookWithProviders(
+          () => {
+            const setCrossEvents = useSetQueryParamsCrossEvents();
+            setCrossEvents([]);
+            return useQueryParamsCrossEvents();
+          },
+          {additionalWrapper: Wrapper}
+        );
+
+        expect(mockSetQueryParams).toHaveBeenCalledWith({crossEvents: null});
+      });
     });
   });
 });

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -474,7 +474,7 @@ export function useSetQueryParamsCrossEvents() {
 
   return useCallback(
     (crossEvents: CrossEvent[]) => {
-      setQueryParams({crossEvents});
+      setQueryParams({crossEvents: crossEvents.length > 0 ? crossEvents : null});
     },
     [setQueryParams]
   );

--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -9,6 +9,12 @@ export type CrossEvent =
   | {query: string; type: 'logs' | 'spans'}
   | {metric: TraceMetric; query: string; type: 'metrics'};
 
+export type CrossEventQueryExtras = {
+  logQuery: string[];
+  metricQuery: string[];
+  spanQuery: string[];
+};
+
 export function getCrossEventsFromLocation(
   location: Location,
   key: string

--- a/static/app/views/explore/spans/crossEvents/crossEventQueryingDropdown.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventQueryingDropdown.tsx
@@ -14,6 +14,7 @@ import {
   useSetQueryParamsCrossEvents,
 } from 'sentry/views/explore/queryParams/context';
 import {isCrossEventType} from 'sentry/views/explore/queryParams/crossEvent';
+import {useCrossEventDatasetAvailability} from 'sentry/views/explore/spans/crossEvents/useCrossEventDatasetAvailability';
 import {
   getCrossEventDropdownItems,
   makeCrossEvent,
@@ -23,6 +24,7 @@ export function CrossEventQueryingDropdown() {
   const organization = useOrganization();
   const crossEvents = useQueryParamsCrossEvents();
   const setCrossEvents = useSetQueryParamsCrossEvents();
+  const crossEventDatasetAvailability = useCrossEventDatasetAvailability(organization);
 
   const onAction = (key: Key) => {
     if (typeof key !== 'string' || !isCrossEventType(key)) {
@@ -52,7 +54,7 @@ export function CrossEventQueryingDropdown() {
       {triggerProps => (
         <DropdownMenu
           onAction={onAction}
-          items={getCrossEventDropdownItems(organization)}
+          items={getCrossEventDropdownItems(crossEventDatasetAvailability)}
           isDisabled={isDisabled}
           triggerProps={{
             ...triggerProps,

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBars.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBars.tsx
@@ -21,6 +21,7 @@ import {
 import {isCrossEventType} from 'sentry/views/explore/queryParams/crossEvent';
 import {SpansTabCrossEventMetricsSearchBar} from 'sentry/views/explore/spans/crossEvents/crossEventMetricsSearchBar';
 import {SpansTabCrossEventSearchBar} from 'sentry/views/explore/spans/crossEvents/crossEventSearchBar';
+import {useCrossEventDatasetAvailability} from 'sentry/views/explore/spans/crossEvents/useCrossEventDatasetAvailability';
 import {
   getCrossEventDatasetOptions,
   makeCrossEvent,
@@ -31,6 +32,7 @@ export function SpansTabCrossEventSearchBars() {
   const organization = useOrganization();
   const crossEvents = useQueryParamsCrossEvents();
   const setCrossEvents = useSetQueryParamsCrossEvents();
+  const crossEventDatasetAvailability = useCrossEventDatasetAvailability(organization);
 
   // Using an effect event here to make sure we're reading only the latest props and not
   // firing based off of the cross events changing
@@ -76,7 +78,7 @@ export function SpansTabCrossEventSearchBars() {
               trigger={triggerProps => (
                 <OverlayTrigger.Button {...triggerProps} {...props} prefix={t('with')} />
               )}
-              options={getCrossEventDatasetOptions(organization)}
+              options={getCrossEventDatasetOptions(crossEventDatasetAvailability)}
               onChange={({value: newValue}) => {
                 if (!isCrossEventType(newValue)) return;
 

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBars.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBars.tsx
@@ -51,11 +51,29 @@ export function SpansTabCrossEventSearchBars() {
     fireErrorToast();
   }, []);
 
-  if (!crossEvents || crossEvents.length === 0) {
+  useEffect(() => {
+    if (!crossEvents) {
+      return;
+    }
+
+    const availableCrossEvents = crossEvents.filter(
+      crossEvent => crossEventDatasetAvailability[crossEvent.type]
+    );
+
+    if (availableCrossEvents.length !== crossEvents.length) {
+      setCrossEvents(availableCrossEvents);
+    }
+  }, [crossEventDatasetAvailability, crossEvents, setCrossEvents]);
+
+  const visibleCrossEvents = crossEvents
+    ?.map((crossEvent, index) => ({crossEvent, index}))
+    .filter(({crossEvent}) => crossEventDatasetAvailability[crossEvent.type]);
+
+  if (!visibleCrossEvents || visibleCrossEvents.length === 0) {
     return null;
   }
 
-  return crossEvents.map((crossEvent, index) => {
+  return visibleCrossEvents.map(({crossEvent, index}, visibleIndex) => {
     let traceItemType = TraceItemDataset.SPANS;
     if (crossEvent.type === 'logs') {
       traceItemType = TraceItemDataset.LOGS;
@@ -63,7 +81,7 @@ export function SpansTabCrossEventSearchBars() {
       traceItemType = TraceItemDataset.TRACEMETRICS;
     }
 
-    const maxCrossEventQueriesReached = index >= MAX_CROSS_EVENT_QUERIES;
+    const maxCrossEventQueriesReached = visibleIndex >= MAX_CROSS_EVENT_QUERIES;
 
     return (
       <Fragment key={`${crossEvent.type}-${index}`}>

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBars.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBars.tsx
@@ -9,7 +9,6 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
@@ -18,6 +17,7 @@ import {
   useQueryParamsCrossEvents,
   useSetQueryParamsCrossEvents,
 } from 'sentry/views/explore/queryParams/context';
+import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
 import {isCrossEventType} from 'sentry/views/explore/queryParams/crossEvent';
 import {SpansTabCrossEventMetricsSearchBar} from 'sentry/views/explore/spans/crossEvents/crossEventMetricsSearchBar';
 import {SpansTabCrossEventSearchBar} from 'sentry/views/explore/spans/crossEvents/crossEventSearchBar';
@@ -28,16 +28,18 @@ import {
 } from 'sentry/views/explore/spans/crossEvents/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
+const EMPTY_CROSS_EVENTS: CrossEvent[] = [];
+
 export function SpansTabCrossEventSearchBars() {
   const organization = useOrganization();
-  const crossEvents = useQueryParamsCrossEvents();
+  const crossEvents = useQueryParamsCrossEvents() ?? EMPTY_CROSS_EVENTS;
   const setCrossEvents = useSetQueryParamsCrossEvents();
   const crossEventDatasetAvailability = useCrossEventDatasetAvailability(organization);
 
   // Using an effect event here to make sure we're reading only the latest props and not
   // firing based off of the cross events changing
   const fireErrorToast = useEffectEvent(() => {
-    if (defined(crossEvents) && crossEvents.length > MAX_CROSS_EVENT_QUERIES) {
+    if (crossEvents.length > MAX_CROSS_EVENT_QUERIES) {
       addErrorMessage(
         t(
           'You can add up to a maximum of %s cross event queries.',
@@ -52,10 +54,6 @@ export function SpansTabCrossEventSearchBars() {
   }, []);
 
   useEffect(() => {
-    if (!crossEvents) {
-      return;
-    }
-
     const availableCrossEvents = crossEvents.filter(
       crossEvent => crossEventDatasetAvailability[crossEvent.type]
     );
@@ -66,10 +64,10 @@ export function SpansTabCrossEventSearchBars() {
   }, [crossEventDatasetAvailability, crossEvents, setCrossEvents]);
 
   const visibleCrossEvents = crossEvents
-    ?.map((crossEvent, index) => ({crossEvent, index}))
+    .map((crossEvent, index) => ({crossEvent, index}))
     .filter(({crossEvent}) => crossEventDatasetAvailability[crossEvent.type]);
 
-  if (!visibleCrossEvents || visibleCrossEvents.length === 0) {
+  if (visibleCrossEvents.length === 0) {
     return null;
   }
 

--- a/static/app/views/explore/spans/crossEvents/useCrossEventDatasetAvailability.tsx
+++ b/static/app/views/explore/spans/crossEvents/useCrossEventDatasetAvailability.tsx
@@ -1,0 +1,37 @@
+import {useMemo} from 'react';
+
+import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import type {Organization} from 'sentry/types/organization';
+import {useProjects} from 'sentry/utils/useProjects';
+import {canUseMetricsUI} from 'sentry/views/explore/metrics/metricsFlags';
+import type {CrossEventType} from 'sentry/views/explore/queryParams/crossEvent';
+
+export type CrossEventDatasetAvailability = Record<CrossEventType, boolean>;
+
+export function useCrossEventDatasetAvailability(
+  organization: Organization
+): CrossEventDatasetAvailability {
+  const {projects} = useProjects();
+  const {selection} = usePageFilters();
+  const canUseMetrics = canUseMetricsUI(organization);
+
+  return useMemo(() => {
+    const explicitlySelectedProjectIds = selection.projects.filter(
+      projectId => projectId !== ALL_ACCESS_PROJECTS && projectId > 0
+    );
+
+    const selectedProjects =
+      explicitlySelectedProjectIds.length > 0
+        ? projects.filter(project =>
+            explicitlySelectedProjectIds.includes(Number(project.id))
+          )
+        : projects;
+
+    return {
+      spans: true,
+      logs: selectedProjects.some(project => project.hasLogs),
+      metrics: canUseMetrics && selectedProjects.some(project => project.hasTraceMetrics),
+    };
+  }, [canUseMetrics, projects, selection.projects]);
+}

--- a/static/app/views/explore/spans/crossEvents/useCrossEventDatasetAvailability.tsx
+++ b/static/app/views/explore/spans/crossEvents/useCrossEventDatasetAvailability.tsx
@@ -29,12 +29,13 @@ export function useCrossEventDatasetAvailability(
       projectId => projectId !== ALL_ACCESS_PROJECTS && projectId > 0
     );
 
-    const selectedProjects =
-      explicitlySelectedProjectIds.length > 0
+    const selectedProjects = selection.projects.includes(ALL_ACCESS_PROJECTS)
+      ? projects
+      : explicitlySelectedProjectIds.length > 0
         ? projects.filter(project =>
             explicitlySelectedProjectIds.includes(Number(project.id))
           )
-        : projects;
+        : projects.filter(project => project.isMember);
 
     return {
       spans: true,

--- a/static/app/views/explore/spans/crossEvents/useCrossEventDatasetAvailability.tsx
+++ b/static/app/views/explore/spans/crossEvents/useCrossEventDatasetAvailability.tsx
@@ -12,11 +12,19 @@ export type CrossEventDatasetAvailability = Record<CrossEventType, boolean>;
 export function useCrossEventDatasetAvailability(
   organization: Organization
 ): CrossEventDatasetAvailability {
-  const {projects} = useProjects();
+  const {initiallyLoaded, projects} = useProjects();
   const {selection} = usePageFilters();
   const canUseMetrics = canUseMetricsUI(organization);
 
   return useMemo(() => {
+    if (!initiallyLoaded) {
+      return {
+        spans: true,
+        logs: true,
+        metrics: canUseMetrics,
+      };
+    }
+
     const explicitlySelectedProjectIds = selection.projects.filter(
       projectId => projectId !== ALL_ACCESS_PROJECTS && projectId > 0
     );
@@ -33,5 +41,5 @@ export function useCrossEventDatasetAvailability(
       logs: selectedProjects.some(project => project.hasLogs),
       metrics: canUseMetrics && selectedProjects.some(project => project.hasTraceMetrics),
     };
-  }, [canUseMetrics, projects, selection.projects]);
+  }, [canUseMetrics, initiallyLoaded, projects, selection.projects]);
 }

--- a/static/app/views/explore/spans/crossEvents/utils.tsx
+++ b/static/app/views/explore/spans/crossEvents/utils.tsx
@@ -2,23 +2,23 @@ import type {SelectOption} from '@sentry/scraps/compactSelect';
 
 import type {DropdownMenuProps} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {canUseMetricsUI} from 'sentry/views/explore/metrics/metricsFlags';
 import type {
   CrossEvent,
   CrossEventType,
 } from 'sentry/views/explore/queryParams/crossEvent';
+import type {CrossEventDatasetAvailability} from 'sentry/views/explore/spans/crossEvents/useCrossEventDatasetAvailability';
 
 export function getCrossEventDropdownItems(
-  organization: Organization
+  availability: CrossEventDatasetAvailability
 ): DropdownMenuProps['items'] {
-  const items: DropdownMenuProps['items'] = [
-    {key: 'spans', label: t('Spans')},
-    {key: 'logs', label: t('Logs')},
-  ];
+  const items: DropdownMenuProps['items'] = [{key: 'spans', label: t('Spans')}];
 
-  if (canUseMetricsUI(organization)) {
+  if (availability.logs) {
+    items.push({key: 'logs', label: t('Logs')});
+  }
+
+  if (availability.metrics) {
     items.push({key: 'metrics', label: t('Application Metrics')});
   }
 
@@ -26,14 +26,17 @@ export function getCrossEventDropdownItems(
 }
 
 export function getCrossEventDatasetOptions(
-  organization: Organization
+  availability: CrossEventDatasetAvailability
 ): Array<SelectOption<CrossEventType>> {
   const options: Array<SelectOption<CrossEventType>> = [
     {value: 'spans', label: t('Spans')},
-    {value: 'logs', label: t('Logs')},
   ];
 
-  if (canUseMetricsUI(organization)) {
+  if (availability.logs) {
+    options.push({value: 'logs', label: t('Logs')});
+  }
+
+  if (availability.metrics) {
     options.push({value: 'metrics', label: t('Application Metrics')});
   }
 

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -1,5 +1,6 @@
 import type {ReactNode} from 'react';
 import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
+import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -10,9 +11,12 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/datePageFilter';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {TagCollection} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {FieldKind} from 'sentry/utils/fields';
 import * as spanTagsModule from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -57,6 +61,22 @@ describe('SpansTabContent', () => {
     },
   });
 
+  function setProjects(projects: Project[], selectedProjectIds?: number[]) {
+    ProjectsStore.loadInitialData(projects);
+    PageFiltersStore.onInitializeUrlState({
+      projects: selectedProjectIds ?? projects.map(p => parseInt(p.id, 10)),
+      environments: [],
+      datetime: {period: '7d', start: null, end: null, utc: null},
+    });
+  }
+
+  function makeProject(params: Partial<Project>) {
+    return ProjectFixture({
+      organization: {id: organization.id, slug: organization.slug},
+      ...params,
+    });
+  }
+
   beforeEach(() => {
     MockApiClient.clearMockResponses();
 
@@ -64,11 +84,7 @@ describe('SpansTabContent', () => {
     jest.spyOn(console, 'error').mockImplementation();
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState({
-      projects: [project].map(p => parseInt(p.id, 10)),
-      environments: [],
-      datetime: {period: '7d', start: null, end: null, utc: null},
-    });
+    setProjects([project]);
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/`,
       method: 'GET',
@@ -481,7 +497,7 @@ describe('SpansTabContent', () => {
   });
 
   describe('cross events', () => {
-    it('displays the cross events dropdown', async () => {
+    it('displays only spans when the selected project has no cross-event data', async () => {
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization,
         additionalWrapper: Wrapper,
@@ -496,13 +512,65 @@ describe('SpansTabContent', () => {
       );
 
       expect(screen.getByRole('menuitemradio', {name: 'Spans'})).toBeInTheDocument();
-      expect(screen.getByRole('menuitemradio', {name: 'Logs'})).toBeInTheDocument();
+      expect(screen.queryByRole('menuitemradio', {name: 'Logs'})).not.toBeInTheDocument();
       expect(
         screen.queryByRole('menuitemradio', {name: 'Application Metrics'})
       ).not.toBeInTheDocument();
     });
 
-    it('displays the metrics option when tracemetrics is enabled', async () => {
+    it('displays logs in the add dropdown and row selector when the selected project has logs', async () => {
+      const logsProject = makeProject({id: '3', slug: 'logs-project', hasLogs: true});
+      setProjects([logsProject]);
+
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {crossEvents: JSON.stringify([{query: '', type: 'spans'}])},
+          },
+        },
+      });
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Add a cross event query'})
+      );
+
+      expect(screen.getByRole('menuitemradio', {name: 'Logs'})).toBeInTheDocument();
+
+      await userEvent.keyboard('{Escape}');
+      await userEvent.click(screen.getByRole('button', {name: /Spans/}));
+
+      expect(screen.getByRole('option', {name: 'Logs'})).toBeInTheDocument();
+    });
+
+    it('hides the metrics option when tracemetrics is enabled but the selected project has no trace metrics', async () => {
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization: {
+          ...organization,
+          features: [...organization.features, 'tracemetrics-enabled'],
+        },
+        additionalWrapper: Wrapper,
+      });
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Add a cross event query'})
+      );
+
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'Application Metrics'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('displays the metrics option when tracemetrics is enabled and the selected project has trace metrics', async () => {
+      const metricsProject = makeProject({
+        id: '3',
+        slug: 'metrics-project',
+        hasTraceMetrics: true,
+      });
+      setProjects([metricsProject]);
+
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization: {
           ...organization,
@@ -518,6 +586,69 @@ describe('SpansTabContent', () => {
       expect(
         screen.getByRole('menuitemradio', {name: 'Application Metrics'})
       ).toBeInTheDocument();
+    });
+
+    it('displays a dataset option when any selected project has that data type', async () => {
+      const spansOnlyProject = makeProject({
+        id: '3',
+        slug: 'spans-only-project',
+        hasLogs: false,
+      });
+      const logsProject = makeProject({id: '4', slug: 'logs-project', hasLogs: true});
+      setProjects([spansOnlyProject, logsProject]);
+
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Add a cross event query'})
+      );
+
+      expect(screen.getByRole('menuitemradio', {name: 'Logs'})).toBeInTheDocument();
+    });
+
+    it('hides dataset options for unselected projects', async () => {
+      const spansOnlyProject = makeProject({
+        id: '3',
+        slug: 'spans-only-project',
+        hasLogs: false,
+      });
+      const logsProject = makeProject({id: '4', slug: 'logs-project', hasLogs: true});
+      setProjects([spansOnlyProject, logsProject], [parseInt(spansOnlyProject.id, 10)]);
+
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Add a cross event query'})
+      );
+
+      expect(screen.queryByRole('menuitemradio', {name: 'Logs'})).not.toBeInTheDocument();
+    });
+
+    it('displays dataset options for all projects', async () => {
+      const spansOnlyProject = makeProject({
+        id: '3',
+        slug: 'spans-only-project',
+        hasLogs: false,
+      });
+      const logsProject = makeProject({id: '4', slug: 'logs-project', hasLogs: true});
+      setProjects([spansOnlyProject, logsProject], [ALL_ACCESS_PROJECTS]);
+
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Add a cross event query'})
+      );
+
+      expect(screen.getByRole('menuitemradio', {name: 'Logs'})).toBeInTheDocument();
     });
 
     it('adds a cross event query', async () => {
@@ -571,6 +702,9 @@ describe('SpansTabContent', () => {
     });
 
     it('adds a cross event search bar when cross event added', async () => {
+      const logsProject = makeProject({id: '3', slug: 'logs-project', hasLogs: true});
+      setProjects([logsProject]);
+
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization,
         additionalWrapper: Wrapper,
@@ -617,6 +751,9 @@ describe('SpansTabContent', () => {
     });
 
     it('changes the cross event search bar when dataset changed', async () => {
+      const logsProject = makeProject({id: '3', slug: 'logs-project', hasLogs: true});
+      setProjects([logsProject]);
+
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization,
         additionalWrapper: Wrapper,
@@ -748,7 +885,7 @@ describe('SpansTabContent', () => {
       await userEvent.click(
         screen.getByRole('button', {name: 'Add a cross event query'})
       );
-      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Logs'}));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Spans'}));
 
       // Should switch to Span tab
       await waitFor(() => {
@@ -782,7 +919,7 @@ describe('SpansTabContent', () => {
       await userEvent.click(
         screen.getByRole('button', {name: 'Add a cross event query'})
       );
-      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Logs'}));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Spans'}));
 
       await waitFor(() => {
         expect(screen.getByRole('tab', {name: 'Span Samples'})).toHaveAttribute(

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -686,6 +686,43 @@ describe('SpansTabContent', () => {
       expect(attributeBreakdownsTab).toHaveAttribute('aria-disabled', 'true');
     });
 
+    it('disables Trace Samples tab when cross events are present', async () => {
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization: {
+          ...organization,
+          features: [...organization.features],
+        },
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {
+              crossEvents: JSON.stringify([{query: '', type: 'logs'}]),
+              table: 'trace',
+            },
+          },
+        },
+      });
+
+      const traceSamplesTab = screen.getByRole('tab', {name: 'Trace Samples'});
+      expect(traceSamplesTab).toHaveAttribute('aria-disabled', 'true');
+      expect(traceSamplesTab).toBeVisible();
+
+      await userEvent.hover(traceSamplesTab);
+      expect(
+        await screen.findByText(
+          'Trace samples do not yet work with Cross-Event queries, use spans tab.'
+        )
+      ).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', {name: 'Span Samples'})).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+      });
+    });
+
     it('switches from Attribute Breakdowns to Span tab when cross event is added', async () => {
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization: {
@@ -714,6 +751,39 @@ describe('SpansTabContent', () => {
       await userEvent.click(screen.getByRole('menuitemradio', {name: 'Logs'}));
 
       // Should switch to Span tab
+      await waitFor(() => {
+        expect(screen.getByRole('tab', {name: 'Span Samples'})).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+      });
+    });
+
+    it('switches from Trace Samples to Span tab when cross event is added', async () => {
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization: {
+          ...organization,
+          features: [...organization.features],
+        },
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {table: 'trace'},
+          },
+        },
+      });
+
+      expect(screen.getByRole('tab', {name: 'Trace Samples'})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Add a cross event query'})
+      );
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Logs'}));
+
       await waitFor(() => {
         expect(screen.getByRole('tab', {name: 'Span Samples'})).toHaveAttribute(
           'aria-selected',

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -677,6 +677,9 @@ describe('SpansTabContent', () => {
     });
 
     it('disables dropdown when there are 2 cross events', () => {
+      const logsProject = makeProject({id: '3', slug: 'logs-project', hasLogs: true});
+      setProjects([logsProject]);
+
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization,
         additionalWrapper: Wrapper,
@@ -723,6 +726,9 @@ describe('SpansTabContent', () => {
     });
 
     it('can remove a cross event query', async () => {
+      const logsProject = makeProject({id: '3', slug: 'logs-project', hasLogs: true});
+      setProjects([logsProject]);
+
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization,
         additionalWrapper: Wrapper,
@@ -779,6 +785,9 @@ describe('SpansTabContent', () => {
     });
 
     it('renders disabled cross event search bar when the limit is reached', () => {
+      const logsProject = makeProject({id: '3', slug: 'logs-project', hasLogs: true});
+      setProjects([logsProject]);
+
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization,
         additionalWrapper: Wrapper,
@@ -803,6 +812,9 @@ describe('SpansTabContent', () => {
     });
 
     it('disables Attribute Breakdowns tab when cross events are present', () => {
+      const logsProject = makeProject({id: '3', slug: 'logs-project', hasLogs: true});
+      setProjects([logsProject]);
+
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization: {
           ...organization,
@@ -824,6 +836,9 @@ describe('SpansTabContent', () => {
     });
 
     it('disables Trace Samples tab when cross events are present', async () => {
+      const logsProject = makeProject({id: '3', slug: 'logs-project', hasLogs: true});
+      setProjects([logsProject]);
+
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization: {
           ...organization,

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -651,6 +651,41 @@ describe('SpansTabContent', () => {
       expect(screen.getByRole('menuitemradio', {name: 'Logs'})).toBeInTheDocument();
     });
 
+    it('hides dataset options from non-member projects when My Projects is selected', async () => {
+      const spansOnlyProject = makeProject({
+        id: '3',
+        slug: 'spans-only-project',
+        hasLogs: false,
+        hasTraceMetrics: false,
+        isMember: true,
+      });
+      const logsAndMetricsProject = makeProject({
+        id: '4',
+        slug: 'logs-and-metrics-project',
+        hasLogs: true,
+        hasTraceMetrics: true,
+        isMember: false,
+      });
+      setProjects([spansOnlyProject, logsAndMetricsProject], []);
+
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization: {
+          ...organization,
+          features: [...organization.features, 'tracemetrics-enabled'],
+        },
+        additionalWrapper: Wrapper,
+      });
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Add a cross event query'})
+      );
+
+      expect(screen.queryByRole('menuitemradio', {name: 'Logs'})).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'Application Metrics'})
+      ).not.toBeInTheDocument();
+    });
+
     it('adds a cross event query', async () => {
       const {router} = render(
         <SpansTabContent datePageFilterProps={datePageFilterProps} />,

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -898,7 +898,7 @@ describe('SpansTabContent', () => {
       await userEvent.hover(traceSamplesTab);
       expect(
         await screen.findByText(
-          'Trace samples do not yet work with Cross-Event queries, use spans tab.'
+          'Trace samples do not yet work with Cross-Event queries. Use the Spans tab instead.'
         )
       ).toBeInTheDocument();
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -57,6 +57,7 @@ import {
   useSetQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 import {ExploreCharts} from 'sentry/views/explore/spans/charts';
+import {useCrossEventDatasetAvailability} from 'sentry/views/explore/spans/crossEvents/useCrossEventDatasetAvailability';
 import {DroppedFieldsAlert} from 'sentry/views/explore/spans/droppedFieldsAlert';
 import {ExtrapolationEnabledAlert} from 'sentry/views/explore/spans/extrapolationEnabledAlert';
 import {SettingsDropdown} from 'sentry/views/explore/spans/settingsDropdown';
@@ -189,7 +190,9 @@ function SpanTabContentSectionInner({
   const id = useQueryParamsId();
   const [tab, setTab] = useTab();
   const [caseInsensitive] = useCaseInsensitivity();
-  const crossEventQueries = useCrossEventQueries();
+  const organization = useOrganization();
+  const crossEventDatasetAvailability = useCrossEventDatasetAvailability(organization);
+  const crossEventQueries = useCrossEventQueries(crossEventDatasetAvailability);
   const sortBys = useQueryParamsSortBys();
   const groupBys = useQueryParamsGroupBys();
 
@@ -208,7 +211,6 @@ function SpanTabContentSectionInner({
     sortBys: sortBys.map(s => (s.kind === 'desc' ? `-${s.field}` : s.field)),
   });
 
-  const organization = useOrganization();
   const hasCrossEventQueries = organization.features.includes(
     'traces-page-cross-event-querying'
   );

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -294,6 +294,7 @@ function SpanTabContentSectionInner({
     tracesTableResult,
     timeseriesResult,
     interval,
+    crossEventQueries,
   });
 
   const error = defined(timeseriesResult.error)

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -44,7 +44,9 @@ interface ExploreTablesProps extends BaseExploreTablesProps {
 }
 
 export function ExploreTables(props: ExploreTablesProps) {
+  const {setTab, tab} = props;
   const crossEvents = useQueryParamsCrossEvents();
+  const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
 
   const aggregateFields = useQueryParamsAggregateFields();
   const setAggregateFields = useSetQueryParamsAggregateFields();
@@ -89,45 +91,53 @@ export function ExploreTables(props: ExploreTablesProps) {
   };
 
   useEffect(() => {
-    if (
-      props.tab === Tab.ATTRIBUTE_BREAKDOWNS &&
-      defined(crossEvents) &&
-      crossEvents.length > 0
-    ) {
-      props.setTab(Tab.SPAN);
+    if ((tab === Tab.TRACE || tab === Tab.ATTRIBUTE_BREAKDOWNS) && hasCrossEvents) {
+      setTab(Tab.SPAN);
     }
-  }, [crossEvents, props]);
+  }, [hasCrossEvents, setTab, tab]);
 
   return (
     <Fragment>
       <Flex justify="between" marginBottom="md" gap="md" wrap="wrap">
-        <Tabs value={props.tab} onChange={props.setTab} size="sm">
+        <Tabs value={tab} onChange={setTab} size="sm" disableOverflow>
           <TabList variant="floating">
             <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
-            <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
+            <TabList.Item
+              key={Tab.TRACE}
+              disabled={hasCrossEvents}
+              tooltip={{
+                title: hasCrossEvents
+                  ? t(
+                      'Trace samples do not yet work with Cross-Event queries, use spans tab.'
+                    )
+                  : undefined,
+              }}
+            >
+              {t('Trace Samples')}
+            </TabList.Item>
             <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
             <TabList.Item
               key={Tab.ATTRIBUTE_BREAKDOWNS}
               textValue={t('Attribute Breakdowns')}
-              disabled={defined(crossEvents) && crossEvents.length > 0}
+              disabled={hasCrossEvents}
             >
               {t('Attribute Breakdowns')}
               <Badge variant="beta">Beta</Badge>
             </TabList.Item>
           </TabList>
         </Tabs>
-        {props.tab === Tab.SPAN ? (
+        {tab === Tab.SPAN ? (
           <Button onClick={openColumnEditor} icon={<IconEdit />} size="sm">
             {t('Edit Table')}
           </Button>
-        ) : props.tab === Mode.AGGREGATE ? (
+        ) : tab === Mode.AGGREGATE ? (
           <Button onClick={openAggregateColumnEditor} icon={<IconEdit />} size="sm">
             {t('Edit Table')}
           </Button>
         ) : (
           <Tooltip
             title={
-              props.tab === Tab.TRACE
+              tab === Tab.TRACE
                 ? t('Editing columns is available for span samples only')
                 : t('Use the Group By and Visualize controls to change table columns')
             }
@@ -138,10 +148,10 @@ export function ExploreTables(props: ExploreTablesProps) {
           </Tooltip>
         )}
       </Flex>
-      {props.tab === Tab.SPAN && <SpansTable {...props} />}
-      {props.tab === Tab.TRACE && <TracesTable {...props} />}
-      {props.tab === Mode.AGGREGATE && <AggregatesTable {...props} />}
-      {props.tab === Tab.ATTRIBUTE_BREAKDOWNS && <AttributeBreakdownsContent />}
+      {tab === Tab.SPAN && <SpansTable {...props} />}
+      {tab === Tab.TRACE && <TracesTable {...props} />}
+      {tab === Mode.AGGREGATE && <AggregatesTable {...props} />}
+      {tab === Tab.ATTRIBUTE_BREAKDOWNS && <AttributeBreakdownsContent />}
     </Fragment>
   );
 }

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -108,7 +108,7 @@ export function ExploreTables(props: ExploreTablesProps) {
               tooltip={{
                 title: hasCrossEvents
                   ? t(
-                      'Trace samples do not yet work with Cross-Event queries, use spans tab.'
+                      'Trace samples do not yet work with Cross-Event queries. Use the Spans tab instead.'
                     )
                   : undefined,
               }}

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -10,7 +10,6 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {IconEdit} from 'sentry/icons/iconEdit';
 import {t} from 'sentry/locale';
 import type {Confidence} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 import {AttributeBreakdownsContent} from 'sentry/views/explore/components/attributeBreakdowns/content';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useSpanItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -46,7 +45,7 @@ interface ExploreTablesProps extends BaseExploreTablesProps {
 export function ExploreTables(props: ExploreTablesProps) {
   const {setTab, tab} = props;
   const crossEvents = useQueryParamsCrossEvents();
-  const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
+  const hasCrossEvents = !!crossEvents?.length;
 
   const aggregateFields = useQueryParamsAggregateFields();
   const setAggregateFields = useSetQueryParamsAggregateFields();


### PR DESCRIPTION
This PR works to solve two issues, the first being temporarily disabling the traces tab when cross-event querying, and secondly adding in better checks to see if users are sending logs or metrics.

The second fix focuses on only showing options for those products that the user is sending data for, no sense in showing logs if they're not sending any.