### PR TITLE
fix(test): Fix flaky filesChanged test by using regex matcher

### DIFF
--- a/static/app/views/explore/releases/detail/commitsAndFiles/filesChanged.spec.tsx
+++ b/static/app/views/explore/releases/detail/commitsAndFiles/filesChanged.spec.tsx
@@ -118,8 +118,10 @@ describe('FilesChanged', () => {
       body: [CommitFileFixture()],
     });
     renderComponent();
-    expect(await screen.findByText('1 file changed')).toBeInTheDocument();
-    expect(screen.getByText('static/app/components/alert.tsx')).toBeInTheDocument();
+    expect(
+      await screen.findByText('static/app/components/alert.tsx')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1 file changed/)).toBeInTheDocument();
   });
 
   it('should render repo picker', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix flaky `filesChanged.spec.tsx` test that was intermittently failing in CI with:

```
TestingLibraryElementError: Unable to find an element with the text: 1 file changed.
This could be because the text is broken up by multiple elements.
```

The `'should render list of files changed'` test used `screen.findByText('1 file changed')` with exact string matching, which could fail when the text rendered by `tn()` inside a `PanelHeader` `<span>` was considered broken up by multiple elements in certain CI environments.

**Changes:**
- Wait for the filename (`static/app/components/alert.tsx`) as the primary async loading signal, since it's a more specific indicator that data has fully loaded
- Use regex matcher (`/1 file changed/`) for the file count assertion, which is more resilient to text splitting across DOM elements per the testing-library recommendation

Fixes: https://sentry.sentry.io/issues/7461336244
Fixes JEST-21QH

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e4d2ba-8ec4-4546-a35d-8295ced21045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e4d2ba-8ec4-4546-a35d-8295ced21045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

