### PR TITLE
fix(repos): Fix virtualized repo list scroll container in non-nested mode

### DIFF
--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
@@ -34,7 +34,7 @@ import {highlightFuseMatches} from 'sentry/utils/highlightFuseMatches';
 import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
 
 const REPO_LIST_MAX_HEIGHT = 400;
-const ESTIMATED_REPO_ROW_HEIGHT = 36;
+const ESTIMATED_REPO_ROW_HEIGHT = 32;
 
 /**
  * Fuse match results keyed by `repository.id`, used to highlight the matched
@@ -670,9 +670,7 @@ function VirtualizedRepoList({
       {items}
     </Grid>
   ) : (
-    <Flex {...commonProps} direction="column">
-      {items}
-    </Flex>
+    <Container {...commonProps}>{items}</Container>
   );
 }
 


### PR DESCRIPTION
The non-nested repo list (single installation) used a `Flex` (`display: flex; flex-direction: column`) as the react-virtual scroll container. A flex container with `max-height` + `overflow-y: auto` doesn't reliably create a scroll context — when dynamic measurement via `measureElement` corrects item sizes, the content height can shift below the `max-height` threshold, collapsing the scroll context so the page scrolls instead of the component. This breaks the virtualizer's scroll tracking and causes the container to visually grow as you scroll.

Fix: use a block-level `Container` (`display: block`) instead. `max-height` + `overflow-y: auto` works correctly on block elements. Also corrects `ESTIMATED_REPO_ROW_HEIGHT` from 36 to 32 to match the actual row height.