### PR TITLE
ref(seer): Promote event routes to stable structured context flag

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -55,12 +55,11 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/explore/traces/trace/:traceSlug/',
   '/issues/',
   '/issues/:groupId/',
-]);
-/** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>([
   '/issues/:groupId/events/',
   '/issues/:groupId/events/:eventId/',
 ]);
+/** New experimental routes where the LLMContext tree provides structured page context. */
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>();
 
 function supportsStructuredContext(
   referrer: string,


### PR DESCRIPTION
+ Move /issues/:groupId/events/ and /issues/:groupId/events/:eventId/ from NEW_STRUCTURED_CONTEXT_ROUTES to STRUCTURED_CONTEXT_ROUTES so they use the broader seer-explorer-context-engine flag, consistent with the other issue routes.

