### PR TITLE
fix(slack): Drop stale aggregateSortBys in metrics explore unfurl

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -268,6 +268,13 @@ def _parse_metrics_url(
         if sort_field:
             sort_values.append(f"-{sort_field}" if kind == "desc" else sort_field)
 
+    # A stale aggregateSortBys (e.g. left over from a previous yAxis or referencing
+    # a different metric than the one being visualized) should be dropped so the
+    # unfurl falls back to the default `-yAxes[0]` topEvents sort, matching the
+    # frontend's validateAggregateSort.
+    if sort_values and not _aggregate_sorts_are_valid(sort_values, y_axes, group_bys):
+        sort_values = []
+
     query = metric_parsed.get("query") or None
 
     return _build_timeseries_query(raw_query, y_axes, group_bys, query, sort_values), chart_type

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1945,6 +1945,87 @@ class UnfurlTest(TestCase):
             "p50(value,my.metric,distribution,millisecond)",
         ]
 
+    def test_unfurl_explore_metrics_drops_aggregate_sort_referencing_unknown_field(
+        self,
+    ) -> None:
+        # The metric JSON's `aggregateSortBys` can reference a metric/function that
+        # isn't in the active `aggregateFields` yAxes (e.g. left over from a prior
+        # visualization). Mirror the frontend's validateAggregateSort by dropping
+        # the stale sort so events-timeseries falls back to `-yAxes[0]`.
+        url = (
+            "https://sentry.io/organizations/org1/explore/metrics/"
+            "?metric=%7B%22aggregateFields%22%3A%5B"
+            "%7B%22yAxes%22%3A%5B%22p95(value%2Cmy.metric%2Cdistribution%2Cmillisecond)%22%5D%7D"
+            "%5D%2C%22aggregateSortBys%22%3A%5B%7B%22field%22%3A"
+            "%22sum(value%2Cother.metric%2Cdistribution%2Cmillisecond)%22%2C%22kind%22%3A%22desc%22%7D%5D%7D"
+            "&project=1&statsPeriod=24h"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("yAxis") == [
+            "p95(value,my.metric,distribution,millisecond)",
+        ]
+        assert args["query"].getlist("sort") == []
+
+    def test_unfurl_explore_metrics_drops_aggregate_sort_when_aggregate_function_differs(
+        self,
+    ) -> None:
+        # Same metric expression but the sort uses a different aggregate function
+        # than the visualized yAxis (sum vs p95). The frontend treats these as
+        # different sort targets, so the unfurl must drop the stale sort too.
+        url = (
+            "https://sentry.io/organizations/org1/explore/metrics/"
+            "?metric=%7B%22aggregateFields%22%3A%5B"
+            "%7B%22yAxes%22%3A%5B%22p95(value%2Cmy.metric%2Cdistribution%2Cmillisecond)%22%5D%7D"
+            "%5D%2C%22aggregateSortBys%22%3A%5B%7B%22field%22%3A"
+            "%22sum(value%2Cmy.metric%2Cdistribution%2Cmillisecond)%22%2C%22kind%22%3A%22desc%22%7D%5D%7D"
+            "&project=1&statsPeriod=24h"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("sort") == []
+
+    def test_unfurl_explore_metrics_keeps_aggregate_sort_when_field_matches_yaxis(
+        self,
+    ) -> None:
+        url = (
+            "https://sentry.io/organizations/org1/explore/metrics/"
+            "?metric=%7B%22aggregateFields%22%3A%5B"
+            "%7B%22groupBy%22%3A%22browser.name%22%7D%2C"
+            "%7B%22yAxes%22%3A%5B%22sum(value%2Cmy.metric%2Cdistribution%2Cmillisecond)%22%5D%7D"
+            "%5D%2C%22aggregateSortBys%22%3A%5B%7B%22field%22%3A"
+            "%22sum(value%2Cmy.metric%2Cdistribution%2Cmillisecond)%22%2C%22kind%22%3A%22desc%22%7D%5D%7D"
+            "&project=1&statsPeriod=24h"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("sort") == [
+            "-sum(value,my.metric,distribution,millisecond)",
+        ]
+
+    def test_unfurl_explore_metrics_keeps_aggregate_sort_when_field_matches_groupby(
+        self,
+    ) -> None:
+        url = (
+            "https://sentry.io/organizations/org1/explore/metrics/"
+            "?metric=%7B%22aggregateFields%22%3A%5B"
+            "%7B%22groupBy%22%3A%22browser.name%22%7D%2C"
+            "%7B%22yAxes%22%3A%5B%22sum(value%2Cmy.metric%2Cdistribution%2Cmillisecond)%22%5D%7D"
+            "%5D%2C%22aggregateSortBys%22%3A%5B%7B%22field%22%3A%22browser.name%22%2C%22kind%22%3A%22asc%22%7D%5D%7D"
+            "&project=1&statsPeriod=24h"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("sort") == ["browser.name"]
+
     def test_unfurl_explore_aggregate_field_takes_precedence_over_visualize(self) -> None:
         url = (
             "https://sentry.io/organizations/org1/explore/traces/"


### PR DESCRIPTION
Drops stale sortBys if they aren't the actually in the visualize.

## Ai generated summary Summary

Mirrors the traces-side `validateAggregateSort` behavior in `_parse_metrics_url` so that when a metrics Explore URL has an `aggregateSortBys` entry referencing a function/metric that isn't in the visualized `aggregateFields` yAxes/groupBys, the stale sort is dropped and the unfurl falls back to the default `-yAxes[0]` topEvents sort — matching the live Explore UI.

Without this, events-timeseries receives a topEvents sort that doesn't match any selected aggregate and returns no data, so the unfurl renders empty.

Covers two of the unchecked rows in DAIN-1589 where the metrics URL's `aggregateSortBys.field` references either a different metric entirely (`processing_errors.sourcemap_configuration...` vs `sentry.seer.request_to_seer`) or the same metric but a different aggregate function (`sum(...)` vs `p95(...)`).

Refs DAIN-1589.

## Test plan

- [x] New unit tests cover: stale sort referencing unknown metric, stale sort with mismatched aggregate function, valid sort matching yAxis, valid sort matching groupBy.
- [x] `pytest tests/sentry/integrations/slack/test_unfurl.py -k explore` (51 passed).
- [x] `prek` clean on changed files.