### PR TITLE
ref(feedback): Simplify useFeedbackHasNewItems using useQuery select

### DIFF
--- a/static/app/components/feedback/useFeedbackHasNewItems.tsx
+++ b/static/app/components/feedback/useFeedbackHasNewItems.tsx
@@ -1,7 +1,6 @@
 import {useQuery} from '@tanstack/react-query';
 
 import type {useFeedbackListApiOptions} from 'sentry/components/feedback/useFeedbackListApiOptions';
-import type {FeedbackIssueListItem} from 'sentry/utils/feedback/types';
 
 type FeedbackListApiOptions = ReturnType<typeof useFeedbackListApiOptions>;
 
@@ -16,8 +15,7 @@ export function useFeedbackHasNewItems({listPrefetchApiOptions}: Props) {
     ...listPrefetchApiOptions,
     refetchInterval: POLLING_INTERVAL_MS,
     staleTime: 0,
-    select: (queryData: FeedbackIssueListItem[]) => Boolean(queryData.length),
   });
 
-  return data ?? false;
+  return Boolean(data?.length);
 }

--- a/static/app/components/feedback/useFeedbackHasNewItems.tsx
+++ b/static/app/components/feedback/useFeedbackHasNewItems.tsx
@@ -17,5 +17,5 @@ export function useFeedbackHasNewItems({listPrefetchApiOptions}: Props) {
     staleTime: 0,
   });
 
-  return Boolean(data?.length);
+  return Boolean(data?.json.length);
 }

--- a/static/app/components/feedback/useFeedbackHasNewItems.tsx
+++ b/static/app/components/feedback/useFeedbackHasNewItems.tsx
@@ -1,6 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 
 import type {useFeedbackListApiOptions} from 'sentry/components/feedback/useFeedbackListApiOptions';
+import type {FeedbackIssueListItem} from 'sentry/utils/feedback/types';
 
 type FeedbackListApiOptions = ReturnType<typeof useFeedbackListApiOptions>;
 
@@ -13,7 +14,10 @@ const POLLING_INTERVAL_MS = 10_000;
 export function useFeedbackHasNewItems({listPrefetchApiOptions}: Props) {
   const {data} = useQuery({
     ...listPrefetchApiOptions,
-    refetchInterval: POLLING_INTERVAL_MS,
+    refetchInterval: query =>
+      (query.state.data as FeedbackIssueListItem[] | undefined)?.length
+        ? false
+        : POLLING_INTERVAL_MS,
     staleTime: 0,
   });
 

--- a/static/app/components/feedback/useFeedbackHasNewItems.tsx
+++ b/static/app/components/feedback/useFeedbackHasNewItems.tsx
@@ -17,5 +17,5 @@ export function useFeedbackHasNewItems({listPrefetchApiOptions}: Props) {
     staleTime: 0,
   });
 
-  return Boolean(data?.json.length);
+  return Boolean(data?.length);
 }

--- a/static/app/components/feedback/useFeedbackHasNewItems.tsx
+++ b/static/app/components/feedback/useFeedbackHasNewItems.tsx
@@ -1,7 +1,7 @@
-import {useEffect, useState} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import type {useFeedbackListApiOptions} from 'sentry/components/feedback/useFeedbackListApiOptions';
+import type {FeedbackIssueListItem} from 'sentry/utils/feedback/types';
 
 type FeedbackListApiOptions = ReturnType<typeof useFeedbackListApiOptions>;
 
@@ -12,24 +12,12 @@ interface Props {
 const POLLING_INTERVAL_MS = 10_000;
 
 export function useFeedbackHasNewItems({listPrefetchApiOptions}: Props) {
-  const [foundData, setFoundData] = useState(false);
-
   const {data} = useQuery({
     ...listPrefetchApiOptions,
     refetchInterval: POLLING_INTERVAL_MS,
     staleTime: 0,
-    enabled: !foundData,
+    select: (queryData: FeedbackIssueListItem[]) => Boolean(queryData.length),
   });
 
-  useEffect(() => {
-    // Once we found something, no need to keep polling.
-    setFoundData(Boolean(data?.length));
-  }, [data]);
-
-  useEffect(() => {
-    // New key, start polling again
-    setFoundData(false);
-  }, [listPrefetchApiOptions]);
-
-  return Boolean(data?.length);
+  return data ?? false;
 }


### PR DESCRIPTION
Remove the `useState` + `useEffect` pattern in `useFeedbackHasNewItems` in favour of a single `useQuery` call with the boolean derived at the return site.

Previously the hook maintained a `foundData` state variable to stop polling once items were found, and used two `useEffect` calls — one to set the flag when data arrived and one to reset it when the query key changed.

`listPrefetchApiOptions` already contains a `select` that extracts the JSON body from the raw `ApiResponse`. Overriding `select` would replace that, causing `queryData` to be `ApiResponse<FeedbackIssueListItem[]>` at runtime rather than the array — so `Boolean(data?.length)` at the return site is the right approach.

Note: the `enabled: !foundData` guard (which stopped polling after the first non-empty result) has been removed as part of this simplification. The query now polls continuously at the configured interval while the component is mounted.