### PR TITLE
ref(flags): Remove organizations:integrations-cursor registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -140,7 +140,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable integration functionality to work deployment integrations like Vercel
     manager.add("organizations:integrations-deployment", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     manager.add("organizations:integrations-claude-code", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:integrations-cursor", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github-copilot-agent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github-platform-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:scm-repositories-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/integrations/cursor/integration.py
+++ b/src/sentry/integrations/cursor/integration.py
@@ -86,6 +86,9 @@ class CursorAgentIntegrationProvider(CodingAgentIntegrationProvider):
     key = "cursor"
     name = "Cursor Agent"
     metadata = metadata
+    # The organizations:integrations-cursor flag has graduated; skip the
+    # parent class's flag check rather than rely on a removed registration.
+    requires_feature_flag = False
 
     def get_pipeline_views(self):
         return []

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -18,7 +18,6 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigurationError
 from sentry.testutils.cases import APITestCase, IntegrationTestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
 
 
@@ -503,7 +502,6 @@ class CursorApiPipelineTest(APITestCase):
     def _advance_step(self, data: dict[str, Any]) -> Any:
         return self.client.post(self._get_pipeline_url(), data=data, format="json")
 
-    @with_feature("organizations:integrations-cursor")
     def test_initialize_pipeline(self) -> None:
         resp = self._initialize_pipeline()
         assert resp.status_code == 200
@@ -512,13 +510,11 @@ class CursorApiPipelineTest(APITestCase):
         assert resp.data["totalSteps"] == 1
         assert resp.data["provider"] == "cursor"
 
-    @with_feature("organizations:integrations-cursor")
     def test_missing_api_key(self) -> None:
         self._initialize_pipeline()
         resp = self._advance_step({})
         assert resp.status_code == 400
 
-    @with_feature("organizations:integrations-cursor")
     @patch(
         "sentry.integrations.cursor.client.CursorAgentClient.verify_api_key",
         return_value=None,


### PR DESCRIPTION
Companion to the FE PR which dropped all features.includes() checks. This removes the registration + the @with_feature decorators in the cursor integration tests. Ship after the FE lands.

FE PR: https://github.com/getsentry/sentry/pull/115016