### PR TITLE
feat(seer): Copy changes and fixup links between pages

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectAddRepoModal/projectAddRepoModal.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectAddRepoModal/projectAddRepoModal.tsx
@@ -261,7 +261,7 @@ export function ProjectAddRepoModal({
             <form.AppField name="agent">
               {field => (
                 <field.Layout.Row
-                  label={t('Preferred Coding Agent')}
+                  label={t('Handoff to Agent')}
                   hintText={t(
                     'Seer will always triage and perform Root Cause Analysis for you, but after that you can hand the results to an agent to create a plan, code a fix, and draft a PR.'
                   )}
@@ -271,15 +271,27 @@ export function ProjectAddRepoModal({
                   ) : agentOptions.isError ? (
                     <LoadingError />
                   ) : (
-                    <field.Select
-                      value={field.state.value}
-                      onChange={field.handleChange}
-                      options={agentOptions.data}
-                      isValueEqual={(a, b) =>
-                        a === b ||
-                        (typeof a === 'object' && typeof b === 'object' && a.id === b.id)
-                      }
-                    />
+                    <Stack gap="md">
+                      <field.Select
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        options={agentOptions.data}
+                        isValueEqual={(a, b) =>
+                          a === b ||
+                          (typeof a === 'object' &&
+                            typeof b === 'object' &&
+                            a.id === b.id)
+                        }
+                      />
+                      <Link
+                        to={{
+                          pathname: `/settings/${organization.slug}/integrations/`,
+                          query: {category: 'coding agent'},
+                        }}
+                      >
+                        {t('Manage Coding Agents')}
+                      </Link>
+                    </Stack>
                   )}
                 </field.Layout.Row>
               )}

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
@@ -4,7 +4,7 @@ import {z} from 'zod';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -102,11 +102,11 @@ export function AutofixAgent({canWrite, preference, project}: Props) {
       >
         {field => (
           <field.Layout.Row
-            label={t('Preferred Coding Agent')}
+            label={t('Handoff to Agent')}
             hintText={
               <Text>
                 {tct(
-                  'Select the coding agent to use when proposing code changes. [manageLink:Manage Coding Agent Integrations]',
+                  'Select your preferred agent to create a plan, and code up an issue fix. Seer Agent will always be used for the Root Cause Analysis step.',
                   {
                     manageLink: (
                       <Link
@@ -126,16 +126,26 @@ export function AutofixAgent({canWrite, preference, project}: Props) {
             ) : agentOptions.isError ? (
               <LoadingError />
             ) : (
-              <field.Select
-                disabled={Boolean(disabledReason)}
-                value={field.state.value}
-                onChange={field.handleChange}
-                options={agentOptions.data}
-                isValueEqual={(a, b) =>
-                  a === b ||
-                  (typeof a === 'object' && typeof b === 'object' && a.id === b.id)
-                }
-              />
+              <Stack gap="md">
+                <field.Select
+                  disabled={Boolean(disabledReason)}
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  options={agentOptions.data}
+                  isValueEqual={(a, b) =>
+                    a === b ||
+                    (typeof a === 'object' && typeof b === 'object' && a.id === b.id)
+                  }
+                />
+                <Link
+                  to={{
+                    pathname: `/settings/${organization.slug}/integrations/`,
+                    query: {category: 'coding agent'},
+                  }}
+                >
+                  {t('Manage Coding Agents')}
+                </Link>
+              </Stack>
             )}
           </field.Layout.Row>
         )}

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesItem.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesItem.tsx
@@ -128,7 +128,7 @@ export function AutofixRepositoriesItem({
           onConfirm={onRemoveRepo}
           header={
             <Heading as="h4">
-              {tct('Are you sure you want to remove [repo] from Seer?', {
+              {tct('Are you sure you want to remove [repo] from Autofix?', {
                 repo: <code>{repository.name}</code>,
               })}
             </Heading>
@@ -136,11 +136,11 @@ export function AutofixRepositoriesItem({
           message={
             repositories.length > 1
               ? tn(
-                  'There will still be %s other repository connected to this project for Root Cause Analysis to use.',
-                  'There will still be %s other repositories connected to this project for Root Cause Analysis to use.',
+                  'There will still be %s other repository connected to this project for Autofix to use.',
+                  'There will still be %s other repositories connected to this project for Autofix to use.',
                   repositories.length - 1
                 )
-              : t('You will no longer be able to use Root Cause Analysis on your issue.')
+              : t('Autofix will be disabled for issues in this project.')
           }
           confirmText={
             <Flex align="center" gap="md">

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.tsx
@@ -141,7 +141,7 @@ export function AutofixRepositories({canWrite, preference, project}: Props) {
         <Flex padding="2xl" align="center" justify="center" gap="xl">
           <img src={seerConfigBug1} alt="" width="130px" height="130px" />
           <Stack gap="lg">
-            <Heading as="h4">{t('Get the most out of Seer')}</Heading>
+            <Heading as="h4">{t('Connect a repository')}</Heading>
             <Flex maxWidth="250px">
               {t(
                 'Connect at least one repository so Seer can gather more insights from your code.'

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -6,12 +6,14 @@ import {Alert} from '@sentry/scraps/alert';
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
-import {Link} from '@sentry/scraps/link';
+import {ExternalLink, Link} from '@sentry/scraps/link';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import type {useUpdateBulkAutofixAutomationSettings} from 'sentry/components/events/autofix/preferences/hooks/useBulkAutofixAutomationSettings';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {IconOpen} from 'sentry/icons/iconOpen';
 import {t, tct, tn} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -44,7 +46,7 @@ const COLUMNS = [
   {
     title: ({organization}: {organization: Organization}) => (
       <Flex gap="sm" align="center">
-        {t('Preferred Coding Agent')}
+        {t('Handoff to Agent')}
         <InfoTip
           title={tct(
             'Select the coding agent to use when proposing code changes. [manageLink:Manage Coding Agent Integrations]',
@@ -188,6 +190,18 @@ export function ProjectTableHeader({
                 })) ?? []
               }
               triggerLabel={t('Agent')}
+              menuFooter={
+                <DropdownMenuFooter>
+                  <Link
+                    to={{
+                      pathname: `/settings/${organization.slug}/integrations/`,
+                      query: {category: 'coding agent'},
+                    }}
+                  >
+                    {t('Manage Coding Agents')}
+                  </Link>
+                </DropdownMenuFooter>
+              }
             />
             <DropdownMenu
               isDisabled={!canWrite}
@@ -219,6 +233,16 @@ export function ProjectTableHeader({
                 },
               }))}
               triggerLabel={t('Automation Steps')}
+              menuFooter={
+                <DropdownMenuFooter>
+                  <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#how-issue-autofix-works">
+                    <Flex gap="sm" align="center">
+                      <IconOpen size="xs" />
+                      {t('Read the Docs')}
+                    </Flex>
+                  </ExternalLink>
+                </DropdownMenuFooter>
+              }
             />
           </TableCellsRemainingContent>
         </TableHeader>


### PR DESCRIPTION
This updates all the labels to be "Handoff to Agent" instead of "Preferred Coding Agent"

Also it adds some links to make Manage Agents more visible, so people can add their own agents in

| Where | Img |
| --- | --- |
| Add Project to Autofix modal | <img width="655" height="144" alt="Image" src="https://github.com/user-attachments/assets/fca6b4a2-cd93-4d22-b563-c6f8846c0d91" />
| Autofix Project Details Settings page | <img width="1037" height="134" alt="Image" src="https://github.com/user-attachments/assets/0aebf76f-dcbf-4511-9c7c-eb50c6dab9ed" />
| Autofix bulk edit actions | <img width="342" height="175" alt="Image" src="https://github.com/user-attachments/assets/9fb53d4f-a7cb-4fdb-8ae5-aa0570fcd7ab" />
| Link to docs from bulk-edit actions | <img width="352" height="215" alt="Image" src="https://github.com/user-attachments/assets/5c6dcb2d-4abc-40d4-a2ed-21c7e7bb9677" />