### PR TITLE
feat(cmdk): Add webhooks keyword to Custom Integrations action

### DIFF
--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -249,6 +249,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
             t('integration'),
             t('internal integration'),
             t('developer settings'),
+            t('webhooks'),
           ],
           description: t('Manage custom integrations'),
           id: 'developer-settings',


### PR DESCRIPTION
## Summary
- Adds `webhooks` as a keyword synonym to the **Custom Integrations** entry in the command palette navigation configuration
- Users searching "webhooks" in cmdk will now be directed to Settings > Developer Settings, which is where webhook URLs are configured per [Sentry docs](https://docs.sentry.io/organization/integrations/integration-platform/webhooks/)

## Test plan
- [ ] Open command palette (Cmd+K) and search "webhooks"
- [ ] Verify "Custom Integrations" appears in the results