### PR TITLE
fix: Disable billing platform exception logging

### DIFF
--- a/src/sentry/billing/platform/core/service.py
+++ b/src/sentry/billing/platform/core/service.py
@@ -129,7 +129,7 @@ def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
                 tags={**metric_tags, "error_type": type(e).__name__},
             )
 
-            logger.exception(
+            logger.info(
                 "billing.service.method.error",
                 extra={
                     "service": service_name,


### PR DESCRIPTION
Change this to info because we expect to get some errors while prototyping the platform