### PR TITLE
ref(flags): Remove organizations:app-store-connect-multiple

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -24,8 +24,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:advanced-search": True,
         # Enable anomaly detection alerts
         "organizations:anomaly-detection-alerts": False,
-        # Enable multiple Apple app-store-connect sources per project.
-        "organizations:app-store-connect-multiple": False,
         # Enable change alerts for an org
         "organizations:change-alerts": True,
         # The overall flag for codecov integration, gated by plans.

--- a/tests/js/getsentry-test/fixtures/am1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am1Plans.ts
@@ -84,7 +84,6 @@ const AM1_TEAM_FEATURES = [
 const AM1_BUSINESS_FEATURES = [
   ...AM1_TEAM_FEATURES,
   'anomaly-detection-alerts',
-  'app-store-connect-multiple',
   'baa',
   'change-alerts',
   'custom-inbound-filters',

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -94,7 +94,6 @@ const AM2_TEAM_FEATURES = [
 const AM2_BUSINESS_FEATURES = [
   ...AM2_TEAM_FEATURES,
   'anomaly-detection-alerts',
-  'app-store-connect-multiple',
   'baa',
   'change-alerts',
   'custom-inbound-filters',

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -114,7 +114,6 @@ const AM3_TEAM_FEATURES = [
 const AM3_BUSINESS_FEATURES = [
   ...AM3_TEAM_FEATURES,
   'anomaly-detection-alerts',
-  'app-store-connect-multiple',
   'baa',
   'change-alerts',
   'custom-inbound-filters',

--- a/tests/js/getsentry-test/fixtures/featureList.ts
+++ b/tests/js/getsentry-test/fixtures/featureList.ts
@@ -92,9 +92,5 @@ export function FeatureListFixture(): Record<string, Feature> {
       description:
         'Configure custom Symbol Servers, Amazon S3 buckets, or GCS buckets for debug files.',
     },
-    'app-store-connect-multiple': {
-      name: 'Multiple App Store Connect apps',
-      description: 'Add multiple Apple App Store Connect apps per project',
-    },
   };
 }


### PR DESCRIPTION
The flag scanner classified this as plan-bound-only — the flag is in plan feature lists but no code calls features.has() for it. Removes the registration and the test fixture entries. The companion plan-list removals in getsentry ship in a separate PR.

<!-- Describe your PR here. -->