### PR TITLE
feat: allow interval on heatmap endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_heatmap.py
+++ b/src/sentry/api/endpoints/organization_events_heatmap.py
@@ -20,7 +20,7 @@ from sentry.snuba.referrer import Referrer
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
-MAX_BUCKETS = 10_000
+MAX_BUCKETS = 1_000
 HEATMAP_DATASETS = {TraceMetrics}
 
 
@@ -109,13 +109,26 @@ class OrganizationEventsHeatmapEndpoint(OrganizationEventsEndpointBase):
                 raise ParseError("zAxis can currently only be `count()`")
             z_function, _, _ = parse_function(zAxis)
 
-            xBuckets = request.GET.get("xBuckets")
-            if xBuckets is None or not xBuckets.isnumeric():
-                raise ParseError("xBuckets must be a number")
+            # if xAxis is time, use interval as x_buckets instead
+            if xAxis == "time":
+                rollup = self.get_rollup(request, snuba_params, 0, True)
+                snuba_params.granularity_secs = rollup
+                x_buckets = int(
+                    snuba_params.date_range.total_seconds() // snuba_params.granularity_secs
+                )
             else:
-                x_buckets = int(xBuckets)
-                if x_buckets <= 0:
-                    raise ParseError("xBuckets must be greater than 0")
+                # Currently unused since time is the only allowed xAxis
+                xBuckets = request.GET.get("xBuckets")
+                if xBuckets is None or not xBuckets.isnumeric():
+                    raise ParseError("xBuckets must be a number")
+                else:
+                    x_buckets = int(xBuckets)
+                    if x_buckets <= 0:
+                        raise ParseError("xBuckets must be greater than 0")
+
+                snuba_params.granularity_secs = int(
+                    (snuba_params.date_range.total_seconds()) // x_buckets
+                )
 
             yBuckets = request.GET.get("yBuckets")
             if yBuckets is None or not yBuckets.isnumeric():
@@ -124,14 +137,9 @@ class OrganizationEventsHeatmapEndpoint(OrganizationEventsEndpointBase):
                 y_buckets = int(yBuckets)
                 if y_buckets <= 0:
                     raise ParseError("yBuckets must be greater than 0")
+                elif y_buckets > MAX_BUCKETS:
+                    raise ParseError(f"yBuckets must be less than {MAX_BUCKETS}")
 
-            # Leaving it as this even though we can query more buckets, just want to do some testing first
-            if x_buckets * y_buckets > MAX_BUCKETS:
-                raise ParseError(f"xBuckets * yBuckets must be less than {MAX_BUCKETS}")
-
-            snuba_params.granularity_secs = int(
-                (snuba_params.date_range.total_seconds()) // x_buckets
-            )
             query = request.GET.get("query", "")
 
         with handle_query_errors():
@@ -152,6 +160,7 @@ class OrganizationEventsHeatmapEndpoint(OrganizationEventsEndpointBase):
             else:
                 # if max == min, then just have 1 bucket
                 bucket_size = 0
+                y_buckets = 1
                 yAxes = {
                     bucket_ranges[0]: f"{z_function}_if(`{yAxis}:{bucket_ranges[0]}`, {yAxis})"
                 }

--- a/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
@@ -52,7 +52,7 @@ class OrganizationEventsHeatmapTraceMetricsEndpointTest(OrganizationEventsEndpoi
                 "start": self.start,
                 "end": self.start + timedelta(hours=6),
                 "yAxis": "value",
-                "xBuckets": 6,
+                "interval": "1h",
                 "yBuckets": 6,
                 "query": "metric.name:foo metric.type:counter",
                 "project": self.project.id,
@@ -84,6 +84,131 @@ class OrganizationEventsHeatmapTraceMetricsEndpointTest(OrganizationEventsEndpoi
                 "name": "value",
                 "start": 120,
                 "end": 720,
+                "bucketCount": 6,
+                "bucketSize": 100,
+            },
+            "zAxis": {
+                "name": "count()",
+                "start": 0,
+                "end": 1,
+            },
+        }
+
+    def test_min_equals_max(self) -> None:
+        metric_values = [6, 0, 6, 3, 0, 3]
+
+        trace_metrics = []
+        for hour, value in enumerate(metric_values):
+            for i in range(value):
+                trace_metrics.append(
+                    self.create_trace_metric(
+                        "foo",
+                        100,
+                        "counter",
+                        timestamp=self.start + timedelta(hours=hour),
+                    )
+                )
+        self.store_eap_items(trace_metrics)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.start + timedelta(hours=6),
+                "yAxis": "value",
+                "interval": "1h",
+                "yBuckets": 100,
+                "query": "metric.name:foo metric.type:counter",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            },
+        )
+        assert response.status_code == 200, response.content
+        expected_response = []
+        for time in range(6):
+            expected_response.append(
+                {
+                    "xAxis": (self.start.timestamp() + (3600 * time)) * 1000,
+                    "yAxis": 100,
+                    "zAxis": metric_values[time],
+                }
+            )
+        assert response.data["values"] == expected_response
+        assert response.data["meta"] == {
+            "dataset": "tracemetrics",
+            "xAxis": {
+                "name": "time",
+                "start": self.start.timestamp() * 1000,
+                "end": self.end.timestamp() * 1000,
+                "bucketCount": 6,
+                "bucketSize": 3600,
+            },
+            "yAxis": {
+                "name": "value",
+                "start": 100,
+                "end": 100,
+                "bucketCount": 1,
+                "bucketSize": 0,
+            },
+            "zAxis": {
+                "name": "count()",
+                "start": 0,
+                "end": 6,
+            },
+        }
+
+    def test_explicit_zero_value(self) -> None:
+        metric_values = [6, 0, 6, 3, 0, 3]
+
+        trace_metrics = []
+        for hour, value in enumerate(metric_values):
+            trace_metrics.append(
+                self.create_trace_metric(
+                    "foo",
+                    100 * value,
+                    "counter",
+                    timestamp=self.start + timedelta(hours=hour),
+                )
+            )
+        self.store_eap_items(trace_metrics)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.start + timedelta(hours=6),
+                "yAxis": "value",
+                "interval": "1h",
+                "yBuckets": 6,
+                "query": "metric.name:foo metric.type:counter",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            },
+        )
+        assert response.status_code == 200, response.content
+        expected_response = []
+        for time in range(6):
+            for yAxis in range(6):
+                expected_response.append(
+                    {
+                        "xAxis": (self.start.timestamp() + (3600 * time)) * 1000,
+                        "yAxis": 100 * yAxis,
+                        "zAxis": 1 if yAxis == min(metric_values[time], 5) else 0,
+                    }
+                )
+
+        assert response.data["values"] == expected_response
+        assert response.data["meta"] == {
+            "dataset": "tracemetrics",
+            "xAxis": {
+                "name": "time",
+                "start": self.start.timestamp() * 1000,
+                "end": self.end.timestamp() * 1000,
+                "bucketCount": 6,
+                "bucketSize": 3600,
+            },
+            "yAxis": {
+                "name": "value",
+                "start": 0,
+                "end": 600,
                 "bucketCount": 6,
                 "bucketSize": 100,
             },


### PR DESCRIPTION
- This allows `interval` to be used on the heatmap endpoint when xAxis is `time` since we have an allowlist on what intervals are allowed and calculating xBuckets for that is annoying
- Changing max_buckets to just be limited to y_buckets for now since the xAxis will be limited by intervals already (and time is currently the only allowed axis)
- Add some extra tests