### PR TITLE
feat(sentry-apps): Add disable/enable toggle to _admin sentry app details

### DIFF
--- a/static/gsAdmin/views/sentryAppDetails.spec.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.spec.tsx
@@ -73,7 +73,7 @@ describe('SentryAppDetails', () => {
     renderSentryAppDetails({isDisabled: true});
 
     expect(await screen.findByText('Enabled:')).toBeInTheDocument();
-    expect(screen.getByText('no')).toBeInTheDocument();
+    expect(screen.getAllByText('no')).toHaveLength(2);
   });
 
   it('sends PUT with isDisabled when disable action is confirmed', async () => {

--- a/static/gsAdmin/views/sentryAppDetails.spec.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.spec.tsx
@@ -1,6 +1,6 @@
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {SentryAppDetails} from 'admin/views/sentryAppDetails';
 
@@ -87,23 +87,17 @@ describe('SentryAppDetails', () => {
     expect(await screen.findByText('Enable App')).toBeInTheDocument();
   });
 
-  it('calls PUT with isDisabled when disable action is used', async () => {
+  it('shows isDisabled detail label', async () => {
     const sentryApp = {
       ...SentryAppFixture({slug: 'test-app', status: 'unpublished'}),
       owner: {slug: 'test-org'},
-      isDisabled: false,
+      isDisabled: true,
     };
 
     MockApiClient.addMockResponse({
       url: `/sentry-apps/${sentryApp.slug}/`,
       method: 'GET',
       body: sentryApp,
-    });
-
-    const putMock = MockApiClient.addMockResponse({
-      url: `/sentry-apps/${sentryApp.slug}/`,
-      method: 'PUT',
-      body: {...sentryApp, isDisabled: true},
     });
 
     render(<SentryAppDetails />, {
@@ -113,15 +107,6 @@ describe('SentryAppDetails', () => {
       },
     });
 
-    await userEvent.click(await screen.findByTestId('detail-actions'));
-    await userEvent.click(await screen.findByRole('option', {name: /Disable App/}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
-
-    await waitFor(() => {
-      expect(putMock).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({data: {isDisabled: true}})
-      );
-    });
+    expect(await screen.findByText('isDisabled')).toBeInTheDocument();
   });
 });

--- a/static/gsAdmin/views/sentryAppDetails.spec.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.spec.tsx
@@ -1,6 +1,6 @@
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SentryAppDetails} from 'admin/views/sentryAppDetails';
 
@@ -35,5 +35,90 @@ describe('SentryAppDetails', () => {
 
     expect(await screen.findByRole('heading', {name: 'Sentry Apps'})).toBeInTheDocument();
     expect(screen.getAllByText('unpublished')).not.toHaveLength(0);
+  });
+
+  it('shows disable action for a non-disabled app', async () => {
+    const sentryApp = {
+      ...SentryAppFixture({slug: 'test-app', status: 'unpublished'}),
+      owner: {slug: 'test-org'},
+      isDisabled: false,
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/sentry-apps/${sentryApp.slug}/`,
+      method: 'GET',
+      body: sentryApp,
+    });
+
+    render(<SentryAppDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/_admin/sentry-apps/${sentryApp.slug}/`},
+        route: '/_admin/sentry-apps/:sentryAppSlug/',
+      },
+    });
+
+    expect(await screen.findByText('Disable App')).toBeInTheDocument();
+    expect(screen.queryByText('disabled')).not.toBeInTheDocument();
+  });
+
+  it('shows enable action and disabled badge for a disabled app', async () => {
+    const sentryApp = {
+      ...SentryAppFixture({slug: 'test-app', status: 'unpublished'}),
+      owner: {slug: 'test-org'},
+      isDisabled: true,
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/sentry-apps/${sentryApp.slug}/`,
+      method: 'GET',
+      body: sentryApp,
+    });
+
+    render(<SentryAppDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/_admin/sentry-apps/${sentryApp.slug}/`},
+        route: '/_admin/sentry-apps/:sentryAppSlug/',
+      },
+    });
+
+    expect(await screen.findByText('Enable App')).toBeInTheDocument();
+    expect(screen.getByText('disabled')).toBeInTheDocument();
+  });
+
+  it('calls PUT with isDisabled when disable action is used', async () => {
+    const sentryApp = {
+      ...SentryAppFixture({slug: 'test-app', status: 'unpublished'}),
+      owner: {slug: 'test-org'},
+      isDisabled: false,
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/sentry-apps/${sentryApp.slug}/`,
+      method: 'GET',
+      body: sentryApp,
+    });
+
+    const putMock = MockApiClient.addMockResponse({
+      url: `/sentry-apps/${sentryApp.slug}/`,
+      method: 'PUT',
+      body: {...sentryApp, isDisabled: true},
+    });
+
+    render(<SentryAppDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/_admin/sentry-apps/${sentryApp.slug}/`},
+        route: '/_admin/sentry-apps/:sentryAppSlug/',
+      },
+    });
+
+    await userEvent.click(await screen.findByText('Disable App'));
+    await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({data: {isDisabled: true}})
+      );
+    });
   });
 });

--- a/static/gsAdmin/views/sentryAppDetails.spec.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.spec.tsx
@@ -57,6 +57,7 @@ describe('SentryAppDetails', () => {
       },
     });
 
+    await userEvent.click(await screen.findByTestId('detail-actions'));
     expect(await screen.findByText('Disable App')).toBeInTheDocument();
     expect(screen.queryByText('disabled')).not.toBeInTheDocument();
   });
@@ -81,8 +82,9 @@ describe('SentryAppDetails', () => {
       },
     });
 
+    expect(await screen.findByText('disabled')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('detail-actions'));
     expect(await screen.findByText('Enable App')).toBeInTheDocument();
-    expect(screen.getByText('disabled')).toBeInTheDocument();
   });
 
   it('calls PUT with isDisabled when disable action is used', async () => {
@@ -111,6 +113,7 @@ describe('SentryAppDetails', () => {
       },
     });
 
+    await userEvent.click(await screen.findByTestId('detail-actions'));
     await userEvent.click(await screen.findByText('Disable App'));
     await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
 

--- a/static/gsAdmin/views/sentryAppDetails.spec.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.spec.tsx
@@ -1,8 +1,32 @@
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SentryAppDetails} from 'admin/views/sentryAppDetails';
+
+function renderSentryAppDetails(overrides: Record<string, any> = {}) {
+  const sentryApp = {
+    ...SentryAppFixture({slug: 'test-app', status: 'unpublished'}),
+    owner: {slug: 'test-org'},
+    isDisabled: false,
+    ...overrides,
+  };
+
+  MockApiClient.addMockResponse({
+    url: `/sentry-apps/${sentryApp.slug}/`,
+    method: 'GET',
+    body: sentryApp,
+  });
+
+  render(<SentryAppDetails />, {
+    initialRouterConfig: {
+      location: {pathname: `/_admin/sentry-apps/${sentryApp.slug}/`},
+      route: '/_admin/sentry-apps/:sentryAppSlug/',
+    },
+  });
+
+  return sentryApp;
+}
 
 describe('SentryAppDetails', () => {
   beforeEach(() => {
@@ -10,52 +34,14 @@ describe('SentryAppDetails', () => {
   });
 
   it('renders an unpublished app without crashing', async () => {
-    const sentryApp = {
-      ...SentryAppFixture({
-        slug: 'cursor-staging',
-        status: 'unpublished',
-      }),
-      owner: {slug: 'cursor'},
-    };
-
-    MockApiClient.addMockResponse({
-      url: `/sentry-apps/${sentryApp.slug}/`,
-      method: 'GET',
-      body: sentryApp,
-    });
-
-    render(<SentryAppDetails />, {
-      initialRouterConfig: {
-        location: {
-          pathname: `/_admin/sentry-apps/${sentryApp.slug}/`,
-        },
-        route: '/_admin/sentry-apps/:sentryAppSlug/',
-      },
-    });
+    renderSentryAppDetails();
 
     expect(await screen.findByRole('heading', {name: 'Sentry Apps'})).toBeInTheDocument();
     expect(screen.getAllByText('unpublished')).not.toHaveLength(0);
   });
 
   it('shows disable action for a non-disabled app', async () => {
-    const sentryApp = {
-      ...SentryAppFixture({slug: 'test-app', status: 'unpublished'}),
-      owner: {slug: 'test-org'},
-      isDisabled: false,
-    };
-
-    MockApiClient.addMockResponse({
-      url: `/sentry-apps/${sentryApp.slug}/`,
-      method: 'GET',
-      body: sentryApp,
-    });
-
-    render(<SentryAppDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/_admin/sentry-apps/${sentryApp.slug}/`},
-        route: '/_admin/sentry-apps/:sentryAppSlug/',
-      },
-    });
+    renderSentryAppDetails({isDisabled: false});
 
     await userEvent.click(await screen.findByTestId('detail-actions'));
     expect(await screen.findByText('Disable App')).toBeInTheDocument();
@@ -63,50 +49,37 @@ describe('SentryAppDetails', () => {
   });
 
   it('shows enable action and disabled badge for a disabled app', async () => {
-    const sentryApp = {
-      ...SentryAppFixture({slug: 'test-app', status: 'unpublished'}),
-      owner: {slug: 'test-org'},
-      isDisabled: true,
-    };
-
-    MockApiClient.addMockResponse({
-      url: `/sentry-apps/${sentryApp.slug}/`,
-      method: 'GET',
-      body: sentryApp,
-    });
-
-    render(<SentryAppDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/_admin/sentry-apps/${sentryApp.slug}/`},
-        route: '/_admin/sentry-apps/:sentryAppSlug/',
-      },
-    });
+    renderSentryAppDetails({isDisabled: true});
 
     expect(await screen.findByText('disabled')).toBeInTheDocument();
     await userEvent.click(screen.getByTestId('detail-actions'));
     expect(await screen.findByText('Enable App')).toBeInTheDocument();
   });
 
-  it('renders isDisabled detail row for a disabled app', async () => {
-    const sentryApp = {
-      ...SentryAppFixture({slug: 'test-app', status: 'unpublished'}),
-      owner: {slug: 'test-org'},
-      isDisabled: true,
-    };
+  it('renders Enabled detail label', async () => {
+    renderSentryAppDetails({isDisabled: false});
 
-    MockApiClient.addMockResponse({
+    expect(await screen.findByText('Enabled:')).toBeInTheDocument();
+  });
+
+  it('sends isDisabled in mutation when disable action is selected', async () => {
+    const sentryApp = renderSentryAppDetails({isDisabled: false});
+
+    const putMock = MockApiClient.addMockResponse({
       url: `/sentry-apps/${sentryApp.slug}/`,
-      method: 'GET',
-      body: sentryApp,
+      method: 'PUT',
+      body: {...sentryApp, isDisabled: true},
     });
 
-    render(<SentryAppDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/_admin/sentry-apps/${sentryApp.slug}/`},
-        route: '/_admin/sentry-apps/:sentryAppSlug/',
-      },
-    });
+    await userEvent.click(await screen.findByTestId('detail-actions'));
+    await userEvent.click(await screen.findByRole('option', {name: /Disable App/}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
 
-    expect(await screen.findByText('isDisabled:')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({data: {isDisabled: true}})
+      );
+    });
   });
 });

--- a/static/gsAdmin/views/sentryAppDetails.spec.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.spec.tsx
@@ -1,6 +1,12 @@
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import {SentryAppDetails} from 'admin/views/sentryAppDetails';
 
@@ -56,14 +62,23 @@ describe('SentryAppDetails', () => {
     expect(await screen.findByText('Enable App')).toBeInTheDocument();
   });
 
-  it('renders Enabled detail label', async () => {
+  it('shows Enabled: yes for a non-disabled app', async () => {
     renderSentryAppDetails({isDisabled: false});
 
     expect(await screen.findByText('Enabled:')).toBeInTheDocument();
+    expect(screen.getByText('yes')).toBeInTheDocument();
   });
 
-  it('sends isDisabled in mutation when disable action is selected', async () => {
+  it('shows Enabled: no for a disabled app', async () => {
+    renderSentryAppDetails({isDisabled: true});
+
+    expect(await screen.findByText('Enabled:')).toBeInTheDocument();
+    expect(screen.getByText('no')).toBeInTheDocument();
+  });
+
+  it('sends PUT with isDisabled when disable action is confirmed', async () => {
     const sentryApp = renderSentryAppDetails({isDisabled: false});
+    renderGlobalModal();
 
     const putMock = MockApiClient.addMockResponse({
       url: `/sentry-apps/${sentryApp.slug}/`,
@@ -81,5 +96,7 @@ describe('SentryAppDetails', () => {
         expect.objectContaining({data: {isDisabled: true}})
       );
     });
+
+    expect(await screen.findByText('disabled')).toBeInTheDocument();
   });
 });

--- a/static/gsAdmin/views/sentryAppDetails.spec.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.spec.tsx
@@ -87,7 +87,7 @@ describe('SentryAppDetails', () => {
     expect(await screen.findByText('Enable App')).toBeInTheDocument();
   });
 
-  it('shows isDisabled detail label', async () => {
+  it('renders isDisabled detail row for a disabled app', async () => {
     const sentryApp = {
       ...SentryAppFixture({slug: 'test-app', status: 'unpublished'}),
       owner: {slug: 'test-org'},
@@ -107,6 +107,6 @@ describe('SentryAppDetails', () => {
       },
     });
 
-    expect(await screen.findByText('isDisabled')).toBeInTheDocument();
+    expect(await screen.findByText('isDisabled:')).toBeInTheDocument();
   });
 });

--- a/static/gsAdmin/views/sentryAppDetails.spec.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.spec.tsx
@@ -114,8 +114,8 @@ describe('SentryAppDetails', () => {
     });
 
     await userEvent.click(await screen.findByTestId('detail-actions'));
-    await userEvent.click(await screen.findByText('Disable App'));
-    await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+    await userEvent.click(await screen.findByRole('option', {name: /Disable App/}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
 
     await waitFor(() => {
       expect(putMock).toHaveBeenCalledWith(

--- a/static/gsAdmin/views/sentryAppDetails.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.tsx
@@ -90,6 +90,20 @@ export function SentryAppDetails() {
       publishingAction = undefined;
   }
 
+  const disableAction: ActionItem = data.isDisabled
+    ? {
+        key: 'enable',
+        name: 'Enable App',
+        help: 'Re-enables this Sentry App',
+        onAction: () => onUpdateMutation.mutate({isDisabled: false}),
+      }
+    : {
+        key: 'disable',
+        name: 'Disable App',
+        help: 'Disables this Sentry App, blocking all API access and webhook delivery',
+        onAction: () => onUpdateMutation.mutate({isDisabled: true}),
+      };
+
   const updateDetailsAction = {
     key: 'update-details',
     name: 'Update Details',
@@ -107,8 +121,8 @@ export function SentryAppDetails() {
 
   const actions =
     publishingAction === undefined
-      ? [updateDetailsAction]
-      : [updateDetailsAction, publishingAction];
+      ? [updateDetailsAction, disableAction]
+      : [updateDetailsAction, publishingAction, disableAction];
   const sentryAppBadgeLevel: Partial<Record<string, NonNullable<BadgeItem['level']>>> = {
     unpublished: 'danger',
     internal: 'warning',
@@ -124,6 +138,7 @@ export function SentryAppDetails() {
           <Link to={`/_admin/customers/${data.owner.slug}/`}>{data.owner.slug}</Link>
         </DetailLabel>
         <DetailLabel title="isAlertable" yesNo={data.isAlertable} />
+        <DetailLabel title="isDisabled" yesNo={data.isDisabled} />
         <DetailLabel title="Popularity">{data.popularity}</DetailLabel>
         <DetailLabel title="Scopes">
           {data.scopes.map((scope: any) => (
@@ -163,6 +178,7 @@ export function SentryAppDetails() {
           name: data.status,
           level: sentryAppBadgeLevel[data.status] ?? 'success',
         },
+        ...(data.isDisabled ? [{name: 'disabled', level: 'danger' as const}] : []),
       ]}
       actions={actions}
       sections={[{content: overview}]}

--- a/static/gsAdmin/views/sentryAppDetails.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.tsx
@@ -138,7 +138,7 @@ export function SentryAppDetails() {
           <Link to={`/_admin/customers/${data.owner.slug}/`}>{data.owner.slug}</Link>
         </DetailLabel>
         <DetailLabel title="isAlertable" yesNo={data.isAlertable} />
-        <DetailLabel title="isDisabled" yesNo={data.isDisabled} />
+        <DetailLabel title="Enabled" yesNo={!data.isDisabled} />
         <DetailLabel title="Popularity">{data.popularity}</DetailLabel>
         <DetailLabel title="Scopes">
           {data.scopes.map((scope: any) => (


### PR DESCRIPTION
Adds a disable/enable sentry app to the Sentry Apps Actions dropdown in _admin. 

Requires the option` sentry-apps.disabled-enforcement `to be on first
Also requires https://github.com/getsentry/sentry/pull/114980 to go in first 

Refs ISWF-1234

## Images

### not disabled + disable button
<img width="784" height="432" alt="image" src="https://github.com/user-attachments/assets/36c132a9-5ab4-49b4-a955-fb64e084ee3f" />

### Disabled + enable button
<img width="803" height="433" alt="image" src="https://github.com/user-attachments/assets/a235ee1e-0cd1-46ac-acbe-198de5e7575a" />
