### PR TITLE
ref(preprod): Add blocklist to filter internal fields from snapshot metadata tooltip

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -308,6 +308,8 @@ function MetadataTooltip({json}: {json: string}) {
   );
 }
 
+const METADATA_BLOCKLIST = new Set(['content_hash', 'key', 'diff_image_key']);
+
 function MetadataInfoButton({
   copyData,
   onCopy,
@@ -316,7 +318,11 @@ function MetadataInfoButton({
   onCopy?: () => void;
 }) {
   const {copy} = useCopyToClipboard();
-  const json = JSON.stringify(copyData, null, 2);
+  const json = JSON.stringify(
+    copyData,
+    (k, v) => (METADATA_BLOCKLIST.has(k) ? undefined : v),
+    2
+  );
 
   return (
     <Tooltip title={<MetadataTooltip json={json} />} maxWidth={480} isHoverable>

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -196,6 +196,21 @@ describe('SnapshotMainContent', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Copy metadata as JSON'}));
 
     const copiedJson = mockCopy.mock.calls.at(-1)?.[0];
-    expect(JSON.parse(copiedJson)).toEqual(renamedPair);
+    expect(JSON.parse(copiedJson)).toEqual({
+      base_image: {
+        display_name: 'Button / light old',
+        height: 180,
+        image_file_name: 'button.light.old.png',
+        width: 320,
+      },
+      diff: null,
+      head_image: {
+        display_name: 'Button / light',
+        group: 'components',
+        height: 180,
+        image_file_name: 'button.light.png',
+        width: 320,
+      },
+    });
   });
 });


### PR DESCRIPTION
Adds a blocklist mechanism to the snapshot metadata info tooltip so we can
explicitly control which fields are hidden from users. The `JSON.stringify`
replacer omits any key in the `METADATA_BLOCKLIST` set.

Currently blocked fields: `content_hash`, `key`, `diff_image_key` — these
are internal identifiers that aren't useful to users viewing snapshot metadata.