### PR TITLE
ref(flags): Remove organizations:tracemetrics-alerts gates (backend)

### DIFF
--- a/src/sentry/explore/utils.py
+++ b/src/sentry/explore/utils.py
@@ -19,10 +19,3 @@ def is_trace_metrics_enabled(organization: Organization, actor: User | None = No
     This replaces individual feature flag checks for consolidated tracemetrics features.
     """
     return features.has("organizations:tracemetrics-enabled", organization, actor=actor)
-
-
-def is_trace_metrics_alerts_enabled(organization: Organization, actor: User | None = None) -> bool:
-    """
-    Check if trace metrics alerts are enabled for the given organization.
-    """
-    return features.has("organizations:tracemetrics-enabled", organization, actor=actor)

--- a/src/sentry/explore/utils.py
+++ b/src/sentry/explore/utils.py
@@ -25,6 +25,4 @@ def is_trace_metrics_alerts_enabled(organization: Organization, actor: User | No
     """
     Check if trace metrics alerts are enabled for the given organization.
     """
-    return features.has(
-        "organizations:tracemetrics-enabled", organization, actor=actor
-    ) and features.has("organizations:tracemetrics-alerts", organization, actor=actor)
+    return features.has("organizations:tracemetrics-enabled", organization, actor=actor)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -432,7 +432,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable removing the schema hints section to declutter the logs UI
     manager.add("organizations:ourlogs-schema-hints-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable alerting on trace metrics
-    manager.add("organizations:tracemetrics-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics product (known internally as tracemetrics) in UI and backend
     manager.add("organizations:tracemetrics-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable equations for trace metrics in alerts

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -15,7 +15,7 @@ from sentry.exceptions import (
     InvalidSearchQuery,
     UnsupportedQuerySubscription,
 )
-from sentry.explore.utils import is_logs_enabled, is_trace_metrics_alerts_enabled
+from sentry.explore.utils import is_logs_enabled, is_trace_metrics_enabled
 from sentry.incidents.logic import (
     check_aggregate_column_support,
     get_column_from_aggregate,
@@ -199,7 +199,7 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
         ) and any([v for v in validated if v == SnubaQueryEventType.EventType.TRACE_ITEM_LOG]):
             raise serializers.ValidationError("You do not have access to the log alerts feature.")
 
-        if not is_trace_metrics_alerts_enabled(
+        if not is_trace_metrics_enabled(
             self.context["organization"], actor=self.context.get("user", None)
         ) and any([v for v in validated if v == SnubaQueryEventType.EventType.TRACE_ITEM_METRIC]):
             raise serializers.ValidationError(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -719,7 +719,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert mock_ourlogs_run_timeseries_query.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:tracemetrics-alerts")
     @with_feature("organizations:tracemetrics-enabled")
     @with_feature("organizations:incidents")
     @patch(
@@ -861,7 +860,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 {
                     "organizations:incidents": True,
                     "organizations:performance-view": True,
-                    "organizations:tracemetrics-alerts": False,
                     "organizations:tracemetrics-enabled": False,
                 },
             ),
@@ -892,7 +890,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 [
                     "organizations:incidents",
                     "organizations:performance-view",
-                    "organizations:tracemetrics-alerts",
                     "organizations:tracemetrics-enabled",
                 ]
             ),
@@ -933,7 +930,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 [
                     "organizations:incidents",
                     "organizations:performance-view",
-                    "organizations:tracemetrics-alerts",
                     "organizations:tracemetrics-enabled",
                 ]
             ),

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -699,7 +699,6 @@ class TestMetricAlertsTraceMetricsValidator(TestMetricAlertsDetectorValidator):
     @with_feature(
         {
             "organizations:performance-view": False,
-            "organizations:tracemetrics-alerts": False,
             "organizations:tracemetrics-enabled": False,
         }
     )
@@ -717,7 +716,6 @@ class TestMetricAlertsTraceMetricsValidator(TestMetricAlertsDetectorValidator):
         [
             "organizations:incidents",
             "organizations:performance-view",
-            "organizations:tracemetrics-alerts",
             "organizations:tracemetrics-enabled",
         ]
     )
@@ -739,7 +737,6 @@ class TestMetricAlertsTraceMetricsValidator(TestMetricAlertsDetectorValidator):
         [
             "organizations:incidents",
             "organizations:performance-view",
-            "organizations:tracemetrics-alerts",
             "organizations:tracemetrics-enabled",
         ]
     )

--- a/tests/sentry/snuba/test_validators.py
+++ b/tests/sentry/snuba/test_validators.py
@@ -308,7 +308,6 @@ class SnubaQueryValidatorTest(TestCase):
     @with_feature(
         {
             "organizations:performance-view": True,
-            "organizations:tracemetrics-alerts": True,
             "organizations:tracemetrics-enabled": True,
             "organizations:custom-metrics": True,
         }

--- a/tests/sentry/workflow_engine/endpoints/test_organization_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_project_detector_index.py
@@ -494,7 +494,6 @@ class OrganizationProjectDetectorIndexPostTest(OrganizationProjectDetectorIndexB
 
     @with_feature(
         [
-            "organizations:tracemetrics-alerts",
             "organizations:tracemetrics-enabled",
         ]
     )


### PR DESCRIPTION
Companion to the FE PR which dropped all features.includes() checks. 

Ship after the FE lands: https://github.com/getsentry/sentry/pull/115018
