### PR TITLE
fix(ai-conversations): Fix page filter isolation, project=-1, and datetime URL params

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -38,10 +38,10 @@ function getConversationDetailUrl(orgSlug: string, conversation: Conversation): 
   const basePath = `/organizations/${orgSlug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${encodeURIComponent(conversation.conversationId)}/`;
   const params = new URLSearchParams();
   if (conversation.startTimestamp) {
-    params.set('start', String(conversation.startTimestamp));
+    params.set('start', new Date(conversation.startTimestamp).toISOString());
   }
   if (conversation.endTimestamp) {
-    params.set('end', String(conversation.endTimestamp));
+    params.set('end', new Date(conversation.endTimestamp).toISOString());
   }
   const qs = params.toString();
   return normalizeUrl(qs ? `${basePath}?${qs}` : basePath);

--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useMemo} from 'react';
-import {parseAsInteger, parseAsString, useQueryStates} from 'nuqs';
+import {parseAsString, useQueryStates} from 'nuqs';
 
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
@@ -14,8 +14,6 @@ function useConversationDetailQueryState() {
     {
       spanId: parseAsString,
       focusedTool: parseAsString,
-      start: parseAsInteger,
-      end: parseAsInteger,
     },
     {history: 'replace'}
   );
@@ -25,14 +23,7 @@ function ConversationDetailPage() {
   const {conversationId} = useParams<{conversationId: string}>();
   const [queryState, setQueryState] = useConversationDetailQueryState();
 
-  const conversation = useMemo(
-    () => ({
-      conversationId,
-      startTimestamp: queryState.start ?? undefined,
-      endTimestamp: queryState.end ?? undefined,
-    }),
-    [conversationId, queryState.start, queryState.end]
-  );
+  const conversation = useMemo(() => ({conversationId}), [conversationId]);
 
   const {nodes, nodeTraceMap, isLoading} = useConversation(conversation);
 

--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -1,16 +1,35 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {SpanFields} from 'sentry/views/insights/types';
 
 import {useConversation} from './useConversation';
+
+const BASE_SPAN = {
+  'gen_ai.conversation.id': 'conv-123',
+  parent_span: 'parent-1',
+  'precise.finish_ts': 1000.5,
+  'precise.start_ts': 1000.0,
+  project: 'test-project',
+  'project.id': 1,
+  'span.name': 'gen_ai.generate',
+  'span.status': 'ok',
+  span_id: 'span-1',
+  trace: 'trace-1',
+  'gen_ai.operation.type': 'ai_client',
+};
 
 describe('useConversation', () => {
   const organization = OrganizationFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    act(() => {
+      PageFiltersStore.reset();
+      PageFiltersStore.init();
+    });
   });
 
   it('returns empty nodes when conversationId is empty', () => {
@@ -223,16 +242,15 @@ describe('useConversation', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    // Verify the API was called with correct timestamps (with 1-hour padding),
-    // ALL_ACCESS_PROJECTS (-1) so it searches across all projects,
-    // and no environment filter so it searches across all environments
+    // Verify the API was called with correct timestamps (with 1-hour padding)
+    // and that project comes from page filters (empty array = my projects), not hardcoded -1
     expect(mockRequest).toHaveBeenCalledWith(
       expect.stringContaining('/ai-conversations/conv-timestamps/'),
       expect.objectContaining({
         query: expect.objectContaining({
           start: new Date(startTimestamp - 60 * 60 * 1000).toISOString(),
           end: new Date(endTimestamp + 60 * 60 * 1000).toISOString(),
-          project: [-1],
+          project: [],
         }),
       })
     );
@@ -324,6 +342,65 @@ describe('useConversation', () => {
     // Sorted by start timestamp: span-a (1000) before span-b (1001)
     expect(result.current.nodes[0]?.id).toBe('span-a');
     expect(result.current.nodes[1]?.id).toBe('span-b');
+  });
+
+  it('uses project from page filters, not hardcoded -1', async () => {
+    act(() => PageFiltersStore.updateProjects([456], []));
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
+      body: [BASE_SPAN],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-123'}),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.stringContaining('/ai-conversations/conv-123/'),
+      expect.objectContaining({
+        query: expect.objectContaining({project: [456]}),
+      })
+    );
+  });
+
+  it('uses page filter datetime when no conversation timestamps are provided', async () => {
+    act(() =>
+      PageFiltersStore.updateDateTime({
+        period: null,
+        start: '2026-04-01T00:00:00',
+        end: '2026-04-07T00:00:00',
+        utc: null,
+      })
+    );
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
+      body: [BASE_SPAN],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-123'}),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.stringContaining('/ai-conversations/conv-123/'),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          start: expect.stringContaining('2026-04-01'),
+          end: expect.stringContaining('2026-04-07'),
+        }),
+      })
+    );
+    // statsPeriod must not be present when explicit dates are set
+    const queryArg = mockRequest.mock.calls[0]![1]!.query;
+    expect(queryArg).not.toHaveProperty('statsPeriod');
   });
 
   it('filters to only gen_ai spans', async () => {

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -1,7 +1,8 @@
 import {useEffect, useMemo} from 'react';
 import {skipToken, useInfiniteQuery} from '@tanstack/react-query';
 
-import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getGenAiOperationTypeFromSpanName} from 'sentry/views/insights/pages/agents/utils/query';
@@ -179,19 +180,23 @@ export function useConversation(
   conversation: UseConversationsOptions
 ): UseConversationResult {
   const organization = useOrganization();
+  const {selection} = usePageFilters();
 
   const ONE_HOUR_MS = 60 * 60 * 1000;
   const hasConversationTimestamps =
     conversation.startTimestamp !== undefined && conversation.endTimestamp !== undefined;
 
-  // Ignore page filters so the conversation is always found.
+  const datetimeParams = hasConversationTimestamps
+    ? {
+        start: new Date(conversation.startTimestamp! - ONE_HOUR_MS).toISOString(),
+        end: new Date(conversation.endTimestamp! + ONE_HOUR_MS).toISOString(),
+      }
+    : normalizeDateTimeParams(selection.datetime);
+
   const queryParams = {
-    project: [ALL_ACCESS_PROJECTS],
+    project: selection.projects,
     per_page: 1000,
-    ...(hasConversationTimestamps && {
-      start: new Date(conversation.startTimestamp! - ONE_HOUR_MS).toISOString(),
-      end: new Date(conversation.endTimestamp! + ONE_HOUR_MS).toISOString(),
-    }),
+    ...datetimeParams,
   };
 
   const {

--- a/static/app/views/explore/conversations/layout.tsx
+++ b/static/app/views/explore/conversations/layout.tsx
@@ -52,7 +52,10 @@ function ConversationsLayoutContent() {
         <Stack flex={1}>
           <ConversationsHeader />
           <NoProjectMessage organization={organization}>
-            <PageFiltersContainer maxPickableDays={MAX_PICKABLE_DAYS}>
+            <PageFiltersContainer
+              maxPickableDays={MAX_PICKABLE_DAYS}
+              storageNamespace="conversations"
+            >
               <Outlet />
             </PageFiltersContainer>
           </NoProjectMessage>

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -30,7 +30,6 @@ import {useShowConversationOnboarding} from 'sentry/views/explore/conversations/
 import {ConversationOnboarding} from 'sentry/views/explore/conversations/onboarding';
 import {MAX_PICKABLE_DAYS} from 'sentry/views/explore/conversations/settings';
 import {AgentSelector} from 'sentry/views/insights/common/components/agentSelector';
-import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams';
 
@@ -42,7 +41,6 @@ function ConversationsOverviewPage() {
     maxPickableDays: MAX_PICKABLE_DAYS,
     maxUpgradableDays: MAX_PICKABLE_DAYS,
   });
-  useDefaultToAllProjects();
   const {
     showOnboarding,
     isLoading: isOnboardingLoading,


### PR DESCRIPTION
Three related page filter bugs in the AI Conversations feature.

## What

**1. Date range always scanned 30 days regardless of user selection**

`PageFiltersContainer` was using the global storage namespace, so wide date ranges set on other pages (e.g. 90d from Performance) leaked into Conversations. The `maxPickableDays=30` clamp then reset any period over 30 days to `statsPeriod=30d`, which the backend used for every query. Fixed with `storageNamespace="conversations"` to isolate this page's filter state.

**2. `project=-1` sent to the conversation detail endpoint even when a real project was selected**

Two causes: the detail hook hardcoded `project: [ALL_ACCESS_PROJECTS]`, and `useDefaultToAllProjects()` in the list page overwrote the store value to `-1` after the user selected a project. The detail hook now reads `selection.projects` from `usePageFilters`. The `useDefaultToAllProjects` call is removed — `PageFiltersContainer` already handles the no-member-projects edge case internally (lines 280–291 in `actions.tsx`), making the hook redundant.

**3. `start`/`end` stripped from URL on direct navigation to a conversation detail link**

The table wrote `start`/`end` as integer ms timestamps (e.g. `?start=1746400000000`). `PageFiltersContainer` owns those same URL keys as ISO datetime strings, and its `initializeUrlState` stripped them during the page filter round-trip. Fixed by writing proper ISO strings instead, which `PageFiltersContainer` parses as valid absolute dates and preserves. The detail page drops its own `nuqs` parsing for `start`/`end` since the page filter now owns them. The `useConversation` hook falls back to `normalizeDateTimeParams(selection.datetime)` when no explicit `startTimestamp`/`endTimestamp` are passed (the trace drawer path is unchanged — it still provides its own bounds with the ±1h buffer).