### PR TITLE
ref(flags): Remove organizations:integrations-cursor gates (frontend)

### DIFF
--- a/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
+++ b/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
@@ -25,10 +25,11 @@ interface CodingAgentIntegrationCtaProps {
 interface AgentConfig {
   displayName: string;
   docsUrl: string;
-  featureFlag: string;
   pluginId: string;
   provider: string;
   target: SeerAutomationHandoffConfiguration['target'];
+  // If unset, the CTA renders without a feature flag gate.
+  featureFlag?: string;
   headingName?: string;
 }
 
@@ -52,7 +53,8 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
       i => i.provider === config.provider
     );
 
-    const hasFeatureFlag = organization.features.includes(config.featureFlag);
+    const hasFeatureFlag =
+      !config.featureFlag || organization.features.includes(config.featureFlag);
     const hasIntegration = Boolean(integration);
     const isAutomationEnabled =
       project.seerScannerAutomation !== false &&

--- a/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
@@ -9,9 +9,7 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 
 describe('CursorIntegrationCta', () => {
   const project = ProjectFixture();
-  const organization = OrganizationFixture({
-    features: ['integrations-cursor'],
-  });
+  const organization = OrganizationFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -32,28 +30,6 @@ describe('CursorIntegrationCta', () => {
       body: {
         integrations: [],
       },
-    });
-  });
-
-  describe('Feature Flag', () => {
-    it('does not render without integrations-cursor feature flag', () => {
-      const orgWithoutFlag = OrganizationFixture({
-        features: [],
-      });
-
-      const {container} = render(<CursorIntegrationCta project={project} />, {
-        organization: orgWithoutFlag,
-      });
-
-      expect(container).toBeEmptyDOMElement();
-    });
-
-    it('renders with integrations-cursor feature flag', async () => {
-      render(<CursorIntegrationCta project={project} />, {
-        organization,
-      });
-
-      expect(await screen.findByText('Cursor Agent Integration')).toBeInTheDocument();
     });
   });
 

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -3,7 +3,6 @@ import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
 
 export const CursorIntegrationCta = makeCodingAgentIntegrationCta({
   provider: 'cursor',
-  featureFlag: 'integrations-cursor',
   target: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
   pluginId: 'cursor',
   displayName: 'Cursor',

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -647,7 +647,7 @@ describe('SeerDrawer', () => {
 
     render(<SeerDrawer event={mockEvent} group={mockGroup} project={mockProject} />, {
       organization: OrganizationFixture({
-        features: ['gen-ai-features', 'integrations-cursor', 'issue-views'],
+        features: ['gen-ai-features', 'issue-views'],
       }),
     });
 
@@ -728,7 +728,7 @@ describe('SeerDrawer', () => {
 
     render(<SeerDrawer event={mockEvent} group={mockGroup} project={mockProject} />, {
       organization: OrganizationFixture({
-        features: ['gen-ai-features', 'integrations-cursor', 'issue-views'],
+        features: ['gen-ai-features', 'issue-views'],
       }),
     });
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -149,7 +149,7 @@ describe('SeerNotices', () => {
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
       organization: {
         ...organization,
-        features: ['integrations-cursor'],
+        features: [],
       },
     });
     await waitFor(() => {
@@ -193,7 +193,7 @@ describe('SeerNotices', () => {
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
       organization: {
         ...organization,
-        features: ['integrations-cursor'],
+        features: [],
       },
     });
 
@@ -252,7 +252,7 @@ describe('SeerNotices', () => {
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
       organization: {
         ...organization,
-        features: ['integrations-cursor'],
+        features: [],
       },
     });
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -112,9 +112,6 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const cursorIntegration = codingAgentIntegrations?.integrations.find(
     integration => integration.provider === 'cursor'
   );
-  const hasCursorFeatureFlagEnabled = Boolean(
-    organization.features.includes('integrations-cursor')
-  );
   const isCursorHandoffConfigured = Boolean(preference?.automation_handoff);
 
   const unreadableRepos = repos.filter(repo => repo.is_readable === false);
@@ -152,9 +149,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   );
 
   const needsCursorIntegration =
-    hasCursorFeatureFlagEnabled &&
-    (!isCursorHandoffConfigured || !cursorIntegration) &&
-    !cursorStepSkipped;
+    (!isCursorHandoffConfigured || !cursorIntegration) && !cursorStepSkipped;
 
   // Calculate incomplete steps
   const stepConditions = [
@@ -422,105 +417,103 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
               )}
 
               {/* Step 5: Cursor Integration */}
-              {hasCursorFeatureFlagEnabled && (
-                <GuidedSteps.Step
-                  key="cursor-integration"
-                  stepKey="cursor-integration"
-                  title={
-                    <Flex align="baseline" gap="sm" display="inline-flex">
-                      <CursorPluginIcon>
-                        <PluginIcon pluginId="cursor" />
-                      </CursorPluginIcon>
-                      {t('Hand Off to Cursor Cloud Agents')}
-                    </Flex>
-                  }
-                  isCompleted={!needsCursorIntegration}
+              <GuidedSteps.Step
+                key="cursor-integration"
+                stepKey="cursor-integration"
+                title={
+                  <Flex align="baseline" gap="sm" display="inline-flex">
+                    <CursorPluginIcon>
+                      <PluginIcon pluginId="cursor" />
+                    </CursorPluginIcon>
+                    {t('Hand Off to Cursor Cloud Agents')}
+                  </Flex>
+                }
+                isCompleted={!needsCursorIntegration}
+              >
+                <StepContentRow>
+                  <StepTextCol>
+                    <CardDescription>
+                      {cursorIntegration ? (
+                        <Fragment>
+                          <span>
+                            {t(
+                              'Enable Seer automation and set up handoff to Cursor Cloud Agents when Seer identifies a root cause.'
+                            )}
+                          </span>
+                          <span>
+                            {tct(
+                              'During automation, Seer will trigger Cursor Cloud Agents to generate and submit pull requests directly to your repos. Configure in [seerProjectSettings:Seer project settings] or [docsLink:read the docs] to learn more.',
+                              {
+                                seerProjectSettings: (
+                                  <Link
+                                    to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
+                                  />
+                                ),
+                                docsLink: (
+                                  <ExternalLink href="https://docs.sentry.io/organization/integrations/cursor/" />
+                                ),
+                              }
+                            )}
+                          </span>
+                        </Fragment>
+                      ) : (
+                        <Fragment>
+                          <span>
+                            {t(
+                              'Connect Cursor to automatically hand off Seer root cause analysis to Cursor Cloud Agents for seamless code fixes.'
+                            )}
+                          </span>
+                          <span>
+                            {tct(
+                              'Set up the [integrationLink:Cursor Integration] to enable automatic handoff. [docsLink:Read the docs] to learn more.',
+                              {
+                                integrationLink: (
+                                  <Link
+                                    to={`/settings/${organization.slug}/integrations/cursor/`}
+                                  />
+                                ),
+                                docsLink: (
+                                  <ExternalLink href="https://docs.sentry.io/organization/integrations/cursor/" />
+                                ),
+                              }
+                            )}
+                          </span>
+                        </Fragment>
+                      )}
+                    </CardDescription>
+                  </StepTextCol>
+                  <StepImageCol>
+                    <CursorCardIllustration
+                      src={alertsEmptyStateImg}
+                      alt="Cursor Integration"
+                    />
+                  </StepImageCol>
+                </StepContentRow>
+                <CustomStepButtons
+                  showBack={firstIncompleteIdx !== 4}
+                  showNext={false}
+                  showSkip={lastIncompleteIdx === 4}
+                  onSkip={handleSkipCursorStep}
                 >
-                  <StepContentRow>
-                    <StepTextCol>
-                      <CardDescription>
-                        {cursorIntegration ? (
-                          <Fragment>
-                            <span>
-                              {t(
-                                'Enable Seer automation and set up handoff to Cursor Cloud Agents when Seer identifies a root cause.'
-                              )}
-                            </span>
-                            <span>
-                              {tct(
-                                'During automation, Seer will trigger Cursor Cloud Agents to generate and submit pull requests directly to your repos. Configure in [seerProjectSettings:Seer project settings] or [docsLink:read the docs] to learn more.',
-                                {
-                                  seerProjectSettings: (
-                                    <Link
-                                      to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
-                                    />
-                                  ),
-                                  docsLink: (
-                                    <ExternalLink href="https://docs.sentry.io/organization/integrations/cursor/" />
-                                  ),
-                                }
-                              )}
-                            </span>
-                          </Fragment>
-                        ) : (
-                          <Fragment>
-                            <span>
-                              {t(
-                                'Connect Cursor to automatically hand off Seer root cause analysis to Cursor Cloud Agents for seamless code fixes.'
-                              )}
-                            </span>
-                            <span>
-                              {tct(
-                                'Set up the [integrationLink:Cursor Integration] to enable automatic handoff. [docsLink:Read the docs] to learn more.',
-                                {
-                                  integrationLink: (
-                                    <Link
-                                      to={`/settings/${organization.slug}/integrations/cursor/`}
-                                    />
-                                  ),
-                                  docsLink: (
-                                    <ExternalLink href="https://docs.sentry.io/organization/integrations/cursor/" />
-                                  ),
-                                }
-                              )}
-                            </span>
-                          </Fragment>
-                        )}
-                      </CardDescription>
-                    </StepTextCol>
-                    <StepImageCol>
-                      <CursorCardIllustration
-                        src={alertsEmptyStateImg}
-                        alt="Cursor Integration"
-                      />
-                    </StepImageCol>
-                  </StepContentRow>
-                  <CustomStepButtons
-                    showBack={firstIncompleteIdx !== 4}
-                    showNext={false}
-                    showSkip={lastIncompleteIdx === 4}
-                    onSkip={handleSkipCursorStep}
-                  >
-                    {cursorIntegration ? (
-                      <Button
-                        onClick={handleSetupCursorHandoff}
-                        size="sm"
-                        variant="primary"
-                      >
-                        {t('Set Seer to hand off to Cursor')}
-                      </Button>
-                    ) : (
-                      <LinkButton
-                        href={`/settings/${organization.slug}/integrations/cursor/`}
-                        size="sm"
-                        variant="primary"
-                      >
-                        {t('Install Cursor Integration')}
-                      </LinkButton>
-                    )}
-                  </CustomStepButtons>
-                </GuidedSteps.Step>
-              )}
+                  {cursorIntegration ? (
+                    <Button
+                      onClick={handleSetupCursorHandoff}
+                      size="sm"
+                      variant="primary"
+                    >
+                      {t('Set Seer to hand off to Cursor')}
+                    </Button>
+                  ) : (
+                    <LinkButton
+                      href={`/settings/${organization.slug}/integrations/cursor/`}
+                      size="sm"
+                      variant="primary"
+                    >
+                      {t('Install Cursor Integration')}
+                    </LinkButton>
+                  )}
+                </CustomStepButtons>
+              </GuidedSteps.Step>
             </StyledGuidedSteps>
             <StepsDivider />
           </motion.div>

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -450,7 +450,7 @@ describe('ProjectSeer', () => {
 
   it('can enable automation handoff to Cursor when Cursor integration is available', async () => {
     const orgWithCursorFeature = OrganizationFixture({
-      features: ['integrations-cursor'],
+      features: [],
     });
 
     const initialProject: Project = {
@@ -708,7 +708,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithCursorFeature = OrganizationFixture({
-        features: ['integrations-cursor'],
+        features: [],
       });
 
       const initialProject: Project = {
@@ -787,7 +787,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithCursorFeature = OrganizationFixture({
-        features: ['integrations-cursor'],
+        features: [],
       });
 
       const initialProject: Project = {
@@ -895,7 +895,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithCursorFeature = OrganizationFixture({
-        features: ['integrations-cursor'],
+        features: [],
       });
 
       const initialProject: Project = {
@@ -985,7 +985,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithCursorFeature = OrganizationFixture({
-        features: ['integrations-cursor'],
+        features: [],
       });
 
       const initialProject: Project = {
@@ -1108,7 +1108,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithBothFeatures = OrganizationFixture({
-        features: ['integrations-cursor', 'integrations-claude-code'],
+        features: ['integrations-claude-code'],
       });
 
       const initialProject: Project = {
@@ -1190,7 +1190,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithCursorFeature = OrganizationFixture({
-        features: ['integrations-cursor'],
+        features: [],
       });
 
       const initialProject: Project = {

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -226,9 +226,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     [project.slug, queryClient, organization.slug]
   );
 
-  const hasCursorIntegration = Boolean(
-    organization.features.includes('integrations-cursor') && cursorIntegration
-  );
+  const hasCursorIntegration = Boolean(cursorIntegration);
 
   const hasClaudeIntegration = Boolean(
     organization.features.includes('integrations-claude-code') && claudeIntegration


### PR DESCRIPTION
Scanner classified this as ga-ready-to-graduate: 100% rolled out with no conditions. Removes the FE gates so Cursor integration UI renders unconditionally.

Backend PR: https://github.com/getsentry/sentry/pull/115017
