### PR TITLE
fix(ourlogs): only show LogsAggregateTable top result colors on first cursor page

### DIFF
--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -22,7 +22,7 @@ import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreA
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTracesTable';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
-import {type useLogsAggregatesTable} from 'sentry/views/explore/logs/useLogsAggregatesTable';
+import {type LogsAggregatesTableResult} from 'sentry/views/explore/logs/useLogsAggregatesTable';
 import type {UseInfiniteLogsQueryResult} from 'sentry/views/explore/logs/useLogsQuery';
 import {useMetricAggregatesTable} from 'sentry/views/explore/metrics/hooks/useMetricAggregatesTable';
 import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetricSamplesTable';
@@ -585,7 +585,7 @@ export function useLogAnalytics({
   aggregateSortBys: readonly Sort[];
   interval: string;
   isTopN: boolean;
-  logsAggregatesTableResult: ReturnType<typeof useLogsAggregatesTable>;
+  logsAggregatesTableResult: LogsAggregatesTableResult;
   logsTableResult: UseInfiniteLogsQueryResult;
   logsTimeseriesResult: ReturnType<typeof useSortedTimeSeries>;
   mode: Mode;

--- a/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
@@ -6,6 +6,7 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {
+  LOGS_AGGREGATE_CURSOR_KEY,
   LOGS_AGGREGATE_FN_KEY,
   LOGS_AGGREGATE_PARAM_KEY,
   LOGS_FIELDS_KEY,
@@ -14,9 +15,22 @@ import {
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_AGGREGATE_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
-import {type useLogsAggregatesTable} from 'sentry/views/explore/logs/useLogsAggregatesTable';
+import {type LogsAggregatesTableResult} from 'sentry/views/explore/logs/useLogsAggregatesTable';
 
 import {LogsAggregateTable} from './logsAggregateTable';
+
+function createAggregatesTableResult(
+  overrides: Partial<LogsAggregatesTableResult>
+): LogsAggregatesTableResult {
+  return {
+    data: undefined,
+    isError: false,
+    isLoading: false,
+    isPending: false,
+    pageLinks: undefined,
+    ...overrides,
+  } as LogsAggregatesTableResult;
+}
 
 describe('LogsAggregateTable', () => {
   const {organization, project} = initializeOrg({
@@ -27,7 +41,7 @@ describe('LogsAggregateTable', () => {
   function LogsAggregateTableWithParamsProvider({
     aggregatesTableResult,
   }: {
-    aggregatesTableResult: ReturnType<typeof useLogsAggregatesTable>;
+    aggregatesTableResult: LogsAggregatesTableResult;
   }) {
     return (
       <LogsQueryParamsProvider
@@ -77,14 +91,9 @@ describe('LogsAggregateTable', () => {
   it('renders loading state', () => {
     render(
       <LogsAggregateTableWithParamsProvider
-        aggregatesTableResult={
-          {
-            isLoading: true,
-            error: null,
-            data: undefined,
-            pageLinks: undefined,
-          } as any
-        }
+        aggregatesTableResult={createAggregatesTableResult({
+          isLoading: true,
+        })}
       />,
       {initialRouterConfig}
     );
@@ -94,14 +103,9 @@ describe('LogsAggregateTable', () => {
   it('renders error state', () => {
     render(
       <LogsAggregateTableWithParamsProvider
-        aggregatesTableResult={
-          {
-            isLoading: false,
-            error: new RequestError('GET', '/', new Error('Error!')),
-            data: undefined,
-            pageLinks: undefined,
-          } as any
-        }
+        aggregatesTableResult={createAggregatesTableResult({
+          error: new RequestError('GET', '/', new Error('Error!')),
+        })}
       />,
       {initialRouterConfig}
     );
@@ -111,31 +115,26 @@ describe('LogsAggregateTable', () => {
   it('renders data rows', () => {
     render(
       <LogsAggregateTableWithParamsProvider
-        aggregatesTableResult={
-          {
-            isLoading: false,
-            error: null,
-            data: {
-              data: [
-                {
-                  'message.template': 'Fetching the latest item id failed.',
-                  'p99(severity_number)': 17.0,
-                },
-                {
-                  'message.template':
-                    '/usr/src/sentry/src/sentry/db/models/manager/base.py:282: derp',
-                  'p99(severity_number)': 13.0,
-                },
-                {
-                  'message.template':
-                    '/usr/src/sentry/src/sentry/db/models/manager/base.py:282: herp',
-                  'p99(severity_number)': 12.0,
-                },
-              ],
-            },
-            pageLinks: undefined,
-          } as any
-        }
+        aggregatesTableResult={createAggregatesTableResult({
+          data: {
+            data: [
+              {
+                'message.template': 'Fetching the latest item id failed.',
+                'p99(severity_number)': 17.0,
+              },
+              {
+                'message.template':
+                  '/usr/src/sentry/src/sentry/db/models/manager/base.py:282: derp',
+                'p99(severity_number)': 13.0,
+              },
+              {
+                'message.template':
+                  '/usr/src/sentry/src/sentry/db/models/manager/base.py:282: herp',
+                'p99(severity_number)': 12.0,
+              },
+            ],
+          },
+        })}
       />,
       {initialRouterConfig}
     );
@@ -151,5 +150,102 @@ describe('LogsAggregateTable', () => {
       expect(cells[1]).toHaveTextContent(expected[i]![0]!);
       expect(cells[2]).toHaveTextContent(expected[i]![1]!);
     });
+  });
+
+  it('renders top result colors when the page is the first one', () => {
+    const aggregatesTableResult = createAggregatesTableResult({
+      data: {
+        data: [
+          {
+            'message.template': 'Fetching the latest item id failed.',
+            'p99(severity_number)': 17.0,
+          },
+          {
+            'message.template':
+              '/usr/src/sentry/src/sentry/db/models/manager/base.py:282: derp',
+            'p99(severity_number)': 13.0,
+          },
+          {
+            'message.template':
+              '/usr/src/sentry/src/sentry/db/models/manager/base.py:282: herp',
+            'p99(severity_number)': 12.0,
+          },
+        ],
+      },
+    });
+
+    const {unmount} = render(
+      <LogsAggregateTableWithParamsProvider
+        aggregatesTableResult={aggregatesTableResult}
+      />,
+      {initialRouterConfig}
+    );
+
+    expect(screen.getAllByTestId('top-results-indicator')).toHaveLength(3);
+
+    unmount();
+
+    render(
+      <LogsAggregateTableWithParamsProvider
+        aggregatesTableResult={aggregatesTableResult}
+      />,
+      {
+        initialRouterConfig: {
+          ...initialRouterConfig,
+          location: {
+            ...initialRouterConfig.location,
+            query: {
+              ...initialRouterConfig.location.query,
+              [LOGS_AGGREGATE_CURSOR_KEY]: '0:3:1',
+            },
+          },
+        },
+      }
+    );
+
+    expect(screen.queryByTestId('top-results-indicator')).not.toBeInTheDocument();
+  });
+
+  it('does not render top result colors when the page is after the first', () => {
+    const aggregatesTableResult = createAggregatesTableResult({
+      data: {
+        data: [
+          {
+            'message.template': 'Fetching the latest item id failed.',
+            'p99(severity_number)': 17.0,
+          },
+          {
+            'message.template':
+              '/usr/src/sentry/src/sentry/db/models/manager/base.py:282: derp',
+            'p99(severity_number)': 13.0,
+          },
+          {
+            'message.template':
+              '/usr/src/sentry/src/sentry/db/models/manager/base.py:282: herp',
+            'p99(severity_number)': 12.0,
+          },
+        ],
+      },
+    });
+
+    render(
+      <LogsAggregateTableWithParamsProvider
+        aggregatesTableResult={aggregatesTableResult}
+      />,
+      {
+        initialRouterConfig: {
+          ...initialRouterConfig,
+          location: {
+            ...initialRouterConfig.location,
+            query: {
+              ...initialRouterConfig.location.query,
+              [LOGS_AGGREGATE_CURSOR_KEY]: '0:3:1',
+            },
+          },
+        },
+      }
+    );
+
+    expect(screen.queryByTestId('top-results-indicator')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/logs/tables/logsAggregateTable.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.tsx
@@ -12,6 +12,7 @@ import {SortLink} from 'sentry/components/tables/gridEditable/sortLink';
 import {IconStack} from 'sentry/icons/iconStack';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {parseCursor} from 'sentry/utils/cursor';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
 import {prettifyTagKey} from 'sentry/utils/fields';
@@ -26,13 +27,14 @@ import {LogFieldRenderer} from 'sentry/views/explore/logs/fieldRenderers';
 import {getTargetWithReadableQueryParams} from 'sentry/views/explore/logs/logsQueryParams';
 import {getLogColors} from 'sentry/views/explore/logs/styles';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-import {type useLogsAggregatesTable} from 'sentry/views/explore/logs/useLogsAggregatesTable';
+import {type LogsAggregatesTableResult} from 'sentry/views/explore/logs/useLogsAggregatesTable';
 import {
   getLogSeverityLevel,
   viewLogsSamplesTarget,
 } from 'sentry/views/explore/logs/utils';
 import {
   useQueryParamsAggregateSortBys,
+  useQueryParamsAggregateCursor,
   useQueryParamsFields,
   useQueryParamsGroupBys,
   useQueryParamsSearch,
@@ -46,7 +48,7 @@ import {
 export function LogsAggregateTable({
   aggregatesTableResult,
 }: {
-  aggregatesTableResult: ReturnType<typeof useLogsAggregatesTable>;
+  aggregatesTableResult: LogsAggregatesTableResult;
 }) {
   const {data, pageLinks, isLoading, error, eventView} = aggregatesTableResult;
 
@@ -63,6 +65,7 @@ export function LogsAggregateTable({
   const visualizes = useQueryParamsVisualizes();
   const setAggregateCursor = useSetQueryParamsAggregateCursor();
   const aggregateSortBys = useQueryParamsAggregateSortBys();
+  const aggregateCursor = useQueryParamsAggregateCursor();
   const topEventsLimit = useQueryParamsTopEventsLimit();
   const search = useQueryParamsSearch();
   const setSearch = useSetQueryParamsSearch();
@@ -209,9 +212,14 @@ export function LogsAggregateTable({
 
             return [
               <Fragment key={`sample-${rowIndex}`}>
-                {topEventsLimit && rowIndex < topEventsLimit && (
-                  <TopResultsIndicator color={palette[rowIndex]!} />
-                )}
+                {topEventsLimit &&
+                  rowIndex < topEventsLimit &&
+                  !parseCursor(aggregateCursor)?.offset && (
+                    <TopResultsIndicator
+                      data-test-id="top-results-indicator"
+                      color={palette[rowIndex]!}
+                    />
+                  )}
                 <Tooltip title={t('View Samples')} containerDisplayMode="flex">
                   <StyledLink to={target}>
                     <IconStack />

--- a/static/app/views/explore/logs/useLogsAggregatesTable.tsx
+++ b/static/app/views/explore/logs/useLogsAggregatesTable.tsx
@@ -34,6 +34,8 @@ interface UseLogsAggregatesTableOptions {
   referrer?: string;
 }
 
+export type LogsAggregatesTableResult = ReturnType<typeof useLogsAggregatesTable>;
+
 export function useLogsAggregatesTable({
   enabled,
   limit,


### PR DESCRIPTION
Also touches up the tests to have a function that spreads default values with an `as`, instead of just an `as any`. And to support that I made a dedicated `LogsAggregatesTableResult` type.

<img width="1508" height="802" alt="Screenshot of a logs Aggregates table showing no 'top results' colors" src="https://github.com/user-attachments/assets/bb8769d2-f5f7-4d66-a81d-a546c7f6c2d8" />

Fixes LOGS-765.