### PR TITLE
feat(repos): Add useSyncRepositories hook with polling and timeout

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -442,6 +442,18 @@ export interface Integration extends CommonIntegration {
 
 type ConfigData = Record<string, unknown> & {
   installationType?: string;
+  /**
+   * ISO timestamp of the last sync that actually changed the repo set
+   * (added, disabled, or restored repos). Stamped alongside `last_sync`
+   * only when the diff was non-empty.
+   */
+  last_repos_change?: string;
+  /**
+   * ISO timestamp of the most recent successful repository sync from the
+   * provider. Stamped by `bump_org_integration_last_sync` on SCM
+   * integrations.
+   */
+  last_sync?: string;
 };
 
 export interface OrganizationIntegration extends Integration {

--- a/static/app/views/settings/organizationRepositoriesV2/index.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/index.tsx
@@ -37,6 +37,7 @@ import {organizationIntegrationsQueryOptions} from 'sentry/views/settings/seer/o
 
 import {useDeleteIntegration} from './useDeleteIntegration';
 import {useInstallationSettings} from './useInstallationSettings';
+import {useSyncRepositories} from './useSyncRepositories';
 
 const SCM_PROVIDER_ORDER = [
   'github',
@@ -131,27 +132,34 @@ export function OrganizationRepositoriesV2() {
     hasAccess,
   });
 
+  const syncStateById = useSyncRepositories(scmIntegrations, {
+    onSynced: () => reposQuery.refetch(),
+  });
+
   const installationsByProviderKey = useMemo(() => {
+    const uninstallButtonProps = hasAccess
+      ? undefined
+      : {
+          disabled: true,
+          tooltipProps: {
+            title: t(
+              'You must be an organization owner, manager or admin to uninstall this provider'
+            ),
+          },
+        };
+
     const installations = scmIntegrations.map<ScmInstallation>(integration => ({
-      integration,
+      integration: configByIntegrationId[integration.id] ?? integration,
       repositories: reposByIntegrationId[integration.id] ?? [],
       reposLoading,
       manageUrl: getProviderConfigUrl(integration) ?? undefined,
       mappedProjectSlugsByRepoId,
       mappingsLoading,
+      isSyncing: syncStateById[integration.id]?.isSyncing ?? false,
       settingsButtonProps: {
         disabled: configByIntegrationId[integration.id] === undefined,
       },
-      uninstallButtonProps: hasAccess
-        ? undefined
-        : {
-            disabled: true,
-            tooltipProps: {
-              title: t(
-                'You must be an organization owner, manager or admin to uninstall this provider'
-              ),
-            },
-          },
+      uninstallButtonProps,
     }));
     return groupBy(installations, i => i.integration.provider.key);
   }, [
@@ -162,6 +170,7 @@ export function OrganizationRepositoriesV2() {
     mappingsLoading,
     configByIntegrationId,
     hasAccess,
+    syncStateById,
   ]);
 
   const handleAddIntegration = (_data: Integration) => {
@@ -249,6 +258,9 @@ export function OrganizationRepositoriesV2() {
                   repoMatches={repoMatches}
                   onUninstall={inst => handleDeleteIntegration(inst.integration)}
                   onSettings={inst => openInstallationSettings(inst.integration)}
+                  onInstallationSync={inst =>
+                    syncStateById[inst.integration.id]?.syncNow()
+                  }
                 />
               ))
           )}

--- a/static/app/views/settings/organizationRepositoriesV2/useSyncRepositories.spec.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/useSyncRepositories.spec.tsx
@@ -1,0 +1,123 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as indicator from 'sentry/actionCreators/indicator';
+
+import {useSyncRepositories} from './useSyncRepositories';
+
+jest.mock('sentry/actionCreators/indicator');
+
+describe('useSyncRepositories', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+  const integration = OrganizationIntegrationsFixture({
+    id: '123',
+    configData: {last_sync: 'old-value'},
+  });
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/',
+      body: integration,
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
+  it('triggers POST and sets isSyncing when syncNow is called', async () => {
+    const syncRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/repo-sync/',
+      method: 'POST',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(() => useSyncRepositories([integration]), {
+      organization,
+    });
+
+    act(() => {
+      result.current['123']!.syncNow();
+    });
+
+    expect(result.current['123']!.isSyncing).toBe(true);
+    expect(syncRequest).toHaveBeenCalled();
+  });
+
+  it('sets isSyncing: false and shows success toast when last_sync changes', async () => {
+    jest.useFakeTimers();
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/repo-sync/',
+      method: 'POST',
+      body: {},
+    });
+
+    const onSynced = jest.fn();
+    const {result} = renderHookWithProviders(
+      () => useSyncRepositories([integration], {onSynced}),
+      {organization}
+    );
+
+    act(() => {
+      result.current['123']!.syncNow();
+    });
+
+    // Update mock to return a changed last_sync value for the next poll
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/',
+      body: OrganizationIntegrationsFixture({
+        id: '123',
+        configData: {last_sync: 'new-value'},
+      }),
+    });
+
+    // Trigger the polling refetch
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    await waitFor(() => {
+      expect(result.current['123']!.isSyncing).toBe(false);
+    });
+
+    expect(indicator.addSuccessMessage).toHaveBeenCalled();
+    expect(onSynced).toHaveBeenCalledWith(integration);
+
+    jest.useRealTimers();
+  });
+
+  it('sets isSyncing: false and shows error toast after timeout', async () => {
+    jest.useFakeTimers();
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/repo-sync/',
+      method: 'POST',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useSyncRepositories([integration], {timeoutMs: 100}),
+      {organization}
+    );
+
+    act(() => {
+      result.current['123']!.syncNow();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => {
+      expect(result.current['123']!.isSyncing).toBe(false);
+    });
+
+    expect(indicator.addErrorMessage).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+});

--- a/static/app/views/settings/organizationRepositoriesV2/useSyncRepositories.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/useSyncRepositories.tsx
@@ -1,0 +1,191 @@
+import {useEffect, useMemo, useReducer, useRef} from 'react';
+import {useQueries} from '@tanstack/react-query';
+import type {UseQueryResult} from '@tanstack/react-query';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+type SyncingState = {
+  lastSyncBefore: string | undefined;
+};
+
+type SyncAction =
+  | {integrationId: string; lastSyncBefore: string | undefined; type: 'start'}
+  | {integrationId: string; type: 'complete'}
+  | {integrationId: string; type: 'timeout'}
+  | {integrationId: string; type: 'error'};
+
+function syncReducer(
+  state: Record<string, SyncingState>,
+  action: SyncAction
+): Record<string, SyncingState> {
+  switch (action.type) {
+    case 'start':
+      return {...state, [action.integrationId]: {lastSyncBefore: action.lastSyncBefore}};
+    case 'complete':
+    case 'timeout':
+    case 'error': {
+      const next = {...state};
+      delete next[action.integrationId];
+      return next;
+    }
+    default:
+      return state;
+  }
+}
+
+export interface SyncState {
+  /**
+   * True from the moment `syncNow` is called until the sync completes,
+   * times out, or errors.
+   */
+  isSyncing: boolean;
+  /**
+   * Kicks off a repository sync for this integration. Records the current
+   * `last_sync` value, fires the POST, then polls until `last_sync` changes
+   * or the timeout elapses.
+   */
+  syncNow: () => void;
+}
+
+interface Options {
+  /**
+   * Called when a sync completes successfully for a specific integration.
+   * Use to trigger a repository list refresh.
+   */
+  onSynced?: (integration: OrganizationIntegration) => void;
+  /**
+   * How long to wait for `last_sync` to change before giving up. Defaults to
+   * 30 seconds.
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * Manages per-integration repository sync state. Returns a map of integration
+ * ID to `SyncState`, which includes an `isSyncing` flag and a `syncNow`
+ * callback. Polling and timeout handling are managed internally.
+ */
+export function useSyncRepositories(
+  integrations: OrganizationIntegration[],
+  options?: Options
+): Record<string, SyncState> {
+  const organization = useOrganization();
+  const {timeoutMs = 30_000} = options ?? {};
+
+  // Tracks integrations currently in-flight: maps integration ID to the
+  // pre-sync `last_sync` value so the polling effect can detect when it changes.
+  const [syncingById, dispatch] = useReducer(syncReducer, {});
+
+  // Use a ref so the effect below doesn't need onSynced as a dependency
+  const onSyncedRef = useRef(options?.onSynced);
+  onSyncedRef.current = options?.onSynced;
+
+  // Timeout timers are side-effect objects — store in a ref, not state.
+  const timeoutTimersRef = useRef<Record<string, number>>({});
+
+  // Holds the latest query results so syncNow() closures read fresh data.
+  const queriesByIdRef = useRef<
+    Record<string, UseQueryResult<OrganizationIntegration, Error>>
+  >({});
+
+  const queriesById = useQueries({
+    queries: integrations.map(integration => ({
+      ...apiOptions.as<OrganizationIntegration>()(
+        '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            integrationId: integration.id,
+          },
+          // Drop staleTime to zero while syncing so refetches return fresh data.
+          staleTime: syncingById[integration.id] ? 0 : 60_000,
+        }
+      ),
+      refetchInterval: syncingById[integration.id] ? 5_000 : false,
+    })),
+    combine: results =>
+      Object.fromEntries(
+        integrations.map((integration, i) => [integration.id, results[i]!])
+      ),
+  });
+
+  queriesByIdRef.current = queriesById;
+
+  // Detect sync completion by comparing last_sync on each poll result.
+  useEffect(() => {
+    const integrationsById = Object.fromEntries(integrations.map(i => [i.id, i]));
+
+    for (const [integrationId, syncingState] of Object.entries(syncingById)) {
+      const integration = integrationsById[integrationId];
+      if (!integration) {
+        dispatch({type: 'complete', integrationId});
+        continue;
+      }
+
+      const data = queriesById[integrationId]?.data;
+      if (!data) continue;
+
+      const currentLastSync = data.configData?.['last_sync'] as string | undefined;
+      if (currentLastSync !== syncingState.lastSyncBefore) {
+        clearTimeout(timeoutTimersRef.current[integrationId]);
+        delete timeoutTimersRef.current[integrationId];
+        dispatch({type: 'complete', integrationId});
+        addSuccessMessage(t('Repositories synced successfully'));
+        onSyncedRef.current?.(integration);
+      }
+    }
+  }, [queriesById, syncingById, integrations]);
+
+  // Cancel any pending timeout timers when the hook unmounts.
+  useEffect(() => {
+    const timers = timeoutTimersRef.current;
+    return () => Object.values(timers).forEach(clearTimeout);
+  }, []);
+
+  return useMemo(() => {
+    const entries = integrations.map(integration => {
+      function syncNow() {
+        const lastSyncBefore = queriesByIdRef.current[integration.id]?.data?.configData?.[
+          'last_sync'
+        ] as string | undefined;
+
+        const timeoutTimer = window.setTimeout(() => {
+          delete timeoutTimersRef.current[integration.id];
+          dispatch({type: 'timeout', integrationId: integration.id});
+          addErrorMessage(t('Repository sync timed out'));
+        }, timeoutMs);
+
+        timeoutTimersRef.current[integration.id] = timeoutTimer;
+        dispatch({type: 'start', integrationId: integration.id, lastSyncBefore});
+
+        fetchMutation({
+          method: 'POST',
+          url: getApiUrl(
+            '/organizations/$organizationIdOrSlug/integrations/$integrationId/repo-sync/',
+            {
+              path: {
+                organizationIdOrSlug: organization.slug,
+                integrationId: integration.id,
+              },
+            }
+          ),
+        }).catch(() => {
+          clearTimeout(timeoutTimersRef.current[integration.id]);
+          delete timeoutTimersRef.current[integration.id];
+          dispatch({type: 'error', integrationId: integration.id});
+          addErrorMessage(t('Failed to start repository sync'));
+        });
+      }
+
+      return [integration.id, {isSyncing: !!syncingById[integration.id], syncNow}];
+    });
+
+    return Object.fromEntries(entries);
+  }, [integrations, syncingById, organization.slug, timeoutMs]);
+}


### PR DESCRIPTION
Replaces the fire-and-forget `useSyncIntegrations` hook with `useSyncRepositories`, a smarter per-integration sync state manager that tracks sync progress and exposes `isSyncing` state to the table UI.

## How it works

When `syncNow()` is called for an integration it:

1. Records the current `last_sync` value from the integration's `configData`
2. Fires a POST to `/repo-sync/`
3. Polls the integration detail endpoint every 5 seconds via TanStack Query's `refetchInterval`
4. On each poll, compares `last_sync` against the recorded value — if it changed, the sync is complete
5. A `setTimeout` fires after 30 seconds if `last_sync` never changes, showing an error toast and stopping the poll

State transitions use a `useReducer` with named actions (`start`, `complete`, `timeout`, `error`) to keep each outcome explicit. Query results are keyed by integration ID (via `useQueries`'s `combine` option) rather than array position, so list reorders can't produce stale lookups.

The hook also accepts an `onSynced` callback (used by the page to refetch the repo list when a sync lands) and exposes `isSyncing` per integration so the table can show a spinner on the repo count tag.