### PR TITLE
fix(ui): Rank trace group by matches with fzf

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -14,6 +14,7 @@ import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
 import {getFieldDefinition} from 'sentry/utils/fields';
+import {fzf} from 'sentry/utils/search/fzf';
 import {
   ToolbarFooterButton,
   ToolbarHeader,
@@ -96,14 +97,20 @@ export function ToolbarGroupByDropdown({
               option.textValue ?? (typeof option.label === 'string' ? option.label : '');
             const normalizedText = text.toLowerCase();
             const normalizedSearch = search.toLowerCase();
+            // Keep Group By's existing substring filtering behavior while using fzf
+            // only to rank the matched options.
             if (!normalizedText.includes(normalizedSearch)) {
               return {score: 0};
             }
-            const isExact = normalizedText === normalizedSearch;
+            const result = fzf(text, normalizedSearch, false);
+            if (result.end === -1) {
+              return {score: 0};
+            }
             const isKnown =
               getFieldDefinition(String(option.value), fieldDefinitionType) !== null;
-            // exact+known=4, exact+unknown=3, partial+known=2, partial+unknown=1
-            return {score: (isExact ? 2 : 0) + (isKnown ? 2 : 1)};
+            const prefixBoost =
+              result.start === 0 && result.end === normalizedSearch.length ? 8 : 0;
+            return {score: Math.max(1, result.score) + prefixBoost + (isKnown ? 2 : 1)};
           },
         }}
         trigger={triggerProps => (


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/109957. Keep the known-field search behavior there, but use fzf to rank matched Group By options so searching org puts organization.slug before flag.evaluation.feature.organizations.

before

<img width="836" height="605" alt="image" src="https://github.com/user-attachments/assets/ed0cd700-b8a5-4f86-8a1b-8e21c83ef3a0" />


after

<img width="833" height="595" alt="image" src="https://github.com/user-attachments/assets/e60ca788-02aa-4c1f-820e-9646b6ebb069" />
