### PR TITLE
fix(explore): Fix flaky virtual streaming test assertions

### DIFF
--- a/static/app/views/explore/logs/useLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.spec.tsx
@@ -753,7 +753,9 @@ describe('Virtual Streaming Integration (Auto Refresh Behaviour)', () => {
 
     // With auto refresh enabled, virtual streaming should be active
     // All data should be visible initially since all the mocked timestamps are well behind `now()`
-    expect(result.current.data).toHaveLength(3);
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(3);
+    });
   });
 
   it('should not apply virtual streaming when auto refresh is disabled', async () => {
@@ -836,7 +838,9 @@ describe('Virtual Streaming Integration (Auto Refresh Behaviour)', () => {
       expect(result.current.isPending).toBe(false);
     });
 
-    expect(result.current.data).toHaveLength(3);
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(3);
+    });
     expect(initialMock).toHaveBeenCalled();
 
     // Fetch next page


### PR DESCRIPTION
Wrap bare `expect` assertions in `waitFor()` to fix flaky virtual streaming tests in `useLogsQuery.spec.tsx`.

`virtualStreamedTimestamp` is initialized inside a `useEffect`, so there is always a render where `isPending` is false but the virtual streaming filter is not yet active. During that gap all rows pass through unfiltered (4 instead of the expected 3). Wrapping the length assertions in `waitFor()` lets the test wait for the effect to run before checking the filtered result.

Affected tests: "should integrate with virtual streaming when auto refresh is enabled" and "should handle multiple pages with virtual streaming".

Made with [Cursor](https://cursor.com)