### PR TITLE
fix(seer): Use self.get_projects() in OrganizationAutofixAutomationSettingsEndpoint

### DIFF
--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -232,7 +232,7 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        accessible_projects = self.get_projects(request, organization)
+        accessible_projects = self.get_projects(request, organization, include_all_accessible=True)
         queryset = Project.objects.filter(id__in={p.id for p in accessible_projects})
 
         query = serializer.validated_data.get("query")

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -232,7 +232,8 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        queryset = Project.objects.filter(organization_id=organization.id)
+        accessible_projects = self.get_projects(request, organization)
+        queryset = Project.objects.filter(id__in={p.id for p in accessible_projects})
 
         query = serializer.validated_data.get("query")
         if query:

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -47,28 +47,6 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             },
         ]
 
-    def test_get_excludes_projects_user_has_no_team_access_to(self) -> None:
-        self.organization.flags.allow_joinleave = False
-        self.organization.save()
-
-        team_a = self.create_team(organization=self.organization)
-        team_b = self.create_team(organization=self.organization)
-
-        user = self.create_user()
-        self.create_member(user=user, organization=self.organization, teams=[team_a])
-
-        project_a = self.create_project(
-            organization=self.organization, teams=[team_a], name="Team A Project"
-        )
-        self.create_project(organization=self.organization, teams=[team_b], name="Team B Project")
-
-        self.login_as(user=user)
-        response = self.client.get(self.url, {})
-
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["projectId"] == project_a.id
-
     def test_get_returns_projects_matching_query(self) -> None:
         project1 = self.create_project(organization=self.organization, name="Project One")
         project2 = self.create_project(organization=self.organization, name="Project Two")
@@ -154,6 +132,28 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
                 "reposCount": 0,
             },
         ]
+
+    def test_get_excludes_projects_user_has_no_team_access_to(self) -> None:
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        team_a = self.create_team(organization=self.organization)
+        team_b = self.create_team(organization=self.organization)
+
+        user = self.create_user()
+        self.create_member(user=user, organization=self.organization, teams=[team_a])
+
+        project_a = self.create_project(
+            organization=self.organization, teams=[team_a], name="Team A Project"
+        )
+        self.create_project(organization=self.organization, teams=[team_b], name="Team B Project")
+
+        self.login_as(user=user)
+        response = self.client.get(self.url, {})
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["projectId"] == project_a.id
 
     def test_post_creates_project_preferences(self):
         project = self.create_project(organization=self.organization)

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -47,6 +47,28 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             },
         ]
 
+    def test_get_excludes_projects_user_has_no_team_access_to(self) -> None:
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        team_a = self.create_team(organization=self.organization)
+        team_b = self.create_team(organization=self.organization)
+
+        user = self.create_user()
+        self.create_member(user=user, organization=self.organization, teams=[team_a])
+
+        project_a = self.create_project(
+            organization=self.organization, teams=[team_a], name="Team A Project"
+        )
+        self.create_project(organization=self.organization, teams=[team_b], name="Team B Project")
+
+        self.login_as(user=user)
+        response = self.client.get(self.url, {})
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["projectId"] == project_a.id
+
     def test_get_returns_projects_matching_query(self) -> None:
         project1 = self.create_project(organization=self.organization, name="Project One")
         project2 = self.create_project(organization=self.organization, name="Project Two")


### PR DESCRIPTION
Fixes https://github.com/getsentry/getsentry/issues/20098 

Use `self.get_projects()` in `OrganizationAutofixAutomationSettingsEndpoint`. Patches closed-membership org attack where member on Team A can view Seer config data for every project in the org, even if they're not a member.