### PR TITLE
feat(spans): Add semantic partitioning option for segments consumer

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3385,6 +3385,11 @@ register(
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "spans.process-segments.semantic-partitioning",
+    default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "indexed-spans.agg-span-waterfall.enable",

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -110,6 +110,8 @@ def _process_message(
     if not options.get("spans.process-segments.consumer.enable"):
         return []
 
+    use_semantic_partitioning = options.get("spans.process-segments.semantic-partitioning")
+
     assert isinstance(message.value, BrokerValue)
 
     try:
@@ -119,17 +121,28 @@ def _process_message(
         processed = process_segment(
             segment["spans"], skip_produce=skip_produce, skip_enrichment=skip_enrichment
         )
-        return [_serialize_payload(span, message.timestamp) for span in processed]
+        return [
+            _serialize_payload(span, message.timestamp, use_semantic_partitioning)
+            for span in processed
+        ]
     except Exception:
         logger.exception("segments.invalid-message")
         raise InvalidMessage(message.value.partition, message.value.offset)
 
 
-def _serialize_payload(span: CompatibleSpan, timestamp: datetime | None) -> Value[KafkaPayload]:
+def _serialize_payload(
+    span: CompatibleSpan, timestamp: datetime | None, use_semantic_partitioning: bool
+) -> Value[KafkaPayload]:
     item = convert_span_to_item(span)
+
+    if use_semantic_partitioning:
+        key = f"{span['project_id']}:{span['trace_id']}:{span['span_id']}".encode()
+    else:
+        key = None
+
     return Value(
         KafkaPayload(
-            key=None,
+            key=key,
             value=item.SerializeToString(),
             headers=[
                 ("item_type", str(item.item_type).encode("ascii")),

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -24,7 +24,12 @@ def build_mock_message(data, topic=None):
     return message
 
 
-@override_options({"spans.process-segments.consumer.enable": True})
+@override_options(
+    {
+        "spans.process-segments.consumer.enable": True,
+        "spans.process-segments.semantic-partitioning": False,
+    }
+)
 @mock.patch(
     "sentry.spans.consumers.process_segments.factory.process_segment",
     side_effect=lambda x, **kwargs: x,


### PR DESCRIPTION
## Summary

Adds a new option `spans.process-segments.semantic-partitioning` that when enabled sets the Kafka partition key to `project_id:trace_id:span_id` for spans produced to the `snuba-items` topic.

## Context

We're investigating duplicate spans being produced during rebalancing. This change makes the deduplicator in the eap-outcomes consumer more effective by ensuring related spans consistently go to the same partition, which may reduce the duplication problem to an acceptable minimum.

We can validate this change by checking outcomes in Clickhouse, while still using other data sources to validate actual fixes we make to the span buffer

## Changes

- Register new option `spans.process-segments.semantic-partitioning` (default: false)
- When enabled, set Kafka partition key to `{project_id}:{trace_id}:{span_id}`
- When disabled, continue using `key=None` (random partitioning)

Refs STREAM-944