### PR TITLE
fix(slack-unfurl): preserve multiple groupBy entries on explore unfurl

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -315,12 +315,20 @@ def _unfurl_explore(
         params["dataset"] = explore_dataset.value
         params["referrer"] = Referrer.EXPLORE_SLACK_UNFURL.value
 
+        # ApiClient iterates params via .items(), which collapses multi-value
+        # QueryDict keys to the last value. Walk lists() and emit a real list
+        # for multi-value keys (e.g. multiple groupBy entries from aggregateField)
+        # so all values reach events-timeseries.
+        api_params: dict[str, str | list[str]] = {
+            key: values if len(values) > 1 else values[0] for key, values in params.lists()
+        }
+
         try:
             resp = client.get(
                 auth=ApiKey(organization_id=org.id, scope_list=["org:read"]),
                 user=user,
                 path=f"/organizations/{org_slug}/events-timeseries/",
-                params=params,
+                params=api_params,
             )
         except Exception:
             _logger.warning("Failed to load events-timeseries for explore unfurl")

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1640,7 +1640,37 @@ class UnfurlTest(TestCase):
 
         # Verify sort is passed to the timeseries API for correct top events
         api_params = mock_client_get.call_args[1]["params"]
-        assert api_params.getlist("sort") == ["-avg(span.duration)"]
+        assert api_params["sort"] == "-avg(span.duration)"
+
+    @patch("sentry.api.client.resolve")
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_forwards_multiple_groupbys_to_api(
+        self, mock_generate_chart: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        # Don't mock client.get — exercise the real API client so we catch
+        # multi-value param collapse on the way to events-timeseries.
+        mock_response = MagicMock(
+            status_code=200,
+            data=self._build_mock_timeseries_response(y_axis="count(span.duration)"),
+        )
+        mock_view = MagicMock(return_value=mock_response)
+        mock_resolve.return_value = (mock_view, (), {})
+
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22transaction%22%7D&aggregateField=%7B%22groupBy%22%3A%22browser.name%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%2C%22chartType%22%3A1%7D&project={self.project.id}&statsPeriod=14d"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        links = [UnfurlableUrl(url=url, args=args)]
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            link_handlers[link_type].fn(self.integration, links, self.user)
+
+        mock_view.assert_called_once()
+        request = mock_view.call_args[0][0]
+        assert request.GET.getlist("groupBy") == ["transaction", "browser.name"]
+        assert request.GET.getlist("yAxis") == ["count(span.duration)"]
+        assert request.GET["dataset"] == "spans"
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",
@@ -1667,7 +1697,7 @@ class UnfurlTest(TestCase):
 
         # Verify explicit aggregateSort from the URL is used instead of the default
         api_params = mock_client_get.call_args[1]["params"]
-        assert api_params.getlist("sort") == ["span.op"]
+        assert api_params["sort"] == "span.op"
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",


### PR DESCRIPTION
Fixes an issue where multiple group bys were not being applied when unfurling

## Ai Summary

- Explore URLs with multiple `aggregateField` groupBy entries (e.g. `groupBy=transaction` AND `groupBy=browser.name`) were collapsing to only the last groupBy when unfurled in Slack — the chart was rendered with a single groupBy instead of all of them.
- Root cause: `ApiClient.request` iterates `params` via `QueryDict.items()`, which yields only the *last* value per key. The explore unfurl was passing a `QueryDict` populated via `setlist("groupBy", [...])`, so only the last groupBy survived to `events-timeseries`.
- Fix: in the explore unfurl, convert the `QueryDict` to a `dict[str, str | list[str]]` (scalars for single-valued keys, lists for multi-valued) before handing to `client.get`. `ApiClient` already handles list values correctly when given a regular dict, so this is a scoped fix that does not touch the app-wide client.
- Same fix unblocks the metrics URL shape (`metric.aggregateFields[]` with multiple `groupBy`) — the metrics parser already collected all groupBys; only the client iteration was dropping them.

## Test plan

- [x] Added `test_unfurl_explore_forwards_multiple_groupbys_to_api` which mocks at `sentry.api.client.resolve` (rather than `client.get`) so the real `ApiClient` runs end-to-end. Asserts `request.GET.getlist("groupBy") == ["transaction", "browser.name"]` on the request reaching the resolved view.
- [x] Verified the new test fails without the fix (`['browser.name']` vs `['transaction', 'browser.name']` — the exact symptom reported).
- [x] All existing explore unfurl tests still pass.
- [x] Two existing assertions updated from `api_params.getlist("sort") == [...]` to `api_params["sort"] == "..."` to match the new dict shape (the `sort` value is single-valued, so it stays a scalar).