### PR TITLE
ref(seer): Promote issue routes to stable structured context flag

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -157,7 +157,10 @@ describe('useSeerExplorer', () => {
       });
     });
 
-    it('falls back to ASCII screenshot on non-dashboard page', async () => {
+    it('falls back to ASCII screenshot on non-structured-context page', async () => {
+      (usePageReferrer as jest.Mock).mockReturnValue({
+        getPageReferrer: () => '/monitors/mobile-builds/',
+      });
       const org = OrganizationFixture({
         features: ['seer-explorer', 'seer-explorer-context-engine'],
       });
@@ -185,7 +188,7 @@ describe('useSeerExplorer', () => {
       });
 
       await waitFor(() => {
-        // usePageReferrer returns '/issues/' by default (from beforeEach) — not in STRUCTURED_CONTEXT_ROUTES
+        // /monitors/mobile-builds/ is not in STRUCTURED_CONTEXT_ROUTES — falls back to ASCII snapshot
         const ctx = postMock.mock.calls[0][1].data.on_page_context;
         expect(() => JSON.parse(ctx)).toThrow();
       });

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -122,7 +122,7 @@ describe('useSeerExplorer', () => {
     });
 
     it('sends structured JSON on dashboard page with feature flag', async () => {
-      (usePageReferrer as jest.Mock).mockReturnValue({
+      jest.mocked(usePageReferrer).mockReturnValue({
         getPageReferrer: () => '/dashboard/:dashboardId/',
       });
       const org = OrganizationFixture({

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -158,7 +158,7 @@ describe('useSeerExplorer', () => {
     });
 
     it('falls back to ASCII screenshot on non-structured-context page', async () => {
-      (usePageReferrer as jest.Mock).mockReturnValue({
+      jest.mocked(usePageReferrer).mockReturnValue({
         getPageReferrer: () => '/monitors/mobile-builds/',
       });
       const org = OrganizationFixture({

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -53,9 +53,11 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/',
   '/explore/traces/',
   '/explore/traces/trace/:traceSlug/',
+  '/issues/',
+  '/issues/:groupId/',
 ]);
 /** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>(['/issues/', '/issues/:groupId/']);
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>();
 
 function supportsStructuredContext(
   referrer: string,


### PR DESCRIPTION
+ Move /issues/ and /issues/:groupId/ from NEW_STRUCTURED_CONTEXT_ROUTES (behind context-engine-structured-page-context) to STRUCTURED_CONTEXT_ROUTES (behind seer-explorer-context-engine) so they use the broader flag. ~400 orgs in closed beta cohort. 
