### PR TITLE
ref(slack): Update chart unfurl link-identity prompt copy

### DIFF
--- a/src/sentry/integrations/slack/message_builder/prompt.py
+++ b/src/sentry/integrations/slack/message_builder/prompt.py
@@ -4,7 +4,7 @@ from sentry.integrations.slack.message_builder.types import SlackBody
 
 from .base.block import BlockSlackMessageBuilder
 
-LINK_IDENTITY_MESSAGE = "Link your Slack identity to Sentry to unfurl charts."
+LINK_IDENTITY_MESSAGE = "Link with Slack to preview charts"
 
 
 class SlackPromptLinkMessageBuilder(BlockSlackMessageBuilder):

--- a/src/sentry/integrations/slack/message_builder/prompt.py
+++ b/src/sentry/integrations/slack/message_builder/prompt.py
@@ -4,7 +4,7 @@ from sentry.integrations.slack.message_builder.types import SlackBody
 
 from .base.block import BlockSlackMessageBuilder
 
-LINK_IDENTITY_MESSAGE = "Link with Slack to preview charts"
+LINK_IDENTITY_MESSAGE = "Link with Slack to preview charts."
 
 
 class SlackPromptLinkMessageBuilder(BlockSlackMessageBuilder):

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -128,7 +128,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
         payload = {
             "channel": slack_request.channel_id,
             "user": slack_request.user_id,
-            "text": "Link your Slack identity to Sentry to unfurl charts.",
+            "text": "Link with Slack to preview charts.",
             **SlackPromptLinkMessageBuilder(associate_url).as_payload(),
         }
 

--- a/tests/sentry/integrations/slack/webhooks/events/test_discover_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_discover_link_shared.py
@@ -158,7 +158,7 @@ class DiscoverLinkSharedEvent(BaseEventTest):
         blocks = orjson.loads(data["blocks"])
 
         assert blocks[0]["type"] == "section"
-        assert blocks[0]["text"]["text"] == "Link your Slack identity to Sentry to unfurl charts."
+        assert blocks[0]["text"]["text"] == "Link with Slack to preview charts."
 
         assert blocks[1]["type"] == "actions"
         assert len(blocks[1]["elements"]) == 2

--- a/tests/sentry/integrations/slack/webhooks/events/test_explore_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_explore_link_shared.py
@@ -98,7 +98,7 @@ class ExploreLinkSharedEvent(BaseEventTest):
         blocks = orjson.loads(data["blocks"])
 
         assert blocks[0]["type"] == "section"
-        assert blocks[0]["text"]["text"] == "Link your Slack identity to Sentry to unfurl charts."
+        assert blocks[0]["text"]["text"] == "Link with Slack to preview charts."
 
         assert blocks[1]["type"] == "actions"
         assert len(blocks[1]["elements"]) == 2


### PR DESCRIPTION
Reword slack identity link message to mention preview instead of unfurl. The term preview is more intuitive and clear