### PR TITLE
fix(explore): Fix flaky FilesChanged test assertion

### DIFF
--- a/static/app/views/explore/releases/detail/commitsAndFiles/filesChanged.spec.tsx
+++ b/static/app/views/explore/releases/detail/commitsAndFiles/filesChanged.spec.tsx
@@ -89,28 +89,17 @@ describe('FilesChanged', () => {
 
   it('should render no files changed', async () => {
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/releases/${encodeURIComponent(
-        release.version
-      )}/repositories/`,
-      body: repos,
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/org-slug/releases/${encodeURIComponent(
         release.version
       )}/commitfiles/`,
       body: [],
     });
     renderComponent();
-    expect(await screen.findByText(/There are no changed files/)).toBeInTheDocument();
+    const emptyState = await screen.findByTestId('empty-state');
+    expect(emptyState).toHaveTextContent(/There are no changed files/);
   });
 
   it('should render list of files changed', async () => {
-    MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/releases/${encodeURIComponent(
-        release.version
-      )}/repositories/`,
-      body: repos,
-    });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/releases/${encodeURIComponent(
         release.version


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix flaky `filesChanged.spec.tsx` test (`should render no files changed`) that intermittently fails in CI with:

```
TestingLibraryElementError: Unable to find an element with the text: /There are no changed files/
```

**Root cause:** The test relied on `findByText` with a regex to match text that only renders after a three-step async fetch chain (repos → release repos → commit files). Under CI resource constraints, this chain can exceed the default `findBy` timeout. Additionally, redundant mock overrides for the release repos endpoint (already covered by `beforeEach`) created multiple mocks for the same URL.

**Fix:**
- Remove redundant release repos mock overrides from individual test bodies (already set in `beforeEach`)
- Wait for the `EmptyStateWarning` container (`data-test-id="empty-state"`) to appear first, then check text content within it — this is more resilient because the structural element only renders after the full async chain completes

Fixes Sentry Issue 7462603949.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2273fa83-722f-4734-8148-644fbef86e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2273fa83-722f-4734-8148-644fbef86e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

