### PR TITLE
ref(repos): Move installation callbacks onto ScmInstallation, add ConnectedInstallation wrapper

### DIFF
--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.spec.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.spec.tsx
@@ -7,7 +7,7 @@ import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary
 import type {Repository} from 'sentry/types/integrations';
 
 import type {ScmInstallation} from './scmRepositoryTable';
-import {ScmRepositoryTable} from './scmRepositoryTable';
+import {InstallationOverrideProvider, ScmRepositoryTable} from './scmRepositoryTable';
 
 // `useVirtualizer` only renders rows whose computed bounding rect overlaps
 // the scroll container. Without a stub it sees a 0×0 viewport and renders
@@ -111,21 +111,15 @@ describe('ScmRepositoryTable', () => {
       render(
         <ScmRepositoryTable
           provider={provider}
-          installations={[makeInstallation()]}
-          onUninstall={onUninstall}
-          onSettings={onSettings}
+          installations={[makeInstallation({onUninstall, onSettings})]}
         />
       );
 
       await userEvent.click(screen.getByRole('button', {name: 'Integration settings'}));
-      expect(onSettings).toHaveBeenCalledWith(
-        expect.objectContaining({integration: expect.anything()})
-      );
+      expect(onSettings).toHaveBeenCalled();
 
       await userEvent.click(screen.getByRole('button', {name: 'Uninstall'}));
-      expect(onUninstall).toHaveBeenCalledWith(
-        expect.objectContaining({integration: expect.anything()})
-      );
+      expect(onUninstall).toHaveBeenCalled();
     });
 
     it('shows a manage repositories link when manageUrl is provided', () => {
@@ -178,8 +172,10 @@ describe('ScmRepositoryTable', () => {
       render(
         <ScmRepositoryTable
           provider={provider}
-          installations={[makeInstallation(), second]}
-          onUninstall={jest.fn()}
+          installations={[
+            makeInstallation({onUninstall: jest.fn()}),
+            {...second, onUninstall: jest.fn()},
+          ]}
         />
       );
 
@@ -285,28 +281,69 @@ describe('ScmRepositoryTable', () => {
       expect(await screen.findByText('Repositories not yet synced.')).toBeInTheDocument();
     });
 
-    it('calls onInstallationSync when Sync now is clicked', async () => {
-      const onInstallationSync = jest.fn();
+    it('renders the sync button via onSync when Sync now is clicked', async () => {
+      const onSync = jest.fn();
       render(
         <ScmRepositoryTable
           provider={provider}
-          installations={[makeInstallation()]}
-          onInstallationSync={onInstallationSync}
+          installations={[makeInstallation({onSync})]}
         />
       );
 
       await userEvent.hover(screen.getByText('3 repositories'));
       await userEvent.click(await screen.findByRole('button', {name: 'Sync now'}));
-      expect(onInstallationSync).toHaveBeenCalledTimes(1);
+      expect(onSync).toHaveBeenCalledTimes(1);
     });
 
-    it('hides the Sync now button when onInstallationSync is not provided', async () => {
+    it('hides the sync button when onSync is not provided', async () => {
       render(
         <ScmRepositoryTable provider={provider} installations={[makeInstallation()]} />
       );
 
       await userEvent.hover(screen.getByText('3 repositories'));
       await screen.findByText('Repositories not yet synced.');
+      expect(screen.queryByRole('button', {name: 'Sync now'})).not.toBeInTheDocument();
+    });
+  });
+
+  describe('installationWrapper', () => {
+    it('injects overrides via InstallationOverrideProvider', async () => {
+      const onSync = jest.fn();
+
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation()]}
+          installationWrapper={({children}) => (
+            <InstallationOverrideProvider value={{isSyncing: false, onSync}}>
+              {children}
+            </InstallationOverrideProvider>
+          )}
+        />
+      );
+
+      await userEvent.hover(screen.getByText('3 repositories'));
+      await userEvent.click(await screen.findByRole('button', {name: 'Sync now'}));
+      expect(onSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows syncing state when isSyncing override is true', async () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation()]}
+          installationWrapper={({children}) => (
+            <InstallationOverrideProvider value={{isSyncing: true}}>
+              {children}
+            </InstallationOverrideProvider>
+          )}
+        />
+      );
+
+      await userEvent.hover(screen.getByText('3 repositories'));
+      expect(
+        await screen.findByText('Re-syncing in the background…')
+      ).toBeInTheDocument();
       expect(screen.queryByRole('button', {name: 'Sync now'})).not.toBeInTheDocument();
     });
   });
@@ -376,8 +413,12 @@ describe('ScmRepositoryTable', () => {
       render(
         <ScmRepositoryTable
           provider={provider}
-          installations={[makeInstallation({mappedProjectSlugsByRepoId: {}})]}
-          repoActions={() => <button aria-label="Project mappings" />}
+          installations={[
+            makeInstallation({
+              mappedProjectSlugsByRepoId: {},
+              repoActions: () => <button aria-label="Project mappings" />,
+            }),
+          ]}
         />
       );
 
@@ -388,8 +429,11 @@ describe('ScmRepositoryTable', () => {
       render(
         <ScmRepositoryTable
           provider={provider}
-          installations={[makeInstallation()]}
-          repoActions={() => <button aria-label="Project mappings" />}
+          installations={[
+            makeInstallation({
+              repoActions: () => <button aria-label="Project mappings" />,
+            }),
+          ]}
         />
       );
 

--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.stories.tsx
@@ -150,9 +150,7 @@ export default Storybook.story('ScmRepositoryTable', story => {
             },
           },
         }))}
-        onInstallationSync={() => {}}
-        onUninstall={() => {}}
-        onSettings={() => {}}
+        // no sync button
       />
     );
   });
@@ -161,7 +159,7 @@ export default Storybook.story('ScmRepositoryTable', story => {
     <ScmRepositoryTable
       provider={GITHUB_PROVIDER}
       installations={EMPTY_INSTALLATION}
-      onInstallationSync={() => {}}
+      // no sync button
     />
   ));
 
@@ -206,9 +204,7 @@ export default Storybook.story('ScmRepositoryTable', story => {
           },
           isSyncing: i === 0,
         }))}
-        onInstallationSync={() => {}}
-        onUninstall={() => {}}
-        onSettings={() => {}}
+        // no sync button
       />
     );
   });
@@ -216,8 +212,6 @@ export default Storybook.story('ScmRepositoryTable', story => {
   story('Loading and disabled', () => (
     <ScmRepositoryTable
       provider={GITHUB_PROVIDER}
-      onUninstall={() => {}}
-      onSettings={() => {}}
       installations={[
         {
           integration: makeIntegration('1', '@org-name-123'),

--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
@@ -1,4 +1,12 @@
-import {Fragment, type ReactNode, useCallback, useMemo, useRef, useState} from 'react';
+import {
+  createContext,
+  Fragment,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import sortBy from 'lodash/sortBy';
@@ -92,10 +100,30 @@ export interface ScmInstallation {
    */
   mappingsLoading?: boolean;
   /**
+   * Called when the user clicks the settings button. When omitted the button
+   * is hidden.
+   */
+  onSettings?: () => void;
+  /**
+   * Called when the user clicks "Sync now" in the repository count tag
+   * tooltip. When omitted the button is hidden.
+   */
+  onSync?: () => void;
+  /**
+   * Called when the user clicks the uninstall button. When omitted the button
+   * is hidden.
+   */
+  onUninstall?: () => void;
+  /**
    * Items rendered into the per-installation overflow (`...`) menu. When
    * omitted or empty, the menu trigger is hidden.
    */
   overflowMenuItems?: MenuItemProps[];
+  /**
+   * Renders an action element in the right slot of each repository row.
+   * Only called when `mappedProjectSlugsByRepoId` is set on the installation.
+   */
+  repoActions?: (repo: Repository) => React.ReactNode;
   /**
    * Whether the parent is still fetching the repository list. Drives the
    * "Loading repositories" empty state and shows a loading indicator
@@ -114,6 +142,11 @@ export interface ScmInstallation {
   uninstallButtonProps?: Omit<ButtonProps, 'onClick'>;
 }
 
+export interface InstallationWrapperProps {
+  children: React.ReactNode;
+  installation: ScmInstallation;
+}
+
 interface ScmRepositoryTableProps {
   /**
    * Installations to render, one expand/collapse section per entry.
@@ -124,29 +157,44 @@ interface ScmRepositoryTableProps {
    */
   provider: IntegrationProvider;
   /**
-   * Called when the user clicks "Sync now" in the repository count tag tooltip.
-   * When omitted the button is hidden.
+   * Optional wrapper component rendered around each installation. Useful for
+   * setting up per-installation state — e.g. wiring a sync hook that feeds
+   * `isSyncing` and `onSync` back into the installation via
+   * `InstallationOverrideProvider`.
    */
-  onInstallationSync?: (installation: ScmInstallation) => void;
-  /**
-   * Called when the user clicks the settings button for an installation.
-   * When omitted the button is hidden.
-   */
-  onSettings?: (installation: ScmInstallation) => void;
-  /**
-   * Called when the user clicks the uninstall button for an installation.
-   * When omitted the button is hidden.
-   */
-  onUninstall?: (installation: ScmInstallation) => void;
-  /**
-   * Renders an action element in the right slot of each repository row.
-   * Only called when `mappedProjectSlugsByRepoId` is set on the installation.
-   */
-  repoActions?: (repo: Repository, installation: ScmInstallation) => ReactNode;
+  installationWrapper?: React.ComponentType<InstallationWrapperProps>;
   /**
    * Fuse match results used to filter and highlight repo names.
    */
   repoMatches?: ScmRepoMatches;
+}
+
+export function ScmRepositoryTable({installations, ...rest}: ScmRepositoryTableProps) {
+  const soleInstallation = installations.length === 1 ? installations[0]! : null;
+
+  if (soleInstallation !== null) {
+    return <SingleInstallTable installation={soleInstallation} {...rest} />;
+  }
+
+  return <MultiInstallTable installations={installations} {...rest} />;
+}
+
+interface OverrideProviderProps {
+  children: React.ReactNode;
+  value: Partial<ScmInstallation>;
+}
+
+/**
+ * Provides overrides that are merged into the nearest installation before
+ * rendering. Use inside an `installationWrapper` component to inject
+ * per-installation state (e.g. `isSyncing`, `onSync`) without prop-drilling.
+ */
+export function InstallationOverrideProvider({value, children}: OverrideProviderProps) {
+  return (
+    <ScmInstallationContext.Provider value={value}>
+      {children}
+    </ScmInstallationContext.Provider>
+  );
 }
 
 /**
@@ -183,83 +231,117 @@ function useExpandedInstallations(installations: ScmInstallation[]) {
   return {expandedIds, toggle};
 }
 
-export function ScmRepositoryTable({
+const ScmInstallationContext = createContext<Partial<ScmInstallation>>({});
+
+/**
+ * Returns the installation merged with any overrides from the nearest
+ * `InstallationOverrideProvider`. When no provider is present the context
+ * is empty and the installation is returned as-is.
+ */
+function useMergedInstallation(installation: ScmInstallation): ScmInstallation {
+  const overrides = useContext(ScmInstallationContext);
+  return useMemo(() => ({...installation, ...overrides}), [installation, overrides]);
+}
+
+interface SoloInstallTableProps extends Omit<ScmRepositoryTableProps, 'installations'> {
+  installation: ScmInstallation;
+}
+
+function SingleInstallTable({
+  installation,
+  installationWrapper: Wrapper,
+  ...rest
+}: SoloInstallTableProps) {
+  const content = <SingleInstallTableContent installation={installation} {...rest} />;
+  return Wrapper ? <Wrapper installation={installation}>{content}</Wrapper> : content;
+}
+
+function SingleInstallTableContent({
+  provider,
+  installation,
+  repoMatches,
+}: SoloInstallTableProps) {
+  const merged = useMergedInstallation(installation);
+
+  return (
+    <Panel role="region" aria-label={provider.name}>
+      <TableHeader>
+        <Flex align="center" gap="sm">
+          {getIntegrationIcon(provider.key, 'sm')}
+          <Text bold>{provider.name}</Text>
+          <Text variant="muted">/</Text>
+          <IntegrationSummary installation={merged} />
+        </Flex>
+        <Flex align="center" gap="sm">
+          <InstallationActions installation={merged} providerName={provider.name} />
+        </Flex>
+      </TableHeader>
+      <VirtualizedRepoList
+        installation={merged}
+        repoMatches={repoMatches}
+        providerName={provider.name}
+      />
+    </Panel>
+  );
+}
+
+function MultiInstallTable({
   provider,
   installations,
-  onSettings,
-  onInstallationSync,
-  onUninstall,
-  repoActions,
+  installationWrapper: Wrapper,
   repoMatches,
 }: ScmRepositoryTableProps) {
-  const soleInstallation = installations.length === 1 ? installations[0]! : null;
-
   const {expandedIds, toggle} = useExpandedInstallations(installations);
 
   return (
     <Panel role="region" aria-label={provider.name}>
-      <Flex
-        justify="between"
-        background="secondary"
-        padding="xs lg"
-        radius="sm sm 0 0"
-        borderBottom="secondary"
-        minHeight="36px"
-      >
+      <TableHeader>
         <Flex align="center" gap="sm">
           {getIntegrationIcon(provider.key, 'sm')}
           <Text bold>{provider.name}</Text>
-          {soleInstallation && (
-            <Fragment>
-              <Text variant="muted">/</Text>
-              <IntegrationSummary installation={soleInstallation} />
-            </Fragment>
-          )}
         </Flex>
-        <Flex align="center" gap="sm">
-          {soleInstallation && (
-            <InstallationActions
-              installation={soleInstallation}
-              providerName={provider.name}
-              onUninstall={onUninstall}
-              onSettings={onSettings}
-              onInstallationSync={onInstallationSync}
+      </TableHeader>
+      <Grid role="list" columns="max-content 1fr" gap="0 md">
+        {installations.map(installation => {
+          const hasSearchHits =
+            repoMatches !== undefined &&
+            installation.repositories.some(r => repoMatches[r.id]);
+          const row = (
+            <InstallationRow
+              provider={provider}
+              installation={installation}
+              expanded={hasSearchHits || expandedIds.has(installation.integration.id)}
+              onToggle={() => toggle(installation.integration.id)}
+              repoMatches={repoMatches}
             />
-          )}
-        </Flex>
-      </Flex>
-      {soleInstallation ? (
-        <VirtualizedRepoList
-          installation={soleInstallation}
-          repoMatches={repoMatches}
-          providerName={provider.name}
-          repoActions={repoActions}
-        />
-      ) : (
-        <Grid role="list" columns="max-content 1fr" gap="0 md">
-          {installations.map(installation => {
-            const hasSearchHits =
-              repoMatches !== undefined &&
-              installation.repositories.some(r => repoMatches[r.id]);
-            return (
-              <InstallationSubgrid key={installation.integration.id} role="listitem">
-                <InstallationRow
-                  provider={provider}
-                  installation={installation}
-                  expanded={hasSearchHits || expandedIds.has(installation.integration.id)}
-                  onToggle={() => toggle(installation.integration.id)}
-                  onUninstall={onUninstall}
-                  onSettings={onSettings}
-                  onInstallationSync={onInstallationSync}
-                  repoActions={repoActions}
-                  repoMatches={repoMatches}
-                />
-              </InstallationSubgrid>
-            );
-          })}
-        </Grid>
-      )}
+          );
+          return Wrapper ? (
+            <Wrapper key={installation.integration.id} installation={installation}>
+              <InstallationSubgrid role="listitem">{row}</InstallationSubgrid>
+            </Wrapper>
+          ) : (
+            <InstallationSubgrid key={installation.integration.id} role="listitem">
+              {row}
+            </InstallationSubgrid>
+          );
+        })}
+      </Grid>
     </Panel>
+  );
+}
+
+function TableHeader({children}: {children: React.ReactNode}) {
+  return (
+    <Flex
+      justify="between"
+      background="secondary"
+      padding="xs lg"
+      radius="sm sm 0 0"
+      borderBottom="secondary"
+      minHeight="36px"
+    >
+      {children}
+    </Flex>
   );
 }
 
@@ -268,10 +350,6 @@ interface InstallationRowProps {
   installation: ScmInstallation;
   onToggle: () => void;
   provider: IntegrationProvider;
-  onInstallationSync?: (installation: ScmInstallation) => void;
-  onSettings?: (installation: ScmInstallation) => void;
-  onUninstall?: (installation: ScmInstallation) => void;
-  repoActions?: (repo: Repository, installation: ScmInstallation) => ReactNode;
   repoMatches?: ScmRepoMatches;
 }
 
@@ -280,13 +358,10 @@ function InstallationRow({
   installation,
   expanded,
   onToggle,
-  onUninstall,
-  onSettings,
-  onInstallationSync,
-  repoActions,
   repoMatches,
 }: InstallationRowProps) {
-  const {expandDisabled} = installation;
+  const merged = useMergedInstallation(installation);
+  const {expandDisabled} = merged;
 
   const handleRowClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (expandDisabled) {
@@ -314,7 +389,7 @@ function InstallationRow({
       <RowButton
         role="button"
         tabIndex={expandDisabled ? -1 : 0}
-        aria-label={installation.integration.name}
+        aria-label={merged.integration.name}
         aria-expanded={expandDisabled ? undefined : expanded}
         aria-disabled={expandDisabled || undefined}
         onClick={handleRowClick}
@@ -323,25 +398,18 @@ function InstallationRow({
         <IconChevron direction={expanded && !expandDisabled ? 'down' : 'right'} />
         <Flex column="2" align="center" justify="between" gap="md">
           <Flex align="center" gap="sm">
-            <IntegrationSummary installation={installation} />
+            <IntegrationSummary installation={merged} />
           </Flex>
           <Flex align="center" gap="md">
-            <InstallationActions
-              installation={installation}
-              providerName={provider.name}
-              onUninstall={onUninstall}
-              onSettings={onSettings}
-              onInstallationSync={onInstallationSync}
-            />
+            <InstallationActions installation={merged} providerName={provider.name} />
           </Flex>
         </Flex>
       </RowButton>
       {expanded && !expandDisabled && (
         <VirtualizedRepoList
-          installation={installation}
+          installation={merged}
           repoMatches={repoMatches}
           providerName={provider.name}
-          repoActions={repoActions}
           nested
         />
       )}
@@ -363,17 +431,13 @@ function IntegrationSummary({installation}: {installation: ScmInstallation}) {
 interface InstallationActionsProps {
   installation: ScmInstallation;
   providerName: string;
-  onInstallationSync?: (installation: ScmInstallation) => void;
-  onSettings?: (installation: ScmInstallation) => void;
-  onUninstall?: (installation: ScmInstallation) => void;
 }
 
 function getRepoCountTooltip(
   installation: ScmInstallation,
-  onInstallationSync: ((installation: ScmInstallation) => void) | undefined,
   lastSync: string | undefined
-): ReactNode {
-  const {reposLoading, isSyncing} = installation;
+): React.ReactNode {
+  const {reposLoading, isSyncing, onSync} = installation;
 
   if (reposLoading) {
     return t('Loading repositories');
@@ -382,8 +446,8 @@ function getRepoCountTooltip(
     return t('Re-syncing in the background…');
   }
 
-  const syncNowButton = onInstallationSync ? (
-    <Button size="xs" variant="link" onClick={() => onInstallationSync(installation)}>
+  const syncNowButton = onSync ? (
+    <Button size="xs" variant="link" onClick={onSync}>
       {t('Sync now')}
     </Button>
   ) : null;
@@ -401,13 +465,7 @@ function getRepoCountTooltip(
   return tct('Repositories not yet synced. [syncNow]', {syncNow: syncNowButton});
 }
 
-function InstallationActions({
-  installation,
-  providerName,
-  onInstallationSync,
-  onUninstall,
-  onSettings,
-}: InstallationActionsProps) {
+function InstallationActions({installation, providerName}: InstallationActionsProps) {
   const {
     manageUrl,
     overflowMenuItems,
@@ -416,6 +474,8 @@ function InstallationActions({
     repositories,
     reposLoading,
     isSyncing,
+    onSettings,
+    onUninstall,
     integration,
   } = installation;
 
@@ -424,11 +484,7 @@ function InstallationActions({
   const lastSync = typeof rawLastSync === 'string' ? rawLastSync : undefined;
 
   const isLoading = reposLoading || isSyncing;
-  const repoCountTooltip = getRepoCountTooltip(
-    installation,
-    onInstallationSync,
-    lastSync
-  );
+  const repoCountTooltip = getRepoCountTooltip(installation, lastSync);
 
   return (
     <Fragment>
@@ -465,7 +521,7 @@ function InstallationActions({
               variant="transparent"
               icon={<IconDelete />}
               {...uninstallButtonProps}
-              onClick={() => onUninstall(installation)}
+              onClick={onUninstall}
             />
           )}
           {onSettings && (
@@ -475,7 +531,7 @@ function InstallationActions({
               variant="transparent"
               icon={<IconSliders />}
               {...settingsButtonProps}
-              onClick={() => onSettings(installation)}
+              onClick={onSettings}
             />
           )}
           {overflowMenuItems && overflowMenuItems.length > 0 && (
@@ -506,7 +562,7 @@ function RepoMappings({
 }: {
   mappingsLoading: boolean | undefined;
   slugs: string[];
-  action?: ReactNode;
+  action?: React.ReactNode;
 }) {
   return (
     <Flex align="center" gap="2xs">
@@ -523,7 +579,6 @@ interface VirtualizedRepoListProps {
   installation: ScmInstallation;
   providerName: string;
   nested?: boolean;
-  repoActions?: (repo: Repository, installation: ScmInstallation) => ReactNode;
   repoMatches?: ScmRepoMatches;
 }
 
@@ -531,7 +586,6 @@ function VirtualizedRepoList({
   installation,
   repoMatches,
   providerName,
-  repoActions,
   nested = false,
 }: VirtualizedRepoListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -550,6 +604,7 @@ function VirtualizedRepoList({
         : repositories.filter(r => repoMatches[r.id]);
     const hasMapping = (id: string) =>
       (mappedProjectSlugsByRepoId?.[id]?.length ?? 0) > 0;
+
     return sortBy(filtered, [r => !hasMapping(r.id), r => r.name]);
   }, [repositories, repoMatches, mappedProjectSlugsByRepoId]);
 
@@ -656,7 +711,7 @@ function VirtualizedRepoList({
                   <RepoMappings
                     slugs={mappedProjectSlugsByRepoId[repo.id] ?? []}
                     mappingsLoading={mappingsLoading}
-                    action={repoActions?.(repo, installation)}
+                    action={installation.repoActions?.(repo)}
                   />
                 )}
               </RepoRow>

--- a/static/app/views/settings/organizationRepositoriesV2/index.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/index.tsx
@@ -1,5 +1,5 @@
 import {useMemo, useState} from 'react';
-import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
+import {useInfiniteQuery, useQuery, useQueryClient} from '@tanstack/react-query';
 import groupBy from 'lodash/groupBy';
 import mapValues from 'lodash/mapValues';
 import sortBy from 'lodash/sortBy';
@@ -19,6 +19,7 @@ import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {
   Integration,
+  OrganizationIntegration,
   Repository,
   RepositoryProjectPathConfig,
 } from 'sentry/types/integrations';
@@ -30,13 +31,86 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {ConnectProviderDropdown} from 'sentry/views/settings/organizationRepositories/connectProviderDropdown';
 import {NoIntegrationsEmptyState} from 'sentry/views/settings/organizationRepositories/noIntegrationsEmptyState';
-import type {ScmInstallation} from 'sentry/views/settings/organizationRepositories/scmRepositoryTable';
-import {ScmRepositoryTable} from 'sentry/views/settings/organizationRepositories/scmRepositoryTable';
+import {
+  InstallationOverrideProvider,
+  type ScmInstallation,
+  ScmRepositoryTable,
+  type InstallationWrapperProps,
+} from 'sentry/views/settings/organizationRepositories/scmRepositoryTable';
 import {useRepoSearch} from 'sentry/views/settings/organizationRepositories/useRepoSearch';
 import {organizationIntegrationsQueryOptions} from 'sentry/views/settings/seer/overview/utils/organizationIntegrationsQueryOptions';
 
 import {useDeleteIntegration} from './useDeleteIntegration';
 import {useInstallationSettings} from './useInstallationSettings';
+
+function ConnectedInstallation({installation, children}: InstallationWrapperProps) {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+
+  const hasAccess = hasEveryAccess(['org:integrations'], {organization});
+
+  const reposOptions = organizationRepositoriesInfiniteOptions({
+    organization,
+    staleTime: 0,
+  });
+  const integrationsOptions = organizationIntegrationsQueryOptions({
+    organization,
+  });
+
+  // XXX: We have to fetch each integration to load the configData. This is not
+  // provided by the integrations list query.
+  const {data: integrationWithConfig} = useQuery(
+    apiOptions.as<OrganizationIntegration>()(
+      '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
+      {
+        path: {
+          organizationIdOrSlug: organization.slug,
+          integrationId: installation.integration.id,
+        },
+        staleTime: 60_000,
+      }
+    )
+  );
+
+  const {openSettings} = useInstallationSettings(integrationWithConfig);
+
+  const handleDelete = useDeleteIntegration({
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: integrationsOptions.queryKey});
+      queryClient.invalidateQueries({queryKey: reposOptions.queryKey});
+    },
+  });
+
+  // Settings cannot be opened until we've loaded the integrationWithConfig
+  const settingsButtonProps = {
+    disabled: integrationWithConfig === undefined,
+  };
+
+  const uninstallButtonProps = hasAccess
+    ? undefined
+    : {
+        disabled: true,
+        tooltipProps: {
+          title: t(
+            'You must be an organization owner, manager or admin to uninstall this provider'
+          ),
+        },
+      };
+
+  const overrides = {
+    integration: integrationWithConfig ?? installation.integration,
+    onSettings: openSettings,
+    settingsButtonProps,
+    onUninstall: () => handleDelete(installation.integration),
+    uninstallButtonProps,
+  } as const;
+
+  return (
+    <InstallationOverrideProvider value={overrides}>
+      {children}
+    </InstallationOverrideProvider>
+  );
+}
 
 const SCM_PROVIDER_ORDER = [
   'github',
@@ -49,7 +123,6 @@ const SCM_PROVIDER_ORDER = [
 
 export function OrganizationRepositoriesV2() {
   const organization = useOrganization();
-  const hasAccess = hasEveryAccess(['org:integrations'], {organization});
   const [searchTerm, setSearchTerm] = useState('');
 
   const providersQuery = useQuery(
@@ -69,6 +142,9 @@ export function OrganizationRepositoriesV2() {
 
   const scmProviderKeys = useMemo(() => scmProviders.map(p => p.key), [scmProviders]);
 
+  // XXX: We avoid passing includeConfig here as it significantly slows down
+  // the request. We'll load the config for each SCM integration in the
+  // ConnectedInstallation component.
   const integrationsQuery = useQuery(
     organizationIntegrationsQueryOptions({organization})
   );
@@ -126,11 +202,6 @@ export function OrganizationRepositoriesV2() {
     codeMappingsQuery.hasNextPage ||
     codeMappingsQuery.isFetchingNextPage;
 
-  const {configByIntegrationId, openInstallationSettings} = useInstallationSettings({
-    scmIntegrations,
-    hasAccess,
-  });
-
   const installationsByProviderKey = useMemo(() => {
     const installations = scmIntegrations.map<ScmInstallation>(integration => ({
       integration,
@@ -139,19 +210,6 @@ export function OrganizationRepositoriesV2() {
       manageUrl: getProviderConfigUrl(integration) ?? undefined,
       mappedProjectSlugsByRepoId,
       mappingsLoading,
-      settingsButtonProps: {
-        disabled: configByIntegrationId[integration.id] === undefined,
-      },
-      uninstallButtonProps: hasAccess
-        ? undefined
-        : {
-            disabled: true,
-            tooltipProps: {
-              title: t(
-                'You must be an organization owner, manager or admin to uninstall this provider'
-              ),
-            },
-          },
     }));
     return groupBy(installations, i => i.integration.provider.key);
   }, [
@@ -160,21 +218,12 @@ export function OrganizationRepositoriesV2() {
     reposLoading,
     mappedProjectSlugsByRepoId,
     mappingsLoading,
-    configByIntegrationId,
-    hasAccess,
   ]);
 
   const handleAddIntegration = (_data: Integration) => {
     integrationsQuery.refetch();
     reposQuery.refetch();
   };
-
-  const handleDeleteIntegration = useDeleteIntegration({
-    onSuccess: () => {
-      integrationsQuery.refetch();
-      reposQuery.refetch();
-    },
-  });
 
   const repoMatches = useRepoSearch(allRepos, searchTerm);
 
@@ -247,8 +296,7 @@ export function OrganizationRepositoriesV2() {
                   provider={provider}
                   installations={installationsByProviderKey[provider.key]!}
                   repoMatches={repoMatches}
-                  onUninstall={inst => handleDeleteIntegration(inst.integration)}
-                  onSettings={inst => openInstallationSettings(inst.integration)}
+                  installationWrapper={ConnectedInstallation}
                 />
               ))
           )}

--- a/static/app/views/settings/organizationRepositoriesV2/useInstallationSettings.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/useInstallationSettings.tsx
@@ -1,10 +1,11 @@
 import {Fragment} from 'react';
-import {mutationOptions, useQueries, useQueryClient} from '@tanstack/react-query';
+import {mutationOptions, useQueryClient} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {DrawerBody, DrawerHeader, useDrawer} from '@sentry/scraps/drawer';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import {BackendJsonAutoSaveForm} from 'sentry/components/backendJsonFormAdapter/backendJsonAutoSaveForm';
 import type {FieldValue} from 'sentry/components/backendJsonFormAdapter/types';
 import {t} from 'sentry/locale';
@@ -19,76 +20,59 @@ const NO_ACCESS_REASON = t(
   'You must be an organization owner, manager, or admin to change these settings.'
 );
 
-interface UseInstallationSettingsOptions {
-  hasAccess: boolean;
-  scmIntegrations: OrganizationIntegration[];
-}
-
 interface UseInstallationSettingsResult {
   /**
-   * Full integration config keyed by integration ID, populated once each
-   * per-integration config query resolves. Values are `undefined` while
-   * their query is still in-flight.
-   */
-  configByIntegrationId: Record<string, OrganizationIntegration | undefined>;
-  /**
-   * Opens a settings drawer for the given integration, rendering each
+   * Opens a settings drawer for the integration, rendering each
    * `configOrganization` field as an auto-saving form. Fields are disabled
    * with a permission tooltip when `hasAccess` is false.
    */
-  openInstallationSettings: (integration: OrganizationIntegration) => void;
+  openSettings: () => void;
 }
 
-export function useInstallationSettings({
-  scmIntegrations,
-  hasAccess,
-}: UseInstallationSettingsOptions): UseInstallationSettingsResult {
+export function useInstallationSettings(
+  integration: OrganizationIntegration | undefined
+): UseInstallationSettingsResult {
   const organization = useOrganization();
-  const {openDrawer} = useDrawer();
+  const hasAccess = hasEveryAccess(['org:integrations'], {organization});
   const queryClient = useQueryClient();
 
-  const configByIntegrationId = useQueries({
-    queries: scmIntegrations.map(integration =>
-      apiOptions.as<OrganizationIntegration>()(
-        '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
-        {
-          path: {
-            organizationIdOrSlug: organization.slug,
-            integrationId: integration.id,
-          },
-          staleTime: 60_000,
-        }
-      )
-    ),
-    combine: results =>
-      Object.fromEntries(
-        scmIntegrations.map((integration, i) => [integration.id, results[i]?.data])
-      ),
-  });
+  const {openDrawer} = useDrawer();
 
-  const openInstallationSettings = (integration: OrganizationIntegration) => {
-    const integrationOptions = apiOptions.as<OrganizationIntegration>()(
+  function openSettings() {
+    if (!integration) {
+      return;
+    }
+
+    const integrationQueryOptions = apiOptions.as<OrganizationIntegration>()(
       '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
       {
-        path: {organizationIdOrSlug: organization.slug, integrationId: integration.id},
+        path: {
+          organizationIdOrSlug: organization.slug,
+          integrationId: integration.id,
+        },
         staleTime: 60_000,
       }
     );
+
     const integrationEndpoint = getApiUrl(
       '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
-      {path: {organizationIdOrSlug: organization.slug, integrationId: integration.id}}
+      {
+        path: {
+          organizationIdOrSlug: organization.slug,
+          integrationId: integration.id,
+        },
+      }
     );
     const integrationMutationOptions = mutationOptions({
       mutationFn: (data: Record<string, unknown>) =>
         fetchMutation({method: 'POST', url: integrationEndpoint, data}),
       onSuccess: () =>
-        queryClient.invalidateQueries({queryKey: integrationOptions.queryKey}),
+        queryClient.invalidateQueries({queryKey: integrationQueryOptions.queryKey}),
     });
 
-    const resolvedIntegration = configByIntegrationId[integration.id] ?? integration;
     const fields = hasAccess
-      ? (resolvedIntegration.configOrganization ?? [])
-      : (resolvedIntegration.configOrganization?.map(f => ({
+      ? (integration.configOrganization ?? [])
+      : (integration.configOrganization?.map(f => ({
           ...f,
           disabled: true,
           disabledReason: NO_ACCESS_REASON,
@@ -119,7 +103,7 @@ export function useInstallationSettings({
                   <BackendJsonAutoSaveForm
                     field={fieldConfig}
                     initialValue={
-                      resolvedIntegration.configData?.[fieldConfig.name] as FieldValue<
+                      integration.configData?.[fieldConfig.name] as FieldValue<
                         typeof fieldConfig
                       >
                     }
@@ -136,7 +120,7 @@ export function useInstallationSettings({
         drawerKey: `integration-settings-${integration.id}`,
       }
     );
-  };
+  }
 
-  return {configByIntegrationId, openInstallationSettings};
+  return {openSettings};
 }


### PR DESCRIPTION
The SCM table is a presentation-only controlled component; wiring React hooks per-installation at the table level would break that abstraction.

Moves `onSettings`/`onUninstall`/`onSync`/`repoActions` from table-level props onto the `ScmInstallation` object itself. Adds `InstallationOverrideProvider` so a wrapper component can inject per-install state (from hooks) without prop-drilling through the table.

Introduces `ConnectedInstallation` in the V2 page as the first consumer: it fetches per-integration config, wires up settings and delete, and merges everything into the installation via the provider. Also refactors `useInstallationSettings` from a multi-integration `useQueries` approach to operating on a single integration.

Part of [VDY-116: Create unified repository list and install flow UX](https://linear.app/getsentry/issue/VDY-116/create-unified-repository-list-and-install-flow-ux)