### PR TITLE
fix(replays): respect Kafka topic overrides

### DIFF
--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -6,6 +6,7 @@ from typing import Any
 from google.cloud.exceptions import NotFound
 from taskbroker_client.retry import Retry
 
+from sentry.conf.types.kafka_definition import Topic
 from sentry.replays.lib.kafka import initialize_replays_publisher
 from sentry.replays.lib.storage import (
     RecordingSegmentStorageMeta,
@@ -25,7 +26,7 @@ from sentry.replays.usecases.reader import fetch_segments_metadata
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import replays_tasks
-from sentry.utils import metrics
+from sentry.utils import kafka_config, metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.pubsub import KafkaPublisher
 
@@ -147,7 +148,10 @@ def archive_replay(publisher: KafkaPublisher, project_id: int, replay_id: str) -
 
     # We publish manually here because we sometimes provide a managed Kafka
     # publisher interface which has its own setup and teardown behavior.
-    publisher.publish("ingest-replay-events", message)
+    publisher.publish(
+        kafka_config.get_topic_definition(Topic.INGEST_REPLAY_EVENTS)["real_topic_name"],
+        message,
+    )
 
 
 def _delete_if_exists(filename: str) -> None:

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -22,6 +22,7 @@ from snuba_sdk import (
 from urllib3 import Retry
 
 from sentry.api.event_search import parse_search_query
+from sentry.conf.types.kafka_definition import Topic
 from sentry.models.organization import Organization
 from sentry.replays.lib.kafka import initialize_replays_publisher
 from sentry.replays.lib.seer_api import ReplayDeleteSeerDataRequest, make_replay_delete_request
@@ -35,6 +36,7 @@ from sentry.replays.usecases.events import archive_event
 from sentry.replays.usecases.query import execute_query, handle_search_filters
 from sentry.replays.usecases.query.configs.aggregate import search_config as agg_search_config
 from sentry.seer.signed_seer_api import SeerViewerContext
+from sentry.utils import kafka_config
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.snuba import (
@@ -71,7 +73,10 @@ def delete_replays(project_id: int, replay_ids: list[str]) -> None:
     """Set the archived bit flag to true on each replay."""
     publisher = initialize_replays_publisher(is_async=True)
     for replay_id in replay_ids:
-        publisher.publish("ingest-replay-events", archive_event(project_id, replay_id))
+        publisher.publish(
+            kafka_config.get_topic_definition(Topic.INGEST_REPLAY_EVENTS)["real_topic_name"],
+            archive_event(project_id, replay_id),
+        )
     publisher.flush()
 
 

--- a/src/sentry/replays/usecases/events.py
+++ b/src/sentry/replays/usecases/events.py
@@ -4,8 +4,9 @@ import time
 import uuid
 from typing import Any
 
+from sentry.conf.types.kafka_definition import Topic
 from sentry.replays.lib.kafka import initialize_replays_publisher
-from sentry.utils import json
+from sentry.utils import json, kafka_config
 
 
 def archive_event(project_id: int, replay_id: str) -> str:
@@ -58,4 +59,7 @@ def _replay_event(project_id: int, replay_id: str, event: dict[str, Any]) -> str
 def publish_replay_event(message: str, is_async: bool) -> None:
     """Publish a replay-event to the replay snuba consumer topic."""
     publisher = initialize_replays_publisher(is_async=is_async)
-    publisher.publish("ingest-replay-events", message)
+    publisher.publish(
+        kafka_config.get_topic_definition(Topic.INGEST_REPLAY_EVENTS)["real_topic_name"],
+        message,
+    )

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from google.api_core.exceptions import ServiceUnavailable
 
 from sentry import features, options, projectoptions
+from sentry.conf.types.kafka_definition import Topic
 from sentry.exceptions import PluginError
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.grouptype import GroupCategory
@@ -34,6 +35,7 @@ from sentry.utils.event_frames import get_sdk_name
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.locking.backends import LockBackend
 from sentry.utils.locking.manager import LockManager
+from sentry.utils.kafka_config import get_topic_definition
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.safe import get_path, safe_execute
 from sentry.utils.sdk import bind_organization_context, set_current_event_project
@@ -923,7 +925,7 @@ def process_replay_link(job: PostProcessJob) -> None:
         metrics.incr("post_process.process_replay_link.id_invalid")
     else:
         publisher.publish(
-            "ingest-replay-events",
+            get_topic_definition(Topic.INGEST_REPLAY_EVENTS)["real_topic_name"],
             json.dumps(kafka_payload),
         )
 


### PR DESCRIPTION
Replay publishers were producing to the hardcoded logical topic "ingest-replay-events". Other Kafka paths resolve logical topic names through get_topic_definition so KAFKA_TOPIC_OVERRIDES are honored.

This updates replay publishers to use the configured real topic name, fixing self-hosted/custom deployments where physical Kafka topic names differ from upstream logical names.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
