### PR TITLE
feat(cells): Remove features from the org listing endpoint

### DIFF
--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -200,7 +200,7 @@ class OrganizationIndexEndpoint(Endpoint):
             request=request,
             queryset=queryset,
             order_by=order_by,
-            on_results=lambda x: serialize(x, request.user),
+            on_results=lambda x: serialize(x, request.user, include_feature_flags=False),
             paginator_cls=paginator_cls,
         )
 

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -223,8 +223,6 @@ class OrganizationsControlListTest(OrganizationIndexTest):
             "allowSuperuserAccess",
             "avatar",
             "dateCreated",
-            "extraOptions",
-            "features",
             "hasAuthProvider",
             "isEarlyAdopter",
             "links",


### PR DESCRIPTION
The "features" list is never actually used by the UI. The related frontend typing fix to remove this field from 
OrganizationSummary is here: https://github.com/getsentry/sentry/pull/115000.

This field has to be removed as it cannot be supported without a cross-cell query (which we should avoid) when this endpoint moves to the control silo. This change makes the current cell variant of the endpoint compatible with the future state.
