### PR TITLE
ref(dashboards): Remove DashboardLastVisited model

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -31,7 +31,7 @@ replays: 0007_organizationmember_replay_access
 
 seer: 0010_drop_legacy_columns
 
-sentry: 1082_drop_neglectedrule_table
+sentry: 1083_remove_dashboardlastvisited
 
 social_auth: 0003_social_auth_json_field
 

--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -856,9 +856,6 @@ def get_default_comparators() -> dict[str, list[JSONScrubbingComparator]]:
             "sentry.dashboardfavoriteuser": [
                 DateUpdatedComparator("date_added", "date_updated"),
             ],
-            "sentry.dashboardlastvisited": [
-                DateUpdatedComparator("last_visited", "date_added", "date_updated"),
-            ],
             "sentry.dashboardrevision": [
                 DateUpdatedComparator("date_added", "date_updated"),
             ],

--- a/src/sentry/migrations/1083_remove_dashboardlastvisited.py
+++ b/src/sentry/migrations/1083_remove_dashboardlastvisited.py
@@ -1,0 +1,40 @@
+import django.db.models.deletion
+import sentry.db.models.fields.foreignkey
+from django.db import migrations
+
+from sentry.new_migrations.migrations import CheckedMigration
+from sentry.new_migrations.monkey.models import SafeDeleteModel
+from sentry.new_migrations.monkey.state import DeletionAction
+
+
+class Migration(CheckedMigration):
+    is_post_deployment = False
+
+    dependencies = [
+        ("sentry", "1082_drop_neglectedrule_table"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="dashboardlastvisited",
+            name="dashboard",
+            field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
+                db_constraint=False,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="sentry.dashboard",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="dashboardlastvisited",
+            name="member",
+            field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
+                db_constraint=False,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="sentry.organizationmember",
+            ),
+        ),
+        SafeDeleteModel(
+            name="DashboardLastVisited",
+            deletion_action=DeletionAction.MOVE_TO_PENDING,
+        ),
+    ]

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -435,23 +435,3 @@ class DashboardRevision(DefaultFieldsModel):
         if old_revision_ids:
             cls.objects.filter(id__in=old_revision_ids).delete()
         return revision
-
-
-@cell_silo_model
-class DashboardLastVisited(DefaultFieldsModel):
-    __relocation_scope__ = RelocationScope.Organization
-
-    dashboard = FlexibleForeignKey("sentry.Dashboard", on_delete=models.CASCADE)
-    member = FlexibleForeignKey("sentry.OrganizationMember", on_delete=models.CASCADE)
-
-    last_visited = models.DateTimeField(null=False, default=timezone.now)
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_dashboardlastvisited"
-        constraints = [
-            UniqueConstraint(
-                fields=["member_id", "dashboard_id"],
-                name="sentry_dashboardlastvisited_unique_last_visited_per_org_member",
-            )
-        ]

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -66,7 +66,6 @@ from sentry.models.counter import Counter
 from sentry.models.dashboard import (
     Dashboard,
     DashboardFavoriteUser,
-    DashboardLastVisited,
     DashboardRevision,
 )
 from sentry.models.dashboard_permissions import DashboardPermissions
@@ -564,11 +563,6 @@ class ExhaustiveFixtures(Fixtures):
             dashboard=dashboard,
             user_id=owner_id,
             organization=org,
-        )
-        DashboardLastVisited.objects.create(
-            dashboard=dashboard,
-            member=invited,
-            last_visited=timezone.now(),
         )
         permissions = DashboardPermissions.objects.create(
             is_editable_by_everyone=True, dashboard=dashboard


### PR DESCRIPTION
The DashboardLastVisited model was added to back per-user "recently viewed" sorting and per-user last_visited reads gated on organizations:dashboards-starred-reordering. That flag was removed (#114817), the writes were removed in the same PR's follow-up, so the model has no remaining readers or writers in product code.

This PR removes the model class, all code references (testutils backups, backup comparators), and adds a MOVE_TO_PENDING migration that drops the FK constraints and removes the model from Django's migration state. The table is preserved for rolling deploy safety; a follow-up PR drops it.

<!-- Describe your PR here. -->