### PR TITLE
ref(flags): Remove organizations:performance-transaction-summary-eap gates (frontend)

### DIFF
--- a/static/app/components/performance/transactionSearchQueryBuilder.tsx
+++ b/static/app/components/performance/transactionSearchQueryBuilder.tsx
@@ -78,17 +78,15 @@ export function TransactionSearchQueryBuilder({
       ...tags,
     };
 
-    if (organization.features.includes('performance-transaction-summary-eap')) {
-      combinedTags['request.method'] = {
-        key: 'request.method',
-        name: 'request.method',
-        kind: FieldKind.FIELD,
-      };
-    }
+    combinedTags['request.method'] = {
+      key: 'request.method',
+      name: 'request.method',
+      kind: FieldKind.FIELD,
+    };
 
     combinedTags.has = getHasTag(combinedTags);
     return combinedTags;
-  }, [organization.features, tags]);
+  }, [tags]);
 
   const filterKeySections = useMemo(
     () => [

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -473,18 +473,11 @@ function renderTransactionAsLinkable(data: EventData, baggage: RenderFunctionBag
 
   const filters = new MutableSearch('');
 
-  const isEap = organization.features.includes('performance-transaction-summary-eap');
   if (data[SpanFields.SPAN_OP]) {
-    filters.addFilterValue(
-      isEap ? SpanFields.SPAN_OP : SpanFields.TRANSACTION_OP,
-      data[SpanFields.SPAN_OP]
-    );
+    filters.addFilterValue(SpanFields.SPAN_OP, data[SpanFields.SPAN_OP]);
   }
   if (data[SpanFields.REQUEST_METHOD]) {
-    filters.addFilterValue(
-      isEap ? 'request.method' : 'http.method',
-      data[SpanFields.REQUEST_METHOD]
-    );
+    filters.addFilterValue('request.method', data[SpanFields.REQUEST_METHOD]);
   }
 
   const target = transactionSummaryRouteWithQuery({

--- a/static/app/views/performance/eap/useTransactionSummaryEAP.tsx
+++ b/static/app/views/performance/eap/useTransactionSummaryEAP.tsx
@@ -1,10 +1,10 @@
-import {useOrganization} from 'sentry/utils/useOrganization';
-
 /**
  * Determines whether we should render the new EAP-based Transaction Summary Page.
+ *
+ * The flag this used to gate (`performance-transaction-summary-eap`) was at
+ * 100% rollout and has been removed. The hook is kept for now so callers can
+ * be cleaned up incrementally — it always returns true.
  */
 export const useTransactionSummaryEAP = (): boolean => {
-  const organization = useOrganization();
-
-  return organization.features.includes('performance-transaction-summary-eap');
+  return true;
 };

--- a/static/app/views/performance/transactionEvents.spec.tsx
+++ b/static/app/views/performance/transactionEvents.spec.tsx
@@ -9,6 +9,13 @@ import TransactionSummaryLayout from 'sentry/views/performance/transactionSummar
 import {Tab as TransactionSummaryTab} from 'sentry/views/performance/transactionSummary/tabs';
 import TransactionEvents from 'sentry/views/performance/transactionSummary/transactionEvents';
 
+// TODO: covers the legacy (non-EAP) path. useTransactionSummaryEAP now
+// always returns true after the flag graduated; mock back to false until
+// the legacy paths are deleted.
+jest.mock('sentry/views/performance/eap/useTransactionSummaryEAP', () => ({
+  useTransactionSummaryEAP: () => false,
+}));
+
 // XXX(epurkhiser): This appears to also be tested by ./transactionSummary/transactionEvents/index.spec.tsx
 
 const renderWithLayout = (data: ReturnType<typeof initializeData>) => {

--- a/static/app/views/performance/transactionSummary/header.spec.tsx
+++ b/static/app/views/performance/transactionSummary/header.spec.tsx
@@ -84,28 +84,8 @@ describe('Performance > Transaction Summary Header', () => {
     expect(await screen.findByRole('tab', {name: 'Overview'})).toBeInTheDocument();
   });
 
-  it('should show Tags tab by default', async () => {
+  it('should hide Tags tab', async () => {
     const {project, organization, router, eventView} = initializeData();
-
-    render(
-      <TransactionHeader
-        eventView={eventView}
-        location={router.location}
-        organization={organization}
-        projects={[project]}
-        projectId={project.id}
-        transactionName="transaction_name"
-        currentTab={Tab.TRANSACTION_SUMMARY}
-      />
-    );
-
-    expect(await screen.findByRole('tab', {name: 'Tags'})).toBeInTheDocument();
-  });
-
-  it('should hide Tags tab when EAP feature is enabled', async () => {
-    const {project, organization, router, eventView} = initializeData({
-      features: ['performance-transaction-summary-eap'],
-    });
 
     render(
       <TransactionHeader

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
@@ -216,16 +216,7 @@ describe('Performance > Transaction Summary > Transaction Events > Index', () =>
     );
   });
 
-  it('should render legacy component when EAP feature is not enabled', async () => {
-    const data = initializeData();
-
-    renderWithLayout(data);
-
-    expect(await screen.findByText('event id')).toBeInTheDocument();
-    expect(screen.queryByText('Span ID')).not.toBeInTheDocument();
-  });
-
-  it('should render EAP component when performance-transaction-summary-eap feature is enabled', async () => {
+  it('should render EAP component', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/trace-items/attributes/',
       body: [],
@@ -241,9 +232,7 @@ describe('Performance > Transaction Summary > Transaction Events > Index', () =>
       match: [(_, options) => options.query?.field?.includes('span_id')],
     });
 
-    const data = initializeData({
-      features: ['performance-view', 'performance-transaction-summary-eap'],
-    });
+    const data = initializeData({features: ['performance-view']});
 
     renderWithLayout(data);
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
@@ -12,6 +12,13 @@ import {
   MOCK_EVENTS_TABLE_DATA,
 } from 'sentry/views/performance/transactionSummary/transactionEvents/testUtils';
 
+// TODO: covers the legacy (non-EAP) path. useTransactionSummaryEAP now
+// always returns true after the flag graduated; mock back to false until
+// the legacy paths are deleted.
+jest.mock('sentry/views/performance/eap/useTransactionSummaryEAP', () => ({
+  useTransactionSummaryEAP: () => false,
+}));
+
 const renderWithLayout = (data: ReturnType<typeof initializeData>) => {
   return render(<TransactionSummaryLayout />, {
     organization: data.organization,
@@ -214,29 +221,5 @@ describe('Performance > Transaction Summary > Transaction Events > Index', () =>
     expect(router.location.query).toEqual(
       expect.objectContaining({showTransactions: 'p50'})
     );
-  });
-
-  it('should render EAP component', async () => {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/trace-items/attributes/',
-      body: [],
-    });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: {
-        data: [{span_id: 'abc123'}],
-        meta: {
-          fields: {},
-        },
-      },
-      match: [(_, options) => options.query?.field?.includes('span_id')],
-    });
-
-    const data = initializeData({features: ['performance-view']});
-
-    renderWithLayout(data);
-
-    expect(await screen.findByText('Span ID')).toBeInTheDocument();
-    expect(screen.queryByText('event id')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -22,6 +22,14 @@ import TransactionSummaryLayout from 'sentry/views/performance/transactionSummar
 import {Tab as TransactionSummaryTab} from 'sentry/views/performance/transactionSummary/tabs';
 import TransactionSummary from 'sentry/views/performance/transactionSummary/transactionOverview';
 
+// TODO: this suite covers the legacy (non-EAP) component path. The
+// useTransactionSummaryEAP hook now always returns true after the
+// performance-transaction-summary-eap flag was graduated; mock it back
+// to false here until the legacy paths are deleted.
+jest.mock('sentry/views/performance/eap/useTransactionSummaryEAP', () => ({
+  useTransactionSummaryEAP: () => false,
+}));
+
 const teams = [
   TeamFixture({id: '1', slug: 'team1', name: 'Team 1'}),
   TeamFixture({id: '2', slug: 'team2', name: 'Team 2'}),

--- a/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.spec.tsx
@@ -87,12 +87,8 @@ describe('RelatedIssues', () => {
     expect(screen.getByText(/No new issues/i)).toBeInTheDocument();
   });
 
-  it('remaps request.method to http.method when EAP is enabled', async () => {
-    const eapOrganization = OrganizationFixture({
-      features: ['performance-transaction-summary-eap'],
-    });
+  it('remaps request.method to http.method', async () => {
     const eapData = initializeOrg({
-      organization: eapOrganization,
       router: {
         location: {
           query: {
@@ -107,12 +103,11 @@ describe('RelatedIssues', () => {
 
     render(
       <RelatedIssues
-        organization={eapOrganization}
+        organization={organization}
         location={eapData.router.location}
         transaction={transaction}
         statsPeriod="14d"
-      />,
-      {organization: eapOrganization}
+      />
     );
 
     const placeholders = screen.queryAllByTestId('loading-placeholder');

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -45,25 +45,6 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
         self.page = TransactionSummaryPage(self.browser)
 
     @patch("django.utils.timezone.now")
-    def test_view_details_from_summary(self, mock_now: MagicMock) -> None:
-        mock_now.return_value = before_now()
-
-        event = make_event(
-            load_data(
-                "transaction", timestamp=before_now(minutes=3), trace="a" * 32, span_id="ab" * 8
-            )
-        )
-        self.store_event(data=event, project_id=self.project.id)
-
-        with self.feature(FEATURES):
-            self.browser.get(self.path)
-            self.page.wait_until_loaded()
-
-            # View the first event details.
-            self.browser.element('[data-test-id="view-id"]').click()
-            self.page.wait_until_loaded()
-
-    @patch("django.utils.timezone.now")
     def test_transaction_threshold_modal(self, mock_now: MagicMock) -> None:
         mock_now.return_value = before_now()
 


### PR DESCRIPTION
Scanner classified this as ga-ready-to-graduate: 100% rolled out with no conditions. Removes the FE feature gates so the EAP transaction summary path is taken unconditionally.

Backend registration removal ships in a companion PR: https://github.com/getsentry/sentry/pull/115015
