### PR TITLE
feat(seer): Suggest projects to setup if they match the search term

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
@@ -104,7 +104,7 @@ export function AutofixAgent({canWrite, preference, project}: Props) {
           <field.Layout.Row
             label={t('Handoff to Agent')}
             hintText={
-              <Text>
+              <Text variant="muted">
                 {tct(
                   'Select your preferred agent to create a plan, and code up an issue fix. Seer Agent will always be used for the Root Cause Analysis step.',
                   {

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -415,7 +415,7 @@ export function SeerProjectTable() {
                                 busy={isLoadingModal}
                                 disabled={isLoadingModal}
                               >
-                                {t('Add %s', [matchingProject.slug])}
+                                {t('Add %s', matchingProject.slug)}
                               </Button>
                             </Flex>
                           ))}

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -167,20 +167,6 @@ export function SeerProjectTable() {
     parseAsSort.withDefault({field: 'project', kind: 'asc'})
   );
 
-  // A default projects if you did a search for a valid project slug, but it's
-  // not configured yet.
-  const matchingProjects = useMemo(
-    () =>
-      searchTerm
-        ? allProjects.filter(project =>
-            project.slug.toLowerCase().includes(searchTerm.toLowerCase())
-          )
-        : [],
-    [allProjects, searchTerm]
-  );
-
-  const {handleAddProjectClick, isLoadingModal} = useAddProjectHandler();
-
   const queryKey = [
     'seer-projects',
     {query: {query: searchTerm, sort, agent: agentFilter}},
@@ -251,6 +237,40 @@ export function SeerProjectTable() {
 
     return filtered;
   }, [sortedProjects, searchTerm, agentFilter, autofixSettingsByProjectId]);
+
+  // Projects matching the search term split into two groups:
+  // - unconfigured: no setting exists in filteredProjects (not set up yet)
+  // - differentAgent: has a setting already but uses a different agent than the filter
+  const matchingProjects = useMemo(() => {
+    if (!searchTerm) {
+      return {unconfigured: [] as Project[], differentAgent: [] as Project[]};
+    }
+
+    const filteredProjectIds = new Set(filteredProjects.map(p => p.id));
+    const configuredProjectIds = new Set(projects.map(p => p.id));
+
+    const matches = allProjects.filter(project =>
+      project.slug.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    const unconfigured: Project[] = [];
+    const differentAgent: Project[] = [];
+
+    for (const project of matches) {
+      if (filteredProjectIds.has(project.id)) {
+        continue;
+      }
+      if (configuredProjectIds.has(project.id)) {
+        differentAgent.push(project);
+      } else {
+        unconfigured.push(project);
+      }
+    }
+
+    return {unconfigured, differentAgent};
+  }, [allProjects, searchTerm, filteredProjects, projects]);
+
+  const {handleAddProjectClick, isLoadingModal} = useAddProjectHandler();
 
   if (
     !fetchingProjects &&
@@ -380,12 +400,12 @@ export function SeerProjectTable() {
                           })}
                     </Flex>
                     <Stack gap="md" align="center">
-                      {matchingProjects.length ? (
+                      {matchingProjects.unconfigured.length ? (
                         <Fragment>
                           <Text variant="muted" bold={false}>
-                            {t('Did you mean one of these?')}
+                            {t('Did you want to set up one of these projects?')}
                           </Text>
-                          {matchingProjects.map(matchingProject => (
+                          {matchingProjects.unconfigured.map(matchingProject => (
                             <Flex key={matchingProject.slug}>
                               <Button
                                 variant="primary"

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {
@@ -32,6 +32,7 @@ import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconSearch} from 'sentry/icons/iconSearch';
 import {t, tct} from 'sentry/locale';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {Project} from 'sentry/types/project';
 import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
 import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
@@ -166,6 +167,20 @@ export function SeerProjectTable() {
     parseAsSort.withDefault({field: 'project', kind: 'asc'})
   );
 
+  // A default projects if you did a search for a valid project slug, but it's
+  // not configured yet.
+  const matchingProjects = useMemo(
+    () =>
+      searchTerm
+        ? allProjects.filter(project =>
+            project.slug.toLowerCase().includes(searchTerm.toLowerCase())
+          )
+        : [],
+    [allProjects, searchTerm]
+  );
+
+  const {handleAddProjectClick, isLoadingModal} = useAddProjectHandler();
+
   const queryKey = [
     'seer-projects',
     {query: {query: searchTerm, sort, agent: agentFilter}},
@@ -260,7 +275,16 @@ export function SeerProjectTable() {
                 )}
               </Text>
               <Flex>
-                <AddProjectButton />
+                <Button
+                  variant="primary"
+                  size="md"
+                  onClick={handleAddProjectClick()}
+                  icon={<IconAdd />}
+                  busy={isLoadingModal}
+                  disabled={isLoadingModal}
+                >
+                  {t('Add Project')}
+                </Button>
               </Flex>
             </Stack>
           </Flex>
@@ -304,7 +328,16 @@ export function SeerProjectTable() {
             />
           </InputGroup>
 
-          <AddProjectButton />
+          <Button
+            variant="primary"
+            size="md"
+            onClick={handleAddProjectClick()}
+            icon={<IconAdd />}
+            busy={isLoadingModal}
+            disabled={isLoadingModal}
+          >
+            {t('Add Project')}
+          </Button>
         </Flex>
         <SimpleTableWithColumns>
           <ProjectTableHeader
@@ -328,20 +361,56 @@ export function SeerProjectTable() {
             </SimpleTable.Empty>
           ) : filteredProjects.length === 0 ? (
             <SimpleTable.Empty>
-              {searchTerm
-                ? agentFilter
-                  ? tct('No projects found matching [searchTerm] with [agentFilter]', {
-                      searchTerm: <code>{searchTerm}</code>,
-                      agentFilter: <code>{getFilteredCodingAgentName(agentFilter)}</code>,
-                    })
-                  : tct('No projects found matching [searchTerm]', {
-                      searchTerm: <code>{searchTerm}</code>,
-                    })
-                : agentFilter
-                  ? tct('No projects found with [agentFilter]', {
-                      agentFilter: <code>{getFilteredCodingAgentName(agentFilter)}</code>,
-                    })
-                  : t('No projects found')}
+              <Text bold>
+                {searchTerm ? (
+                  <Stack gap="3xl">
+                    <Flex gap="xs" align="center">
+                      {agentFilter
+                        ? tct(
+                            'No configured projects found matching [searchTerm] with [agentFilter]',
+                            {
+                              searchTerm: <code>{searchTerm}</code>,
+                              agentFilter: (
+                                <code>{getFilteredCodingAgentName(agentFilter)}</code>
+                              ),
+                            }
+                          )
+                        : tct('No configured projects found matching [searchTerm]', {
+                            searchTerm: <code>{searchTerm}</code>,
+                          })}
+                    </Flex>
+                    <Stack gap="md" align="center">
+                      {matchingProjects.length ? (
+                        <Fragment>
+                          <Text variant="muted" bold={false}>
+                            {t('Did you mean one of these?')}
+                          </Text>
+                          {matchingProjects.map(matchingProject => (
+                            <Flex key={matchingProject.slug}>
+                              <Button
+                                variant="primary"
+                                size="xs"
+                                onClick={handleAddProjectClick(matchingProject)}
+                                icon={<IconAdd />}
+                                busy={isLoadingModal}
+                                disabled={isLoadingModal}
+                              >
+                                {t('Add %s', [matchingProject.slug])}
+                              </Button>
+                            </Flex>
+                          ))}
+                        </Fragment>
+                      ) : null}
+                    </Stack>
+                  </Stack>
+                ) : agentFilter ? (
+                  tct('No projects found with [agentFilter]', {
+                    agentFilter: <code>{getFilteredCodingAgentName(agentFilter)}</code>,
+                  })
+                ) : (
+                  t('No projects found')
+                )}
+              </Text>
             </SimpleTable.Empty>
           ) : (
             filteredProjects.map(project => (
@@ -367,21 +436,26 @@ const SimpleTableWithColumns = styled(SimpleTable)`
   overflow: visible;
 `;
 
-function AddProjectButton() {
+function useAddProjectHandler() {
   const [isLoadingModal, setIsLoadingModal] = useState(false);
 
-  return (
-    <Button
-      variant="primary"
-      size="md"
-      onClick={async () => {
+  return {
+    isLoadingModal,
+    handleAddProjectClick: (defaultProject?: Project) => {
+      return async () => {
         setIsLoadingModal(true);
         try {
           const {ProjectAddRepoModal} =
             await import('getsentry/views/seerAutomation/components/projectAddRepoModal/projectAddRepoModal');
 
           openModal(
-            deps => <ProjectAddRepoModal {...deps} title={t('Add Project to Autofix')} />,
+            deps => (
+              <ProjectAddRepoModal
+                {...deps}
+                title={t('Add Project to Autofix')}
+                defaultProject={defaultProject}
+              />
+            ),
             {
               modalCss: css`
                 width: 700px;
@@ -391,12 +465,7 @@ function AddProjectButton() {
         } finally {
           setIsLoadingModal(false);
         }
-      }}
-      icon={<IconAdd />}
-      busy={isLoadingModal}
-      disabled={isLoadingModal}
-    >
-      {t('Add Project')}
-    </Button>
-  );
+      };
+    },
+  };
 }


### PR DESCRIPTION
Trying to build a little delightful kind of feature: If someone searches for a project in the Seer > Autofix settings and nothing is found, lets suggest project names that are similar to the search term, so it's easy to onboard them.

The idea is that if the org has a long list of projects already added then it's hard to know what's added or not already. Therefore 'search + one click' is easier than 'search + modal + search again'.

**After**
<img width="1052" height="501" alt="SCR-20260506-pisl" src="https://github.com/user-attachments/assets/d132fc94-cb1b-443c-9a3b-c20fc4c963ae" />
<img width="1051" height="467" alt="SCR-20260506-pitp" src="https://github.com/user-attachments/assets/9e291cb6-f882-4e84-839b-fb5e1a0eb466" />

**Before**
<img width="1011" height="460" alt="SCR-20260506-pjyz" src="https://github.com/user-attachments/assets/38e601fc-b0f9-4862-9e13-717c14b52f14" />

