### PR TITLE
fix(replays): make sure the replay player doesn't reset on a background update

### DIFF
--- a/static/app/utils/replays/hooks/usePollReplayRecord.tsx
+++ b/static/app/utils/replays/hooks/usePollReplayRecord.tsx
@@ -21,7 +21,10 @@ export function usePollReplayRecord({
     getApiUrl('/organizations/$organizationIdOrSlug/replays/$replayId/', {
       path: {organizationIdOrSlug: orgSlug, replayId},
     }),
-    {}, // we use {} to avoid colliding with the queryKey used by useReplayData
+    {
+      // we use { isPolling: true } to avoid colliding with the queryKey used by useReplayData
+      query: {isPolling: true},
+    },
   ];
 
   const {data} = useApiQuery<{data: ReplayRecord}>(queryKey, {


### PR DESCRIPTION
using an empty object to prevent cache collision does no longer work because empty objects get stripped from the QueryKey. This didn't surface earlier because apiOptions and useApiQuery were using a different cache structure, but now they are unified so useReplayData and usePollReplayRecord re-use the same cache.

Using the same cache _should_ be fine but here it's not because this will lead to new ReplayPlayer instances being created, as they depend on the query result. The real issue is that we re-create ReplayPlayer instances in useMemo, which needs a proper follow-up fix:

https://github.com/getsentry/sentry/blob/7e47f8d9537e68e5a3f53307184ad9791549c0f6/static/app/utils/replays/hooks/useLoadReplayReader.tsx#L68-L88
