### PR TITLE
ref(flags): Remove organizations:tracemetrics-alerts gates (frontend)

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -501,7 +501,6 @@ describe('Incident Rules Form', () => {
         'performance-view',
         'visibility-explore-view',
         'tracemetrics-enabled',
-        'tracemetrics-alerts',
       ];
       const rule = MetricRuleFixture();
       createWrapper({
@@ -629,7 +628,6 @@ describe('Incident Rules Form', () => {
         ...organization.features,
         'performance-view',
         'tracemetrics-enabled',
-        'tracemetrics-alerts',
         'tracemetrics-equations-in-explore',
         'tracemetrics-equations-in-alerts',
       ];

--- a/static/app/views/alerts/wizard/index.spec.tsx
+++ b/static/app/views/alerts/wizard/index.spec.tsx
@@ -216,7 +216,6 @@ describe('AlertWizard', () => {
         'performance-view',
         'visibility-explore-view',
         'tracemetrics-enabled',
-        'tracemetrics-alerts',
       ],
       access: ['org:write', 'alerts:write'],
     });

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -786,14 +786,13 @@ describe('DetectorEdit', () => {
   });
 
   describe('Metric Detector with Metrics dataset', () => {
-    it('shows metrics dataset option when tracemetrics-alerts feature flag is enabled', async () => {
+    it('shows metrics dataset option', async () => {
       const metricsOrganization = OrganizationFixture({
         features: [
           'workflow-engine-ui',
           'visibility-explore-view',
           'performance-view',
           'tracemetrics-enabled',
-          'tracemetrics-alerts',
         ],
       });
 
@@ -829,7 +828,6 @@ describe('DetectorEdit', () => {
           'visibility-explore-view',
           'performance-view',
           'tracemetrics-enabled',
-          'tracemetrics-alerts',
         ],
       });
 
@@ -894,28 +892,6 @@ describe('DetectorEdit', () => {
           `/organizations/${metricsOrganization.slug}/monitors/999/`
         );
       });
-    });
-
-    it('does not show metrics dataset option without tracemetrics-alerts feature flag', async () => {
-      render(<DetectorNewSettings />, {
-        organization,
-        initialRouterConfig: {
-          ...initialRouterConfig,
-          location: {
-            ...initialRouterConfig.location,
-            query: {detectorType: 'metric_issue', project: project.id},
-          },
-        },
-      });
-
-      await screen.findByText('New Monitor');
-
-      // Open dataset dropdown
-      await userEvent.click(screen.getByText('Errors'));
-
-      expect(
-        screen.queryByRole('menuitemradio', {name: /Metrics/})
-      ).not.toBeInTheDocument();
     });
   });
 

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -19,9 +19,7 @@ export const canUseMetricsSavedQueriesUI = (organization: Organization) => {
 };
 
 export const canUseMetricsAlertsUI = (organization: Organization) => {
-  return (
-    canUseMetricsUI(organization) && organization.features.includes('tracemetrics-alerts')
-  );
+  return canUseMetricsUI(organization);
 };
 
 export const canUseMetricsStatsBytesUI = (organization: Organization) => {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -31,11 +31,7 @@ const mockOpenSaveQueryModal = jest.mocked(modal.openSaveQueryModal);
 
 describe('useSaveAsMetricItems', () => {
   const organization = OrganizationFixture({
-    features: [
-      'tracemetrics-enabled',
-      'tracemetrics-alerts',
-      'tracemetrics-equations-in-alerts',
-    ],
+    features: ['tracemetrics-enabled', 'tracemetrics-equations-in-alerts'],
   });
   const project = ProjectFixture({id: '1'});
   const queryClient = makeTestQueryClient();


### PR DESCRIPTION
Scanner classified this as ga-ready-to-graduate: 100% rolled out with no conditions. Removes the FE gate so trace metrics alerts UI renders unconditionally for orgs with the underlying tracemetrics-enabled flag.

Backend registration removal ships in a companion PR: https://github.com/getsentry/sentry/pull/115019
