### PR TITLE
feat(autofix): Better autoscroll on autofix drawer

### DIFF
--- a/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
+++ b/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
@@ -1,4 +1,3 @@
-import {useCallback, useEffect, useRef, useState, type UIEventHandler} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -8,7 +7,7 @@ import {type AutofixSection} from 'sentry/components/events/autofix/useExplorerA
 import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
 import {StyledMarkedText} from 'sentry/components/events/autofix/v3/styled';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {defined} from 'sentry/utils';
+import {useAutoScroll} from 'sentry/utils/useAutoScroll';
 
 interface ArtifactLoadingDetailsProps {
   blocks: AutofixSection['blocks'];
@@ -19,7 +18,9 @@ export function ArtifactLoadingDetails({
   loadingMessage,
   blocks,
 }: ArtifactLoadingDetailsProps) {
-  const {containerRef, bottomRef, onScrollHandler} = useAutoScroll(blocks);
+  const {containerRef, onScrollHandler} = useAutoScroll({
+    key: blocks,
+  });
 
   return (
     <ArtifactDetails>
@@ -47,46 +48,13 @@ export function ArtifactLoadingDetails({
 
           return null;
         })}
-        <Flex ref={bottomRef} direction="row" gap="md">
+        <Flex direction="row" gap="md">
           <StyledLoadingIndicator size={16} />
           <Text variant="muted">{loadingMessage}</Text>
         </Flex>
       </Flex>
     </ArtifactDetails>
   );
-}
-
-function useAutoScroll(blocks: AutofixSection['blocks']) {
-  const [canAutoScroll, setCanAutoScroll] = useState(true);
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  const bottomRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    const bottom = bottomRef.current;
-    if (!canAutoScroll || !defined(container) || !defined(bottom)) {
-      return;
-    }
-
-    if (container.scrollHeight <= container.clientHeight) {
-      return;
-    }
-
-    bottomRef.current?.scrollIntoView({behavior: 'smooth', block: 'end'});
-  }, [blocks, canAutoScroll]);
-
-  const onScrollHandler: UIEventHandler = useCallback(event => {
-    const {scrollTop, scrollHeight, clientHeight} = event.currentTarget;
-    const atBottom = scrollHeight - scrollTop - clientHeight < 1;
-    setCanAutoScroll(atBottom);
-  }, []);
-
-  return {
-    containerRef,
-    bottomRef,
-    onScrollHandler,
-  };
 }
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`

--- a/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
+++ b/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
@@ -19,6 +19,7 @@ export function ArtifactLoadingDetails({
   blocks,
 }: ArtifactLoadingDetailsProps) {
   const {containerRef, onScrollHandler} = useAutoScroll({
+    enabled: true,
     key: blocks,
   });
 

--- a/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
+++ b/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {useCallback, useEffect, useRef, useState, type UIEventHandler} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -19,22 +19,7 @@ export function ArtifactLoadingDetails({
   loadingMessage,
   blocks,
 }: ArtifactLoadingDetailsProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const bottomRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    const bottom = bottomRef.current;
-    if (!defined(container) || !defined(bottom)) {
-      return;
-    }
-
-    if (container.scrollHeight <= container.clientHeight) {
-      return;
-    }
-
-    bottomRef.current?.scrollIntoView({behavior: 'smooth', block: 'end'});
-  }, [blocks]);
+  const {containerRef, bottomRef, onScrollHandler} = useAutoScroll(blocks);
 
   return (
     <ArtifactDetails>
@@ -44,6 +29,7 @@ export function ArtifactLoadingDetails({
         ref={containerRef}
         maxHeight="200px"
         overflowY="auto"
+        onScroll={onScrollHandler}
       >
         {blocks.map((block, index) => {
           if (block.message.role === 'user') {
@@ -55,6 +41,10 @@ export function ArtifactLoadingDetails({
             return <StyledMarkedText key={index} text={block.message.content} />;
           }
 
+          if (block.message.thinking_content) {
+            return <StyledMarkedText key={index} text={block.message.thinking_content} />;
+          }
+
           return null;
         })}
         <Flex ref={bottomRef} direction="row" gap="md">
@@ -64,6 +54,39 @@ export function ArtifactLoadingDetails({
       </Flex>
     </ArtifactDetails>
   );
+}
+
+function useAutoScroll(blocks: AutofixSection['blocks']) {
+  const [canAutoScroll, setCanAutoScroll] = useState(true);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const bottom = bottomRef.current;
+    if (!canAutoScroll || !defined(container) || !defined(bottom)) {
+      return;
+    }
+
+    if (container.scrollHeight <= container.clientHeight) {
+      return;
+    }
+
+    bottomRef.current?.scrollIntoView({behavior: 'smooth', block: 'end'});
+  }, [blocks, canAutoScroll]);
+
+  const onScrollHandler: UIEventHandler = useCallback(event => {
+    const {scrollTop, scrollHeight, clientHeight} = event.currentTarget;
+    const atBottom = scrollHeight - scrollTop - clientHeight < 1;
+    setCanAutoScroll(atBottom);
+  }, []);
+
+  return {
+    containerRef,
+    bottomRef,
+    onScrollHandler,
+  };
 }
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`

--- a/static/app/components/events/autofix/v3/body.tsx
+++ b/static/app/components/events/autofix/v3/body.tsx
@@ -1,14 +1,20 @@
-import type {ReactNode} from 'react';
+import type {ReactNode, RefObject, UIEventHandler} from 'react';
 import styled from '@emotion/styled';
 
 import {DrawerBody} from '@sentry/scraps/drawer';
 
 interface SeerDrawerBody {
   children: ReactNode;
+  onScroll?: UIEventHandler;
+  ref?: RefObject<HTMLDivElement | null>;
 }
 
-export function SeerDrawerBody({children}: SeerDrawerBody) {
-  return <StyledDrawerBody>{children}</StyledDrawerBody>;
+export function SeerDrawerBody({children, onScroll, ref}: SeerDrawerBody) {
+  return (
+    <StyledDrawerBody ref={ref} onScroll={onScroll}>
+      {children}
+    </StyledDrawerBody>
+  );
 }
 
 const StyledDrawerBody = styled(DrawerBody)`

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -1,12 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type UIEventHandler,
-} from 'react';
+import {Fragment, useMemo} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -32,7 +24,6 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
-import {defined} from 'sentry/utils';
 import type {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 
 interface SeerDrawerContentProps {
@@ -46,8 +37,6 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
     () => getOrderedAutofixSections(autofix.runState),
     [autofix.runState]
   );
-
-  const {containerRef, bottomRef, onScrollHandler} = useAutoScroll(autofix);
 
   if (
     // autofix results are loading
@@ -67,7 +56,7 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
   }
 
   return (
-    <Flex ref={containerRef} onScroll={onScrollHandler} direction="column" gap="lg">
+    <Flex direction="column" gap="lg">
       <SeerDrawerArtifacts autofix={autofix} sections={sections} groupId={group.id} />
       {autofix.runState?.status === 'completed' && (
         <SeerDrawerNextStep group={group} autofix={autofix} sections={sections} />
@@ -89,7 +78,6 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
           {message}
         </Alert>
       ))}
-      <div ref={bottomRef} />
     </Flex>
   );
 }
@@ -138,34 +126,4 @@ function SeerDrawerArtifacts({autofix, groupId, sections}: SeerDrawerArtifactsPr
       })}
     </Fragment>
   );
-}
-
-function useAutoScroll(autofix: ReturnType<typeof useExplorerAutofix>) {
-  const [canAutoScroll, setCanAutoScroll] = useState(true);
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  const bottomRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    const bottom = bottomRef.current;
-    if (!canAutoScroll || !defined(container) || !defined(bottom)) {
-      return;
-    }
-
-    // only want to scroll when the run is in a completed state
-    if (autofix.runState?.status !== 'completed') {
-      return;
-    }
-
-    bottom.scrollIntoView({behavior: 'smooth', block: 'end'});
-  }, [autofix.runState?.status, canAutoScroll]);
-
-  const onScrollHandler: UIEventHandler = useCallback(event => {
-    const {scrollTop, scrollHeight, clientHeight} = event.currentTarget;
-    const atBottom = scrollHeight - scrollTop - clientHeight < 1;
-    setCanAutoScroll(atBottom);
-  }, []);
-
-  return {containerRef, bottomRef, onScrollHandler};
 }

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -1,4 +1,12 @@
-import {Fragment, useMemo} from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type UIEventHandler,
+} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -24,6 +32,7 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
 import type {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 
 interface SeerDrawerContentProps {
@@ -37,6 +46,8 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
     () => getOrderedAutofixSections(autofix.runState),
     [autofix.runState]
   );
+
+  const {containerRef, bottomRef, onScrollHandler} = useAutoScroll(autofix);
 
   if (
     // autofix results are loading
@@ -56,7 +67,7 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
   }
 
   return (
-    <Flex direction="column" gap="lg">
+    <Flex ref={containerRef} onScroll={onScrollHandler} direction="column" gap="lg">
       <SeerDrawerArtifacts autofix={autofix} sections={sections} groupId={group.id} />
       {autofix.runState?.status === 'completed' && (
         <SeerDrawerNextStep group={group} autofix={autofix} sections={sections} />
@@ -78,6 +89,7 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
           {message}
         </Alert>
       ))}
+      <div ref={bottomRef} />
     </Flex>
   );
 }
@@ -126,4 +138,34 @@ function SeerDrawerArtifacts({autofix, groupId, sections}: SeerDrawerArtifactsPr
       })}
     </Fragment>
   );
+}
+
+function useAutoScroll(autofix: ReturnType<typeof useExplorerAutofix>) {
+  const [canAutoScroll, setCanAutoScroll] = useState(true);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const bottom = bottomRef.current;
+    if (!canAutoScroll || !defined(container) || !defined(bottom)) {
+      return;
+    }
+
+    // only want to scroll when the run is in a completed state
+    if (autofix.runState?.status !== 'completed') {
+      return;
+    }
+
+    bottom.scrollIntoView({behavior: 'smooth', block: 'end'});
+  }, [autofix.runState?.status, canAutoScroll]);
+
+  const onScrollHandler: UIEventHandler = useCallback(event => {
+    const {scrollTop, scrollHeight, clientHeight} = event.currentTarget;
+    const atBottom = scrollHeight - scrollTop - clientHeight < 1;
+    setCanAutoScroll(atBottom);
+  }, []);
+
+  return {containerRef, bottomRef, onScrollHandler};
 }

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useMemo, useRef} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
 
@@ -38,7 +38,16 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
     [aiAutofix.runState?.blocks]
   );
 
+  // For autoscroll, we only want to turn it on if we ever encounter a processing state.
+  // If not, it indicates the users is viewing an already completed autofix, so we do
+  // not want to enable autoscroll.
+  const enableAutoScroll = useRef(false);
+  if (aiAutofix.runState?.status === 'processing') {
+    enableAutoScroll.current = true;
+  }
+
   const {containerRef, onScrollHandler} = useAutoScroll({
+    enabled: enableAutoScroll.current,
     key: aiAutofix.runState,
   });
 

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -17,6 +17,7 @@ import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
+import {useAutoScroll} from 'sentry/utils/useAutoScroll';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 
@@ -37,6 +38,10 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
     [aiAutofix.runState?.blocks]
   );
 
+  const {containerRef, onScrollHandler} = useAutoScroll({
+    key: aiAutofix.runState,
+  });
+
   return (
     <Flex
       className="seer-drawer-container"
@@ -51,7 +56,7 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
         onReset={handleRestart}
         referrer={referrer}
       />
-      <SeerDrawerBody>
+      <SeerDrawerBody ref={containerRef} onScroll={onScrollHandler}>
         {aiConfig.isAutofixSetupLoading ? (
           <Flex data-test-id="ai-setup-loading-indicator" direction="column" gap="xl">
             <Placeholder height="10rem" />

--- a/static/app/utils/useAutoScroll.tsx
+++ b/static/app/utils/useAutoScroll.tsx
@@ -3,10 +3,11 @@ import {useCallback, useEffect, useRef, type UIEventHandler} from 'react';
 import {defined} from 'sentry/utils';
 
 interface UseAutoScrollOptions {
+  enabled: boolean;
   key: unknown;
 }
 
-export function useAutoScroll({key}: UseAutoScrollOptions) {
+export function useAutoScroll({enabled, key}: UseAutoScrollOptions) {
   const canAutoScroll = useRef(true);
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -14,15 +15,15 @@ export function useAutoScroll({key}: UseAutoScrollOptions) {
   useEffect(() => {
     const container = containerRef.current;
 
-    if (!canAutoScroll.current || !defined(container)) {
+    if (!enabled || !canAutoScroll.current || !defined(container)) {
       return;
     }
 
-    container.scrollTo({
+    container.scrollTo?.({
       top: container.scrollHeight,
       behavior: 'smooth',
     });
-  }, [key]);
+  }, [enabled, key]);
 
   const onScrollHandler: UIEventHandler = useCallback(event => {
     const {scrollTop, scrollHeight, clientHeight} = event.currentTarget;

--- a/static/app/utils/useAutoScroll.tsx
+++ b/static/app/utils/useAutoScroll.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState, type UIEventHandler} from 'react';
+import {useCallback, useEffect, useRef, type UIEventHandler} from 'react';
 
 import {defined} from 'sentry/utils';
 
@@ -7,14 +7,14 @@ interface UseAutoScrollOptions {
 }
 
 export function useAutoScroll({key}: UseAutoScrollOptions) {
-  const [canAutoScroll, setCanAutoScroll] = useState(true);
+  const canAutoScroll = useRef(true);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const container = containerRef.current;
 
-    if (!canAutoScroll || !defined(container)) {
+    if (!canAutoScroll.current || !defined(container)) {
       return;
     }
 
@@ -22,12 +22,12 @@ export function useAutoScroll({key}: UseAutoScrollOptions) {
       top: container.scrollHeight,
       behavior: 'smooth',
     });
-  }, [canAutoScroll, key]);
+  }, [key]);
 
   const onScrollHandler: UIEventHandler = useCallback(event => {
     const {scrollTop, scrollHeight, clientHeight} = event.currentTarget;
     const atBottom = scrollHeight - scrollTop - clientHeight < 1;
-    setCanAutoScroll(atBottom);
+    canAutoScroll.current = atBottom;
   }, []);
 
   return {

--- a/static/app/utils/useAutoScroll.tsx
+++ b/static/app/utils/useAutoScroll.tsx
@@ -3,7 +3,7 @@ import {useCallback, useEffect, useRef, useState, type UIEventHandler} from 'rea
 import {defined} from 'sentry/utils';
 
 interface UseAutoScrollOptions {
-  key: any;
+  key: unknown;
 }
 
 export function useAutoScroll({key}: UseAutoScrollOptions) {

--- a/static/app/utils/useAutoScroll.tsx
+++ b/static/app/utils/useAutoScroll.tsx
@@ -1,0 +1,37 @@
+import {useCallback, useEffect, useRef, useState, type UIEventHandler} from 'react';
+
+import {defined} from 'sentry/utils';
+
+interface UseAutoScrollOptions {
+  key: any;
+}
+
+export function useAutoScroll({key}: UseAutoScrollOptions) {
+  const [canAutoScroll, setCanAutoScroll] = useState(true);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (!canAutoScroll || !defined(container)) {
+      return;
+    }
+
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior: 'smooth',
+    });
+  }, [canAutoScroll, key]);
+
+  const onScrollHandler: UIEventHandler = useCallback(event => {
+    const {scrollTop, scrollHeight, clientHeight} = event.currentTarget;
+    const atBottom = scrollHeight - scrollTop - clientHeight < 1;
+    setCanAutoScroll(atBottom);
+  }, []);
+
+  return {
+    containerRef,
+    onScrollHandler,
+  };
+}


### PR DESCRIPTION
Make sure to scroll to the bottom when each section is finished loading. Also make sure to cancel the auto scroll behaviour if the user scrolled upwards.