### PR TITLE
ref(dashboards): Remove top_n and stacked_area display type handling

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -98,9 +98,8 @@ def validate_id(self, value):
 
 
 def is_table_display_type(display_type):
-    return (
-        display_type
-        == DashboardWidgetDisplayTypes.as_text_choices()[DashboardWidgetDisplayTypes.TABLE][0]
+    return display_type == DashboardWidgetDisplayTypes.get_type_name(
+        DashboardWidgetDisplayTypes.TABLE
     )
 
 
@@ -411,16 +410,6 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
 
         if data.get("display_type") == DashboardWidgetDisplayTypes.TEXT:
             return self._validate_text_widget(data)
-
-        if (
-            not data.get("id")
-            and data.get("display_type") in DashboardWidgetDisplayTypes.DEPRECATED_TYPES
-        ):
-            raise serializers.ValidationError(
-                {
-                    "display_type": f"{DashboardWidgetDisplayTypes.get_type_name(data['display_type'])} is no longer a supported display type."
-                }
-            )
 
         query_errors = []
         all_columns: set[str] = set()
@@ -1123,13 +1112,6 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
                     )
 
     def update_widget(self, widget, data):
-        if widget.display_type in DashboardWidgetDisplayTypes.DEPRECATED_TYPES:
-            raise serializers.ValidationError(
-                {
-                    "display_type": f"{DashboardWidgetDisplayTypes.get_type_name(widget.display_type)} is no longer a supported display type. Please use `area` instead."
-                }
-            )
-
         prev_layout = widget.detail.get("layout") if widget.detail else None
         prev_axis_range = widget.detail.get("axis_range") if widget.detail else None
         prev_legend_type = widget.detail.get("legend_type") if widget.detail else None

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1123,6 +1123,13 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
                     )
 
     def update_widget(self, widget, data):
+        if widget.display_type in DashboardWidgetDisplayTypes.DEPRECATED_TYPES:
+            raise serializers.ValidationError(
+                {
+                    "display_type": f"{DashboardWidgetDisplayTypes.get_type_name(widget.display_type)} is no longer a supported display type. Please delete and recreate this widget."
+                }
+            )
+
         prev_layout = widget.detail.get("layout") if widget.detail else None
         prev_axis_range = widget.detail.get("axis_range") if widget.detail else None
         prev_legend_type = widget.detail.get("legend_type") if widget.detail else None

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1126,7 +1126,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         if widget.display_type in DashboardWidgetDisplayTypes.DEPRECATED_TYPES:
             raise serializers.ValidationError(
                 {
-                    "display_type": f"{DashboardWidgetDisplayTypes.get_type_name(widget.display_type)} is no longer a supported display type. Please delete and recreate this widget."
+                    "display_type": f"{DashboardWidgetDisplayTypes.get_type_name(widget.display_type)} is no longer a supported display type. Please use `area` instead."
                 }
             )
 

--- a/src/sentry/dashboards/models/generate_dashboard_artifact.py
+++ b/src/sentry/dashboards/models/generate_dashboard_artifact.py
@@ -15,7 +15,6 @@ DISPLAY_TYPE_BLOCKLIST: set[str] = {
     "rage_and_dead_clicks",
     "wheel",
     "agents_traces_table",
-    "stacked_area",
 }
 
 # Most of these are deprecated, not selectable in the UI, or don't make sense for generated dashboards.

--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -63,9 +63,7 @@ DASHBOARDS_CHART_SIZE: ChartSize = {"width": 1200, "height": 400}
 _TIMESERIES_DISPLAY_TYPES = {
     DashboardWidgetDisplayTypes.LINE_CHART: "line",
     DashboardWidgetDisplayTypes.AREA_CHART: "area",
-    DashboardWidgetDisplayTypes.STACKED_AREA_CHART: "area",
     DashboardWidgetDisplayTypes.BAR_CHART: "bar",
-    DashboardWidgetDisplayTypes.TOP_N: "area",
 }
 
 

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -177,11 +177,9 @@ DiscoverFullFallbackWidgetType = [
 class DashboardWidgetDisplayTypes(TypesClass):
     LINE_CHART = 0
     AREA_CHART = 1
-    STACKED_AREA_CHART = 2
     BAR_CHART = 3
     TABLE = 4
     BIG_NUMBER = 6
-    TOP_N = 7
     DETAILS = 8
     CATEGORICAL_BAR_CHART = 9
     WHEEL = 10
@@ -192,11 +190,9 @@ class DashboardWidgetDisplayTypes(TypesClass):
     TYPES = [
         (LINE_CHART, "line"),
         (AREA_CHART, "area"),
-        (STACKED_AREA_CHART, "stacked_area"),
         (BAR_CHART, "bar"),
         (TABLE, "table"),
         (BIG_NUMBER, "big_number"),
-        (TOP_N, "top_n"),
         (DETAILS, "details"),
         (CATEGORICAL_BAR_CHART, "categorical_bar"),
         (WHEEL, "wheel"),
@@ -206,13 +202,6 @@ class DashboardWidgetDisplayTypes(TypesClass):
         (AGENTS_TRACES_TABLE, "agents_traces_table"),
     ]
     TYPE_NAMES = [t[1] for t in TYPES]
-
-    # Display types that the frontend no longer exposes in either the widget
-    # builder dropdown or the widget library. TOP_N is converted to AREA at
-    # every UI entry point (widget library, builder URL deserialization). New
-    # widgets cannot be created with these and existing widgets cannot be
-    # updated; clients must delete and recreate them with a supported type.
-    DEPRECATED_TYPES: list[int] = [STACKED_AREA_CHART, TOP_N]
 
 
 @cell_silo_model

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -210,8 +210,8 @@ class DashboardWidgetDisplayTypes(TypesClass):
     # Display types that the frontend no longer exposes in either the widget
     # builder dropdown or the widget library. TOP_N is converted to AREA at
     # every UI entry point (widget library, builder URL deserialization). New
-    # widgets should not be created with these, but existing widgets remain
-    # editable.
+    # widgets cannot be created with these and existing widgets cannot be
+    # updated; clients must delete and recreate them with a supported type.
     DEPRECATED_TYPES: list[int] = [STACKED_AREA_CHART, TOP_N]
 
 

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -1696,9 +1696,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         widgets = self.get_widgets(self.dashboard.id)
         self.assert_serialized_widget(data["widgets"][0], widgets[0])
 
-    def test_update_widget_with_deprecated_display_type_is_allowed(self) -> None:
-        # Existing widgets created via the API with deprecated display types
-        # should remain editable; the rejection only applies to new widgets.
+    def test_update_widget_with_deprecated_display_type_is_rejected(self) -> None:
         deprecated_widget = DashboardWidget.objects.create(
             dashboard=self.dashboard,
             order=4,
@@ -1729,10 +1727,11 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             ],
         }
         response = self.do_request("put", self.url(self.dashboard.id), data=data)
-        assert response.status_code == 200, response.data
+        assert response.status_code == 400, response.data
+        assert "stacked_area is no longer a supported display type" in str(response.data)
 
         deprecated_widget.refresh_from_db()
-        assert deprecated_widget.title == "Renamed stacked area"
+        assert deprecated_widget.title == "Stacked area"
         assert deprecated_widget.display_type == DashboardWidgetDisplayTypes.STACKED_AREA_CHART
 
     def test_update_widget_add_query(self) -> None:

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -1696,44 +1696,6 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         widgets = self.get_widgets(self.dashboard.id)
         self.assert_serialized_widget(data["widgets"][0], widgets[0])
 
-    def test_update_widget_with_deprecated_display_type_is_rejected(self) -> None:
-        deprecated_widget = DashboardWidget.objects.create(
-            dashboard=self.dashboard,
-            order=4,
-            title="Stacked area",
-            display_type=DashboardWidgetDisplayTypes.STACKED_AREA_CHART,
-            widget_type=DashboardWidgetTypes.DISCOVER,
-            interval="1d",
-            limit=5,
-        )
-        DashboardWidgetQuery.objects.create(
-            widget=deprecated_widget,
-            name="Transactions",
-            fields=["count()"],
-            columns=[],
-            aggregates=["count()"],
-            conditions="event.type:transaction",
-            order=0,
-        )
-
-        data: dict[str, Any] = {
-            "title": "First dashboard",
-            "widgets": [
-                {"id": str(self.widget_1.id)},
-                {"id": str(self.widget_2.id)},
-                {"id": str(self.widget_3.id)},
-                {"id": str(self.widget_4.id)},
-                {"id": str(deprecated_widget.id), "title": "Renamed stacked area"},
-            ],
-        }
-        response = self.do_request("put", self.url(self.dashboard.id), data=data)
-        assert response.status_code == 400, response.data
-        assert "stacked_area is no longer a supported display type" in str(response.data)
-
-        deprecated_widget.refresh_from_db()
-        assert deprecated_widget.title == "Stacked area"
-        assert deprecated_widget.display_type == DashboardWidgetDisplayTypes.STACKED_AREA_CHART
-
     def test_update_widget_add_query(self) -> None:
         data: dict[str, Any] = {
             "title": "First dashboard",

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2469,33 +2469,3 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert not Dashboard.objects.filter(
             organization=self.organization, title="Invalid Dashboard"
         ).exists()
-
-    def test_post_with_deprecated_display_type_rejected(self) -> None:
-        data: dict[str, Any] = {
-            "title": "Dashboard with Deprecated Widget",
-            "widgets": [
-                {
-                    "displayType": "stacked_area",
-                    "interval": "5m",
-                    "title": "Stacked area",
-                    "queries": [
-                        {
-                            "name": "Transactions",
-                            "fields": ["count()"],
-                            "columns": [],
-                            "aggregates": ["count()"],
-                            "conditions": "event.type:transaction",
-                        }
-                    ],
-                },
-            ],
-        }
-        response = self.do_request("post", self.url, data=data)
-        assert response.status_code == 400, response.data
-        assert (
-            "stacked_area is no longer a supported display type."
-            in response.data["widgets"][0]["displayType"][0]
-        )
-        assert not Dashboard.objects.filter(
-            organization=self.organization, title="Dashboard with Deprecated Widget"
-        ).exists()

--- a/tests/sentry/migrations/test_1080_backfill_deprecated_dashboard_widget_display_types.py
+++ b/tests/sentry/migrations/test_1080_backfill_deprecated_dashboard_widget_display_types.py
@@ -1,6 +1,10 @@
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetDisplayTypes
 from sentry.testutils.cases import TestMigrations
 
+# Display type IDs that existed before the 1080 backfill removed them.
+_LEGACY_STACKED_AREA_CHART = 2
+_LEGACY_TOP_N = 7
+
 
 class BackfillDeprecatedDashboardWidgetDisplayTypesTest(TestMigrations):
     migrate_from = "1079_purge_scm_legacy_org_options"
@@ -15,28 +19,28 @@ class BackfillDeprecatedDashboardWidgetDisplayTypesTest(TestMigrations):
         self.top_n_null_limit = DashboardWidget.objects.create(
             dashboard=dashboard,
             title="top_n null limit",
-            display_type=DashboardWidgetDisplayTypes.TOP_N,
+            display_type=_LEGACY_TOP_N,
             order=0,
             limit=None,
         )
         self.top_n_explicit_limit = DashboardWidget.objects.create(
             dashboard=dashboard,
             title="top_n explicit limit",
-            display_type=DashboardWidgetDisplayTypes.TOP_N,
+            display_type=_LEGACY_TOP_N,
             order=1,
             limit=3,
         )
         self.stacked_area_null_limit = DashboardWidget.objects.create(
             dashboard=dashboard,
             title="stacked_area null limit",
-            display_type=DashboardWidgetDisplayTypes.STACKED_AREA_CHART,
+            display_type=_LEGACY_STACKED_AREA_CHART,
             order=2,
             limit=None,
         )
         self.stacked_area_explicit_limit = DashboardWidget.objects.create(
             dashboard=dashboard,
             title="stacked_area explicit limit",
-            display_type=DashboardWidgetDisplayTypes.STACKED_AREA_CHART,
+            display_type=_LEGACY_STACKED_AREA_CHART,
             order=3,
             limit=8,
         )


### PR DESCRIPTION
## Summary

The 1080 backfill migration (`1080_backfill_deprecated_dashboard_widget_display_types`) converted every `top_n` and `stacked_area` widget to `area`, so neither value can appear in the database anymore. Strip the now-dead handling end-to-end:

- Remove `STACKED_AREA_CHART`, `TOP_N`, and `DEPRECATED_TYPES` from `DashboardWidgetDisplayTypes`.
- Drop the create-time and update-time deprecation branches in `DashboardWidgetSerializer`.
- Drop the slack unfurl mappings for the two types.
- Remove the `stacked_area` entry from `generate_dashboard_artifact.DISPLAY_TYPE_BLOCKLIST`.
- Fix `is_table_display_type`, which relied on `as_text_choices()[TABLE]` happening to land on `"table"` because the enum id matched the list position; shrinking `TYPES` exposed that fragility. Switched to `get_type_name(TABLE)`.
- Update the 1080 migration test to reference the historic display-type ids by integer literal since the constants no longer exist.