### PR TITLE
fix(integrations): allow blank overview on sentry app form

### DIFF
--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -124,7 +124,10 @@ class SentryAppParser(Serializer):
         help_text="Marks whether or not the custom integration can be used in an alert rule.",
     )
     overview = serializers.CharField(
-        required=False, allow_null=True, help_text="The custom integration's description."
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="The custom integration's description.",
     )
     verifyInstall = serializers.BooleanField(
         required=False,


### PR DESCRIPTION
Fixes the issue below that occurs when clearing the field and attempting to save. Since the field is optional, saving without a value should be allowed.

https://github.com/user-attachments/assets/9bbfc9d6-1e82-42c5-a82c-b68c2f6aea97


Note: this form is not yet migrated to the tanstack form


