### PR TITLE
ref(flags): Move 2 should-be-permanent flags to permanent.py 

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -141,6 +141,14 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:workflow-engine-log-evaluations": False,
     }
 
+    # Flagpole cannot control system-scoped flags — keep these as INTERNAL.
+    permanent_system_features = {
+        # Enables user registration.
+        "auth:register": True,
+        # Enable support for multiple regions, and org slug subdomains (customer-domains).
+        "system:multi-region": False,
+    }
+
     for org_feature, default in permanent_organization_features.items():
         manager.add(
             org_feature,
@@ -168,19 +176,10 @@ def register_permanent_features(manager: FeatureManager) -> None:
             api_expose=False,
         )
 
-    # Enable support for multiple regions, and org slug subdomains (customer-domains).
-    manager.add(
-        "system:multi-region",
-        SystemFeature,
-        FeatureHandlerStrategy.INTERNAL,
-        default=False,
-        api_expose=False,
-    )
-
-    # Enables user registration.
-    manager.add(
-        "auth:register",
-        SystemFeature,
-        FeatureHandlerStrategy.INTERNAL,
-        default=True,
-    )
+    for system_feature, default in permanent_system_features.items():
+        manager.add(
+            system_feature,
+            SystemFeature,
+            FeatureHandlerStrategy.INTERNAL,
+            default=default,
+        )

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -120,6 +120,8 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:integrations-scm-multi-org": True,
         # Enable issue view endpoints and UI
         "organizations:issue-views": False,
+        # Display profile durations on the stats page
+        "organizations:continuous-profiling-stats": False,
     }
 
     permanent_project_features = {
@@ -173,4 +175,12 @@ def register_permanent_features(manager: FeatureManager) -> None:
         FeatureHandlerStrategy.INTERNAL,
         default=False,
         api_expose=False,
+    )
+
+    # Enables user registration.
+    manager.add(
+        "auth:register",
+        SystemFeature,
+        FeatureHandlerStrategy.INTERNAL,
+        default=True,
     )

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -36,8 +36,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # You won't be able to control system feature flags with flagpole, as flagpole only handles
     # organization or project scoped features. You would need to use an option instead.
 
-    # Enables user registration.
-    manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL, default=True)
     # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION is not enabled).
     manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL, default=True)
     # Controls whether or not the relocation endpoints can be used.
@@ -64,8 +62,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:code-review-experiments-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable continuous profiling
     manager.add("organizations:continuous-profiling", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Display profile durations on the stats page
-    manager.add("organizations:continuous-profiling-stats", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable the ingestion of profile functions metrics into EAP
     manager.add("projects:profile-functions-metrics-eap-ingestion", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables read only dashboards


### PR DESCRIPTION
Per the flag scanner, these flags use the INTERNAL strategy with no
flagpole config and are subscription-managed (granted via plan
handlers / feature lists), so they belong in permanent.py rather than
temporary.py. Pure registration move — no behavior change.

- auth:register
- organizations:continuous-profiling-stats