### PR TITLE
chore(tests) Improve assertion failure messages for analytics events

### DIFF
--- a/src/sentry/testutils/helpers/analytics.py
+++ b/src/sentry/testutils/helpers/analytics.py
@@ -68,8 +68,12 @@ def assert_any_analytics_event(
     for recorded_event in recorded_events:
         if type(expected_event) is not type(recorded_event):
             continue
-        assert_event_equal(expected_event, recorded_event, exclude_fields)
-        return
+        try:
+            assert_event_equal(expected_event, recorded_event, exclude_fields)
+            return
+        except AssertionError as err:
+            # Store the last failing match to include in the final output
+            field_error = str(err)
 
     raise AssertionError(f"Event {expected_event} not found. {field_error}.")
 

--- a/src/sentry/testutils/helpers/analytics.py
+++ b/src/sentry/testutils/helpers/analytics.py
@@ -28,7 +28,11 @@ def assert_event_equal(
     for field in fields(expected_event):
         if exclude_fields and field.name in exclude_fields:
             continue
-        assert getattr(expected_event, field.name) == getattr(recorded_event, field.name)
+        expected_field = getattr(expected_event, field.name)
+        recorded_field = getattr(recorded_event, field.name)
+        assert expected_field == recorded_field, (
+            f"Expected event differed for {field.name}. Expected: {expected_field}. Got: {recorded_field}"
+        )
 
 
 def assert_analytics_events_recorded(
@@ -60,14 +64,16 @@ def assert_any_analytics_event(
     exclude_fields: list[str] | None = None,
 ) -> None:
     recorded_events = get_all_analytics_events(mock_record)
+    field_error = ""
     for recorded_event in recorded_events:
         try:
             assert_event_equal(expected_event, recorded_event, exclude_fields)
             return
-        except AssertionError:
+        except AssertionError as err:
+            field_error = str(err)
             pass
 
-    raise AssertionError(f"Event {expected_event} not found")
+    raise AssertionError(f"Event {expected_event} not found. {field_error}")
 
 
 def assert_not_analytics_event(

--- a/src/sentry/testutils/helpers/analytics.py
+++ b/src/sentry/testutils/helpers/analytics.py
@@ -66,14 +66,12 @@ def assert_any_analytics_event(
     recorded_events = get_all_analytics_events(mock_record)
     field_error = ""
     for recorded_event in recorded_events:
-        try:
-            assert_event_equal(expected_event, recorded_event, exclude_fields)
-            return
-        except AssertionError as err:
-            field_error = str(err)
-            pass
+        if type(expected_event) is not type(recorded_event):
+            continue
+        assert_event_equal(expected_event, recorded_event, exclude_fields)
+        return
 
-    raise AssertionError(f"Event {expected_event} not found. {field_error}")
+    raise AssertionError(f"Event {expected_event} not found. {field_error}.")
 
 
 def assert_not_analytics_event(


### PR DESCRIPTION
For large events, figuring out which attribute is the problem can be hard. The assertion helper should make this simpler.
