### PR TITLE
fix(auth): Prefer session user over IdP email in SSO identity resolution

### DIFF
--- a/src/sentry/auth/exceptions.py
+++ b/src/sentry/auth/exceptions.py
@@ -9,3 +9,7 @@ class ProviderNotRegistered(NotRegistered):
 
 class IdentityNotValid(Exception):
     pass
+
+
+class AuthIdentityUserMismatch(Exception):
+    pass

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -25,7 +25,7 @@ from sentry import audit_log, features
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_details_from_session
 from sentry.audit_log.services.log import AuditLogEvent, log_service
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
-from sentry.auth.exceptions import IdentityNotValid
+from sentry.auth.exceptions import AuthIdentityUserMismatch, IdentityNotValid
 from sentry.auth.idpmigration import (
     SSO_VERIFICATION_KEY,
     get_verification_value_from_key,
@@ -108,20 +108,23 @@ class AuthIdentityHandler:
 
     @cached_property
     def user(self) -> User | AnonymousUser:
+        # Session identity is authoritative for authenticated users.
+        # Fetch from DB to unwrap SimpleLazyObject<RpcUser> into a real User
+        # instance that auth.login() and model operations require.
+        if self.request.user.is_authenticated:
+            return User.objects.get(id=self.request.user.id)
+        # For unauthenticated flows (e.g. is_account_verified), resolve by IdP email.
         email = self.identity.get("email")
         if email:
             try:
-                user = resolve_email_to_user(email, organization=self.organization)
+                return (
+                    resolve_email_to_user(email, organization=self.organization)
+                    or self.request.user
+                )
             except AmbiguousUserFromEmail as e:
-                user = e.users[0]
-                self.warn_about_ambiguous_email(email, e.users, user)
-            if user is not None:
-                return user
-        return (
-            User.objects.get(id=self.request.user.id)
-            if self.request.user.is_authenticated
-            else self.request.user
-        )
+                self.warn_about_ambiguous_email(email, e.users, e.users[0])
+                return e.users[0]
+        return self.request.user  # AnonymousUser
 
     @staticmethod
     def warn_about_ambiguous_email(email: str, users: Collection[User], chosen_user: User) -> None:
@@ -325,6 +328,20 @@ class AuthIdentityHandler:
         """
         Given an already authenticated user, attach or re-attach an identity.
         """
+        if self.request.user.is_authenticated and self.request.user.id != self.user.id:
+            logger.error(
+                "sso.login-pipeline.attach-identity-user-mismatch",
+                extra={
+                    "organization_id": self.organization.id,
+                    "session_user_id": self.request.user.id,
+                    "target_user_id": self.user.id,
+                    "idp_identity_email": self.identity.get("email"),
+                },
+            )
+            # Defense in depth: shouldn't be possible to reach this point if the user is authenticated.
+            # self.user is resolved to request.user earlier in the flow.
+            raise AuthIdentityUserMismatch
+
         # prioritize identifying by the SSO provider's user ID
         with transaction.atomic(router.db_for_write(AuthIdentity)):
             auth_identity = self._get_auth_identity(ident=self.identity["id"])
@@ -509,20 +526,13 @@ class AuthIdentityHandler:
         self,
         state: AuthHelperSessionStore,
     ) -> HttpResponse:
-        """
-        Flow is activated upon a user logging in to where an AuthIdentity is
-        not present.
+        """Handle an SSO login where no AuthIdentity exists yet for this IdP identity.
 
-        XXX(dcramer): this docstring is out of date
+        Determines whether to link an existing account or create a new one:
 
-        The flow will attempt to answer the following:
-
-        - Is there an existing user with the same email address? Should they be
-          merged?
-
-        - Is there an existing user (via authentication) that should be merged?
-
-        - Should I create a new user based on this identity?
+        - Authenticated session user who is an org member: auto-link.
+        - Unauthenticated user who proved email ownership via verification link: auto-link.
+        - Otherwise: show a confirmation page to merge, create, or log in.
         """
         op = self.request.POST.get("op")
 
@@ -553,7 +563,15 @@ class AuthIdentityHandler:
             )
 
         is_new_account = not self.user.is_authenticated  # stateful
-        if self._app_user and (self.identity.get("email_verified") or is_account_verified):
+        session_owns_target = (
+            self.request.user.is_authenticated and self.request.user.id == self.user.id
+        )
+        # TODO: Unauthenticated users with a trusted IdP email_verified claim
+        # now see a confirmation page instead of auto-linking. Consider restoring
+        # email_verified trust for known-trustworthy providers (Google, GitHub)
+        # or hard-code the other SAML/OAuth IdPs to always have email_verified=False.
+        # (they should always be untrusted).
+        if self._app_user and (session_owns_target or is_account_verified):
             # we only allow this flow to happen if the existing user has
             # membership, otherwise we short circuit because it might be
             # an attempt to hijack membership of another organization
@@ -584,7 +602,7 @@ class AuthIdentityHandler:
             is_new_account = True
 
         try:
-            if op == "confirm" and ((self.request.user.id == self.user.id) or is_account_verified):
+            if op == "confirm" and (self.request.user.is_authenticated or is_account_verified):
                 auth_identity = self.handle_attach_identity()
             elif op == "confirm":
                 logger.info(
@@ -619,6 +637,11 @@ class AuthIdentityHandler:
                 return self._build_confirmation_response(is_new_account)
             else:
                 return self._build_confirmation_response(is_new_account)
+        except AuthIdentityUserMismatch:
+            messages.add_message(self.request, messages.ERROR, ERR_UID_MISMATCH)
+            return HttpResponseRedirect(
+                reverse("sentry-auth-organization", args=[self.organization.slug])
+            )
         except IntegrityError:
             logger.info(
                 "sso.login-pipeline.integrity-error",
@@ -1032,11 +1055,7 @@ class AuthHelper(Pipeline[AuthProvider, AuthHelperSessionStore]):
             organization_id=self.organization.id, provider=self.provider.key, config=config
         )
 
-        # The setup flow should always link the identity to the admin who is
-        # performing setup, so override the email to ensure resolve_email_to_user
-        # returns the authenticated user rather than whoever the IdP asserted.
-        setup_identity = {**identity, "email": request.user.email}
-        self.auth_handler(setup_identity).handle_attach_identity(om)
+        self.auth_handler(identity).handle_attach_identity(om)
 
         auth.mark_sso_complete(request, self.organization.id)
 

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TypedDict
 from unittest import mock
 
+import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, models, router, transaction
 from django.http import HttpResponseRedirect
@@ -11,6 +12,7 @@ from django.test import Client, RequestFactory
 
 from sentry import audit_log
 from sentry.analytics.events.user_signup import UserSignUpEvent
+from sentry.auth.exceptions import AuthIdentityUserMismatch
 from sentry.auth.helper import (
     ERR_IDENTITY_CONFLICT,
     ERR_USER_SUSPENDED,
@@ -18,6 +20,7 @@ from sentry.auth.helper import (
     AuthHelper,
     AuthIdentityHandler,
 )
+from sentry.auth.idpmigration import SSO_VERIFICATION_KEY
 from sentry.auth.providers.dummy import DummyProvider
 from sentry.auth.store import FLOW_LOGIN, FLOW_SETUP_PROVIDER, AuthHelperSessionStore
 from sentry.hybridcloud.models.outbox import outbox_context
@@ -144,6 +147,24 @@ class UserResolutionTest(AuthIdentityHandlerTest):
 
         # Should resolve to user1 (org member) not user2 (primary email)
         assert handler.user == user1
+
+    def test_authenticated_user_resolves_to_session_user(self) -> None:
+        """Session user takes priority over IdP email resolution."""
+        session_user = self.set_up_user()
+        victim = self.create_user(email=self.email)
+
+        assert self.handler.user == session_user
+        assert self.handler.user != victim
+
+    def test_unauthenticated_with_no_email_match_resolves_to_anonymous(self) -> None:
+        identity: _Identity = {
+            "id": "sso_unknown",
+            "email": "nobody@nowhere.com",
+            "name": "Unknown",
+            "data": {},
+        }
+        handler = self._handler_with(identity)
+        assert isinstance(handler.user, AnonymousUser)
 
 
 @control_silo_test
@@ -471,6 +492,38 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
         self._test_with_identity_belonging_to_another_user(request_user)
         assert not AuthIdentity.objects.filter(id=existing_identity.id).exists()
 
+    def test_raises_on_session_user_mismatch(self) -> None:
+        """Defense-in-depth: handle_attach_identity must refuse to write
+        when the session user differs from the resolved target user."""
+        self.set_up_user()
+        other_user = self.create_user(email="other@example.com")
+        identity: _Identity = {
+            "id": "sso_id_456",
+            "email": other_user.email,
+            "name": "Other",
+            "data": {},
+        }
+        # Build handler while unauthenticated so self.user resolves by email,
+        # then set request.user to simulate a post-login state mismatch.
+        unauthenticated_request = _set_up_request()
+        with assume_test_silo_mode(SiloMode.CELL):
+            rpc_organization = serialize_rpc_organization(self.organization)
+        handler = AuthIdentityHandler(
+            self.auth_provider_inst,
+            DummyProvider(),
+            rpc_organization,
+            unauthenticated_request,
+            identity,
+        )
+        assert handler.user == other_user
+        handler.request.user = self.request.user
+
+        with pytest.raises(AuthIdentityUserMismatch):
+            handler.handle_attach_identity()
+        assert not AuthIdentity.objects.filter(
+            auth_provider=self.auth_provider_inst, ident=identity["id"]
+        ).exists()
+
 
 @control_silo_test
 class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
@@ -510,10 +563,30 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
 
     @mock.patch("sentry.auth.helper.render_to_response")
     @mock.patch("sentry.auth.helper.send_one_time_account_confirm_link")
-    def test_unauthenticated_with_existing_user(
+    def test_unauthenticated_with_secondary_email_shows_login(
         self, mock_create_key: mock.MagicMock, mock_render: mock.MagicMock
     ) -> None:
-        existing_user = self.create_user(email=self.email)
+        """When the IdP asserts a verified secondary email, the unauthenticated
+        user should be shown the login page rather than auto-linked."""
+        existing_user = self.create_user(email="primary@example.com")
+        self.create_useremail(user=existing_user, email=self.email, is_verified=True)
+
+        context = self._test_simple(mock_render, "sentry/auth-confirm-identity.html")
+        assert not mock_create_key.called
+        assert context["existing_user"] == existing_user
+        assert "login_form" in context
+
+    @mock.patch("sentry.auth.helper.render_to_response")
+    @mock.patch("sentry.auth.helper.send_one_time_account_confirm_link")
+    def test_unauthenticated_with_unverified_secondary_email_shows_login(
+        self, mock_create_key: mock.MagicMock, mock_render: mock.MagicMock
+    ) -> None:
+        """An unverified secondary email still resolves via resolve_email_to_user
+        (no is_verified filter on the query), so the user should be shown the
+        login page."""
+        existing_user = self.create_user(email="primary@example.com")
+        self.create_useremail(user=existing_user, email=self.email, is_verified=False)
+
         context = self._test_simple(mock_render, "sentry/auth-confirm-identity.html")
         assert not mock_create_key.called
         assert context["existing_user"] == existing_user
@@ -567,29 +640,113 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
         )
 
     @mock.patch("sentry.auth.helper.messages")
-    @mock.patch("sentry.auth.helper.render_to_response")
-    def test_confirm_merge_user_mismatch_shows_error(
-        self, mock_render: mock.MagicMock, mock_messages: mock.MagicMock
+    def test_confirm_links_to_session_user_not_email_resolved_user(
+        self, mock_messages: mock.MagicMock
     ) -> None:
-        from sentry.auth.helper import ERR_MERGE_FAILED
-
-        # Log in as a different user than the one resolved by identity email
-        different_user = self.create_user(email="other@example.com")
-        self.request.user = different_user
-        # Create the user that matches the identity email
+        # When authenticated as user A and the IdP asserts user B's email,
+        # confirming must link the identity to user A (session user).
+        session_user = self.create_user(email="other@example.com")
+        self.request.user = session_user
+        with assume_test_silo_mode(SiloMode.CELL):
+            self.create_member(user=session_user, organization=self.organization, role="member")
+        # Create the user whose email the IdP asserted
         self.create_user(email=self.email)
 
         self.request.POST = {"op": "confirm"}
-        response = self.handler.handle_unknown_identity(self.state)
+        self.handler.handle_unknown_identity(self.state)
+
+        auth_identity = AuthIdentity.objects.get(
+            auth_provider=self.auth_provider_inst, ident=self.identity["id"]
+        )
+        assert auth_identity.user_id == session_user.id
+
+    @mock.patch("sentry.auth.helper.messages")
+    def test_confirm_links_to_session_user_not_secondary_email_user(
+        self, mock_messages: mock.MagicMock
+    ) -> None:
+        """When authenticated as user A and the IdP asserts an email that is a
+        verified secondary on user B, confirming links to user A (session user)."""
+        session_user = self.create_user(email="session@example.com")
+        self.request.user = session_user
+        with assume_test_silo_mode(SiloMode.CELL):
+            self.create_member(user=session_user, organization=self.organization, role="member")
+        other_user = self.create_user(email="primary@example.com")
+        self.create_useremail(user=other_user, email=self.email, is_verified=True)
+
+        self.request.POST = {"op": "confirm"}
+        self.handler.handle_unknown_identity(self.state)
+
+        auth_identity = AuthIdentity.objects.get(
+            auth_provider=self.auth_provider_inst, ident=self.identity["id"]
+        )
+        assert auth_identity.user_id == session_user.id
+
+    @mock.patch("sentry.auth.helper.messages")
+    @mock.patch("sentry.auth.helper.auth")
+    def test_is_account_verified_auto_links_unauthenticated_user(
+        self, mock_auth: mock.MagicMock, mock_messages: mock.MagicMock
+    ) -> None:
+        """Unauthenticated user who proved email ownership via verification link
+        should auto-link without needing IdP email_verified."""
+        existing_user = self.create_user(email=self.email)
+        with assume_test_silo_mode(SiloMode.CELL):
+            member = self.create_member(
+                user=existing_user, organization=self.organization, role="member"
+            )
+
+        mock_auth.login.return_value = True
+        mock_auth.get_login_redirect.return_value = "/organizations/test-org/issues/"
+
+        # Simulate the is_account_verified flow: session has verification key
+        # that resolves to a value matching this user + email
+        verification_value = {
+            "user_id": existing_user.id,
+            "email": self.email,
+            "member_id": member.id,
+            "identity_id": self.identity["id"],
+        }
+        with (
+            mock.patch(
+                "sentry.auth.helper.get_verification_value_from_key",
+                return_value=verification_value,
+            ),
+        ):
+            self.request.session[SSO_VERIFICATION_KEY] = "test-verification-key"
+            self.handler.handle_unknown_identity(self.state)
+
+        auth_identity = AuthIdentity.objects.get(
+            auth_provider=self.auth_provider_inst, ident=self.identity["id"]
+        )
+        assert auth_identity.user_id == existing_user.id
+
+    @mock.patch("sentry.auth.helper.render_to_response")
+    @mock.patch("sentry.auth.helper.send_one_time_account_confirm_link")
+    def test_idp_email_verified_does_not_auto_link_unauthenticated_user(
+        self, mock_create_key: mock.MagicMock, mock_render: mock.MagicMock
+    ) -> None:
+        """IdP-asserted email_verified=True must not bypass the login gate
+        for unauthenticated users."""
+        existing_user = self.create_user(email=self.email)
+        with assume_test_silo_mode(SiloMode.CELL):
+            self.create_member(user=existing_user, organization=self.organization, role="member")
+
+        identity: _Identity = {
+            "id": self.identity["id"],
+            "email": self.email,
+            "name": self.identity["name"],
+            "data": {},
+        }
+        handler = self._handler_with(identity)
+        handler.identity["email_verified"] = True
+
+        response = handler.handle_unknown_identity(self.state)
 
         assert response is mock_render.return_value
-        mock_messages.add_message.assert_called_once_with(
-            self.request,
-            mock_messages.ERROR,
-            ERR_MERGE_FAILED,
-        )
-
-    # TODO: More test cases for various values of request.POST.get("op")
+        template = mock_render.call_args.args[0]
+        assert template == "sentry/auth-confirm-identity.html"
+        assert not AuthIdentity.objects.filter(
+            auth_provider=self.auth_provider_inst, ident=self.identity["id"]
+        ).exists()
 
 
 @control_silo_test

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -15,6 +15,7 @@ from sentry.analytics.events.user_signup import UserSignUpEvent
 from sentry.auth.exceptions import AuthIdentityUserMismatch
 from sentry.auth.helper import (
     ERR_IDENTITY_CONFLICT,
+    ERR_MERGE_FAILED,
     ERR_USER_SUSPENDED,
     OK_LINK_IDENTITY,
     AuthHelper,
@@ -747,6 +748,77 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
         assert not AuthIdentity.objects.filter(
             auth_provider=self.auth_provider_inst, ident=self.identity["id"]
         ).exists()
+
+    @mock.patch("sentry.auth.helper.messages")
+    @mock.patch("sentry.auth.helper.render_to_response")
+    def test_confirm_unauthenticated_unverified_shows_merge_error(
+        self, mock_render: mock.MagicMock, mock_messages: mock.MagicMock
+    ) -> None:
+        """op=confirm without authentication or email verification shows ERR_MERGE_FAILED."""
+        self.create_user(email=self.email)
+
+        self.request.POST = {"op": "confirm"}
+        response = self.handler.handle_unknown_identity(self.state)
+
+        assert response is mock_render.return_value
+        mock_messages.add_message.assert_called_once_with(
+            self.request,
+            mock_messages.ERROR,
+            ERR_MERGE_FAILED,
+        )
+
+    @mock.patch("sentry.auth.helper.messages")
+    def test_newuser_creates_account_and_identity(self, mock_messages: mock.MagicMock) -> None:
+        """op=newuser creates a new User and links the AuthIdentity to them."""
+        self.request.POST = {"op": "newuser"}
+        self.handler.handle_unknown_identity(self.state)
+
+        auth_identity = AuthIdentity.objects.get(
+            auth_provider=self.auth_provider_inst, ident=self.identity["id"]
+        )
+        assert auth_identity.user.email == self.email
+
+    @mock.patch("sentry.auth.helper.auth")
+    @mock.patch("sentry.auth.helper.render_to_response")
+    def test_login_with_valid_credentials_returns_confirmation(
+        self, mock_render: mock.MagicMock, mock_auth: mock.MagicMock
+    ) -> None:
+        """op=login with valid credentials calls _login and re-shows the confirmation page."""
+        existing_user = self.create_user(email=self.email)
+        mock_auth.login.return_value = True
+
+        mock_form = mock.MagicMock()
+        mock_form.is_valid.return_value = True
+        mock_form.get_user.return_value = existing_user
+
+        self.request.POST = {"op": "login"}
+        with mock.patch.object(
+            type(self.handler), "_login_form", new_callable=lambda: property(lambda s: mock_form)
+        ):
+            response = self.handler.handle_unknown_identity(self.state)
+
+        assert response is mock_render.return_value
+        mock_auth.login.assert_called_once()
+
+    @mock.patch("sentry.auth.helper.auth")
+    @mock.patch("sentry.auth.helper.render_to_response")
+    def test_login_with_invalid_credentials_returns_confirmation(
+        self, mock_render: mock.MagicMock, mock_auth: mock.MagicMock
+    ) -> None:
+        """op=login with bad credentials logs the failure and re-shows the confirmation page."""
+        self.create_user(email=self.email)
+
+        mock_form = mock.MagicMock()
+        mock_form.is_valid.return_value = False
+
+        self.request.POST = {"op": "login", "username": self.email}
+        with mock.patch.object(
+            type(self.handler), "_login_form", new_callable=lambda: property(lambda s: mock_form)
+        ):
+            response = self.handler.handle_unknown_identity(self.state)
+
+        assert response is mock_render.return_value
+        mock_auth.log_auth_failure.assert_called_once()
 
 
 @control_silo_test

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -677,6 +677,8 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         the ident changed from the SSO provider), we should be re-linking
         the identity automatically (without prompt) assuming the user is
         a member of the org.
+
+        Session ownership is sufficient — no IdP email_verified claim needed.
         """
         auth_provider = AuthProvider.objects.create(
             organization_id=self.organization.id, provider="dummy"
@@ -704,8 +706,8 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         # updated to be something else)
         resp = self.client.post(path, {"email": "adfadsf@example.com"})
 
-        # there should be no prompt as we auto merge the identity
-        assert resp.status_code == 200
+        # authenticated member auto-links without prompt
+        assert resp.status_code == 302
 
     def test_flow_authenticated_without_verified_without_password(self) -> None:
         """


### PR DESCRIPTION
This change fixes the user resolution method to prefer a signed in user rather than the user submitted through identity claims. Trusting the identity claims from IdPs have been the cause of many account takeover vulnerabilities, so we want to make sure that when doing SSO account linking, we're linking the signed-in user rather than the resolved user in the IdP claim.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
