### PR TITLE
ref(flags): Remove organizations:symbol-sources gates (frontend)

### DIFF
--- a/static/app/views/settings/projectDebugFiles/index.spec.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.spec.tsx
@@ -123,7 +123,7 @@ describe('ProjectDebugFiles', () => {
     });
 
     render(<ProjectDebugFiles />, {
-      organization: {...organization, features: ['symbol-sources']},
+      organization,
       outletContext: {project},
       initialRouterConfig,
     });

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -43,7 +43,6 @@ export default function ProjectDebugSymbols() {
 
   const query = location.query.query as string | undefined;
   const cursor = location.query.cursor as string | undefined;
-  const hasSymbolSourcesFeatureFlag = organization.features.includes('symbol-sources');
 
   const debugFilesApiOptions = apiOptions.as<DebugFile[]>()(
     '/projects/$organizationIdOrSlug/$projectIdOrSlug/files/dsyms/',
@@ -83,7 +82,6 @@ export default function ProjectDebugSymbols() {
     refetch: refetchSymbolSources,
   } = useQuery({
     ...symbolSourcesOptions,
-    enabled: hasSymbolSourcesFeatureFlag,
     retry: 0,
   });
 
@@ -138,33 +136,29 @@ export default function ProjectDebugSymbols() {
         `)}
       />
 
-      {organization.features.includes('symbol-sources') && (
-        <Fragment>
-          <ProjectPermissionAlert project={project} />
+      <ProjectPermissionAlert project={project} />
 
-          {isLoadingSymbolSources ? (
-            <LoadingIndicator />
-          ) : isErrorSymbolSources ? (
-            <LoadingError
-              onRetry={refetchSymbolSources}
-              message={t('There was an error loading repositories.')}
-            />
-          ) : (
-            <Sources
-              api={api}
-              location={location}
-              project={project}
-              organization={organization}
-              customRepositories={
-                (project.symbolSources
-                  ? JSON.parse(project.symbolSources)
-                  : []) as CustomRepo[]
-              }
-              builtinSymbolSources={project.builtinSymbolSources ?? []}
-              builtinSymbolSourceOptions={builtinSymbolSources ?? []}
-            />
-          )}
-        </Fragment>
+      {isLoadingSymbolSources ? (
+        <LoadingIndicator />
+      ) : isErrorSymbolSources ? (
+        <LoadingError
+          onRetry={refetchSymbolSources}
+          message={t('There was an error loading repositories.')}
+        />
+      ) : (
+        <Sources
+          api={api}
+          location={location}
+          project={project}
+          organization={organization}
+          customRepositories={
+            (project.symbolSources
+              ? JSON.parse(project.symbolSources)
+              : []) as CustomRepo[]
+          }
+          builtinSymbolSources={project.builtinSymbolSources ?? []}
+          builtinSymbolSourceOptions={builtinSymbolSources ?? []}
+        />
       )}
 
       {isLoadingDebugFiles ? (


### PR DESCRIPTION
Scanner classified this as default-removable: registered with default=True, no SaaS overrides, no plan list entries, no custom handler — and the gates are pure no-ops.

Drops the `organization.features.includes('symbol-sources')` checks in projectDebugFiles, the `enabled:` query gating on the same flag, and the test fixture that explicitly added the flag (now redundant).

BE PR: https://github.com/getsentry/sentry/pull/114993