### PR TITLE
ref(flags): Remove organizations:insights-prebuilt-dashboards

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -82,8 +82,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-drilldown-flow", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable prebuilt dashboards for insights modules
     manager.add("organizations:dashboards-prebuilt-insights-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Replaces insights ui with prebuilt dashboards
-    manager.add("organizations:insights-prebuilt-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the details widget for dashboards
     manager.add("organizations:dashboards-details-widget", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable text widgets for dashboards


### PR DESCRIPTION
Removes the `organizations:insights-prebuilt-dashboards` feature flag declaration from `temporary.py`.

This flag has been fully released and there are no remaining usages of it in the codebase — only the declaration is being removed.

Companion PR in `sentry-options-automator` removes the corresponding flagpole entry: https://github.com/getsentry/sentry-options-automator/pull/7684

🤖 Generated with [Claude Code](https://claude.com/claude-code)