### PR TITLE
ref(dashboards): Drop DashboardLastVisited table

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -31,7 +31,7 @@ replays: 0007_organizationmember_replay_access
 
 seer: 0010_drop_legacy_columns
 
-sentry: 1083_remove_dashboardlastvisited
+sentry: 1084_delete_dashboardlastvisited
 
 social_auth: 0003_social_auth_json_field
 

--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -78,6 +78,7 @@ class SiloRouter:
         "sentry_code_review_event": SiloMode.CELL,
         "sentry_customdynamicsamplingrule": SiloMode.CELL,
         "sentry_customdynamicsamplingruleproject": SiloMode.CELL,
+        "sentry_dashboardlastvisited": SiloMode.CELL,
         "sentry_dashboardtombstone": SiloMode.CELL,
         "sentry_dashboardwidgetsnapshot": SiloMode.CELL,
         "sentry_datasecrecywaiver": SiloMode.CELL,

--- a/src/sentry/migrations/1084_delete_dashboardlastvisited.py
+++ b/src/sentry/migrations/1084_delete_dashboardlastvisited.py
@@ -1,0 +1,18 @@
+from sentry.new_migrations.migrations import CheckedMigration
+from sentry.new_migrations.monkey.models import SafeDeleteModel
+from sentry.new_migrations.monkey.state import DeletionAction
+
+
+class Migration(CheckedMigration):
+    is_post_deployment = False
+
+    dependencies = [
+        ("sentry", "1083_remove_dashboardlastvisited"),
+    ]
+
+    operations = [
+        SafeDeleteModel(
+            name="DashboardLastVisited",
+            deletion_action=DeletionAction.DELETE,
+        ),
+    ]


### PR DESCRIPTION
Drop the sentry_dashboardlastvisited table from PostgreSQL via
SafeDeleteModel(DELETE).

Do not merge until #(prev PR) has been deployed and verified — the
prior PR removes Django's knowledge of the model and drops FK
constraints, but leaves the table in place for rolling deploy safety.

PR Stack:
1. Remove model + MOVE_TO_PENDING migration
2. **this PR** — DELETE migration to drop the table