### PR TITLE
fix(slack): Hide legend pagination on chart unfurls

### DIFF
--- a/static/app/chartcuterie/timeseries.tsx
+++ b/static/app/chartcuterie/timeseries.tsx
@@ -29,15 +29,33 @@ const CHART_SIZE = {width: 1200, height: 400};
  */
 const MAX_LEGEND_ITEMS = 4;
 
-function buildBoundedLegendData(names: string[]) {
+/**
+ * Builds the legend.data array and a synthetic placeholder series for the
+ * "+N more" overflow indicator.
+ *
+ * ECharts silently drops legend.data entries that don't match a series name
+ * (see LegendView.js — items are only drawn when getSeriesByName matches or a
+ * legendVisualProvider claims them). So to render an overflow indicator we
+ * must also push an empty series whose name matches.
+ *
+ * The slice keeps the total entry count at MAX_LEGEND_ITEMS even when
+ * overflowing, so the legend never wraps off the reserved single row.
+ */
+function buildBoundedLegend(names: string[]) {
   if (names.length <= MAX_LEGEND_ITEMS) {
-    return names;
+    return {data: names, indicatorSeries: []};
   }
-  const hiddenCount = names.length - MAX_LEGEND_ITEMS;
-  return [
-    ...names.slice(0, MAX_LEGEND_ITEMS),
-    {name: `+${hiddenCount} more`, icon: 'none'},
-  ];
+  const visibleCount = MAX_LEGEND_ITEMS - 1;
+  const hiddenCount = names.length - visibleCount;
+  const indicatorName = `+${hiddenCount} more`;
+  return {
+    data: [...names.slice(0, visibleCount), {name: indicatorName, icon: 'none'}],
+    // Empty line series gives ECharts a name to match the legend entry to.
+    // No data points means nothing is plotted; `silent` suppresses tooltips.
+    indicatorSeries: [
+      {type: 'line' as const, name: indicatorName, data: [], silent: true},
+    ],
+  };
 }
 
 /**
@@ -140,17 +158,18 @@ export const makeTimeseriesCharts = (
           return plottable?.toSeries(plottingOptions) ?? [];
         });
 
+        const legend = buildBoundedLegend(
+          timeSeries.map(ts => formatTimeSeriesLabel(ts))
+        );
+
         return {
           ...defaults,
-          legend: {
-            ...defaults.legend,
-            data: buildBoundedLegendData(timeSeries.map(ts => formatTimeSeriesLabel(ts))),
-          },
+          legend: {...defaults.legend, data: legend.data},
           yAxis,
           xAxis,
           useUTC: true,
           color,
-          series,
+          series: [...series, ...legend.indicatorSeries],
         };
       }
 
@@ -179,17 +198,16 @@ export const makeTimeseriesCharts = (
         return plottable?.toSeries(plottingOptions) ?? [];
       });
 
+      const legend = buildBoundedLegend(sorted.map(ts => formatTimeSeriesLabel(ts)));
+
       return {
         ...defaults,
-        legend: {
-          ...defaults.legend,
-          data: buildBoundedLegendData(sorted.map(ts => formatTimeSeriesLabel(ts))),
-        },
+        legend: {...defaults.legend, data: legend.data},
         yAxis,
         xAxis,
         useUTC: true,
         color,
-        series,
+        series: [...series, ...legend.indicatorSeries],
       };
     },
     ...CHART_SIZE,

--- a/static/app/chartcuterie/timeseries.tsx
+++ b/static/app/chartcuterie/timeseries.tsx
@@ -22,6 +22,25 @@ const FONT_SIZE = 28;
 const CHART_SIZE = {width: 1200, height: 400};
 
 /**
+ * Maximum legend entries shown on the static unfurl image. Anything beyond
+ * this is collapsed into a "+N more" indicator so the legend stays on a
+ * single row (the unfurl is non-interactive, so pagination/wrapping aren't
+ * useful — users click through to the live chart to see everything).
+ */
+const MAX_LEGEND_ITEMS = 4;
+
+function buildBoundedLegendData(names: string[]) {
+  if (names.length <= MAX_LEGEND_ITEMS) {
+    return names;
+  }
+  const hiddenCount = names.length - MAX_LEGEND_ITEMS;
+  return [
+    ...names.slice(0, MAX_LEGEND_ITEMS),
+    {name: `+${hiddenCount} more`, icon: 'none'},
+  ];
+}
+
+/**
  * Builds a y-axis axisLabel formatter from the first timeseries metadata.
  */
 function makeYAxisFormatter(timeSeries: TimeSeries[]) {
@@ -52,6 +71,9 @@ export const makeTimeseriesCharts = (
     backgroundColor: theme.tokens.background.primary,
     legend: Legend({
       theme,
+      // 'plain' disables ECharts' built-in legend pagination, which is non-functional
+      // on a static unfurl image. Overflow is bounded via `data` below (see MAX_LEGEND_ITEMS).
+      type: 'plain',
       icon: 'roundRect',
       itemHeight: 16,
       itemWidth: 16,
@@ -64,11 +86,6 @@ export const makeTimeseriesCharts = (
         lineHeight: FONT_SIZE * 1.1,
         fontFamily: DEFAULT_FONT_FAMILY,
       },
-      pageTextStyle: {
-        fontSize: FONT_SIZE,
-        fontFamily: DEFAULT_FONT_FAMILY,
-      },
-      pageIconSize: FONT_SIZE * 0.6,
     }),
     yAxis: YAxis({
       theme,
@@ -125,6 +142,10 @@ export const makeTimeseriesCharts = (
 
         return {
           ...defaults,
+          legend: {
+            ...defaults.legend,
+            data: buildBoundedLegendData(timeSeries.map(ts => formatTimeSeriesLabel(ts))),
+          },
           yAxis,
           xAxis,
           useUTC: true,
@@ -160,6 +181,10 @@ export const makeTimeseriesCharts = (
 
       return {
         ...defaults,
+        legend: {
+          ...defaults.legend,
+          data: buildBoundedLegendData(sorted.map(ts => formatTimeSeriesLabel(ts))),
+        },
         yAxis,
         xAxis,
         useUTC: true,

--- a/static/app/chartcuterie/timeseries.tsx
+++ b/static/app/chartcuterie/timeseries.tsx
@@ -42,14 +42,19 @@ const MAX_LEGEND_ITEMS = 4;
  * overflowing, so the legend never wraps off the reserved single row.
  */
 function buildBoundedLegend(names: string[]) {
-  if (names.length <= MAX_LEGEND_ITEMS) {
-    return {data: names, indicatorSeries: []};
+  // Dedupe first: grouped multi-yAxis responses produce one TimeSeries per
+  // (group, yAxis) pair, but `formatTimeSeriesLabel` returns just the group
+  // when groupBy is present. Without dedup, duplicates would consume cap
+  // slots and inflate the "+N more" count.
+  const uniqueNames = Array.from(new Set(names));
+  if (uniqueNames.length <= MAX_LEGEND_ITEMS) {
+    return {data: uniqueNames, indicatorSeries: []};
   }
   const visibleCount = MAX_LEGEND_ITEMS - 1;
-  const hiddenCount = names.length - visibleCount;
+  const hiddenCount = uniqueNames.length - visibleCount;
   const indicatorName = `+${hiddenCount} more`;
   return {
-    data: [...names.slice(0, visibleCount), {name: indicatorName, icon: 'none'}],
+    data: [...uniqueNames.slice(0, visibleCount), {name: indicatorName, icon: 'none'}],
     // Empty line series gives ECharts a name to match the legend entry to.
     // No data points means nothing is plotted; `silent` suppresses tooltips.
     indicatorSeries: [


### PR DESCRIPTION
Removes the legend pagination in the slack image, chartcuterie returns an image, so having pagination in the image like below doesn't make sense because you can't interact with it
<img width="1200" height="400" alt="image" src="https://github.com/user-attachments/assets/3893d188-0092-4a9a-b620-14a6af2bec0d" />
