### PR TITLE
perf(files): Add organization_id to artifact bundle lookup queries

### DIFF
--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -466,6 +466,7 @@ def get_artifact_bundles_containing_url(
                     dist_name=dist_name,
                 )
             ),
+            organization_id=project.organization.id,
         )
         .values_list("id", "date_added")
         .order_by("-date_last_modified", "-id")[:MAX_BUNDLES_QUERY]
@@ -482,6 +483,7 @@ def get_artifact_bundles_by_release(
     """
     return set(
         ArtifactBundle.objects.filter(
+            organization_id=project.organization.id,
             releaseartifactbundle__organization_id=project.organization.id,
             releaseartifactbundle__release_name=release_name,
             releaseartifactbundle__dist_name=dist_name,


### PR DESCRIPTION
Adds the redundant `organization_id` predicate to the outer `ArtifactBundle` query in `get_artifact_bundles_containing_url` and `get_artifact_bundles_by_release`. Without it Postgres has to scan the full table before evaluating the EXISTS subqueries. `organization_id` is already indexed (`db_index=True`) on `ArtifactBundle` so this should narrow the scan significantly.

[artifact-lookup transaction summary](https://sentry.sentry.io/insights/summary/?project=1&referrer=event-tags-table&statsPeriod=30d&transaction=%2Fapi%2F0%2Fprojects%2F%7Borganization_id_or_slug%7D%2F%7Bproject_id_or_slug%7D%2Fartifact-lookup%2F)

Before:
```sql
SELECT "sentry_artifactbundle"."id", "sentry_artifactbundle"."date_added"
FROM "sentry_artifactbundle"
WHERE (
  EXISTS(SELECT 1 FROM "sentry_artifactbundleindex" U0
    WHERE U0."artifact_bundle_id" = "sentry_artifactbundle"."id"
      AND U0."organization_id" = %s
      AND UPPER(U0."url"::text) LIKE UPPER(%s) LIMIT 1)
  AND EXISTS(SELECT 1 FROM "sentry_projectartifactbundle" U0
    WHERE U0."artifact_bundle_id" = "sentry_artifactbundle"."id"
      AND U0."project_id" = %s LIMIT 1)
  AND EXISTS(SELECT 1 FROM "sentry_releaseartifactbundle" U0
    WHERE U0."artifact_bundle_id" = "sentry_artifactbundle"."id"
      AND U0."dist_name" = %s
      AND U0."organization_id" = %s
      AND U0."release_name" = %s LIMIT 1)
)
ORDER BY "sentry_artifactbundle"."date_last_modified" DESC, 1 DESC
LIMIT 5
```

After:
```sql
SELECT "sentry_artifactbundle"."id", "sentry_artifactbundle"."date_added"
FROM "sentry_artifactbundle"
WHERE (
  EXISTS(SELECT 1 FROM "sentry_artifactbundleindex" U0
    WHERE U0."artifact_bundle_id" = "sentry_artifactbundle"."id"
      AND U0."organization_id" = %s
      AND UPPER(U0."url"::text) LIKE UPPER(%s) LIMIT 1)
  AND EXISTS(SELECT 1 FROM "sentry_projectartifactbundle" U0
    WHERE U0."artifact_bundle_id" = "sentry_artifactbundle"."id"
      AND U0."project_id" = %s LIMIT 1)
  AND EXISTS(SELECT 1 FROM "sentry_releaseartifactbundle" U0
    WHERE U0."artifact_bundle_id" = "sentry_artifactbundle"."id"
      AND U0."dist_name" = %s
      AND U0."organization_id" = %s
      AND U0."release_name" = %s LIMIT 1)
  AND "sentry_artifactbundle"."organization_id" = %s
)
ORDER BY "sentry_artifactbundle"."date_last_modified" DESC, 1 DESC
LIMIT 5
```