### PR TITLE
chore(lint-rules): Enabling warn/off rules in unicorn block with no/minimal violations

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -794,16 +794,16 @@ export default typescript.config([
 
       'unicorn/filename-case': ['off', {case: 'camelCase'}], // TODO(ryan953): Fix violations and enable this rule
       'unicorn/no-array-push-push': 'off', // TODO(ryan953): Fix violations and enable this rule
-      'unicorn/no-single-promise-in-promise-methods': 'warn', // TODO(ryan953): Fix violations and enable this rule
+      'unicorn/no-single-promise-in-promise-methods': 'error',
       'unicorn/no-static-only-class': 'off', // TODO(ryan953): Fix violations and enable this rule
       'unicorn/no-this-assignment': 'off', // TODO(ryan953): Fix violations and enable this rule
       'unicorn/no-zero-fractions': 'off', // TODO(ryan953): Fix violations and enable this rule
       'unicorn/prefer-array-flat': 'off', // TODO(ryan953): Fix violations and enable this rule
-      'unicorn/prefer-default-parameters': 'warn', // TODO(ryan953): Fix violations and enable this rule
+      'unicorn/prefer-default-parameters': 'error',
       'unicorn/prefer-logical-operator-over-ternary': 'off', // TODO(ryan953): Fix violations and enable this rule
       'unicorn/prefer-native-coercion-functions': 'off', // TODO(ryan953): Fix violations and enable this rule
       'unicorn/prefer-object-from-entries': 'off', // TODO(ryan953): Fix violations and enable this rule
-      'unicorn/prefer-prototype-methods': 'warn', // TODO(ryan953): Fix violations and enable this rule
+      'unicorn/prefer-prototype-methods': 'error',
       'unicorn/prefer-regexp-test': 'off', // TODO(ryan953): Fix violations and enable this rule
       'unicorn/throw-new-error': 'off', // TODO(ryan953): Fix violations and enable this rule
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -796,7 +796,7 @@ export default typescript.config([
       'unicorn/no-array-push-push': 'off', // TODO(ryan953): Fix violations and enable this rule
       'unicorn/no-single-promise-in-promise-methods': 'error',
       'unicorn/no-static-only-class': 'off', // TODO(ryan953): Fix violations and enable this rule
-      'unicorn/no-this-assignment': 'off', // TODO(ryan953): Fix violations and enable this rule
+      'unicorn/no-this-assignment': 'error',
       'unicorn/no-zero-fractions': 'off', // TODO(ryan953): Fix violations and enable this rule
       'unicorn/prefer-array-flat': 'off', // TODO(ryan953): Fix violations and enable this rule
       'unicorn/prefer-default-parameters': 'error',


### PR DESCRIPTION
Promotes four unicorn rules from warn/off to error. No violations existed in the codebase for any of them, so these are pure config changes.

`unicorn/no-single-promise-in-promise-methods` — Flags Promise.all/race/any/allSettled called with a single-element array, where the wrapping is unnecessary. Violations fixed: 0

`unicorn/prefer-default-parameters` — Flags manual default assignments inside a function body (x = x ?? 'default') that should be expressed as a default parameter. Violations fixed: 0

`unicorn/prefer-prototype-methods` — Flags using an empty instance to access prototype methods ([].slice.call(x)) in favor of the explicit prototype form (Array.prototype.slice.call(x)). Violations fixed: 0

`unicorn/no-this-assignment` — Flags assigning this to a local variable (const self = this), a pattern used to work around this binding issues that are better solved with arrow functions. Violations fixed: 1