### PR TITLE
fix(charts): Hide overlapping time-series y-axis labels

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -266,6 +266,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const leftYAxis = TimeSeriesWidgetYAxis(
     {
       axisLabel: {
+        hideOverlap: true,
         formatter: (value: number) =>
           formatYAxisValue(value, leftYAxisType, unitForType[leftYAxisType] ?? undefined),
       },
@@ -279,6 +280,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     ? TimeSeriesWidgetYAxis(
         {
           axisLabel: {
+            hideOverlap: true,
             formatter: (value: number) =>
               formatYAxisValue(
                 value,


### PR DESCRIPTION
Prevent compact time-series charts from rendering crowded y-axis labels by letting ECharts hide overlapping y-axis labels.

This keeps tick selection, data ranges, and label sizing in ECharts instead of adding caller-specific axis controls.