### PR TITLE
feat(slack): Default Explore unfurl interval to match frontend

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -4,6 +4,7 @@ import html
 import logging
 import re
 from collections.abc import Callable, Mapping
+from datetime import timedelta
 from typing import Any, TypedDict
 from urllib.parse import urlparse
 
@@ -30,6 +31,7 @@ from sentry.snuba.referrer import Referrer
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.utils import json
+from sentry.utils.dates import parse_stats_period, parse_timestamp
 
 _logger = logging.getLogger(__name__)
 
@@ -37,6 +39,46 @@ DEFAULT_PERIOD = "14d"
 TOP_N = 5
 
 EXPLORE_CHART_SIZE: ChartSize = {"width": 1200, "height": 400}
+
+# Mirrors the frontend's MINIMUM_INTERVAL ladder in
+# static/app/utils/useChartInterval.tsx. All Explore views call
+# `useChartInterval()` with the default `USE_SMALLEST` strategy, so the
+# interval the UI picks when none is in the URL is exactly the value this
+# ladder returns for the selected time range. Keep the thresholds and
+# intervals in sync with that file so unfurled charts bucket data the same
+# way as the live Explore UI.
+_DEFAULT_INTERVAL_LADDER: tuple[tuple[timedelta, str], ...] = (
+    (timedelta(days=30), "3h"),
+    (timedelta(days=14), "1h"),
+    (timedelta(days=4), "30m"),
+    (timedelta(hours=48), "10m"),
+    (timedelta(hours=12), "5m"),
+    (timedelta(0), "1m"),
+)
+
+
+def _query_time_range(params: QueryDict) -> timedelta:
+    """Return the selected time range, mirroring the frontend's
+    `getDiffInMinutes`: prefer absolute start/end, otherwise parse statsPeriod."""
+    start = params.get("start")
+    end = params.get("end")
+    if start and end:
+        try:
+            return max(parse_timestamp(end) - parse_timestamp(start), timedelta(0))
+        except (ValueError, TypeError):
+            pass
+
+    period = params.get("statsPeriod") or DEFAULT_PERIOD
+    parsed = parse_stats_period(period)
+    return parsed if parsed is not None else timedelta(0)
+
+
+def _default_interval_for_query(params: QueryDict) -> str:
+    diff = _query_time_range(params)
+    for threshold, interval in _DEFAULT_INTERVAL_LADDER:
+        if diff >= threshold:
+            return interval
+    return "1m"
 
 
 def _aggregate_sorts_are_valid(
@@ -110,6 +152,12 @@ def _build_timeseries_query(
 
     if sort_values:
         out.setlist("sort", sort_values)
+
+    if not out.get("statsPeriod") and not out.get("start"):
+        out["statsPeriod"] = DEFAULT_PERIOD
+
+    if not out.get("interval"):
+        out["interval"] = _default_interval_for_query(out)
 
     return out
 
@@ -308,9 +356,6 @@ def _unfurl_explore(
                 # Default to descending by the first yAxis, matching Explore's
                 # defaultAggregateSortBys behavior
                 params.setlist("sort", [f"-{y_axes[0]}"])
-
-        if not params.get("statsPeriod") and not params.get("start"):
-            params["statsPeriod"] = DEFAULT_PERIOD
 
         params["dataset"] = explore_dataset.value
         params["referrer"] = Referrer.EXPLORE_SLACK_UNFURL.value

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -201,7 +201,9 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                 LinkType.EXPLORE,
                 {
                     "org_slug": "org1",
-                    "query": QueryDict("yAxis=avg(span.duration)&project=1&statsPeriod=24h"),
+                    "query": QueryDict(
+                        "yAxis=avg(span.duration)&project=1&statsPeriod=24h&interval=5m"
+                    ),
                     "chart_type": None,
                     "dataset": SupportedTraceItemType.SPANS,
                 },
@@ -213,7 +215,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                 LinkType.EXPLORE,
                 {
                     "org_slug": "org1",
-                    "query": QueryDict("yAxis=count(span.duration)&statsPeriod=24h"),
+                    "query": QueryDict("yAxis=count(span.duration)&statsPeriod=24h&interval=5m"),
                     "chart_type": None,
                     "dataset": SupportedTraceItemType.SPANS,
                 },
@@ -225,7 +227,9 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                 LinkType.EXPLORE,
                 {
                     "org_slug": "org1",
-                    "query": QueryDict("yAxis=sum(payload_size)&project=1&statsPeriod=24h"),
+                    "query": QueryDict(
+                        "yAxis=sum(payload_size)&project=1&statsPeriod=24h&interval=5m"
+                    ),
                     "chart_type": None,
                     "dataset": SupportedTraceItemType.LOGS,
                 },
@@ -237,7 +241,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                 LinkType.EXPLORE,
                 {
                     "org_slug": "org1",
-                    "query": QueryDict("yAxis=count(payload_size)&statsPeriod=24h"),
+                    "query": QueryDict("yAxis=count(payload_size)&statsPeriod=24h&interval=5m"),
                     "chart_type": None,
                     "dataset": SupportedTraceItemType.LOGS,
                 },
@@ -249,7 +253,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                 LinkType.EXPLORE,
                 {
                     "org_slug": "org1",
-                    "query": QueryDict("yAxis=sum(value)&project=1&statsPeriod=7d"),
+                    "query": QueryDict("yAxis=sum(value)&project=1&statsPeriod=7d&interval=30m"),
                     "chart_type": None,
                     "dataset": SupportedTraceItemType.TRACEMETRICS,
                 },
@@ -261,7 +265,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                 LinkType.EXPLORE,
                 {
                     "org_slug": "org1",
-                    "query": QueryDict("yAxis=avg(value)&statsPeriod=24h"),
+                    "query": QueryDict("yAxis=avg(value)&statsPeriod=24h&interval=5m"),
                     "chart_type": None,
                     "dataset": SupportedTraceItemType.TRACEMETRICS,
                 },
@@ -2000,6 +2004,75 @@ class UnfurlTest(TestCase):
         call_kwargs = mock_client_get.call_args[1]
         api_params = call_kwargs["params"]
         assert api_params["interval"] == "1h"
+
+    def test_match_link_explore_default_interval_ladder(self) -> None:
+        # Mirrors MINIMUM_INTERVAL in static/app/utils/useChartInterval.tsx — if
+        # this list changes, the ladder in explore.py must change with it.
+        cases = [
+            ("1h", "1m"),
+            ("6h", "1m"),
+            ("12h", "5m"),
+            ("2d", "10m"),
+            ("4d", "30m"),
+            ("14d", "1h"),
+            ("30d", "3h"),
+        ]
+        for stats_period, expected_interval in cases:
+            url = (
+                f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/"
+                f"?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D"
+                f"&project={self.project.id}&statsPeriod={stats_period}"
+            )
+            _, args = match_link(url)
+            assert args is not None
+            assert args["query"]["interval"] == expected_interval, (
+                f"statsPeriod={stats_period} expected {expected_interval}, "
+                f"got {args['query']['interval']}"
+            )
+
+    def test_match_link_explore_default_interval_for_logs_and_metrics(self) -> None:
+        # Logs and metrics use the same useChartInterval default as traces, so
+        # the URL → timeseries conversion should pick the same interval for the
+        # same time range.
+        urls = [
+            (
+                f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/"
+                f"?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D"
+                f"&project={self.project.id}&statsPeriod=14d"
+            ),
+            (
+                f"https://sentry.io/organizations/{self.organization.slug}/explore/metrics/"
+                f"?metric=%7B%22aggregateFields%22%3A%5B%7B%22yAxes%22%3A%5B%22sum(value)%22%5D%7D%5D%7D"
+                f"&project={self.project.id}&statsPeriod=14d"
+            ),
+        ]
+        for url in urls:
+            _, args = match_link(url)
+            assert args is not None
+            assert args["query"]["interval"] == "1h"
+
+    def test_match_link_explore_default_interval_when_no_stats_period(self) -> None:
+        # When neither statsPeriod nor start/end is supplied, the unfurl falls
+        # back to DEFAULT_PERIOD (14d), so the default interval should be 1h.
+        url = (
+            f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/"
+            f"?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D"
+            f"&project={self.project.id}"
+        )
+        _, args = match_link(url)
+        assert args is not None
+        assert args["query"]["statsPeriod"] == "14d"
+        assert args["query"]["interval"] == "1h"
+
+    def test_match_link_explore_preserves_explicit_interval(self) -> None:
+        url = (
+            f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/"
+            f"?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D"
+            f"&project={self.project.id}&statsPeriod=24h&interval=1h"
+        )
+        _, args = match_link(url)
+        assert args is not None
+        assert args["query"]["interval"] == "1h"
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",


### PR DESCRIPTION
Match explores ui default interval selection with backend, so if a user pastes a explore url not containing an interval, the interval uses matches between unfurl and explore.
 There's some complications to work through to make the logic more shared, so for now i copied over the frontend logic.