### PR TITLE
feat(dynamic-sampling): add query chunking iterator

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/tasks/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/queries.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -22,6 +22,29 @@ from sentry.snuba.spans_rpc import Spans
 
 def _get_aggregate_int(row: Mapping[str, Any], column: str) -> int:
     return int(row.get(column, 0))
+
+
+def run_eap_spans_table_query_in_chunks(
+    query: dict[str, Any],
+    chunk_size: int = 1000,
+) -> Iterator[list[dict[str, Any]]]:
+    offset = 0
+
+    while True:
+        result = Spans.run_table_query(**query, offset=offset, limit=chunk_size + 1)
+        data = result.get("data", [])
+        more_results = len(data) > chunk_size
+
+        if more_results:
+            data = data[:chunk_size]
+
+        if data:
+            yield data
+
+        if not more_results:
+            return
+
+        offset += chunk_size
 
 
 def get_eap_organization_volume(

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import patch
 
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
+
 from sentry.dynamic_sampling.per_org.tasks.configuration import (
     BaseDynamicSamplingConfiguration,
     get_configuration,
@@ -13,34 +15,67 @@ from sentry.dynamic_sampling.per_org.tasks.queries import (
 )
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.models.organization import Organization
+from sentry.search.eap.constants import SAMPLING_MODE_HIGHEST_ACCURACY
+from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.events.types import SnubaParams
+from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import SnubaTestCase, SpanTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 
 
-class EAPSpansTableQueryChunkingTest(TestCase):
+class EAPSpansTableQueryChunkingTest(TestCase, SnubaTestCase, SpanTestCase):
     def test_iterates_query_data_in_offset_chunks(self) -> None:
-        calls: list[tuple[int, int]] = []
-        query = {"query_string": "is_transaction:true"}
+        organization = self.create_organization()
+        project = self.create_project(organization=organization)
+        other_project = self.create_project(organization=organization)
+        timestamp = before_now(minutes=15)
 
-        def run_table_query(**kwargs):
-            calls.append((kwargs["offset"], kwargs["limit"]))
-            assert kwargs["query_string"] == "is_transaction:true"
+        self.store_spans(
+            [
+                self.create_span(
+                    {"is_segment": True},
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp,
+                ),
+                self.create_span(
+                    {"is_segment": True},
+                    organization=organization,
+                    project=other_project,
+                    start_ts=timestamp + timedelta(seconds=1),
+                ),
+            ]
+        )
 
-            if kwargs["offset"] == 0:
-                return {"data": [{"project.id": 1}, {"project.id": 2}, {"project.id": 3}]}
-            return {"data": [{"project.id": 3}]}
+        batches = list(
+            run_eap_spans_table_query_in_chunks(
+                {
+                    "params": SnubaParams(
+                        start=timestamp - timedelta(minutes=1),
+                        end=timestamp + timedelta(minutes=1),
+                        projects=[project, other_project],
+                        organization=organization,
+                    ),
+                    "query_string": "is_transaction:true",
+                    "selected_columns": ["project.id", "count()", "count_sample()"],
+                    "orderby": ["project.id"],
+                    "referrer": Referrer.DYNAMIC_SAMPLING_PER_ORG_GET_EAP_ORG_VOLUME.value,
+                    "config": SearchResolverConfig(
+                        auto_fields=True,
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SERVER_ONLY,
+                    ),
+                    "sampling_mode": SAMPLING_MODE_HIGHEST_ACCURACY,
+                },
+                chunk_size=1,
+            )
+        )
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.tasks.queries.Spans.run_table_query",
-            side_effect=run_table_query,
-        ):
-            batches = list(run_eap_spans_table_query_in_chunks(query, chunk_size=2))
-
-        assert batches == [
-            [{"project.id": 1}, {"project.id": 2}],
-            [{"project.id": 3}],
-        ]
-        assert calls == [(0, 3), (2, 3)]
+        assert len(batches) == 2
+        assert [len(batch) for batch in batches] == [1, 1]
+        assert {row["project.id"] for batch in batches for row in batch} == {
+            project.id,
+            other_project.id,
+        }
 
 
 class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
@@ -7,11 +7,40 @@ from sentry.dynamic_sampling.per_org.tasks.configuration import (
     BaseDynamicSamplingConfiguration,
     get_configuration,
 )
-from sentry.dynamic_sampling.per_org.tasks.queries import get_eap_organization_volume
+from sentry.dynamic_sampling.per_org.tasks.queries import (
+    get_eap_organization_volume,
+    run_eap_spans_table_query_in_chunks,
+)
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.models.organization import Organization
 from sentry.testutils.cases import SnubaTestCase, SpanTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
+
+
+class EAPSpansTableQueryChunkingTest(TestCase):
+    def test_iterates_query_data_in_offset_chunks(self) -> None:
+        calls: list[tuple[int, int]] = []
+        query = {"query_string": "is_transaction:true"}
+
+        def run_table_query(**kwargs):
+            calls.append((kwargs["offset"], kwargs["limit"]))
+            assert kwargs["query_string"] == "is_transaction:true"
+
+            if kwargs["offset"] == 0:
+                return {"data": [{"project.id": 1}, {"project.id": 2}, {"project.id": 3}]}
+            return {"data": [{"project.id": 3}]}
+
+        with patch(
+            "sentry.dynamic_sampling.per_org.tasks.queries.Spans.run_table_query",
+            side_effect=run_table_query,
+        ):
+            batches = list(run_eap_spans_table_query_in_chunks(query, chunk_size=2))
+
+        assert batches == [
+            [{"project.id": 1}, {"project.id": 2}],
+            [{"project.id": 3}],
+        ]
+        assert calls == [(0, 3), (2, 3)]
 
 
 class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):


### PR DESCRIPTION
- We will need a way to get all of the results in all of the longer queries for this new pipeline
- Add a function that creates an iterator over a batch of results