### PR TITLE
feat(iswf): Removes retry decorator from workflow_engine tasks

### DIFF
--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -2,6 +2,7 @@ from dataclasses import asdict
 
 from django.db.models import Value
 from taskbroker_client.retry import Retry
+from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry.eventstream.base import GroupState
 from sentry.models.activity import Activity
@@ -9,7 +10,7 @@ from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.services.eventstore.models import GroupEvent
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker import namespaces
 from sentry.utils import metrics
 from sentry.utils.exceptions import timeout_grouping_context
@@ -74,14 +75,24 @@ def build_trigger_action_task_params(
     name="sentry.workflow_engine.tasks.trigger_action",
     namespace=namespaces.workflow_engine_tasks,
     processing_deadline_duration=30,
-    retry=Retry(times=3, delay=5),
+    retry=Retry(
+        times=3,
+        delay=5,
+        on=(Exception, ProcessingDeadlineExceeded),
+        ignore=(
+            Action.DoesNotExist,
+            Group.DoesNotExist,
+            Project.DoesNotExist,
+            ProjectNotActiveError,
+            Workflow.DoesNotExist,
+        ),
+    ),
     silo_mode=SiloMode.CELL,
-)
-@retry(
-    timeouts=True,
-    raise_on_no_retries=False,
-    ignore_and_capture=(Action.DoesNotExist, Group.DoesNotExist),
-    ignore=(Project.DoesNotExist, ProjectNotActiveError, Workflow.DoesNotExist),
+    silenced_exceptions=(
+        Project.DoesNotExist,
+        ProjectNotActiveError,
+        Workflow.DoesNotExist,
+    ),
 )
 def trigger_action(
     action_id: int,

--- a/src/sentry/workflow_engine/tasks/delayed_workflows.py
+++ b/src/sentry/workflow_engine/tasks/delayed_workflows.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from taskbroker_client.retry import Retry
+from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import workflow_engine_tasks
 from sentry.utils.exceptions import quiet_redis_noise
 from sentry.workflow_engine.utils import log_context
@@ -17,10 +18,9 @@ logger = log_context.get_logger("sentry.workflow_engine.tasks.delayed_workflows"
     name="sentry.workflow_engine.tasks.delayed_workflows",
     namespace=workflow_engine_tasks,
     processing_deadline_duration=60,
-    retry=Retry(times=5, delay=5),
+    retry=Retry(times=5, delay=5, on=(ProcessingDeadlineExceeded,)),
     silo_mode=SiloMode.CELL,
 )
-@retry(timeouts=True)
 @log_context.root()
 def process_delayed_workflows(
     project_id: int, batch_key: str | None = None, *args: Any, **kwargs: Any

--- a/src/sentry/workflow_engine/tasks/delayed_workflows.py
+++ b/src/sentry/workflow_engine/tasks/delayed_workflows.py
@@ -18,7 +18,14 @@ logger = log_context.get_logger("sentry.workflow_engine.tasks.delayed_workflows"
     name="sentry.workflow_engine.tasks.delayed_workflows",
     namespace=workflow_engine_tasks,
     processing_deadline_duration=60,
-    retry=Retry(times=5, delay=5, on=(ProcessingDeadlineExceeded,)),
+    retry=Retry(
+        times=5,
+        delay=5,
+        on=(
+            Exception,
+            ProcessingDeadlineExceeded,
+        ),
+    ),
     silo_mode=SiloMode.CELL,
 )
 @log_context.root()

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -6,6 +6,7 @@ from typing import Any
 from django.db import router, transaction
 from google.api_core.exceptions import RetryError
 from taskbroker_client.retry import Retry, retry_task
+from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry.eventstream.base import GroupState
 from sentry.locks import locks
@@ -15,7 +16,7 @@ from sentry.models.project import Project
 from sentry.sentry_apps.tasks.service_hooks import kick_off_service_hooks
 from sentry.services.eventstore.models import GroupEvent
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker import namespaces
 from sentry.utils import metrics
 from sentry.utils.exceptions import quiet_redis_noise
@@ -37,10 +38,9 @@ logger = log_context.get_logger(__name__)
     name="sentry.workflow_engine.tasks.process_workflow_activity",
     namespace=namespaces.workflow_engine_tasks,
     processing_deadline_duration=60,
-    retry=Retry(times=3, delay=5),
+    retry=Retry(times=3, delay=5, on=(Exception,)),
     silo_mode=SiloMode.CELL,
 )
-@retry
 def process_workflow_activity(activity_id: int, group_id: int, detector_id: int) -> None:
     """
     Process a workflow task identified by the given activity, group, and detector.
@@ -89,14 +89,25 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
     name="sentry.workflow_engine.tasks.process_workflows_event",
     namespace=namespaces.workflow_engine_tasks,
     processing_deadline_duration=60,
-    retry=Retry(times=3, delay=5),
+    retry=Retry(
+        times=3,
+        delay=5,
+        on=(Exception, ProcessingDeadlineExceeded),
+        ignore=(
+            EventNotFoundError,
+            Group.DoesNotExist,
+            Project.DoesNotExist,
+            ProjectNotActiveError,
+        ),
+    ),
     silo_mode=SiloMode.CELL,
-)
-@retry(
-    timeouts=True,
-    exclude=EventNotFoundError,
-    ignore=(Group.DoesNotExist, Project.DoesNotExist, ProjectNotActiveError),
-    on_silent=DataConditionGroup.DoesNotExist,
+    silenced_exceptions=(
+        EventNotFoundError,
+        DataConditionGroup.DoesNotExist,
+        Group.DoesNotExist,
+        Project.DoesNotExist,
+        ProjectNotActiveError,
+    ),
 )
 def process_workflows_event(
     event_id: str,


### PR DESCRIPTION
Removes usages of the `@retry` decorator from workflow engine tasks, translating them into their taskbroker equivalent.


Relies on #114936 to be merged first.