### PR TITLE
feat: Add a random duration task for testing

### DIFF
--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 from time import sleep
 from typing import Any
 
@@ -97,3 +98,24 @@ def timed_task(sleep_seconds: float | str, *args: list[Any], **kwargs: dict[str,
 def simple_task_compressed(*args: list[Any], **kwargs: dict[str, Any]) -> None:
     sleep(0.1)
     logger.debug("simple_task_compressed complete")
+
+
+@exampletasks.register(name="examples.simple_task_with_random_duration")
+def simple_task_with_random_duration(
+    distribution: str, a: int, b: int, *args: list[Any], **kwargs: dict[str, Any]
+) -> None:
+    """
+    Runs tasks that sleep for a random duration, based on the distribution and the parameters.
+    For uniform distribution, the parameters are the minimum and maximum duration.
+    For gauss distribution, the parameters are the mean and standard deviation.
+    For exponential distribution, the first parameter is the lambda (lambd is 1.0 divided by the desired mean).
+    """
+    if distribution == "uniform":
+        sleep(random.uniform(a, b))
+    elif distribution == "gauss":
+        sleep(random.normalvariate(mu=a, sigma=b))  # random.gauss isn't threadsafe
+    elif distribution == "exponential":
+        sleep(random.expovariate(lambd=a))
+    else:
+        raise ValueError(f"Invalid distribution: {distribution}")
+    logger.debug("simple_task_with_random_duration complete")

--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -111,9 +111,11 @@ def simple_task_with_random_duration(
     For exponential distribution, the first parameter is the lambda (lambd is 1.0 divided by the desired mean).
     """
     if distribution == "uniform":
+        if a > b or a < 0 or b < 0:
+            raise ValueError(f"Invalid parameters for uniform distribution: a={a}, b={b}")
         sleep(random.uniform(a, b))
     elif distribution == "gauss":
-        sleep(random.normalvariate(mu=a, sigma=b))  # random.gauss isn't threadsafe
+        sleep(max(0, random.normalvariate(mu=a, sigma=b)))  # random.gauss isn't threadsafe
     elif distribution == "exponential":
         sleep(random.expovariate(lambd=a))
     else:

--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -102,7 +102,7 @@ def simple_task_compressed(*args: list[Any], **kwargs: dict[str, Any]) -> None:
 
 @exampletasks.register(name="examples.simple_task_with_random_duration")
 def simple_task_with_random_duration(
-    distribution: str, a: int, b: int, *args: list[Any], **kwargs: dict[str, Any]
+    distribution: str, a: float, b: float, *args: list[Any], **kwargs: dict[str, Any]
 ) -> None:
     """
     Runs tasks that sleep for a random duration, based on the distribution and the parameters.

--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -117,6 +117,8 @@ def simple_task_with_random_duration(
     elif distribution == "gauss":
         sleep(max(0, random.normalvariate(mu=a, sigma=b)))  # random.gauss isn't threadsafe
     elif distribution == "exponential":
+        if a <= 0:
+            raise ValueError(f"Invalid parameter for exponential distribution: a={a}")
         sleep(random.expovariate(lambd=a))
     else:
         raise ValueError(f"Invalid distribution: {distribution}")


### PR DESCRIPTION
This allows us to generate tasks with random durations, along different distributions. We can use
this to mimic different workloads on the taskbrokers.