### PR TITLE
fix(dashboards): Preserve prebuilt globalFilter chips when cloning

### DIFF
--- a/static/app/views/dashboards/hooks/useDuplicateDashboard.spec.tsx
+++ b/static/app/views/dashboards/hooks/useDuplicateDashboard.spec.tsx
@@ -134,14 +134,94 @@ describe('useDuplicateDashboard', () => {
       );
     });
 
+    // The saved span.system override is preserved alongside the prebuilt
+    // span.action / span.domain chips that the user never modified.
     expect(createMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         data: expect.objectContaining({
-          filters: savedFilters,
+          filters: {
+            globalFilter: expect.arrayContaining([
+              expect.objectContaining({
+                tag: expect.objectContaining({key: 'span.system'}),
+                value: 'postgresql',
+              }),
+              expect.objectContaining({
+                tag: expect.objectContaining({key: 'span.action'}),
+                value: '',
+              }),
+              expect.objectContaining({
+                tag: expect.objectContaining({key: 'span.domain'}),
+                value: '',
+              }),
+            ]),
+          },
           projects: [1, 2],
           environment: ['production'],
           period: '7d',
+        }),
+      })
+    );
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('preserves prebuilt-only globalFilter chips when no saved filters exist', async () => {
+    // Web Vitals defines `browser.name` and `user.geo.subregion` chips in its
+    // prebuilt config. They live only in the static config — not the DB
+    // record — so cloning must not drop them.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/77/`,
+      body: DashboardFixture([], {
+        id: '77',
+        prebuiltId: PrebuiltDashboardId.WEB_VITALS,
+        filters: {},
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/`,
+      method: 'GET',
+      body: [
+        DashboardFixture([], {
+          id: '78',
+          prebuiltId: PrebuiltDashboardId.WEB_VITALS_SUMMARY,
+        }),
+      ],
+    });
+    const createMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/`,
+      method: 'POST',
+      body: DashboardFixture([], {id: '200'}),
+    });
+
+    const onSuccess = jest.fn();
+    const {result} = renderHookWithProviders(() => useDuplicateDashboard({onSuccess}), {
+      organization,
+    });
+
+    await act(async () => {
+      await result.current(
+        DashboardListItemFixture({
+          id: '77',
+          prebuiltId: PrebuiltDashboardId.WEB_VITALS,
+        }),
+        'grid'
+      );
+    });
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          filters: {
+            globalFilter: expect.arrayContaining([
+              expect.objectContaining({
+                tag: expect.objectContaining({key: 'browser.name'}),
+              }),
+              expect.objectContaining({
+                tag: expect.objectContaining({key: 'user.geo.subregion'}),
+              }),
+            ]),
+          },
         }),
       })
     );
@@ -161,7 +241,10 @@ describe('useDuplicatePrebuiltDashboard', () => {
       globalFilter: [
         {
           dataset: WidgetType.SPANS,
-          tag: {key: 'db.normalized_description', name: 'db.normalized_description'},
+          tag: {
+            key: 'sentry.normalized_description',
+            name: 'sentry.normalized_description',
+          },
           value: '*billing*',
         },
       ],
@@ -197,10 +280,75 @@ describe('useDuplicatePrebuiltDashboard', () => {
       expect.anything(),
       expect.objectContaining({
         data: expect.objectContaining({
-          filters: savedFilters,
+          filters: {
+            globalFilter: [
+              expect.objectContaining({
+                tag: expect.objectContaining({key: 'sentry.normalized_description'}),
+                value: '*billing*',
+              }),
+            ],
+          },
           projects: [3, 4],
           environment: ['staging'],
           period: '14d',
+        }),
+      })
+    );
+    expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({id: '300'}));
+  });
+
+  it('preserves prebuilt-only globalFilter chips when duplicating Web Vitals from the dashboard view', async () => {
+    // Reproduces DAIN-1598: cloning Web Vitals from inside the dashboard
+    // dropped the `browser.name` / `user.geo.subregion` chips that come from
+    // the prebuilt config but aren't persisted to the DB record.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/55/`,
+      body: DashboardFixture([], {
+        id: '55',
+        prebuiltId: PrebuiltDashboardId.WEB_VITALS,
+        filters: {},
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/`,
+      method: 'GET',
+      body: [
+        DashboardFixture([], {
+          id: '56',
+          prebuiltId: PrebuiltDashboardId.WEB_VITALS_SUMMARY,
+        }),
+      ],
+    });
+    const createMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/`,
+      method: 'POST',
+      body: DashboardFixture([], {id: '300'}),
+    });
+
+    const onSuccess = jest.fn();
+    const {result} = renderHookWithProviders(
+      () => useDuplicatePrebuiltDashboard({onSuccess}),
+      {organization}
+    );
+
+    await act(async () => {
+      await result.current.duplicatePrebuiltDashboard('55');
+    });
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          filters: {
+            globalFilter: expect.arrayContaining([
+              expect.objectContaining({
+                tag: expect.objectContaining({key: 'browser.name'}),
+              }),
+              expect.objectContaining({
+                tag: expect.objectContaining({key: 'user.geo.subregion'}),
+              }),
+            ]),
+          },
         }),
       })
     );

--- a/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
@@ -7,6 +7,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {mergeGlobalFilters} from 'sentry/views/dashboards/globalFilter/utils';
 import type {DashboardDetails, DashboardListItem} from 'sentry/views/dashboards/types';
 import {cloneDashboard} from 'sentry/views/dashboards/utils';
 import {
@@ -133,9 +134,21 @@ export function useDuplicatePrebuiltDashboard({onSuccess}: UseDuplicateDashboard
  * This includes both the DashboardFilters object (globalFilter, release) and
  * the page-level filters (projects, environment, date range) which are stored
  * as top-level fields.
+ *
+ * The target's globalFilter chips (from the prebuilt config) are merged with
+ * the saved globalFilter values so that prebuilt-only filters aren't dropped.
+ * This mirrors how `OrgDashboards` merges these filters for display.
  */
 function copySavedFilters(target: DashboardDetails, source: DashboardDetails): void {
-  target.filters = source.filters;
+  const sourceFilters = source.filters ?? {};
+  const mergedGlobalFilter = mergeGlobalFilters(
+    target.filters?.globalFilter ?? [],
+    sourceFilters.globalFilter ?? []
+  );
+  target.filters = {
+    ...sourceFilters,
+    globalFilter: mergedGlobalFilter,
+  };
   target.projects = source.projects;
   target.environment = source.environment;
   target.period = source.period;


### PR DESCRIPTION
Fixes bug where global filters were not being duplicated from the prebuilt dashboards config

Duplicated Before Fix
<img width="1437" height="171" alt="image" src="https://github.com/user-attachments/assets/6840f197-5b15-4c8a-99fe-8e343d2025c3" />

Duplicated After Fix
<img width="1442" height="166" alt="image" src="https://github.com/user-attachments/assets/def14f29-92a9-4e00-a5ff-fa5c53f12805" />
