### PR TITLE
feat(spans): Add opt-in logging for flushed segments

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3348,6 +3348,11 @@ register(
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "spans.buffer.flusher.log-flushed-segments",
+    default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # List of trace_ids to enable debug logging for. Empty = debug off.
 # When set, logs detailed metrics about zunionstore set sizes, key existence, and trace structure.

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -329,9 +329,24 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
                     continue
 
                 with metrics.timer("spans.buffer.flusher.produce", tags={"shard": shard_tag}):
-                    for flushed_segment in flushed_segments.values():
+                    log_flushed_segments = options.get("spans.buffer.flusher.log-flushed-segments")
+
+                    for segment_key, flushed_segment in flushed_segments.items():
                         if not flushed_segment.spans:
                             continue
+
+                        if log_flushed_segments:
+                            logger.info(
+                                "spans.buffer.flushed_segment",
+                                extra={
+                                    "segment_key": segment_key.decode("utf-8", errors="replace"),
+                                    "queue_key": flushed_segment.queue_key.decode(
+                                        "utf-8", errors="replace"
+                                    ),
+                                    "span_count": len(flushed_segment.spans),
+                                    "project_id": flushed_segment.project_id,
+                                },
+                            )
 
                         for message in flushed_segment.to_messages():
                             kafka_payload = KafkaPayload(None, orjson.dumps(message), [])

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -33,6 +33,7 @@ DEFAULT_OPTIONS = {
     "spans.buffer.flusher.use-stuck-detector": False,
     "spans.buffer.flusher.flush-lock-ttl": 0,
     "spans.buffer.flusher-cumulative-logger-enabled": False,
+    "spans.buffer.flusher.log-flushed-segments": False,
     "spans.buffer.compression.level": 0,
     "spans.buffer.pipeline-batch-size": 0,
     "spans.buffer.max-spans-per-evalsha": 0,


### PR DESCRIPTION
## Summary

Adds a new option `spans.buffer.flusher.log-flushed-segments` that when enabled logs each flushed segment with:
- segment_key
- queue_key  
- span_count
- project_id

The option is checked once per flush cycle (not per segment) to minimize overhead.

Refs STREAM-945