### PR TITLE
ref(features): remove organizations:discover flag

### DIFF
--- a/src/sentry/discover/endpoints/discover_homepage_query.py
+++ b/src/sentry/discover/endpoints/discover_homepage_query.py
@@ -38,9 +38,7 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
     )
 
     def has_feature(self, organization, request):
-        return features.has(
-            "organizations:discover", organization, actor=request.user
-        ) or features.has("organizations:discover-query", organization, actor=request.user)
+        return features.has("organizations:discover-query", organization, actor=request.user)
 
     def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -44,9 +44,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
     permission_classes = (DiscoverSavedQueryPermission,)
 
     def has_feature(self, organization, request):
-        return features.has(
-            "organizations:discover", organization, actor=request.user
-        ) or features.has("organizations:discover-query", organization, actor=request.user)
+        return features.has("organizations:discover-query", organization, actor=request.user)
 
     @extend_schema(
         operation_id="List an Organization's Discover Saved Queries",

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -56,9 +56,7 @@ class DiscoverSavedQueryDetailEndpoint(DiscoverSavedQueryBase):
     }
 
     def has_feature(self, organization, request):
-        return features.has(
-            "organizations:discover", organization, actor=request.user
-        ) or features.has("organizations:discover-query", organization, actor=request.user)
+        return features.has("organizations:discover-query", organization, actor=request.user)
 
     @extend_schema(
         operation_id="Retrieve an Organization's Discover Saved Query",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -110,8 +110,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:intercom-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable default anomaly detection metric monitor for new projects
     manager.add("organizations:default-anomaly-detector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable the 'discover' interface. (might be unused)
-    manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable the discover saved queries deprecation warnings
     manager.add("organizations:discover-saved-queries-deprecation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable migration of transaction widgets and queries to spans

--- a/tests/acceptance/test_organization_switch.py
+++ b/tests/acceptance/test_organization_switch.py
@@ -57,10 +57,7 @@ class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
             for page in ["issues", "releases", "discover", "user-feedback"]
         ]
 
-        with (
-            self.settings(SENTRY_SINGLE_ORGANIZATION=False),
-            self.feature("organizations:discover"),
-        ):
+        with self.settings(SENTRY_SINGLE_ORGANIZATION=False):
             for transition_url in transition_urls:
                 navigate_to_issues_page(self.organization.slug)
                 open_project_selector()

--- a/tests/sentry/api/endpoints/test_internal_ea_features.py
+++ b/tests/sentry/api/endpoints/test_internal_ea_features.py
@@ -17,5 +17,4 @@ class TestInternalEAFeaturesEndpoint(APITestCase):
         assert len(Organization.objects.all()) == 0
         assert response.status_code == 200
         assert response.data["ea_features"]
-        assert "organizations:discover" not in response.data["ea_features"]
         assert response.data["missing_from_self_hosted"]

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -470,7 +470,6 @@ class UnfurlTest(TestCase):
         with self.feature(
             [
                 "organizations:incidents",
-                "organizations:discover",
                 "organizations:discover-basic",
                 "organizations:metric-alert-chartcuterie",
             ]
@@ -522,7 +521,6 @@ class UnfurlTest(TestCase):
         with self.feature(
             [
                 "organizations:incidents",
-                "organizations:discover",
                 "organizations:performance-view",
                 "organizations:metric-alert-chartcuterie",
             ]
@@ -580,7 +578,6 @@ class UnfurlTest(TestCase):
         with self.feature(
             [
                 "organizations:incidents",
-                "organizations:discover",
                 "organizations:performance-view",
                 "organizations:metric-alert-chartcuterie",
             ]
@@ -640,7 +637,6 @@ class UnfurlTest(TestCase):
         with self.feature(
             [
                 "organizations:incidents",
-                "organizations:discover",
                 "organizations:performance-view",
                 "organizations:metric-alert-chartcuterie",
             ]
@@ -689,7 +685,6 @@ class UnfurlTest(TestCase):
         with self.feature(
             [
                 "organizations:incidents",
-                "organizations:discover",
                 "organizations:performance-view",
                 "organizations:metric-alert-chartcuterie",
             ]
@@ -728,7 +723,6 @@ class UnfurlTest(TestCase):
         with self.feature(
             [
                 "organizations:incidents",
-                "organizations:discover",
                 "organizations:discover-basic",
                 "organizations:metric-alert-chartcuterie",
             ]
@@ -955,7 +949,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):
@@ -1021,7 +1014,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):
@@ -1073,7 +1065,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):
@@ -1141,7 +1132,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):
@@ -1202,7 +1192,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):
@@ -1246,7 +1235,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):
@@ -1304,7 +1292,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):
@@ -1338,7 +1325,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):
@@ -1375,7 +1361,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):
@@ -1428,7 +1413,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):
@@ -1483,7 +1467,6 @@ class UnfurlTest(TestCase):
 
         with self.feature(
             [
-                "organizations:discover",
                 "organizations:discover-basic",
             ]
         ):

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -36,7 +36,7 @@ class DiscoverSavedQueryBase(APITestCase, SnubaTestCase):
 
 @thread_leak_allowlist(reason="sentry sdk background worker", issue=97042)
 class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
-    feature_name = "organizations:discover"
+    feature_name = "organizations:discover-query"
 
     def setUp(self) -> None:
         super().setUp()

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -12,7 +12,7 @@ from sentry.testutils.helpers.datetime import before_now
 
 
 class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
-    feature_name = "organizations:discover"
+    feature_name = "organizations:discover-query"
 
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
The `organizations:discover` flag is dead weight: every gate using it was an OR with `organizations:discover-query` (permanent + default=True), so the OR is always true and the flag never meaningfully gates anything.

Removes the registration and all references. Tests that gated on `organizations:discover` now use `organizations:discover-query`.