### PR TITLE
feat(onboarding): Add platformProductInfo.generated.ts for SCM info-only platforms

### DIFF
--- a/static/app/data/platformProductInfo.generated.ts
+++ b/static/app/data/platformProductInfo.generated.ts
@@ -1,0 +1,87 @@
+// DO NOT EDIT — regenerate via `pnpm gen:platform-info`.
+//
+// Generated from sentry-docs frontmatter (`docs/platforms/<lang>/[common/]<feature>/index.mdx`).
+// Drives the informational card variant on the SCM onboarding step for
+// platforms whose onboarding is wizard-driven (i.e. the install step calls
+// out to the `@sentry/wizard` CLI), since toggles aren't actionable in that
+// flow but communicating which products apply still is.
+//
+// Scope filters applied during generation:
+//   1. Platforms curated in `platformProductAvailability` are excluded — the
+//      curated map is the source of truth for their toggles, and the consumer
+//      (`scmPlatformFeatures.tsx`) routes between the two via
+//      `platform in platformProductAvailability`.
+//   2. Platforms whose `gettingStartedDocs/<id>/` files don't reference the
+//      wizard CLI are excluded — without a wizard AND without curated
+//      toggles, the consumer renders nothing on the SCM step.
+//
+// To extend scope, drop the corresponding filter in
+// `scripts/genPlatformProductInfo.ts`.
+
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {PlatformKey} from 'sentry/types/project';
+
+export const PLATFORM_PRODUCT_INFO: Partial<
+  Record<PlatformKey, readonly ProductSolution[]>
+> = {
+  android: [
+    ProductSolution.LOGS,
+    ProductSolution.SESSION_REPLAY,
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+  ],
+  'apple-ios': [
+    ProductSolution.LOGS,
+    ProductSolution.SESSION_REPLAY,
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+  ],
+  flutter: [
+    ProductSolution.LOGS,
+    ProductSolution.SESSION_REPLAY,
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+  ],
+  'javascript-nextjs': [
+    ProductSolution.LOGS,
+    ProductSolution.SESSION_REPLAY,
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+    ProductSolution.METRICS,
+  ],
+  'javascript-nuxt': [
+    ProductSolution.LOGS,
+    ProductSolution.SESSION_REPLAY,
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+    ProductSolution.METRICS,
+  ],
+  'javascript-react-router': [
+    ProductSolution.LOGS,
+    ProductSolution.SESSION_REPLAY,
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+    ProductSolution.METRICS,
+  ],
+  'javascript-remix': [
+    ProductSolution.LOGS,
+    ProductSolution.SESSION_REPLAY,
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+    ProductSolution.METRICS,
+  ],
+  'javascript-sveltekit': [
+    ProductSolution.LOGS,
+    ProductSolution.SESSION_REPLAY,
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+    ProductSolution.METRICS,
+  ],
+  'react-native': [
+    ProductSolution.LOGS,
+    ProductSolution.SESSION_REPLAY,
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+    ProductSolution.METRICS,
+  ],
+};

--- a/static/app/data/platformProductInfo.generated.ts
+++ b/static/app/data/platformProductInfo.generated.ts
@@ -29,18 +29,21 @@ export const PLATFORM_PRODUCT_INFO: Partial<
     ProductSolution.SESSION_REPLAY,
     ProductSolution.PERFORMANCE_MONITORING,
     ProductSolution.PROFILING,
+    ProductSolution.METRICS,
   ],
   'apple-ios': [
     ProductSolution.LOGS,
     ProductSolution.SESSION_REPLAY,
     ProductSolution.PERFORMANCE_MONITORING,
     ProductSolution.PROFILING,
+    ProductSolution.METRICS,
   ],
   flutter: [
     ProductSolution.LOGS,
     ProductSolution.SESSION_REPLAY,
     ProductSolution.PERFORMANCE_MONITORING,
     ProductSolution.PROFILING,
+    ProductSolution.METRICS,
   ],
   'javascript-nextjs': [
     ProductSolution.LOGS,

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -1,0 +1,132 @@
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {DisabledProducts} from 'sentry/components/onboarding/productSelection';
+import {Placeholder} from 'sentry/components/placeholder';
+import {t, tct} from 'sentry/locale';
+
+import type {FeatureMeta} from './useScmFeatureMeta';
+
+interface ScmFeatureInfoCardsProps {
+  availableFeatures: ProductSolution[];
+  disabledProducts: DisabledProducts;
+  featureMeta: Record<ProductSolution, FeatureMeta>;
+  isVolumeLoading?: boolean;
+  platformName?: string;
+}
+
+// Informational variant of the SCM feature card list. Renders the products
+// applicable to the user-selected platform without offering toggles, used for
+// platforms whose onboarding is wizard-driven (the wizard CLI handles
+// configuration; toggles aren't actionable). Visual treatment is a placeholder;
+// designer iterates on this separately.
+export function ScmFeatureInfoCards({
+  availableFeatures,
+  disabledProducts,
+  featureMeta,
+  platformName,
+  isVolumeLoading,
+}: ScmFeatureInfoCardsProps) {
+  return (
+    <Stack gap="xl" width="100%" justify="center">
+      <Stack gap="md">
+        {platformName ? (
+          <Heading as="h3" size="xl">
+            {tct('Available with [platformName]', {
+              platformName: (
+                <Text as="span" bold variant="accent">
+                  {platformName}
+                </Text>
+              ),
+            })}
+          </Heading>
+        ) : null}
+        <Text size="lg" variant="secondary" density="comfortable">
+          {t('In the next step, run our setup wizard to choose what to instrument')}
+        </Text>
+      </Stack>
+      <Grid
+        gap="2xl"
+        columns={{xs: '1fr', sm: '1fr 1fr'}}
+        border="secondary"
+        radius="lg"
+        padding="2xl"
+      >
+        {availableFeatures.map(feature => {
+          const meta = featureMeta[feature];
+          const Icon = meta.icon;
+          const disabledProduct = disabledProducts[feature];
+          const isDisabled = !meta.alwaysEnabled && !!disabledProduct;
+          return (
+            <Tooltip
+              key={feature}
+              title={disabledProduct?.reason}
+              disabled={!isDisabled}
+              delay={100}
+            >
+              <Grid
+                columns="min-content 1fr"
+                rows="min-content min-content"
+                gap={{xs: 'xs md', sm: 'xs lg'}}
+                align="center"
+                areas={`
+                    "icon label"
+                    ". description"
+                  `}
+              >
+                <Container area="icon">
+                  {containerProps => (
+                    <Icon
+                      {...containerProps}
+                      size="md"
+                      variant={isDisabled ? 'muted' : undefined}
+                    />
+                  )}
+                </Container>
+                <Flex area="label" gap="sm" align="center">
+                  <Text bold size="md" variant={isDisabled ? 'muted' : undefined}>
+                    {meta.label}
+                  </Text>
+                  {meta.alwaysEnabled ? (
+                    <Tag variant="muted">{t('Always on')}</Tag>
+                  ) : null}
+                </Flex>
+                <Stack gap="md" area="description">
+                  <Text
+                    variant={isDisabled ? 'muted' : 'secondary'}
+                    density="comfortable"
+                  >
+                    {meta.description}
+                  </Text>
+                  <Container>
+                    {isVolumeLoading ? (
+                      <Placeholder height="20px" width="100px" />
+                    ) : (
+                      <Tooltip
+                        title={meta.volumeTooltip}
+                        delay={100}
+                        disabled={isDisabled}
+                      >
+                        <Text
+                          variant="muted"
+                          underline="dotted"
+                          size="sm"
+                          density="comfortable"
+                        >
+                          {meta.volume}
+                        </Text>
+                      </Tooltip>
+                    )}
+                  </Container>
+                </Stack>
+              </Grid>
+            </Tooltip>
+          );
+        })}
+      </Grid>
+    </Stack>
+  );
+}

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -31,9 +31,11 @@ export function ScmFeatureSelectionCards({
         <Heading as="h3" size="xl">
           {t('What do you want to instrument?')}
         </Heading>
-        <Text size="sm" variant="secondary">
-          {t('Choose one or more')}
-        </Text>
+        {availableFeatures.length > 1 ? (
+          <Text size="sm" variant="secondary">
+            {t('Choose one or more')}
+          </Text>
+        ) : null}
       </Flex>
       <Stack gap="md">
         {availableFeatures.map(feature => {

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -4,7 +4,13 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 import {TeamFixture} from 'sentry-fixture/team';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import {openConsoleModal, openModal} from 'sentry/actionCreators/modal';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -113,8 +119,9 @@ describe('ScmPlatformFeatures', () => {
       }
     );
 
-    expect(await screen.findByText('Next.js')).toBeInTheDocument();
-    expect(screen.getByText('Django')).toBeInTheDocument();
+    const radioGroup = await screen.findByRole('radiogroup');
+    expect(within(radioGroup).getByText('Next.js')).toBeInTheDocument();
+    expect(within(radioGroup).getByText('Django')).toBeInTheDocument();
   });
 
   it('auto-selects first detected platform', async () => {
@@ -147,8 +154,112 @@ describe('ScmPlatformFeatures', () => {
     );
 
     expect(
-      await screen.findByText('What do you want to instrument?')
+      await screen.findByRole('heading', {level: 3, name: 'Available with Next.js'})
     ).toBeInTheDocument();
+  });
+
+  describe('feature card variants', () => {
+    it('renders informational cards for wizard-driven platforms (no toggles)', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {platforms: [DetectedPlatformFixture()]},
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+          }),
+        }
+      );
+
+      expect(
+        await screen.findByRole('heading', {level: 3, name: 'Available with Next.js'})
+      ).toBeInTheDocument();
+      expect(screen.getByText('Error monitoring')).toBeInTheDocument();
+      expect(screen.getByText('Tracing')).toBeInTheDocument();
+      expect(screen.getByText('Session replay')).toBeInTheDocument();
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('What do you want to instrument?')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders toggleable cards for curated platforms', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {
+          platforms: [DetectedPlatformFixture({platform: 'python', language: 'Python'})],
+        },
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+          }),
+        }
+      );
+
+      expect(
+        await screen.findByText('What do you want to instrument?')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', {name: /Tracing/})).toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', {level: 3, name: /^Available with /})
+      ).not.toBeInTheDocument();
+    });
+
+    it('skips the feature-cards block for platforms in neither map', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {platforms: []},
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+            selectedPlatform: {
+              key: 'nintendo-switch',
+              name: 'Nintendo Switch',
+              language: 'nintendo-switch',
+              type: 'console',
+              link: null,
+              category: 'all',
+            },
+          }),
+        }
+      );
+
+      await screen.findByRole('button', {name: 'Continue'});
+
+      expect(
+        screen.queryByRole('heading', {level: 3, name: /^Available with /})
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('What do you want to instrument?')
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/unlimited volume for 14 days/)).not.toBeInTheDocument();
+    });
   });
 
   it('clicking "Change platform" shows manual picker', async () => {
@@ -569,7 +680,7 @@ describe('ScmPlatformFeatures', () => {
         }
       );
 
-      await screen.findByText('What do you want to instrument?');
+      await screen.findByRole('heading', {level: 3, name: 'Available with Next.js'});
 
       const detectedCalls = trackAnalyticsSpy.mock.calls.filter(
         ([event, params]) =>

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -4,7 +4,7 @@ import {LayoutGroup, motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -19,6 +19,7 @@ import {
   platformProductAvailability,
 } from 'sentry/components/onboarding/productSelection';
 import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
+import {PLATFORM_PRODUCT_INFO} from 'sentry/data/platformProductInfo.generated';
 import {platforms} from 'sentry/data/platforms';
 import {IconBroadcast, IconBusiness, IconGeneric} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -31,6 +32,7 @@ import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
+import {ScmFeatureInfoCards} from 'sentry/views/onboarding/components/scmFeatureInfoCards';
 import {ScmFeatureSelectionCards} from 'sentry/views/onboarding/components/scmFeatureSelectionCards';
 import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCard';
 import {useScmFeatureMeta} from 'sentry/views/onboarding/components/useScmFeatureMeta';
@@ -87,6 +89,11 @@ function shouldSuggestFramework(platformKey: PlatformKey): boolean {
     info?.type === 'language' &&
     Object.values(SupportedLanguages).includes(info.language as SupportedLanguages)
   );
+}
+
+function getPlatformName(platformKey: PlatformKey | undefined) {
+  if (!platformKey) return;
+  return getPlatformInfo(platformKey)?.name;
 }
 
 export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
@@ -160,6 +167,8 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
   // Derive platform from explicit selection, falling back to first detected
   const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
 
+  const currentPlatformName = getPlatformName(currentPlatformKey);
+
   // Fire scm_platform_selected once when detection auto-resolves a platform
   // and the user hasn't explicitly chosen one. Otherwise a user who accepts
   // the recommendation and clicks Continue never emits the event, leaving
@@ -181,16 +190,35 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
     });
   }, [detectedPlatformKey, selectedPlatform?.key, organization]);
 
-  const availableFeatures = useMemo(() => {
+  // Wizard-driven platforms render an informational variant since the wizard CLI
+  // owns product configuration and toggles aren't actionable.
+  const featureMode = useMemo<'toggleable' | 'informational' | 'none'>(() => {
     if (!currentPlatformKey) {
+      return 'none';
+    }
+    if (currentPlatformKey in platformProductAvailability) {
+      return 'toggleable';
+    }
+    if (currentPlatformKey in PLATFORM_PRODUCT_INFO) {
+      return 'informational';
+    }
+    return 'none';
+  }, [currentPlatformKey]);
+
+  const availableFeatures = useMemo(() => {
+    if (!currentPlatformKey || featureMode === 'none') {
       return [];
     }
-    const features = new Set([
+    const sourceProducts =
+      featureMode === 'toggleable'
+        ? platformProductAvailability[currentPlatformKey]
+        : PLATFORM_PRODUCT_INFO[currentPlatformKey];
+    const features = new Set<ProductSolution>([
       ProductSolution.ERROR_MONITORING,
-      ...(platformProductAvailability[currentPlatformKey] ?? []),
+      ...(sourceProducts ?? []),
     ]);
     return FEATURE_DISPLAY_ORDER.filter(f => features.has(f));
-  }, [currentPlatformKey]);
+  }, [currentPlatformKey, featureMode]);
 
   const disabledProducts = useMemo(
     () => getDisabledProducts(organization),
@@ -458,14 +486,16 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
         </Heading>
         <LayoutGroup>
           <Stack gap="md" paddingTop="sm">
-            <Heading as="h3" size="xl">
+            <Heading as="h3" size="lg">
               {t('Choose your SDK')}
             </Heading>
-            <Text variant="muted" size="lg" density="comfortable">
-              {t(
-                'Each Sentry project collects data from one service or app. Select a language or framework you want to get started monitoring with our SDKs.'
-              )}
-            </Text>
+            <Container>
+              <Text variant="muted" size="md" density="comfortable">
+                {t(
+                  'Each Sentry project collects data from one service or app. Select a language or framework you want to get started monitoring with our SDKs.'
+                )}
+              </Text>
+            </Container>
           </Stack>
           {showDetectedPlatforms ? (
             <MotionStack
@@ -567,8 +597,8 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
               />
             </MotionStack>
           )}
-          <MotionStack layout="position" width="100%">
-            {availableFeatures.length > 0 && (
+          {featureMode !== 'none' && (
+            <MotionStack layout="position" width="100%">
               <Stack gap="2xl" paddingTop="xs">
                 <Flex
                   padding="lg"
@@ -591,17 +621,27 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
                     )}
                   </Text>
                 </Flex>
-                <ScmFeatureSelectionCards
-                  availableFeatures={availableFeatures}
-                  selectedFeatures={currentFeatures}
-                  disabledProducts={disabledProducts}
-                  onToggleFeature={handleToggleFeature}
-                  featureMeta={featureMeta}
-                  isVolumeLoading={isFeatureMetaLoading}
-                />
+                {featureMode === 'toggleable' ? (
+                  <ScmFeatureSelectionCards
+                    availableFeatures={availableFeatures}
+                    selectedFeatures={currentFeatures}
+                    disabledProducts={disabledProducts}
+                    onToggleFeature={handleToggleFeature}
+                    featureMeta={featureMeta}
+                    isVolumeLoading={isFeatureMetaLoading}
+                  />
+                ) : (
+                  <ScmFeatureInfoCards
+                    availableFeatures={availableFeatures}
+                    disabledProducts={disabledProducts}
+                    featureMeta={featureMeta}
+                    platformName={currentPlatformName}
+                    isVolumeLoading={isFeatureMetaLoading}
+                  />
+                )}
               </Stack>
-            )}
-          </MotionStack>
+            </MotionStack>
+          )}
           <MotionFlex
             layout="position"
             align="center"


### PR DESCRIPTION
Add the generated TS module the SCM onboarding step will consume in a follow-up PR to render informational (non-toggleable) feature cards for the 9 platforms whose onboarding is wizard-driven and aren't already curated in `platformProductAvailability`.

The map is derived from sentry-docs feature-page frontmatter (the SDK team's `notSupported`/`supported` declarations) via the codegen script in [PR 1](https://github.com/getsentry/sentry/pull/115177). Two filters apply: (1) platforms already curated in `platformProductAvailability` are excluded, and (2) only platforms whose `gettingStartedDocs/<id>/` files reference the `@sentry/wizard` CLI are included.

**SDK reviewers — what to look for**

If your SDK appears in the generated map and a feature is incorrectly listed (or missing), please flag. Specifically: if the file says a platform supports a feature its SDK doesn't (or vice versa), comment inline.

The 9 platforms in the file:
- `android`, `apple-ios`, `flutter`, `react-native` (mobile)
- `javascript-nextjs`, `javascript-nuxt`, `javascript-react-router`, `javascript-remix`, `javascript-sveltekit` (JavaScript framework wizards)

**Regen**

Run `pnpm gen:platform-info` (script lives in the parent stacked PR) against a sibling `sentry-docs` checkout.

**Stack**
- [PR 1](https://github.com/getsentry/sentry/pull/115177): Add platformProductInfo codegen script
- **PR 2 (this):** Add platformProductInfo.generated.ts for SCM info-only platforms
- [PR 3](https://github.com/getsentry/sentry/pull/115144): Render info-only feature cards for wizard-driven platforms