### PR TITLE
fix(ourlogs): add minWidth to LogsInfiniteTable

### DIFF
--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -515,7 +515,7 @@ export function LogsTabContent({datePageFilterProps, tableExpando}: LogsTabProps
                 </TableActionsContainer>
               )}
             </LogsTableActionsContainer>
-            <LogsItemContainer>
+            <LogsItemContainer overflowX="auto">
               {tableTab === 'logs' ? (
                 <LogsInfiniteTable
                   analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -137,7 +137,7 @@ export const LogTable = styled(ContentsTable)<{minWidth: string}>`
   flex-direction: column;
   margin-bottom: 0;
   overflow-x: hidden;
-  min-width: p.minWidth;
+  min-width: ${p => p.minWidth};
 `;
 
 export const LogTableBody = styled(TableBody)<{

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -130,14 +130,14 @@ function ContentsTable(props: React.ComponentProps<typeof Table>) {
   return <Table contentsBody {...props} />;
 }
 
-export const LogTable = styled(ContentsTable)<{minWidth?: number}>`
+export const LogTable = styled(ContentsTable)<{minWidth: string}>`
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
   margin-bottom: 0;
   overflow-x: hidden;
-  ${p => (p.minWidth ? `min-width: ${p.minWidth}px;` : ``)}
+  min-width: p.minWidth;
 `;
 
 export const LogTableBody = styled(TableBody)<{

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -130,13 +130,14 @@ function ContentsTable(props: React.ComponentProps<typeof Table>) {
   return <Table contentsBody {...props} />;
 }
 
-export const LogTable = styled(ContentsTable)`
+export const LogTable = styled(ContentsTable)<{minWidth?: number}>`
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
   margin-bottom: 0;
   overflow-x: hidden;
+  ${p => (p.minWidth ? `min-width: ${p.minWidth}px;` : ``)}
 `;
 
 export const LogTableBody = styled(TableBody)<{

--- a/static/app/views/explore/logs/tables/calculateLogsTableMinWidth.spec.tsx
+++ b/static/app/views/explore/logs/tables/calculateLogsTableMinWidth.spec.tsx
@@ -6,7 +6,7 @@ describe('calculateLogsTableMinWidth', () => {
     ['576px', 4],
     ['704px', 6],
     ['832px', 8],
-  ])('returns length %d when given %d fields', (expected, fields) => {
+  ])('returns length %s when given %d fields', (expected, fields) => {
     expect(calculateLogsTableMinWidth(fields)).toBe(expected);
   });
 });

--- a/static/app/views/explore/logs/tables/calculateLogsTableMinWidth.spec.tsx
+++ b/static/app/views/explore/logs/tables/calculateLogsTableMinWidth.spec.tsx
@@ -1,0 +1,12 @@
+import {calculateLogsTableMinWidth} from 'sentry/views/explore/logs/tables/calculateLogsTableMinWidth';
+
+describe('calculateLogsTableMinWidth', () => {
+  it.each([
+    ['448px', 2],
+    ['576px', 4],
+    ['704px', 6],
+    ['832px', 8],
+  ])('returns length %d when given %d fields', (expected, fields) => {
+    expect(calculateLogsTableMinWidth(fields)).toBe(expected);
+  });
+});

--- a/static/app/views/explore/logs/tables/calculateLogsTableMinWidth.tsx
+++ b/static/app/views/explore/logs/tables/calculateLogsTableMinWidth.tsx
@@ -1,0 +1,6 @@
+const MIN_WIDTH_BASE_PX = 256;
+const MIN_WIDTH_PER_FIELD_PX = 64;
+
+export function calculateLogsTableMinWidth(fields: number) {
+  return `${MIN_WIDTH_BASE_PX + (fields + 1) * MIN_WIDTH_PER_FIELD_PX}px`;
+}

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -30,7 +30,6 @@ import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {useDimensions} from 'sentry/utils/useDimensions';
-import {useLocation} from 'sentry/utils/useLocation';
 import {
   TableBodyCell,
   TableHead,
@@ -56,6 +55,7 @@ import {
   LogTableBody,
   LogTableRow,
 } from 'sentry/views/explore/logs/styles';
+import {calculateLogsTableMinWidth} from 'sentry/views/explore/logs/tables/calculateLogsTableMinWidth';
 import {LogsEmptyResults} from 'sentry/views/explore/logs/tables/logsEmptyResults';
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
 import {
@@ -450,8 +450,6 @@ export function LogsInfiniteTable({
     };
   }, []);
 
-  const {minWidthBase = '256', minWidthPerColumn = '64'} = useLocation().query;
-
   // For replay context, render empty states outside the table for proper centering
   if (hasReplay && (isPending || isError || isEmpty)) {
     return (
@@ -481,17 +479,13 @@ export function LogsInfiniteTable({
   return (
     <Fragment>
       <LogTable
-        minWidth={
-          typeof minWidthBase === 'string' && typeof minWidthPerColumn === 'string'
-            ? Number(minWidthBase) + (fields.length + 1) * Number(minWidthPerColumn)
-            : undefined
-        }
         ref={tableRef}
         style={initialTableStyles}
         css={tableStaticCSS}
         height="100%"
         hideBorder={embedded}
         data-test-id="logs-table"
+        minWidth={calculateLogsTableMinWidth(fields.length)}
         showVerticalScrollbar={embeddedStyling?.showVerticalScrollbar}
       >
         {embedded ? null : (

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -30,6 +30,7 @@ import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import {useLocation} from 'sentry/utils/useLocation';
 import {
   TableBodyCell,
   TableHead,
@@ -449,6 +450,8 @@ export function LogsInfiniteTable({
     };
   }, []);
 
+  const {minWidthBase = '256', minWidthPerColumn = '64'} = useLocation().query;
+
   // For replay context, render empty states outside the table for proper centering
   if (hasReplay && (isPending || isError || isEmpty)) {
     return (
@@ -478,6 +481,11 @@ export function LogsInfiniteTable({
   return (
     <Fragment>
       <LogTable
+        minWidth={
+          typeof minWidthBase === 'string' && typeof minWidthPerColumn === 'string'
+            ? Number(minWidthBase) + (fields.length + 1) * Number(minWidthPerColumn)
+            : undefined
+        }
         ref={tableRef}
         style={initialTableStyles}
         css={tableStaticCSS}


### PR DESCRIPTION
Applies a minimum width to the Explore > Logs infinite logs table. It's based on the number of columns: 256px + 64px for each column, including the default project icon one.

You'll need `ourlogs-table-expando` feature flag or `logsTableExpando=true` in the query params to see this.


https://github.com/user-attachments/assets/ac39b3bc-67d0-4758-bbaf-24d2b6731257



Fixes LOGS-734.