### PR TITLE
fix(aci): Revalidate medium threshold when high threshold changes

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metric.spec.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.spec.tsx
@@ -143,6 +143,36 @@ describe('NewMetricDetectorForm', () => {
     expect(within(preview).getByText('FB')).toBeInTheDocument();
   });
 
+  it('clears medium threshold error when high threshold is updated', async () => {
+    render(
+      <DetectorFormProvider detectorType="metric_issue">
+        <NewMetricDetectorForm />
+      </DetectorFormProvider>,
+      {organization}
+    );
+
+    const highThreshold = await screen.findByRole('spinbutton', {
+      name: 'High threshold',
+    });
+    const mediumThreshold = screen.getByRole('spinbutton', {
+      name: 'Medium threshold',
+    });
+
+    // Set medium higher than high (invalid for "above" condition)
+    await userEvent.type(highThreshold, '50');
+    await userEvent.type(mediumThreshold, '100');
+
+    expect(
+      screen.getByText('Medium threshold must be lower than high threshold (50)')
+    ).toBeInTheDocument();
+
+    // Update high threshold to be above medium — error should clear
+    await userEvent.clear(highThreshold);
+    await userEvent.type(highThreshold, '200');
+
+    expect(screen.queryByText(/Medium threshold must be/)).not.toBeInTheDocument();
+  });
+
   it('removes is filters when switching away from the errors dataset', async () => {
     render(
       <DetectorFormProvider detectorType="metric_issue">

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -225,6 +225,20 @@ function validateMediumThreshold({
   return [];
 }
 
+// The medium threshold's validation depends on the high threshold value, but the
+// form model only validates the field being edited. Without this, the medium
+// threshold's error tooltip persists after the high threshold is corrected.
+function useRevalidateMediumThreshold() {
+  const formContext = useContext(FormContext);
+  const highThreshold = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.highThreshold
+  );
+
+  useEffect(() => {
+    formContext.form?.validateField(METRIC_DETECTOR_FORM_FIELDS.mediumThreshold);
+  }, [highThreshold, formContext.form]);
+}
+
 interface PriorityRowProps {
   aggregate: string;
   detectionType: 'static' | 'percent';
@@ -496,6 +510,7 @@ function CustomizeMetricSection({step}: {step?: number}) {
 }
 
 function DetectSection({step}: {step?: number}) {
+  useRevalidateMediumThreshold();
   const detectionType = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.detectionType
   );


### PR DESCRIPTION
Closes ISWF-2516

The medium threshold validation depends on the high threshold value, but the form model only validates the field being edited. This caused the medium threshold error tooltip to persist after correcting the high threshold to a valid value. Adds a `useRevalidateMediumThreshold` hook that triggers revalidation of the medium threshold whenever the high threshold changes, and a test covering the fix.