### PR TITLE
fix(replay): Preserve player time when toggling sidebar chevron

### DIFF
--- a/static/app/components/splitPanel.spec.tsx
+++ b/static/app/components/splitPanel.spec.tsx
@@ -1,0 +1,118 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SplitPanel} from 'sentry/components/splitPanel';
+
+const defaultLeftSide = {
+  content: <div data-test-id="left-content">left</div>,
+  default: 200,
+  min: 100,
+  max: 600,
+};
+const defaultTopSide = {
+  content: <div data-test-id="top-content">top</div>,
+  default: 200,
+  min: 100,
+  max: 600,
+};
+
+describe('SplitPanel', () => {
+  describe('left/right', () => {
+    it('renders left, divider, and right when right is provided', () => {
+      render(
+        <SplitPanel
+          availableSize={1000}
+          left={defaultLeftSide}
+          right={<div data-test-id="right-content">right</div>}
+        />
+      );
+
+      expect(screen.getByTestId('left-content')).toBeInTheDocument();
+      expect(screen.getByTestId('right-content')).toBeInTheDocument();
+    });
+
+    it('omits the divider and right pane when right is null', () => {
+      render(<SplitPanel availableSize={1000} left={defaultLeftSide} right={null} />);
+
+      expect(screen.getByTestId('left-content')).toBeInTheDocument();
+      expect(screen.queryByTestId('right-content')).not.toBeInTheDocument();
+    });
+
+    it('preserves DOM identity of left.content when toggling right between content and null', () => {
+      const {rerender} = render(
+        <SplitPanel
+          availableSize={1000}
+          left={defaultLeftSide}
+          right={<div data-test-id="right-content">right</div>}
+        />
+      );
+
+      const leftBefore = screen.getByTestId('left-content');
+
+      rerender(<SplitPanel availableSize={1000} left={defaultLeftSide} right={null} />);
+
+      const leftAfterCollapse = screen.getByTestId('left-content');
+      expect(leftAfterCollapse).toBe(leftBefore);
+
+      rerender(
+        <SplitPanel
+          availableSize={1000}
+          left={defaultLeftSide}
+          right={<div data-test-id="right-content">right</div>}
+        />
+      );
+
+      const leftAfterExpand = screen.getByTestId('left-content');
+      expect(leftAfterExpand).toBe(leftBefore);
+    });
+  });
+
+  describe('top/bottom', () => {
+    it('renders top, divider, and bottom when bottom is provided', () => {
+      render(
+        <SplitPanel
+          availableSize={1000}
+          top={defaultTopSide}
+          bottom={<div data-test-id="bottom-content">bottom</div>}
+        />
+      );
+
+      expect(screen.getByTestId('top-content')).toBeInTheDocument();
+      expect(screen.getByTestId('bottom-content')).toBeInTheDocument();
+    });
+
+    it('omits the divider and bottom pane when bottom is null', () => {
+      render(<SplitPanel availableSize={1000} top={defaultTopSide} bottom={null} />);
+
+      expect(screen.getByTestId('top-content')).toBeInTheDocument();
+      expect(screen.queryByTestId('bottom-content')).not.toBeInTheDocument();
+    });
+
+    it('preserves DOM identity of top.content when toggling bottom between content and null', () => {
+      const {rerender} = render(
+        <SplitPanel
+          availableSize={1000}
+          top={defaultTopSide}
+          bottom={<div data-test-id="bottom-content">bottom</div>}
+        />
+      );
+
+      const topBefore = screen.getByTestId('top-content');
+
+      rerender(<SplitPanel availableSize={1000} top={defaultTopSide} bottom={null} />);
+
+      const topAfterCollapse = screen.getByTestId('top-content');
+      expect(topAfterCollapse).toBe(topBefore);
+
+      rerender(
+        <SplitPanel
+          availableSize={1000}
+          top={defaultTopSide}
+          bottom={<div data-test-id="bottom-content">bottom</div>}
+        />
+      );
+
+      const topAfterExpand = screen.getByTestId('top-content');
+      expect(topAfterExpand).toBe(topBefore);
+    });
+  });
+});

--- a/static/app/components/splitPanel.tsx
+++ b/static/app/components/splitPanel.tsx
@@ -1,4 +1,4 @@
-import {createContext, useCallback, useMemo} from 'react';
+import {createContext, Fragment, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Stack} from '@sentry/scraps/layout';
@@ -149,53 +149,35 @@ export function SplitPanel(props: SplitPanelProps) {
     [isMaximized, isMinimized, setSize, max, min, initialSize]
   );
 
-  if (isLeftRight) {
-    const {left: a, right: b} = props;
+  const [a, b, direction, orientation] = isLeftRight
+    ? ([props.left, props.right, 'leftright', 'columns'] as const)
+    : ([props.top, props.bottom, 'updown', 'rows'] as const);
 
-    return (
-      <SplitPanelContext value={contextValue}>
-        <SplitPanelContainer
-          className={isHeld ? 'disable-iframe-pointer' : undefined}
-          orientation="columns"
-          size={sizePct}
-        >
-          <Stack wrap="nowrap" flexGrow={1} minWidth="0" minHeight="0">
-            {a.content}
-          </Stack>
-          <SplitDivider
-            data-is-held={isHeld}
-            data-slide-direction="leftright"
-            onDoubleClick={onDoubleClick}
-            onMouseDown={handleMouseDown}
-          />
-          <Stack wrap="nowrap" flexGrow={1} minWidth="0" minHeight="0">
-            {b}
-          </Stack>
-        </SplitPanelContainer>
-      </SplitPanelContext>
-    );
-  }
+  const isCollapsed = b === null || b === undefined;
 
-  const {top: a, bottom: b} = props;
   return (
     <SplitPanelContext value={contextValue}>
       <SplitPanelContainer
-        orientation="rows"
-        size={sizePct}
         className={isHeld ? 'disable-iframe-pointer' : undefined}
+        orientation={orientation}
+        size={isCollapsed ? '100%' : sizePct}
       >
         <Stack wrap="nowrap" flexGrow={1} minWidth="0" minHeight="0">
           {a.content}
         </Stack>
-        <SplitDivider
-          data-is-held={isHeld}
-          data-slide-direction="updown"
-          onDoubleClick={onDoubleClick}
-          onMouseDown={handleMouseDown}
-        />
-        <Stack wrap="nowrap" flexGrow={1} minWidth="0" minHeight="0">
-          {b}
-        </Stack>
+        {isCollapsed ? null : (
+          <Fragment>
+            <SplitDivider
+              data-is-held={isHeld}
+              data-slide-direction={direction}
+              onDoubleClick={onDoubleClick}
+              onMouseDown={handleMouseDown}
+            />
+            <Stack wrap="nowrap" flexGrow={1} minWidth="0" minHeight="0">
+              {b}
+            </Stack>
+          </Fragment>
+        )}
       </SplitPanelContainer>
     </SplitPanelContext>
   );

--- a/static/app/views/explore/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/explore/replays/detail/layout/replayLayout.tsx
@@ -95,17 +95,6 @@ function ReplayLayoutBody({
     </ErrorBoundary>
   );
 
-  if (layout === LayoutKey.VIDEO_ONLY) {
-    return (
-      <BodyGrid>
-        <Stack wrap="nowrap" minHeight="0" ref={measureRef}>
-          {video}
-          {controller}
-        </Stack>
-      </BodyGrid>
-    );
-  }
-
   const focusArea =
     isLoading || replayRecord?.is_archived ? (
       <Placeholder width="100%" height="100%" />
@@ -125,54 +114,42 @@ function ReplayLayoutBody({
     return (
       <BodyGrid>
         <Stack wrap="nowrap" minHeight="0" ref={measureRef}>
-          {hasSize ? <PanelContainer key={layout}>{focusArea}</PanelContainer> : null}
+          {hasSize ? <PanelContainer>{focusArea}</PanelContainer> : null}
         </Stack>
       </BodyGrid>
     );
   }
 
-  if (layout === LayoutKey.SIDEBAR_LEFT) {
-    return (
-      <BodyGrid>
-        <Stack wrap="nowrap" minHeight="0" ref={measureRef}>
-          {hasSize ? (
-            <SplitPanel
-              layout={layout}
-              key={layout}
-              availableSize={width}
-              left={{
-                content: <PanelContainer key={layout}>{video}</PanelContainer>,
-                default: width * 0.5,
-                min: MIN_SIDEBAR_WIDTH,
-                max: width - MIN_CONTENT_WIDTH,
-              }}
-              right={focusArea}
-            />
-          ) : null}
-        </Stack>
-        {controller}
-      </BodyGrid>
-    );
-  }
+  const isFocusAreaCollapsed = layout === LayoutKey.VIDEO_ONLY;
+  const effectiveLayout = isFocusAreaCollapsed ? defaultLayout : layout;
+  const isLeftRight = effectiveLayout === LayoutKey.SIDEBAR_LEFT;
 
-  // layout === 'topbar'
+  const splitPanelProps = isLeftRight
+    ? {
+        availableSize: width,
+        left: {
+          content: <PanelContainer>{video}</PanelContainer>,
+          default: width * 0.5,
+          min: MIN_SIDEBAR_WIDTH,
+          max: width - MIN_CONTENT_WIDTH,
+        },
+        right: isFocusAreaCollapsed ? null : focusArea,
+      }
+    : {
+        availableSize: height,
+        top: {
+          content: <PanelContainer>{video}</PanelContainer>,
+          default: (height - DIVIDER_SIZE) * 0.5,
+          min: MIN_VIDEO_HEIGHT,
+          max: height - DIVIDER_SIZE - MIN_CONTENT_HEIGHT,
+        },
+        bottom: isFocusAreaCollapsed ? null : focusArea,
+      };
+
   return (
     <BodyGrid>
       <Stack wrap="nowrap" minHeight="0" ref={measureRef}>
-        {hasSize ? (
-          <SplitPanel
-            layout={layout}
-            key={layout}
-            availableSize={height}
-            top={{
-              content: <PanelContainer>{video}</PanelContainer>,
-              default: (height - DIVIDER_SIZE) * 0.5,
-              min: MIN_VIDEO_HEIGHT,
-              max: height - DIVIDER_SIZE - MIN_CONTENT_HEIGHT,
-            }}
-            bottom={focusArea}
-          />
-        ) : null}
+        {hasSize ? <SplitPanel layout={effectiveLayout} {...splitPanelProps} /> : null}
       </Stack>
       {controller}
     </BodyGrid>


### PR DESCRIPTION
Toggling the replay sidebar chevron jumps `currentTime` back to 0:00 because each layout branch in `replayLayout.tsx` renders a different component tree. That remounts `ReplayView` and causes the rrweb `Replayer` to be recreated.

This changes the `VIDEO_ONLY`, `SIDEBAR_LEFT`, and `TOPBAR` replay layouts to now render in the same tree: `ReplaySplitPanel` with the player in the first pane (left/top) and the focus area in the second (right/bottom). 

This unifies a bunch of identical -or at least similar- code paths in `replayLayout.tsx` and `splitPanel.tsx`, and adds `splitPanel.spec.tsx` while I'm in the area.

Fixes REPLAY-907.

Made with [Cursor](https://cursor.com)