### PR TITLE
chore(iswf): Removes retry decorators from integration-related tasks

### DIFF
--- a/src/sentry/integrations/github/tasks/codecov_account_link.py
+++ b/src/sentry/integrations/github/tasks/codecov_account_link.py
@@ -8,7 +8,7 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization import organization_service
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import (
     integrations_control_tasks,
     integrations_control_throttled_tasks,
@@ -22,11 +22,11 @@ account_link_endpoint = "/sentry/internal/account/link/"
 @instrumented_task(
     name="sentry.integrations.github.tasks.codecov_account_link",
     namespace=integrations_control_tasks,
-    retry=Retry(times=3),
+    retry=Retry(times=3, on=(Exception,), ignore=(ConfigurationError,)),
     processing_deadline_duration=60,
     silo_mode=SiloMode.CONTROL,
+    silenced_exceptions=(ConfigurationError,),
 )
-@retry(exclude=(ConfigurationError,))
 def codecov_account_link(
     integration_id: int,
     organization_id: int,
@@ -38,10 +38,10 @@ def codecov_account_link(
     name="sentry.integrations.github.tasks.backfill_codecov_account_link",
     silo_mode=SiloMode.CONTROL,
     namespace=integrations_control_throttled_tasks,
-    retry=Retry(times=3),
+    retry=Retry(times=3, on=(Exception,), ignore=(ConfigurationError,)),
     processing_deadline_duration=60,
+    silenced_exceptions=(ConfigurationError,),
 )
-@retry(exclude=(ConfigurationError,))
 def backfill_codecov_account_link(
     integration_id: int,
     organization_id: int,

--- a/src/sentry/integrations/github/tasks/codecov_account_unlink.py
+++ b/src/sentry/integrations/github/tasks/codecov_account_unlink.py
@@ -6,7 +6,7 @@ from sentry.codecov.client import CodecovApiClient, ConfigurationError, GitProvi
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_control_tasks
 
 logger = logging.getLogger(__name__)
@@ -17,11 +17,11 @@ account_unlink_endpoint = "/sentry/internal/account/unlink/"
 @instrumented_task(
     name="sentry.integrations.github.tasks.codecov_account_unlink",
     namespace=integrations_control_tasks,
-    retry=Retry(times=3),
+    retry=Retry(times=3, on=(Exception,), ignore=(ConfigurationError,)),
     processing_deadline_duration=60,
     silo_mode=SiloMode.CONTROL,
+    silenced_exceptions=(ConfigurationError,),
 )
-@retry(exclude=(ConfigurationError,))
 def codecov_account_unlink(
     integration_id: int,
     organization_ids: list[int],

--- a/src/sentry/integrations/github/tasks/link_all_repos.py
+++ b/src/sentry/integrations/github/tasks/link_all_repos.py
@@ -15,7 +15,7 @@ from sentry.organizations.services.organization import organization_service
 from sentry.plugins.providers.integration_repository import get_integration_repository_provider
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_control_tasks
 
 logger = logging.getLogger(__name__)
@@ -38,11 +38,11 @@ def get_repo_config(repo: Mapping[str, Any], integration_id: int) -> GitHubRepoI
 @instrumented_task(
     name="sentry.integrations.github.tasks.link_all_repos",
     namespace=integrations_control_tasks,
-    retry=Retry(times=3),
+    retry=Retry(times=3, on=(Exception,), ignore=(KeyError,)),
     processing_deadline_duration=60,
     silo_mode=SiloMode.CONTROL,
+    silenced_exceptions=(KeyError,),
 )
-@retry(exclude=(KeyError,))
 def link_all_repos(
     integration_key: str,
     integration_id: int,

--- a/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
+++ b/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
@@ -19,7 +19,7 @@ from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers.integration_repository import get_integration_repository_provider
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_control_tasks
 
 from .link_all_repos import GitHubRepoInputConfig, get_repo_config
@@ -30,11 +30,11 @@ logger = logging.getLogger(__name__)
 @instrumented_task(
     name="sentry.integrations.github.tasks.sync_repos_on_install_change",
     namespace=integrations_control_tasks,
-    retry=Retry(times=3, delay=120),
+    retry=Retry(times=3, delay=120, on=(Exception,), ignore=(KeyError,)),
     processing_deadline_duration=120,
     silo_mode=SiloMode.CONTROL,
+    silenced_exceptions=(KeyError,),
 )
-@retry(exclude=(KeyError,))
 def sync_repos_on_install_change(
     integration_id: int,
     action: str,

--- a/src/sentry/integrations/jira/tasks.py
+++ b/src/sentry/integrations/jira/tasks.py
@@ -11,16 +11,16 @@ from sentry.models.project import Project
 from sentry.plugins.base import plugins
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_control_tasks, integrations_tasks
 
 
 @instrumented_task(
     name="sentry.integrations.jira.tasks.migrate_issues",
     namespace=integrations_tasks,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(times=5, delay=60 * 5, on=(Exception,), ignore=(Integration.DoesNotExist,)),
+    silenced_exceptions=(Integration.DoesNotExist,),
 )
-@retry(exclude=(Integration.DoesNotExist))
 def migrate_issues(integration_id: int, organization_id: int) -> None:
     from sentry_plugins.jira.plugin import JiraPlugin
 
@@ -117,10 +117,10 @@ def migrate_issues(integration_id: int, organization_id: int) -> None:
 @instrumented_task(
     name="sentry.integrations.jira.tasks.sync_metadata",
     namespace=integrations_control_tasks,
-    retry=Retry(times=5, delay=20),
+    retry=Retry(times=5, delay=20, on=(IntegrationError,), ignore=(Integration.DoesNotExist,)),
     silo_mode=SiloMode.CONTROL,
+    silenced_exceptions=(Integration.DoesNotExist,),
 )
-@retry(on=(IntegrationError,), exclude=(Integration.DoesNotExist,))
 def sync_metadata(integration_id: int) -> None:
     from sentry.integrations.jira.integration import JiraIntegration
     from sentry.integrations.jira_server.integration import JiraServerIntegration

--- a/src/sentry/integrations/opsgenie/tasks.py
+++ b/src/sentry/integrations/opsgenie/tasks.py
@@ -10,7 +10,7 @@ from sentry.integrations.opsgenie.metrics import record_event
 from sentry.integrations.services.integration.service import integration_service
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
 
 ALERT_LEGACY_INTEGRATIONS = {"id": "sentry.rules.actions.notify_event.NotifyEventAction"}
@@ -24,9 +24,14 @@ logger = logging.getLogger(__name__)
 @instrumented_task(
     name="sentry.integrations.opsgenie.tasks.migrate_opsgenie_plugins",
     namespace=integrations_tasks,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(
+        times=5,
+        delay=60 * 5,
+        on=(Exception,),
+        ignore=(Integration.DoesNotExist, OrganizationIntegration.DoesNotExist),
+    ),
+    silenced_exceptions=(Integration.DoesNotExist, OrganizationIntegration.DoesNotExist),
 )
-@retry(exclude=(Integration.DoesNotExist, OrganizationIntegration.DoesNotExist))
 def migrate_opsgenie_plugin(integration_id: int, organization_id: int) -> None:
     with record_event(OnCallInteractionType.MIGRATE_PLUGIN).capture():
         from sentry_plugins.opsgenie.plugin import OpsGeniePlugin

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -42,7 +42,7 @@ from sentry.shared_integrations.exceptions import (
     IntegrationError,
 )
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_control_tasks
 from sentry.utils import metrics
 from sentry.utils.cursored_scheduler import CursoredScheduler
@@ -135,11 +135,10 @@ def _halt_broken_integration(
 @instrumented_task(
     name="sentry.integrations.source_code_management.sync_repos.sync_repos_for_org",
     namespace=integrations_control_tasks,
-    retry=Retry(times=3, delay=120),
+    retry=Retry(times=3, delay=120, on=(Exception,)),
     processing_deadline_duration=120,
     silo_mode=SiloMode.CONTROL,
 )
-@retry()
 def sync_repos_for_org(organization_integration_id: int) -> None:
     """
     Sync repositories for a single OrganizationIntegration.
@@ -419,11 +418,10 @@ def _get_sync_context(
 @instrumented_task(
     name="sentry.integrations.source_code_management.sync_repos.create_repos_batch",
     namespace=integrations_control_tasks,
-    retry=Retry(times=3, delay=120),
+    retry=Retry(times=3, delay=120, on=(Exception,)),
     processing_deadline_duration=120,
     silo_mode=SiloMode.CONTROL,
 )
-@retry()
 def create_repos_batch(
     organization_integration_id: int,
     repo_configs: list[dict[str, object]],
@@ -460,11 +458,10 @@ def create_repos_batch(
 @instrumented_task(
     name="sentry.integrations.source_code_management.sync_repos.disable_repos_batch",
     namespace=integrations_control_tasks,
-    retry=Retry(times=3, delay=120),
+    retry=Retry(times=3, delay=120, on=(Exception,)),
     processing_deadline_duration=120,
     silo_mode=SiloMode.CONTROL,
 )
-@retry()
 def disable_repos_batch(
     organization_integration_id: int,
     external_ids: list[str],
@@ -507,11 +504,10 @@ def disable_repos_batch(
 @instrumented_task(
     name="sentry.integrations.source_code_management.sync_repos.restore_repos_batch",
     namespace=integrations_control_tasks,
-    retry=Retry(times=3, delay=120),
+    retry=Retry(times=3, delay=120, on=(Exception,)),
     processing_deadline_duration=120,
     silo_mode=SiloMode.CONTROL,
 )
-@retry()
 def restore_repos_batch(
     organization_integration_id: int,
     external_ids: list[str],

--- a/src/sentry/integrations/tasks/create_comment.py
+++ b/src/sentry/integrations/tasks/create_comment.py
@@ -12,7 +12,7 @@ from sentry.integrations.tasks import should_comment_sync
 from sentry.models.activity import Activity
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
 from sentry.types.activity import ActivityType
 
@@ -20,10 +20,10 @@ from sentry.types.activity import ActivityType
 @instrumented_task(
     name="sentry.integrations.tasks.create_comment",
     namespace=integrations_tasks,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(times=5, delay=60 * 5, on=(Exception,), ignore=(Integration.DoesNotExist,)),
     silo_mode=SiloMode.CELL,
+    silenced_exceptions=(Integration.DoesNotExist,),
 )
-@retry(exclude=(Integration.DoesNotExist))
 def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> None:
     try:
         external_issue = ExternalIssue.objects.get(id=external_issue_id)

--- a/src/sentry/integrations/tasks/kick_off_status_syncs.py
+++ b/src/sentry/integrations/tasks/kick_off_status_syncs.py
@@ -2,17 +2,16 @@ from taskbroker_client.retry import Retry
 
 from sentry.models.grouplink import GroupLink
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
+from sentry.tasks.base import instrumented_task, track_group_async_operation
 from sentry.taskworker.namespaces import integrations_tasks
 
 
 @instrumented_task(
     name="sentry.integrations.tasks.kick_off_status_syncs",
     namespace=integrations_tasks,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(times=5, delay=60 * 5, on=(Exception,)),
     silo_mode=SiloMode.CELL,
 )
-@retry()
 @track_group_async_operation
 def kick_off_status_syncs(project_id: int, group_id: int) -> None:
     """This is run async to avoid extra queries in the EventManager."""

--- a/src/sentry/integrations/tasks/migrate_repo.py
+++ b/src/sentry/integrations/tasks/migrate_repo.py
@@ -9,18 +9,27 @@ from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import organization_service
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_control_tasks
 
 
 @instrumented_task(
     name="sentry.integrations.tasks.migrate_repo",
     namespace=integrations_control_tasks,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(
+        times=5,
+        delay=60 * 5,
+        on=(Exception,),
+        ignore=(Integration.DoesNotExist, Repository.DoesNotExist, Organization.DoesNotExist),
+    ),
     processing_deadline_duration=60,
     silo_mode=SiloMode.CONTROL,
+    silenced_exceptions=(
+        Integration.DoesNotExist,
+        Repository.DoesNotExist,
+        Organization.DoesNotExist,
+    ),
 )
-@retry(exclude=(Integration.DoesNotExist, Repository.DoesNotExist, Organization.DoesNotExist))
 def migrate_repo(repo_id: int, integration_id: int, organization_id: int) -> None:
     from sentry.plugins.migrator import Migrator
 

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -21,7 +21,7 @@ from sentry.shared_integrations.exceptions import (
     IntegrationError,
 )
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
 from sentry.users.models.user import User
 from sentry.users.services.user.service import user_service
@@ -31,17 +31,26 @@ from sentry.users.services.user.service import user_service
     name="sentry.integrations.tasks.sync_assignee_outbound",
     namespace=integrations_tasks,
     processing_deadline_duration=30,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(
+        times=5,
+        delay=60 * 5,
+        on=(Exception,),
+        ignore=(
+            ExternalIssue.DoesNotExist,
+            Integration.DoesNotExist,
+            User.DoesNotExist,
+            Organization.DoesNotExist,
+            IntegrationError,
+        ),
+    ),
     silo_mode=SiloMode.CELL,
-)
-@retry(
-    exclude=(
+    silenced_exceptions=(
         ExternalIssue.DoesNotExist,
         Integration.DoesNotExist,
         User.DoesNotExist,
         Organization.DoesNotExist,
         IntegrationError,
-    )
+    ),
 )
 def sync_assignee_outbound(
     external_issue_id: int,

--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -21,7 +21,7 @@ from sentry.models.organization import Organization
 from sentry.models.release import Release, ReleaseStatus, follows_semver_versioning_scheme
 from sentry.signals import issue_resolved, issue_unresolved
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
+from sentry.tasks.base import instrumented_task, track_group_async_operation
 from sentry.taskworker.namespaces import integrations_tasks
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
@@ -193,10 +193,10 @@ def group_was_recently_resolved(group: Group) -> bool:
     name="sentry.integrations.tasks.sync_status_inbound",
     namespace=integrations_tasks,
     processing_deadline_duration=150,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(times=5, delay=60 * 5, on=(Exception,), ignore=(Integration.DoesNotExist,)),
     silo_mode=SiloMode.CELL,
+    silenced_exceptions=(Integration.DoesNotExist,),
 )
-@retry(exclude=(Integration.DoesNotExist,))
 @track_group_async_operation
 def sync_status_inbound(
     integration_id: int, organization_id: int, issue_key: str, data: Mapping[str, Any]

--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -16,17 +16,17 @@ from sentry.integrations.services.integration import integration_service
 from sentry.models.group import Group, GroupStatus
 from sentry.shared_integrations.exceptions import ApiUnauthorized, IntegrationFormError
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
+from sentry.tasks.base import instrumented_task, track_group_async_operation
 from sentry.taskworker.namespaces import integrations_tasks
 
 
 @instrumented_task(
     name="sentry.integrations.tasks.sync_status_outbound",
     namespace=integrations_tasks,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(times=5, delay=60 * 5, on=(Exception,), ignore=(Integration.DoesNotExist,)),
     silo_mode=SiloMode.CELL,
+    silenced_exceptions=(Integration.DoesNotExist,),
 )
-@retry(exclude=(Integration.DoesNotExist,))
 @track_group_async_operation
 def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
     groups = Group.objects.filter(

--- a/src/sentry/integrations/tasks/update_comment.py
+++ b/src/sentry/integrations/tasks/update_comment.py
@@ -12,7 +12,7 @@ from sentry.integrations.tasks import should_comment_sync
 from sentry.models.activity import Activity
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
 from sentry.types.activity import ActivityType
 
@@ -20,11 +20,11 @@ from sentry.types.activity import ActivityType
 @instrumented_task(
     name="sentry.tasks.integrations.update_comment",
     namespace=integrations_tasks,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(times=5, delay=60 * 5, on=(Exception,), ignore=(Integration.DoesNotExist,)),
     silo_mode=SiloMode.CELL,
+    silenced_exceptions=(Integration.DoesNotExist,),
 )
 # TODO(jess): Add more retry exclusions once ApiClients have better error handling
-@retry(exclude=(Integration.DoesNotExist))
 def update_comment(external_issue_id: int, user_id: int, group_note_id: int) -> None:
     try:
         external_issue = ExternalIssue.objects.get(id=external_issue_id)

--- a/src/sentry/integrations/vsts/tasks/kickoff_subscription_check.py
+++ b/src/sentry/integrations/vsts/tasks/kickoff_subscription_check.py
@@ -7,17 +7,16 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_control_tasks
 
 
 @instrumented_task(
     name="sentry.integrations.vsts.tasks.kickoff_vsts_subscription_check",
     namespace=integrations_control_tasks,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(times=5, delay=60 * 5, on=(Exception,)),
     silo_mode=SiloMode.CONTROL,
 )
-@retry()
 def kickoff_vsts_subscription_check() -> None:
     from sentry.integrations.vsts.tasks import vsts_subscription_check
 

--- a/src/sentry/integrations/vsts/tasks/subscription_check.py
+++ b/src/sentry/integrations/vsts/tasks/subscription_check.py
@@ -9,17 +9,22 @@ from sentry.integrations.tasks import logger
 from sentry.models.apitoken import generate_token
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_control_tasks
 
 
 @instrumented_task(
     name="sentry.integrations.vsts.tasks.vsts_subscription_check",
     namespace=integrations_control_tasks,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(
+        times=5,
+        delay=60 * 5,
+        on=(Exception,),
+        ignore=(ApiError, ApiUnauthorized, Integration.DoesNotExist, IdentityNotValid),
+    ),
     silo_mode=SiloMode.CONTROL,
+    silenced_exceptions=(ApiError, ApiUnauthorized, Integration.DoesNotExist, IdentityNotValid),
 )
-@retry(exclude=(ApiError, ApiUnauthorized, Integration.DoesNotExist, IdentityNotValid))
 def vsts_subscription_check(integration_id: int, organization_id: int) -> None:
     from sentry.integrations.vsts.integration import VstsIntegration
 

--- a/tests/sentry/integrations/github/tasks/test_link_all_repos.py
+++ b/tests/sentry/integrations/github/tasks/test_link_all_repos.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import responses
 from django.db import IntegrityError
-from taskbroker_client.retry import RetryTaskError
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.integration import GitHubIntegrationProvider
@@ -11,6 +10,7 @@ from sentry.integrations.github.tasks.link_all_repos import link_all_repos
 from sentry.integrations.source_code_management.metrics import LinkAllReposHaltReason
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric, assert_slo_metric
 from sentry.testutils.cases import IntegrationTestCase
@@ -206,7 +206,7 @@ class LinkAllReposTestCase(IntegrationTestCase):
             status=400,
         )
 
-        with pytest.raises(RetryTaskError):
+        with pytest.raises(ApiError):
             link_all_repos(
                 integration_key=self.key,
                 integration_id=self.integration.id,

--- a/tests/sentry/integrations/tasks/test_create_comment.py
+++ b/tests/sentry/integrations/tasks/test_create_comment.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-from taskbroker_client.retry import RetryTaskError
 
 from sentry.integrations.example import ExampleIntegration
 from sentry.integrations.models import ExternalIssue, Integration
@@ -157,7 +156,7 @@ class TestCreateComment(TestCase):
             integration=self.example_integration,
         )
 
-        with pytest.raises(RetryTaskError):
+        with pytest.raises(Exception, match="Something went wrong creating comment"):
             create_comment(external_issue.id, self.user.id, self.activity.id)
 
         assert_failure_metric(mock_record_event, Exception("Something went wrong creating comment"))

--- a/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-from taskbroker_client.retry import RetryTaskError
 
 from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.example import ExampleIntegration
@@ -72,7 +71,7 @@ class TestSyncAssigneeOutbound(TestCase):
     ) -> None:
         mock_sync_assignee.side_effect = raise_sync_assignee_exception
 
-        with pytest.raises(RetryTaskError):
+        with pytest.raises(Exception, match="Something went wrong"):
             sync_assignee_outbound(self.external_issue.id, self.user.id, True, None)
 
         mock_record_failure.assert_called_once()

--- a/tests/sentry/integrations/tasks/test_sync_status_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_status_outbound.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-from taskbroker_client.retry import RetryTaskError
 
 from sentry.integrations.example import ExampleIntegration
 from sentry.integrations.models import ExternalIssue, Integration
@@ -110,7 +109,7 @@ class TestSyncStatusOutbound(TestCase):
             group=self.group, key="foo_integration", integration=self.example_integration
         )
 
-        with pytest.raises(RetryTaskError):
+        with pytest.raises(Exception, match="Something went wrong"):
             sync_status_outbound(self.group.id, external_issue_id=external_issue.id)
 
         assert mock_record_failure.call_count == 1

--- a/tests/sentry/integrations/tasks/test_update_comment.py
+++ b/tests/sentry/integrations/tasks/test_update_comment.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-from taskbroker_client.retry import RetryTaskError
 
 from sentry.integrations.example import ExampleIntegration
 from sentry.integrations.models import ExternalIssue, Integration
@@ -150,7 +149,7 @@ class TestUpdateComment(TestCase):
             integration=self.example_integration,
         )
 
-        with pytest.raises(RetryTaskError):
+        with pytest.raises(Exception, match="Something went wrong updating comment"):
             update_comment(external_issue.id, self.user.id, self.activity.id)
 
         assert_failure_metric(mock_record_event, Exception("Something went wrong updating comment"))


### PR DESCRIPTION
Continuing the work of #114937, this PR removes more of the old `@retry` decorators from tasks, updating them to their closest equivalent in Taskbroker.
