### PR TITLE
feat(repos): Add sync now button and polling logic in repos v2

### DIFF
--- a/static/app/views/settings/organizationRepositoriesV2/index.spec.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/index.spec.tsx
@@ -236,6 +236,57 @@ describe('OrganizationRepositoriesV2', () => {
     ).toBeEnabled();
   });
 
+  describe('sync', () => {
+    it('clicking Sync now fires a POST to the repo-sync endpoint', async () => {
+      setupDefaultMocks();
+
+      const syncRequest = MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/integrations/${GITHUB_INTEGRATION.id}/repo-sync/`,
+        method: 'POST',
+        body: {},
+      });
+
+      render(<OrganizationRepositoriesV2 />);
+
+      await userEvent.hover(await screen.findByText('0 repositories'));
+      await userEvent.click(await screen.findByRole('button', {name: 'Sync now'}));
+
+      await waitFor(() => expect(syncRequest).toHaveBeenCalledTimes(1));
+    });
+
+    it('does not show Sync now when the user lacks org:integrations access', async () => {
+      setupDefaultMocks();
+
+      render(<OrganizationRepositoriesV2 />, {
+        organization: OrganizationFixture({access: []}),
+      });
+
+      await userEvent.hover(await screen.findByText('0 repositories'));
+      await screen.findByText('Repositories not yet synced.');
+      expect(screen.queryByRole('button', {name: 'Sync now'})).not.toBeInTheDocument();
+    });
+
+    it('shows re-syncing tooltip state while sync is in progress', async () => {
+      setupDefaultMocks();
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/integrations/${GITHUB_INTEGRATION.id}/repo-sync/`,
+        method: 'POST',
+        body: {},
+      });
+
+      render(<OrganizationRepositoriesV2 />);
+
+      await userEvent.hover(await screen.findByText('0 repositories'));
+      await userEvent.click(await screen.findByRole('button', {name: 'Sync now'}));
+
+      await userEvent.hover(screen.getByText('0 repositories'));
+      expect(
+        await screen.findByText('Re-syncing in the background…')
+      ).toBeInTheDocument();
+    });
+  });
+
   it('opens a settings drawer with backend fields and POSTs changes to the integration endpoint', async () => {
     const integration = OrganizationIntegrationsFixture({
       id: '1',

--- a/static/app/views/settings/organizationRepositoriesV2/index.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/index.tsx
@@ -42,6 +42,7 @@ import {organizationIntegrationsQueryOptions} from 'sentry/views/settings/seer/o
 
 import {useDeleteIntegration} from './useDeleteIntegration';
 import {useInstallationSettings} from './useInstallationSettings';
+import {useSyncRepositories} from './useSyncRepositories';
 
 function ConnectedInstallation({installation, children}: InstallationWrapperProps) {
   const organization = useOrganization();
@@ -81,6 +82,10 @@ function ConnectedInstallation({installation, children}: InstallationWrapperProp
     },
   });
 
+  const {syncNow, isSyncing} = useSyncRepositories(installation.integration, {
+    onSynced: () => queryClient.invalidateQueries({queryKey: reposOptions.queryKey}),
+  });
+
   // Settings cannot be opened until we've loaded the integrationWithConfig
   const settingsButtonProps = {
     disabled: integrationWithConfig === undefined,
@@ -103,6 +108,8 @@ function ConnectedInstallation({installation, children}: InstallationWrapperProp
     settingsButtonProps,
     onUninstall: () => handleDelete(installation.integration),
     uninstallButtonProps,
+    onSync: hasAccess ? syncNow : undefined,
+    isSyncing,
   } as const;
 
   return (

--- a/static/app/views/settings/organizationRepositoriesV2/useSyncRepositories.spec.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/useSyncRepositories.spec.tsx
@@ -1,0 +1,214 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as indicator from 'sentry/actionCreators/indicator';
+
+import {useSyncRepositories} from './useSyncRepositories';
+
+jest.mock('sentry/actionCreators/indicator');
+
+describe('useSyncRepositories', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+  const integration = OrganizationIntegrationsFixture({
+    id: '123',
+    configData: {last_sync: 'old-value'},
+  });
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/',
+      body: integration,
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
+  it('syncNow is undefined while the integration query is loading', () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/',
+      body: integration,
+      asyncDelay: 10_000,
+    });
+
+    const {result} = renderHookWithProviders(() => useSyncRepositories(integration), {
+      organization,
+    });
+
+    expect(result.current.syncNow).toBeUndefined();
+  });
+
+  it('syncNow becomes undefined while a sync is in progress', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/repo-sync/',
+      method: 'POST',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(() => useSyncRepositories(integration), {
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.syncNow).toBeDefined());
+
+    act(() => {
+      result.current.syncNow?.();
+    });
+
+    expect(result.current.syncNow).toBeUndefined();
+  });
+
+  it('triggers POST and sets isSyncing to true when syncNow is called', async () => {
+    const syncRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/repo-sync/',
+      method: 'POST',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(() => useSyncRepositories(integration), {
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.syncNow).toBeDefined());
+
+    act(() => {
+      result.current.syncNow?.();
+    });
+
+    expect(syncRequest).toHaveBeenCalled();
+    expect(result.current.isSyncing).toBe(true);
+  });
+
+  it('sets isSyncing to false and shows success toast when last_sync changes', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/repo-sync/',
+      method: 'POST',
+      body: {},
+    });
+
+    const onSynced = jest.fn();
+    const {result} = renderHookWithProviders(
+      () =>
+        useSyncRepositories(integration, {
+          onSynced,
+          pollingConfig: [{pollInterval: 5_000, phaseTimeout: 30_000}],
+        }),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.syncNow).toBeDefined());
+
+    jest.useFakeTimers();
+
+    act(() => {
+      result.current.syncNow?.();
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/',
+      body: OrganizationIntegrationsFixture({
+        id: '123',
+        configData: {last_sync: 'new-value'},
+      }),
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    // Restore real timers so waitFor's interval can tick and the refetch
+    // Promise chain resolves naturally.
+    jest.useRealTimers();
+
+    await waitFor(() => expect(result.current.isSyncing).toBe(false));
+
+    expect(indicator.addSuccessMessage).toHaveBeenCalledWith(
+      'Repositories synced successfully'
+    );
+    expect(onSynced).toHaveBeenCalled();
+  });
+
+  it('shows a still-syncing toast and advances poll interval at phase boundary', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/repo-sync/',
+      method: 'POST',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useSyncRepositories(integration, {
+          pollingConfig: [
+            {
+              pollInterval: 5_000,
+              phaseTimeout: 100,
+              transitionToast: 'Repositories still syncing, this may take a few minutes',
+            },
+            {pollInterval: 30_000, phaseTimeout: 60_000},
+          ],
+        }),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.syncNow).toBeDefined());
+
+    jest.useFakeTimers();
+
+    act(() => {
+      result.current.syncNow?.();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    jest.useRealTimers();
+
+    expect(indicator.addLoadingMessage).toHaveBeenCalledWith(
+      'Repositories still syncing, this may take a few minutes'
+    );
+    expect(result.current.isSyncing).toBe(true);
+  });
+
+  it('sets isSyncing to false and shows error toast after all phases are exhausted', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/repo-sync/',
+      method: 'POST',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useSyncRepositories(integration, {
+          pollingConfig: [{pollInterval: 5_000, phaseTimeout: 100}],
+        }),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.syncNow).toBeDefined());
+
+    jest.useFakeTimers();
+
+    act(() => {
+      result.current.syncNow?.();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    jest.useRealTimers();
+
+    await waitFor(() => {
+      expect(result.current.isSyncing).toBe(false);
+    });
+
+    expect(indicator.addErrorMessage).toHaveBeenCalledWith(
+      'Repositories still syncing — giving up polling. Come back later to check.'
+    );
+  });
+});

--- a/static/app/views/settings/organizationRepositoriesV2/useSyncRepositories.tsx
+++ b/static/app/views/settings/organizationRepositoriesV2/useSyncRepositories.tsx
@@ -1,0 +1,250 @@
+import {useEffect, useRef, useState} from 'react';
+import {useQuery} from '@tanstack/react-query';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+interface PollPhaseConfig {
+  /**
+   * How long to remain in this phase before advancing to the next, or timing
+   * out if last.
+   */
+  phaseTimeout: number;
+  /**
+   * Milliseconds between polls during this phase.
+   */
+  pollInterval: number;
+  /**
+   * Toast shown when this phase ends and the next one begins. Not shown for
+   * the final phase, which triggers the timeout error instead.
+   */
+  transitionToast?: string;
+}
+
+interface UsePhaseTimerOptions {
+  onTimeout: () => void;
+}
+
+interface UsePhaseTimerResult {
+  cancel: () => void;
+  currentPhase: PollPhaseConfig | null;
+  start: () => void;
+}
+
+/**
+ * Manages  multi-phase timer progression. Each phase runs for `phaseTimeout`
+ * ms before either advancing to the next phase (showing `transitionToast` if
+ * set) or calling `onTimeout` when the last phase expires.
+ */
+function usePhaseTimer(
+  config: PollPhaseConfig[],
+  {onTimeout}: UsePhaseTimerOptions
+): UsePhaseTimerResult {
+  const [phaseIndex, setPhaseIndex] = useState<number | null>(null);
+
+  const timerRef = useRef<number | null>(null);
+  const configRef = useRef(config);
+  configRef.current = config;
+  const onTimeoutRef = useRef(onTimeout);
+  onTimeoutRef.current = onTimeout;
+
+  // Stored in a ref to allow recursion without useCallback deps.
+  const scheduleRef = useRef<(idx: number) => void>(() => {});
+  scheduleRef.current = (idx: number) => {
+    const phase = configRef.current[idx];
+    if (!phase) return;
+
+    timerRef.current = window.setTimeout(() => {
+      const nextIdx = idx + 1;
+      if (nextIdx < configRef.current.length) {
+        if (phase.transitionToast) {
+          addLoadingMessage(phase.transitionToast);
+        }
+        setPhaseIndex(nextIdx);
+        scheduleRef.current(nextIdx);
+      } else {
+        timerRef.current = null;
+        setPhaseIndex(null);
+        onTimeoutRef.current();
+      }
+    }, phase.phaseTimeout);
+  };
+
+  function start() {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    setPhaseIndex(0);
+    scheduleRef.current(0);
+  }
+
+  function cancel() {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = null;
+    setPhaseIndex(null);
+  }
+
+  useEffect(() => {
+    const timer = timerRef;
+    return () => {
+      if (timer.current !== null) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const currentPhase = phaseIndex === null ? null : (config[phaseIndex] ?? null);
+
+  return {start, cancel, currentPhase};
+}
+
+interface SyncState {
+  /**
+   * Are we waiting for an integration installation to have synced?
+   */
+  isSyncing: boolean;
+  /**
+   * Kicks off a repository sync for this integration. Records the current
+   * `last_sync` value, fires the POST, then polls until `last_sync` changes
+   * or all polling phases are exhausted. Undefined while the integration
+   * query is loading or a sync is already in progress.
+   */
+  syncNow: (() => void) | undefined;
+}
+
+interface Options {
+  /**
+   * Called when a sync completes successfully.
+   * Use to trigger a repository list refresh.
+   */
+  onSynced?: () => void;
+  /**
+   * Polling phases to work through before giving up. Each phase defines how
+   * frequently to poll and how long to stay in that phase. Defaults to a
+   * two-phase backoff: every 5 seconds for 30 seconds, then every 30 seconds
+   * for 4.5 minutes (5 minutes total).
+   */
+  pollingConfig?: PollPhaseConfig[];
+}
+
+/**
+ * Default two-phase backoff: poll aggressively for the first 30 seconds,
+ * then slow down to every 30 seconds for up to 4.5 more minutes (5 min total).
+ */
+const DEFAULT_POLLING_CONFIG = [
+  {
+    pollInterval: 5_000,
+    phaseTimeout: 30_000,
+    transitionToast: t('Repositories still syncing, this may take a few minutes'),
+  },
+  {
+    pollInterval: 30_000,
+    phaseTimeout: 60_000 * 4.5,
+  },
+] as const satisfies PollPhaseConfig[];
+
+/**
+ * Manages repository sync state for a single integration. Returns an
+ * `isSyncing` flag and a `syncNow` callback. Polling and timeout handling
+ * are managed internally via configurable phases.
+ */
+export function useSyncRepositories(
+  integration: OrganizationIntegration,
+  options?: Options
+): SyncState {
+  const organization = useOrganization();
+
+  const integrationId = integration.id;
+  const organizationIdOrSlug = organization.slug;
+
+  const pollingConfig = options?.pollingConfig ?? DEFAULT_POLLING_CONFIG;
+
+  const [lastSyncBefore, setLastSyncBefore] = useState<string | undefined>(undefined);
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  const onSyncedRef = useRef(options?.onSynced);
+  onSyncedRef.current = options?.onSynced;
+
+  function startSyncing() {
+    setIsSyncing(true);
+    addLoadingMessage(t('Repository sync started, this may take a few moments'));
+  }
+
+  function stopSyncing() {
+    setIsSyncing(false);
+    setLastSyncBefore(undefined);
+  }
+
+  const phaseTimer = usePhaseTimer(pollingConfig, {
+    onTimeout: () => {
+      stopSyncing();
+      addErrorMessage(
+        t('Repositories still syncing — giving up polling. Come back later to check.')
+      );
+    },
+  });
+
+  const phaseTimerRef = useRef(phaseTimer);
+  phaseTimerRef.current = phaseTimer;
+
+  const query = useQuery({
+    ...apiOptions.as<OrganizationIntegration>()(
+      '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
+      {
+        path: {organizationIdOrSlug, integrationId},
+        // Drop staleTime to zero while syncing so refetches return fresh data.
+        staleTime: isSyncing ? 0 : 60_000,
+      }
+    ),
+    refetchInterval: phaseTimer.currentPhase?.pollInterval ?? false,
+  });
+
+  // Detect sync completion by comparing last_sync on each poll result.
+  useEffect(() => {
+    if (!isSyncing || !query.data) return;
+
+    const currentLastSync = query.data.configData?.last_sync as string | undefined;
+    if (currentLastSync !== lastSyncBefore) {
+      phaseTimerRef.current.cancel();
+      stopSyncing();
+      addSuccessMessage(t('Repositories synced successfully'));
+      onSyncedRef.current?.();
+    }
+  }, [query.data, isSyncing, lastSyncBefore]);
+
+  // syncNow is undefined while the query is loading or a sync is in progress,
+  // guaranteeing that lastSyncBefore is always captured from real data.
+  const syncNow =
+    query.data && !isSyncing
+      ? () => {
+          setLastSyncBefore(query.data.configData?.last_sync as string | undefined);
+          startSyncing();
+          phaseTimerRef.current.start();
+
+          fetchMutation({
+            method: 'POST',
+            url: getApiUrl(
+              '/organizations/$organizationIdOrSlug/integrations/$integrationId/repo-sync/',
+              {
+                path: {organizationIdOrSlug, integrationId},
+              }
+            ),
+          })
+            .then(() => {
+              query.refetch();
+            })
+            .catch(() => {
+              phaseTimerRef.current.cancel();
+              stopSyncing();
+              addErrorMessage(t('Failed to start repository sync'));
+            });
+        }
+      : undefined;
+
+  return {syncNow, isSyncing};
+}


### PR DESCRIPTION
Adds a `useSyncRepositories` hook that wires up a "Sync now" button in the repository count tooltip for each SCM installation on the repos v2 page.

When clicked, it POSTs to the `repo-sync` endpoint, records the current `last_sync` value, then polls the integration endpoint on a two-phase backoff (every 5s for 30s, then every 30s for up to 4.5 more minutes) until `last_sync` changes. On completion it invalidates the repos query cache to trigger a refresh. On timeout it shows an error toast and stops polling.

Access-gated: the sync button is only wired up when the user has `org:integrations` permission.