### PR TITLE
fix(slack): Clamp too-fine URL interval in explore unfurl to ladder minimum

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -81,6 +81,21 @@ def _default_interval_for_query(params: QueryDict) -> str:
     return "1m"
 
 
+def _clamp_interval(url_interval: str, minimum_interval: str) -> str:
+    """Match the frontend's `useChartIntervalImpl`: if the URL's explicit
+    interval is finer than the minimum the ladder allows for the selected
+    time range, fall back to the minimum. Stale URLs (e.g. an `interval=1m`
+    pasted from a 1h view into a 7d view) would otherwise produce thousands
+    of buckets that events-timeseries rejects, so the unfurl renders empty."""
+    url_td = parse_stats_period(url_interval)
+    minimum_td = parse_stats_period(minimum_interval)
+    if url_td is None:
+        return minimum_interval
+    if minimum_td is not None and url_td < minimum_td:
+        return minimum_interval
+    return url_interval
+
+
 def _aggregate_sorts_are_valid(
     sort_values: list[str], y_axes: list[str], group_bys: list[str]
 ) -> bool:
@@ -156,8 +171,11 @@ def _build_timeseries_query(
     if not out.get("statsPeriod") and not out.get("start"):
         out["statsPeriod"] = DEFAULT_PERIOD
 
-    if not out.get("interval"):
-        out["interval"] = _default_interval_for_query(out)
+    minimum_interval = _default_interval_for_query(out)
+    url_interval = out.get("interval")
+    out["interval"] = (
+        _clamp_interval(url_interval, minimum_interval) if url_interval else minimum_interval
+    )
 
     return out
 

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2081,6 +2081,57 @@ class UnfurlTest(TestCase):
                 f"got {args['query']['interval']}"
             )
 
+    def test_match_link_explore_clamps_too_fine_url_interval_to_ladder_minimum(
+        self,
+    ) -> None:
+        # Mirrors the frontend's useChartIntervalImpl: if the URL's explicit
+        # interval is finer than the ladder minimum for the time range it falls
+        # back to the minimum. Without clamping, a stale `interval=1m` pasted
+        # into a 7d view yields ~10k buckets that events-timeseries rejects.
+        cases = [
+            # 7d → ladder minimum is 30m; 1m must be clamped up.
+            (
+                f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/"
+                f"?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D"
+                f"&interval=1m&project={self.project.id}&statsPeriod=7d",
+                "30m",
+            ),
+            # 30d → ladder minimum is 3h; 5m must be clamped up.
+            (
+                f"https://sentry.io/organizations/{self.organization.slug}/explore/metrics/"
+                f"?metric=%7B%22aggregateFields%22%3A%5B%7B%22yAxes%22%3A%5B%22sum(value)%22%5D%7D%5D%7D"
+                f"&interval=5m&project={self.project.id}&statsPeriod=30d",
+                "3h",
+            ),
+            # 14d → ladder minimum is 1h; 1m must be clamped up.
+            (
+                f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/"
+                f"?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D"
+                f"&interval=1m&project={self.project.id}&statsPeriod=14d",
+                "1h",
+            ),
+        ]
+        for url, expected_interval in cases:
+            _, args = match_link(url)
+            assert args is not None
+            assert args["query"]["interval"] == expected_interval, (
+                f"url={url}: expected {expected_interval}, got {args['query']['interval']}"
+            )
+
+    def test_match_link_explore_keeps_url_interval_when_coarser_than_minimum(
+        self,
+    ) -> None:
+        # An explicit interval that is at or above the ladder minimum should be
+        # forwarded as-is — only too-fine intervals are clamped.
+        url = (
+            f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/"
+            f"?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D"
+            f"&interval=6h&project={self.project.id}&statsPeriod=7d"
+        )
+        _, args = match_link(url)
+        assert args is not None
+        assert args["query"]["interval"] == "6h"
+
     def test_match_link_explore_default_interval_for_logs_and_metrics(self) -> None:
         # Logs and metrics use the same useChartInterval default as traces, so
         # the URL → timeseries conversion should pick the same interval for the


### PR DESCRIPTION
Generated with claude, ensures we fallback to the minimum possible interval, if the one in the query params is too granualar.

## Summary

The frontend's `useChartIntervalImpl` ignores a URL `interval` that's finer than `MINIMUM_INTERVAL` for the selected time range and falls back to the ladder minimum (e.g. `interval=1m&statsPeriod=7d` → `30m`). The unfurl previously forwarded the URL's interval verbatim, so a stale `interval=1m` pasted from a 1h view into a 7d view produced ~10k buckets that events-timeseries rejected, and the chart rendered empty.

Mirror the frontend: in `_build_timeseries_query`, if the URL's explicit interval is finer than `_default_interval_for_query` (which already mirrors `MINIMUM_INTERVAL`), clamp it up to the ladder minimum. Coarser intervals are still forwarded as-is.

Covers the unchecked `dashboards.dashboard.onEdit` URL in DAIN-1589 (`interval=1m&statsPeriod=7d`).

Refs DAIN-1589.