### PR TITLE
ref(supergroups): drop deprecated `RCASource`

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -1,7 +1,6 @@
 import hashlib
 import hmac
 import logging
-from enum import StrEnum
 from typing import Any, Literal, NotRequired, TypedDict
 from urllib.parse import urlparse
 
@@ -415,10 +414,6 @@ class SummarizeIssueRequest(TypedDict):
     experiment_variant: NotRequired[str | None]
 
 
-class RCASource(StrEnum):
-    LIGHTWEIGHT = "LIGHTWEIGHT"
-
-
 class LightweightRCAClusterRequest(TypedDict):
     group_id: int
     issue: dict[str, Any]
@@ -430,13 +425,11 @@ class LightweightRCAClusterRequest(TypedDict):
 class SupergroupsGetRequest(TypedDict):
     organization_id: int
     supergroup_id: int
-    rca_source: str
 
 
 class SupergroupsGetByGroupIdsRequest(TypedDict):
     organization_id: int
     group_ids: list[int]
-    rca_source: str
 
 
 class SupergroupDetailData(TypedDict):

--- a/src/sentry/seer/supergroups/by_group.py
+++ b/src/sentry/seer/supergroups/by_group.py
@@ -7,7 +7,6 @@ import orjson
 from sentry.models.organization import Organization
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
-    RCASource,
     SeerViewerContext,
     SupergroupsByGroupIdsResponse,
     make_supergroups_get_by_group_ids_request,
@@ -24,7 +23,6 @@ def get_supergroups_by_group_ids(
         {
             "organization_id": organization.id,
             "group_ids": list(group_ids),
-            "rca_source": RCASource.LIGHTWEIGHT,
         },
         SeerViewerContext(organization_id=organization.id, user_id=user_id),
         timeout=10,

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
@@ -12,7 +12,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
-from sentry.seer.signed_seer_api import RCASource, SeerViewerContext, make_supergroups_get_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_supergroups_get_request
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,6 @@ class OrganizationSupergroupDetailsEndpoint(OrganizationEndpoint):
             {
                 "organization_id": organization.id,
                 "supergroup_id": supergroup_id,
-                "rca_source": RCASource.LIGHTWEIGHT,
             },
             SeerViewerContext(organization_id=organization.id, user_id=request.user.id),
             timeout=10,

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
@@ -36,15 +36,3 @@ class OrganizationSupergroupDetailsEndpointTest(APITestCase):
         assert response.data["id"] == 1
         assert response.data["title"] == "NullPointerException in auth"
         assert response.data["group_ids"] == [10, 20]
-
-    @patch(
-        "sentry.seer.supergroups.endpoints.organization_supergroup_details.make_supergroups_get_request"
-    )
-    def test_rca_source_is_lightweight(self, mock_seer):
-        mock_seer.return_value = mock_seer_response({"id": 1, "title": "test"})
-
-        with self.feature("organizations:top-issues-ui"):
-            self.get_success_response(self.organization.slug, "1")
-
-        body = mock_seer.call_args.args[0]
-        assert body["rca_source"] == "LIGHTWEIGHT"

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
@@ -76,19 +76,6 @@ class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
             )
 
     @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
-    def test_rca_source_is_lightweight(self, mock_seer):
-        mock_seer.return_value = mock_seer_response({"data": []})
-
-        with self.feature("organizations:top-issues-ui"):
-            self.get_success_response(
-                self.organization.slug,
-                group_id=[self.unresolved_group.id],
-            )
-
-        body = mock_seer.call_args.args[0]
-        assert body["rca_source"] == "LIGHTWEIGHT"
-
-    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
     def test_assignee_summary(self, mock_seer):
         user_a = self.create_user(email="a@example.com")
         user_b = self.create_user(email="b@example.com")


### PR DESCRIPTION
Seer now only does lightweight RCA read/write and doesn't read the `rca_source` part of the request anymore, so we can drop it from sentry.