### PR TITLE
fix(span-buffer): Fix flusher processes leaking on timeout

### DIFF
--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -1,6 +1,7 @@
 import logging
 import multiprocessing
 import multiprocessing.context
+import multiprocessing.process
 import threading
 import time
 from collections.abc import Callable, Mapping
@@ -517,15 +518,12 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
 
         self.next_step.join(timeout)
 
-        # Wait for all processes to finish
+        # Wait for all processes to finish, then kill them
         for process_index, process in self.processes.items():
-            if deadline is not None:
-                remaining_time = deadline - time.time()
-                if remaining_time <= 0:
-                    break
-
             while process.is_alive() and (deadline is None or deadline > time.time()):
                 time.sleep(0.1)
 
-            if isinstance(process, multiprocessing.Process):
-                process.terminate()
+            if isinstance(process, multiprocessing.process.BaseProcess):
+                if process.is_alive():
+                    metrics.incr("spans.buffer.flusher.killed_live_process")
+                process.kill()

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -19,6 +19,16 @@ def _payload(span_id: str) -> bytes:
     return orjson.dumps({"span_id": span_id})
 
 
+def _blocking_main_for_join_test(
+    buffer, shards, stopped, current_drift, backpressure_since, healthy_since, produce_to_pipe
+):
+    """Module-level function for multiprocessing (must be picklable)."""
+    healthy_since.value = int(time.time())
+    # Block ignoring stopped to simulate stuck I/O (e.g., blocked on Kafka produce)
+    while True:
+        sleep(0.1)
+
+
 @override_options({**DEFAULT_OPTIONS, "spans.buffer.max-flush-segments": 1})
 def test_backpressure() -> None:
     # Flush very aggressively to make join() faster
@@ -216,3 +226,68 @@ def test_flusher_timeout_waiting_for_processes_startup() -> None:
             next_step=Noop(),
             produce_to_pipe=lambda project_id, payload, dropped: None,
         )
+
+
+def test_flusher_join_timeout_kills_all_processes() -> None:
+    """Test that all flusher processes are killed even if join times out.
+
+    Reproduces a bug where hitting the join timeout would break out of the loop
+    early, without calling kill() on remaining processes.
+    """
+    import multiprocessing
+    import multiprocessing.process
+
+    buffer = SpansBuffer(assigned_shards=[0, 1, 2])
+
+    # Track which process indices had kill() called
+    kill_called_for: set[int] = set()
+    flusher = None  # Will be set below, needed for patched_kill closure
+
+    # Patch BaseProcess.kill to track calls (SpawnProcess inherits from this)
+    original_kill = multiprocessing.process.BaseProcess.kill
+
+    def patched_kill(self):
+        # Find which process_index this is
+        if flusher is not None:
+            for idx, proc in flusher.processes.items():
+                if proc is self:
+                    kill_called_for.add(idx)
+                    break
+        return original_kill(self)
+
+    with (
+        mock.patch.object(SpanFlusher, "main", _blocking_main_for_join_test),
+        mock.patch.object(multiprocessing.process.BaseProcess, "kill", patched_kill),
+        override_options(
+            {
+                "spans.buffer.flusher.max-unhealthy-seconds": 10,
+                "spans.buffer.flusher.use-stuck-detector": False,
+            }
+        ),
+    ):
+        # Don't use produce_to_pipe so we get real multiprocessing.Process instances
+        flusher = SpanFlusher(
+            buffer,
+            next_step=Noop(),
+            max_processes=3,
+        )
+
+        try:
+            assert len(flusher.processes) == 3
+            for process in flusher.processes.values():
+                assert process.is_alive()
+
+            # With 0.01s timeout, next_step.join() consumes it, then we should still
+            # iterate through ALL processes and call kill() on each
+            flusher.join(timeout=0.01)
+
+            # EXPECTED: kill() should be called on all 3 processes
+            assert kill_called_for == {0, 1, 2}, (
+                f"kill() should be called on all processes, "
+                f"but was only called on: {kill_called_for}"
+            )
+        finally:
+            # Clean up: forcibly kill any leaked processes
+            for process in flusher.processes.values():
+                if process.is_alive():
+                    original_kill(process)

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -241,7 +241,7 @@ def test_flusher_join_timeout_kills_all_processes() -> None:
 
     # Track which process indices had kill() called
     kill_called_for: set[int] = set()
-    flusher = None  # Will be set below, needed for patched_kill closure
+    flusher: SpanFlusher | None = None  # Will be set below, needed for patched_kill closure
 
     # Patch BaseProcess.kill to track calls (SpawnProcess inherits from this)
     original_kill = multiprocessing.process.BaseProcess.kill
@@ -289,5 +289,6 @@ def test_flusher_join_timeout_kills_all_processes() -> None:
         finally:
             # Clean up: forcibly kill any leaked processes
             for process in flusher.processes.values():
+                assert isinstance(process, multiprocessing.process.BaseProcess)
                 if process.is_alive():
                     original_kill(process)


### PR DESCRIPTION
When one flusher process blocks join(), we give up on terminating any
other flusher processes. This can cause all kinds of double-flushing
during rebalancing, which is the symptom we're investigating.

We don't have evidence though that this is actually what's happening.
The containers also exit really quickly, and we have no join-timeout
configured. Still, let's fix the bug and add a metric to be sure.

ref STREAM-881
