### PR TITLE
chore(objectstore): temporarily disable proxy endpoint in s4s2

### DIFF
--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -27,6 +27,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
 from sentry.objectstore import parse_accept_encoding
 from sentry.ratelimits.config import RateLimitConfig
+from sentry.types.cell import get_local_cell
 
 
 @cell_silo_endpoint
@@ -76,6 +77,11 @@ class ObjectstoreEndpoint(Endpoint):
         path: str,
     ) -> Response | StreamingHttpResponse:
         assert request.method
+
+        # TODO(FS-300): Re-enable this endpoint in S4S2 after secret versions are fixed
+        if get_local_cell().name == "s4s2":
+            return Response({"detail": "Unauthorized"}, status=401)
+
         target_url = get_target_url(path)
 
         headers = dict(request.headers)


### PR DESCRIPTION
Ref FS-354
Ref FS-300

we need to temporarily disable objectstore auth enforcement in s4s2 to address an issue with the secrets in that region. this endpoint needs to be disabled while that fix is deployed as otherwise we would be introducing a totally unauthenticated IDOR vuln.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
