### PR TITLE
fix(search): Fix userCount filter for issues-stats endpoint

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -936,6 +936,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         *SKIP_SNUBA_FIELDS,
         "last_seen",
         "times_seen",
+        "user_count",
         "date",
         "timestamp",  # We merge this with start/end, so don't want to include it as its own
         # condition

--- a/src/sentry/seer/endpoints/issue_view_title_generate.py
+++ b/src/sentry/seer/endpoints/issue_view_title_generate.py
@@ -34,6 +34,7 @@ is:unresolved issue.priority:[high, medium] -> Prioritized Issues
 is:unresolved assigned_or_suggested:me -> Assigned to Me
 is:unresolved http.status_code:5* -> Request Errors
 is:unresolved timesSeen:>100 -> High Volume Issues
+is:unresolved user_count:>100 -> High User Count Issues
 browser.name:Safari is:unresolved -> Safari Issues
 is:unresolved oauth -> OAuth Issues
 is:unresolved -> Unresolved Issues"""

--- a/src/sentry/seer/endpoints/issue_view_title_generate.py
+++ b/src/sentry/seer/endpoints/issue_view_title_generate.py
@@ -34,7 +34,7 @@ is:unresolved issue.priority:[high, medium] -> Prioritized Issues
 is:unresolved assigned_or_suggested:me -> Assigned to Me
 is:unresolved http.status_code:5* -> Request Errors
 is:unresolved timesSeen:>100 -> High Volume Issues
-is:unresolved user_count:>100 -> High User Count Issues
+is:unresolved userCount:>100 -> High User Count Issues
 browser.name:Safari is:unresolved -> Safari Issues
 is:unresolved oauth -> OAuth Issues
 is:unresolved -> Unresolved Issues"""


### PR DESCRIPTION
## Summary
- Adds `user_count` to `GroupSerializerSnuba.skip_snuba_fields` to fix a 500 error on the `/issues-stats/` endpoint when filtering by `userCount`. Like `times_seen`, `user_count` is an aggregation field that must be handled via HAVING clause in the main search query, not passed as a WHERE condition by the serializer.
- Adds a `user_count` few-shot example to the issue view title generation LLM prompt so saved views filtering by user count get appropriate auto-generated titles.

## Test plan
- [ ] Query `userCount:>10` on the issue list and verify the issues-stats endpoint no longer returns 500
- [ ] Save an issue view with a `userCount` filter and verify the auto-generated title is reasonable