### PR TITLE
ref(issues): Drop redundant list comprehension in handle_ignored

### DIFF
--- a/src/sentry/issues/ignored.py
+++ b/src/sentry/issues/ignored.py
@@ -154,6 +154,6 @@ def handle_ignored(
                 actor=serialized_user[0] if serialized_user else None,
             )
     else:
-        GroupSnooze.objects.filter(group__in=[group.id for group in group_list]).delete()
+        GroupSnooze.objects.filter(group__in=group_list).delete()
 
     return new_status_details


### PR DESCRIPTION
Django's ORM extracts the primary key automatically when model instances are passed to an `__in` lookup, so the explicit `[group.id for group in group_list]` is unnecessary work.