### PR TITLE
fix(search-query-builder): Allow wildcard ops for all string filters

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -230,6 +230,42 @@ describe('SearchQueryBuilder', () => {
         ).not.toBeInTheDocument();
       });
 
+      it('displays wildcard footer for fields with null valueType', async () => {
+        const getNullableStringFieldDefinition: FieldDefinitionGetter = key => {
+          if (key !== 'nullable_string') {
+            return getFieldDefinition(key);
+          }
+
+          return {
+            kind: FieldKind.FIELD,
+            valueType: null,
+          };
+        };
+
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            getFieldDefinition={getNullableStringFieldDefinition}
+            filterKeys={{
+              ...defaultProps.filterKeys,
+              nullable_string: {
+                key: 'nullable_string',
+                name: 'Nullable String',
+                kind: FieldKind.FIELD,
+              },
+            }}
+            initialQuery="nullable_string:hello"
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: nullable_string'})
+        );
+
+        expect(await screen.findByText('Type to search suggestions')).toBeInTheDocument();
+        expect(screen.getByText('Wildcard (*) matching allowed')).toBeInTheDocument();
+      });
+
       it('renders swap to is for * when using a wildcard operator', async () => {
         render(
           <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1090,10 +1090,17 @@ describe('SearchQueryBuilder', () => {
       await userEvent.keyboard('a:b{enter}');
 
       expect(await screen.findByRole('row', {name: 'foo'})).toBeInTheDocument();
-      expect(await screen.findByRole('row', {name: 'a:b'})).toBeInTheDocument();
+      expect(
+        await screen.findByRole('row', {
+          name: `a:${WildcardOperators.CONTAINS}b`,
+        })
+      ).toBeInTheDocument();
 
       expect(mockOnChange).toHaveBeenCalledTimes(1);
-      expect(mockOnChange).toHaveBeenCalledWith('foo a:b', expect.anything());
+      expect(mockOnChange).toHaveBeenCalledWith(
+        `foo a:${WildcardOperators.CONTAINS}b`,
+        expect.anything()
+      );
     });
 
     it('adds default value for filter when typing <filter>:', async () => {
@@ -1164,6 +1171,19 @@ describe('SearchQueryBuilder', () => {
         'browser.name:Firefox',
         expect.anything()
       );
+    });
+
+    it('defaults to contains when adding a default-string filter', async () => {
+      render(<SearchQueryBuilder {...defaultProps} />);
+
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      await userEvent.click(screen.getByRole('option', {name: 'custom_tag_name'}));
+
+      expect(
+        screen.getByRole('row', {
+          name: `custom_tag_name:${WildcardOperators.CONTAINS}""`,
+        })
+      ).toBeInTheDocument();
     });
 
     it('does not switch operator to "is" when filter already has a value', async () => {
@@ -1322,7 +1342,7 @@ describe('SearchQueryBuilder', () => {
       );
 
       const browserNameFilter = await screen.findByRole('row', {
-        name: '!browser.name:""',
+        name: `!browser.name:${WildcardOperators.CONTAINS}""`,
       });
       expect(browserNameFilter).toBeInTheDocument();
     });

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -245,7 +245,7 @@ describe('SearchQueryBuilder', () => {
         render(
           <SearchQueryBuilder
             {...defaultProps}
-            getFieldDefinition={getNullableStringFieldDefinition}
+            fieldDefinitionGetter={getNullableStringFieldDefinition}
             filterKeys={{
               ...defaultProps.filterKeys,
               nullable_string: {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3447,6 +3447,22 @@ describe('SearchQueryBuilder', () => {
         expect(doesNotEndWithOption).toBeInTheDocument();
       });
 
+      it('default-string filters have wildcard operator options', async () => {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="custom_tag_name:hello" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {
+            name: 'Edit operator for filter: custom_tag_name',
+          })
+        );
+
+        expect(await screen.findByRole('option', {name: 'contains'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'starts with'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'ends with'})).toBeInTheDocument();
+      });
+
       it('replaces the value for fields that do not allow multiple values', async () => {
         render(
           <SearchQueryBuilder {...defaultProps} initialQuery="release.version:1.0.0" />

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.spec.tsx
@@ -1,13 +1,25 @@
-import {Token} from 'sentry/components/searchSyntax/parser';
+import type {TokenResult} from 'sentry/components/searchSyntax/parser';
+import {parseSearch, TermOperator, Token} from 'sentry/components/searchSyntax/parser';
 import {FieldKind, FieldValueType, type FieldDefinition} from 'sentry/utils/fields';
 
 import {
   areWildcardOperatorsAllowed,
   escapeTagValueForSearch,
   formatFilterValue,
+  getValidOpsForFilter,
   unescapeAsteriskSearchValue,
   unescapeTagValue,
 } from './utils';
+
+function parseFilterToken(query: string): TokenResult<Token.FILTER> {
+  const token = parseSearch(query)?.find(
+    (result): result is TokenResult<Token.FILTER> => result.type === Token.FILTER
+  );
+
+  expect(token).toBeDefined();
+
+  return token!;
+}
 
 describe('areWildcardOperatorsAllowed', () => {
   it('returns false when fieldDefinition is null', () => {
@@ -71,6 +83,75 @@ describe('areWildcardOperatorsAllowed', () => {
     };
 
     expect(areWildcardOperatorsAllowed(fieldDefinition)).toBe(false);
+  });
+});
+
+describe('getValidOpsForFilter', () => {
+  it('allows wildcard operators for fields with a null valueType', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: null,
+    };
+
+    expect(
+      getValidOpsForFilter({
+        filterToken: parseFilterToken('message:hello'),
+        fieldDefinition,
+      })
+    ).toEqual(expect.arrayContaining([TermOperator.CONTAINS]));
+  });
+
+  it('allows wildcard operators when the field definition is missing', () => {
+    expect(
+      getValidOpsForFilter({
+        filterToken: parseFilterToken('custom_tag_name:hello'),
+        fieldDefinition: null,
+      })
+    ).toEqual(expect.arrayContaining([TermOperator.CONTAINS]));
+  });
+
+  it('does not allow wildcard operators when allowWildcard is false', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      allowWildcard: false,
+    };
+
+    expect(
+      getValidOpsForFilter({
+        filterToken: parseFilterToken('message:hello'),
+        fieldDefinition,
+      })
+    ).not.toEqual(expect.arrayContaining([TermOperator.CONTAINS]));
+  });
+
+  it('does not allow wildcard operators when disallowWildcardOperators is true', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      disallowWildcardOperators: true,
+    };
+
+    expect(
+      getValidOpsForFilter({
+        filterToken: parseFilterToken('message:hello'),
+        fieldDefinition,
+      })
+    ).not.toEqual(expect.arrayContaining([TermOperator.CONTAINS]));
+  });
+
+  it('does not allow wildcard operators for non-string effective value types', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.NUMBER,
+    };
+
+    expect(
+      getValidOpsForFilter({
+        filterToken: parseFilterToken('timesSeen:10'),
+        fieldDefinition,
+      })
+    ).not.toEqual(expect.arrayContaining([TermOperator.CONTAINS]));
   });
 });
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -94,13 +94,13 @@ export function getValidOpsForFilter({
     comparisonOperators.forEach(op => validOps.add(op));
   }
 
-  // Conditionally remove wildcard operators if:
-  // - Feature flag is not enabled
-  // - Field definition does not allow wildcard operators
-  // - Field definition is a string field
+  // Conditionally remove wildcard operators unless the effective field value
+  // type is string and the field definition has not opted out.
   if (
-    !areWildcardOperatorsAllowed(fieldDefinition) ||
-    fieldDefinition?.valueType !== FieldValueType.STRING
+    !areWildcardOperatorsAllowed(
+      fieldDefinition,
+      getFilterValueType(filterToken, fieldDefinition)
+    )
   ) {
     wildcardOperators.forEach(op => validOps.delete(op));
   }
@@ -305,21 +305,18 @@ export function getLabelAndOperatorFromToken(token: TokenResult<Token.FILTER>) {
  *
  * The logic is:
  * - If `disallowWildcardOperators` is explicitly true, wildcard operators are not allowed
- * - If `disallowWildcardOperators` is explicitly false or undefined, check `allowWildcard` (defaults to true)
+ * - If the effective value type is string, check `allowWildcard` (defaults to true)
  */
 export function areWildcardOperatorsAllowed(
-  fieldDefinition: FieldDefinition | null
+  fieldDefinition: FieldDefinition | null,
+  valueType: FieldValueType | null = fieldDefinition?.valueType ?? null
 ): boolean {
-  if (!fieldDefinition) {
+  if (fieldDefinition?.disallowWildcardOperators === true) {
     return false;
   }
 
-  if (fieldDefinition.disallowWildcardOperators === true) {
-    return false;
-  }
-
-  if (fieldDefinition.valueType === FieldValueType.STRING) {
-    return fieldDefinition.allowWildcard ?? true;
+  if (valueType === FieldValueType.STRING) {
+    return fieldDefinition?.allowWildcard ?? true;
   }
 
   return false;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -294,12 +294,12 @@ export function tokenSupportsMultipleValues(
   }
 }
 
-// Filters support wildcards if they are string filters and it is not explicity disallowed
-function keySupportsWildcard(fieldDefinition: FieldDefinition | null) {
-  const isStringFilter =
-    !fieldDefinition || fieldDefinition?.valueType === FieldValueType.STRING;
-
-  return isStringFilter && fieldDefinition?.allowWildcard !== false;
+// Filters support wildcards if they are string filters and it is not explicitly disallowed
+function keySupportsWildcard(
+  fieldDefinition: FieldDefinition | null,
+  valueType: FieldValueType
+) {
+  return valueType === FieldValueType.STRING && fieldDefinition?.allowWildcard !== false;
 }
 
 function useSelectionIndex({
@@ -635,7 +635,10 @@ export function SearchQueryBuilderValueCombobox({
     filterKeys,
     fieldDefinition
   );
-  const canUseWildcard = disallowWildcard ? false : keySupportsWildcard(fieldDefinition);
+  const valueType = getFilterValueType(token, fieldDefinition);
+  const canUseWildcard = disallowWildcard
+    ? false
+    : keySupportsWildcard(fieldDefinition, valueType);
   const [inputValue, setInputValue] = useState(() =>
     getInitialInputValue(token, canSelectMultipleValues)
   );
@@ -793,7 +796,6 @@ export function SearchQueryBuilderValueCombobox({
         }
       }
 
-      const valueType = getFilterValueType(token, fieldDefinition);
       const valueForSaving =
         escapeSearchValue && valueType === FieldValueType.STRING
           ? escapeTagValueForSearch(value)
@@ -871,6 +873,7 @@ export function SearchQueryBuilderValueCombobox({
     [
       token,
       fieldDefinition,
+      valueType,
       getSuggestedFilterKey,
       canSelectMultipleValues,
       analyticsData,
@@ -1017,7 +1020,6 @@ export function SearchQueryBuilderValueCombobox({
     };
   }, [showDatePicker]);
 
-  const valueType = getFilterValueType(token, fieldDefinition);
   const placeholder =
     token.filter === FilterType.HAS
       ? prettifyTagKey(token.value.text)

--- a/static/app/components/searchQueryBuilder/tokens/utils.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.spec.tsx
@@ -1,0 +1,33 @@
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
+import {FieldKind, FieldValueType, type FieldDefinition} from 'sentry/utils/fields';
+
+import {getInitialFilterText} from './utils';
+
+describe('getInitialFilterText', () => {
+  it('defaults missing field definitions to contains', () => {
+    expect(getInitialFilterText('custom_tag_name', null)).toBe(
+      `custom_tag_name:${WildcardOperators.CONTAINS}""`
+    );
+  });
+
+  it('defaults null value types to contains', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: null,
+    };
+
+    expect(getInitialFilterText('message', fieldDefinition)).toBe(
+      `message:${WildcardOperators.CONTAINS}""`
+    );
+  });
+
+  it('does not default to contains when wildcard operators are disallowed', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      disallowWildcardOperators: true,
+    };
+
+    expect(getInitialFilterText('message', fieldDefinition)).toBe('message:""');
+  });
+});

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -136,7 +136,7 @@ export function getInitialFilterText(
     case FieldValueType.PERCENTAGE:
       return `${keyText}:>${defaultValue}`;
     case FieldValueType.STRING: {
-      return areWildcardOperatorsAllowed(fieldDefinition)
+      return areWildcardOperatorsAllowed(fieldDefinition, valueType)
         ? `${keyText}:${WildcardOperators.CONTAINS}${defaultValue}`
         : `${keyText}:${defaultValue}`;
     }

--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -1,5 +1,6 @@
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 import {FieldKind} from 'sentry/utils/fields';
 import type {SearchBarData} from 'sentry/views/dashboards/datasetConfig/base';
 import {FilterSelector} from 'sentry/views/dashboards/globalFilter/filterSelector';
@@ -36,7 +37,9 @@ describe('FilterSelector', () => {
       />
     );
 
-    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ' :'});
+    const button = screen.getByRole('button', {
+      name: `${mockGlobalFilter.tag.key} contains`,
+    });
     await userEvent.click(button);
 
     expect(screen.getByText('chrome')).toBeInTheDocument();
@@ -54,7 +57,9 @@ describe('FilterSelector', () => {
       />
     );
 
-    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ' :'});
+    const button = screen.getByRole('button', {
+      name: `${mockGlobalFilter.tag.key} contains`,
+    });
     await userEvent.click(button);
 
     await userEvent.click(screen.getByRole('checkbox', {name: 'Select firefox'}));
@@ -63,7 +68,7 @@ describe('FilterSelector', () => {
 
     expect(mockOnUpdateFilter).toHaveBeenCalledWith({
       ...mockGlobalFilter,
-      value: 'browser:[firefox,chrome]',
+      value: `browser:${WildcardOperators.CONTAINS}[firefox,chrome]`,
     });
 
     await userEvent.click(button);
@@ -71,7 +76,7 @@ describe('FilterSelector', () => {
 
     expect(mockOnUpdateFilter).toHaveBeenCalledWith({
       ...mockGlobalFilter,
-      value: 'browser:chrome',
+      value: `browser:${WildcardOperators.CONTAINS}chrome`,
     });
   });
 
@@ -102,7 +107,9 @@ describe('FilterSelector', () => {
       />
     );
 
-    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ' :'});
+    const button = screen.getByRole('button', {
+      name: `${mockGlobalFilter.tag.key} contains`,
+    });
     await userEvent.click(button);
     await userEvent.click(screen.getByRole('button', {name: 'Remove Filter'}));
 
@@ -202,7 +209,7 @@ describe('FilterSelector', () => {
     );
 
     const button = screen.getByRole('button', {
-      name: SpanFields.USER_GEO_SUBREGION + ' :',
+      name: `${SpanFields.USER_GEO_SUBREGION} contains`,
     });
     await userEvent.click(button);
 
@@ -232,7 +239,9 @@ describe('FilterSelector', () => {
       />
     );
 
-    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ' :'});
+    const button = screen.getByRole('button', {
+      name: `${mockGlobalFilter.tag.key} contains`,
+    });
     await userEvent.click(button);
 
     // Wait for options to load - both values should be visible initially

--- a/static/app/views/explore/releases/list/index.spec.tsx
+++ b/static/app/views/explore/releases/list/index.spec.tsx
@@ -13,6 +13,7 @@ import {
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 import {ReleasesSortOption} from 'sentry/constants/releases';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import ReleasesList from 'sentry/views/explore/releases/list/';
@@ -731,7 +732,7 @@ describe('ReleasesList', () => {
           query: expect.objectContaining({
             per_page: 25,
             statsPeriod: '14d',
-            query: 'sha:abcdef1 branch:main !size_state:not_ran',
+            query: `sha:abcdef1 branch:${WildcardOperators.CONTAINS}main !size_state:not_ran`,
           }),
         })
       )


### PR DESCRIPTION
This PR fixes an issue where we were only defaulting/allowing wildcard operators for known string attributes, when we should allow it for all string attributes.

Closes EXP-936