### PR TITLE
perf(settings): Collapse unused fields in project list requests

### DIFF
--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -125,6 +125,7 @@ function ContextPickerContent({
         selectedOrgSlug && needProject
           ? {organizationIdOrSlug: selectedOrgSlug}
           : skipToken,
+      query: {collapse: ['latestDeploys', 'unusedFeatures']},
       staleTime: Infinity,
     })
   );

--- a/static/app/views/settings/organizationAuthTokens/index.spec.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.spec.tsx
@@ -95,7 +95,10 @@ describe('OrganizationAuthTokensIndex', () => {
     expect(projectsMock).toHaveBeenCalledTimes(1);
     expect(projectsMock).toHaveBeenCalledWith(
       PROJECTS_ENDPOINT,
-      expect.objectContaining({method: 'GET', query: {query: `id:${project.id}`}})
+      expect.objectContaining({
+        method: 'GET',
+        query: {collapse: ['latestDeploys', 'unusedFeatures'], query: `id:${project.id}`},
+      })
     );
   });
 

--- a/static/app/views/settings/organizationAuthTokens/index.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.tsx
@@ -66,7 +66,10 @@ function TokenList({
   const {data: projects, isPending: isLoadingProjects} = useQuery({
     ...apiOptions.as<Project[]>()('/organizations/$organizationIdOrSlug/projects/', {
       path: {organizationIdOrSlug: organization.slug},
-      query: {query: idQueryParams},
+      query: {
+        query: idQueryParams,
+        collapse: ['latestDeploys', 'unusedFeatures'],
+      },
       staleTime: 0,
     }),
     enabled: hasProjects,

--- a/static/app/views/settings/organizationProjects/index.tsx
+++ b/static/app/views/settings/organizationProjects/index.tsx
@@ -54,6 +54,7 @@ function OrganizationProjects() {
         query,
         per_page: ITEMS_PER_PAGE,
         statsPeriod: '24h',
+        collapse: ['latestDeploys', 'unusedFeatures'],
       },
       staleTime: 0,
     }),

--- a/static/app/views/setupWizard/utils/useOrganizationProjects.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationProjects.tsx
@@ -15,7 +15,7 @@ export function useOrganizationProjects({
     ...apiOptions.as<Project[]>()('/organizations/$organizationIdOrSlug/projects/', {
       path: organization ? {organizationIdOrSlug: organization.slug} : skipToken,
       host: organization?.region.url,
-      query: {query},
+      query: {query, collapse: ['latestDeploys', 'unusedFeatures']},
       staleTime: 0,
     }),
     refetchOnWindowFocus: true,


### PR DESCRIPTION
Adds `collapse: ['latestDeploys', 'unusedFeatures']` to four more call sites hitting the projects endpoint that don't use those fields. Speeds things up for larger orgs.

- context picker modal
- org auth tokens project lookup
- setup wizard project list
- settings project list

Matches the pattern from #114886 which did the same for team projects.