### PR TITLE
chore(alerts): Remove should_fire_workflow_actions

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -28,7 +28,6 @@ from sentry.incidents.endpoints.serializers.incident import (
     IncidentSerializer,
 )
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
-from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import (
     AlertRuleDetectionType,
     AlertRuleThresholdType,
@@ -508,7 +507,6 @@ def generate_incident_trigger_email_context(
     notification_uuid: str | None = None,
     detector_serialized_response: DetectorSerializerResponse | None = None,
 ) -> dict[str, Any]:
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
     from sentry.seer.anomaly_detection.types import AnomalyDetectionThresholdType
 
     snuba_query = metric_issue_context.snuba_query
@@ -576,40 +574,28 @@ def generate_incident_trigger_email_context(
     if notification_uuid:
         alert_link_params["notification_uuid"] = notification_uuid
 
-    if should_fire_workflow_actions(organization, MetricIssue.type_id):
-        # lookup the incident_id from the open_period_identifier
-        try:
-            incident_group_open_period = IncidentGroupOpenPeriod.objects.get(
-                group_open_period_id=metric_issue_context.open_period_identifier
-            )
-            incident_identifier = incident_group_open_period.incident_identifier
-        except IncidentGroupOpenPeriod.DoesNotExist:
-            # the corresponding metric detector was not dual written
-            incident_identifier = get_fake_id_from_object_id(
-                metric_issue_context.open_period_identifier
-            )
+    # lookup the incident_id from the open_period_identifier
+    try:
+        incident_group_open_period = IncidentGroupOpenPeriod.objects.get(
+            group_open_period_id=metric_issue_context.open_period_identifier
+        )
+        incident_identifier = incident_group_open_period.incident_identifier
+    except IncidentGroupOpenPeriod.DoesNotExist:
+        # the corresponding metric detector was not dual written
+        incident_identifier = get_fake_id_from_object_id(
+            metric_issue_context.open_period_identifier
+        )
 
-        alert_link = organization.absolute_url(
-            reverse(
-                "sentry-metric-alert",
-                kwargs={
-                    "organization_slug": organization.slug,
-                    "incident_id": incident_identifier,
-                },
-            ),
-            query=urlencode(alert_link_params),
-        )
-    else:
-        alert_link = organization.absolute_url(
-            reverse(
-                "sentry-metric-alert",
-                kwargs={
-                    "organization_slug": organization.slug,
-                    "incident_id": metric_issue_context.open_period_identifier,
-                },
-            ),
-            query=urlencode(alert_link_params),
-        )
+    alert_link = organization.absolute_url(
+        reverse(
+            "sentry-metric-alert",
+            kwargs={
+                "organization_slug": organization.slug,
+                "incident_id": incident_identifier,
+            },
+        ),
+        query=urlencode(alert_link_params),
+    )
     # We don't have user muting for workflows in the new workflow engine system
     # so we don't need to show the snooze alert url
     snooze_alert_url = None

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -6,16 +6,14 @@ from typing import Any
 from django.db import router, transaction
 from taskbroker_client.retry import Retry
 
-from sentry.incidents.models.alert_rule import AlertRuleStatus, AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleStatus
 from sentry.incidents.models.incident import (
     Incident,
-    IncidentActivity,
     IncidentStatus,
     IncidentStatusMethod,
 )
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
-from sentry.models.project import Project
 from sentry.silo.base import SiloMode
 from sentry.snuba.models import QuerySubscription
 from sentry.snuba.query_subscriptions.consumer import register_subscriber
@@ -56,50 +54,7 @@ def handle_trigger_action(
     metric_value: float | int | None = None,
     **kwargs: Any,
 ) -> None:
-    from sentry.incidents.grouptype import MetricIssue
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-
-    try:
-        action = AlertRuleTriggerAction.objects.select_related(
-            "alert_rule_trigger", "alert_rule_trigger__alert_rule"
-        ).get(id=action_id)
-    except AlertRuleTriggerAction.DoesNotExist:
-        metrics.incr("incidents.alert_rules.action.skipping_missing_action")
-        return
-
-    try:
-        incident = Incident.objects.select_related("organization").get(id=incident_id)
-    except Incident.DoesNotExist:
-        metrics.incr("incidents.alert_rules.action.skipping_missing_incident")
-        return
-
-    try:
-        project = Project.objects.get(id=project_id)
-    except Project.DoesNotExist:
-        metrics.incr("incidents.alert_rules.action.skipping_missing_project")
-        return
-
-    incident_activity = (
-        IncidentActivity.objects.filter(incident=incident, value=new_status).order_by("-id").first()
-    )
-    notification_uuid = str(incident_activity.notification_uuid) if incident_activity else None
-    if notification_uuid is None:
-        metrics.incr("incidents.alert_rules.action.incident_activity_missing")
-
-    # We should only fire using the legacy registry if we are not using the workflow engine
-    if not should_fire_workflow_actions(incident.organization, MetricIssue.type_id):
-        metrics.incr(
-            f"incidents.alert_rules.action.{AlertRuleTriggerAction.Type(action.type).name.lower()}.{method}"
-        )
-
-        getattr(action, method)(
-            action,
-            incident,
-            project,
-            metric_value=metric_value,
-            new_status=IncidentStatus(new_status),
-            notification_uuid=notification_uuid,
-        )
+    pass
 
 
 @instrumented_task(

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -107,28 +107,12 @@ def fetch_environment_name(rule_env: int) -> str | None:
 def get_rule_environment_param_from_rule(
     rule_id: int, rule_environment_id: int | None, organization: Organization, type_id: int
 ) -> dict[str, str]:
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-
     params = {}
-    if should_fire_workflow_actions(organization, type_id):
-        if (
-            rule_environment_id is not None
-            and (environment_name := fetch_environment_name(rule_environment_id)) is not None
-        ):
-            params["environment"] = environment_name
-    else:
-        try:
-            rule = Rule.objects.get(id=rule_id)
-        except Rule.DoesNotExist:
-            rule_env = None
-        else:
-            rule_env = rule.environment_id
-
-        if (
-            rule_env is not None
-            and (environment_name := fetch_environment_name(rule_env)) is not None
-        ):
-            params["environment"] = environment_name
+    if (
+        rule_environment_id is not None
+        and (environment_name := fetch_environment_name(rule_environment_id)) is not None
+    ):
+        params["environment"] = environment_name
     return params
 
 
@@ -267,19 +251,10 @@ def build_attachment_replay_link(
 
 
 def build_rule_url(rule: Any, group: Group, project: Project) -> str:
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-
     org_slug = group.organization.slug
     project_slug = project.slug
-    if should_fire_workflow_actions(group.organization, group.type):
-        rule_id = get_key_from_rule_data(rule, "legacy_rule_id")
-        rule_url = (
-            f"/organizations/{org_slug}/issues/alerts/rules/{project_slug}/{rule_id}/details/"
-        )
-    else:
-        rule_url = (
-            f"/organizations/{org_slug}/issues/alerts/rules/{project_slug}/{rule.id}/details/"
-        )
+    rule_id = get_key_from_rule_data(rule, "legacy_rule_id")
+    rule_url = f"/organizations/{org_slug}/issues/alerts/rules/{project_slug}/{rule_id}/details/"
 
     return absolute_uri(rule_url)
 

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -8,7 +8,6 @@ from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.models.environment import Environment
 from sentry.models.group import Group
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.team import Team
@@ -104,9 +103,7 @@ def fetch_environment_name(rule_env: int) -> str | None:
         return env.name
 
 
-def get_rule_environment_param_from_rule(
-    rule_id: int, rule_environment_id: int | None, organization: Organization, type_id: int
-) -> dict[str, str]:
+def get_rule_environment_param_from_rule(rule_environment_id: int | None) -> dict[str, str]:
     params = {}
     if (
         rule_environment_id is not None
@@ -130,11 +127,7 @@ def get_title_link(
     other_params = {}
     # add in rule id if we have it
     if rule_id:
-        other_params.update(
-            get_rule_environment_param_from_rule(
-                rule_id, rule_environment_id, group.organization, group.type
-            )
-        )
+        other_params.update(get_rule_environment_param_from_rule(rule_environment_id))
         # hard code for issue alerts
         other_params["alert_rule_id"] = str(rule_id)
         other_params["alert_type"] = "issue"

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -202,8 +202,6 @@ def incident_attachment_info(
     referrer: str = "metric_alert",
     notification_uuid: str | None = None,
 ) -> AttachmentInfo:
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-
     status = get_status_text(metric_issue_context.new_status)
 
     text = ""
@@ -228,38 +226,30 @@ def incident_attachment_info(
     if notification_uuid:
         title_link_params["notification_uuid"] = notification_uuid
 
-    from sentry.incidents.grouptype import MetricIssue
-
-    # TODO(iamrajjoshi): This will need to be updated once we plan out Metric Alerts rollout
-    if should_fire_workflow_actions(organization, MetricIssue.type_id):
-        try:
-            alert_rule_id = AlertRuleDetector.objects.values_list("alert_rule_id", flat=True).get(
-                detector_id=alert_context.action_identifier_id
-            )
-            if alert_rule_id is None:
-                raise ValueError("Alert rule id not found when querying for AlertRuleDetector")
-        except AlertRuleDetector.DoesNotExist:
-            # the corresponding metric detector was not dual written
-            alert_rule_id = get_fake_id_from_object_id(alert_context.action_identifier_id)
-
-        workflow_engine_params = title_link_params.copy()
-
-        try:
-            open_period_incident = IncidentGroupOpenPeriod.objects.get(
-                group_open_period_id=metric_issue_context.open_period_identifier
-            )
-            workflow_engine_params["alert"] = str(open_period_incident.incident_identifier)
-        except IncidentGroupOpenPeriod.DoesNotExist:
-            # the corresponding metric detector was not dual written
-            workflow_engine_params["alert"] = str(
-                get_fake_id_from_object_id(metric_issue_context.open_period_identifier)
-            )
-
-        title_link = build_title_link(alert_rule_id, organization, workflow_engine_params)
-    else:
-        title_link = build_title_link(
-            alert_context.action_identifier_id, organization, title_link_params
+    try:
+        alert_rule_id = AlertRuleDetector.objects.values_list("alert_rule_id", flat=True).get(
+            detector_id=alert_context.action_identifier_id
         )
+        if alert_rule_id is None:
+            raise ValueError("Alert rule id not found when querying for AlertRuleDetector")
+    except AlertRuleDetector.DoesNotExist:
+        # the corresponding metric detector was not dual written
+        alert_rule_id = get_fake_id_from_object_id(alert_context.action_identifier_id)
+
+    workflow_engine_params = title_link_params.copy()
+
+    try:
+        open_period_incident = IncidentGroupOpenPeriod.objects.get(
+            group_open_period_id=metric_issue_context.open_period_identifier
+        )
+        workflow_engine_params["alert"] = str(open_period_incident.incident_identifier)
+    except IncidentGroupOpenPeriod.DoesNotExist:
+        # the corresponding metric detector was not dual written
+        workflow_engine_params["alert"] = str(
+            get_fake_id_from_object_id(metric_issue_context.open_period_identifier)
+        )
+
+    title_link = build_title_link(alert_rule_id, organization, workflow_engine_params)
 
     return AttachmentInfo(
         title=title,

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -9,7 +9,6 @@ from sentry.integrations.opsgenie.metrics import record_event, record_lifecycle_
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
-from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.utils.links import create_link_to_workflow
 from sentry.notifications.utils.rules import get_key_from_rule_data, split_rules_by_rule_workflow_id
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -57,10 +56,7 @@ class OpsgenieClient(ApiClient):
         organization = group.project.organization
         rule_urls = []
         for rule in rules:
-            rule_id = rule.id
-            if should_fire_workflow_actions(organization, group.type):
-                rule_id = get_key_from_rule_data(rule, "legacy_rule_id")
-
+            rule_id = get_key_from_rule_data(rule, "legacy_rule_id")
             path = f"/organizations/{organization.slug}/issues/alerts/rules/{group.project.slug}/{rule_id}/details/"
             rule_urls.append(organization.absolute_url(path))
         return rule_urls

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -9,7 +9,6 @@ import orjson
 import sentry_sdk
 from slack_sdk.errors import SlackApiError
 
-from sentry.api.serializers.rest_framework.rule import ACTION_UUID_KEY
 from sentry.constants import ISSUE_ALERTS_THREAD_DEFAULT
 from sentry.incidents.grouptype import MetricIssue
 from sentry.integrations.messaging.metrics import (
@@ -295,74 +294,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 organization_id=organization.id,
                 integration_id=integration.id,
             )
-
-    def _send_issue_alert_notification(
-        self,
-        event: GroupEvent,
-        futures: Sequence[RuleFuture],
-        tags: set,
-        integration: RpcIntegration,
-        channel: str,
-        notification_uuid: str | None = None,
-    ) -> None:
-        """Send an issue alert notification to Slack."""
-        rules = [f.rule for f in futures]
-        rule = rules[0] if rules else None
-        rule_to_use = self.rule if self.rule else rule
-        rule_id = rule_to_use.id if rule_to_use else None
-        rule_action_uuid = self.data.get(ACTION_UUID_KEY, None)
-
-        if not rule_action_uuid:
-            # We are logging because this should never happen, all actions should have an uuid
-            # We can monitor for this, and create an alert if this ever appears
-            _default_logger.info(
-                "No action uuid",
-                extra={
-                    "rule_id": rule_id,
-                    "notification_uuid": notification_uuid,
-                },
-            )
-
-        new_notification_message_object = NewIssueAlertNotificationMessage(
-            rule_fire_history_id=self.rule_fire_history.id if self.rule_fire_history else None,
-            rule_action_uuid=rule_action_uuid,
-        )
-
-        open_period_start: datetime | None = None
-        if event.group.issue_type.type_id == UptimeDomainCheckFailure.type_id:
-            open_period_start = open_period_start_for_group(event.group)
-            new_notification_message_object.open_period_start = open_period_start
-
-        # Get thread timestamp using the provided method and args
-        with MessagingInteractionEvent(
-            MessagingInteractionType.GET_PARENT_NOTIFICATION, SlackMessagingSpec()
-        ).capture() as lifecycle:
-            thread_ts = SlackNotifyServiceAction._get_issue_alert_thread_ts(
-                lifecycle=lifecycle,
-                event=event,
-                new_notification_message_object=new_notification_message_object,
-                organization=self.project.organization,
-                rule_id=rule_id,
-                rule_action_uuid=rule_action_uuid,
-                open_period_start=open_period_start,
-            )
-
-        save_method = None
-        if rule_action_uuid and rule_id:
-            save_method = SlackNotifyServiceAction._save_issue_alert_notification_message
-
-        self._send_notification(
-            event=event,
-            futures=futures,
-            tags=tags,
-            integration=integration,
-            channel=channel,
-            notification_uuid=notification_uuid,
-            notification_message_object=new_notification_message_object,
-            save_notification_method=save_method,
-            thread_ts=thread_ts,
-        )
-        self.record_notification_sent(event, channel, rule, notification_uuid)
 
     def _send_notification_action_notification(
         self,

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -327,6 +327,8 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 integration=integration,
                 channel=channel,
             )
+            self.record_notification_sent(event, channel, rule, notification_uuid)
+            return
 
         try:
             action = Action.objects.get(id=action_id)

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -458,8 +458,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     def after(
         self, event: GroupEvent, notification_uuid: str | None = None
     ) -> Generator[CallbackFuture]:
-        from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-
         channel = self.get_option("channel_id")
         tags = set(self.get_tags_list())
 
@@ -470,16 +468,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
 
         # integration is captured in a closure, type assert the None case is handled.
         integration: RpcIntegration = i
-
-        def send_notification(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
-            self._send_issue_alert_notification(
-                event=event,
-                futures=futures,
-                tags=tags,
-                integration=integration,
-                channel=channel,
-                notification_uuid=notification_uuid,
-            )
 
         def send_notification_noa(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             self._send_notification_action_notification(
@@ -501,10 +489,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             },
             skip_internal=False,
         )
-        if should_fire_workflow_actions(self.project.organization, event.group.type):
-            yield self.future(send_notification_noa, key=key)
-        else:
-            yield self.future(send_notification, key=key)
+        yield self.future(send_notification_noa, key=key)
 
     def render_label(self) -> str:
         tags = self.get_tags_list()

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -15,8 +15,6 @@ from sentry.integrations.messaging.metrics import (
     MessagingInteractionEvent,
     MessagingInteractionType,
 )
-from sentry.integrations.repository import get_default_issue_alert_repository
-from sentry.integrations.repository.base import NotificationMessageValidationError
 from sentry.integrations.repository.issue_alert import NewIssueAlertNotificationMessage
 from sentry.integrations.repository.notification_action import (
     NewNotificationActionNotificationMessage,
@@ -30,8 +28,6 @@ from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.utils.threads import NotificationActionThreadUtils
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import EventLifecycle
-from sentry.models.options.organization_option import OrganizationOption
-from sentry.models.organization import Organization
 from sentry.models.rule import Rule
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
 from sentry.notifications.utils.open_period import open_period_start_for_group
@@ -156,80 +152,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             lifecycle.add_extras(log_params)
             record_lifecycle_termination_level(lifecycle, e)
             return None
-
-    @classmethod
-    def _save_issue_alert_notification_message(
-        cls,
-        data: NewIssueAlertNotificationMessage,
-    ) -> None:
-        """Save an issue alert notification message to the repository."""
-        try:
-            issue_repository = get_default_issue_alert_repository()
-            issue_repository.create_notification_message(data=data)
-        except NotificationMessageValidationError as err:
-            extra = data.__dict__ if data else None
-            _default_logger.info(
-                "Validation error for new issue alert notification message",
-                exc_info=err,
-                extra=extra,
-            )
-        except Exception:
-            # if there's an error trying to save a notification message, don't let that error block this flow
-            # we already log at the repository layer, no need to log again here
-            pass
-
-    @classmethod
-    def _get_issue_alert_thread_ts(
-        cls,
-        organization: Organization,
-        lifecycle: EventLifecycle,
-        rule_id: int | None,
-        rule_action_uuid: str | None,
-        event: GroupEvent,
-        open_period_start: datetime | None,
-        new_notification_message_object: NewIssueAlertNotificationMessage,
-    ) -> str | None:
-        """Find the thread in which to post an issue alert notification as a reply.
-
-        Return None to post the notification as a top-level message.
-        """
-        # We need to search by rule action uuid and rule id, so only search if they exist
-        if not (
-            rule_action_uuid
-            and rule_id
-            and OrganizationOption.objects.get_value(
-                organization=organization,
-                key="sentry:issue_alerts_thread_flag",
-                default=ISSUE_ALERTS_THREAD_DEFAULT,
-            )
-        ):
-            return None
-
-        try:
-            issue_repository = get_default_issue_alert_repository()
-            parent_notification_message = issue_repository.get_parent_notification_message(
-                rule_id=rule_id,
-                group_id=event.group.id,
-                rule_action_uuid=rule_action_uuid,
-                open_period_start=open_period_start,
-            )
-        except Exception as e:
-            lifecycle.record_halt(e)
-            # if there's an error trying to grab a parent notification, don't let that error block this flow
-            # we already log at the repository layer, no need to log again here
-            return None
-
-        if parent_notification_message is None:
-            return None
-
-        # If a parent notification exists for this rule and action, then we can reply in a thread
-        # Make sure we track that this reply will be in relation to the parent row
-        new_notification_message_object.parent_notification_message_id = (
-            parent_notification_message.id
-        )
-        # To reply to a thread, use the specific key in the payload as referenced by the docs
-        # https://api.slack.com/methods/chat.postMessage#arg_thread_ts
-        return parent_notification_message.message_identifier
 
     def _send_notification(
         self,

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -43,7 +43,6 @@ from sentry.models.group import Group
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.rule import Rule
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
-from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.notifications.activity.archive import ArchiveActivityNotification
 from sentry.notifications.notifications.activity.assigned import AssignedActivityNotification
 from sentry.notifications.notifications.activity.base import GroupActivityNotification
@@ -254,33 +253,18 @@ class SlackService:
             parent_notifications: Generator[
                 NotificationActionNotificationMessage | IssueAlertNotificationMessage
             ]
-            will_fire_workflow_actions = should_fire_workflow_actions(
-                group.organization, group.type
-            )
+
             if group.issue_type.type_id == UptimeDomainCheckFailure.type_id:
                 use_open_period_start = True
                 open_period_start = open_period_start_for_group(group)
-                if will_fire_workflow_actions:
-                    parent_notifications = self._notification_action_repository.get_all_parent_notification_messages_by_filters(
-                        group_ids=[group.id],
-                        open_period_start=open_period_start,
-                    )
-                else:
-                    parent_notifications = self._issue_alert_repository.get_all_parent_notification_messages_by_filters(
-                        group_ids=[group.id],
-                        project_ids=[activity.project.id],
-                        open_period_start=open_period_start,
-                    )
+                parent_notifications = self._notification_action_repository.get_all_parent_notification_messages_by_filters(
+                    group_ids=[group.id],
+                    open_period_start=open_period_start,
+                )
             else:
-                if will_fire_workflow_actions:
-                    parent_notifications = self._notification_action_repository.get_all_parent_notification_messages_by_filters(
-                        group_ids=[group.id],
-                    )
-                else:
-                    parent_notifications = self._issue_alert_repository.get_all_parent_notification_messages_by_filters(
-                        group_ids=[group.id],
-                        project_ids=[activity.project.id],
-                    )
+                parent_notifications = self._notification_action_repository.get_all_parent_notification_messages_by_filters(
+                    group_ids=[group.id],
+                )
 
         # We don't wrap this in a lifecycle because _handle_parent_notification is already wrapped in a lifecycle
         parent_notification_count = 0

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -296,16 +296,11 @@ class SlackService:
                             "parent notification does not have a message identifier, skipping"
                         )
                         continue
-                    if isinstance(parent_notification, NotificationActionNotificationMessage):
-                        channel_id = (
-                            self._get_channel_id_from_parent_notification_notification_action(
-                                parent_notification
-                            )
-                        )
-                    else:
-                        channel_id = self._get_channel_id_from_parent_notification(
-                            parent_notification
-                        )
+
+                    channel_id = self._get_channel_id_from_parent_notification_notification_action(
+                        parent_notification
+                    )
+
                     self._send_notification_to_slack_channel(
                         channel_id=channel_id,
                         message_identifier=parent_notification.message_identifier,

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -15,7 +15,6 @@ from sentry.constants import METRIC_ALERTS_THREAD_DEFAULT, ObjectStatus
 from sentry.incidents.charts import build_metric_alert_chart
 from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
 from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
-from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.incident import IncidentStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -53,7 +52,6 @@ from sentry.integrations.slack.utils.threads import NotificationActionThreadUtil
 from sentry.models.group import Group
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
-from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.utils.open_period import open_period_start_for_group
 from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
     DetectorSerializerResponse,
@@ -442,28 +440,15 @@ def send_incident_alert_notification(
     )
 
     # TODO(iamrajjoshi): This will need to be updated once we plan out Metric Alerts rollout
-    if should_fire_workflow_actions(organization, MetricIssue.type_id):
-        return _handle_workflow_engine_notification(
-            organization=organization,
-            notification_context=notification_context,
-            metric_issue_context=metric_issue_context,
-            integration=integration,
-            attachments=attachments,
-            text=text,
-            channel=channel,
-        )
-    else:
-        # TODO(iamrajjoshi): This needs to be deleted after ACI
-        return _handle_legacy_notification(
-            organization=organization,
-            alert_context=alert_context,
-            notification_context=notification_context,
-            metric_issue_context=metric_issue_context,
-            integration=integration,
-            attachments=attachments,
-            text=text,
-            channel=channel,
-        )
+    return _handle_workflow_engine_notification(
+        organization=organization,
+        notification_context=notification_context,
+        metric_issue_context=metric_issue_context,
+        integration=integration,
+        attachments=attachments,
+        text=text,
+        channel=channel,
+    )
 
 
 @dataclass(frozen=True, eq=True)

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -359,49 +359,6 @@ def _handle_workflow_engine_notification(
     )
 
 
-def _handle_legacy_notification(
-    organization: Organization,
-    alert_context: AlertContext,
-    notification_context: NotificationContext,
-    metric_issue_context: MetricIssueContext,
-    integration: RpcIntegration,
-    attachments: str,
-    text: str,
-    channel: str,
-) -> bool:
-    repository = get_default_metric_alert_repository()
-    parent_notification_message = _fetch_parent_notification_message_for_incident(
-        organization=organization,
-        alert_context=alert_context,
-        notification_context=notification_context,
-        metric_issue_context=metric_issue_context,
-        repository=repository,
-    )
-
-    new_notification_message_object = _build_new_metric_alert_notification_message_payload(
-        notification_context=notification_context,
-        metric_issue_context=metric_issue_context,
-        parent_notification_message=parent_notification_message,
-    )
-
-    reply_broadcast, thread_ts = _get_thread_config(
-        parent_notification_message, metric_issue_context.new_status
-    )
-
-    return _send_notification(
-        integration=integration,
-        metric_issue_context=metric_issue_context,
-        attachments=attachments,
-        text=text,
-        channel=channel,
-        thread_ts=thread_ts,
-        reply_broadcast=reply_broadcast,
-        notification_message_object=new_notification_message_object,
-        save_notification_method=_save_notification_message_metric_alert,
-        repository=repository,
-    )
-
-
 def send_incident_alert_notification(
     organization: Organization,
     alert_context: AlertContext,

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -27,16 +27,8 @@ from sentry.integrations.messaging.metrics import (
     MessagingInteractionType,
 )
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.repository import (
-    get_default_metric_alert_repository,
-    get_default_notification_action_repository,
-)
+from sentry.integrations.repository import get_default_notification_action_repository
 from sentry.integrations.repository.base import BaseNewNotificationMessage
-from sentry.integrations.repository.metric_alert import (
-    MetricAlertNotificationMessage,
-    MetricAlertNotificationMessageRepository,
-    NewMetricAlertNotificationMessage,
-)
 from sentry.integrations.repository.notification_action import (
     NewNotificationActionNotificationMessage,
     NotificationActionNotificationMessage,
@@ -50,7 +42,6 @@ from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.utils.threads import NotificationActionThreadUtils
 from sentry.models.group import Group
-from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.notifications.utils.open_period import open_period_start_for_group
 from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
@@ -62,9 +53,7 @@ _logger = logging.getLogger(__name__)
 
 
 def _get_thread_config(
-    parent_notification_message: (
-        NotificationActionNotificationMessage | MetricAlertNotificationMessage | None
-    ),
+    parent_notification_message: (NotificationActionNotificationMessage | None),
     incident_status: IncidentStatus,
 ) -> tuple[bool, str | None]:
     if parent_notification_message is None:
@@ -76,40 +65,6 @@ def _get_thread_config(
         reply_broadcast = True
 
     return reply_broadcast, parent_notification_message.message_identifier
-
-
-def _fetch_parent_notification_message_for_incident(
-    organization: Organization,
-    alert_context: AlertContext,
-    notification_context: NotificationContext,
-    metric_issue_context: MetricIssueContext,
-    repository: MetricAlertNotificationMessageRepository,
-) -> MetricAlertNotificationMessage | None:
-    parent_notification_message = None
-
-    with MessagingInteractionEvent(
-        interaction_type=MessagingInteractionType.GET_PARENT_NOTIFICATION,
-        spec=SlackMessagingSpec(),
-    ).capture() as lifecycle:
-        # Only grab the parent notification message for thread use if the feature is on
-        # Otherwise, leave it empty, and it will not create a thread
-        if OrganizationOption.objects.get_value(
-            organization=organization,
-            key="sentry:metric_alerts_thread_flag",
-            default=METRIC_ALERTS_THREAD_DEFAULT,
-        ):
-            try:
-                parent_notification_message = repository.get_parent_notification_message(
-                    alert_rule_id=alert_context.action_identifier_id,
-                    incident_id=metric_issue_context.id,
-                    trigger_action_id=notification_context.id,
-                )
-            except Exception as e:
-                lifecycle.record_halt(e)
-                # if there's an error trying to grab a parent notification, don't let that error block this flow
-                pass
-
-    return parent_notification_message
 
 
 def _fetch_parent_notification_message_for_notification_action(
@@ -158,25 +113,6 @@ def _build_new_notification_message_payload(
         action_id=notification_context.id,
         group_id=metric_issue_context.id,
         open_period_start=open_period_start,
-    )
-
-    if parent_notification_message is not None:
-        # Make sure we track that this reply will be in relation to the parent row
-        new_notification_message_object.parent_notification_message_id = (
-            parent_notification_message.id
-        )
-
-    return new_notification_message_object
-
-
-def _build_new_metric_alert_notification_message_payload(
-    notification_context: NotificationContext,
-    metric_issue_context: MetricIssueContext,
-    parent_notification_message: MetricAlertNotificationMessage | None,
-) -> NewMetricAlertNotificationMessage:
-    new_notification_message_object = NewMetricAlertNotificationMessage(
-        incident_id=metric_issue_context.id,
-        trigger_action_id=notification_context.id,
     )
 
     if parent_notification_message is not None:
@@ -290,17 +226,6 @@ def _send_notification[Msg: BaseNewNotificationMessage, Repo](
 
     save_notification_method(notification_message_object, repository)
     return True
-
-
-def _save_notification_message_metric_alert(
-    notification_message_object: NewMetricAlertNotificationMessage,
-    repository: MetricAlertNotificationMessageRepository,
-) -> None:
-    try:
-        repository = get_default_metric_alert_repository()
-        repository.create_notification_message(data=notification_message_object)
-    except Exception:
-        pass
 
 
 def _save_notification_message_notification_action(

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -320,8 +320,6 @@ def send_incident_alert_notification(
         notification_uuid=notification_uuid,
         detector_serialized_response=detector_serialized_response,
     )
-
-    # TODO(iamrajjoshi): This will need to be updated once we plan out Metric Alerts rollout
     return _handle_workflow_engine_notification(
         organization=organization,
         notification_context=notification_context,

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -133,17 +133,14 @@ def update_group(
 def get_rule(
     slack_request: SlackActionRequest, organization: Organization, group_type: int
 ) -> Rule | None:
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-
     """Get the rule that fired"""
     rule_id = slack_request.callback_data.get("rule")
     if not rule_id:
         return None
     try:
         rule = Rule.objects.get(id=rule_id)
-        if should_fire_workflow_actions(organization, group_type):
-            # We need to add the legacy_rule_id field to the rule data since the message builder will use it to build the link to the rule
-            rule.data["actions"][0]["legacy_rule_id"] = rule.id
+        # We need to add the legacy_rule_id field to the rule data since the message builder will use it to build the link to the rule
+        rule.data["actions"][0]["legacy_rule_id"] = rule.id
     except Rule.DoesNotExist:
         return None
     return rule

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -51,7 +51,6 @@ from sentry.integrations.utils.scope import bind_org_context_from_integration
 from sentry.locks import locks
 from sentry.models.activity import ActivityIntegration
 from sentry.models.group import Group
-from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.rule import Rule
 from sentry.notifications.services import notifications_service
@@ -130,9 +129,7 @@ def update_group(
     return resp
 
 
-def get_rule(
-    slack_request: SlackActionRequest, organization: Organization, group_type: int
-) -> Rule | None:
+def get_rule(slack_request: SlackActionRequest) -> Rule | None:
     """Get the rule that fired"""
     rule_id = slack_request.callback_data.get("rule")
     if not rule_id:
@@ -359,7 +356,7 @@ class SlackActionEndpoint(Endpoint):
         if not group:
             return self.respond(status=403)
 
-        rule = get_rule(slack_request, group.organization, group.type)
+        rule = get_rule(slack_request)
         identity = slack_request.get_identity()
         # Determine the acting user by Slack identity.
         identity_user = slack_request.get_identity_user()

--- a/src/sentry/notifications/models/notificationmessage.py
+++ b/src/sentry/notifications/models/notificationmessage.py
@@ -44,7 +44,7 @@ class NotificationMessage(Model):
     # Reference to another notification if we choose to modify the original message or reply to it (like start a thread)
     parent_notification_message = FlexibleForeignKey("self", null=True)
 
-    # Related information regarding Alert Rules (Metric Alerts) # this has data
+    # Related information regarding Alert Rules (Metric Alerts)
     incident = FlexibleForeignKey("sentry.Incident", null=True)
     trigger_action = FlexibleForeignKey("sentry.AlertRuleTriggerAction", null=True)
 

--- a/src/sentry/notifications/models/notificationmessage.py
+++ b/src/sentry/notifications/models/notificationmessage.py
@@ -48,7 +48,7 @@ class NotificationMessage(Model):
     incident = FlexibleForeignKey("sentry.Incident", null=True)
     trigger_action = FlexibleForeignKey("sentry.AlertRuleTriggerAction", null=True)
 
-    # Related information regarding Rules (Issue Alerts) # this is all empty in redash
+    # Related information regarding Rules (Issue Alerts)
     rule_fire_history = FlexibleForeignKey("sentry.RuleFireHistory", null=True)
     rule_action_uuid = CharField(null=True, db_index=True)
 

--- a/src/sentry/notifications/models/notificationmessage.py
+++ b/src/sentry/notifications/models/notificationmessage.py
@@ -44,11 +44,11 @@ class NotificationMessage(Model):
     # Reference to another notification if we choose to modify the original message or reply to it (like start a thread)
     parent_notification_message = FlexibleForeignKey("self", null=True)
 
-    # Related information regarding Alert Rules (Metric Alerts)
+    # Related information regarding Alert Rules (Metric Alerts) # this has data
     incident = FlexibleForeignKey("sentry.Incident", null=True)
     trigger_action = FlexibleForeignKey("sentry.AlertRuleTriggerAction", null=True)
 
-    # Related information regarding Rules (Issue Alerts)
+    # Related information regarding Rules (Issue Alerts) # this is all empty in redash
     rule_fire_history = FlexibleForeignKey("sentry.RuleFireHistory", null=True)
     rule_action_uuid = CharField(null=True, db_index=True)
 

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -2,7 +2,6 @@ import logging
 
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.activity import Activity
-from sentry.models.organization import Organization
 from sentry.notifications.notification_action.registry import (
     group_type_notification_registry,
     issue_alert_handler_registry,
@@ -17,10 +16,6 @@ from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.types import ActionInvocation
 
 logger = logging.getLogger(__name__)
-
-
-def should_fire_workflow_actions(org: Organization, type_id: int) -> bool:
-    return True
 
 
 def execute_via_group_type_registry(invocation: ActionInvocation) -> None:

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -109,8 +109,6 @@ def build_description(
 
 
 def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-
     """Create an issue for a given event"""
     organization = event.group.project.organization
 
@@ -122,11 +120,9 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
         generate_footer = future.kwargs.get("generate_footer")
 
         # If we invoked this handler from the notification action, we need to replace the rule_id with the legacy_rule_id, so we link notifications correctly
-        action_id = None
-        if should_fire_workflow_actions(organization, event.group.type):
-            # In the Notification Action, we store the rule_id in the action_id field
-            action_id = rule_id
-            rule_id = data.get("legacy_rule_id")
+        # In the Notification Action, we store the rule_id in the action_id field
+        action_id = rule_id
+        rule_id = data.get("legacy_rule_id")
 
         integration = integration_service.get_integration(
             integration_id=integration_id,

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -108,7 +108,6 @@ def trigger_action(
 ) -> None:
     import uuid
 
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
     from sentry.workflow_engine.processors.detector import get_preferred_detector
 
     # Generate UUID if not provided (handles version skew at task boundary)
@@ -153,21 +152,7 @@ def trigger_action(
         tags={"action_type": action.type, "detector_type": detector.type},
         sample_rate=1.0,
     )
-
-    should_trigger_actions = should_fire_workflow_actions(
-        detector.project.organization, event_data.group.type
-    )
-
-    if should_trigger_actions:
-        # Set up a timeout grouping context because we want to make sure any Sentry timeout reporting
-        # in this scope is grouped properly.
-        with timeout_grouping_context(action.type):
-            action.trigger(event_data, notification_uuid=notification_uuid, workflow_id=workflow_id)
-    else:
-        logger.info(
-            "workflow_engine.triggered_actions.dry-run",
-            extra={
-                "action_ids": [action_id],
-                "event_data": asdict(event_data),
-            },
-        )
+    # Set up a timeout grouping context because we want to make sure any Sentry timeout reporting
+    # in this scope is grouped properly.
+    with timeout_grouping_context(action.type):
+        action.trigger(event_data, notification_uuid=notification_uuid)

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -1,5 +1,3 @@
-from dataclasses import asdict
-
 from taskbroker_client.retry import Retry
 from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
@@ -155,4 +153,4 @@ def trigger_action(
     # Set up a timeout grouping context because we want to make sure any Sentry timeout reporting
     # in this scope is grouped properly.
     with timeout_grouping_context(action.type):
-        action.trigger(event_data, notification_uuid=notification_uuid)
+        action.trigger(event_data, notification_uuid=notification_uuid, workflow_id=workflow_id)


### PR DESCRIPTION
`should_fire_workflow_actions` has been set to True for over 3 months so we can safely remove it and all the else blocks for when it's not set to true.