### PR TITLE
fix(ourlogs): correct logs modal exports payload data

### DIFF
--- a/static/app/components/exports/dataExport.tsx
+++ b/static/app/components/exports/dataExport.tsx
@@ -18,7 +18,6 @@ export interface LogsQueryInfo {
   sort: string[];
   end?: string;
   environment?: string[];
-  limit?: number;
   start?: string;
   statsPeriod?: string;
 }

--- a/static/app/components/exports/useDataExport.spec.ts
+++ b/static/app/components/exports/useDataExport.spec.ts
@@ -44,7 +44,7 @@ describe('useDataExport', () => {
 
     await waitFor(() => {
       expect(addErrorMessage).toHaveBeenCalledWith(
-        "We tried our hardest, but we couldn't export your data. Give it another go."
+        "We tried our hardest, but we couldn't export your data. Try waiting a minute then giving it another go."
       );
     });
 

--- a/static/app/components/exports/useDataExport.spec.ts
+++ b/static/app/components/exports/useDataExport.spec.ts
@@ -169,21 +169,17 @@ describe('useDataExport', () => {
 
     await result.current({
       format: 'csv',
-      queryInfo: {
-        ...mockPayload.queryInfo,
-        limit: 10_000,
-      },
+      queryInfo: mockPayload.queryInfo,
       queryType: mockPayload.queryType,
+      limit: 10_000,
     });
 
     expect(exportMock).toHaveBeenCalledWith('/organizations/org-slug/data-export/', {
       data: {
         format: 'csv',
         query_type: mockPayload.queryType,
-        query_info: {
-          ...mockPayload.queryInfo,
-          limit: 10_000,
-        },
+        query_info: mockPayload.queryInfo,
+        limit: 10_000,
       },
       error: expect.any(Function),
       method: 'POST',

--- a/static/app/components/exports/useDataExport.ts
+++ b/static/app/components/exports/useDataExport.ts
@@ -123,7 +123,7 @@ export function useDataExport({
           } else {
             addErrorMessage(
               t(
-                "We tried our hardest, but we couldn't export your data. Give it another go."
+                "We tried our hardest, but we couldn't export your data. Try waiting a minute then giving it another go."
               )
             );
           }

--- a/static/app/components/exports/useDataExport.ts
+++ b/static/app/components/exports/useDataExport.ts
@@ -29,6 +29,7 @@ export interface DataExportPayload {
   queryType: ExportQueryType;
 
   format?: DataExportFormat;
+  limit?: number;
 }
 
 interface UseDataExportOptions {
@@ -85,7 +86,7 @@ export function useDataExport({
   const api = useApi();
 
   return useCallback(
-    async ({format = 'csv', queryInfo, queryType}: DataExportPayload) => {
+    async ({format = 'csv', limit, queryInfo, queryType}: DataExportPayload) => {
       inProgressCallback?.(true);
 
       const result = await api
@@ -98,6 +99,7 @@ export function useDataExport({
             method: 'POST',
             data: {
               format,
+              limit,
               query_info: queryInfo,
               query_type: queryType,
             },

--- a/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
@@ -169,11 +169,11 @@ describe('LogsExportModal', () => {
       expect.objectContaining({
         data: {
           format: 'csv',
-          query_type: 'trace_item_full_export',
+          limit: aboveSyncLimit,
+          query_type: 'Explore',
           query_info: {
             ...queryInfo,
             dataset: 'logs',
-            limit: aboveSyncLimit,
           },
         },
         method: 'POST',

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -47,7 +47,7 @@ export function LogsExportModal({
   const estimatedRowCount = useLogsExportEstimatedRowCount(tableData.length);
   const payload = useMemo(
     () => ({
-      queryType: ExportQueryType.TRACE_ITEM_FULL_EXPORT,
+      queryType: ExportQueryType.EXPLORE,
       queryInfo: {
         ...queryInfo,
         dataset: TraceItemDataset.LOGS,
@@ -83,11 +83,9 @@ export function LogsExportModal({
       if (passedSyncLimit) {
         await handleDataExport({
           format: value.format,
-          queryInfo: {
-            ...payload.queryInfo,
-            limit: value.limit,
-          },
+          queryInfo: payload.queryInfo,
           queryType: payload.queryType,
+          limit: value.limit,
         });
       } else {
         downloadLogs({


### PR DESCRIPTION
Fixes two issues:

* `limit` should be a top-level field, not inside `queryInfo`
* `query_type`: should be `"Explore"`, not `"trace_item_full_export"`

Fixes LOGS-766.

Made with [Cursor](https://cursor.com)