### PR TITLE
feat(cells): Drop deprecated requireEmailVerification field

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -137,7 +137,6 @@ class OrganizationSummarySerializerResponseOptional(TypedDict, total=False):
     onboardingTasks: list[OnboardingTasksSerializerResponse]  # Only if access=... is passed
 
 
-@extend_schema_serializer(exclude_fields=["requireEmailVerification"])
 class OrganizationSummarySerializerResponse(OrganizationSummarySerializerResponseOptional):
     id: str
     slug: str
@@ -146,7 +145,6 @@ class OrganizationSummarySerializerResponse(OrganizationSummarySerializerRespons
     dateCreated: datetime
     isEarlyAdopter: bool
     require2FA: bool
-    requireEmailVerification: bool
     avatar: SerializedAvatarFields
     links: _Links
     hasAuthProvider: bool
@@ -482,8 +480,6 @@ class OrganizationSummarySerializer(Serializer):
             "dateCreated": obj.date_added,
             "isEarlyAdopter": bool(obj.flags.early_adopter),
             "require2FA": bool(obj.flags.require_2fa),
-            # requireEmailVerification has been deprecated
-            "requireEmailVerification": False,
             "avatar": avatar,
             "allowMemberInvite": not obj.flags.disable_member_invite,
             "allowMemberProjectCreation": not obj.flags.disable_member_project_creation,
@@ -712,8 +708,6 @@ class OrganizationSerializer(OrganizationSummarySerializer):
             ),
             "openMembership": bool(obj.flags.allow_joinleave),
             "require2FA": bool(obj.flags.require_2fa),
-            # The requireEmailVerification feature has been removed, this field is deprecated.
-            "requireEmailVerification": False,
             "allowSharedIssues": not obj.flags.disable_shared_issues,
             "enhancedPrivacy": bool(obj.flags.enhanced_privacy),
             "dataScrubber": bool(
@@ -871,7 +865,6 @@ class OrganizationSerializer(OrganizationSummarySerializer):
 @extend_schema_serializer(
     exclude_fields=[
         "availableRoles",
-        "requireEmailVerification",
         "genAIConsent",
         "quota",
         "rollbackEnabled",

--- a/src/sentry/hybridcloud/services/organization_mapping/model.py
+++ b/src/sentry/hybridcloud/services/organization_mapping/model.py
@@ -44,6 +44,7 @@ class RpcOrganizationMappingUpdate(RpcModel):
     allow_joinleave: bool = False
     disable_new_visibility_features: bool = False
     enhanced_privacy: bool = False
+    # Deprecated: the require_email_verification feature has been removed.
     require_email_verification: bool = False
     disable_member_project_creation: bool = False
     prevent_superuser_access: bool = False

--- a/src/sentry/models/organizationmapping.py
+++ b/src/sentry/models/organizationmapping.py
@@ -56,6 +56,7 @@ class OrganizationMapping(Model):
     early_adopter = models.BooleanField(default=False, db_default=False)
     disable_shared_issues = models.BooleanField(default=False, db_default=False)
     disable_new_visibility_features = models.BooleanField(default=False, db_default=False)
+    # Deprecated: the require_email_verification feature has been removed.
     require_email_verification = models.BooleanField(default=False, db_default=False)
     codecov_access = models.BooleanField(default=False, db_default=False)
     disable_member_project_creation = models.BooleanField(default=False, db_default=False)

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -229,7 +229,6 @@ class OrganizationsControlListTest(OrganizationIndexTest):
             "isEarlyAdopter",
             "links",
             "require2FA",
-            "requireEmailVerification",
             "status",
         }
         assert control_response.data[0] == {


### PR DESCRIPTION
The requireEmailVerification feature has been removed and the API field has been hardcoded to False for some time. Drop it from the organization summary/details response shapes and the schema exclude lists. Mark the underlying OrganizationMapping column and RPC flag as deprecated - they can be migrated out as a follow up.
