### PR TITLE
chore(cells) Remove remaining usage of deprecated provisioning options

### DIFF
--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -52,16 +52,7 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         create_default_team: bool,
         organization_id: int,
         is_test: bool = False,
-        # TODO(cells) Deprecated use owner instead
-        user_id: int | None = None,
-        # TODO(cells) Deprecated use owner instead
-        email: str | None = None,
     ) -> Organization:
-        assert owner or (user_id is None and email) or (user_id and email is None), (
-            "Must set either owner or one of user_id or email"
-        )
-        if not user_id and owner:
-            user_id = owner.id
         truncated_name = organization_name[:ORGANIZATION_NAME_MAX_LENGTH]
         org = Organization.objects.create(
             id=organization_id, name=truncated_name, slug=slug, is_test=is_test
@@ -73,14 +64,8 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         # or a bug in the slugify implementation, so we reject the organization creation
         assert org.slug == slug, "Organization slug should not have been modified on save"
 
-        om = (
-            OrganizationMember.objects.create(
-                user_id=user_id, organization=org, role=roles.get_top_dog().id
-            )
-            if user_id
-            else OrganizationMember.objects.create(
-                email=email, organization=org, role=roles.get_top_dog().id
-            )
+        om = OrganizationMember.objects.create(
+            user_id=owner.id, organization=org, role=roles.get_top_dog().id
         )
 
         if create_default_team:
@@ -110,7 +95,7 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
             try:
                 provisioning_user_is_org_owner = (
                     matching_org.get_default_owner().id
-                    == provision_payload.provision_options.owning_user_id
+                    == provision_payload.provision_options.owner.id
                 )
             except IndexError:
                 # get_default_owner raises this when the org has no default owner
@@ -164,8 +149,6 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         with outbox_context(transaction.atomic(router.db_for_write(Organization))):
             organization = self._create_organization_and_team(
                 owner=provision_options.owner,
-                user_id=provision_options.owning_user_id,
-                email=provision_options.owning_email,
                 slug=provision_options.slug,
                 organization_name=provision_options.name,
                 create_default_team=provision_options.create_default_team,

--- a/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
@@ -156,7 +156,7 @@ class DatabaseBackedControlOrganizationProvisioningService(
             org_slug_res = OrganizationSlugReservation(
                 slug=slug,
                 organization_id=org_id,
-                user_id=org_provision_args.provision_options.owning_user_id,
+                user_id=org_provision_args.provision_options.owner.id,
                 cell_name=cell_name,
             )
 

--- a/tests/sentry/hybridcloud/services/test_cell_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/services/test_cell_organization_provisioning.py
@@ -40,7 +40,6 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
                 name="Santry",
                 slug="santry",
                 owner=rpc_user,
-                owning_user_id=rpc_user.id,
                 is_test=is_test,
                 create_default_team=create_default_team,
             ),
@@ -54,9 +53,7 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
             org: Organization = Organization.objects.get(id=organization_id)
             assert org.slug == provisioning_options.provision_options.slug
             assert org.name == provisioning_options.provision_options.name
-            assert (
-                org.get_default_owner().id == provisioning_options.provision_options.owning_user_id
-            )
+            assert org.get_default_owner().id == provisioning_options.provision_options.owner.id
         assert org.is_test == provisioning_options.provision_options.is_test
 
     def assert_has_default_team_and_membership(self, organization_id: int, user_id: int) -> None:

--- a/tests/sentry/hybridcloud/services/test_control_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/services/test_control_organization_provisioning.py
@@ -56,8 +56,6 @@ class TestControlOrganizationProvisioningBase(TestCase):
                 name=name,
                 slug=slug,
                 owner=rpc_user,
-                owning_user_id=rpc_user.id,
-                owning_email=rpc_user.email,
                 create_default_team=default_team,
                 is_test=False,
             ),
@@ -201,8 +199,11 @@ class TestControlOrganizationProvisioningSlugUpdates(TestControlOrganizationProv
         test_org_slug_reservation = self.provision_organization()
 
         new_user = self.create_user()
+        new_user_rpc = serialize_generic_user(new_user)
+        assert new_user_rpc
+
         conflicting_slug = "foobar"
-        self.provisioning_args.provision_options.owning_user_id = new_user.id
+        self.provisioning_args.provision_options.owner = new_user_rpc
         self.provisioning_args.provision_options.slug = conflicting_slug
         org_slug_res_with_conflict = self.provision_organization()
 
@@ -236,8 +237,11 @@ class TestControlOrganizationProvisioningSlugUpdates(TestControlOrganizationProv
         original_slug = test_org_slug_reservation.slug
 
         new_user = self.create_user()
+        new_user_rpc = serialize_generic_user(new_user)
+        assert new_user_rpc
+
         conflicting_slug = "foobar"
-        self.provisioning_args.provision_options.owning_user_id = new_user.id
+        self.provisioning_args.provision_options.owner = new_user_rpc
         self.provisioning_args.provision_options.slug = conflicting_slug
         org_with_conflicting_slug = self.provision_organization()
 
@@ -263,8 +267,11 @@ class TestControlOrganizationProvisioningSlugUpdates(TestControlOrganizationProv
         original_slug = org_reservation.slug
 
         conflicting_owner = self.create_user()
+        conflicting_owner_rpc = serialize_generic_user(conflicting_owner)
+        assert conflicting_owner_rpc
+
         conflicting_slug = "conflicty"
-        self.provisioning_args.provision_options.owning_user_id = conflicting_owner.id
+        self.provisioning_args.provision_options.owner = conflicting_owner_rpc
         self.provisioning_args.provision_options.slug = conflicting_slug
         conflicting_slug_reservation = self.provision_organization(cell_name="de")
 


### PR DESCRIPTION
There were still a few references to owning_user_id and owning_user_email that need to be removed.

Refs INFRENG-186
