### PR TITLE
prototype(logs): Add row pinning to logs explorer

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -487,6 +487,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:ourlogs-modal-export", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the expand/collapse table height toggle in the logs UI
     manager.add("organizations:ourlogs-table-expando", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable row pinning in the logs UI
+    manager.add("organizations:ourlogs-pinning", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable various explore related dev features, may be used by internal branches for testing.
     manager.add("organizations:explore-dev-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable alerting on trace metrics

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -23,6 +23,8 @@ import {LogsTabOnboarding} from 'sentry/views/explore/logs/logsOnboarding';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
 import {useOurLogsTableExpando} from 'sentry/views/explore/logs/tables/useOurLogsTableExpando';
+import {LogsHoveredLogIdProvider} from 'sentry/views/explore/logs/useLogsHoveredLogId';
+import {LogsPinnedRowsProvider} from 'sentry/views/explore/logs/useLogsPinnedRows';
 import {
   useQueryParamsId,
   useQueryParamsTitle,
@@ -68,21 +70,25 @@ export default function LogsContent() {
               analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
               source="location"
             >
-              <LogsHeader />
-              <LogsPageDataProvider allowHighFidelity>
-                {defined(onboardingProject) ? (
-                  <LogsTabOnboarding
-                    organization={organization}
-                    project={onboardingProject}
-                    datePageFilterProps={datePageFilterProps}
-                  />
-                ) : (
-                  <LogsTabContent
-                    datePageFilterProps={datePageFilterProps}
-                    tableExpando={tableExpando}
-                  />
-                )}
-              </LogsPageDataProvider>
+              <LogsPinnedRowsProvider>
+                <LogsHoveredLogIdProvider>
+                  <LogsHeader />
+                  <LogsPageDataProvider allowHighFidelity>
+                    {defined(onboardingProject) ? (
+                      <LogsTabOnboarding
+                        organization={organization}
+                        project={onboardingProject}
+                        datePageFilterProps={datePageFilterProps}
+                      />
+                    ) : (
+                      <LogsTabContent
+                        datePageFilterProps={datePageFilterProps}
+                        tableExpando={tableExpando}
+                      />
+                    )}
+                  </LogsPageDataProvider>
+                </LogsHoveredLogIdProvider>
+              </LogsPinnedRowsProvider>
             </LogsQueryParamsProvider>
           </LogsPageStack>
         </AnalyticsArea>

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -122,23 +122,40 @@ export const LogTableRow = styled(TableRow)<LogTableRowProps>`
   }
 `;
 
-export const PinActionButton = styled(Button)<{isPinned: boolean}>`
+export const PinIcon = styled('button')<{isPinned: boolean}>`
+  all: unset;
   position: absolute;
   top: 50%;
   right: -33px;
   transform: translateY(-50%);
-  padding: ${p => p.theme.space.xs};
+  cursor: pointer;
 
   display: flex;
   align-items: center;
+  justify-content: center;
+
+  color: ${p =>
+    p.isPinned
+      ? p.theme.tokens.content.accent
+      : p.theme.tokens.content.secondary};
 
   opacity: ${p => (p.isPinned ? 1 : 0)};
-  transition: opacity 0.1s;
+  transition:
+    opacity 0.1s,
+    color 0.1s;
   z-index: 1;
+
+  &:hover {
+    color: ${p => p.theme.tokens.content.accent};
+  }
 
   &:focus-visible {
     opacity: 1;
+    outline: 2px solid ${p => p.theme.tokens.focus.default};
+    outline-offset: 2px;
+    border-radius: 2px;
   }
+
   ${LogTableRow}:hover & {
     opacity: 1;
   }
@@ -161,9 +178,10 @@ export const PinnedRowsDivider = styled('div')`
   grid-column: 1 / -1;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   gap: ${p => p.theme.space.md};
-  padding: ${p => p.theme.space.xs} 0;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.xl};
+  background-color: ${p => p.theme.tokens.background.secondary};
   border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
 `;
 
@@ -305,8 +323,28 @@ export const DetailsBody = styled('div')`
   }
 `;
 
-export const StyledChevronButton = styled(Button)`
+export const StyledChevronIcon = styled('button')`
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 23px;
+  height: 24px;
+  flex-shrink: 0;
   margin-right: ${p => p.theme.space.xs};
+  color: ${p => p.theme.tokens.content.secondary};
+  transition: color 0.1s;
+
+  &:hover {
+    color: ${p => p.theme.tokens.content.primary};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${p => p.theme.tokens.focus.default};
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 `;
 
 const DEFAULT_SIZE = '8px';

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -66,6 +66,25 @@ export const LogTableRow = styled(TableRow)<LogTableRowProps>`
     }
   }
 
+  &[data-row-pinned='true']:not(thead > &) {
+    background-color: ${p => p.theme.tokens.background.transparent.accent.muted};
+
+    &:hover {
+      background-color: ${p =>
+        p.theme.tokens.interactive.transparent.accent.selected.background.active};
+    }
+  }
+
+  &[data-row-hover-linked='true']:not(thead > &) {
+    background-color: ${p =>
+      p.theme.tokens.interactive.transparent.accent.selected.background.active};
+
+    &:hover {
+      background-color: ${p =>
+        p.theme.tokens.interactive.transparent.accent.selected.background.active};
+    }
+  }
+
   &.beforeHoverTime + &.afterHoverTime:before {
     border-top: 1px solid ${p => p.theme.tokens.border.accent.moderate};
     content: '';
@@ -103,6 +122,51 @@ export const LogTableRow = styled(TableRow)<LogTableRowProps>`
   }
 `;
 
+export const PinActionButton = styled(Button)<{isPinned: boolean}>`
+  position: absolute;
+  top: 50%;
+  right: -33px;
+  transform: translateY(-50%);
+  padding: ${p => p.theme.space.xs};
+
+  display: flex;
+  align-items: center;
+
+  opacity: ${p => (p.isPinned ? 1 : 0)};
+  transition: opacity 0.1s;
+  z-index: 1;
+
+  &:focus-visible {
+    opacity: 1;
+  }
+  ${LogTableRow}:hover & {
+    opacity: 1;
+  }
+`;
+
+export const CellContentWrapper = styled('div')`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+export const PinnedRowsSection = styled('div')`
+  display: contents;
+`;
+
+export const PinnedRowsDivider = styled('div')`
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${p => p.theme.space.md};
+  padding: ${p => p.theme.space.xs} 0;
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+
 export const LogAttributeTreeWrapper = styled('div')`
   padding: ${p => p.theme.space.md} ${p => p.theme.space.md};
   border-bottom: 0px;
@@ -110,6 +174,7 @@ export const LogAttributeTreeWrapper = styled('div')`
 
 export const LogTableBodyCell = styled(TableBodyCell)`
   min-height: ${LOGS_GRID_BODY_ROW_HEIGHT}px;
+  position: relative;
 
   padding: 2px ${p => p.theme.space.xl};
 
@@ -123,6 +188,10 @@ export const LogTableBodyCell = styled(TableBodyCell)`
 
   &:last-child {
     padding: 2px ${p => p.theme.space.xl};
+  }
+
+  &:last-child[data-has-pin-feature] {
+    padding-right: 56px;
   }
 `;
 

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -23,13 +23,14 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {JumpButtons} from 'sentry/components/replays/jumpButtons';
 import {useJumpButtons} from 'sentry/components/replays/useJumpButtons';
 import {GridResizer} from 'sentry/components/tables/gridEditable/styles';
-import {IconArrow, IconWarning} from 'sentry/icons';
+import {IconArrow, IconChevron, IconClose, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   TableBodyCell,
   TableHead,
@@ -54,6 +55,8 @@ import {
   LogTable,
   LogTableBody,
   LogTableRow,
+  PinnedRowsDivider,
+  PinnedRowsSection,
 } from 'sentry/views/explore/logs/styles';
 import {LogsEmptyResults} from 'sentry/views/explore/logs/tables/logsEmptyResults';
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
@@ -61,6 +64,11 @@ import {
   OurLogKnownFieldKey,
   type OurLogsResponseItem,
 } from 'sentry/views/explore/logs/types';
+import {
+  useClearAllLogPins,
+  useLogsPinnedRows,
+  useToggleLogPinnedRow,
+} from 'sentry/views/explore/logs/useLogsPinnedRows';
 import {
   createPseudoLogResponseItem,
   getDynamicLogsNextFetchThreshold,
@@ -219,6 +227,23 @@ export function LogsInfiniteTable({
       logEnd: new Date(quantizedEnd).toISOString(),
     };
   }, [baseData]);
+
+  const organization = useOrganization();
+  const hasPinning = organization.features.includes('ourlogs-pinning');
+  const pinnedRowIds = useLogsPinnedRows();
+  const togglePin = useToggleLogPinnedRow();
+  const clearAllPins = useClearAllLogPins();
+  const [pinnedSectionCollapsed, setPinnedSectionCollapsed] = useState(false);
+
+  const pinnedRows = useMemo(() => {
+    if (!hasPinning || pinnedRowIds.size === 0 || !baseData) {
+      return [];
+    }
+    return baseData.filter(
+      row =>
+        isRegularLogResponseItem(row) && pinnedRowIds.has(row[OurLogKnownFieldKey.ID])
+    );
+  }, [hasPinning, pinnedRowIds, baseData]);
 
   const tableRef = useRef<HTMLTableElement>(null);
   const tableBodyRef = useRef<HTMLTableSectionElement>(null);
@@ -529,6 +554,62 @@ export function LogsInfiniteTable({
           {isRefetching && !hasReplay && (
             <HoveringRowLoadingRenderer position="top" isEmbedded={embedded} />
           )}
+          {hasPinning && pinnedRows.length > 0 && !embedded && (
+            <Fragment>
+              {!pinnedSectionCollapsed && (
+                <PinnedRowsSection>
+                  {pinnedRows.map(pinnedRow => {
+                    const pinnedId = pinnedRow[OurLogKnownFieldKey.ID];
+                    const pinnedExpandKey = `pinned-${pinnedId}`;
+                    return (
+                      <LogRowContent
+                        key={pinnedExpandKey}
+                        dataRow={pinnedRow}
+                        meta={meta}
+                        highlightTerms={highlightTerms}
+                        embedded={false}
+                        sharedHoverTimeoutRef={sharedHoverTimeoutRef}
+                        isPinned
+                        onTogglePin={togglePin}
+                        expandKey={pinnedExpandKey}
+                        onExpand={handleExpand}
+                        onCollapse={handleCollapse}
+                        isExpanded={expandedLogRows.has(pinnedExpandKey)}
+                        onExpandHeight={handleExpandHeight}
+                        logStart={logStart}
+                        logEnd={logEnd}
+                      />
+                    );
+                  })}
+                </PinnedRowsSection>
+              )}
+              <PinnedRowsDivider>
+                <Button
+                  size="xs"
+                  icon={
+                    <IconChevron
+                      size="xs"
+                      direction={pinnedSectionCollapsed ? 'down' : 'up'}
+                    />
+                  }
+                  onClick={() => setPinnedSectionCollapsed(prev => !prev)}
+                >
+                  {pinnedSectionCollapsed
+                    ? t('Expand %s pinned', pinnedRows.length)
+                    : t('Collapse %s pinned', pinnedRows.length)}
+                </Button>
+                <Button
+                  size="xs"
+                  variant="transparent"
+                  icon={<IconClose size="xs" />}
+                  onClick={clearAllPins}
+                  aria-label={t('Clear all pins')}
+                >
+                  {t('Clear all')}
+                </Button>
+              </PinnedRowsDivider>
+            </Fragment>
+          )}
           {virtualItems.map(virtualRow => {
             const dataRow = data?.[virtualRow.index];
 
@@ -545,6 +626,12 @@ export function LogsInfiniteTable({
                   embeddedOptions={embeddedOptions}
                   sharedHoverTimeoutRef={sharedHoverTimeoutRef}
                   key={virtualRow.key}
+                  isPinned={
+                    hasPinning &&
+                    isRegularLogResponseItem(dataRow) &&
+                    pinnedRowIds.has(dataRow[OurLogKnownFieldKey.ID])
+                  }
+                  onTogglePin={hasPinning ? togglePin : undefined}
                   onExpand={handleExpand}
                   onCollapse={handleCollapse}
                   logStart={logStart}

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -71,8 +71,8 @@ import {
   LogsTableBodyFirstCell,
   LogTableBodyCell,
   LogTableRow,
-  PinActionButton,
-  StyledChevronButton,
+  PinIcon,
+  StyledChevronIcon,
   TraceIconStyleWrapper,
 } from 'sentry/views/explore/logs/styles';
 import {
@@ -371,14 +371,13 @@ export const LogRowContent = memo(function LogRowContent({
             {isPseudoRow ? (
               <span className="log-table-row-pseudo-row-chevron-replacement" />
             ) : blockRowExpanding ? null : shouldRenderHoverElements ? (
-              <StyledChevronButton
-                icon={<IconChevron size="xs" direction={expanded ? 'down' : 'right'} />}
+              <StyledChevronIcon
                 aria-label={t('Toggle trace details')}
                 aria-expanded={expanded}
-                size="zero"
-                variant="transparent"
                 onClick={() => toggleExpanded()}
-              />
+              >
+                <IconChevron size="xs" direction={expanded ? 'down' : 'right'} />
+              </StyledChevronIcon>
             ) : (
               <span className="log-table-row-chevron-button">{chevronIcon}</span>
             )}
@@ -446,17 +445,16 @@ export const LogRowContent = memo(function LogRowContent({
           const hasExtraPadding = hasPinning && !embedded && !isPseudoRow && isLastField;
 
           const pinButton = showPinButton ? (
-            <PinActionButton
-              icon={<IconPin isSolid={isPinned} size="xs" />}
-              aria-label={isPinned ? t('Unpin log row') : t('Pin log row')}
-              size="zero"
-              variant={isPinned ? 'primary' : undefined}
+            <PinIcon
               isPinned={isPinned}
+              aria-label={isPinned ? t('Unpin log row') : t('Pin log row')}
               onClick={(e: React.MouseEvent) => {
                 e.stopPropagation();
                 onTogglePin?.(logId);
               }}
-            />
+            >
+              <IconPin isSolid={isPinned} size="xs" />
+            </PinIcon>
           ) : null;
 
           const cellContent = shouldRenderActions ? (

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -11,7 +11,7 @@ import {EmptyStreamWrapper} from 'sentry/components/emptyStateWarning';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
-import {IconAdd, IconJson, IconSubtract, IconWarning} from 'sentry/icons';
+import {IconAdd, IconJson, IconPin, IconSubtract, IconWarning} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
@@ -58,6 +58,7 @@ import {
 import {useLogsFrozenIsFrozen} from 'sentry/views/explore/logs/logsFrozenContext';
 import {useLogsAnalyticsPageSource} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {
+  CellContentWrapper,
   DetailsBody,
   DetailsContent,
   DetailsWrapper,
@@ -70,6 +71,7 @@ import {
   LogsTableBodyFirstCell,
   LogTableBodyCell,
   LogTableRow,
+  PinActionButton,
   StyledChevronButton,
   TraceIconStyleWrapper,
 } from 'sentry/views/explore/logs/styles';
@@ -78,6 +80,10 @@ import {
   type OurLogsResponseItem,
 } from 'sentry/views/explore/logs/types';
 import {useLogAttributesTreeActions} from 'sentry/views/explore/logs/useLogAttributesTreeActions';
+import {
+  useLogsHoveredLogId,
+  useSetLogsHoveredLogId,
+} from 'sentry/views/explore/logs/useLogsHoveredLogId';
 import {useExploreLogsTableRow} from 'sentry/views/explore/logs/useLogsQuery';
 import {
   adjustAliases,
@@ -108,13 +114,16 @@ type LogsRowProps = {
     openWithExpandedIds?: string[];
     replay?: ReplayEmbeddedTableOptions;
   };
+  expandKey?: string;
   isExpanded?: boolean;
+  isPinned?: boolean;
   logEnd?: string;
   logStart?: string;
   onCollapse?: (logItemId: string) => void;
   onEmbeddedRowClick?: (logItemId: string, event: React.MouseEvent) => void;
   onExpand?: (logItemId: string) => void;
   onExpandHeight?: (logItemId: string, estimatedHeight: number) => void;
+  onTogglePin?: (logId: string) => void;
 };
 
 const ALLOWED_CELL_ACTIONS: Actions[] = [
@@ -145,10 +154,13 @@ export const LogRowContent = memo(function LogRowContent({
   highlightTerms,
   meta,
   sharedHoverTimeoutRef,
+  expandKey: expandKeyProp,
   isExpanded,
+  isPinned: isPinnedProp,
   onExpand,
   onCollapse,
   onExpandHeight,
+  onTogglePin,
   blockRowExpanding,
   onEmbeddedRowClick,
   logStart,
@@ -163,6 +175,14 @@ export const LogRowContent = memo(function LogRowContent({
   const setAutorefresh = useSetLogsAutoRefresh();
   const measureRef = useRef<HTMLTableRowElement>(null);
   const [shouldRenderHoverElements, setShouldRenderHoverElements] = useState(false);
+
+  const hasPinning = organization.features.includes('ourlogs-pinning');
+  const hoveredLogId = useLogsHoveredLogId();
+  const setHoveredLogId = useSetLogsHoveredLogId();
+  const logId = String(dataRow[OurLogKnownFieldKey.ID]);
+  const expandKey = expandKeyProp ?? logId;
+  const isPinned = isPinnedProp ?? false;
+  const isHoverLinked = hasPinning && hoveredLogId === logId;
 
   // This only applies in embedded views where clicking doesn't expand row details.
   function onClick(event: SyntheticEvent) {
@@ -206,9 +226,9 @@ export const LogRowContent = memo(function LogRowContent({
   function toggleExpanded() {
     if (onExpand) {
       if (isExpanded) {
-        onCollapse?.(String(dataRow[OurLogKnownFieldKey.ID]));
+        onCollapse?.(expandKey);
       } else {
-        onExpand?.(String(dataRow[OurLogKnownFieldKey.ID]));
+        onExpand?.(expandKey);
       }
     } else {
       setExpanded(e => !e);
@@ -226,12 +246,9 @@ export const LogRowContent = memo(function LogRowContent({
 
   useLayoutEffect(() => {
     if (measureRef.current && isExpanded) {
-      onExpandHeight?.(
-        String(dataRow[OurLogKnownFieldKey.ID]),
-        measureRef.current.clientHeight
-      );
+      onExpandHeight?.(expandKey, measureRef.current.clientHeight);
     }
-  }, [isExpanded, onExpandHeight, dataRow]);
+  }, [isExpanded, onExpandHeight, expandKey]);
 
   const addSearchFilter = useAddSearchFilter();
   const theme = useTheme();
@@ -327,12 +344,25 @@ export const LogRowContent = memo(function LogRowContent({
       <LogTableRow
         data-test-id="log-table-row"
         data-row-highlighted={isPseudoRow}
+        data-row-pinned={isPinned}
+        data-row-hover-linked={isHoverLinked}
         {...omit(rowInteractProps, 'className')}
         className={classNames(rowInteractProps.className, replayTimeClasses)}
         onMouseEnter={e => {
           setShouldRenderHoverElements(true);
+          if (hasPinning && isPinned) {
+            setHoveredLogId(logId);
+          }
           if (rowInteractProps.onMouseEnter) {
             rowInteractProps.onMouseEnter(e);
+          }
+        }}
+        onMouseLeave={e => {
+          if (hasPinning) {
+            setHoveredLogId(null);
+          }
+          if (rowInteractProps.onMouseLeave) {
+            rowInteractProps.onMouseLeave(e);
           }
         }}
       >
@@ -370,8 +400,9 @@ export const LogRowContent = memo(function LogRowContent({
             )}
           </LogFirstCellContent>
         </LogsTableBodyFirstCell>
-        {fields?.map(field => {
+        {fields?.map((field, fieldIndex) => {
           const value = (dataRow as OurLogsResponseItem)[field];
+          const isLastField = fieldIndex === (fields?.length ?? 0) - 1;
 
           if (!defined(value)) {
             return <LogTableBodyCell key={field} />;
@@ -405,42 +436,77 @@ export const LogRowContent = memo(function LogRowContent({
             field !== OurLogKnownFieldKey.TIMESTAMP &&
             shouldRenderHoverElements;
 
+          const showPinButton =
+            hasPinning &&
+            !embedded &&
+            !isPseudoRow &&
+            isLastField &&
+            (isPinned || shouldRenderHoverElements);
+
+          const hasExtraPadding = hasPinning && !embedded && !isPseudoRow && isLastField;
+
+          const pinButton = showPinButton ? (
+            <PinActionButton
+              icon={<IconPin isSolid={isPinned} size="xs" />}
+              aria-label={isPinned ? t('Unpin log row') : t('Pin log row')}
+              size="zero"
+              variant={isPinned ? 'primary' : undefined}
+              isPinned={isPinned}
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                onTogglePin?.(logId);
+              }}
+            />
+          ) : null;
+
+          const cellContent = shouldRenderActions ? (
+            <CellAction
+              column={discoverColumn}
+              dataRow={dataRow as unknown as TableDataRow}
+              handleCellAction={(actions, cellValue) => {
+                switch (actions) {
+                  case Actions.ADD:
+                    addSearchFilter({
+                      key: field,
+                      value: cellValue,
+                    });
+                    break;
+                  case Actions.EXCLUDE:
+                    addSearchFilter({
+                      key: field,
+                      value: cellValue,
+                      negated: true,
+                    });
+                    break;
+                  case Actions.COPY_TO_CLIPBOARD:
+                    copyToClipboard(cellValue);
+                    break;
+                  default:
+                    break;
+                }
+              }}
+              allowActions={ALLOWED_CELL_ACTIONS}
+              triggerType={ActionTriggerType.ELLIPSIS}
+            >
+              {renderedField}
+              {pinButton}
+            </CellAction>
+          ) : pinButton ? (
+            <CellContentWrapper>
+              {renderedField}
+              {pinButton}
+            </CellContentWrapper>
+          ) : (
+            renderedField
+          );
+
           return (
-            <LogTableBodyCell key={field} data-test-id={'log-table-cell-' + field}>
-              {shouldRenderActions ? (
-                <CellAction
-                  column={discoverColumn}
-                  dataRow={dataRow as unknown as TableDataRow}
-                  handleCellAction={(actions, cellValue) => {
-                    switch (actions) {
-                      case Actions.ADD:
-                        addSearchFilter({
-                          key: field,
-                          value: cellValue,
-                        });
-                        break;
-                      case Actions.EXCLUDE:
-                        addSearchFilter({
-                          key: field,
-                          value: cellValue,
-                          negated: true,
-                        });
-                        break;
-                      case Actions.COPY_TO_CLIPBOARD:
-                        copyToClipboard(cellValue);
-                        break;
-                      default:
-                        break;
-                    }
-                  }}
-                  allowActions={ALLOWED_CELL_ACTIONS}
-                  triggerType={ActionTriggerType.ELLIPSIS}
-                >
-                  {renderedField}
-                </CellAction>
-              ) : (
-                renderedField
-              )}
+            <LogTableBodyCell
+              key={field}
+              data-test-id={'log-table-cell-' + field}
+              data-has-pin-feature={hasExtraPadding ? '' : undefined}
+            >
+              {cellContent}
             </LogTableBodyCell>
           );
         })}

--- a/static/app/views/explore/logs/useLogsHoveredLogId.tsx
+++ b/static/app/views/explore/logs/useLogsHoveredLogId.tsx
@@ -1,0 +1,40 @@
+import type {ReactNode} from 'react';
+import {createContext, useCallback, useContext, useMemo, useState} from 'react';
+
+interface LogsHoveredLogIdContextValue {
+  hoveredLogId: string | null;
+  setHoveredLogId: (id: string | null) => void;
+}
+
+const LogsHoveredLogIdContext = createContext<LogsHoveredLogIdContextValue | null>(null);
+
+export function LogsHoveredLogIdProvider({children}: {children: ReactNode}) {
+  const [hoveredLogId, setHoveredLogIdState] = useState<string | null>(null);
+
+  const setHoveredLogId = useCallback((id: string | null) => {
+    setHoveredLogIdState(id);
+  }, []);
+
+  const value = useMemo(
+    () => ({hoveredLogId, setHoveredLogId}),
+    [hoveredLogId, setHoveredLogId]
+  );
+
+  return (
+    <LogsHoveredLogIdContext.Provider value={value}>
+      {children}
+    </LogsHoveredLogIdContext.Provider>
+  );
+}
+
+const noop = () => {};
+
+export function useLogsHoveredLogId(): string | null {
+  const ctx = useContext(LogsHoveredLogIdContext);
+  return ctx?.hoveredLogId ?? null;
+}
+
+export function useSetLogsHoveredLogId(): (id: string | null) => void {
+  const ctx = useContext(LogsHoveredLogIdContext);
+  return ctx?.setHoveredLogId ?? noop;
+}

--- a/static/app/views/explore/logs/useLogsPinnedRows.tsx
+++ b/static/app/views/explore/logs/useLogsPinnedRows.tsx
@@ -1,0 +1,93 @@
+import type {ReactNode} from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import {decodeList} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+
+const LOGS_PINNED_KEY = 'logsPinned';
+
+interface LogsPinnedRowsContextValue {
+  clearAllPins: () => void;
+  pinnedRows: Set<string>;
+  togglePinnedRow: (id: string) => void;
+}
+
+const LogsPinnedRowsContext = createContext<LogsPinnedRowsContextValue | null>(null);
+
+export function LogsPinnedRowsProvider({children}: {children: ReactNode}) {
+  const location = useLocation();
+
+  const [pinnedRows, setPinnedRows] = useState<Set<string>>(() => {
+    const pinned = decodeList(location.query?.[LOGS_PINNED_KEY]).filter(Boolean);
+    return new Set(pinned);
+  });
+
+  const togglePinnedRow = useCallback((id: string) => {
+    setPinnedRows(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const clearAllPins = useCallback(() => {
+    setPinnedRows(new Set());
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (pinnedRows.size === 0) {
+      params.delete(LOGS_PINNED_KEY);
+    } else {
+      params.delete(LOGS_PINNED_KEY);
+      for (const id of pinnedRows) {
+        params.append(LOGS_PINNED_KEY, id);
+      }
+    }
+    const newSearch = params.toString();
+    const newUrl = newSearch
+      ? `${window.location.pathname}?${newSearch}${window.location.hash}`
+      : `${window.location.pathname}${window.location.hash}`;
+    window.history.replaceState(window.history.state, '', newUrl);
+  }, [pinnedRows]);
+
+  const value = useMemo(
+    () => ({pinnedRows, togglePinnedRow, clearAllPins}),
+    [pinnedRows, togglePinnedRow, clearAllPins]
+  );
+
+  return (
+    <LogsPinnedRowsContext.Provider value={value}>
+      {children}
+    </LogsPinnedRowsContext.Provider>
+  );
+}
+
+const EMPTY_SET = new Set<string>();
+const noop = () => {};
+
+export function useLogsPinnedRows(): Set<string> {
+  const ctx = useContext(LogsPinnedRowsContext);
+  return ctx?.pinnedRows ?? EMPTY_SET;
+}
+
+export function useToggleLogPinnedRow(): (id: string) => void {
+  const ctx = useContext(LogsPinnedRowsContext);
+  return ctx?.togglePinnedRow ?? noop;
+}
+
+export function useClearAllLogPins(): () => void {
+  const ctx = useContext(LogsPinnedRowsContext);
+  return ctx?.clearAllPins ?? noop;
+}


### PR DESCRIPTION
[POC prototype from Design]

Add the ability to pin log rows in the logs explorer table. Pinned rows appear in a collapsible section at the top of the table while remaining visible in the chronological list. Hovering any copy highlights all instances via a shared hover context. Pins persist in the URL for shareability.

Key implementation details:
- New `organizations:ourlogs-pinning` feature flag
- Context-based state with URL sync via replaceState (avoids React Router re-renders)
- Pinned/chronological rows use independent expand keys so expanding one copy doesn't expand the other
- Pin button appears on row hover next to the existing ellipsis menu
- "Clear all" button and collapse/expand toggle in the pinned section divider