### PR TITLE
feat(repositories): Filter out active repositories from the sync

### DIFF
--- a/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
+++ b/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
@@ -93,14 +93,13 @@ def sync_repos_on_install_change(
             organization_id=organization_id,
             provider_key=integration.provider,
         ).capture():
-            _sync_repos_for_org(
+            repos_changed = _sync_repos_for_org(
                 integration=integration,
                 rpc_org=rpc_org,
                 provider=provider,
                 repos_added=repos_added,
                 repos_removed=repos_removed,
             )
-            repos_changed = bool(repos_added or repos_removed)
             bump_org_integration_last_sync(oi.id, repos_changed=repos_changed)
 
 
@@ -111,7 +110,10 @@ def _sync_repos_for_org(
     provider: str,
     repos_added: list[GitHubInstallationRepo],
     repos_removed: list[GitHubInstallationRepo],
-) -> None:
+) -> bool:
+    """Returns True if any repos were created, reactivated, or disabled."""
+    changed = False
+
     if repos_added:
         integration_repo_provider = get_integration_repository_provider(integration)
         repo_configs: list[GitHubRepoInputConfig] = []
@@ -128,6 +130,7 @@ def _sync_repos_for_org(
                     configs=repo_configs, organization=rpc_org
                 )
             )
+            changed = bool(created_repos or reactivated_repos)
 
             for created_repo in created_repos:
                 log_repo_change(
@@ -147,65 +150,71 @@ def _sync_repos_for_org(
                     provider=integration.provider,
                 )
 
-    if repos_removed:
-        external_ids = [str(repo["id"]) for repo in repos_removed]
+    if not repos_removed:
+        return changed
 
-        active_skipped = set(
-            repository_service.find_recently_active_repo_external_ids(
-                organization_id=rpc_org.id,
-                integration_id=integration.id,
-                provider=provider,
-                external_ids=external_ids,
-                cutoff_days=DISABLE_ACTIVITY_CUTOFF_DAYS,
-            )
-        )
-        safe_to_disable = [eid for eid in external_ids if eid not in active_skipped]
+    external_ids = [str(repo["id"]) for repo in repos_removed]
 
-        if active_skipped:
-            logger.info(
-                "sync_repos_on_install_change.disable_skipped_due_to_activity",
-                extra={
-                    "integration_id": integration.id,
-                    "organization_id": rpc_org.id,
-                    "candidate_count": len(external_ids),
-                    "skipped_count": len(active_skipped),
-                    "skipped_ids": list(active_skipped),
-                    "cutoff_days": DISABLE_ACTIVITY_CUTOFF_DAYS,
-                },
-            )
-            metrics.distribution(
-                "scm.repo_sync_on_install_change.disable_skipped_due_to_activity",
-                len(active_skipped),
-                tags={"provider": integration.provider},
-                sample_rate=1.0,
-            )
-
-        existing_repos = repository_service.get_repositories(
+    active_skipped = set(
+        repository_service.find_recently_active_repo_external_ids(
             organization_id=rpc_org.id,
             integration_id=integration.id,
-            providers=[provider],
+            provider=provider,
+            external_ids=external_ids,
+            cutoff_days=DISABLE_ACTIVITY_CUTOFF_DAYS,
         )
-        repo_by_eid = {
-            r.external_id: r
-            for r in existing_repos
-            if r.external_id and r.status == ObjectStatus.ACTIVE
-        }
+    )
+    safe_to_disable = [eid for eid in external_ids if eid not in active_skipped]
 
-        if safe_to_disable:
-            repository_service.disable_repositories_by_external_ids(
+    if active_skipped:
+        logger.info(
+            "sync_repos_on_install_change.disable_skipped_due_to_activity",
+            extra={
+                "integration_id": integration.id,
+                "organization_id": rpc_org.id,
+                "candidate_count": len(external_ids),
+                "skipped_count": len(active_skipped),
+                "skipped_ids": list(active_skipped),
+                "cutoff_days": DISABLE_ACTIVITY_CUTOFF_DAYS,
+            },
+        )
+        metrics.distribution(
+            "scm.repo_sync_on_install_change.disable_skipped_due_to_activity",
+            len(active_skipped),
+            tags={"provider": integration.provider},
+            sample_rate=1.0,
+        )
+
+    if not safe_to_disable:
+        return changed
+
+    existing_repos = repository_service.get_repositories(
+        organization_id=rpc_org.id,
+        integration_id=integration.id,
+        providers=[provider],
+    )
+    repo_by_eid = {
+        r.external_id: r
+        for r in existing_repos
+        if r.external_id and r.status == ObjectStatus.ACTIVE
+    }
+
+    repository_service.disable_repositories_by_external_ids(
+        organization_id=rpc_org.id,
+        integration_id=integration.id,
+        provider=provider,
+        external_ids=safe_to_disable,
+    )
+
+    for eid in safe_to_disable:
+        sentry_repo = repo_by_eid.get(eid)
+        if sentry_repo:
+            log_repo_change(
+                event_name="REPO_DISABLED",
                 organization_id=rpc_org.id,
-                integration_id=integration.id,
-                provider=provider,
-                external_ids=safe_to_disable,
+                repo=sentry_repo,
+                source="GitHub webhook",
+                provider=integration.provider,
             )
 
-        for eid in safe_to_disable:
-            sentry_repo = repo_by_eid.get(eid)
-            if sentry_repo:
-                log_repo_change(
-                    event_name="REPO_DISABLED",
-                    organization_id=rpc_org.id,
-                    repo=sentry_repo,
-                    source="GitHub webhook",
-                    provider=integration.provider,
-                )
+    return True

--- a/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
+++ b/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
@@ -14,13 +14,17 @@ from sentry.integrations.source_code_management.metrics import (
     SCMIntegrationInteractionType,
 )
 from sentry.integrations.source_code_management.repo_audit import log_repo_change
-from sentry.integrations.source_code_management.sync_repos import bump_org_integration_last_sync
+from sentry.integrations.source_code_management.sync_repos import (
+    DISABLE_ACTIVITY_CUTOFF_DAYS,
+    bump_org_integration_last_sync,
+)
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers.integration_repository import get_integration_repository_provider
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_control_tasks
+from sentry.utils import metrics
 
 from .link_all_repos import GitHubRepoInputConfig, get_repo_config
 
@@ -144,8 +148,38 @@ def _sync_repos_for_org(
                 )
 
     if repos_removed:
-        # Look up repos before disabling to get their IDs and names
         external_ids = [str(repo["id"]) for repo in repos_removed]
+
+        active_skipped = set(
+            repository_service.find_recently_active_repo_external_ids(
+                organization_id=rpc_org.id,
+                integration_id=integration.id,
+                provider=provider,
+                external_ids=external_ids,
+                cutoff_days=DISABLE_ACTIVITY_CUTOFF_DAYS,
+            )
+        )
+        safe_to_disable = [eid for eid in external_ids if eid not in active_skipped]
+
+        if active_skipped:
+            logger.info(
+                "sync_repos_on_install_change.disable_skipped_due_to_activity",
+                extra={
+                    "integration_id": integration.id,
+                    "organization_id": rpc_org.id,
+                    "candidate_count": len(external_ids),
+                    "skipped_count": len(active_skipped),
+                    "skipped_ids": list(active_skipped),
+                    "cutoff_days": DISABLE_ACTIVITY_CUTOFF_DAYS,
+                },
+            )
+            metrics.distribution(
+                "scm.repo_sync_on_install_change.disable_skipped_due_to_activity",
+                len(active_skipped),
+                tags={"provider": integration.provider},
+                sample_rate=1.0,
+            )
+
         existing_repos = repository_service.get_repositories(
             organization_id=rpc_org.id,
             integration_id=integration.id,
@@ -157,15 +191,15 @@ def _sync_repos_for_org(
             if r.external_id and r.status == ObjectStatus.ACTIVE
         }
 
-        repository_service.disable_repositories_by_external_ids(
-            organization_id=rpc_org.id,
-            integration_id=integration.id,
-            provider=provider,
-            external_ids=external_ids,
-        )
+        if safe_to_disable:
+            repository_service.disable_repositories_by_external_ids(
+                organization_id=rpc_org.id,
+                integration_id=integration.id,
+                provider=provider,
+                external_ids=safe_to_disable,
+            )
 
-        for repo in repos_removed:
-            eid = str(repo["id"])
+        for eid in safe_to_disable:
             sentry_repo = repo_by_eid.get(eid)
             if sentry_repo:
                 log_repo_change(

--- a/tests/sentry/integrations/github/tasks/test_sync_repos_on_install_change.py
+++ b/tests/sentry/integrations/github/tasks/test_sync_repos_on_install_change.py
@@ -8,6 +8,7 @@ from sentry.integrations.github.tasks.sync_repos_on_install_change import (
 )
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.auditlogentry import AuditLogEntry
+from sentry.models.commit import Commit
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
@@ -241,6 +242,35 @@ class SyncReposOnInstallChangeTestCase(IntegrationTestCase):
         oi.refresh_from_db()
         assert oi.config["last_sync"] > "2020-01-01T00:00:00+00:00"
         assert oi.config["last_repos_change"] == "2020-01-01T00:00:00+00:00"
+
+    def test_skips_disable_for_repo_with_recent_activity(self, _: MagicMock) -> None:
+        with assume_test_silo_mode(SiloMode.CELL):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="getsentry/old-repo",
+                external_id="3",
+                provider="integrations:github",
+                integration_id=self.integration.id,
+                status=ObjectStatus.ACTIVE,
+            )
+            Commit.objects.create(
+                organization_id=self.organization.id,
+                repository_id=repo.id,
+                key="abc123",
+            )
+
+        with self.feature(FEATURE_FLAG):
+            sync_repos_on_install_change(
+                integration_id=self.integration.id,
+                action="removed",
+                repos_added=[],
+                repos_removed=self._make_repos_removed(),
+                repository_selection="selected",
+            )
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            repo.refresh_from_db()
+            assert repo.status == ObjectStatus.ACTIVE
 
     def test_does_not_disable_already_disabled_repos(self, _: MagicMock) -> None:
         with assume_test_silo_mode(SiloMode.CELL):


### PR DESCRIPTION
Just for safety, filter out active repos when we disable, at least for now.

<!-- Describe your PR here. -->