### PR TITLE
fix(repositories): Fix serialization error during repo sync

### DIFF
--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -42,7 +42,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
         *,
         organization_id: int,
         integration_id: int | None = None,
-        external_id: int | None = None,
+        external_id: str | None = None,
         providers: list[str] | None = None,
         has_integration: bool | None = None,
         has_provider: bool | None = None,

--- a/src/sentry/integrations/services/repository/service.py
+++ b/src/sentry/integrations/services/repository/service.py
@@ -45,7 +45,7 @@ class RepositoryService(RpcService):
         *,
         organization_id: int,
         integration_id: int | None = None,
-        external_id: int | None = None,
+        external_id: str | None = None,
         providers: list[str] | None = None,
         has_integration: bool | None = None,
         has_provider: bool | None = None,


### PR DESCRIPTION
This fixes a problem when syncing repos where we pass a string, but the type is an int and so pydantic causes a failure.

Fixes SENTRY-5NHN
