### PR TITLE
chore(data-forwarding): Ensure DataForwarding page is usable for members/team-admins

### DIFF
--- a/src/sentry/integrations/api/endpoints/data_forwarding_details.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_details.py
@@ -114,7 +114,7 @@ class DataForwardingDetailsEndpoint(OrganizationEndpoint):
         if serializer.is_valid():
             data_forwarder = serializer.save()
             return Response(
-                serialize(data_forwarder, request.user, include_config=True),
+                serialize(data_forwarder, request.user, access=request.access),
                 status=status.HTTP_200_OK,
             )
         # Validation failed - return None to signal caller ddto try other operations
@@ -231,7 +231,7 @@ class DataForwardingDetailsEndpoint(OrganizationEndpoint):
             ).update(is_enabled=False)
 
         return Response(
-            serialize(data_forwarder, request.user),
+            serialize(data_forwarder, request.user, access=request.access),
             status=status.HTTP_200_OK,
         )
 
@@ -277,7 +277,7 @@ class DataForwardingDetailsEndpoint(OrganizationEndpoint):
         if serializer.is_valid():
             serializer.save()
             return Response(
-                serialize(data_forwarder, request.user, include_config=True),
+                serialize(data_forwarder, request.user, access=request.access),
                 status=status.HTTP_200_OK,
             )
 

--- a/src/sentry/integrations/api/endpoints/data_forwarding_details.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_details.py
@@ -114,7 +114,7 @@ class DataForwardingDetailsEndpoint(OrganizationEndpoint):
         if serializer.is_valid():
             data_forwarder = serializer.save()
             return Response(
-                serialize(data_forwarder, request.user),
+                serialize(data_forwarder, request.user, include_config=True),
                 status=status.HTTP_200_OK,
             )
         # Validation failed - return None to signal caller ddto try other operations
@@ -277,7 +277,7 @@ class DataForwardingDetailsEndpoint(OrganizationEndpoint):
         if serializer.is_valid():
             serializer.save()
             return Response(
-                serialize(data_forwarder, request.user),
+                serialize(data_forwarder, request.user, include_config=True),
                 status=status.HTTP_200_OK,
             )
 

--- a/src/sentry/integrations/api/endpoints/data_forwarding_index.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_index.py
@@ -26,7 +26,7 @@ from sentry.web.decorators import set_referrer_policy
 
 class OrganizationDataForwardingDetailsPermission(OrganizationPermission):
     scope_map = {
-        "GET": ["org:write"],
+        "GET": ["org:read"],
         "POST": ["org:write"],
     }
 
@@ -59,10 +59,12 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
         """
         queryset = DataForwarder.objects.filter(organization_id=organization.id)
 
+        include_config = request.access.has_scope("org:write")
+
         return self.paginate(
             request=request,
             queryset=queryset,
-            on_results=lambda x: serialize(x, request.user),
+            on_results=lambda x: serialize(x, request.user, include_config=include_config),
             paginator_cls=OffsetPaginator,
         )
 
@@ -97,5 +99,6 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
             return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         return self.respond(
-            serialize(serializer.save(), request.user), status=status.HTTP_201_CREATED
+            serialize(serializer.save(), request.user, include_config=True),
+            status=status.HTTP_201_CREATED,
         )

--- a/src/sentry/integrations/api/endpoints/data_forwarding_index.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_index.py
@@ -59,14 +59,10 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
         """
         queryset = DataForwarder.objects.filter(organization_id=organization.id)
 
-        include_config = request.access.has_scope("org:write")
-
         return self.paginate(
             request=request,
             queryset=queryset,
-            on_results=lambda x: serialize(
-                x, request.user, include_config=include_config, access=request.access
-            ),
+            on_results=lambda x: serialize(x, request.user, access=request.access),
             paginator_cls=OffsetPaginator,
         )
 
@@ -101,6 +97,6 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
             return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         return self.respond(
-            serialize(serializer.save(), request.user, include_config=True),
+            serialize(serializer.save(), request.user, access=request.access),
             status=status.HTTP_201_CREATED,
         )

--- a/src/sentry/integrations/api/endpoints/data_forwarding_index.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_index.py
@@ -64,7 +64,9 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
         return self.paginate(
             request=request,
             queryset=queryset,
-            on_results=lambda x: serialize(x, request.user, include_config=include_config),
+            on_results=lambda x: serialize(
+                x, request.user, include_config=include_config, access=request.access
+            ),
             paginator_cls=OffsetPaginator,
         )
 

--- a/src/sentry/integrations/api/serializers/models/data_forwarder.py
+++ b/src/sentry/integrations/api/serializers/models/data_forwarder.py
@@ -23,6 +23,7 @@ class DataForwarderProjectResponse(TypedDict):
     isEnabled: bool
     dataForwarderId: str
     project: ProjectResponse
+    # The overrides + effectiveConfig fields are omitted unless request has `org:write`, since the values are sensitive.
     overrides: dict[str, str]
     effectiveConfig: dict[str, str]
     dateAdded: datetime
@@ -36,7 +37,8 @@ class DataForwarderResponse(TypedDict):
     enrollNewProjects: bool
     enrolledProjects: list[ProjectResponse]
     provider: str
-    config: dict[str, str]
+    # The config is omitted unless request has `org:write`, since the values are sensitive.
+    config: dict[str, str] | None
     projectConfigs: list[DataForwarderProjectResponse]
     dateAdded: datetime
     dateUpdated: datetime
@@ -69,6 +71,7 @@ class DataForwarderSerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> DataForwarderResponse:
+        include_config = kwargs.get("include_config", False)
         project_configs = attrs.get("project_configs", set())
 
         return {
@@ -85,9 +88,10 @@ class DataForwarderSerializer(Serializer):
                 for project_config in project_configs
             ],
             "provider": obj.provider,
-            "config": obj.config,
+            "config": obj.config if include_config else None,
             "projectConfigs": [
-                serialize(project_config, user=user) for project_config in project_configs
+                serialize(project_config, user=user, include_config=include_config)
+                for project_config in project_configs
             ],
             "dateAdded": obj.date_added,
             "dateUpdated": obj.date_updated,
@@ -103,6 +107,7 @@ class DataForwarderProjectSerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> DataForwarderProjectResponse:
+        include_config = kwargs.get("include_config", False)
         return {
             "id": str(obj.id),
             "isEnabled": obj.is_enabled,
@@ -112,8 +117,8 @@ class DataForwarderProjectSerializer(Serializer):
                 "slug": obj.project.slug,
                 "platform": obj.project.platform,
             },
-            "overrides": obj.overrides,
-            "effectiveConfig": obj.get_config(),
+            "overrides": obj.overrides if include_config else {},
+            "effectiveConfig": obj.get_config() if include_config else {},
             "dateAdded": obj.date_added,
             "dateUpdated": obj.date_updated,
         }

--- a/src/sentry/integrations/api/serializers/models/data_forwarder.py
+++ b/src/sentry/integrations/api/serializers/models/data_forwarder.py
@@ -6,6 +6,7 @@ from typing import Any, TypedDict
 from django.contrib.auth.models import AnonymousUser
 
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.auth.access import Access
 from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.users.models.user import User
@@ -71,7 +72,8 @@ class DataForwarderSerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> DataForwarderResponse:
-        include_config = kwargs.get("include_config", False)
+        access: Access | None = kwargs.get("access")
+        has_config_access = access.has_scope("org:write") if access else False
         project_configs = attrs.get("project_configs", set())
 
         return {
@@ -88,14 +90,9 @@ class DataForwarderSerializer(Serializer):
                 for project_config in project_configs
             ],
             "provider": obj.provider,
-            "config": obj.config if include_config else None,
+            "config": obj.config if has_config_access else None,
             "projectConfigs": [
-                serialize(
-                    project_config,
-                    user=user,
-                    include_config=include_config,
-                    access=kwargs.get("access"),
-                )
+                serialize(project_config, user=user, access=access)
                 for project_config in project_configs
             ],
             "dateAdded": obj.date_added,
@@ -112,11 +109,14 @@ class DataForwarderProjectSerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> DataForwarderProjectResponse:
-        include_config = kwargs.get("include_config", False)
-        access = kwargs.get("access")
-        has_project_write = include_config or (
-            access is not None and access.has_project_scope(obj.project, "project:write")
-        )
+        access: Access | None = kwargs.get("access")
+        has_config_access = False
+        has_override_access = False
+        if access:
+            has_config_access = access.has_scope("org:write")
+            has_override_access = has_config_access or access.has_project_scope(
+                obj.project, "project:write"
+            )
         return {
             "id": str(obj.id),
             "isEnabled": obj.is_enabled,
@@ -126,8 +126,8 @@ class DataForwarderProjectSerializer(Serializer):
                 "slug": obj.project.slug,
                 "platform": obj.project.platform,
             },
-            "overrides": obj.overrides if has_project_write else {},
-            "effectiveConfig": obj.get_config() if include_config else {},
+            "overrides": obj.overrides if has_override_access else {},
+            "effectiveConfig": obj.get_config() if has_config_access else {},
             "dateAdded": obj.date_added,
             "dateUpdated": obj.date_updated,
         }

--- a/src/sentry/integrations/api/serializers/models/data_forwarder.py
+++ b/src/sentry/integrations/api/serializers/models/data_forwarder.py
@@ -90,7 +90,12 @@ class DataForwarderSerializer(Serializer):
             "provider": obj.provider,
             "config": obj.config if include_config else None,
             "projectConfigs": [
-                serialize(project_config, user=user, include_config=include_config)
+                serialize(
+                    project_config,
+                    user=user,
+                    include_config=include_config,
+                    access=kwargs.get("access"),
+                )
                 for project_config in project_configs
             ],
             "dateAdded": obj.date_added,
@@ -108,6 +113,10 @@ class DataForwarderProjectSerializer(Serializer):
         **kwargs: Any,
     ) -> DataForwarderProjectResponse:
         include_config = kwargs.get("include_config", False)
+        access = kwargs.get("access")
+        has_project_write = include_config or (
+            access is not None and access.has_project_scope(obj.project, "project:write")
+        )
         return {
             "id": str(obj.id),
             "isEnabled": obj.is_enabled,
@@ -117,7 +126,7 @@ class DataForwarderProjectSerializer(Serializer):
                 "slug": obj.project.slug,
                 "platform": obj.project.platform,
             },
-            "overrides": obj.overrides if include_config else {},
+            "overrides": obj.overrides if has_project_write else {},
             "effectiveConfig": obj.get_config() if include_config else {},
             "dateAdded": obj.date_added,
             "dateUpdated": obj.date_updated,

--- a/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
+++ b/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
@@ -114,16 +114,23 @@ class DataForwardingIndexGetTest(DataForwardingIndexEndpointTest):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(my_forwarder.id)
 
-    def test_get_requires_org_write_permission(self) -> None:
+    def test_get_denied_for_non_member(self) -> None:
         user_without_permission = self.create_user()
         self.login_as(user=user_without_permission)
 
         self.get_error_response(self.organization.slug, status_code=403)
 
-    def test_get_denied_for_member_role(self) -> None:
-        self.create_data_forwarder(
+    def test_get_redacts_config_for_member_role(self) -> None:
+        data_forwarder = self.create_data_forwarder(
             provider=DataForwarderProviderSlug.SEGMENT,
             config={"write_key": "test_key"},
+        )
+        project = self.create_project(organization=self.organization)
+        self.create_data_forwarder_project(
+            data_forwarder=data_forwarder,
+            project=project,
+            is_enabled=True,
+            overrides={"write_key": "override_key"},
         )
 
         member_user = self.create_user()
@@ -135,9 +142,15 @@ class DataForwardingIndexGetTest(DataForwardingIndexEndpointTest):
         )
         self.login_as(user=member_user)
 
-        self.get_error_response(self.organization.slug, status_code=403)
+        response = self.get_success_response(self.organization.slug)
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(data_forwarder.id)
+        assert response.data[0]["provider"] == DataForwarderProviderSlug.SEGMENT
+        assert response.data[0]["config"] is None
+        assert response.data[0]["projectConfigs"][0]["overrides"] == {}
+        assert response.data[0]["projectConfigs"][0]["effectiveConfig"] == {}
 
-    def test_get_allowed_for_manager_role(self) -> None:
+    def test_get_includes_config_for_manager_role(self) -> None:
         data_forwarder = self.create_data_forwarder(
             provider=DataForwarderProviderSlug.SEGMENT,
             config={"write_key": "test_key"},
@@ -154,6 +167,7 @@ class DataForwardingIndexGetTest(DataForwardingIndexEndpointTest):
         response = self.get_success_response(self.organization.slug)
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(data_forwarder.id)
+        assert response.data[0]["config"] == {"write_key": "test_key"}
 
     def test_get_with_disabled_data_forwarder(self) -> None:
         data_forwarder = self.create_data_forwarder(

--- a/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
+++ b/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
@@ -150,6 +150,34 @@ class DataForwardingIndexGetTest(DataForwardingIndexEndpointTest):
         assert response.data[0]["projectConfigs"][0]["overrides"] == {}
         assert response.data[0]["projectConfigs"][0]["effectiveConfig"] == {}
 
+    def test_get_shows_overrides_for_team_admin(self) -> None:
+        data_forwarder = self.create_data_forwarder(
+            provider=DataForwarderProviderSlug.SEGMENT,
+            config={"write_key": "test_key"},
+        )
+        project = self.create_project(organization=self.organization, teams=[self.team])
+        self.create_data_forwarder_project(
+            data_forwarder=data_forwarder,
+            project=project,
+            is_enabled=True,
+            overrides={"write_key": "override_key"},
+        )
+
+        team_admin_user = self.create_user()
+        member = self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+        )
+        self.create_team_membership(team=self.team, member=member, role="admin")
+        self.login_as(user=team_admin_user)
+
+        response = self.get_success_response(self.organization.slug)
+        assert len(response.data) == 1
+        assert response.data[0]["config"] is None
+        assert response.data[0]["projectConfigs"][0]["overrides"] == {"write_key": "override_key"}
+        assert response.data[0]["projectConfigs"][0]["effectiveConfig"] == {}
+
     def test_get_includes_config_for_manager_role(self) -> None:
         data_forwarder = self.create_data_forwarder(
             provider=DataForwarderProviderSlug.SEGMENT,

--- a/tests/sentry/integrations/api/endpoints/test_data_forwarding_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_data_forwarding_details.py
@@ -253,6 +253,61 @@ class DataForwardingDetailsPutTest(DataForwardingDetailsEndpointTest):
         assert project_config.overrides == {"new": "value"}
         assert not project_config.is_enabled
 
+    def test_update_project_overrides_response_redacts_config(self) -> None:
+        """A project:write user updating an override must not see global config or other projects' overrides."""
+        data_forwarder = self.create_data_forwarder(
+            provider=DataForwarderProviderSlug.SEGMENT,
+            config={"write_key": "global_secret"},
+        )
+
+        my_project = self.create_project(organization=self.organization, teams=[self.team])
+        other_project = self.create_project(organization=self.organization, teams=[])
+
+        self.create_data_forwarder_project(
+            data_forwarder=data_forwarder,
+            project=my_project,
+            overrides={"write_key": "my_override"},
+        )
+        self.create_data_forwarder_project(
+            data_forwarder=data_forwarder,
+            project=other_project,
+            overrides={"write_key": "other_secret"},
+        )
+
+        team_admin = self.create_user()
+        self.create_member(
+            user=team_admin,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+            teamRole="admin",
+        )
+        self.login_as(user=team_admin)
+
+        payload = {
+            "project_id": my_project.id,
+            "overrides": {"write_key": "updated_override"},
+            "is_enabled": True,
+        }
+
+        response = self.get_success_response(
+            self.organization.slug, data_forwarder.id, status_code=200, **payload
+        )
+
+        assert response.data["config"] is None
+
+        project_configs_by_id = {
+            int(pc["project"]["id"]): pc for pc in response.data["projectConfigs"]
+        }
+
+        my_config = project_configs_by_id[my_project.id]
+        assert my_config["overrides"] == {"write_key": "updated_override"}
+        assert my_config["effectiveConfig"] == {}
+
+        other_config = project_configs_by_id[other_project.id]
+        assert other_config["overrides"] == {}
+        assert other_config["effectiveConfig"] == {}
+
     def test_update_unenroll_projects_with_project_write(self) -> None:
         data_forwarder = self.create_data_forwarder(
             provider=DataForwarderProviderSlug.SEGMENT,


### PR DESCRIPTION
Prevents the data forwarding pages from crashing on 403s and presents helpful error states and alerts.

To maintain security:
- The sensitive `DataForwarder.config` and `DataForwarderProject.effectiveConfig` fields will not be serialized without `org:write`
- If the requesting user does have `project:write` for a `DFP`, we serialize the `DFP.overrides`, but still not the `effectiveConfig` to avoid leaking `DF.config`
- If the requesting user lacks all relevant scopes, all possible fields containing configuration appear empty (`DF.config`, `DFP.effectiveConfig`, `DFP.overrides`)

This is just the backend update, see https://github.com/getsentry/sentry/pull/114966