### PR TITLE
fix(lint): address `@sentry/require-fake-timer-cleanup` violations

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -878,7 +878,7 @@ export default typescript.config([
 
       'jest/prefer-hooks-in-order': 'error',
       'jest/prefer-hooks-on-top': 'error',
-      '@sentry/require-fake-timer-cleanup': 'warn',
+      '@sentry/require-fake-timer-cleanup': 'error',
 
       'jest/expect-expect': 'off', // Disabled as we have many tests which render as simple validations
       'jest/no-conditional-expect': 'off', // TODO(ryan953): Fix violations then delete this line

--- a/static/app/actionCreators/projects.spec.tsx
+++ b/static/app/actionCreators/projects.spec.tsx
@@ -6,8 +6,16 @@ describe('Projects ActionCreators', () => {
   const api = new MockApiClient();
   const {organization, project} = initializeOrg();
 
-  it('loadStatsForProject', () => {
+  beforeEach(() => {
     jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('loadStatsForProject', () => {
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
     });
@@ -35,7 +43,6 @@ describe('Projects ActionCreators', () => {
   });
 
   it('loadStatsForProjectFixture() with additional query', () => {
-    jest.useFakeTimers();
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
     });

--- a/static/app/components/autoComplete.spec.tsx
+++ b/static/app/components/autoComplete.spec.tsx
@@ -31,7 +31,13 @@ describe('AutoComplete', () => {
     onOpen: jest.fn(),
   };
 
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
   afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
     jest.resetAllMocks();
     autoCompleteState = [];
   });
@@ -135,7 +141,6 @@ describe('AutoComplete', () => {
 
     it('only tries to close once if input is blurred and click outside occurs', async () => {
       createWrapper();
-      jest.useFakeTimers();
       fireEvent.focus(input);
       fireEvent.blur(input);
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
@@ -148,7 +153,6 @@ describe('AutoComplete', () => {
 
     it('only calls onClose dropdown menu when input is blurred', () => {
       createWrapper();
-      jest.useFakeTimers();
       fireEvent.focus(input);
       fireEvent.blur(input);
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
@@ -320,7 +324,6 @@ describe('AutoComplete', () => {
 
     it('can reset input when menu closes', () => {
       const wrapper = createWrapper();
-      jest.useFakeTimers();
       wrapper.rerender(createComponent({resetInputOnClose: true}));
       fireEvent.focus(input);
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
@@ -353,7 +356,6 @@ describe('AutoComplete', () => {
 
     it('remains closed when input is focused, but calls `onOpen`', () => {
       createWrapper({isOpen: false});
-      jest.useFakeTimers();
 
       expect(screen.queryByTestId('test-autocomplete')).not.toBeInTheDocument();
 
@@ -367,7 +369,6 @@ describe('AutoComplete', () => {
 
     it('remains open when input focus/blur events occur, but calls `onClose`', () => {
       createWrapper({isOpen: true});
-      jest.useFakeTimers();
       fireEvent.focus(input);
       fireEvent.blur(input);
       act(() => jest.runAllTimers());
@@ -537,7 +538,6 @@ describe('AutoComplete', () => {
 
     it('can reset input value when menu closes', () => {
       const wrapper = createWrapper({isOpen: true});
-      jest.useFakeTimers();
       wrapper.rerender(createComponent({resetInputOnClose: true}));
       fireEvent.focus(input);
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
@@ -676,7 +676,6 @@ describe('AutoComplete', () => {
 
   it('does not reset highlight state if `closeOnSelect` is false and we select a new item', () => {
     createWrapper({closeOnSelect: false});
-    jest.useFakeTimers();
     fireEvent.focus(input);
     expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
 

--- a/static/app/components/confirm.spec.tsx
+++ b/static/app/components/confirm.spec.tsx
@@ -129,8 +129,16 @@ describe('Confirm', () => {
   });
 
   describe('async onConfirm', () => {
-    it('should not close the modal until the promise is resolved', async () => {
+    beforeEach(() => {
       jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    });
+
+    it('should not close the modal until the promise is resolved', async () => {
       const onConfirmAsync = jest.fn().mockImplementation(
         () =>
           new Promise(resolve => {
@@ -167,7 +175,6 @@ describe('Confirm', () => {
     });
 
     it('displays an error message if the promise is rejected', async () => {
-      jest.useFakeTimers();
       const onConfirmAsync = jest.fn().mockImplementation(
         () =>
           new Promise((_, reject) => {

--- a/static/app/components/core/useScrollLock.spec.tsx
+++ b/static/app/components/core/useScrollLock.spec.tsx
@@ -13,6 +13,7 @@ describe('useScrollLock', () => {
   });
 
   afterEach(() => {
+    jest.runOnlyPendingTimers();
     jest.useRealTimers();
     document.body.removeChild(container);
   });

--- a/static/app/components/deprecatedAsyncComponent.spec.tsx
+++ b/static/app/components/deprecatedAsyncComponent.spec.tsx
@@ -108,8 +108,16 @@ describe('DeprecatedAsyncComponent', () => {
       }
     }
 
-    it('calls onLoadAllEndpointsSuccess when all endpoints have been loaded', () => {
+    beforeEach(() => {
       jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    });
+
+    it('calls onLoadAllEndpointsSuccess when all endpoints have been loaded', () => {
       jest
         .spyOn(MockApiClient.prototype, 'request')
         .mockImplementation((url, options) => {

--- a/static/app/components/forms/useFormTypingAnimation.spec.tsx
+++ b/static/app/components/forms/useFormTypingAnimation.spec.tsx
@@ -14,6 +14,7 @@ describe('useFormTypingAnimation', () => {
   });
 
   afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
     jest.useRealTimers();
   });
 

--- a/static/app/components/frontendVersionContext.spec.tsx
+++ b/static/app/components/frontendVersionContext.spec.tsx
@@ -33,6 +33,7 @@ describe('FrontendVersionProvider', () => {
   });
 
   afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
     jest.restoreAllMocks();
     jest.useRealTimers();
   });

--- a/static/app/components/groupHeaderRow.spec.tsx
+++ b/static/app/components/groupHeaderRow.spec.tsx
@@ -76,24 +76,34 @@ describe('GroupHeaderRow', () => {
     expect(screen.getByText('metadata value')).toBeInTheDocument();
   });
 
-  it('preloads group on hover', async () => {
-    jest.useFakeTimers();
-    const mockFetchGroup = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/`,
-      body: group,
+  describe('hover preloading', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
     });
 
-    render(<GroupHeaderRow data={group} />);
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    });
 
-    const groupLink = screen.getByRole('link');
+    it('preloads group on hover', async () => {
+      const mockFetchGroup = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues/${group.id}/`,
+        body: group,
+      });
 
-    // Should not be called right away
-    await userEvent.hover(groupLink, {delay: null});
-    expect(mockFetchGroup).not.toHaveBeenCalled();
+      render(<GroupHeaderRow data={group} />);
 
-    // Called after 300ms
-    jest.advanceTimersByTime(301);
-    expect(mockFetchGroup).toHaveBeenCalled();
+      const groupLink = screen.getByRole('link');
+
+      // Should not be called right away
+      await userEvent.hover(groupLink, {delay: null});
+      expect(mockFetchGroup).not.toHaveBeenCalled();
+
+      // Called after 300ms
+      jest.advanceTimersByTime(301);
+      expect(mockFetchGroup).toHaveBeenCalled();
+    });
   });
 
   it('keeps sort in link when query has sort', () => {

--- a/static/app/components/hovercard.spec.tsx
+++ b/static/app/components/hovercard.spec.tsx
@@ -47,51 +47,61 @@ describe('Hovercard', () => {
     expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
   });
 
-  it('respects displayTimeout to delay hiding card when hover is removed', async () => {
-    const DISPLAY_TIMEOUT = 100;
-    render(
-      <Hovercard
-        position="top"
-        body="Hovercard Body"
-        header="Hovercard Header"
-        displayTimeout={DISPLAY_TIMEOUT}
-      >
-        Hovercard Trigger
-      </Hovercard>
-    );
+  describe('with fake timers', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      try {
+        act(() => jest.runOnlyPendingTimers());
+      } catch {
+        // ignore errors if timers were already restored
+      }
+      jest.useRealTimers();
+    });
 
-    jest.useFakeTimers();
-    await userEvent.hover(screen.getByText('Hovercard Trigger'), {delay: null});
-    await userEvent.unhover(screen.getByText('Hovercard Trigger'), {delay: null});
+    it('respects displayTimeout to delay hiding card when hover is removed', async () => {
+      const DISPLAY_TIMEOUT = 100;
+      render(
+        <Hovercard
+          position="top"
+          body="Hovercard Body"
+          header="Hovercard Header"
+          displayTimeout={DISPLAY_TIMEOUT}
+        >
+          Hovercard Trigger
+        </Hovercard>
+      );
 
-    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT - 1));
-    jest.useRealTimers();
+      await userEvent.hover(screen.getByText('Hovercard Trigger'), {delay: null});
+      await userEvent.unhover(screen.getByText('Hovercard Trigger'), {delay: null});
 
-    expect(screen.getByText(/Hovercard Body/)).toBeInTheDocument();
-    expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
-  });
+      act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT - 1));
 
-  it('hides the cards after the display timeout when hover is removed', async () => {
-    const DISPLAY_TIMEOUT = 100;
-    render(
-      <Hovercard
-        position="top"
-        body="Hovercard Body"
-        header="Hovercard Header"
-        displayTimeout={DISPLAY_TIMEOUT}
-      >
-        Hovercard Trigger
-      </Hovercard>
-    );
+      expect(screen.getByText(/Hovercard Body/)).toBeInTheDocument();
+      expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
+    });
 
-    jest.useFakeTimers();
-    await userEvent.hover(screen.getByText('Hovercard Trigger'), {delay: null});
-    await userEvent.unhover(screen.getByText('Hovercard Trigger'), {delay: null});
+    it('hides the cards after the display timeout when hover is removed', async () => {
+      const DISPLAY_TIMEOUT = 100;
+      render(
+        <Hovercard
+          position="top"
+          body="Hovercard Body"
+          header="Hovercard Header"
+          displayTimeout={DISPLAY_TIMEOUT}
+        >
+          Hovercard Trigger
+        </Hovercard>
+      );
 
-    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT));
-    jest.useRealTimers();
+      await userEvent.hover(screen.getByText('Hovercard Trigger'), {delay: null});
+      await userEvent.unhover(screen.getByText('Hovercard Trigger'), {delay: null});
 
-    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
+      act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT));
+
+      expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/app/components/indicators.spec.tsx
+++ b/static/app/components/indicators.spec.tsx
@@ -156,21 +156,33 @@ describe('Indicators', () => {
     expect(screen.queryByTestId('toast')).not.toBeInTheDocument();
   });
 
-  it('hides after 10s', () => {
-    jest.useFakeTimers();
-    const {container} = render(<Indicators />);
+  describe('with fake timers', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      try {
+        act(() => jest.runOnlyPendingTimers());
+      } catch {
+        // ignore errors if timers were already restored
+      }
+      jest.useRealTimers();
+    });
 
-    act(() => addMessage('Duration', '', {append: true, duration: 10000}));
-    act(() => jest.advanceTimersByTime(9000));
-    expect(screen.getByTestId('toast')).toHaveTextContent('Duration');
+    it('hides after 10s', () => {
+      const {container} = render(<Indicators />);
 
-    // Still visible
-    act(() => jest.advanceTimersByTime(999));
-    expect(screen.getByTestId('toast')).toHaveTextContent('Duration');
+      act(() => addMessage('Duration', '', {append: true, duration: 10000}));
+      act(() => jest.advanceTimersByTime(9000));
+      expect(screen.getByTestId('toast')).toHaveTextContent('Duration');
 
-    act(() => jest.advanceTimersByTime(2));
-    expect(container).toHaveTextContent('');
-    expect(screen.queryByTestId('toast')).not.toBeInTheDocument();
-    jest.useRealTimers();
+      // Still visible
+      act(() => jest.advanceTimersByTime(999));
+      expect(screen.getByTestId('toast')).toHaveTextContent('Duration');
+
+      act(() => jest.advanceTimersByTime(2));
+      expect(container).toHaveTextContent('');
+      expect(screen.queryByTestId('toast')).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/app/components/lazyLoad.spec.tsx
+++ b/static/app/components/lazyLoad.spec.tsx
@@ -1,6 +1,6 @@
 import {lazy} from 'react';
 
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {LazyLoad} from 'sentry/components/lazyLoad';
 
@@ -24,6 +24,7 @@ describe('LazyLoad', () => {
   });
   afterEach(() => {
     jest.restoreAllMocks();
+    act(() => jest.runOnlyPendingTimers());
     jest.useRealTimers();
   });
 

--- a/static/app/components/modals/redirectToProject.spec.tsx
+++ b/static/app/components/modals/redirectToProject.spec.tsx
@@ -9,9 +9,15 @@ jest.mock('sentry/utils/recreateRoute', () => ({
 }));
 
 describe('RedirectToProjectModal', () => {
-  it('has timer to redirect to new slug after mounting', () => {
+  beforeEach(() => {
     jest.useFakeTimers();
+  });
+  afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
+  });
 
+  it('has timer to redirect to new slug after mounting', () => {
     renderGlobalModal();
 
     act(() =>

--- a/static/app/components/replays/canvasReplayerPlugin.spec.ts
+++ b/static/app/components/replays/canvasReplayerPlugin.spec.ts
@@ -94,7 +94,6 @@ function createReplayer(getNodeImpl: (id: number) => Node | null) {
 describe('canvasReplayerPlugin', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.clearAllTimers();
     (canvasMutation as jest.Mock).mockClear();
   });
 

--- a/static/app/components/replays/canvasReplayerPlugin.spec.ts
+++ b/static/app/components/replays/canvasReplayerPlugin.spec.ts
@@ -49,8 +49,6 @@ type EventWithTime = {
   type: number;
 };
 
-jest.useFakeTimers();
-
 // Ensure canvas.toDataURL exists under JSDOM
 beforeAll(() => {
   jest
@@ -95,8 +93,14 @@ function createReplayer(getNodeImpl: (id: number) => Node | null) {
 
 describe('canvasReplayerPlugin', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllTimers();
     (canvasMutation as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   it('does not clear current canvas snapshot when flushing queued sync events before processing a canvas event', async () => {

--- a/static/app/components/replays/replayLiveIndicator.spec.tsx
+++ b/static/app/components/replays/replayLiveIndicator.spec.tsx
@@ -20,9 +20,14 @@ jest.mock('sentry/utils/replays/hooks/useReplayProjectSlug', () => ({
   useReplayProjectSlug: () => 'test-project',
 }));
 
-jest.useFakeTimers();
-
 describe('useLiveBadge', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
+  });
   it('should return isLive=true when replay finished within 5 minutes', () => {
     const now = Date.now();
     const startedAt = new Date(now - 60_000); // 1 minute ago
@@ -120,7 +125,12 @@ describe('useLiveRefresh', () => {
   }
 
   beforeEach(() => {
+    jest.useFakeTimers();
     MockApiClient.clearMockResponses();
+  });
+  afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
   });
 
   it('should not show refresh button when replay is undefined', () => {

--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -8,7 +8,6 @@ import {VideoReplayer} from './videoReplayer';
 // replays.
 //
 // advancing by 2000ms ~== 20000s in Timer, but this may depend on hardware, TBD
-jest.useFakeTimers();
 jest.spyOn(window.HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
 jest
   .spyOn(window.HTMLMediaElement.prototype, 'play')
@@ -16,7 +15,11 @@ jest
 
 describe('VideoReplayer - no starting gap', () => {
   beforeEach(() => {
-    jest.clearAllTimers();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   const attachments = [
@@ -255,7 +258,11 @@ describe('VideoReplayer - no starting gap', () => {
 
 describe('VideoReplayer - with starting gap', () => {
   beforeEach(() => {
-    jest.clearAllTimers();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   const attachments = [
@@ -376,7 +383,11 @@ describe('VideoReplayer - with starting gap', () => {
 
 describe('VideoReplayer - with ending gap', () => {
   beforeEach(() => {
-    jest.clearAllTimers();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   const attachments = [

--- a/static/app/components/search/index.spec.tsx
+++ b/static/app/components/search/index.spec.tsx
@@ -1,6 +1,6 @@
 import Fuse from 'fuse.js';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import type {SearchProps} from 'sentry/components/search';
@@ -77,22 +77,30 @@ describe('Search', () => {
     jest.clearAllMocks();
   });
 
-  it('renders search results from source', async () => {
-    jest.useFakeTimers();
-    render(<Search {...makeSearchProps()} />);
+  describe('with fake timers', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    });
 
-    await userEvent.click(screen.getByPlaceholderText('Search Input'), {delay: null});
-    await userEvent.keyboard('Export', {delay: null});
+    it('renders search results from source', async () => {
+      render(<Search {...makeSearchProps()} />);
 
-    jest.advanceTimersByTime(500);
-    jest.useRealTimers();
+      await userEvent.click(screen.getByPlaceholderText('Search Input'), {delay: null});
+      await userEvent.keyboard('Export', {delay: null});
 
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Vandelay Industries - Export/))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Vandelay Industries - Import/))
-    ).not.toBeInTheDocument();
+      jest.advanceTimersByTime(500);
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/Vandelay Industries - Export/))
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(textWithMarkupMatcher(/Vandelay Industries - Import/))
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('navigates to a route when item has to prop', async () => {

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -435,39 +435,107 @@ describe('Core StackTrace', () => {
     );
   });
 
-  it('renders source map info tooltip when frame map metadata exists', async () => {
-    jest.useFakeTimers();
-    const {event, stacktrace} = makeStackTraceData();
-    const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
+  describe('with fake timers', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    });
 
-    render(
-      <TestStackTraceProvider
-        event={event}
-        stacktrace={{
-          ...stacktrace,
-          frames: [
-            {
-              ...frame,
-              inApp: true,
-              origAbsPath: '/home/ubuntu/raven/scripts/runner.min.js',
-              mapUrl: 'https://cdn.example.com/runner.min.js.map',
-            },
-          ],
-        }}
-      >
-        <DisplayOptions />
-        <StackTraceFrames frameContextComponent={FrameContent} />
-      </TestStackTraceProvider>
-    );
+    it('renders source map info tooltip when frame map metadata exists', async () => {
+      const {event, stacktrace} = makeStackTraceData();
+      const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
 
-    await userEvent.hover(screen.getByText('raven/scripts/runner.py'), {delay: null});
-    act(() => jest.advanceTimersByTime(2000));
+      render(
+        <TestStackTraceProvider
+          event={event}
+          stacktrace={{
+            ...stacktrace,
+            frames: [
+              {
+                ...frame,
+                inApp: true,
+                origAbsPath: '/home/ubuntu/raven/scripts/runner.min.js',
+                mapUrl: 'https://cdn.example.com/runner.min.js.map',
+              },
+            ],
+          }}
+        >
+          <DisplayOptions />
+          <StackTraceFrames frameContextComponent={FrameContent} />
+        </TestStackTraceProvider>
+      );
 
-    expect(await screen.findByText('Source Map')).toBeInTheDocument();
-    expect(
-      await screen.findByText('https://cdn.example.com/runner.min.js.map')
-    ).toBeInTheDocument();
-    jest.useRealTimers();
+      await userEvent.hover(screen.getByText('raven/scripts/runner.py'), {delay: null});
+      act(() => jest.advanceTimersByTime(2000));
+
+      expect(await screen.findByText('Source Map')).toBeInTheDocument();
+      expect(
+        await screen.findByText('https://cdn.example.com/runner.min.js.map')
+      ).toBeInTheDocument();
+    });
+
+    it('shows a tooltip with absPath when hovering filename', async () => {
+      const {event, stacktrace} = makeStackTraceData();
+      const frameWithAbsolutePath = {
+        ...stacktrace.frames[stacktrace.frames.length - 1]!,
+        filename: 'raven/scripts/runner.py',
+        absPath: '/home/ubuntu/raven/scripts/runner.py',
+        inApp: false,
+      };
+
+      render(
+        <TestStackTraceProvider
+          event={event}
+          stacktrace={{
+            ...stacktrace,
+            frames: [frameWithAbsolutePath],
+          }}
+        >
+          <DisplayOptions />
+          <StackTraceFrames frameContextComponent={FrameContent} />
+        </TestStackTraceProvider>
+      );
+
+      await userEvent.hover(screen.getByText('raven/scripts/runner.py'), {delay: null});
+      act(() => jest.advanceTimersByTime(2000));
+      expect(
+        await screen.findByText('/home/ubuntu/raven/scripts/runner.py')
+      ).toBeInTheDocument();
+    });
+
+    it('shows URL link in tooltip when absPath is an http URL', async () => {
+      const {event, stacktrace} = makeStackTraceData();
+      const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
+
+      render(
+        <TestStackTraceProvider
+          event={event}
+          stacktrace={{
+            ...stacktrace,
+            frames: [
+              {
+                ...frame,
+                absPath: 'https://example.com/static/app.js',
+                filename: 'app.js',
+                inApp: true,
+              },
+            ],
+          }}
+        >
+          <StackTraceFrames frameContextComponent={FrameContent} />
+        </TestStackTraceProvider>
+      );
+
+      await userEvent.hover(screen.getByText('app.js'), {delay: null});
+      act(() => jest.advanceTimersByTime(2000));
+
+      expect(
+        await screen.findByRole('link', {name: 'https://example.com/static/app.js'})
+      ).toBeInTheDocument();
+    });
   });
 
   it('renders unminify action when frame source map debugger data is unresolved', async () => {
@@ -580,37 +648,6 @@ describe('Core StackTrace', () => {
         lineNo: 112,
       })
     );
-  });
-
-  it('shows a tooltip with absPath when hovering filename', async () => {
-    jest.useFakeTimers();
-    const {event, stacktrace} = makeStackTraceData();
-    const frameWithAbsolutePath = {
-      ...stacktrace.frames[stacktrace.frames.length - 1]!,
-      filename: 'raven/scripts/runner.py',
-      absPath: '/home/ubuntu/raven/scripts/runner.py',
-      inApp: false,
-    };
-
-    render(
-      <TestStackTraceProvider
-        event={event}
-        stacktrace={{
-          ...stacktrace,
-          frames: [frameWithAbsolutePath],
-        }}
-      >
-        <DisplayOptions />
-        <StackTraceFrames frameContextComponent={FrameContent} />
-      </TestStackTraceProvider>
-    );
-
-    await userEvent.hover(screen.getByText('raven/scripts/runner.py'), {delay: null});
-    act(() => jest.advanceTimersByTime(2000));
-    expect(
-      await screen.findByText('/home/ubuntu/raven/scripts/runner.py')
-    ).toBeInTheDocument();
-    jest.useRealTimers();
   });
 
   it('shows copy path and code mapping setup actions on hover for collapsed frames', async () => {
@@ -959,38 +996,5 @@ describe('Core StackTrace', () => {
     expect(
       await screen.findByText('https://cdn.thirdparty.net/js/tracker.js')
     ).toBeInTheDocument();
-  });
-
-  it('shows URL link in tooltip when absPath is an http URL', async () => {
-    jest.useFakeTimers({advanceTimers: true});
-    const {event, stacktrace} = makeStackTraceData();
-    const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
-
-    render(
-      <TestStackTraceProvider
-        event={event}
-        stacktrace={{
-          ...stacktrace,
-          frames: [
-            {
-              ...frame,
-              absPath: 'https://example.com/static/app.js',
-              filename: 'app.js',
-              inApp: true,
-            },
-          ],
-        }}
-      >
-        <StackTraceFrames frameContextComponent={FrameContent} />
-      </TestStackTraceProvider>
-    );
-
-    await userEvent.hover(screen.getByText('app.js'), {delay: null});
-    act(() => jest.advanceTimersByTime(2000));
-
-    expect(
-      await screen.findByRole('link', {name: 'https://example.com/static/app.js'})
-    ).toBeInTheDocument();
-    jest.useRealTimers();
   });
 });

--- a/static/app/components/version.spec.tsx
+++ b/static/app/components/version.spec.tsx
@@ -32,15 +32,24 @@ describe('Version', () => {
     });
   });
 
-  it('shows raw version in tooltip', async () => {
-    jest.useFakeTimers();
-    render(<Version version={VERSION} tooltipRawVersion />);
-    expect(screen.queryByText(VERSION)).not.toBeInTheDocument();
+  describe('with fake timers', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    });
 
-    // Activate tooltip
-    await userEvent.hover(screen.getByText('1.0.0 (20200101)'), {delay: null});
-    act(() => jest.advanceTimersByTime(50));
+    it('shows raw version in tooltip', async () => {
+      render(<Version version={VERSION} tooltipRawVersion />);
+      expect(screen.queryByText(VERSION)).not.toBeInTheDocument();
 
-    expect(await screen.findByText(VERSION)).toBeInTheDocument();
+      // Activate tooltip
+      await userEvent.hover(screen.getByText('1.0.0 (20200101)'), {delay: null});
+      act(() => jest.advanceTimersByTime(50));
+
+      expect(await screen.findByText(VERSION)).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -226,55 +226,63 @@ describe('LogsInfiniteTable', () => {
     expect(loadingIndicator).toBeInTheDocument();
   });
 
-  it('should be interactable', async () => {
-    jest.useFakeTimers();
-    const traceItemMocks = [];
-    for (const log of mockLogsData) {
-      traceItemMocks.push(
-        MockApiClient.addMockResponse({
-          url: `/projects/${organization.slug}/${project.slug}/trace-items/${log[OurLogKnownFieldKey.ID]}/`,
-          method: 'GET',
-          body: {
-            itemId: log[OurLogKnownFieldKey.ID],
-            links: null,
-            meta: {},
-            timestamp: log[OurLogKnownFieldKey.TIMESTAMP],
-            attributes: [],
-          },
-        })
-      );
-    }
-    renderWithProviders(
-      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('logs-table')).toBeInTheDocument();
+  describe('with fake timers', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
     });
 
-    const allTreeRows = await screen.findAllByTestId('log-table-row');
-    expect(allTreeRows).toHaveLength(3);
-    for (const row of allTreeRows) {
-      for (const field of visibleColumnFields) {
-        await userEvent.hover(row, {delay: null});
-        act(() => {
-          jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
-        });
-        const cell = await within(row).findByTestId(`log-table-cell-${field}`);
-        const actionsButton = within(cell).queryByRole('button', {
-          name: 'Actions',
-        });
-        if (field === 'timestamp') {
-          expect(actionsButton).toBeNull();
-        } else {
-          expect(actionsButton).toBeInTheDocument();
+    it('should be interactable', async () => {
+      const traceItemMocks = [];
+      for (const log of mockLogsData) {
+        traceItemMocks.push(
+          MockApiClient.addMockResponse({
+            url: `/projects/${organization.slug}/${project.slug}/trace-items/${log[OurLogKnownFieldKey.ID]}/`,
+            method: 'GET',
+            body: {
+              itemId: log[OurLogKnownFieldKey.ID],
+              links: null,
+              meta: {},
+              timestamp: log[OurLogKnownFieldKey.TIMESTAMP],
+              attributes: [],
+            },
+          })
+        );
+      }
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('logs-table')).toBeInTheDocument();
+      });
+
+      const allTreeRows = await screen.findAllByTestId('log-table-row');
+      expect(allTreeRows).toHaveLength(3);
+      for (const row of allTreeRows) {
+        for (const field of visibleColumnFields) {
+          await userEvent.hover(row, {delay: null});
+          act(() => {
+            jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
+          });
+          const cell = await within(row).findByTestId(`log-table-cell-${field}`);
+          const actionsButton = within(cell).queryByRole('button', {
+            name: 'Actions',
+          });
+          if (field === 'timestamp') {
+            expect(actionsButton).toBeNull();
+          } else {
+            expect(actionsButton).toBeInTheDocument();
+          }
         }
       }
-    }
-    for (const mock of traceItemMocks) {
-      expect(mock).toHaveBeenCalled();
-    }
-    jest.useRealTimers();
+      for (const mock of traceItemMocks) {
+        expect(mock).toHaveBeenCalled();
+      }
+    });
   });
 
   it('should not be interactable on embedded views', async () => {

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -209,36 +209,44 @@ describe('logsTableRow', () => {
     });
   });
 
-  it('hovering the row causes prefetching of the row details', async () => {
-    jest.useFakeTimers();
-    expect(rowDetailsMock).toHaveBeenCalledTimes(0);
-    render(
-      <LogRowContent
-        dataRow={rowData}
-        highlightTerms={[]}
-        meta={LogFixtureMeta(rowData)}
-        sharedHoverTimeoutRef={{current: null}}
-      />,
-      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
-    );
-
-    expect(screen.queryByLabelText('Toggle trace details')).not.toBeInTheDocument(); // Fake button
-    const row = screen.getByTestId('log-table-row');
-    await userEvent.hover(row, {delay: null});
-
-    expect(rowDetailsMock).toHaveBeenCalledTimes(0);
-    expect(screen.getByLabelText('Toggle trace details')).toBeInTheDocument(); // Real button immediately rendered
-
-    // Wrap timer advancement in act to avoid warnings
-    act(() => {
-      jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
+  describe('with fake timers', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
     });
 
-    await waitFor(() => {
-      // Prefetching is triggered after the hover timeout
-      expect(rowDetailsMock).toHaveBeenCalledTimes(1);
+    it('hovering the row causes prefetching of the row details', async () => {
+      expect(rowDetailsMock).toHaveBeenCalledTimes(0);
+      render(
+        <LogRowContent
+          dataRow={rowData}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowData)}
+          sharedHoverTimeoutRef={{current: null}}
+        />,
+        {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+      );
+
+      expect(screen.queryByLabelText('Toggle trace details')).not.toBeInTheDocument(); // Fake button
+      const row = screen.getByTestId('log-table-row');
+      await userEvent.hover(row, {delay: null});
+
+      expect(rowDetailsMock).toHaveBeenCalledTimes(0);
+      expect(screen.getByLabelText('Toggle trace details')).toBeInTheDocument(); // Real button immediately rendered
+
+      // Wrap timer advancement in act to avoid warnings
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
+      });
+
+      await waitFor(() => {
+        // Prefetching is triggered after the hover timeout
+        expect(rowDetailsMock).toHaveBeenCalledTimes(1);
+      });
     });
-    jest.useRealTimers();
   });
 
   it('renders row details', async () => {

--- a/static/app/views/explore/replays/detail/ai/useRotatingMessage.spec.ts
+++ b/static/app/views/explore/replays/detail/ai/useRotatingMessage.spec.ts
@@ -10,6 +10,7 @@ describe('useRotatingMessage', () => {
   });
 
   afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
     jest.useRealTimers();
     jest.restoreAllMocks();
   });

--- a/static/app/views/explore/replays/detail/header/replayDetailsUserBadge.spec.tsx
+++ b/static/app/views/explore/replays/detail/header/replayDetailsUserBadge.spec.tsx
@@ -28,10 +28,14 @@ function replayRecordFixture(replayRecord?: Partial<HydratedReplayRecord>) {
   });
 }
 
-jest.useFakeTimers();
 describe('replayDetailsUserBadge', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     MockApiClient.clearMockResponses();
+  });
+  afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
   });
 
   it('should show LIVE badge when last received segment is within 5 minutes', async () => {

--- a/static/app/views/issueDetails/useEngagedViewTracking.spec.tsx
+++ b/static/app/views/issueDetails/useEngagedViewTracking.spec.tsx
@@ -21,6 +21,7 @@ describe('useEngagedViewTracking', () => {
   });
 
   afterEach(() => {
+    jest.runOnlyPendingTimers();
     jest.useRealTimers();
     jest.clearAllMocks();
   });

--- a/static/app/views/issueList/issueViews/createIssueViewModal.spec.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewModal.spec.tsx
@@ -123,6 +123,7 @@ describe('CreateIssueViewModal', () => {
     });
 
     afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
       jest.useRealTimers();
     });
 

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -4,7 +4,7 @@ import {MemberFixture} from 'sentry-fixture/member';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {StreamGroup} from 'sentry/components/stream/group';
@@ -36,6 +36,7 @@ describe('IssueList -> Polling', () => {
   let pollRequest: jest.Mock;
 
   afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
     jest.useRealTimers();
     MockApiClient.clearMockResponses();
   });

--- a/static/app/views/navigation/primary/whatsNew.spec.tsx
+++ b/static/app/views/navigation/primary/whatsNew.spec.tsx
@@ -72,174 +72,179 @@ describe('WhatsNew', () => {
     expect(screen.queryByText(/No recent updates/)).not.toBeInTheDocument();
   });
 
-  it('displays the unread indicator when there are unseen broadcasts', async () => {
-    jest.useFakeTimers();
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/broadcasts/',
-      match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
-      body: [
-        BroadcastFixture({
-          id: '1',
-          title: 'Test Broadcast 1',
-          category: 'blog',
-          hasSeen: false,
-        }),
-        BroadcastFixture({
-          id: '2',
-          title: 'Test Broadcast 2',
-          category: 'blog',
-          hasSeen: false,
-        }),
-        BroadcastFixture({
-          id: '3',
-          title: 'Test Broadcast 3',
-          category: 'blog',
-          hasSeen: true,
-        }),
-      ],
+  describe('with fake timers', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
     });
 
-    render(<PrimaryNavigationWhatsNew />);
-
-    await waitFor(() =>
-      expect(
-        screen
-          .getByRole('button', {name: "What's New"})
-          .querySelector('[data-unread-indicator]')
-      ).toBeInTheDocument()
-    );
-  });
-
-  it('does not call the mark-seen endpoint when all broadcasts are already seen', async () => {
-    jest.useFakeTimers();
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/broadcasts/',
-      match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
-      body: [
-        BroadcastFixture({id: '1', title: 'Seen Broadcast 1', hasSeen: true}),
-        BroadcastFixture({id: '2', title: 'Seen Broadcast 2', hasSeen: true}),
-        BroadcastFixture({id: '3', title: 'Seen Broadcast 3', hasSeen: true}),
-      ],
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
     });
 
-    const putMock = MockApiClient.addMockResponse({
-      url: '/broadcasts/',
-      method: 'PUT',
-    });
+    it('displays the unread indicator when there are unseen broadcasts', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/broadcasts/',
+        match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
+        body: [
+          BroadcastFixture({
+            id: '1',
+            title: 'Test Broadcast 1',
+            category: 'blog',
+            hasSeen: false,
+          }),
+          BroadcastFixture({
+            id: '2',
+            title: 'Test Broadcast 2',
+            category: 'blog',
+            hasSeen: false,
+          }),
+          BroadcastFixture({
+            id: '3',
+            title: 'Test Broadcast 3',
+            category: 'blog',
+            hasSeen: true,
+          }),
+        ],
+      });
 
-    render(<PrimaryNavigationWhatsNew />);
+      render(<PrimaryNavigationWhatsNew />);
 
-    await userEvent.click(screen.getByRole('button', {name: "What's New"}), {
-      delay: null,
-    });
-
-    await screen.findByText('Seen Broadcast 1');
-
-    act(() => jest.advanceTimersByTime(2000));
-
-    await waitFor(() => {
-      expect(putMock).not.toHaveBeenCalled();
-    });
-  });
-
-  it('marks unseen broadcasts as seen after opening the panel', async () => {
-    jest.useFakeTimers();
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/broadcasts/',
-      match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
-      body: [
-        BroadcastFixture({
-          id: '1',
-          title: 'Test Broadcast 1',
-          category: 'blog',
-          hasSeen: false,
-        }),
-        BroadcastFixture({
-          id: '2',
-          title: 'Test Broadcast 2',
-          category: 'blog',
-          hasSeen: false,
-        }),
-        BroadcastFixture({
-          id: '3',
-          title: 'Test Broadcast 3',
-          category: 'blog',
-          hasSeen: true,
-        }),
-      ],
-    });
-
-    const putMock = MockApiClient.addMockResponse({
-      url: '/broadcasts/',
-      method: 'PUT',
-    });
-
-    render(<PrimaryNavigationWhatsNew />);
-
-    await userEvent.click(screen.getByRole('button', {name: "What's New"}), {
-      delay: null,
-    });
-
-    await screen.findByText('Test Broadcast 1');
-
-    act(() => jest.advanceTimersByTime(2000));
-
-    await waitFor(() => {
-      expect(putMock).toHaveBeenCalledWith(
-        '/broadcasts/',
-        expect.objectContaining({
-          method: 'PUT',
-          query: {id: ['1', '2']},
-          data: {hasSeen: '1'},
-        })
+      await waitFor(() =>
+        expect(
+          screen
+            .getByRole('button', {name: "What's New"})
+            .querySelector('[data-unread-indicator]')
+        ).toBeInTheDocument()
       );
     });
-  });
 
-  it('hides the unread indicator after broadcasts are marked as seen', async () => {
-    jest.useFakeTimers();
+    it('does not call the mark-seen endpoint when all broadcasts are already seen', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/broadcasts/',
+        match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
+        body: [
+          BroadcastFixture({id: '1', title: 'Seen Broadcast 1', hasSeen: true}),
+          BroadcastFixture({id: '2', title: 'Seen Broadcast 2', hasSeen: true}),
+          BroadcastFixture({id: '3', title: 'Seen Broadcast 3', hasSeen: true}),
+        ],
+      });
 
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/broadcasts/',
-      match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
-      body: [
-        BroadcastFixture({
-          id: '1',
-          title: 'Test Broadcast 1',
-          category: 'blog',
-          hasSeen: false,
-        }),
-        BroadcastFixture({
-          id: '2',
-          title: 'Test Broadcast 2',
-          category: 'blog',
-          hasSeen: false,
-        }),
-      ],
+      const putMock = MockApiClient.addMockResponse({
+        url: '/broadcasts/',
+        method: 'PUT',
+      });
+
+      render(<PrimaryNavigationWhatsNew />);
+
+      await userEvent.click(screen.getByRole('button', {name: "What's New"}), {
+        delay: null,
+      });
+
+      await screen.findByText('Seen Broadcast 1');
+
+      act(() => jest.advanceTimersByTime(2000));
+
+      await waitFor(() => {
+        expect(putMock).not.toHaveBeenCalled();
+      });
     });
 
-    render(<PrimaryNavigationWhatsNew />);
+    it('marks unseen broadcasts as seen after opening the panel', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/broadcasts/',
+        match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
+        body: [
+          BroadcastFixture({
+            id: '1',
+            title: 'Test Broadcast 1',
+            category: 'blog',
+            hasSeen: false,
+          }),
+          BroadcastFixture({
+            id: '2',
+            title: 'Test Broadcast 2',
+            category: 'blog',
+            hasSeen: false,
+          }),
+          BroadcastFixture({
+            id: '3',
+            title: 'Test Broadcast 3',
+            category: 'blog',
+            hasSeen: true,
+          }),
+        ],
+      });
 
-    const whatsNewButton = screen.getByRole('button', {name: "What's New"});
-    await waitFor(() =>
-      expect(whatsNewButton.querySelector('[data-unread-indicator]')).toBeInTheDocument()
-    );
+      const putMock = MockApiClient.addMockResponse({
+        url: '/broadcasts/',
+        method: 'PUT',
+      });
 
-    await userEvent.click(whatsNewButton, {
-      delay: null,
+      render(<PrimaryNavigationWhatsNew />);
+
+      await userEvent.click(screen.getByRole('button', {name: "What's New"}), {
+        delay: null,
+      });
+
+      await screen.findByText('Test Broadcast 1');
+
+      act(() => jest.advanceTimersByTime(2000));
+
+      await waitFor(() => {
+        expect(putMock).toHaveBeenCalledWith(
+          '/broadcasts/',
+          expect.objectContaining({
+            method: 'PUT',
+            query: {id: ['1', '2']},
+            data: {hasSeen: '1'},
+          })
+        );
+      });
     });
 
-    await screen.findByText('Test Broadcast 1');
+    it('hides the unread indicator after broadcasts are marked as seen', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/broadcasts/',
+        match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
+        body: [
+          BroadcastFixture({
+            id: '1',
+            title: 'Test Broadcast 1',
+            category: 'blog',
+            hasSeen: false,
+          }),
+          BroadcastFixture({
+            id: '2',
+            title: 'Test Broadcast 2',
+            category: 'blog',
+            hasSeen: false,
+          }),
+        ],
+      });
 
-    act(() => jest.advanceTimersByTime(2000));
+      render(<PrimaryNavigationWhatsNew />);
 
-    await waitFor(() => {
-      expect(
-        whatsNewButton.querySelector('[data-unread-indicator]')
-      ).not.toBeInTheDocument();
+      const whatsNewButton = screen.getByRole('button', {name: "What's New"});
+      await waitFor(() =>
+        expect(
+          whatsNewButton.querySelector('[data-unread-indicator]')
+        ).toBeInTheDocument()
+      );
+
+      await userEvent.click(whatsNewButton, {
+        delay: null,
+      });
+
+      await screen.findByText('Test Broadcast 1');
+
+      act(() => jest.advanceTimersByTime(2000));
+
+      await waitFor(() => {
+        expect(
+          whatsNewButton.querySelector('[data-unread-indicator]')
+        ).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -299,43 +304,52 @@ describe('WhatsNew', () => {
     expect(screen.getByText('Unique Title')).toBeInTheDocument();
   });
 
-  it('marks unseen duplicate broadcasts as seen when the panel is opened', async () => {
-    jest.useFakeTimers();
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/broadcasts/',
-      match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
-      body: [
-        BroadcastFixture({id: '1', title: 'Duplicate Title', hasSeen: false}),
-        BroadcastFixture({id: '2', title: 'Duplicate Title', hasSeen: false}),
-        BroadcastFixture({id: '3', title: 'Unique Title', hasSeen: true}),
-      ],
+  describe('with fake timers (duplicate broadcasts)', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
     });
 
-    const putMock = MockApiClient.addMockResponse({
-      url: '/broadcasts/',
-      method: 'PUT',
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
     });
 
-    render(<PrimaryNavigationWhatsNew />);
+    it('marks unseen duplicate broadcasts as seen when the panel is opened', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/broadcasts/',
+        match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
+        body: [
+          BroadcastFixture({id: '1', title: 'Duplicate Title', hasSeen: false}),
+          BroadcastFixture({id: '2', title: 'Duplicate Title', hasSeen: false}),
+          BroadcastFixture({id: '3', title: 'Unique Title', hasSeen: true}),
+        ],
+      });
 
-    await userEvent.click(screen.getByRole('button', {name: "What's New"}), {
-      delay: null,
-    });
+      const putMock = MockApiClient.addMockResponse({
+        url: '/broadcasts/',
+        method: 'PUT',
+      });
 
-    await screen.findByText('Duplicate Title');
+      render(<PrimaryNavigationWhatsNew />);
 
-    act(() => jest.advanceTimersByTime(2000));
+      await userEvent.click(screen.getByRole('button', {name: "What's New"}), {
+        delay: null,
+      });
 
-    await waitFor(() => {
-      expect(putMock).toHaveBeenCalledWith(
-        '/broadcasts/',
-        expect.objectContaining({
-          method: 'PUT',
-          query: {id: ['1', '2']},
-          data: {hasSeen: '1'},
-        })
-      );
+      await screen.findByText('Duplicate Title');
+
+      act(() => jest.advanceTimersByTime(2000));
+
+      await waitFor(() => {
+        expect(putMock).toHaveBeenCalledWith(
+          '/broadcasts/',
+          expect.objectContaining({
+            method: 'PUT',
+            query: {id: ['1', '2']},
+            data: {hasSeen: '1'},
+          })
+        );
+      });
     });
   });
 

--- a/static/app/views/onboarding/components/onboardingSkipButton.spec.tsx
+++ b/static/app/views/onboarding/components/onboardingSkipButton.spec.tsx
@@ -46,41 +46,50 @@ describe('OnboardingSkipButton', () => {
     jest.clearAllMocks();
   });
 
-  it.each(MAPPED_CASES)(
-    'renders and fires the expected analytics for $stepId',
-    async ({stepId, sidebarSource, referrer}) => {
+  describe('with fake timers', () => {
+    beforeEach(() => {
       jest.useFakeTimers();
-      const openSpy = jest.spyOn(OnboardingDrawerStore, 'open');
+    });
 
-      try {
-        render(<OnboardingSkipButton stepId={stepId} />);
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    });
 
-        const button = screen.getByRole('button', {name: 'Skip setup'});
-        expect(button).toHaveAttribute(
-          'href',
-          `/organizations/org-slug/issues/?referrer=${referrer}`
-        );
+    it.each(MAPPED_CASES)(
+      'renders and fires the expected analytics for $stepId',
+      async ({stepId, sidebarSource, referrer}) => {
+        const openSpy = jest.spyOn(OnboardingDrawerStore, 'open');
 
-        await userEvent.click(button, {delay: null});
+        try {
+          render(<OnboardingSkipButton stepId={stepId} />);
 
-        expect(trackAnalytics).toHaveBeenCalledWith(
-          'onboarding.scm_header_skip_clicked',
-          expect.objectContaining({step: stepId})
-        );
+          const button = screen.getByRole('button', {name: 'Skip setup'});
+          expect(button).toHaveAttribute(
+            'href',
+            `/organizations/org-slug/issues/?referrer=${referrer}`
+          );
 
-        jest.runAllTimers();
+          await userEvent.click(button, {delay: null});
 
-        expect(trackAnalytics).toHaveBeenCalledWith(
-          'quick_start.opened',
-          expect.objectContaining({source: sidebarSource})
-        );
-        expect(openSpy).toHaveBeenCalled();
-      } finally {
-        jest.useRealTimers();
-        openSpy.mockRestore();
+          expect(trackAnalytics).toHaveBeenCalledWith(
+            'onboarding.scm_header_skip_clicked',
+            expect.objectContaining({step: stepId})
+          );
+
+          jest.runAllTimers();
+
+          expect(trackAnalytics).toHaveBeenCalledWith(
+            'quick_start.opened',
+            expect.objectContaining({source: sidebarSource})
+          );
+          expect(openSpy).toHaveBeenCalled();
+        } finally {
+          openSpy.mockRestore();
+        }
       }
-    }
-  );
+    );
+  });
 
   it('renders nothing for unmapped steps', () => {
     const {container} = render(

--- a/static/app/views/onboarding/createSampleEventButton.spec.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.spec.tsx
@@ -7,7 +7,6 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {trackAnalytics} from 'sentry/utils/analytics';
 import CreateSampleEventButton from 'sentry/views/onboarding/createSampleEventButton';
 
-jest.useFakeTimers();
 jest.mock('sentry/utils/analytics');
 
 describe('CreateSampleEventButton', () => {
@@ -30,8 +29,13 @@ describe('CreateSampleEventButton', () => {
     );
   }
 
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
   afterEach(() => {
-    MockApiClient.clearMockResponses();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   it('creates a sample event', async () => {
@@ -85,6 +89,11 @@ describe('CreateSampleEventButton', () => {
       method: 'POST',
       body: {groupID},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
+      statusCode: 404,
+      body: {},
+    });
 
     await userEvent.click(await screen.findByRole('button', {name: createSampleText}), {
       delay: null,
@@ -115,6 +124,11 @@ describe('CreateSampleEventButton', () => {
       url: `/projects/${org.slug}/${project.slug}/create-sample/`,
       method: 'POST',
       body: {groupID},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
+      statusCode: 404,
+      body: {},
     });
 
     await userEvent.click(await screen.findByRole('button', {name: createSampleText}), {

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -140,43 +140,52 @@ describe('Onboarding', () => {
       });
     });
 
-    it('calls trackAnalytics and activateSidebar on skip click', async () => {
-      jest.useFakeTimers();
-      const openSpy = jest.spyOn(OnboardingDrawerStore, 'open');
+    describe('with fake timers', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
 
-      try {
-        render(
-          <OnboardingContextProvider>
-            <OnboardingWithoutContext />
-          </OnboardingContextProvider>,
-          {
-            initialRouterConfig: {
-              location: {
-                pathname: '/onboarding/org-slug/welcome/',
-              },
-              route: '/onboarding/:orgId/:step/',
-            },
-          }
-        );
-
-        await userEvent.click(screen.getByRole('link', {name: 'Skip onboarding.'}), {
-          delay: null,
-        });
-
-        expect(trackAnalytics).toHaveBeenCalledWith(
-          'growth.onboarding_clicked_skip',
-          expect.objectContaining({
-            source: 'targeted_onboarding',
-          })
-        );
-
-        jest.runAllTimers();
-
-        expect(openSpy).toHaveBeenCalled();
-      } finally {
+      afterEach(() => {
+        act(() => jest.runOnlyPendingTimers());
         jest.useRealTimers();
-        openSpy.mockRestore();
-      }
+      });
+
+      it('calls trackAnalytics and activateSidebar on skip click', async () => {
+        const openSpy = jest.spyOn(OnboardingDrawerStore, 'open');
+
+        try {
+          render(
+            <OnboardingContextProvider>
+              <OnboardingWithoutContext />
+            </OnboardingContextProvider>,
+            {
+              initialRouterConfig: {
+                location: {
+                  pathname: '/onboarding/org-slug/welcome/',
+                },
+                route: '/onboarding/:orgId/:step/',
+              },
+            }
+          );
+
+          await userEvent.click(screen.getByRole('link', {name: 'Skip onboarding.'}), {
+            delay: null,
+          });
+
+          expect(trackAnalytics).toHaveBeenCalledWith(
+            'growth.onboarding_clicked_skip',
+            expect.objectContaining({
+              source: 'targeted_onboarding',
+            })
+          );
+
+          jest.runAllTimers();
+
+          expect(openSpy).toHaveBeenCalled();
+        } finally {
+          openSpy.mockRestore();
+        }
+      });
     });
   });
 
@@ -245,48 +254,57 @@ describe('Onboarding', () => {
       });
     });
 
-    it('calls trackAnalytics and activateSidebar on skip click', async () => {
-      jest.useFakeTimers();
-      const openSpy = jest.spyOn(OnboardingDrawerStore, 'open');
-
-      const organization = OrganizationFixture({
-        features: ['onboarding-new-welcome-ui'],
+    describe('with fake timers', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
       });
 
-      try {
-        render(
-          <OnboardingContextProvider>
-            <OnboardingWithoutContext />
-          </OnboardingContextProvider>,
-          {
-            organization,
-            initialRouterConfig: {
-              location: {
-                pathname: `/onboarding/${organization.slug}/welcome/`,
-              },
-              route: '/onboarding/:orgId/:step/',
-            },
-          }
-        );
+      afterEach(() => {
+        act(() => jest.runOnlyPendingTimers());
+        jest.useRealTimers();
+      });
 
-        await userEvent.click(screen.getByRole('button', {name: 'Skip onboarding'}), {
-          delay: null,
+      it('calls trackAnalytics and activateSidebar on skip click', async () => {
+        const openSpy = jest.spyOn(OnboardingDrawerStore, 'open');
+
+        const organization = OrganizationFixture({
+          features: ['onboarding-new-welcome-ui'],
         });
 
-        expect(trackAnalytics).toHaveBeenCalledWith(
-          'growth.onboarding_clicked_skip',
-          expect.objectContaining({
-            source: 'targeted_onboarding',
-          })
-        );
+        try {
+          render(
+            <OnboardingContextProvider>
+              <OnboardingWithoutContext />
+            </OnboardingContextProvider>,
+            {
+              organization,
+              initialRouterConfig: {
+                location: {
+                  pathname: `/onboarding/${organization.slug}/welcome/`,
+                },
+                route: '/onboarding/:orgId/:step/',
+              },
+            }
+          );
 
-        jest.runAllTimers();
+          await userEvent.click(screen.getByRole('button', {name: 'Skip onboarding'}), {
+            delay: null,
+          });
 
-        expect(openSpy).toHaveBeenCalled();
-      } finally {
-        jest.useRealTimers();
-        openSpy.mockRestore();
-      }
+          expect(trackAnalytics).toHaveBeenCalledWith(
+            'growth.onboarding_clicked_skip',
+            expect.objectContaining({
+              source: 'targeted_onboarding',
+            })
+          );
+
+          jest.runAllTimers();
+
+          expect(openSpy).toHaveBeenCalled();
+        } finally {
+          openSpy.mockRestore();
+        }
+      });
     });
   });
 

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.spec.tsx
@@ -13,10 +13,12 @@ import {PartialTraceDataWarning} from './partialTraceDataWarning';
 describe('PartialTraceDataWarning', () => {
   describe('when the trace is older than 30 days', () => {
     beforeAll(() => {
-      jest.useFakeTimers().setSystemTime(new Date(2025, 0, 31));
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2025, 0, 31));
     });
 
     afterAll(() => {
+      jest.runOnlyPendingTimers();
       jest.useRealTimers();
     });
 
@@ -66,10 +68,12 @@ describe('PartialTraceDataWarning', () => {
 
   describe('when the trace is younger than 30 days', () => {
     beforeAll(() => {
-      jest.useFakeTimers().setSystemTime(new Date(2025, 0, 1));
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2025, 0, 1));
     });
 
     afterAll(() => {
+      jest.runOnlyPendingTimers();
       jest.useRealTimers();
     });
 

--- a/static/app/views/performance/newTraceDetails/traceWaterfallState.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfallState.spec.tsx
@@ -132,6 +132,7 @@ describe('TraceWaterfallState', () => {
     });
 
     afterEach(() => {
+      jest.runOnlyPendingTimers();
       jest.useRealTimers();
     });
 

--- a/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
@@ -188,70 +188,77 @@ describe('BuildDetails', () => {
     expect(await screen.findByText('Running size analysis')).toBeInTheDocument();
   });
 
-  it('refetches size analysis when size_info state transitions from processing to completed', async () => {
-    jest.useFakeTimers();
-
-    MockApiClient.clearMockResponses();
-
-    MockApiClient.addMockResponse({
-      url: QUOTA_STATE_URL,
-      method: 'GET',
-      body: {hasSizeQuota: true, hasDistributionQuota: true},
+  describe('refetches size analysis when size_info state transitions from processing to completed', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
     });
 
-    let callCount = 0;
-    const buildDetailsMock = MockApiClient.addMockResponse({
-      url: BUILD_DETAILS_URL,
-      method: 'GET',
-      body: () => {
-        callCount++;
-        if (callCount === 1) {
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    });
+
+    it('refetches size analysis when size_info state transitions from processing to completed', async () => {
+      MockApiClient.clearMockResponses();
+
+      MockApiClient.addMockResponse({
+        url: QUOTA_STATE_URL,
+        method: 'GET',
+        body: {hasSizeQuota: true, hasDistributionQuota: true},
+      });
+
+      let callCount = 0;
+      const buildDetailsMock = MockApiClient.addMockResponse({
+        url: BUILD_DETAILS_URL,
+        method: 'GET',
+        body: () => {
+          callCount++;
+          if (callCount === 1) {
+            return PreprodBuildDetailsWithSizeInfoFixture({
+              state: BuildDetailsSizeAnalysisState.PROCESSING,
+            });
+          }
           return PreprodBuildDetailsWithSizeInfoFixture({
-            state: BuildDetailsSizeAnalysisState.PROCESSING,
+            state: BuildDetailsSizeAnalysisState.COMPLETED,
+            size_metrics: [
+              {
+                metrics_artifact_type: MetricsArtifactType.MAIN_ARTIFACT,
+                install_size_bytes: 1024000,
+                download_size_bytes: 512000,
+              },
+            ],
+            base_size_metrics: [],
           });
-        }
-        return PreprodBuildDetailsWithSizeInfoFixture({
-          state: BuildDetailsSizeAnalysisState.COMPLETED,
-          size_metrics: [
-            {
-              metrics_artifact_type: MetricsArtifactType.MAIN_ARTIFACT,
-              install_size_bytes: 1024000,
-              download_size_bytes: 512000,
-            },
-          ],
-          base_size_metrics: [],
-        });
-      },
+        },
+      });
+
+      const appSizeMock = MockApiClient.addMockResponse({
+        url: SIZE_ANALYSIS_URL,
+        method: 'GET',
+        body: createMockSizeAnalysisData(),
+      });
+
+      render(<BuildDetails />, {
+        organization,
+        initialRouterConfig,
+      });
+
+      await waitFor(() => expect(buildDetailsMock).toHaveBeenCalledTimes(1));
+      expect(await screen.findByText('Running size analysis')).toBeInTheDocument();
+
+      // Size analysis should only be called once initially
+      expect(appSizeMock).toHaveBeenCalledTimes(1);
+
+      // Advance past the 10s refetchInterval to trigger the polling refetch
+      act(() => {
+        jest.advanceTimersByTime(10_000);
+      });
+
+      await waitFor(() => expect(buildDetailsMock).toHaveBeenCalledTimes(2));
+
+      // After the state transition, size analysis should be refetched
+      await waitFor(() => expect(appSizeMock).toHaveBeenCalledTimes(2));
     });
-
-    const appSizeMock = MockApiClient.addMockResponse({
-      url: SIZE_ANALYSIS_URL,
-      method: 'GET',
-      body: createMockSizeAnalysisData(),
-    });
-
-    render(<BuildDetails />, {
-      organization,
-      initialRouterConfig,
-    });
-
-    await waitFor(() => expect(buildDetailsMock).toHaveBeenCalledTimes(1));
-    expect(await screen.findByText('Running size analysis')).toBeInTheDocument();
-
-    // Size analysis should only be called once initially
-    expect(appSizeMock).toHaveBeenCalledTimes(1);
-
-    // Advance past the 10s refetchInterval to trigger the polling refetch
-    act(() => {
-      jest.advanceTimersByTime(10_000);
-    });
-
-    await waitFor(() => expect(buildDetailsMock).toHaveBeenCalledTimes(2));
-
-    // After the state transition, size analysis should be refetched
-    await waitFor(() => expect(appSizeMock).toHaveBeenCalledTimes(2));
-
-    jest.useRealTimers();
   });
 
   it('does not refetch size analysis when size_info remains in completed state', async () => {
@@ -299,63 +306,70 @@ describe('BuildDetails', () => {
     await waitFor(() => expect(appSizeMock).toHaveBeenCalledTimes(1));
   });
 
-  it('does not refetch size analysis when size_info transitions from pending to processing', async () => {
-    jest.useFakeTimers();
-
-    MockApiClient.clearMockResponses();
-
-    MockApiClient.addMockResponse({
-      url: QUOTA_STATE_URL,
-      method: 'GET',
-      body: {hasSizeQuota: true, hasDistributionQuota: true},
+  describe('does not refetch size analysis when size_info transitions from pending to processing', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
     });
 
-    let callCount = 0;
-    const buildDetailsMock = MockApiClient.addMockResponse({
-      url: BUILD_DETAILS_URL,
-      method: 'GET',
-      body: () => {
-        callCount++;
-        if (callCount === 1) {
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    });
+
+    it('does not refetch size analysis when size_info transitions from pending to processing', async () => {
+      MockApiClient.clearMockResponses();
+
+      MockApiClient.addMockResponse({
+        url: QUOTA_STATE_URL,
+        method: 'GET',
+        body: {hasSizeQuota: true, hasDistributionQuota: true},
+      });
+
+      let callCount = 0;
+      const buildDetailsMock = MockApiClient.addMockResponse({
+        url: BUILD_DETAILS_URL,
+        method: 'GET',
+        body: () => {
+          callCount++;
+          if (callCount === 1) {
+            return PreprodBuildDetailsWithSizeInfoFixture({
+              state: BuildDetailsSizeAnalysisState.PENDING,
+            });
+          }
           return PreprodBuildDetailsWithSizeInfoFixture({
-            state: BuildDetailsSizeAnalysisState.PENDING,
+            state: BuildDetailsSizeAnalysisState.PROCESSING,
           });
-        }
-        return PreprodBuildDetailsWithSizeInfoFixture({
-          state: BuildDetailsSizeAnalysisState.PROCESSING,
-        });
-      },
+        },
+      });
+
+      const appSizeMock = MockApiClient.addMockResponse({
+        url: SIZE_ANALYSIS_URL,
+        method: 'GET',
+        body: createMockSizeAnalysisData(),
+      });
+
+      render(<BuildDetails />, {
+        organization,
+        initialRouterConfig,
+      });
+
+      await waitFor(() => expect(buildDetailsMock).toHaveBeenCalledTimes(1));
+      // First call returns PENDING state - shows queued message
+      expect(await screen.findByText('Queued for analysis')).toBeInTheDocument();
+
+      // Advance past the 10s refetchInterval to trigger the polling refetch
+      act(() => {
+        jest.advanceTimersByTime(10_000);
+      });
+
+      await waitFor(() => expect(buildDetailsMock).toHaveBeenCalledTimes(2));
+
+      // Second call returns PROCESSING state - shows processing message
+      expect(await screen.findByText('Running size analysis')).toBeInTheDocument();
+
+      // Size analysis should not be refetched since we're still processing
+      expect(appSizeMock).toHaveBeenCalledTimes(1);
     });
-
-    const appSizeMock = MockApiClient.addMockResponse({
-      url: SIZE_ANALYSIS_URL,
-      method: 'GET',
-      body: createMockSizeAnalysisData(),
-    });
-
-    render(<BuildDetails />, {
-      organization,
-      initialRouterConfig,
-    });
-
-    await waitFor(() => expect(buildDetailsMock).toHaveBeenCalledTimes(1));
-    // First call returns PENDING state - shows queued message
-    expect(await screen.findByText('Queued for analysis')).toBeInTheDocument();
-
-    // Advance past the 10s refetchInterval to trigger the polling refetch
-    act(() => {
-      jest.advanceTimersByTime(10_000);
-    });
-
-    await waitFor(() => expect(buildDetailsMock).toHaveBeenCalledTimes(2));
-
-    // Second call returns PROCESSING state - shows processing message
-    expect(await screen.findByText('Running size analysis')).toBeInTheDocument();
-
-    // Size analysis should not be refetched since we're still processing
-    expect(appSizeMock).toHaveBeenCalledTimes(1);
-
-    jest.useRealTimers();
   });
 
   describe('quota warning banner', () => {

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -216,41 +216,53 @@ describe('CreateProject', () => {
     expect(screen.getByPlaceholderText('project-slug')).toHaveValue('apple-ios');
   });
 
-  it('should preserve user-entered project slug when filter bar auto-selects a platform', async () => {
-    // Regression test: PlatformPicker's debounceSearch captured setPlatform from the
-    // initial render. After the user typed a slug, handlePlatformChange was recreated with
-    // the new projectName — but debounceSearch still held the stale version with
-    // projectName='', so auto-selection via the filter bar would wipe the user's slug.
-    const {organization} = initializeOrg({
-      organization: {
-        access: ['project:read'],
-        features: ['team-roles'],
-        allowMemberProjectCreation: true,
-      },
+  describe('should preserve user-entered project slug when filter bar auto-selects a platform', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
     });
 
-    jest.useFakeTimers();
-    render(<CreateProject />, {organization});
-
-    await userEvent.type(screen.getByPlaceholderText('project-slug'), 'my-custom-slug', {
-      delay: null,
-    });
-    expect(screen.getByPlaceholderText('project-slug')).toHaveValue('my-custom-slug');
-
-    // Type a platform name that exactly matches "Android" (triggers debounce auto-selection)
-    await userEvent.type(screen.getByPlaceholderText('Filter Platforms'), 'android', {
-      delay: null,
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
     });
 
-    // Run all pending timers and flush React state updates
-    act(() => {
-      jest.runAllTimers();
+    it('should preserve user-entered project slug when filter bar auto-selects a platform', async () => {
+      // Regression test: PlatformPicker's debounceSearch captured setPlatform from the
+      // initial render. After the user typed a slug, handlePlatformChange was recreated with
+      // the new projectName — but debounceSearch still held the stale version with
+      // projectName='', so auto-selection via the filter bar would wipe the user's slug.
+      const {organization} = initializeOrg({
+        organization: {
+          access: ['project:read'],
+          features: ['team-roles'],
+          allowMemberProjectCreation: true,
+        },
+      });
+
+      render(<CreateProject />, {organization});
+
+      await userEvent.type(
+        screen.getByPlaceholderText('project-slug'),
+        'my-custom-slug',
+        {
+          delay: null,
+        }
+      );
+      expect(screen.getByPlaceholderText('project-slug')).toHaveValue('my-custom-slug');
+
+      // Type a platform name that exactly matches "Android" (triggers debounce auto-selection)
+      await userEvent.type(screen.getByPlaceholderText('Filter Platforms'), 'android', {
+        delay: null,
+      });
+
+      // Run all pending timers and flush React state updates
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      // The user's slug must be preserved, not replaced by the auto-selected platform id
+      expect(screen.getByPlaceholderText('project-slug')).toHaveValue('my-custom-slug');
     });
-
-    jest.useRealTimers();
-
-    // The user's slug must be preserved, not replaced by the auto-selected platform id
-    expect(screen.getByPlaceholderText('project-slug')).toHaveValue('my-custom-slug');
   });
 
   it('should allow platform to fill the project name again after the user clears it', async () => {

--- a/static/app/views/projectsDashboard/index.spec.tsx
+++ b/static/app/views/projectsDashboard/index.spec.tsx
@@ -551,77 +551,86 @@ describe('ProjectsDashboard', () => {
       TeamStore.loadInitialData(teamsWithStatTestProjects);
     });
 
-    it('uses ProjectsStatsStore to load stats', async () => {
-      ProjectsStore.loadInitialData(projects);
-
-      jest.useFakeTimers();
-      ProjectsStatsStore.onStatsLoadSuccess([
-        {...projects[0]!, stats: [[1517281200, 2]]},
-      ]);
-      const loadStatsSpy = jest.spyOn(projectsActions, 'loadStatsForProject');
-      const mock = MockApiClient.addMockResponse({
-        url: `/organizations/${org.slug}/projects/`,
-        body: projects.map(project => ({
-          ...project,
-          stats: [
-            [1517281200, 2],
-            [1517310000, 1],
-          ],
-        })),
+    describe('with fake timers', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
       });
 
-      const {unmount} = render(<ProjectsDashboard />);
-
-      expect(loadStatsSpy).toHaveBeenCalledTimes(6);
-      expect(mock).not.toHaveBeenCalled();
-
-      const projectSummary = screen.getAllByTestId('summary-links');
-      // Has 5 Loading Cards because 1 project has been loaded in store already
-      expect(
-        within(projectSummary[0]!).getByTestId('loading-placeholder')
-      ).toBeInTheDocument();
-      expect(
-        within(projectSummary[1]!).getByTestId('loading-placeholder')
-      ).toBeInTheDocument();
-      expect(
-        within(projectSummary[2]!).getByTestId('loading-placeholder')
-      ).toBeInTheDocument();
-      expect(
-        within(projectSummary[3]!).getByTestId('loading-placeholder')
-      ).toBeInTheDocument();
-      expect(within(projectSummary[4]!).getByText('Errors: 2')).toBeInTheDocument();
-      expect(
-        within(projectSummary[5]!).getByTestId('loading-placeholder')
-      ).toBeInTheDocument();
-
-      // Advance timers so that batched request fires
-      act(() => jest.advanceTimersByTime(51));
-      expect(mock).toHaveBeenCalledTimes(1);
-      // query ids = 3, 2, 4 = bookmarked
-      // 1 - already loaded in store so shouldn't be in query
-      expect(mock).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          query: expect.objectContaining({
-            query: 'id:3 id:2 id:4 id:5 id:6',
-          }),
-        })
-      );
-      jest.useRealTimers();
-
-      // All cards have loaded
-      await waitFor(() => {
-        expect(within(projectSummary[0]!).getByText('Errors: 3')).toBeInTheDocument();
+      afterEach(() => {
+        act(() => jest.runOnlyPendingTimers());
+        jest.useRealTimers();
       });
-      expect(within(projectSummary[1]!).getByText('Errors: 3')).toBeInTheDocument();
-      expect(within(projectSummary[2]!).getByText('Errors: 3')).toBeInTheDocument();
-      expect(within(projectSummary[3]!).getByText('Errors: 3')).toBeInTheDocument();
-      expect(within(projectSummary[4]!).getByText('Errors: 3')).toBeInTheDocument();
-      expect(within(projectSummary[5]!).getByText('Errors: 3')).toBeInTheDocument();
 
-      // Resets store when it unmounts
-      unmount();
-      expect(ProjectsStatsStore.getAll()).toEqual({});
+      it('uses ProjectsStatsStore to load stats', async () => {
+        ProjectsStore.loadInitialData(projects);
+
+        ProjectsStatsStore.onStatsLoadSuccess([
+          {...projects[0]!, stats: [[1517281200, 2]]},
+        ]);
+        const loadStatsSpy = jest.spyOn(projectsActions, 'loadStatsForProject');
+        const mock = MockApiClient.addMockResponse({
+          url: `/organizations/${org.slug}/projects/`,
+          body: projects.map(project => ({
+            ...project,
+            stats: [
+              [1517281200, 2],
+              [1517310000, 1],
+            ],
+          })),
+        });
+
+        const {unmount} = render(<ProjectsDashboard />);
+
+        expect(loadStatsSpy).toHaveBeenCalledTimes(6);
+        expect(mock).not.toHaveBeenCalled();
+
+        const projectSummary = screen.getAllByTestId('summary-links');
+        // Has 5 Loading Cards because 1 project has been loaded in store already
+        expect(
+          within(projectSummary[0]!).getByTestId('loading-placeholder')
+        ).toBeInTheDocument();
+        expect(
+          within(projectSummary[1]!).getByTestId('loading-placeholder')
+        ).toBeInTheDocument();
+        expect(
+          within(projectSummary[2]!).getByTestId('loading-placeholder')
+        ).toBeInTheDocument();
+        expect(
+          within(projectSummary[3]!).getByTestId('loading-placeholder')
+        ).toBeInTheDocument();
+        expect(within(projectSummary[4]!).getByText('Errors: 2')).toBeInTheDocument();
+        expect(
+          within(projectSummary[5]!).getByTestId('loading-placeholder')
+        ).toBeInTheDocument();
+
+        // Advance timers so that batched request fires
+        act(() => jest.advanceTimersByTime(51));
+        expect(mock).toHaveBeenCalledTimes(1);
+        // query ids = 3, 2, 4 = bookmarked
+        // 1 - already loaded in store so shouldn't be in query
+        expect(mock).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query: 'id:3 id:2 id:4 id:5 id:6',
+            }),
+          })
+        );
+
+        // All cards have loaded
+        await waitFor(() => {
+          expect(within(projectSummary[0]!).getByText('Errors: 3')).toBeInTheDocument();
+        });
+        expect(within(projectSummary[1]!).getByText('Errors: 3')).toBeInTheDocument();
+        expect(within(projectSummary[2]!).getByText('Errors: 3')).toBeInTheDocument();
+        expect(within(projectSummary[3]!).getByText('Errors: 3')).toBeInTheDocument();
+        expect(within(projectSummary[4]!).getByText('Errors: 3')).toBeInTheDocument();
+        expect(within(projectSummary[5]!).getByText('Errors: 3')).toBeInTheDocument();
+
+        // Resets store when it unmounts
+        unmount();
+        expect(ProjectsStatsStore.getAll()).toEqual({});
+      });
     });
   });
 });

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.spec.tsx
@@ -51,24 +51,34 @@ describe('Settings Breadcrumb Dropdown', () => {
     expect(screen.getByText('foo')).toBeInTheDocument();
   });
 
-  it('closes after entering dropdown and then leaving after timeout', async () => {
-    jest.useFakeTimers();
-    createWrapper();
+  describe('dropdown close timeout', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
 
-    await userEvent.hover(screen.getByText('The Crumb'), {delay: null});
-    expect(screen.getByText('foo')).toBeInTheDocument();
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    });
 
-    await userEvent.hover(screen.getByText('foo'), {delay: null});
-    expect(screen.getByText('foo')).toBeInTheDocument();
+    it('closes after entering dropdown and then leaving after timeout', async () => {
+      createWrapper();
 
-    await userEvent.unhover(screen.getByText('foo'), {delay: null});
+      await userEvent.hover(screen.getByText('The Crumb'), {delay: null});
+      expect(screen.getByText('foo')).toBeInTheDocument();
 
-    // The menu will not disappear until after a timeout
-    expect(screen.getByText('foo')).toBeInTheDocument();
+      await userEvent.hover(screen.getByText('foo'), {delay: null});
+      expect(screen.getByText('foo')).toBeInTheDocument();
 
-    // Menu disappears after timeout
-    await act(() => jest.runAllTimersAsync());
-    expect(screen.queryByText('foo')).not.toBeInTheDocument();
+      await userEvent.unhover(screen.getByText('foo'), {delay: null});
+
+      // The menu will not disappear until after a timeout
+      expect(screen.getByText('foo')).toBeInTheDocument();
+
+      // Menu disappears after timeout
+      await act(() => jest.runAllTimersAsync());
+      expect(screen.queryByText('foo')).not.toBeInTheDocument();
+    });
   });
 
   it('closes other breadcrumbs upon hover immediately', async () => {

--- a/static/eslint/eslintPluginSentry/require-fake-timer-cleanup.ts
+++ b/static/eslint/eslintPluginSentry/require-fake-timer-cleanup.ts
@@ -99,16 +99,18 @@ export const requireFakeTimerCleanup = ESLintUtils.RuleCreator.withoutDocs({
           }
         }
 
-        if (!hasUseRealTimersInCleanup) {
-          context.report({
-            node: useFakeTimersCalls[0]!,
-            messageId: 'missingCleanup',
-          });
-        } else if (!hasRunOnlyPendingTimersInCleanup) {
-          context.report({
-            node: useFakeTimersCalls[0]!,
-            messageId: 'missingRunOnlyPendingTimers',
-          });
+        if (useFakeTimersCalls[0]) {
+          if (!hasUseRealTimersInCleanup) {
+            context.report({
+              node: useFakeTimersCalls[0],
+              messageId: 'missingCleanup',
+            });
+          } else if (!hasRunOnlyPendingTimersInCleanup) {
+            context.report({
+              node: useFakeTimersCalls[0],
+              messageId: 'missingRunOnlyPendingTimers',
+            });
+          }
         }
       },
     };

--- a/static/gsApp/components/creditCardEdit/intentForms/innerIntentForm.spec.tsx
+++ b/static/gsApp/components/creditCardEdit/intentForms/innerIntentForm.spec.tsx
@@ -36,26 +36,33 @@ describe('InnerIntentForm', () => {
     });
   });
 
-  it('shows warning when Stripe hooks return null', async () => {
-    jest.useFakeTimers();
-
-    const stripeImport = await import('@stripe/react-stripe-js');
-    jest.spyOn(stripeImport, 'useStripe').mockReturnValue(null as any);
-    jest.spyOn(stripeImport, 'useElements').mockReturnValue(null as any);
-
-    render(<InnerIntentForm {...defaultProps} />);
-
-    act(() => {
-      jest.advanceTimersByTime(10001);
+  describe('stripe loading timeout', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
     });
 
-    expect(
-      screen.getByText(
-        /To add or update your payment method, you may need to disable any ad or tracker blocking extensions/
-      )
-    ).toBeInTheDocument();
+    afterEach(() => {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    });
 
-    jest.useRealTimers();
+    it('shows warning when Stripe hooks return null', async () => {
+      const stripeImport = await import('@stripe/react-stripe-js');
+      jest.spyOn(stripeImport, 'useStripe').mockReturnValue(null as any);
+      jest.spyOn(stripeImport, 'useElements').mockReturnValue(null as any);
+
+      render(<InnerIntentForm {...defaultProps} />);
+
+      act(() => {
+        jest.advanceTimersByTime(10001);
+      });
+
+      expect(
+        screen.getByText(
+          /To add or update your payment method, you may need to disable any ad or tracker blocking extensions/
+        )
+      ).toBeInTheDocument();
+    });
   });
 
   it('shows error message when provided', () => {

--- a/static/gsApp/components/upsellModal/details.spec.tsx
+++ b/static/gsApp/components/upsellModal/details.spec.tsx
@@ -152,41 +152,55 @@ describe('Upsell Modal Details', () => {
     expect(screen.getByTestId('tracing')).toHaveAttribute('aria-selected');
   });
 
-  it('cycles the list on a timer when no section is clicked', async () => {
-    jest.useFakeTimers();
-    const sub = SubscriptionFixture({
-      organization,
-      plan: 'mm2_a_100k',
-      canTrial: true,
-      isTrial: false,
-      isFree: false,
+  describe('cycling timer', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
     });
 
-    render(
-      <Details
-        source="test"
-        subscription={sub}
-        organization={organization}
-        onCloseModal={jest.fn()}
-      />
-    );
+    afterEach(() => {
+      try {
+        act(() => jest.runOnlyPendingTimers());
+      } catch {
+        // test may have already restored real timers
+      }
+      jest.useRealTimers();
+    });
 
-    // First timeout is waiting for it to cycle to a feature
-    act(() => jest.advanceTimersByTime(10000));
+    it('cycles the list on a timer when no section is clicked', async () => {
+      const sub = SubscriptionFixture({
+        organization,
+        plan: 'mm2_a_100k',
+        canTrial: true,
+        isTrial: false,
+        isFree: false,
+      });
 
-    // First feature in the displayed list.
-    const tracing = screen.getByTestId('tracing');
-    expect(tracing).toHaveAttribute('aria-selected');
+      render(
+        <Details
+          source="test"
+          subscription={sub}
+          organization={organization}
+          onCloseModal={jest.fn()}
+        />
+      );
 
-    // Next timeout is for it to cycle to the _next_ feature
-    act(() => jest.advanceTimersByTime(8000));
+      // First timeout is waiting for it to cycle to a feature
+      act(() => jest.advanceTimersByTime(10000));
 
-    // Avoid act warning after state change
-    jest.useRealTimers();
-    await act(tick);
+      // First feature in the displayed list.
+      const tracing = screen.getByTestId('tracing');
+      expect(tracing).toHaveAttribute('aria-selected');
 
-    // Tracing should now not be highlighted.
-    expect(tracing).not.toHaveAttribute('aria-selected');
+      // Next timeout is for it to cycle to the _next_ feature
+      act(() => jest.advanceTimersByTime(8000));
+
+      // Switch to real timers so framer-motion exit animations complete
+      jest.useRealTimers();
+      await act(tick);
+
+      // Tracing should now not be highlighted.
+      expect(tracing).not.toHaveAttribute('aria-selected');
+    });
   });
 
   it('displays "Unlimited Custom Dashboards" feature name', async () => {

--- a/static/gsApp/hooks/useMaxPickableDays.spec.tsx
+++ b/static/gsApp/hooks/useMaxPickableDays.spec.tsx
@@ -11,7 +11,12 @@ import {useMaxPickableDays} from './useMaxPickableDays';
 
 describe('useMaxPickableDays', () => {
   describe('without subscription effective retentions', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
     afterEach(() => {
+      jest.runOnlyPendingTimers();
       jest.useRealTimers();
     });
 
@@ -42,7 +47,7 @@ describe('useMaxPickableDays', () => {
     });
 
     it('returns 30/90 for spans', () => {
-      jest.useFakeTimers().setSystemTime(new Date(2026, 0, 1));
+      jest.setSystemTime(new Date(2026, 0, 1));
       const {result} = renderHookWithProviders(() =>
         useMaxPickableDays({
           dataCategories: [DataCategory.SPANS],
@@ -85,7 +90,7 @@ describe('useMaxPickableDays', () => {
     });
 
     it('returns 30/90 for many', () => {
-      jest.useFakeTimers().setSystemTime(new Date(2026, 0, 1));
+      jest.setSystemTime(new Date(2026, 0, 1));
       const {result} = renderHookWithProviders(() =>
         useMaxPickableDays({
           dataCategories: [
@@ -139,11 +144,13 @@ describe('useMaxPickableDays', () => {
     });
 
     beforeEach(() => {
+      jest.useFakeTimers();
       SubscriptionStore.set(organization.slug, subscription);
     });
 
     afterEach(() => {
-      jest.clearAllTimers();
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
     });
 
     it('returns 30/90 for transactions', () => {
@@ -177,7 +184,7 @@ describe('useMaxPickableDays', () => {
     });
 
     it('returns 121/121 for spans on 2025/12/31', () => {
-      jest.useFakeTimers().setSystemTime(new Date(2025, 11, 31));
+      jest.setSystemTime(new Date(2025, 11, 31));
       const {result} = renderHookWithProviders(
         () =>
           useMaxPickableDays({
@@ -194,7 +201,7 @@ describe('useMaxPickableDays', () => {
     });
 
     it('returns 396/396 for spans on 2027/01/01', () => {
-      jest.useFakeTimers().setSystemTime(new Date(2027, 0, 1));
+      jest.setSystemTime(new Date(2027, 0, 1));
       const {result} = renderHookWithProviders(
         () =>
           useMaxPickableDays({
@@ -243,7 +250,7 @@ describe('useMaxPickableDays', () => {
     });
 
     it('returns 396/396 for many without flag', () => {
-      jest.useFakeTimers().setSystemTime(new Date(2027, 0, 1));
+      jest.setSystemTime(new Date(2027, 0, 1));
       const {result} = renderHookWithProviders(
         () =>
           useMaxPickableDays({

--- a/static/gsApp/hooks/useRouteActivatedHook.spec.tsx
+++ b/static/gsApp/hooks/useRouteActivatedHook.spec.tsx
@@ -48,15 +48,17 @@ describe('useRouteActivatedHook', () => {
   const props = genProps();
 
   beforeEach(() => {
+    jest.useFakeTimers();
     SubscriptionStore.set(organization.slug, subscription);
   });
 
   afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
     (rawTrackAnalyticsEvent as jest.Mock).mockClear();
   });
 
   it('calls rawTrackAnalyticsEvent after one seconds if org is set', () => {
-    jest.useFakeTimers();
     const {result} = renderHook(useRouteActivatedHook, {
       initialProps: props,
     });
@@ -80,7 +82,6 @@ describe('useRouteActivatedHook', () => {
   });
 
   it('does not call rawTrackAnalyticsEvent if org is not set', () => {
-    jest.useFakeTimers();
     renderHook(useRouteActivatedHook, {
       initialProps: props,
     });
@@ -89,7 +90,6 @@ describe('useRouteActivatedHook', () => {
   });
 
   it('only calls rawTrackAnalyticsEvent once and ignores later param updates', () => {
-    jest.useFakeTimers();
     const {result} = renderHook(useRouteActivatedHook, {
       initialProps: props,
     });
@@ -114,7 +114,6 @@ describe('useRouteActivatedHook', () => {
   });
 
   it('only calls rawTrackAnalyticsEvent once when URL query params are updated', () => {
-    jest.useFakeTimers();
     const {result, rerender} = renderHook(useRouteActivatedHook, {
       initialProps: props,
     });
@@ -134,7 +133,6 @@ describe('useRouteActivatedHook', () => {
   });
 
   it('disable route analytics', () => {
-    jest.useFakeTimers();
     const {result} = renderHook(useRouteActivatedHook, {
       initialProps: props,
     });
@@ -145,7 +143,6 @@ describe('useRouteActivatedHook', () => {
   });
 
   it('disables and re-enables analytics', () => {
-    jest.useFakeTimers();
     const {result} = renderHook(useRouteActivatedHook, {
       initialProps: props,
     });
@@ -159,7 +156,6 @@ describe('useRouteActivatedHook', () => {
   });
 
   it('re-initializes after route changes', () => {
-    jest.useFakeTimers();
     const {result, rerender} = renderHook(useRouteActivatedHook, {
       initialProps: props,
     });
@@ -195,7 +191,6 @@ describe('useRouteActivatedHook', () => {
   });
 
   it('overrwite event names', () => {
-    jest.useFakeTimers();
     const {result} = renderHook(useRouteActivatedHook, {
       initialProps: props,
     });
@@ -218,7 +213,6 @@ describe('useRouteActivatedHook', () => {
   });
 
   it('route changes triggers early analytics event', () => {
-    jest.useFakeTimers();
     let loadTime = Date.now();
 
     const {result, rerender} = renderHook(useRouteActivatedHook, {


### PR DESCRIPTION
This addresses 13 violations from enabling `@sentry/require-fake-timer-cleanup`.

Stacked PR on top of #114758