### PR TITLE
fix(spans): Preserve canonical segment names

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -2,7 +2,7 @@ import logging
 import types
 import uuid
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, cast
 
 import sentry_sdk
 from django.conf import settings
@@ -32,7 +32,7 @@ from sentry.receivers.onboarding import record_release_received
 from sentry.signals import first_insight_span_received, first_transaction_received
 from sentry.spans.consumers.process_segments.enrichment import TreeEnricher, compute_breakdowns
 from sentry.spans.consumers.process_segments.shim import build_shim_event_data, make_compatible
-from sentry.spans.consumers.process_segments.types import CompatibleSpan, attribute_value
+from sentry.spans.consumers.process_segments.types import Attribute, CompatibleSpan, attribute_value
 from sentry.spans.grouping.api import load_span_grouping_config
 from sentry.utils import metrics
 from sentry.utils.dates import to_datetime
@@ -180,17 +180,26 @@ def _enrich_spans(
 
 @metrics.wraps("spans.consumers.process_segments.add_segment_name")
 def _add_segment_name(segment: CompatibleSpan, spans: Sequence[CompatibleSpan]) -> None:
-    segment_name = segment.get("name")
+    # Prefer sentry.segment.name, then fall back to the v1 description for backwards
+    # compatibility, and finally to the name if all else fails.
+    segment_name = (
+        attribute_value(segment, ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME)
+        or segment.get("description")
+        or segment.get("name")
+    )
     if not segment_name:
         return
 
     for span in spans:
         if not attribute_value(span, ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME):
             span["attributes"] = span.get("attributes") or {}
-            span["attributes"][ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME] = {  # type: ignore[index]
-                "type": "string",
-                "value": segment_name,
-            }
+            span["attributes"][ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME] = cast(  # type: ignore[index]
+                Attribute,
+                {
+                    "type": "string",
+                    "value": segment_name,
+                },
+            )
 
 
 @metrics.wraps("spans.consumers.process_segments.compute_breakdowns")

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -271,9 +271,55 @@ class TestSpansTask(TestCase):
         signals = [args[0][1] for args in mock_track.call_args_list]
         assert signals == ["has_transactions", "has_insights_agent_monitoring"]
 
-    def test_segment_name_propagation(self) -> None:
+    def test_segment_name_propagation_prefers_segment_name_attribute(self) -> None:
         child_span, segment_span = self.generate_basic_spans()
         segment_span["name"] = "my segment name"
+        segment_span["description"] = "my segment description"
+        segment_span["attributes"]["sentry.segment.name"] = {
+            "type": "string",
+            "value": "my segment attribute",
+        }
+
+        processed_spans = process_segment([child_span, segment_span])
+
+        assert len(processed_spans) == 2
+        child_span, segment_span = processed_spans
+        segment_attributes = segment_span["attributes"] or {}
+        assert segment_attributes["sentry.segment.name"] == {
+            "type": "string",
+            "value": "my segment attribute",
+        }
+        child_attributes = child_span["attributes"] or {}
+        assert child_attributes["sentry.segment.name"] == {
+            "type": "string",
+            "value": "my segment attribute",
+        }
+
+    def test_segment_name_propagation_falls_back_to_description(self) -> None:
+        child_span, segment_span = self.generate_basic_spans()
+        segment_span["name"] = "my segment name"
+        segment_span["description"] = "my segment description"
+        del segment_span["attributes"]["sentry.transaction"]
+
+        processed_spans = process_segment([child_span, segment_span])
+
+        assert len(processed_spans) == 2
+        child_span, segment_span = processed_spans
+        segment_attributes = segment_span["attributes"] or {}
+        assert segment_attributes["sentry.segment.name"] == {
+            "type": "string",
+            "value": "my segment description",
+        }
+        child_attributes = child_span["attributes"] or {}
+        assert child_attributes["sentry.segment.name"] == {
+            "type": "string",
+            "value": "my segment description",
+        }
+
+    def test_segment_name_propagation_falls_back_to_name(self) -> None:
+        child_span, segment_span = self.generate_basic_spans()
+        segment_span["name"] = "my segment name"
+        del segment_span["attributes"]["sentry.transaction"]
 
         processed_spans = process_segment([child_span, segment_span])
 
@@ -290,9 +336,10 @@ class TestSpansTask(TestCase):
             "value": "my segment name",
         }
 
-    def test_segment_name_propagation_when_name_missing(self) -> None:
+    def test_segment_name_propagation_when_source_missing(self) -> None:
         child_span, segment_span = self.generate_basic_spans()
         del segment_span["name"]
+        del segment_span["attributes"]["sentry.transaction"]
 
         processed_spans = process_segment([child_span, segment_span])
 


### PR DESCRIPTION
Currently v1 child spans are getting the wrong `sentry.segment.name` value which uses the span name instead of the span description.

Order:
- `sentry.segment.name` is authoritative if present.
- For v1 compatibility, if it is missing, use the `span.description`.
- For v2 compatibility, use the `span.name` (has no `span.description`).

