### PR TITLE
feat(cmdk): Default to keepPreviousData in cmdkQueryOptions

### DIFF
--- a/static/app/components/commandPalette/types.tsx
+++ b/static/app/components/commandPalette/types.tsx
@@ -1,5 +1,5 @@
 import type {ReactNode} from 'react';
-import {type UseQueryOptions} from '@tanstack/react-query';
+import {keepPreviousData, type UseQueryOptions} from '@tanstack/react-query';
 import type {LocationDescriptor} from 'history';
 
 interface Action {
@@ -34,7 +34,7 @@ export type CMDKQueryOptions<TData = unknown> = BaseCMDKQueryOptions<TData> & {
 export function cmdkQueryOptions<TData = unknown>(
   options: BaseCMDKQueryOptions<TData>
 ): CMDKQueryOptions<TData> {
-  return {...options, meta: {cmdk: true}};
+  return {placeholderData: keepPreviousData, ...options, meta: {cmdk: true}};
 }
 
 interface CommandPaletteActionLink extends Action {


### PR DESCRIPTION
Sets `placeholderData: keepPreviousData` as the default in `cmdkQueryOptions`, so command palette queries retain their previous results while refetching. This prevents the result list from flickering to empty when the query key changes (e.g. as the user types a search).

The default is applied first in the spread, so any caller can override it by passing their own `placeholderData`.