### PR TITLE
ref(issue-details): Use React components for event markline tooltip

### DIFF
--- a/static/app/components/core/renderToString.tsx
+++ b/static/app/components/core/renderToString.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode} from 'react';
+import {type ReactNode, useCallback} from 'react';
 import {flushSync} from 'react-dom';
 import {createRoot} from 'react-dom/client';
 import {ThemeProvider, useTheme} from '@emotion/react';
@@ -21,6 +21,9 @@ const renderToString = (tree: ReactNode) => {
 export const useRenderToString = () => {
   const theme = useTheme();
 
-  return (tree: ReactNode) =>
-    renderToString(<ThemeProvider theme={theme}>{tree}</ThemeProvider>);
+  return useCallback(
+    (tree: ReactNode) =>
+      renderToString(<ThemeProvider theme={theme}>{tree}</ThemeProvider>),
+    [theme]
+  );
 };

--- a/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
@@ -23,22 +23,20 @@ function SeriesRow({
   totalCount: string;
 }) {
   return (
-    <Flex>
-      <Flex justify="between" gap="xs" flexGrow={1}>
-        <Flex gap="xs" align="center">
-          <Container
-            width="10px"
-            height="10px"
-            radius="full"
-            display="inline-block"
-            style={{backgroundColor: color}}
-          />
-          <Text size="sm">{label}</Text>
-        </Flex>
-        <Text size="sm" variant="muted">
-          {totalCount}
-        </Text>
+    <Flex justify="between" gap="xs" flexGrow={1}>
+      <Flex gap="xs" align="center">
+        <Container
+          width="10px"
+          height="10px"
+          radius="full"
+          display="inline-block"
+          style={{backgroundColor: color}}
+        />
+        <Text size="sm">{label}</Text>
       </Flex>
+      <Text size="sm" variant="muted">
+        {totalCount}
+      </Text>
     </Flex>
   );
 }

--- a/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
@@ -202,6 +202,7 @@ export function useCurrentEventMarklineSeries({
                   {time}
                 </Text>
               </Flex>
+              <div className="tooltip-arrow" />
             </Stack>
           );
         },

--- a/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
@@ -1,6 +1,11 @@
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {useRenderToString} from '@sentry/scraps/renderToString';
+import {Separator} from '@sentry/scraps/separator';
+import {Text} from '@sentry/scraps/text';
+
 import {MarkLine} from 'sentry/components/charts/components/markLine';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -8,8 +13,34 @@ import type {Group} from 'sentry/types/group';
 import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
 
-function getTooltipMarker(color: string): string {
-  return `<span style="display:inline-block;margin-right:4px;border-radius:10px;width:10px;height:10px;background-color:${color};"></span>`;
+function SeriesRow({
+  color,
+  label,
+  totalCount,
+}: {
+  color: string;
+  label: string;
+  totalCount: string;
+}) {
+  return (
+    <Flex>
+      <Flex justify="between" gap="xs" flexGrow={1}>
+        <Flex gap="xs" align="center">
+          <Container
+            width="10px"
+            height="10px"
+            radius="full"
+            display="inline-block"
+            style={{backgroundColor: color}}
+          />
+          <Text size="sm">{label}</Text>
+        </Flex>
+        <Text size="sm" variant="muted">
+          {totalCount}
+        </Text>
+      </Flex>
+    </Flex>
+  );
 }
 
 interface UseEventMarklineSeriesProps {
@@ -44,6 +75,7 @@ export function useCurrentEventMarklineSeries({
 }: UseEventMarklineSeriesProps) {
   const theme = useTheme();
   const eventView = useIssueDetailsEventView({group});
+  const renderToString = useRenderToString();
 
   return useMemo(() => {
     if (!event) {
@@ -126,31 +158,52 @@ export function useCurrentEventMarklineSeries({
             ?.find(s => s.name === closestEventSeries.name)
             ?.value?.toLocaleString();
 
-          // Use inline style for bold since CSS overrides <strong> to normal weight
-          const seriesRows = [
-            `<div><span class="tooltip-label" style="font-weight:bold;">${t('Current Event')}</span></div>`,
-          ];
+          const seriesRows: React.ReactNode[] = [];
 
           if (isFiltered && totalCount) {
             seriesRows.push(
-              `<div><span class="tooltip-label">${getTooltipMarker(colors.total)}<strong>${labels.total}</strong></span> ${totalCount}</div>`
+              <SeriesRow
+                key="total"
+                color={colors.total}
+                label={labels.total}
+                totalCount={totalCount}
+              />
             );
             seriesRows.push(
-              `<div><span class="tooltip-label">${getTooltipMarker(colors.matching)}<strong>${labels.matching}</strong></span> ${matchingCount}</div>`
+              <SeriesRow
+                key="matching"
+                color={colors.matching}
+                label={labels.matching}
+                totalCount={matchingCount}
+              />
             );
           } else {
             seriesRows.push(
-              `<div><span class="tooltip-label">${getTooltipMarker(colors.default)}<strong>${labels.default}</strong></span> ${matchingCount}</div>`
+              <SeriesRow
+                key="default"
+                color={colors.default}
+                label={labels.default}
+                totalCount={matchingCount}
+              />
             );
           }
 
-          return [
-            '<div class="tooltip-series">',
-            ...seriesRows,
-            '</div>',
-            `<div class="tooltip-footer">${time}</div>`,
-            '<div class="tooltip-arrow"></div>',
-          ].join('');
+          return renderToString(
+            <Stack gap="lg" padding="lg 0">
+              <Stack gap="md" padding="0 lg">
+                <Text size="sm" variant="muted" bold>
+                  {t('Current Event')}
+                </Text>
+                {seriesRows}
+              </Stack>
+              <Separator orientation="horizontal" padding="0" />
+              <Flex padding="0 lg">
+                <Text size="xs" variant="muted">
+                  {time}
+                </Text>
+              </Flex>
+            </Stack>
+          );
         },
       },
     });
@@ -169,5 +222,6 @@ export function useCurrentEventMarklineSeries({
     isFiltered,
     unfilteredEventSeries,
     seriesType,
+    renderToString,
   ]);
 }

--- a/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
@@ -196,7 +196,7 @@ export function useCurrentEventMarklineSeries({
               </Stack>
               <Separator orientation="horizontal" padding="0" />
               <Flex padding="0 lg">
-                <Text size="xs" variant="muted">
+                <Text size="sm" variant="muted">
                   {time}
                 </Text>
               </Flex>


### PR DESCRIPTION
Replace raw HTML string concatenation in the current event markline tooltip
with `renderToString` and scraps primitives (`Stack`, `Flex`, `Text`,
`Container`, `Separator`). Removes custom CSS class names, inline style
hacks, and the `getTooltipMarker` HTML helper.

before:

<img width="466" height="278" alt="Screenshot 2026-05-07 at 09 40 51" src="https://github.com/user-attachments/assets/21192789-68a3-46b5-a0d9-a4014faed898" />

after:

<img width="563" height="344" alt="Screenshot 2026-05-07 at 10 27 09" src="https://github.com/user-attachments/assets/7e5d4803-a1ce-4a44-a4e3-e2de1bbe87d4" />

