### PR TITLE
Update SDK version and options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ dependencies = [
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.10.1",
-  "sentry-sdk[http2]>=2.47.0",
+  "sentry-sdk[http2]>=2.59.0",
   "sentry-usage-accountant>=0.0.10",
   # remove once there are no unmarked transitive dependencies on setuptools
   "setuptools>=70.0.0",

--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Literal, NotRequired, TypedDict
 
-from sentry_sdk.types import Event, Hint
+from sentry_sdk.types import Event, Hint, Log
 
 
 class SdkConfig(TypedDict):
@@ -21,6 +21,8 @@ class SdkConfig(TypedDict):
     traces_sampler: NotRequired[Callable[[dict[str, Any]], float]]
     before_send: NotRequired[Callable[[Event, Hint], Event | None]]
     before_send_transaction: NotRequired[Callable[[Event, Hint], Event | None]]
+    enable_logs: NotRequired[bool]
+    before_send_log: NotRequired[Callable[[Log, Hint], Log | None]]
     profiles_sample_rate: NotRequired[float]
     profiles_sampler: NotRequired[Callable[[dict[str, Any]], float]]
     profiler_mode: NotRequired[Literal["sleep", "thread", "gevent", "unknown"]]

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -311,20 +311,17 @@ class Dsns(NamedTuple):
 
 def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
     sdk_options = settings.SENTRY_SDK_CONFIG.copy()
-    sdk_options["send_client_reports"] = True
     sdk_options["add_full_stack"] = True
-    sdk_options["enable_http_request_source"] = True
     sdk_options["traces_sampler"] = traces_sampler
-    sdk_options["before_send_transaction"] = before_send_transaction
     sdk_options["before_send"] = before_send
+    sdk_options["before_send_transaction"] = before_send_transaction
+    sdk_options["enable_logs"] = True
+    sdk_options["before_send_log"] = before_send_log
     sdk_options["release"] = (
         f"backend@{sdk_options['release']}" if "release" in sdk_options else None
     )
     sdk_options.setdefault("_experiments", {}).update(
         transport_http2=options.get("sdk_http2_experiment.enabled"),
-        before_send_log=before_send_log,
-        enable_logs=True,
-        enable_metrics=True,
     )
 
     # Modify SENTRY_SDK_CONFIG in your deployment scripts to specify your desired DSN

--- a/uv.lock
+++ b/uv.lock
@@ -2332,7 +2332,7 @@ requires-dist = [
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.10.1" },
-    { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.47.0" },
+    { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.59.0" },
     { name = "sentry-usage-accountant", specifier = ">=0.0.10" },
     { name = "setuptools", specifier = ">=70.0.0" },
     { name = "simplejson", specifier = ">=3.17.6" },
@@ -2552,14 +2552,14 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.47.0"
+version = "2.59.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_sdk-2.47.0-py2.py3-none-any.whl", hash = "sha256:d72f8c61025b7d1d9e52510d03a6247b280094a327dd900d987717a4fce93412" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_sdk-2.59.0-py2.py3-none-any.whl", hash = "sha256:abcf65ee9a9d9cdebf9ad369782408ecca9c1c792686ef06ba34f5ab233527fe" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
`send_client_reports` defaults to `True`. `enable_http_request_source` defaults to `True`. `enable_metrics` defaults to `True`. `before_send_log` and `enable_logs` are no longer experimental.

Bumping to latest version of the SDK.