### PR TITLE
fix(slack): Use logsAggregateSortBys for explore logs unfurl chart sort

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -182,9 +182,12 @@ def _parse_traces_url(raw_query: QueryDict, default_y_axis: str) -> tuple[QueryD
 
 
 def _parse_logs_url(raw_query: QueryDict, default_y_axis: str) -> tuple[QueryDict, int | None]:
-    """Logs visualizations live in aggregateField; query/sort use logs-specific keys
-    and sorts target table columns rather than aggregate fields, so they're not
-    validated against yAxes/groupBys."""
+    """Logs visualizations live in aggregateField; query/sort use logs-specific
+    keys. `logsSortBys` targets table columns (typically `timestamp`), so when
+    the unfurl is in topEvents mode (groupBys present) it would feed
+    events-timeseries a sort field that isn't an aggregate, returning no data.
+    Drop it in that case so the unfurl falls back to the default `-yAxes[0]`
+    aggregate sort, matching the Explore UI."""
     y_axes, group_bys, chart_type = _parse_aggregate_field_entries(
         raw_query.getlist("aggregateField")
     )
@@ -195,7 +198,7 @@ def _parse_logs_url(raw_query: QueryDict, default_y_axis: str) -> tuple[QueryDic
     query_values = raw_query.getlist("logsQuery")
     query = query_values[0] if query_values else None
 
-    sort_values = raw_query.getlist("logsSortBys")
+    sort_values = [] if group_bys else raw_query.getlist("logsSortBys")
 
     return _build_timeseries_query(raw_query, y_axes, group_bys, query, sort_values), chart_type
 

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -182,12 +182,13 @@ def _parse_traces_url(raw_query: QueryDict, default_y_axis: str) -> tuple[QueryD
 
 
 def _parse_logs_url(raw_query: QueryDict, default_y_axis: str) -> tuple[QueryDict, int | None]:
-    """Logs visualizations live in aggregateField; query/sort use logs-specific
-    keys. `logsSortBys` targets table columns (typically `timestamp`), so when
-    the unfurl is in topEvents mode (groupBys present) it would feed
-    events-timeseries a sort field that isn't an aggregate, returning no data.
-    Drop it in that case so the unfurl falls back to the default `-yAxes[0]`
-    aggregate sort, matching the Explore UI."""
+    """Logs visualizations live in aggregateField. The chart's topEvents sort
+    comes from `logsAggregateSortBys` (the aggregate-mode chart sort) — not
+    `logsSortBys`, which is the samples-mode logs table sort (typically
+    `-timestamp`) and would feed events-timeseries a non-aggregate sort field
+    in topEvents mode, returning no data. Validate the aggregate sort against
+    the active yAxes/groupBys like the traces parser, otherwise fall back to
+    the default `-yAxes[0]` topEvents sort."""
     y_axes, group_bys, chart_type = _parse_aggregate_field_entries(
         raw_query.getlist("aggregateField")
     )
@@ -198,7 +199,9 @@ def _parse_logs_url(raw_query: QueryDict, default_y_axis: str) -> tuple[QueryDic
     query_values = raw_query.getlist("logsQuery")
     query = query_values[0] if query_values else None
 
-    sort_values = [] if group_bys else raw_query.getlist("logsSortBys")
+    sort_values = raw_query.getlist("logsAggregateSortBys")
+    if sort_values and not _aggregate_sorts_are_valid(sort_values, y_axes, group_bys):
+        sort_values = []
 
     return _build_timeseries_query(raw_query, y_axes, group_bys, query, sort_values), chart_type
 

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2165,12 +2165,11 @@ class UnfurlTest(TestCase):
         assert api_params["dataset"] == "logs"
         assert api_params["yAxis"] == "sum(payload_size)"
 
-    def test_map_explore_query_args_logs_drops_table_sort_when_groupby_present(self) -> None:
-        # In aggregate mode the Explore UI keeps `logsSortBys` (a table sort,
-        # typically `-timestamp`) in the URL even though the chart's topEvents
-        # ranking is by the aggregate. Forwarding the table sort as `sort` to
-        # events-timeseries would feed it a non-aggregate sort field and return
-        # no data, so drop it and let `unfurl_explore` default to `-yAxes[0]`.
+    def test_map_explore_query_args_logs_ignores_table_sort_for_chart(self) -> None:
+        # `logsSortBys` is the samples-mode logs table sort (typically
+        # `-timestamp`). The unfurl is rendering the chart, not the table, so
+        # the table sort must not leak into the events-timeseries `sort` param —
+        # it would feed topEvents a non-aggregate field and return no data.
         url = (
             f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/"
             "?aggregateField=%7B%22groupBy%22%3A%22browser.name%22%7D"
@@ -2183,10 +2182,51 @@ class UnfurlTest(TestCase):
         assert link_type == LinkType.EXPLORE
         assert args is not None
         assert args["query"].getlist("groupBy") == ["browser.name"]
+        # logsSortBys is ignored — `unfurl_explore` will default to
+        # `-count(message)` for the topEvents sort.
         assert args["query"].getlist("sort") == []
 
-    def test_map_explore_query_args_logs_query_and_sort(self) -> None:
-        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D&logsQuery=severity%3Aerror&logsSortBys=-timestamp&project={self.project.id}&statsPeriod=24h"
+    def test_map_explore_query_args_logs_uses_aggregate_sort(self) -> None:
+        # `logsAggregateSortBys` is the aggregate-mode chart sort. When it
+        # references the active yAxis it should be forwarded to
+        # events-timeseries as the topEvents sort.
+        url = (
+            f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/"
+            "?aggregateField=%7B%22groupBy%22%3A%22severity%22%7D"
+            "&aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D"
+            "&logsAggregateSortBys=-count(message)&mode=aggregate"
+            f"&project={self.project.id}&statsPeriod=7d"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("sort") == ["-count(message)"]
+
+    def test_map_explore_query_args_logs_drops_stale_aggregate_sort(self) -> None:
+        # If `logsAggregateSortBys` references a function that isn't in the
+        # active yAxes/groupBys, drop it so the unfurl falls back to
+        # `-yAxes[0]`, mirroring the frontend's validateAggregateSort.
+        url = (
+            f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/"
+            "?aggregateField=%7B%22groupBy%22%3A%22severity%22%7D"
+            "&aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D"
+            "&logsAggregateSortBys=-p95(message.length)&mode=aggregate"
+            f"&project={self.project.id}&statsPeriod=7d"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("sort") == []
+
+    def test_map_explore_query_args_logs_query(self) -> None:
+        url = (
+            f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/"
+            "?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D"
+            "&logsQuery=severity%3Aerror"
+            f"&project={self.project.id}&statsPeriod=24h"
+        )
         link_type, args = match_link(url)
 
         if not args or not link_type:
@@ -2195,7 +2235,6 @@ class UnfurlTest(TestCase):
         assert link_type == LinkType.EXPLORE
         assert args["dataset"] == SupportedTraceItemType.LOGS
         assert args["query"]["query"] == "severity:error"
-        assert args["query"]["sort"] == "-timestamp"
         assert args["query"]["yAxis"] == "count(message)"
 
     def test_map_explore_query_args_spans_query_and_sort(self) -> None:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2165,6 +2165,26 @@ class UnfurlTest(TestCase):
         assert api_params["dataset"] == "logs"
         assert api_params["yAxis"] == "sum(payload_size)"
 
+    def test_map_explore_query_args_logs_drops_table_sort_when_groupby_present(self) -> None:
+        # In aggregate mode the Explore UI keeps `logsSortBys` (a table sort,
+        # typically `-timestamp`) in the URL even though the chart's topEvents
+        # ranking is by the aggregate. Forwarding the table sort as `sort` to
+        # events-timeseries would feed it a non-aggregate sort field and return
+        # no data, so drop it and let `unfurl_explore` default to `-yAxes[0]`.
+        url = (
+            f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/"
+            "?aggregateField=%7B%22groupBy%22%3A%22browser.name%22%7D"
+            "&aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D"
+            "&logsSortBys=-timestamp&mode=aggregate"
+            f"&project={self.project.id}&statsPeriod=7d"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("groupBy") == ["browser.name"]
+        assert args["query"].getlist("sort") == []
+
     def test_map_explore_query_args_logs_query_and_sort(self) -> None:
         url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D&logsQuery=severity%3Aerror&logsSortBys=-timestamp&project={self.project.id}&statsPeriod=24h"
         link_type, args = match_link(url)


### PR DESCRIPTION
## Summary

`logsSortBys` is the samples-mode logs **table** sort (typically `-timestamp`); the chart's topEvents sort lives under `logsAggregateSortBys`. The unfurl was forwarding `logsSortBys` as the events-timeseries `sort` — fine when there were no groupBys (sort is ignored without topEvents), but as soon as a logs URL had a `groupBy` the chart became a topEvents query and the table sort fed it a non-aggregate field, returning no data.

Switch the parser to read `logsAggregateSortBys` (the actual chart sort), and validate it against the active yAxes/groupBys the same way the traces aggregate sort path does. Stale or unknown sort fields are dropped so the unfurl falls back to `-yAxes[0]`. `logsSortBys` no longer reaches the chart query at all.

Covers the unchecked logs aggregate-mode URL in DAIN-1589.

Refs DAIN-1589.

## Test plan

- [x] New unit tests cover: `logsSortBys` ignored even when present in URL; `logsAggregateSortBys` forwarded when valid; stale `logsAggregateSortBys` dropped.
- [x] Existing logs unfurl tests still pass.
- [x] `pytest tests/sentry/integrations/slack/test_unfurl.py -k "logs or explore"` (52 passed).
- [x] `prek` clean on changed files.