### PR TITLE
refactor(preprod): Align snapshot status checks UI with PR comments pattern

### DIFF
--- a/static/app/views/settings/project/preprod/getSnapshotStatusChecks.ts
+++ b/static/app/views/settings/project/preprod/getSnapshotStatusChecks.ts
@@ -6,7 +6,7 @@ const FAIL_ON_REMOVED_KEY = 'sentry:preprod_snapshot_status_checks_fail_on_remov
 const FAIL_ON_CHANGED_KEY = 'sentry:preprod_snapshot_status_checks_fail_on_changed';
 const FAIL_ON_RENAMED_KEY = 'sentry:preprod_snapshot_status_checks_fail_on_renamed';
 
-export function useSnapshotStatusChecks(project: Project) {
+export function getSnapshotStatusChecks(project: Project) {
   const enabled =
     project.preprodSnapshotStatusChecksEnabled ??
     project.options?.[ENABLED_KEY] !== false;

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
@@ -3,6 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {SnapshotStatusChecks} from 'sentry/views/settings/project/preprod/snapshotStatusChecks';
 
 describe('SnapshotStatusChecks', () => {
@@ -134,6 +135,7 @@ describe('SnapshotStatusChecks', () => {
 
   it('immediately hides failure condition toggles when status checks are disabled', async () => {
     const project = ProjectFixture({options: {}});
+    ProjectsStore.loadInitialData([project]);
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
     const mock = MockApiClient.addMockResponse({
       url: projectEndpoint,
@@ -152,7 +154,7 @@ describe('SnapshotStatusChecks', () => {
     );
 
     expect(
-      screen.getByText('Enable status checks to configure failure conditions')
+      await screen.findByText('Enable status checks to configure failure conditions')
     ).toBeInTheDocument();
     expect(
       screen.queryByRole('checkbox', {name: 'Fail on Changed Snapshots'})

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -1,4 +1,5 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment} from 'react';
+import {mutationOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
@@ -10,9 +11,10 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
-import {useSnapshotStatusChecks} from './useSnapshotStatusChecks';
+import {getSnapshotStatusChecks} from './getSnapshotStatusChecks';
 
 const schema = z.object({
   preprodSnapshotStatusChecksEnabled: z.boolean(),
@@ -32,31 +34,34 @@ type SnapshotStatusCheckField = {
 
 export function SnapshotStatusChecks() {
   const organization = useOrganization();
-  const {project} = useProjectSettingsOutlet();
+  const {project: outletProject} = useProjectSettingsOutlet();
+  const project = useProjectFromId({project_id: outletProject.id}) ?? outletProject;
   const {enabled, failOnAdded, failOnRemoved, failOnChanged, failOnRenamed} =
-    useSnapshotStatusChecks(project);
-  const [statusChecksEnabled, setStatusChecksEnabled] = useState(enabled);
+    getSnapshotStatusChecks(project);
 
   const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
 
-  useEffect(() => {
-    setStatusChecksEnabled(enabled);
-  }, [enabled]);
-
-  const mutationOptions = {
+  const projectMutationOptions = mutationOptions({
     mutationFn: (data: Partial<Schema>) =>
       fetchMutation<Project>({
         url: projectEndpoint,
         method: 'PUT',
         data,
       }),
-    onSuccess: (response: Project) => ProjectsStore.onUpdateSuccess(response),
-  };
-
-  const enabledMutationOptions = {
-    ...mutationOptions,
-    onError: () => setStatusChecksEnabled(enabled),
-  };
+    onMutate: data => {
+      const previous = ProjectsStore.getById(project.id);
+      ProjectsStore.onUpdateSuccess({id: project.id, ...data});
+      return () => {
+        if (previous) {
+          ProjectsStore.onUpdateSuccess(previous);
+        }
+      };
+    },
+    onSuccess: response => ProjectsStore.onUpdateSuccess(response),
+    onError: (_error, _variables, rollback) => {
+      rollback?.();
+    },
+  });
 
   const failureConditionFields = [
     {
@@ -91,7 +96,7 @@ export function SnapshotStatusChecks() {
         name="preprodSnapshotStatusChecksEnabled"
         schema={schema}
         initialValue={enabled}
-        mutationOptions={enabledMutationOptions}
+        mutationOptions={projectMutationOptions}
       >
         {field => (
           <field.Layout.Row
@@ -100,18 +105,12 @@ export function SnapshotStatusChecks() {
               'Sentry will post status checks based on snapshot changes in your builds.'
             )}
           >
-            <field.Switch
-              checked={field.state.value}
-              onChange={value => {
-                setStatusChecksEnabled(value);
-                field.handleChange(value);
-              }}
-            />
+            <field.Switch checked={field.state.value} onChange={field.handleChange} />
           </field.Layout.Row>
         )}
       </AutoSaveForm>
 
-      {statusChecksEnabled ? (
+      {enabled ? (
         <Fragment>
           {failureConditionFields.map(({name, initialValue, label, hintText}) => (
             <AutoSaveForm
@@ -119,7 +118,7 @@ export function SnapshotStatusChecks() {
               name={name}
               schema={schema}
               initialValue={initialValue}
-              mutationOptions={mutationOptions}
+              mutationOptions={projectMutationOptions}
             >
               {field => (
                 <field.Layout.Row label={label} hintText={hintText}>


### PR DESCRIPTION
## Summary
- Refactored `SnapshotStatusChecks` to follow the same patterns as `SnapshotPrCommentsToggle`
- Replaced local `useState`/`useEffect` with `useProjectFromId` for reactive store reads
- Added `mutationOptions()` wrapper with optimistic `onMutate` and rollback on error
- Renamed `useSnapshotStatusChecks` → `getSnapshotStatusChecks` to match `getSnapshotPrComments` naming (it's a plain function, not a hook)