### PR TITLE
feat(repos): Move sync status from footer into per-install repository count tag

### DIFF
--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.spec.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.spec.tsx
@@ -206,7 +206,7 @@ describe('ScmRepositoryTable', () => {
       expect(screen.getByText('No repositories available.')).toBeInTheDocument();
     });
 
-    it('shows a loading message in the body and a loading indicator on the tag when reposLoading', () => {
+    it('shows a loading indicator on the tag and loading text in the body when reposLoading', () => {
       render(
         <ScmRepositoryTable
           provider={provider}
@@ -214,8 +214,8 @@ describe('ScmRepositoryTable', () => {
         />
       );
 
-      // Tag always shows the count (0 while loading), with a StatusIndicator alongside it.
-      expect(screen.getByText('0 repos')).toBeInTheDocument();
+      // Tag shows the count with a loading indicator icon.
+      expect(screen.getByText('0 repositories')).toBeInTheDocument();
       // Body shows loading text when no repos have arrived yet.
       const repoList = screen.getByRole('list', {name: 'Repositories'});
       expect(within(repoList).getByText('Loading repositories')).toBeInTheDocument();
@@ -254,40 +254,60 @@ describe('ScmRepositoryTable', () => {
     });
   });
 
-  describe('footer', () => {
-    it('shows last-synced time when lastSyncedAt is provided', () => {
+  describe('repository count tag', () => {
+    it('shows last-synced date in the tooltip when configData has last_sync', async () => {
       render(
         <ScmRepositoryTable
           provider={provider}
-          installations={[makeInstallation()]}
-          lastSyncedAt={new Date(Date.now() - 5 * 60 * 1000)}
+          installations={[
+            makeInstallation({
+              integration: OrganizationIntegrationsFixture({
+                id: '1',
+                configData: {
+                  last_sync: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+                },
+              }),
+            }),
+          ]}
         />
       );
 
-      expect(screen.getByText(/Last synced/)).toBeInTheDocument();
+      await userEvent.hover(screen.getByText('3 repositories'));
+      expect(await screen.findByText(/Repositories last synced/)).toBeInTheDocument();
     });
 
-    it('shows a sync button when onSync is provided', async () => {
-      const onSync = jest.fn();
-      render(
-        <ScmRepositoryTable
-          provider={provider}
-          installations={[makeInstallation()]}
-          onSync={onSync}
-        />
-      );
-
-      await userEvent.click(screen.getByRole('button', {name: 'Sync'}));
-      expect(onSync).toHaveBeenCalledTimes(1);
-    });
-
-    it('hides the footer when neither lastSyncedAt nor onSync is provided', () => {
+    it('shows "not synced yet" in the tooltip when lastSync is absent', async () => {
       render(
         <ScmRepositoryTable provider={provider} installations={[makeInstallation()]} />
       );
 
-      expect(screen.queryByText(/Last synced/)).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', {name: 'Sync'})).not.toBeInTheDocument();
+      await userEvent.hover(screen.getByText('3 repositories'));
+      expect(await screen.findByText('Repositories not yet synced.')).toBeInTheDocument();
+    });
+
+    it('calls onInstallationSync when Sync now is clicked', async () => {
+      const onInstallationSync = jest.fn();
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation()]}
+          onInstallationSync={onInstallationSync}
+        />
+      );
+
+      await userEvent.hover(screen.getByText('3 repositories'));
+      await userEvent.click(await screen.findByRole('button', {name: 'Sync now'}));
+      expect(onInstallationSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the Sync now button when onInstallationSync is not provided', async () => {
+      render(
+        <ScmRepositoryTable provider={provider} installations={[makeInstallation()]} />
+      );
+
+      await userEvent.hover(screen.getByText('3 repositories'));
+      await screen.findByText('Repositories not yet synced.');
+      expect(screen.queryByRole('button', {name: 'Sync now'})).not.toBeInTheDocument();
     });
   });
 

--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.stories.tsx
@@ -141,9 +141,16 @@ export default Storybook.story('ScmRepositoryTable', story => {
     return (
       <ScmRepositoryTable
         provider={GITHUB_PROVIDER}
-        installations={installations}
-        lastSyncedAt={new Date(Date.now() - 5 * 60 * 1000)}
-        onSync={() => {}}
+        installations={installations.map((inst, i) => ({
+          ...inst,
+          integration: {
+            ...inst.integration,
+            configData: {
+              last_sync: new Date(Date.now() - (i + 1) * 5 * 60 * 1000).toISOString(),
+            },
+          },
+        }))}
+        onInstallationSync={() => {}}
         onUninstall={() => {}}
         onSettings={() => {}}
       />
@@ -154,8 +161,7 @@ export default Storybook.story('ScmRepositoryTable', story => {
     <ScmRepositoryTable
       provider={GITHUB_PROVIDER}
       installations={EMPTY_INSTALLATION}
-      lastSyncedAt={new Date(Date.now() - 5 * 60 * 1000)}
-      onSync={() => {}}
+      onInstallationSync={() => {}}
     />
   ));
 
@@ -182,6 +188,28 @@ export default Storybook.story('ScmRepositoryTable', story => {
           repoMatches={repoMatches}
         />
       </Flex>
+    );
+  });
+
+  story('Syncing', () => {
+    const installations = useStoryInstallations();
+    return (
+      <ScmRepositoryTable
+        provider={GITHUB_PROVIDER}
+        installations={installations.map((inst, i) => ({
+          ...inst,
+          integration: {
+            ...inst.integration,
+            configData: {
+              last_sync: new Date(Date.now() - (i + 1) * 5 * 60 * 1000).toISOString(),
+            },
+          },
+          isSyncing: i === 0,
+        }))}
+        onInstallationSync={() => {}}
+        onUninstall={() => {}}
+        onSettings={() => {}}
+      />
     );
   });
 

--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
@@ -19,9 +19,9 @@ import {
   IconChevron,
   IconDelete,
   IconEllipsis,
+  IconInfo,
   IconOpen,
   IconSliders,
-  IconSync,
 } from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import type {
@@ -64,6 +64,11 @@ export interface ScmInstallation {
    */
   initiallyExpanded?: boolean;
   /**
+   * When true, the tag icon switches to a loading indicator and the tooltip
+   * shows "Re-syncing in the background…" instead of the sync button.
+   */
+  isSyncing?: boolean;
+  /**
    * Optional URL to the upstream provider's installation-management page
    * (e.g. GitHub's app settings). Surfaced as a "Manage repositories" link in
    * the empty state and the no-search-results state.
@@ -92,8 +97,8 @@ export interface ScmInstallation {
   overflowMenuItems?: MenuItemProps[];
   /**
    * Whether the parent is still fetching the repository list. Drives the
-   * "Loading repositories" empty state and hides the repo-count tag while
-   * `repositories` is still empty.
+   * "Loading repositories" empty state and shows a loading indicator
+   * alongside the repository count tag.
    */
   reposLoading?: boolean;
   /**
@@ -118,18 +123,15 @@ interface ScmRepositoryTableProps {
    */
   provider: IntegrationProvider;
   /**
-   * When provided, renders a "Last synced N ago" label in the footer.
+   * Called when the user clicks "Sync now" in the repository count tag tooltip.
+   * When omitted the button is hidden.
    */
-  lastSyncedAt?: Date;
+  onInstallationSync?: (installation: ScmInstallation) => void;
   /**
    * Called when the user clicks the settings button for an installation.
    * When omitted the button is hidden.
    */
   onSettings?: (installation: ScmInstallation) => void;
-  /**
-   * When provided, renders a Sync button in the footer.
-   */
-  onSync?: () => void;
   /**
    * Called when the user clicks the uninstall button for an installation.
    * When omitted the button is hidden.
@@ -183,14 +185,12 @@ function useExpandedInstallations(installations: ScmInstallation[]) {
 export function ScmRepositoryTable({
   provider,
   installations,
-  lastSyncedAt,
   onSettings,
-  onSync,
+  onInstallationSync,
   onUninstall,
   repoActions,
   repoMatches,
 }: ScmRepositoryTableProps) {
-  const showFooter = lastSyncedAt !== undefined || onSync !== undefined;
   const soleInstallation = installations.length === 1 ? installations[0]! : null;
 
   const {expandedIds, toggle} = useExpandedInstallations(installations);
@@ -222,6 +222,7 @@ export function ScmRepositoryTable({
               providerName={provider.name}
               onUninstall={onUninstall}
               onSettings={onSettings}
+              onInstallationSync={onInstallationSync}
             />
           )}
         </Flex>
@@ -248,6 +249,7 @@ export function ScmRepositoryTable({
                   onToggle={() => toggle(installation.integration.id)}
                   onUninstall={onUninstall}
                   onSettings={onSettings}
+                  onInstallationSync={onInstallationSync}
                   repoActions={repoActions}
                   repoMatches={repoMatches}
                 />
@@ -255,34 +257,6 @@ export function ScmRepositoryTable({
             );
           })}
         </Grid>
-      )}
-      {showFooter && (
-        <Flex
-          align="center"
-          gap="md"
-          background="secondary"
-          borderTop="primary"
-          radius="0 0 md md"
-          padding="md xl"
-        >
-          {lastSyncedAt !== undefined && (
-            <Text variant="muted" size="sm">
-              {tct('Last synced [timeSince] ago', {
-                timeSince: <TimeSince date={lastSyncedAt} suffix="" />,
-              })}
-            </Text>
-          )}
-          {onSync && (
-            <Button
-              variant="transparent"
-              size="zero"
-              icon={<IconSync size="xs" />}
-              onClick={onSync}
-            >
-              {t('Sync')}
-            </Button>
-          )}
-        </Flex>
       )}
     </Panel>
   );
@@ -293,6 +267,7 @@ interface InstallationRowProps {
   installation: ScmInstallation;
   onToggle: () => void;
   provider: IntegrationProvider;
+  onInstallationSync?: (installation: ScmInstallation) => void;
   onSettings?: (installation: ScmInstallation) => void;
   onUninstall?: (installation: ScmInstallation) => void;
   repoActions?: (repo: Repository, installation: ScmInstallation) => ReactNode;
@@ -306,6 +281,7 @@ function InstallationRow({
   onToggle,
   onUninstall,
   onSettings,
+  onInstallationSync,
   repoActions,
   repoMatches,
 }: InstallationRowProps) {
@@ -354,6 +330,7 @@ function InstallationRow({
               providerName={provider.name}
               onUninstall={onUninstall}
               onSettings={onSettings}
+              onInstallationSync={onInstallationSync}
             />
           </Flex>
         </Flex>
@@ -372,23 +349,12 @@ function InstallationRow({
 }
 
 function IntegrationSummary({installation}: {installation: ScmInstallation}) {
-  const {integration, repositories, reposLoading} = installation;
+  const {integration} = installation;
   return (
     <Fragment>
       {getIntegrationIcon(integration.provider.key, 'sm')}
       <Text bold>{integration.name}</Text>
-      {integration.status === 'disabled' ? (
-        <Tag variant="warning">{t('Disabled')}</Tag>
-      ) : (
-        <Fragment>
-          <Tag variant="muted">{tn('%s repo', '%s repos', repositories.length)}</Tag>
-          {reposLoading && (
-            <Tooltip title={t('Loading repositories')} skipWrapper>
-              <StatusIndicator variant="accent" />
-            </Tooltip>
-          )}
-        </Fragment>
-      )}
+      {integration.status === 'disabled' && <Tag variant="warning">{t('Disabled')}</Tag>}
     </Fragment>
   );
 }
@@ -396,6 +362,7 @@ function IntegrationSummary({installation}: {installation: ScmInstallation}) {
 interface InstallationActionsProps {
   installation: ScmInstallation;
   providerName: string;
+  onInstallationSync?: (installation: ScmInstallation) => void;
   onSettings?: (installation: ScmInstallation) => void;
   onUninstall?: (installation: ScmInstallation) => void;
 }
@@ -403,13 +370,63 @@ interface InstallationActionsProps {
 function InstallationActions({
   installation,
   providerName,
+  onInstallationSync,
   onUninstall,
   onSettings,
 }: InstallationActionsProps) {
-  const {manageUrl, overflowMenuItems, settingsButtonProps, uninstallButtonProps} =
-    installation;
+  const {
+    manageUrl,
+    overflowMenuItems,
+    settingsButtonProps,
+    uninstallButtonProps,
+    repositories,
+    reposLoading,
+    isSyncing,
+    integration,
+  } = installation;
+
+  const isDisabled = integration.status === 'disabled';
+  const rawLastSync = integration.configData?.['last_sync'];
+  const lastSync = typeof rawLastSync === 'string' ? rawLastSync : undefined;
+
+  const syncNowButton =
+    onInstallationSync && !isSyncing ? (
+      <Button size="xs" variant="link" onClick={() => onInstallationSync(installation)}>
+        {t('Sync now')}
+      </Button>
+    ) : null;
+
+  const isLoading = reposLoading || isSyncing;
+
+  const repoCountTooltip = reposLoading
+    ? t('Loading repositories')
+    : isSyncing
+      ? t('Re-syncing in the background…')
+      : lastSync
+        ? tct('Repositories last synced to Sentry [date]. [syncNow]', {
+            date: (
+              <strong>
+                <TimeSince disabledAbsoluteTooltip date={lastSync} />
+              </strong>
+            ),
+            syncNow: syncNowButton,
+          })
+        : tct('Repositories not yet synced. [syncNow]', {
+            syncNow: syncNowButton,
+          });
+
   return (
     <Fragment>
+      {!isDisabled && (
+        <Tooltip isHoverable={!isLoading} title={repoCountTooltip} skipWrapper>
+          <Tag
+            variant="muted"
+            icon={isLoading ? <StatusIndicator variant="accent" /> : <IconInfo />}
+          >
+            {tn('%s repository', '%s repositories', repositories.length)}
+          </Tag>
+        </Tooltip>
+      )}
       {manageUrl && (
         <LinkButton
           tooltipProps={{

--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
@@ -386,7 +386,7 @@ function InstallationActions({
   } = installation;
 
   const isDisabled = integration.status === 'disabled';
-  const rawLastSync = integration.configData?.['last_sync'];
+  const rawLastSync = integration.configData?.last_sync;
   const lastSync = typeof rawLastSync === 'string' ? rawLastSync : undefined;
 
   const syncNowButton =


### PR DESCRIPTION
Replace the shared footer (last-synced label + Sync button) with a per-installation repository-count tag that carries all sync context in a hover tooltip. The tooltip shows the `last_sync` timestamp from `configData`, a "Re-syncing in the background…" message while `isSyncing` is true, and a "Sync now" button driven by the new `onInstallationSync` prop.

Removes the old `lastSyncedAt` and `onSync` props from `ScmRepositoryTableProps`.