### PR TITLE
fix(alerts): Add SpansIndexed to alert rule dataset mappings

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -505,6 +505,7 @@ query_datasets_to_type = {
     Dataset.PerformanceMetrics: SnubaQuery.Type.PERFORMANCE,
     Dataset.Metrics: SnubaQuery.Type.CRASH_RATE,
     Dataset.EventsAnalyticsPlatform: SnubaQuery.Type.PERFORMANCE,
+    Dataset.SpansIndexed: SnubaQuery.Type.PERFORMANCE,
 }
 
 

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -67,6 +67,7 @@ QUERY_TYPE_VALID_DATASETS = {
         Dataset.Transactions,
         Dataset.PerformanceMetrics,
         Dataset.EventsAnalyticsPlatform,
+        Dataset.SpansIndexed,
     },
     SnubaQuery.Type.CRASH_RATE: {Dataset.Metrics},
 }


### PR DESCRIPTION
** im not on this team so not 100% sure if this is the right fix ** 

`Dataset.SpansIndexed` was missing from two dataset mapping dicts, causing a
`KeyError: <Dataset.SpansIndexed: 'spans'>` when creating or modifying alert
rules with `dataset: "spans"`. This was caught on canary in release `7c562f85cb45`
(SENTRY-5PEF).

**`query_datasets_to_type`** in `src/sentry/incidents/logic.py` — maps datasets
to `SnubaQuery.Type`. Missing entry caused the KeyError on the alert-rules
validation path.

**`QUERY_TYPE_VALID_DATASETS`** in `src/sentry/snuba/snuba_query_validator.py` —
validates that a dataset is allowed for a given query type. Without this entry,
`SpansIndexed` would fail validation even after fixing the first dict.

Both map `SpansIndexed` to `PERFORMANCE`, consistent with `Transactions` and
`EventsAnalyticsPlatform`.