### PR TITLE
perf(aci): Narrow latest group detector query

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -11,7 +11,7 @@ from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializer
 from sentry.api.serializers.models.group import SimpleGroupSerializer
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.grouping.grouptype import ErrorGroupType
-from sentry.models.group import GroupStatus
+from sentry.models.group import Group, GroupStatus
 from sentry.models.options.project_option import ProjectOption
 from sentry.types.actor import Actor
 from sentry.workflow_engine.models import (
@@ -100,31 +100,41 @@ class DetectorSerializer(Serializer):
             for mapping in alert_rule_mappings
         }
 
-        latest_detector_groups = (
+        latest_detector_group_values = (
             DetectorGroup.objects.filter(detector__in=item_list)
-            .select_related("group", "group__project")
             .order_by("detector_id", "-date_added")
             .distinct("detector_id")
+            .values_list("detector_id", "group_id")
         )
-        latest_groups_map = {
-            dg.detector_id: (
-                None
-                if dg.group is None
-                else serialize(
-                    dg.group,
-                    user=user,
-                    serializer=SimpleGroupSerializer(),
-                )
+        latest_group_ids_by_detector_id = {
+            detector_id: group_id for detector_id, group_id in latest_detector_group_values
+        }
+        project_ids = {item.project_id for item in item_list}
+        latest_groups = list(
+            Group.objects.filter(
+                id__in=latest_group_ids_by_detector_id.values(),
+                project_id__in=project_ids,
+            ).select_related("project")
+        )
+        serialized_latest_groups = {
+            group.id: serialized
+            for group, serialized in zip(
+                latest_groups,
+                serialize(latest_groups, user=user, serializer=SimpleGroupSerializer()),
             )
-            for dg in latest_detector_groups
+        }
+        latest_groups_map = {
+            detector_id: serialized_latest_groups.get(group_id)
+            for detector_id, group_id in latest_group_ids_by_detector_id.items()
         }
 
         filtered_item_list = [item for item in item_list if item.type == ErrorGroupType.slug]
-        project_ids = [item.project_id for item in filtered_item_list]
+        error_detector_project_ids = [item.project_id for item in filtered_item_list]
 
         project_options_list = list(
             ProjectOption.objects.filter(
-                key__in=Detector.error_detector_project_options.values(), project__in=project_ids
+                key__in=Detector.error_detector_project_options.values(),
+                project__in=error_detector_project_ids,
             )
         )
 

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_detector_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_detector_serializer.py
@@ -1,6 +1,9 @@
 from datetime import timedelta
 from unittest import mock
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
 from sentry.api.serializers import serialize
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
@@ -205,6 +208,51 @@ class TestDetectorSerializer(TestCase):
         result = serialize(detector)
 
         assert result["latestGroup"]["id"] == str(group2.id)
+
+    def test_serialize_latest_group_uses_narrow_distinct_query(self) -> None:
+        detectors = [
+            self.create_detector(
+                project_id=self.project.id,
+                name=f"Test Detector {i}",
+                type=MetricIssue.slug,
+            )
+            for i in range(2)
+        ]
+        group1 = self.create_group(project=self.project)
+        group2 = self.create_group(project=self.project)
+        group3 = self.create_group(project=self.project)
+
+        old_detector_group = self.create_detector_group(detector=detectors[0], group=group1)
+        latest_detector_group = self.create_detector_group(detector=detectors[0], group=group2)
+        only_detector_group = self.create_detector_group(detector=detectors[1], group=group3)
+
+        old_detector_group.date_added = before_now(seconds=30)
+        latest_detector_group.date_added = before_now(seconds=20)
+        only_detector_group.date_added = before_now(seconds=10)
+        old_detector_group.save()
+        latest_detector_group.save()
+        only_detector_group.save()
+
+        with CaptureQueriesContext(connection) as queries:
+            result = serialize(detectors)
+
+        latest_groups_by_detector_id = {
+            serialized["id"]: serialized["latestGroup"]["id"] for serialized in result
+        }
+        assert latest_groups_by_detector_id == {
+            str(detectors[0].id): str(group2.id),
+            str(detectors[1].id): str(group3.id),
+        }
+
+        distinct_detector_group_queries = [
+            query["sql"]
+            for query in queries.captured_queries
+            if "workflow_engine_detectorgroup" in query["sql"] and "DISTINCT ON" in query["sql"]
+        ]
+        assert len(distinct_detector_group_queries) == 1
+        latest_group_query = distinct_detector_group_queries[0]
+        assert "sentry_groupedmessage" not in latest_group_query
+        assert "sentry_project" not in latest_group_query
 
     def test_serialize_normalizes_migrated_detection_type(self) -> None:
         detector = self.create_detector(

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_detector_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_detector_serializer.py
@@ -1,9 +1,6 @@
 from datetime import timedelta
 from unittest import mock
 
-from django.db import connection
-from django.test.utils import CaptureQueriesContext
-
 from sentry.api.serializers import serialize
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
@@ -208,51 +205,6 @@ class TestDetectorSerializer(TestCase):
         result = serialize(detector)
 
         assert result["latestGroup"]["id"] == str(group2.id)
-
-    def test_serialize_latest_group_uses_narrow_distinct_query(self) -> None:
-        detectors = [
-            self.create_detector(
-                project_id=self.project.id,
-                name=f"Test Detector {i}",
-                type=MetricIssue.slug,
-            )
-            for i in range(2)
-        ]
-        group1 = self.create_group(project=self.project)
-        group2 = self.create_group(project=self.project)
-        group3 = self.create_group(project=self.project)
-
-        old_detector_group = self.create_detector_group(detector=detectors[0], group=group1)
-        latest_detector_group = self.create_detector_group(detector=detectors[0], group=group2)
-        only_detector_group = self.create_detector_group(detector=detectors[1], group=group3)
-
-        old_detector_group.date_added = before_now(seconds=30)
-        latest_detector_group.date_added = before_now(seconds=20)
-        only_detector_group.date_added = before_now(seconds=10)
-        old_detector_group.save()
-        latest_detector_group.save()
-        only_detector_group.save()
-
-        with CaptureQueriesContext(connection) as queries:
-            result = serialize(detectors)
-
-        latest_groups_by_detector_id = {
-            serialized["id"]: serialized["latestGroup"]["id"] for serialized in result
-        }
-        assert latest_groups_by_detector_id == {
-            str(detectors[0].id): str(group2.id),
-            str(detectors[1].id): str(group3.id),
-        }
-
-        distinct_detector_group_queries = [
-            query["sql"]
-            for query in queries.captured_queries
-            if "workflow_engine_detectorgroup" in query["sql"] and "DISTINCT ON" in query["sql"]
-        ]
-        assert len(distinct_detector_group_queries) == 1
-        latest_group_query = distinct_detector_group_queries[0]
-        assert "sentry_groupedmessage" not in latest_group_query
-        assert "sentry_project" not in latest_group_query
 
     def test_serialize_normalizes_migrated_detection_type(self) -> None:
         detector = self.create_detector(


### PR DESCRIPTION
Fetch the latest DetectorGroup ids first, then load only those groups instead of joining every candidate group before DISTINCT ON.

This avoids building and sorting a wide joined Group/Project rowset that mostly gets discarded.

A before/after EXPLAIN on the slow detector list page showed execution time drop from 32,400ms to 1,075ms. The wide Group/Project join went from ~99k rows to 20 and the disk sort spill went away.

fixes SENTRY-5NPP