### PR TITLE
chore(dynamic-sampling): add status to duration metrics in per-org pipeline

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/tasks/configuration.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/configuration.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from sentry import options, quotas
 from sentry.constants import SAMPLING_MODE_DEFAULT, TARGET_SAMPLE_RATE_DEFAULT, ObjectStatus
 from sentry.dynamic_sampling.per_org.tasks.telemetry import (
-    DynamicSamplingTaskStatus,
+    DynamicSamplingException,
     TelemetryStatus,
 )
 from sentry.dynamic_sampling.rules.utils import ProjectId
@@ -90,7 +90,7 @@ class AutomaticDynamicSamplingConfiguration(BaseDynamicSamplingConfiguration):
                 organization_id=organization.id
             )
         except ObjectDoesNotExist as exc:
-            raise DynamicSamplingTaskStatus(TelemetryStatus.NO_SUBSCRIPTION) from exc
+            raise DynamicSamplingException(TelemetryStatus.NO_SUBSCRIPTION) from exc
 
     @property
     def is_enabled(self) -> bool:

--- a/src/sentry/dynamic_sampling/per_org/tasks/configuration.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/configuration.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 
+from django.core.exceptions import ObjectDoesNotExist
+
 from sentry import options, quotas
 from sentry.constants import SAMPLING_MODE_DEFAULT, TARGET_SAMPLE_RATE_DEFAULT, ObjectStatus
+from sentry.dynamic_sampling.per_org.tasks.telemetry import (
+    DynamicSamplingTaskStatus,
+    TelemetryStatus,
+)
 from sentry.dynamic_sampling.rules.utils import ProjectId
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
 from sentry.dynamic_sampling.utils import has_custom_dynamic_sampling
@@ -79,7 +85,12 @@ class AutomaticDynamicSamplingConfiguration(BaseDynamicSamplingConfiguration):
     def __init__(self, organization: Organization) -> None:
         super().__init__(organization)
         self.measure = self._get_sampling_measure()
-        self.sample_rate = quotas.backend.get_blended_sample_rate(organization_id=organization.id)
+        try:
+            self.sample_rate = quotas.backend.get_blended_sample_rate(
+                organization_id=organization.id
+            )
+        except ObjectDoesNotExist as exc:
+            raise DynamicSamplingTaskStatus(TelemetryStatus.NO_SUBSCRIPTION) from exc
 
     @property
     def is_enabled(self) -> bool:

--- a/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
@@ -40,7 +40,9 @@ class TelemetryStatus(StrEnum):
     ROLLOUT_EXCLUDED = "rollout_excluded"
 
 
-class DynamicSamplingTaskStatus(Exception):
+class DynamicSamplingException(Exception):
+    """This exception allows a task to bubble up the status to the caller, for the task decorator to emit a metric with a status that derives from the status recorded in the exception."""
+
     def __init__(self, status: TelemetryStatus) -> None:
         super().__init__(status.value)
         self.status = status
@@ -108,7 +110,7 @@ def track_dynamic_sampling(func: F) -> F:
                     result = TelemetryStatus.ROLLOUT_DISABLED
                 else:
                     result = func(*args, **kwargs)
-            except DynamicSamplingTaskStatus as exc:
+            except DynamicSamplingException as exc:
                 result = exc.status
             except Exception as exc:
                 sentry_sdk.capture_exception(exc)

--- a/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Generator, Mapping
+from contextlib import contextmanager
 from enum import StrEnum
 from typing import TypeVar
 
@@ -30,12 +31,19 @@ class TelemetryStatus(StrEnum):
     DISPATCHED = "dispatched"
     FAILED = "failed"
     KILLSWITCHED = "killswitched"
+    NO_SUBSCRIPTION = "no_subscription"
     NO_VOLUME = "no_volume"
     NOT_IN_ROLLOUT = "not_in_rollout"
     ORG_HAS_NO_DYNAMIC_SAMPLING = "org_has_no_dynamic_sampling"
     ORG_NOT_FOUND = "org_not_found"
     ROLLOUT_DISABLED = "rollout_disabled"
     ROLLOUT_EXCLUDED = "rollout_excluded"
+
+
+class DynamicSamplingTaskStatus(Exception):
+    def __init__(self, status: TelemetryStatus) -> None:
+        super().__init__(status.value)
+        self.status = status
 
 
 def emit_status(
@@ -62,6 +70,28 @@ def emit_gauge(metric: str, value: float, *, tags: Mapping[str, str] | None = No
     )
 
 
+def _get_status_from_result(result: object) -> TelemetryStatus:
+    if isinstance(result, TelemetryStatus):
+        return result
+    return TelemetryStatus.COMPLETED
+
+
+@contextmanager
+def emit_duration(metric: str) -> Generator[Callable[[object], TelemetryStatus]]:
+    with metrics.timer(metric, sample_rate=metrics_sample_rate()) as duration_tags:
+        try:
+
+            def set_status_from_result(result: object) -> TelemetryStatus:
+                status = _get_status_from_result(result)
+                duration_tags["status"] = status.value
+                return status
+
+            yield set_status_from_result
+        except Exception:
+            duration_tags["status"] = TelemetryStatus.FAILED.value
+            raise
+
+
 def track_dynamic_sampling(func: F) -> F:
     status_metric = f"{METRIC_PREFIX}.{func.__name__}.status"
     duration_metric = f"{METRIC_PREFIX}.{func.__name__}.duration"
@@ -69,7 +99,8 @@ def track_dynamic_sampling(func: F) -> F:
     @functools.wraps(func)
     def wrapper(*args: object, **kwargs: object) -> object:
         result: object
-        with metrics.timer(duration_metric, sample_rate=metrics_sample_rate()):
+        status: TelemetryStatus
+        with emit_duration(duration_metric) as set_duration_status:
             try:
                 if is_killswitch_engaged():
                     result = TelemetryStatus.KILLSWITCHED
@@ -77,16 +108,16 @@ def track_dynamic_sampling(func: F) -> F:
                     result = TelemetryStatus.ROLLOUT_DISABLED
                 else:
                     result = func(*args, **kwargs)
+            except DynamicSamplingTaskStatus as exc:
+                result = exc.status
             except Exception as exc:
                 sentry_sdk.capture_exception(exc)
                 emit_status(status_metric, TelemetryStatus.FAILED)
                 raise
 
-        if isinstance(result, TelemetryStatus):
-            emit_status(status_metric, result)
-            return result
+            status = set_duration_status(result)
 
-        emit_status(status_metric, TelemetryStatus.COMPLETED)
+        emit_status(status_metric, status)
         return result
 
     return wrapper  # type: ignore[return-value]

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_configuration.py
@@ -15,7 +15,7 @@ from sentry.dynamic_sampling.per_org.tasks.configuration import (
     get_configuration,
 )
 from sentry.dynamic_sampling.per_org.tasks.telemetry import (
-    DynamicSamplingTaskStatus,
+    DynamicSamplingException,
     TelemetryStatus,
 )
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
@@ -91,7 +91,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                 "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
                 side_effect=ObjectDoesNotExist,
             ),
-            pytest.raises(DynamicSamplingTaskStatus) as exc_info,
+            pytest.raises(DynamicSamplingException) as exc_info,
         ):
             get_configuration(org.id)
 

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_configuration.py
@@ -5,6 +5,7 @@ from typing import NamedTuple
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ObjectDoesNotExist
 
 from sentry.dynamic_sampling.per_org.tasks.configuration import (
     AutomaticDynamicSamplingConfiguration,
@@ -12,6 +13,10 @@ from sentry.dynamic_sampling.per_org.tasks.configuration import (
     CustomDynamicSamplingProjectConfiguration,
     NoDynamicSamplingConfiguration,
     get_configuration,
+)
+from sentry.dynamic_sampling.per_org.tasks.telemetry import (
+    DynamicSamplingTaskStatus,
+    TelemetryStatus,
 )
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
 from sentry.models.organization import Organization
@@ -77,6 +82,20 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
             getattr(configuration, "measure")
         with pytest.raises(AttributeError):
             getattr(configuration, "sample_rate")
+
+    def test_subscription_backed_org_without_subscription_bubbles_terminal_status(self) -> None:
+        org = self.create_organization()
+
+        with (
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
+                side_effect=ObjectDoesNotExist,
+            ),
+            pytest.raises(DynamicSamplingTaskStatus) as exc_info,
+        ):
+            get_configuration(org.id)
+
+        assert exc_info.value.status == TelemetryStatus.NO_SUBSCRIPTION
 
     def test_am2_ignores_project_mode_option(self) -> None:
         org = self.create_organization()

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_scheduler.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from django.core.exceptions import ObjectDoesNotExist
+
 from sentry.dynamic_sampling.per_org.tasks.configuration import BaseDynamicSamplingConfiguration
 from sentry.dynamic_sampling.per_org.tasks.scheduler import (
     BUCKET_COUNT,
@@ -176,6 +178,24 @@ class SchedulePerOrgCalculationsTest(TestCase):
             result = run_calculations_per_org_task(org.id)
 
         assert result == TelemetryStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
+        get_volume.assert_not_called()
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_run_calculations_per_org_skips_org_without_subscription(self) -> None:
+        org = self.create_organization()
+
+        with (
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
+                side_effect=ObjectDoesNotExist,
+            ),
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.scheduler.get_eap_organization_volume"
+            ) as get_volume,
+        ):
+            result = run_calculations_per_org_task(org.id)
+
+        assert result == TelemetryStatus.NO_SUBSCRIPTION
         get_volume.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_telemetry.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_telemetry.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from sentry.dynamic_sampling.per_org.tasks.telemetry import (
-    DynamicSamplingTaskStatus,
+    DynamicSamplingException,
     TelemetryStatus,
     track_dynamic_sampling,
 )
@@ -94,7 +94,7 @@ def test_emits_returned_terminal_status_without_completed_status() -> None:
 def test_emits_terminal_status_exception_without_failed_status() -> None:
     @track_dynamic_sampling
     def skipped() -> None:
-        raise DynamicSamplingTaskStatus(TelemetryStatus.NO_SUBSCRIPTION)
+        raise DynamicSamplingException(TelemetryStatus.NO_SUBSCRIPTION)
 
     timer, timer_tags = _capture_timer_tags()
     with (

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_telemetry.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_telemetry.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
 
 from sentry.dynamic_sampling.per_org.tasks.telemetry import (
+    DynamicSamplingTaskStatus,
     TelemetryStatus,
     track_dynamic_sampling,
 )
@@ -17,14 +19,31 @@ _GATE_OPTIONS = {
 }
 
 
+def _capture_timer_tags() -> tuple[object, dict[str, str]]:
+    tags: dict[str, str] = {}
+
+    @contextmanager
+    def timer(*args: object, **kwargs: object):
+        yield tags
+
+    return timer, tags
+
+
 @override_options(_GATE_OPTIONS)
 def test_records_duration_and_reraises_with_failed_status_on_exception() -> None:
     @track_dynamic_sampling
     def boom() -> None:
         raise ValueError("nope")
 
-    with pytest.raises(ValueError):
+    timer, timer_tags = _capture_timer_tags()
+
+    with (
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer),
+        pytest.raises(ValueError),
+    ):
         boom()
+
+    assert timer_tags["status"] == TelemetryStatus.FAILED.value
 
 
 @override_options(_GATE_OPTIONS)
@@ -33,14 +52,18 @@ def test_passes_result_through_and_emits_completed_on_success() -> None:
     def add(x: int, y: int) -> int:
         return x + y
 
+    timer, timer_tags = _capture_timer_tags()
     with (
-        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer") as timer,
+        patch(
+            "sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer
+        ) as timer_mock,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
     ):
         assert add(2, 3) == 5
 
-    timer.assert_called_once_with("dynamic_sampling.add.duration", sample_rate=1.0)
+    timer_mock.assert_called_once_with("dynamic_sampling.add.duration", sample_rate=1.0)
+    assert timer_tags["status"] == TelemetryStatus.COMPLETED.value
     emit.assert_called_once_with("dynamic_sampling.add.status", TelemetryStatus.COMPLETED)
     sdk.capture_exception.assert_not_called()
 
@@ -51,13 +74,39 @@ def test_emits_returned_terminal_status_without_completed_status() -> None:
     def skipped() -> TelemetryStatus:
         return TelemetryStatus.NOT_IN_ROLLOUT
 
+    timer, timer_tags = _capture_timer_tags()
     with (
-        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer") as timer,
+        patch(
+            "sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer
+        ) as timer_mock,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
     ):
         assert skipped() == TelemetryStatus.NOT_IN_ROLLOUT
 
-    timer.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
+    timer_mock.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
+    assert timer_tags["status"] == TelemetryStatus.NOT_IN_ROLLOUT.value
     emit.assert_called_once_with("dynamic_sampling.skipped.status", TelemetryStatus.NOT_IN_ROLLOUT)
+    sdk.capture_exception.assert_not_called()
+
+
+@override_options(_GATE_OPTIONS)
+def test_emits_terminal_status_exception_without_failed_status() -> None:
+    @track_dynamic_sampling
+    def skipped() -> None:
+        raise DynamicSamplingTaskStatus(TelemetryStatus.NO_SUBSCRIPTION)
+
+    timer, timer_tags = _capture_timer_tags()
+    with (
+        patch(
+            "sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer
+        ) as timer_mock,
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
+    ):
+        assert skipped() == TelemetryStatus.NO_SUBSCRIPTION
+
+    timer_mock.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
+    assert timer_tags["status"] == TelemetryStatus.NO_SUBSCRIPTION.value
+    emit.assert_called_once_with("dynamic_sampling.skipped.status", TelemetryStatus.NO_SUBSCRIPTION)
     sdk.capture_exception.assert_not_called()


### PR DESCRIPTION
- Add a status to the duration metric for the new pipeline, so that we can check durations depending on the status of the task. Otherwise, the short duration of no-op tasks will drown out any change in the tasks that do run, making this not observable. 
- Add a new exception type to support this, which takes the custom status as a parameter will then be specifically caught in the task decorator, and attaching it as status to the metrics. 