### PR TITLE
feat(cells): Remove features from organization summary

### DIFF
--- a/static/app/components/core/avatar/__stories__/fixtures.tsx
+++ b/static/app/components/core/avatar/__stories__/fixtures.tsx
@@ -25,7 +25,6 @@ export const ORGANIZATION: OrganizationSummary = {
   },
   codecovAccess: false,
   dateCreated: '2021-01-01',
-  features: [],
   hideAiFeatures: false,
   isEarlyAdopter: false,
   issueAlertsThreadFlag: false,

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -69,6 +69,7 @@ export interface Organization extends OrganizationSummary {
   defaultRole: string;
   enhancedPrivacy: boolean;
   eventsMemberAdmin: boolean;
+  features: string[];
   hasGranularReplayPermissions: boolean;
   isDefault: boolean;
   isDynamicallySampled: boolean;

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -23,7 +23,7 @@ export interface OrganizationSummary {
   avatar: Avatar;
   codecovAccess: boolean;
   dateCreated: string;
-  features: string[];
+  // features: string[];
   hideAiFeatures: boolean;
   id: string;
   isEarlyAdopter: boolean;

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -23,7 +23,6 @@ export interface OrganizationSummary {
   avatar: Avatar;
   codecovAccess: boolean;
   dateCreated: string;
-  // features: string[];
   hideAiFeatures: boolean;
   id: string;
   isEarlyAdopter: boolean;

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -7,11 +7,7 @@ import {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
 import type {Event} from 'sentry/types/event';
-import type {
-  NewQuery,
-  Organization,
-  OrganizationSummary,
-} from 'sentry/types/organization';
+import type {NewQuery, Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {toArray} from 'sentry/utils/array/toArray';
@@ -458,7 +454,7 @@ function generateExpandedConditions(
 }
 
 type FieldGeneratorOpts = {
-  organization: OrganizationSummary;
+  organization: Organization;
   aggregations?: Record<string, Aggregation>;
   customMeasurements?: Array<{functions: string[]; key: string}> | null;
   fieldKeys?: string[];


### PR DESCRIPTION
The org list is moving to control, where features won't be available on OrganizationSummary without a cross cell request (which we should avoid).

The field was never needed by the UI -- it was only referenced by discover but we always have the full organization in this scenario, so we can fix the issue by narrowing the type.
