### PR TITLE
fix(digests): Prefer workflow_id over legacy_rule_id in get_rule_or_workflow_id

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -192,28 +192,20 @@ def get_rules_from_workflows(project: Project, workflow_ids: set[int]) -> dict[i
 
     for workflow_id, workflow in workflows.items():
         alert_workflow = alert_rule_workflows_map.get(workflow_id)
+        label = workflow.name
+        data: dict[str, Any] = {"actions": [{"workflow_id": workflow_id}]}
+
         if alert_workflow:
             if rule := bulk_rules.get(alert_workflow.rule_id):
                 assert rule.project_id == project.id, "Rule must belong to Project"
-                try:
-                    rule.data["actions"][0]["legacy_rule_id"] = rule.id
-                    rule.data["actions"][0]["workflow_id"] = workflow_id
-                except KeyError:
-                    # This shouldn't happen, but isn't a deal breaker if it does
-                    sentry_sdk.capture_exception(
-                        Exception(f"Rule {rule.id} does not have a legacy_rule_id"),
-                        level="warning",
-                    )
-                rules[workflow_id] = rule
-                continue
+                label = rule.label
+                data["actions"][0]["legacy_rule_id"] = rule.id
 
-        # Create synthetic Rule when no AlertRuleWorkflow or no Rule found
         rules[workflow_id] = Rule(
-            label=workflow.name,
+            label=label,
             id=workflow_id,
             project_id=project.id,
-            # We need to do this so that the links are built correctly downstream
-            data={"actions": [{"workflow_id": workflow_id}]},
+            data=data,
         )
 
     return rules

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -80,7 +80,8 @@ def event_to_record(
     event: Event | GroupEvent,
     rules: Sequence[Rule],
     notification_uuid: str | None = None,
-    identifier_key: IdentifierKey = IdentifierKey.RULE,
+    *,
+    identifier_key: IdentifierKey,
 ) -> Record:
     if not rules:
         logger.warning("Creating record for %s that does not contain any rules!", event)

--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -133,7 +133,8 @@ def build_custom_digest(
     legacy_to_digest_id: dict[int, int] = {}
     for rule in original_digest:
         all_rule_ids.add(rule.id)
-        legacy_id = rule.data.get("actions", [{}])[0].get("legacy_rule_id")
+        actions = rule.data.get("actions") or []
+        legacy_id = actions[0].get("legacy_rule_id") if actions else None
         if legacy_id is not None:
             all_rule_ids.add(int(legacy_id))
             legacy_to_digest_id[int(legacy_id)] = rule.id

--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -125,10 +125,28 @@ def build_custom_digest(
 ) -> Digest:
     """Given a digest and a set of events, filter the digest to only records that include the events."""
     user_digest: Digest = {}
+
+    # Collect all rule IDs to check for snoozes: both the digest key IDs
+    # (workflow IDs for workflow-based rules) and any legacy_rule_ids stored
+    # in the rule data. Snoozes are stored against real Rule DB IDs.
+    all_rule_ids: set[int] = set()
+    legacy_to_digest_id: dict[int, int] = {}
+    for rule in original_digest:
+        all_rule_ids.add(rule.id)
+        legacy_id = rule.data.get("actions", [{}])[0].get("legacy_rule_id")
+        if legacy_id is not None:
+            all_rule_ids.add(int(legacy_id))
+            legacy_to_digest_id[int(legacy_id)] = rule.id
+
     rule_snoozes = RuleSnooze.objects.filter(
-        Q(user_id=participant.id) | Q(user_id__isnull=True), rule__in=original_digest.keys()
-    ).values_list("rule", flat=True)
-    snoozed_rule_ids = {rule for rule in rule_snoozes}
+        Q(user_id=participant.id) | Q(user_id__isnull=True), rule_id__in=all_rule_ids
+    ).values_list("rule_id", flat=True)
+    snoozed_rule_ids: set[int] = set()
+    for snoozed_id in rule_snoozes:
+        snoozed_rule_ids.add(snoozed_id)
+        # If a legacy rule ID is snoozed, also mark the corresponding digest key ID
+        if snoozed_id in legacy_to_digest_id:
+            snoozed_rule_ids.add(legacy_to_digest_id[snoozed_id])
 
     for rule, rule_groups in original_digest.items():
         if rule.id in snoozed_rule_ids:

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -34,11 +34,11 @@ def split_rules_by_rule_workflow_id(rules: Sequence[Rule]) -> RulesAndWorkflows:
 
 def get_rule_or_workflow_id(rule: Rule) -> tuple[RuleIdType, str]:
     try:
-        return ("legacy_rule_id", get_key_from_rule_data(rule, "legacy_rule_id"))
+        return ("workflow_id", get_key_from_rule_data(rule, "workflow_id"))
     except AssertionError:
         pass
 
     try:
-        return ("workflow_id", get_key_from_rule_data(rule, "workflow_id"))
+        return ("legacy_rule_id", get_key_from_rule_data(rule, "legacy_rule_id"))
     except AssertionError:
         return ("legacy_rule_id", str(rule.id))

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -44,7 +44,7 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.project import Project
-from sentry.notifications.utils.rules import get_rule_or_workflow_id
+from sentry.notifications.utils.rules import get_key_from_rule_data
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.metrics import (
     SentryAppEventType,
@@ -713,12 +713,14 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
 
         # If the future comes from a rule with a UI component form in the schema, append the issue alert payload
         # TODO(ecosystem): We need to change this payload format after alerts create issues
+        # Sentry app webhooks always use the legacy rule id for backward compatibility.
+        # Ignore test notifications (id == -1).
         id = f.rule.id
-
-        # if we are using the new workflow engine, we need to use the legacy rule id
-        # Ignore test notifications
         if int(id) != -1:
-            _, id = get_rule_or_workflow_id(f.rule)
+            try:
+                id = get_key_from_rule_data(f.rule, "legacy_rule_id")
+            except AssertionError:
+                pass
 
         settings = f.kwargs.get("schema_defined_settings")
         if settings:

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -12,7 +12,12 @@ from sentry.digests.notifications import (
     split_key,
     unsplit_key,
 )
-from sentry.digests.types import NotificationWithRuleObjects, Record, RecordWithRuleObjects
+from sentry.digests.types import (
+    IdentifierKey,
+    NotificationWithRuleObjects,
+    Record,
+    RecordWithRuleObjects,
+)
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.models.rule import Rule
@@ -39,7 +44,9 @@ class BindRecordsTestCase(TestCase):
 
     @cached_property
     def record(self) -> Record:
-        return event_to_record(self.event, (self.rule,), self.notification_uuid)
+        return event_to_record(
+            self.event, (self.rule,), self.notification_uuid, identifier_key=IdentifierKey.RULE
+        )
 
     @property
     def group_mapping(self) -> dict[int, Group]:

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -67,7 +67,9 @@ class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
             ),
         ]
 
-        records = [event_to_record(event, (rule,)) for event in events]
+        records = [
+            event_to_record(event, (rule,), identifier_key=IdentifierKey.RULE) for event in events
+        ]
 
         digest = build_digest(project, sort_records(records))[0]
 
@@ -234,10 +236,9 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
         ]
 
     def test_simple(self) -> None:
-        records = [
-            event_to_record(event, (self.rule,))
-            for event in self.team1_events + self.team2_events + self.user4_events
-        ]
+        records = []
+        for event in self.team1_events + self.team2_events + self.user4_events:
+            records.extend(_get_records(self.project, (self.rule,), event))
         digest = build_digest(self.project, sort_records(records))[0]
 
         expected_result = {
@@ -284,7 +285,9 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
     def test_direct_email(self) -> None:
         """When the action type is not Issue Owners, then the target actor gets a digest."""
         self.project_ownership.update(fallthrough=False)
-        records = [event_to_record(event, (self.rule,)) for event in self.team1_events]
+        records = []
+        for event in self.team1_events:
+            records.extend(_get_records(self.project, (self.rule,), event))
         digest = build_digest(self.project, sort_records(records))[0]
 
         expected_result = {self.user1.id: set(self.team1_events)}
@@ -410,7 +413,9 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
         events = self.create_events_from_filenames(
             self.project, ["hello.moz", "goodbye.moz", "hola.moz", "adios.moz"]
         )
-        records = [event_to_record(event, (self.rule,)) for event in events + self.team1_events]
+        records = []
+        for event in events + self.team1_events:
+            records.extend(_get_records(self.project, (self.rule,), event))
         digest = build_digest(self.project, sort_records(records))[0]
         expected_result = {
             self.user1.id: set(events),

--- a/tests/sentry/integrations/msteams/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/msteams/notifications/test_issue_alert.py
@@ -54,7 +54,7 @@ class MSTeamsIssueAlertNotificationTest(MSTeamsActivityNotificationTest):
         assert 4 == len(body)
 
         assert (
-            f"Alert triggered [{rule.label}](http://testserver/organizations/baz/issues/alerts/rules/bar/{rule.id}/details/)"
+            f"Alert triggered [{rule.label}](http://testserver/organizations/{self.organization.slug}/monitors/alerts/{rule.data['actions'][0]['workflow_id']}/)"
             == body[0]["text"]
         )
         assert (
@@ -104,7 +104,7 @@ class MSTeamsIssueAlertNotificationTest(MSTeamsActivityNotificationTest):
         assert 4 == len(body)
 
         assert (
-            f"Alert triggered [{rule.label}](http://testserver/organizations/baz/issues/alerts/rules/bar/{rule.id}/details/)"
+            f"Alert triggered [{rule.label}](http://testserver/organizations/{self.organization.slug}/monitors/alerts/{rule.data['actions'][0]['workflow_id']}/)"
             == body[0]["text"]
         )
         assert (

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -99,8 +99,8 @@ class OpsgenieClientTest(APITestCase):
             "priority": "P2",
             "details": {
                 "Project Name": self.project.name,
-                "Triggering Rules": "my rule",
-                "Triggering Rule URLs": f"http://example.com/organizations/baz/issues/alerts/rules/{self.project.slug}/{rule.id}/details/",
+                "Triggering Workflows": "my rule",
+                "Triggering Workflow URLs": f"http://example.com/organizations/{self.organization.slug}/monitors/alerts/{rule.data['actions'][0]['workflow_id']}/",
                 "Sentry Group": "Hello world",
                 "Sentry ID": group_id,
                 "Logger": "",
@@ -166,8 +166,8 @@ class OpsgenieClientTest(APITestCase):
             "priority": "P2",
             "details": {
                 "Project Name": self.project.name,
-                "Triggering Rules": rule.label,
-                "Triggering Rule URLs": f"http://example.com/organizations/baz/issues/alerts/rules/{self.project.slug}/{rule.data['actions'][0]['legacy_rule_id']}/details/",
+                "Triggering Workflows": rule.label,
+                "Triggering Workflow URLs": f"http://example.com/organizations/{self.organization.slug}/monitors/alerts/{rule.data['actions'][0]['workflow_id']}/",
                 "Sentry Group": "Hello world",
                 "Sentry ID": group_id,
                 "Logger": "",

--- a/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
+++ b/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
@@ -242,7 +242,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|*Hello world*>"
         )
 
         # Test action should not create a notification message
@@ -324,7 +324,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|*Hello world*>"
         )
 
         assert NotificationMessage.objects.all().count() == 1
@@ -381,7 +381,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|*Hello world*>"
         )
 
         assert NotificationMessage.objects.all().count() == 2

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -10,6 +10,7 @@ import sentry
 from sentry.constants import ObjectStatus
 from sentry.digests.backends.redis import RedisBackend
 from sentry.digests.notifications import event_to_record
+from sentry.digests.types import IdentifierKey
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.slack.message_builder.issues import get_tags
@@ -57,6 +58,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             name="ja rule",
             action_data=[action_data],
         )
+        self.workflow_id = self.rule.data["actions"][0]["workflow_id"]
 
     def test_issue_alert_user_block(self) -> None:
         """
@@ -81,13 +83,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/issues/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/monitors/alerts/{self.workflow_id}/|ja rule>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&workflow_id={self.workflow_id}&alert_type=issue|*Hello world*>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -119,7 +121,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/issues/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/monitors/alerts/{self.workflow_id}/|ja rule>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks_with_culprit_blocks(
@@ -129,7 +131,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             event.group,
             "issue_alert-slack",
             alert_type=FineTuningAPIKey.ALERTS,
-            issue_link_extra_params=f"&alert_rule_id={self.rule.id}&alert_type=issue",
+            issue_link_extra_params=f"&workflow_id={self.workflow_id}&alert_type=issue",
         )
 
     @mock.patch("sentry.integrations.slack.message_builder.issues.get_tags", new=fake_get_tags)
@@ -172,7 +174,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/issues/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/monitors/alerts/{self.workflow_id}/|ja rule>"
         )
         assert len(blocks) == 4
 
@@ -201,7 +203,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/issues/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/monitors/alerts/{self.workflow_id}/|ja rule>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
 
@@ -212,7 +214,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             event.group,
             "issue_alert-slack",
             alert_type="alerts",
-            issue_link_extra_params=f"&alert_rule_id={self.rule.id}&alert_type=issue",
+            issue_link_extra_params=f"&workflow_id={self.workflow_id}&alert_type=issue",
         )
 
     @patch(
@@ -315,13 +317,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = notification.notification_uuid
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/issues/alerts/rules/{event.project.slug}/{rule.id}/details/|ja rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/monitors/alerts/{rule.data['actions'][0]['workflow_id']}/|ja rule>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|*Hello world*>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -349,13 +351,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = notification.notification_uuid
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/issues/alerts/rules/{event.project.slug}/{rule.id}/details/|ja rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/monitors/alerts/{rule.data['actions'][0]['workflow_id']}/|ja rule>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment=production&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment=production&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|*Hello world*>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -485,13 +487,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/issues/alerts/rules/{event.project.slug}/{rule.id}/details/|ja rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/monitors/alerts/{rule.data['actions'][0]['workflow_id']}/|ja rule>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|*Hello world*>"
         )
         # Verify suggested assignees are in the context block and footer is last
         context_blocks = [b for b in blocks if b.get("type") == "context"]
@@ -629,7 +631,12 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
         key = f"mail:p:{self.project.id}"
-        backend.add(key, event_to_record(event, [rule]), increment_delay=0, maximum_delay=0)
+        backend.add(
+            key,
+            event_to_record(event, [rule], identifier_key=IdentifierKey.WORKFLOW),
+            increment_delay=0,
+            maximum_delay=0,
+        )
 
         with self.tasks():
             deliver_digest(key)
@@ -721,13 +728,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         assert (
             fallback_text
-            == f"Alert triggered <http://example.com/organizations/{event.organization.slug}/issues/alerts/rules/{event.project.slug}/{rule.id}/details/|ja rule>"
+            == f"Alert triggered <http://example.com/organizations/{event.organization.slug}/monitors/alerts/{rule.data['actions'][0]['workflow_id']}/|ja rule>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|*Hello world*>"
         )
         assert (
             blocks[5]["elements"][0]["text"]
@@ -935,7 +942,12 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
         key = f"mail:p:{self.project.id}:IssueOwners::AllMembers"
-        backend.add(key, event_to_record(event, [rule]), increment_delay=0, maximum_delay=0)
+        backend.add(
+            key,
+            event_to_record(event, [rule], identifier_key=IdentifierKey.WORKFLOW),
+            increment_delay=0,
+            maximum_delay=0,
+        )
 
         with self.tasks():
             deliver_digest(key)
@@ -946,13 +958,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/issues/alerts/rules/{event.project.slug}/{rule.id}/details/|Test Alert>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/monitors/alerts/{rule.data['actions'][0]['workflow_id']}/|Test Alert>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|*Hello world*>"
         )
         assert (
             blocks[4]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -64,6 +64,7 @@ def build_test_message_blocks(
     notes: str | None = None,
     rule: IssueAlertRule | None = None,
     legacy_rule_id: int | None = None,
+    workflow_id: int | None = None,
 ) -> dict[str, Any]:
     project = group.project
 
@@ -79,7 +80,9 @@ def build_test_message_blocks(
             title_link += f"/events/{event.event_id}"
     title_link += "/?referrer=slack"
     if rule:
-        if legacy_rule_id:
+        if workflow_id:
+            title_link += f"&workflow_id={workflow_id}&alert_type=issue"
+        elif legacy_rule_id:
             title_link += f"&alert_rule_id={legacy_rule_id}&alert_type=issue"
         else:
             title_link += f"&alert_rule_id={rule.id}&alert_type=issue"
@@ -87,7 +90,9 @@ def build_test_message_blocks(
     title_text = f":red_circle: <{title_link}|*{formatted_title}*>"
 
     if rule:
-        if legacy_rule_id:
+        if workflow_id:
+            block_id = f'{{"issue":{group.id},"rule":{workflow_id}}}'
+        elif legacy_rule_id:
             block_id = f'{{"issue":{group.id},"rule":{legacy_rule_id}}}'
         else:
             block_id = f'{{"issue":{group.id},"rule":{rule.id}}}'
@@ -212,7 +217,9 @@ def build_test_message_blocks(
         blocks.append(notes_section)
 
     if rule:
-        if legacy_rule_id:
+        if workflow_id:
+            context_text = f"Project: <http://testserver/organizations/{project.organization.slug}/issues/?project={project.id}|{project.slug}>    Alert: <http://testserver/organizations/{project.organization.slug}/monitors/alerts/{workflow_id}/|{rule.label}>    Short ID: {group.qualified_short_id}"
+        elif legacy_rule_id:
             context_text = f"Project: <http://testserver/organizations/{project.organization.slug}/issues/?project={project.id}|{project.slug}>    Alert: <http://testserver/organizations/{project.organization.slug}/issues/alerts/rules/bar/{legacy_rule_id}/details/|{rule.label}>    Short ID: {group.qualified_short_id}"
         else:
             context_text = f"Project: <http://testserver/organizations/{project.organization.slug}/issues/?project={project.id}|{project.slug}>    Alert: <http://testserver/organizations/{project.organization.slug}/issues/alerts/rules/bar/{rule.id}/details/|{rule.label}>    Short ID: {group.qualified_short_id}"
@@ -348,7 +355,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             users={self.user},
             group=group,
             rule=rule,
-            legacy_rule_id=rule.data["actions"][0]["legacy_rule_id"],
+            workflow_id=rule.data["actions"][0]["workflow_id"],
         )
         # add extra tag to message
         assert SlackIssuesMessageBuilder(

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -17,6 +17,7 @@ from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.userreport import UserReportWithGroupSerializer
 from sentry.digests.notifications import build_digest, event_to_record
+from sentry.digests.types import IdentifierKey
 from sentry.event_manager import EventManager, get_event_type
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.ownership import grammar
@@ -1467,7 +1468,11 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         rule = project.rule_set.all().order_by("id")[0]
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
         digest = build_digest(
-            project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
+            project,
+            (
+                event_to_record(event, (rule,), identifier_key=IdentifierKey.RULE),
+                event_to_record(event2, (rule,), identifier_key=IdentifierKey.RULE),
+            ),
         )
 
         with self.tasks():
@@ -1523,7 +1528,11 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         rule = project.rule_set.all().order_by("id")[0]
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
         digest = build_digest(
-            project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
+            project,
+            (
+                event_to_record(event, (rule,), identifier_key=IdentifierKey.RULE),
+                event_to_record(event2, (rule,), identifier_key=IdentifierKey.RULE),
+            ),
         )
 
         features = ["organizations:session-replay"]
@@ -1562,7 +1571,11 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
         digest = build_digest(
-            project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
+            project,
+            (
+                event_to_record(event, (rule,), identifier_key=IdentifierKey.RULE),
+                event_to_record(event2, (rule,), identifier_key=IdentifierKey.RULE),
+            ),
         )
 
         with self.tasks():
@@ -1600,7 +1613,11 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
 
         ProjectOwnership.objects.create(project_id=project.id, fallthrough=True)
         digest = build_digest(
-            project, (event_to_record(event, (rule,)), event_to_record(event2, (rule2,)))
+            project,
+            (
+                event_to_record(event, (rule,), identifier_key=IdentifierKey.RULE),
+                event_to_record(event2, (rule2,), identifier_key=IdentifierKey.WORKFLOW),
+            ),
         )
 
         with self.tasks():
@@ -1650,7 +1667,11 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
 
         ProjectOwnership.objects.create(project_id=project.id, fallthrough=True)
         digest = build_digest(
-            project, (event_to_record(event, (rule,)), event_to_record(event2, (rule2,)))
+            project,
+            (
+                event_to_record(event, (rule,), identifier_key=IdentifierKey.RULE),
+                event_to_record(event2, (rule2,), identifier_key=IdentifierKey.WORKFLOW),
+            ),
         )
 
         with self.tasks():
@@ -1696,7 +1717,11 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
 
         ProjectOwnership.objects.create(project_id=project.id, fallthrough=True)
         digest = build_digest(
-            project, (event_to_record(event, (rule,)), event_to_record(event2, (rule2,)))
+            project,
+            (
+                event_to_record(event, (rule,), identifier_key=IdentifierKey.RULE),
+                event_to_record(event2, (rule2,), identifier_key=IdentifierKey.WORKFLOW),
+            ),
         )
 
         with self.tasks():
@@ -1721,7 +1746,9 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         event = self.store_event(data={}, project_id=self.project.id)
         rule = self.project.rule_set.all().order_by("id")[0]
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
-        digest = build_digest(self.project, (event_to_record(event, (rule,)),))
+        digest = build_digest(
+            self.project, (event_to_record(event, (rule,), identifier_key=IdentifierKey.RULE),)
+        )
         self.adapter.notify_digest(
             self.project,
             digest,
@@ -1749,7 +1776,11 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         rule = self.project.rule_set.all().order_by("id")[0]
 
         digest = build_digest(
-            self.project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
+            self.project,
+            (
+                event_to_record(event, (rule,), identifier_key=IdentifierKey.RULE),
+                event_to_record(event2, (rule,), identifier_key=IdentifierKey.RULE),
+            ),
         )
 
         with self.tasks():
@@ -1790,7 +1821,11 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         rule = self.create_project_rule(name="a rule", action_data=[action_data])
 
         digest = build_digest(
-            project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
+            project,
+            (
+                event_to_record(event, (rule,), identifier_key=IdentifierKey.WORKFLOW),
+                event_to_record(event2, (rule,), identifier_key=IdentifierKey.WORKFLOW),
+            ),
         )
 
         with self.tasks():

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -150,7 +150,7 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
                 organization_id=self.organization.id,
                 project_id=self.project.id,
                 provider="email",
-                alert_id=self.rule.id,
+                alert_id=workflow_id,
                 alert_type="issue_alert",
                 external_id="ANY",
                 notification_uuid="ANY",

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -12,6 +12,7 @@ from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.digests.backends.base import Backend
 from sentry.digests.backends.redis import RedisBackend
 from sentry.digests.notifications import event_to_record
+from sentry.digests.types import IdentifierKey
 from sentry.mail.analytics import EmailNotificationSent
 from sentry.models.projectownership import ProjectOwnership
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -61,7 +62,10 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
 
         assert event is not None
         backend.add(
-            self.key, event_to_record(event, [self.rule]), increment_delay=0, maximum_delay=0
+            self.key,
+            event_to_record(event, [self.rule], identifier_key=IdentifierKey.WORKFLOW),
+            increment_delay=0,
+            maximum_delay=0,
         )
 
     def run_test(
@@ -117,12 +121,13 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
         assert isinstance(message, EmailMultiAlternatives)
         assert isinstance(message.alternatives[0][0], str)
         assert "notification_uuid" in message.alternatives[0][0]
+        workflow_id = self.rule.data["actions"][0]["workflow_id"]
         assert_any_analytics_event(
             mock_record,
             EmailNotificationSent(
                 category="digest",
                 notification_uuid="ANY",
-                alert_id=self.rule.id,
+                alert_id=workflow_id,
                 project_id=self.project.id,
                 organization_id=self.organization.id,
                 id=0,
@@ -292,13 +297,17 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         notification_uuid = str(uuid.uuid4())
         backend.add(
             key,
-            event_to_record(event1, [rule], notification_uuid),
+            event_to_record(
+                event1, [rule], notification_uuid, identifier_key=IdentifierKey.WORKFLOW
+            ),
             increment_delay=0,
             maximum_delay=0,
         )
         backend.add(
             key,
-            event_to_record(event2, [rule], notification_uuid),
+            event_to_record(
+                event2, [rule], notification_uuid, identifier_key=IdentifierKey.WORKFLOW
+            ),
             increment_delay=0,
             maximum_delay=0,
         )
@@ -315,11 +324,12 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         assert len(blocks) == 7
         assert blocks[0]["text"]["text"] == fallback_text
 
+        workflow_id = rule.data["actions"][0]["workflow_id"]
         assert event1.group
-        event1_alert_title = f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{event1.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event1.group.title}*>"
+        event1_alert_title = f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{event1.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&workflow_id={workflow_id}&alert_type=issue|*{event1.group.title}*>"
 
         assert event2.group
-        event2_alert_title = f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{event2.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event2.group.title}*>"
+        event2_alert_title = f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{event2.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&workflow_id={workflow_id}&alert_type=issue|*{event2.group.title}*>"
 
         # digest order not definitive
         try:
@@ -366,7 +376,9 @@ class DigestSlackNotification(SlackActivityNotificationTest):
             )
             backend.add(
                 key,
-                event_to_record(event, [rule], notification_uuid),
+                event_to_record(
+                    event, [rule], notification_uuid, identifier_key=IdentifierKey.WORKFLOW
+                ),
                 increment_delay=0,
                 maximum_delay=0,
             )

--- a/tests/sentry/tasks/test_digests.py
+++ b/tests/sentry/tasks/test_digests.py
@@ -9,6 +9,7 @@ from django.core.mail.message import EmailMultiAlternatives
 import sentry
 from sentry.digests.backends.redis import RedisBackend
 from sentry.digests.notifications import event_to_record
+from sentry.digests.types import IdentifierKey
 from sentry.models.projectownership import ProjectOwnership
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import TestCase
@@ -39,13 +40,17 @@ class DeliverDigestTest(TestCase):
             notification_uuid = str(uuid.uuid4())
             backend.add(
                 key,
-                event_to_record(event, [rule], notification_uuid),
+                event_to_record(
+                    event, [rule], notification_uuid, identifier_key=IdentifierKey.WORKFLOW
+                ),
                 increment_delay=0,
                 maximum_delay=0,
             )
             backend.add(
                 key,
-                event_to_record(event_2, [rule], notification_uuid),
+                event_to_record(
+                    event_2, [rule], notification_uuid, identifier_key=IdentifierKey.WORKFLOW
+                ),
                 increment_delay=0,
                 maximum_delay=0,
             )


### PR DESCRIPTION
This should result in us not using actual Rule data, but preferring Rules generated from Workflows wherever possible.
Given that Rule data isn't canonical anymore and is known to be not perfectly consistent with workflow data, this is more correct and a step toward the Rule deprecation we need to pursue.
