### PR TITLE
fix(sentryapps): need GET to be exception cased to view the app status in _admin

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -62,7 +62,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
         "PUT": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (SentryAppDetailsEndpointPermission,)
-    allow_disabled_sentry_app_for_methods = {"DELETE", "PUT"}
+    allow_disabled_sentry_app_for_methods = {"DELETE", "PUT", "GET"}
 
     @extend_schema(
         operation_id="Retrieve a custom integration by ID or slug.",

--- a/tests/sentry/sentry_apps/api/bases/test_disabled_sentry_app.py
+++ b/tests/sentry/sentry_apps/api/bases/test_disabled_sentry_app.py
@@ -22,9 +22,9 @@ class DisabledSentryAppDetailsTest(APITestCase):
         self.login_as(self.user)
 
     @override_options(OPTION)
-    def test_get_disabled_app_returns_403(self) -> None:
+    def test_get_disabled_app_returns_200(self) -> None:
         disable_app(self.app)
-        self.get_error_response(self.app.slug, status_code=403)
+        self.get_success_response(self.app.slug, status_code=200)
 
     @override_options(OPTION)
     def test_get_non_disabled_app_returns_200(self) -> None:


### PR DESCRIPTION
If we don't exception case the sentry app page in _admin will be unable to load for disabled apps