### PR TITLE
fix(seer): Stop on-completion hook from re-pushing terminally errored repos

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -393,6 +393,27 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             )
             return
 
+        # Errored repos are terminal — re-pushing would re-fire this hook in a loop.
+        diffs_by_repo = state.get_diffs_by_repo()
+        errored_repos = [
+            repo
+            for repo in diffs_by_repo
+            if (pr_state := state.repo_pr_states.get(repo)) is not None
+            and pr_state.pr_creation_status == "error"
+        ]
+        if errored_repos and all(
+            state._is_repo_synced(repo) or repo in errored_repos for repo in diffs_by_repo
+        ):
+            logger.info(
+                "autofix.on_completion_hook.skip_errored_pushes",
+                extra={
+                    "run_id": run_id,
+                    "organization_id": group.organization.id,
+                    "errored_repos": errored_repos,
+                },
+            )
+            return
+
         logger.info(
             "autofix.on_completion_hook.pushing_changes",
             extra={"run_id": run_id, "organization_id": group.organization.id},

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -405,7 +405,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             state._is_repo_synced(repo) or repo in errored_repos for repo in diffs_by_repo
         ):
             logger.info(
-                "autofix.on_completion_hook.skip_errored_pushes",
+                "autofix.on_completion_hook.skip_no_pushable_repos",
                 extra={
                     "run_id": run_id,
                     "organization_id": group.organization.id,

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -7,6 +7,7 @@ from sentry.seer.agent.client_models import (
     FilePatch,
     MemoryBlock,
     Message,
+    RepoPRState,
     SeerRunState,
 )
 from sentry.seer.autofix.autofix_agent import AutofixStep
@@ -253,6 +254,69 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
             referrer=AutofixReferrer.ON_COMPLETION_HOOK,
             state=state,
         )
+
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
+    def test_push_changes_skips_when_all_unsynced_repos_errored(self, mock_push_changes):
+        """Does not re-push when every un-synced repo is already in pr_creation_status='error'."""
+        state = run_state(
+            blocks=[
+                root_cause_memory_block(),
+                solution_memory_block(),
+                code_changes_memory_block(),
+            ],
+            metadata={
+                "group_id": self.group.id,
+                "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+        state.repo_pr_states = {
+            "test-repo": RepoPRState(
+                repo_name="test-repo",
+                pr_creation_status="error",
+                pr_creation_error="No write access to repository test-repo",
+            )
+        }
+        AutofixOnCompletionHook._push_changes(self.group, 123, state)
+        mock_push_changes.assert_not_called()
+
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
+    def test_push_changes_pushes_when_any_unsynced_repo_not_errored(self, mock_push_changes):
+        """Still pushes when a repo with diffs has no PR state yet (e.g. newly added)."""
+        state = run_state(
+            blocks=[
+                root_cause_memory_block(),
+                solution_memory_block(),
+                code_changes_memory_block(),
+                MemoryBlock(
+                    id="block-code-changes-2",
+                    message=Message(
+                        role="assistant",
+                        content="more code changes",
+                        metadata={"step": "code_changes"},
+                    ),
+                    timestamp="2026-02-10T00:00:00Z",
+                    merged_file_patches=[
+                        AgentFilePatch(
+                            repo_name="other-repo",
+                            patch=FilePatch(path="x.py", type="M", added=1, removed=0),
+                        )
+                    ],
+                ),
+            ],
+            metadata={
+                "group_id": self.group.id,
+                "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+        state.repo_pr_states = {
+            "test-repo": RepoPRState(
+                repo_name="test-repo",
+                pr_creation_status="error",
+                pr_creation_error="No write access to repository test-repo",
+            )
+        }
+        AutofixOnCompletionHook._push_changes(self.group, 123, state)
+        mock_push_changes.assert_called_once()
 
 
 class TestPipelineConstants(TestCase):


### PR DESCRIPTION
## Summary

A failed Seer create-pr task fires the on-completion hook on completion. The hook saw an unsynced repo (no `commit_sha`) and called `trigger_push_changes`, which re-enqueued the failing task — a tight infinite loop producing 10k+ Sentry events per affected run (see [SEER-6YS](https://sentry.sentry.io/issues/SEER-6YS), 46k+ occurrences).

This skips `trigger_push_changes` when every un-synced repo with diffs is already in `pr_creation_status == "error"`. User-initiated retries (which reset `pr_creation_status`) are unaffected.

## Test plan

- [x] Unit tests for the skip and non-skip cases
- [ ] Verify SEER-6YS event volume drops in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)
