### PR TITLE
feat(ourlogs): bump export modal select default value from 100 to 500 for release to GA

### DIFF
--- a/static/app/views/explore/logs/exports/generateLogExportRowCountOptions.spec.tsx
+++ b/static/app/views/explore/logs/exports/generateLogExportRowCountOptions.spec.tsx
@@ -2,26 +2,33 @@ import {generateLogExportRowCountOptions} from 'sentry/views/explore/logs/export
 
 describe('generateLogExportRowCountOptions', () => {
   it('adds an abbreviated (All) option when estimate is between predefined thresholds', () => {
-    expect(generateLogExportRowCountOptions(1_500)).toEqual([
-      {label: '100', value: 100},
-      {label: '500', value: 500},
-      {label: '1,000', value: 1_000},
-      {label: '1.5K (All)', value: 1_500},
-    ]);
+    expect(generateLogExportRowCountOptions(1_500)).toEqual({
+      rowCountDefault: {label: '500', value: 500},
+      rowCountOptions: [
+        {label: '100', value: 100},
+        {label: '500', value: 500},
+        {label: '1,000', value: 1_000},
+        {label: '1.5K (All)', value: 1_500},
+      ],
+    });
   });
 
   it('adds an abbreviated (All) option when estimate is below the first predefined threshold', () => {
-    expect(generateLogExportRowCountOptions(50)).toEqual([
-      {label: '50 (All)', value: 50},
-    ]);
+    expect(generateLogExportRowCountOptions(50)).toEqual({
+      rowCountDefault: {label: '50 (All)', value: 50},
+      rowCountOptions: [{label: '50 (All)', value: 50}],
+    });
   });
 
   it('does not add an (All) option when estimate equals a predefined threshold', () => {
-    expect(generateLogExportRowCountOptions(10_000)).toEqual([
-      {label: '100', value: 100},
-      {label: '500', value: 500},
-      {label: '1,000', value: 1_000},
-      {label: '10,000', value: 10_000},
-    ]);
+    expect(generateLogExportRowCountOptions(10_000)).toEqual({
+      rowCountDefault: {label: '500', value: 500},
+      rowCountOptions: [
+        {label: '100', value: 100},
+        {label: '500', value: 500},
+        {label: '1,000', value: 1_000},
+        {label: '10,000', value: 10_000},
+      ],
+    });
   });
 });

--- a/static/app/views/explore/logs/exports/generateLogExportRowCountOptions.ts
+++ b/static/app/views/explore/logs/exports/generateLogExportRowCountOptions.ts
@@ -4,7 +4,7 @@ import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {formatNumber} from 'sentry/utils/number/formatNumber';
 import {QUERY_PAGE_LIMIT} from 'sentry/views/explore/logs/constants';
 
-const ROW_COUNT_VALUE_DEFAULT = 100;
+export const ROW_COUNT_VALUE_DEFAULT = 500;
 
 /**
  * Keep this in sync with data_export.py on the backend
@@ -12,8 +12,8 @@ const ROW_COUNT_VALUE_DEFAULT = 100;
 export const ROW_COUNT_VALUE_SYNC_LIMIT = QUERY_PAGE_LIMIT;
 
 const ROW_COUNT_VALUES = [
+  100,
   ROW_COUNT_VALUE_DEFAULT,
-  500,
   ROW_COUNT_VALUE_SYNC_LIMIT,
   10_000,
   50_000,

--- a/static/app/views/explore/logs/exports/generateLogExportRowCountOptions.ts
+++ b/static/app/views/explore/logs/exports/generateLogExportRowCountOptions.ts
@@ -4,7 +4,7 @@ import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {formatNumber} from 'sentry/utils/number/formatNumber';
 import {QUERY_PAGE_LIMIT} from 'sentry/views/explore/logs/constants';
 
-export const ROW_COUNT_VALUE_DEFAULT = 500;
+const ROW_COUNT_VALUE_DEFAULT = 500;
 
 /**
  * Keep this in sync with data_export.py on the backend
@@ -20,24 +20,26 @@ const ROW_COUNT_VALUES = [
   100_000,
 ];
 
-export function generateLogExportRowCountOptions(
-  estimatedRowCount: number
-): Array<SelectValue<number>> {
-  const rowOptions: Array<SelectValue<number>> = ROW_COUNT_VALUES.map(value => ({
+export function generateLogExportRowCountOptions(estimatedRowCount: number) {
+  const rowCountOptions: Array<SelectValue<number>> = ROW_COUNT_VALUES.map(value => ({
     label: formatNumber(value),
     value,
   })).filter(({value}) => value <= estimatedRowCount);
 
   if (
-    !rowOptions.length ||
-    (estimatedRowCount > rowOptions[rowOptions.length - 1]!.value &&
-      rowOptions.length < ROW_COUNT_VALUES.length)
+    !rowCountOptions.length ||
+    (estimatedRowCount > rowCountOptions[rowCountOptions.length - 1]!.value &&
+      rowCountOptions.length < ROW_COUNT_VALUES.length)
   ) {
-    rowOptions.push({
+    rowCountOptions.push({
       label: t('%s (All)', formatAbbreviatedNumber(estimatedRowCount)),
       value: estimatedRowCount,
     });
   }
 
-  return rowOptions;
+  const rowCountDefault =
+    rowCountOptions.find(({value}) => value === ROW_COUNT_VALUE_DEFAULT) ??
+    rowCountOptions[0]!;
+
+  return {rowCountOptions, rowCountDefault};
 }

--- a/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
@@ -131,7 +131,7 @@ describe('LogsExportModal', () => {
     });
 
     expect(mockDownloadLogs).toHaveBeenCalledWith({
-      rows: tableData.slice(0, 100),
+      rows: tableData.slice(0, 500),
       fields: queryInfo.field,
       filename: 'logs',
       format: 'csv',

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -58,9 +58,12 @@ export function LogsExportModal({
   );
   const handleDataExport = useDataExport();
   const rowCountOptions = generateLogExportRowCountOptions(estimatedRowCount);
+  const rowCountOptionsDefault = rowCountOptions.find(
+    option => option.value === ROW_COUNT_VALUE_DEFAULT
+  );
   const defaultValues: ExportModalFormValues = {
     format: 'csv',
-    limit: rowCountOptions[0]!.value,
+    limit: ROW_COUNT_VALUE_DEFAULT,
   };
 
   const form = useScrapsForm({
@@ -140,9 +143,7 @@ export function LogsExportModal({
                   options={rowCountOptions}
                   onChange={field.handleChange}
                   value={field.state.value}
-                  defaultValue={rowCountOptions.find(
-                    option => option.value === ROW_COUNT_VALUE_DEFAULT
-                  )}
+                  defaultValue={rowCountOptionsDefault}
                 />
               </field.Layout.Stack>
             )}

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -17,6 +17,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {downloadLogs} from 'sentry/views/explore/logs/exports/downloadLogs';
 import {
   generateLogExportRowCountOptions,
+  ROW_COUNT_VALUE_DEFAULT,
   ROW_COUNT_VALUE_SYNC_LIMIT,
 } from 'sentry/views/explore/logs/exports/generateLogExportRowCountOptions';
 import {useLogsExportEstimatedRowCount} from 'sentry/views/explore/logs/exports/useLogsExportEstimatedRowCount';
@@ -139,7 +140,9 @@ export function LogsExportModal({
                   options={rowCountOptions}
                   onChange={field.handleChange}
                   value={field.state.value}
-                  defaultValue={rowCountOptions[0]}
+                  defaultValue={rowCountOptions.find(
+                    option => option.value === ROW_COUNT_VALUE_DEFAULT
+                  )}
                 />
               </field.Layout.Stack>
             )}

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -58,9 +58,6 @@ export function LogsExportModal({
   );
   const handleDataExport = useDataExport();
   const rowCountOptions = generateLogExportRowCountOptions(estimatedRowCount);
-  const rowCountOptionsDefault = rowCountOptions.find(
-    option => option.value === ROW_COUNT_VALUE_DEFAULT
-  );
   const defaultValues: ExportModalFormValues = {
     format: 'csv',
     limit: ROW_COUNT_VALUE_DEFAULT,
@@ -143,7 +140,9 @@ export function LogsExportModal({
                   options={rowCountOptions}
                   onChange={field.handleChange}
                   value={field.state.value}
-                  defaultValue={rowCountOptionsDefault}
+                  defaultValue={rowCountOptions.find(
+                    option => option.value === ROW_COUNT_VALUE_DEFAULT
+                  )}
                 />
               </field.Layout.Stack>
             )}

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -17,7 +17,6 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {downloadLogs} from 'sentry/views/explore/logs/exports/downloadLogs';
 import {
   generateLogExportRowCountOptions,
-  ROW_COUNT_VALUE_DEFAULT,
   ROW_COUNT_VALUE_SYNC_LIMIT,
 } from 'sentry/views/explore/logs/exports/generateLogExportRowCountOptions';
 import {useLogsExportEstimatedRowCount} from 'sentry/views/explore/logs/exports/useLogsExportEstimatedRowCount';
@@ -57,10 +56,11 @@ export function LogsExportModal({
     [queryInfo]
   );
   const handleDataExport = useDataExport();
-  const rowCountOptions = generateLogExportRowCountOptions(estimatedRowCount);
+  const {rowCountDefault, rowCountOptions} =
+    generateLogExportRowCountOptions(estimatedRowCount);
   const defaultValues: ExportModalFormValues = {
     format: 'csv',
-    limit: ROW_COUNT_VALUE_DEFAULT,
+    limit: rowCountDefault.value,
   };
 
   const form = useScrapsForm({
@@ -140,9 +140,7 @@ export function LogsExportModal({
                   options={rowCountOptions}
                   onChange={field.handleChange}
                   value={field.state.value}
-                  defaultValue={rowCountOptions.find(
-                    option => option.value === ROW_COUNT_VALUE_DEFAULT
-                  )}
+                  defaultValue={rowCountDefault}
                 />
               </field.Layout.Stack>
             )}


### PR DESCRIPTION
Coming out of discussion with @bcoe and @manessaraj: we'll have the default be 500. Otherwise we're ready to ship 🚀 100k is supported nicely for the current API.

Adding an "include all columns" checkbox will be next, once some backend stress testing is done.