### PR TITLE
ref(flags): Remove organizations:symbol-sources gates (backend)

### DIFF
--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -344,18 +344,6 @@ E.g. `['release', 'environment']`""",
         return validate_pii_config_update(organization, value)
 
     def validate_builtinSymbolSources(self, value):
-        if not value:
-            return value
-
-        from sentry import features
-
-        organization = self.context["project"].organization
-        request = self.context["request"]
-        has_sources = features.has("organizations:symbol-sources", organization, actor=request.user)
-
-        if not has_sources:
-            raise serializers.ValidationError("Organization is not allowed to set symbol sources")
-
         return value
 
     def validate_symbolSources(self, sources_json) -> str:

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -388,8 +388,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sentry-app-webhook-requests", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable mobile starfish ui module view
     manager.add("organizations:starfish-mobile-ui-module", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Allow organizations to configure all symbol sources.
-    manager.add("organizations:symbol-sources", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable static ClickHouse sampling for `OrganizationTagsEndpoint`
     manager.add("organizations:tag-key-sample-n", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dynamic grouping UI (top issues)

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -542,12 +542,7 @@ def get_sources_for_project(project):
     project_source = get_internal_source(project)
     sources.append(project_source)
 
-    # Check that the organization still has access to symbol sources. This
-    # controls both builtin and external sources.
     organization = project.organization
-
-    if not features.has("organizations:symbol-sources", organization):
-        return sources
 
     # Custom sources have their own feature flag. Check them independently.
     if features.has("organizations:custom-symbol-sources", organization):

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -95,7 +95,6 @@ class OrganizationSummarySerializerTest(TestCase):
             "shared-issues",
             "sso-basic",
             "sso-saml2",
-            "symbol-sources",
             "team-insights",
             "team-roles",
             "uptime",

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -1220,9 +1220,7 @@ class ProjectUpdateTest(APITestCase):
 
     @mock.patch("sentry.api.base.create_audit_entry")
     def test_redacted_symbol_source_secrets(self, create_audit_entry: mock.MagicMock) -> None:
-        with Feature(
-            {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": True}
-        ):
+        with Feature({"organizations:custom-symbol-sources": True}):
             config = {
                 "id": "honk",
                 "name": "honk source",
@@ -1275,9 +1273,7 @@ class ProjectUpdateTest(APITestCase):
     def test_redacted_symbol_source_secrets_unknown_secret(
         self, create_audit_entry: mock.MagicMock
     ) -> None:
-        with Feature(
-            {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": True}
-        ):
+        with Feature({"organizations:custom-symbol-sources": True}):
             config = {
                 "id": "honk",
                 "name": "honk source",

--- a/tests/sentry/lang/native/test_sources.py
+++ b/tests/sentry/lang/native/test_sources.py
@@ -11,7 +11,7 @@ from sentry.lang.native.sources import (
     filter_ignored_sources,
     get_sources_for_project,
 )
-from sentry.testutils.helpers import Feature, override_options
+from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -52,13 +52,9 @@ class TestGcpBearerAuthentication:
     @django_db_all
     def test_sources_gcp_bearer_authentication(self, mock_get_gcp_token, default_project) -> None:
         mock_get_gcp_token.return_value = "ya29.TOKEN"
-        features = {
-            "organizations:symbol-sources": True,
-        }
         default_project.update_option("sentry:builtin_symbol_sources", ["aaa", "bbb"])
 
-        with Feature(features):
-            sources = get_sources_for_project(default_project)
+        sources = get_sources_for_project(default_project)
 
         for i in (1, 2):
             assert "client_email" not in sources[i]
@@ -70,15 +66,11 @@ class TestGcpBearerAuthentication:
     @django_db_all
     def test_source_alias(self, mock_get_gcp_token, default_project) -> None:
         mock_get_gcp_token.return_value = "ya29.TOKEN"
-        features = {
-            "organizations:symbol-sources": True,
-        }
         default_project.update_option("sentry:builtin_symbol_sources", ["ccc"])
 
         builtin_sources_before = copy.deepcopy(settings.SENTRY_BUILTIN_SOURCES)
 
-        with Feature(features):
-            sources = get_sources_for_project(default_project)
+        sources = get_sources_for_project(default_project)
 
         assert builtin_sources_before == copy.deepcopy(settings.SENTRY_BUILTIN_SOURCES)
 
@@ -100,13 +92,9 @@ class TestGcpBearerAuthentication:
     @django_db_all
     def test_source_with_private_key(self, mock_get_gcp_token, default_project) -> None:
         mock_get_gcp_token.return_value = "ya29.TOKEN"
-        features = {
-            "organizations:symbol-sources": True,
-        }
         default_project.update_option("sentry:builtin_symbol_sources", ["ddd"])
 
-        with Feature(features):
-            sources = get_sources_for_project(default_project)
+        sources = get_sources_for_project(default_project)
 
         assert sources[1]["name"] == "ddd"
         assert sources[1]["client_email"] == "application@project-id.iam.gserviceaccount.com"
@@ -121,13 +109,9 @@ class TestGcpBearerAuthentication:
         uses pre-fetched token.
         """
         mock_get_gcp_token.return_value = "ya29.TOKEN"
-        features = {
-            "organizations:symbol-sources": True,
-        }
         default_project.update_option("sentry:builtin_symbol_sources", ["eee"])
 
-        with Feature(features):
-            sources = get_sources_for_project(default_project)
+        sources = get_sources_for_project(default_project)
 
         assert sources[1]["name"] == "ddd"
         assert "token" not in sources[1]

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -31,20 +31,8 @@ CUSTOM_SOURCE_CONFIG = """
 
 
 @django_db_all
-def test_sources_no_feature(default_project) -> None:
-    features = {"organizations:symbol-sources": False, "organizations:custom-symbol-sources": False}
-
-    with Feature(features):
-        sources = get_sources_for_project(default_project)
-
-    assert len(sources) == 1
-    assert sources[0]["type"] == "sentry"
-    assert sources[0]["id"] == "sentry:project"
-
-
-@django_db_all
 def test_sources_builtin(default_project) -> None:
-    features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": False}
+    features = {"organizations:custom-symbol-sources": False}
 
     default_project.update_option("sentry:builtin_symbol_sources", ["microsoft"])
 
@@ -60,7 +48,7 @@ def test_sources_builtin(default_project) -> None:
 # not lead to an error. It should simply be ignored.
 @django_db_all
 def test_sources_builtin_unknown(default_project) -> None:
-    features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": False}
+    features = {"organizations:custom-symbol-sources": False}
 
     default_project.update_option("sentry:builtin_symbol_sources", ["invalid"])
 
@@ -71,24 +59,9 @@ def test_sources_builtin_unknown(default_project) -> None:
     assert source_ids == ["sentry:project"]
 
 
-# Test that previously saved builtin sources are not returned if the feature for
-# builtin sources is missing at query time.
-@django_db_all
-def test_sources_builtin_disabled(default_project) -> None:
-    features = {"organizations:symbol-sources": False, "organizations:custom-symbol-sources": False}
-
-    default_project.update_option("sentry:builtin_symbol_sources", ["microsoft"])
-
-    with Feature(features):
-        sources = get_sources_for_project(default_project)
-
-    source_ids = list(map(lambda s: s["id"], sources))
-    assert source_ids == ["sentry:project"]
-
-
 @django_db_all
 def test_sources_custom(default_project) -> None:
-    features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": True}
+    features = {"organizations:custom-symbol-sources": True}
 
     # Remove builtin sources explicitly to avoid defaults
     default_project.update_option("sentry:builtin_symbol_sources", [])
@@ -107,7 +80,7 @@ def test_sources_custom(default_project) -> None:
 # custom sources is missing at query time.
 @django_db_all
 def test_sources_custom_disabled(default_project) -> None:
-    features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": False}
+    features = {"organizations:custom-symbol-sources": False}
 
     default_project.update_option("sentry:builtin_symbol_sources", [])
     default_project.update_option("sentry:symbol_sources", CUSTOM_SOURCE_CONFIG)

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -75,7 +75,6 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
 
     _FEATURES = {
         "organizations:event-attachments": True,
-        "organizations:symbol-sources": False,
         "organizations:custom-symbol-sources": False,
     }
 


### PR DESCRIPTION
Scanner classified this as default-removable: registered with default=True, no SaaS overrides, no plan list entries, no custom handler — gates are pure no-ops.

Drops:
- The features.has() check in project_details validate_builtinSymbolSources (the "Organization is not allowed to set symbol sources" path was unreachable when default=True everywhere)
- The features.has() early-return in lang/native/sources.get_sources_for_project
- The registration in temporary.py
- The `symbol-sources` entry in test_organization.py expected list
- Tests that exercised the False path (test_sources_no_feature, test_sources_builtin_disabled in test_symbolicator.py)

FE PR: https://github.com/getsentry/sentry/pull/114991
