### PR TITLE
fix(dashboards): Default text widgets to 1 row tall

### DIFF
--- a/static/app/views/dashboards/layoutUtils.tsx
+++ b/static/app/views/dashboards/layoutUtils.tsx
@@ -90,7 +90,11 @@ export function pickDefinedStoreKeys(layout: Layout): WidgetLayout {
 }
 
 export function getDefaultWidgetHeight(displayType: DisplayType): number {
-  if (displayType === DisplayType.BIG_NUMBER || displayType === DisplayType.DETAILS) {
+  if (
+    displayType === DisplayType.BIG_NUMBER ||
+    displayType === DisplayType.DETAILS ||
+    displayType === DisplayType.TEXT
+  ) {
     return 1;
   }
   return 2;


### PR DESCRIPTION
Newly added text/markdown widgets now default to a single row tall instead of two, matching their typical content size and avoiding empty space on the dashboard grid.

`getDefaultWidgetHeight` already returned `1` for `BIG_NUMBER` and `DETAILS`; this extends the same treatment to `DisplayType.TEXT`.

Fixes DAIN-1640