### PR TITLE
fix(api): Validate more user-provided integer ids

### DIFF
--- a/src/sentry/api/endpoints/organization_api_key_details.py
+++ b/src/sentry/api/endpoints/organization_api_key_details.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -15,6 +17,7 @@ from sentry.api.serializers import serialize
 from sentry.conf.server import SENTRY_SCOPES
 from sentry.models.apikey import ApiKey
 from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 
 
 class ApiKeySerializer(serializers.ModelSerializer):
@@ -41,11 +44,16 @@ class OrganizationApiKeyDetailsEndpoint(ControlSiloOrganizationEndpoint):
     }
     permission_classes = (OrganizationAdminPermission,)
 
-    def convert_args(self, request: Request, api_key_id: str, *args, **kwargs):
+    def convert_args(
+        self, request: Request, api_key_id: str, *args: Any, **kwargs: Any
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         args, kwargs = super().convert_args(request, *args, **kwargs)
         organization = kwargs["organization"]
+        validated_api_key_id = to_valid_int_id("api_key_id", api_key_id, raise_404=True)
         try:
-            kwargs["api_key"] = ApiKey.objects.get(id=api_key_id, organization_id=organization.id)
+            kwargs["api_key"] = ApiKey.objects.get(
+                id=validated_api_key_id, organization_id=organization.id
+            )
         except ApiKey.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/organization_auth_token_details.py
+++ b/src/sentry/api/endpoints/organization_auth_token_details.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -14,6 +16,7 @@ from sentry.api.permissions import DisallowImpersonatedTokenCreation
 from sentry.api.serializers import serialize
 from sentry.models.orgauthtoken import MAX_NAME_LENGTH, OrgAuthToken
 from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 
 
 @control_silo_endpoint
@@ -27,12 +30,17 @@ class OrganizationAuthTokenDetailsEndpoint(ControlSiloOrganizationEndpoint):
     authentication_classes = (SessionNoAuthTokenAuthentication,)
     permission_classes = (OrgAuthTokenPermission, DisallowImpersonatedTokenCreation)
 
-    def convert_args(self, request: Request, token_id, *args, **kwargs):
+    def convert_args(
+        self, request: Request, token_id: str, *args: Any, **kwargs: Any
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         args, kwargs = super().convert_args(request, *args, **kwargs)
         organization = kwargs["organization"]
+        validated_token_id = to_valid_int_id("token_id", token_id, raise_404=True)
         try:
             kwargs["instance"] = OrgAuthToken.objects.get(
-                organization_id=organization.id, id=token_id, date_deactivated__isnull=True
+                organization_id=organization.id,
+                id=validated_token_id,
+                date_deactivated__isnull=True,
             )
         except OrgAuthToken.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/api/endpoints/organization_search_details.py
+++ b/src/sentry/api/endpoints/organization_search_details.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.db.models import Q
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,6 +20,7 @@ from sentry.api.serializers.rest_framework.savedsearch import (
 from sentry.models.organization import Organization
 from sentry.models.savedsearch import SavedSearch, Visibility
 from sentry.models.search_common import SearchType
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 
 
 class OrganizationSearchEditPermission(OrganizationSearchPermission):
@@ -45,8 +48,17 @@ class OrganizationSearchDetailsEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationSearchEditPermission,)
 
-    def convert_args(self, request: Request, organization_id_or_slug, search_id, *args, **kwargs):
+    def convert_args(
+        self,
+        request: Request,
+        organization_id_or_slug: int | str,
+        search_id: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         (args, kwargs) = super().convert_args(request, organization_id_or_slug, *args, **kwargs)
+
+        validated_search_id = to_valid_int_id("search_id", search_id, raise_404=True)
 
         # Only allow users to delete their own personal searches OR
         # organization level searches
@@ -57,7 +69,7 @@ class OrganizationSearchDetailsEndpoint(OrganizationEndpoint):
             search = SavedSearch.objects.get(
                 org_search | personal_search,
                 organization=kwargs["organization"],
-                id=search_id,
+                id=validated_search_id,
             )
         except SavedSearch.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_details.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_details.py
@@ -20,6 +20,7 @@ from sentry.models.release_threshold.constants import (
 )
 from sentry.models.release_threshold.constants import TriggerType as ReleaseThresholdTriggerType
 from sentry.models.release_threshold.release_threshold import ReleaseThreshold
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 
 
 class ReleaseThresholdPUTData(TypedDict):
@@ -66,9 +67,12 @@ class ReleaseThresholdDetailsEndpoint(ProjectEndpoint):
         **kwargs: Any,
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         parsed_args, parsed_kwargs = super().convert_args(request, *args, **kwargs)
+        validated_id = to_valid_int_id(
+            "release_threshold", kwargs["release_threshold"], raise_404=True
+        )
         try:
             parsed_kwargs["release_threshold"] = ReleaseThreshold.objects.get(
-                id=kwargs["release_threshold"],
+                id=validated_id,
                 project=parsed_kwargs["project"],
             )
         except ReleaseThreshold.DoesNotExist:

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -28,6 +28,7 @@ from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.receivers.rule_snooze import _update_workflow_engine_models
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
@@ -91,12 +92,15 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint, Generic[T]):
     permission_classes = (ProjectAlertRulePermission,)
     rule_field: str  # abstract, value comes from child class
 
-    def convert_args(self, request: Request, rule_id: int, *args, **kwargs):
+    def convert_args(
+        self, request: Request, rule_id: str | int, *args: Any, **kwargs: Any
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         (args, kwargs) = super().convert_args(request, *args, **kwargs)
         project = kwargs["project"]
+        validated_rule_id = to_valid_int_id("rule_id", rule_id, raise_404=True)
         try:
             queryset = self.fetch_rule_list(project=project)
-            rule = queryset.get(id=rule_id)
+            rule = queryset.get(id=validated_rule_id)
         except ObjectDoesNotExist:
             raise NotFound(detail="Rule does not exist")
 


### PR DESCRIPTION
We have a slow stream of exceptions (and 500s) from malformed IDs.
This uses an already well-used helper in 14 methods across 5 endpoints to ensure we get a clean 400 rather than a messy 500 we need to triage.