### PR TITLE
ref(flags): Remove organizations:integrations-deployment

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -137,8 +137,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Starfish: extract metrics from the spans
     manager.add("organizations:indexed-spans-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # These flags follow the pattern expected by IntegrationProvider.requires_feature_flag's usage on the config endpoint
-    # Enable integration functionality to work deployment integrations like Vercel
-    manager.add("organizations:integrations-deployment", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     manager.add("organizations:integrations-claude-code", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-cursor", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github-copilot-agent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -77,7 +77,6 @@ class OrganizationSummarySerializerTest(TestCase):
             "integrations-alert-rule",
             "integrations-chat-unfurl",
             "integrations-codeowners",
-            "integrations-deployment",
             "integrations-enterprise-alert-rule",
             "integrations-enterprise-incident-management",
             "integrations-event-hooks",

--- a/tests/sentry/web/frontend/test_vercel_extension_configuration.py
+++ b/tests/sentry/web/frontend/test_vercel_extension_configuration.py
@@ -9,7 +9,6 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
@@ -56,7 +55,6 @@ class VercelExtensionConfigurationTest(TestCase):
         }
 
     @responses.activate
-    @with_feature("organizations:integrations-deployment")
     def test_logged_in_one_org(self) -> None:
         self.login_as(self.user)
 
@@ -152,7 +150,6 @@ class VercelExtensionConfigurationTest(TestCase):
         )
 
     @responses.activate
-    @with_feature("organizations:integrations-deployment")
     def test_logged_in_one_org_customer_domain(self) -> None:
         self.login_as(self.user)
 


### PR DESCRIPTION
Scanner classified this as default-removable: registered with default=True, no SaaS overrides, no plan list entries, no custom handler — and no production code calls features.has() for it. The only "references" are an apidoc example string, two test decorators that gate Vercel extension config tests on the (always-on) flag, and the expected-features fixture in test_organization.

Removes the registration, the test decorators, and the fixture entry. The integration metadata still uses `featureGate: "integrations-deployment"` for category-display purposes (FE maps it to a "deployment" category) — that's a pure label, no flag check.