### PR TITLE
fix(issues): Resolve custom tag / column name collision on issue details page

### DIFF
--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import functools
 import logging
 from typing import TYPE_CHECKING, Any
 
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import options
 from sentry.api.serializers import serialize
 from sentry.issues.grouptype import GroupCategory
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
@@ -16,6 +18,7 @@ from sentry.services import eventstore
 from sentry.services.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.occurrences_rpc import Occurrences
+from sentry.utils.snuba import get_snuba_column_name
 from sentry.utils.validators import normalize_event_id
 
 if TYPE_CHECKING:
@@ -84,6 +87,10 @@ def get_query_builder_for_group(
     else:
         orderby_list = [orderby, "id"]
 
+    column_resolver = None
+    if options.get("issues.search.use-tag-aware-condition-resolver"):
+        column_resolver = functools.partial(get_snuba_column_name, dataset=dataset)
+
     return DiscoverQueryBuilder(
         dataset=dataset,
         query=f"issue:{group.qualified_short_id} {query}",
@@ -95,6 +102,7 @@ def get_query_builder_for_group(
         offset=offset,
         config=QueryBuilderConfig(
             functions_acl=["column_hash"],
+            column_resolver=column_resolver,
         ),
     )
 

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 
 from django.contrib.auth.models import AnonymousUser
@@ -101,6 +101,7 @@ def issue_search_query_to_conditions(
 
     # the transformed conditions is generic and isn't 'dataset aware', we need to map the generic columns
     # being queried to the appropriate dataset column
+    column_resolver: Callable[[str], str]
     if options.get("issues.search.use-tag-aware-condition-resolver"):
         column_resolver = functools.partial(get_snuba_column_name, dataset=dataset)
     else:

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 from collections.abc import Sequence
 from typing import Any
@@ -12,6 +13,7 @@ from rest_framework.response import Response
 from snuba_sdk import Column, Condition, Op, Or
 from snuba_sdk.legacy import is_condition, parse_condition
 
+from sentry import options
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
@@ -51,6 +53,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.models.user import User
 from sentry.utils import metrics
+from sentry.utils.snuba import get_snuba_column_name
 
 
 def issue_search_query_to_conditions(
@@ -98,9 +101,12 @@ def issue_search_query_to_conditions(
 
     # the transformed conditions is generic and isn't 'dataset aware', we need to map the generic columns
     # being queried to the appropriate dataset column
-    resolved_legacy_conditions = (
-        resolve_conditions(legacy_conditions, resolve_column(dataset)) or []
-    )
+    if options.get("issues.search.use-tag-aware-condition-resolver"):
+        column_resolver = functools.partial(get_snuba_column_name, dataset=dataset)
+    else:
+        column_resolver = resolve_column(dataset)
+
+    resolved_legacy_conditions = resolve_conditions(legacy_conditions, column_resolver) or []
 
     # convert the legacy condition format into the SnQL condition format
     snql_conditions: list[Condition] = []

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -307,8 +307,11 @@ class BaseQueryBuilder:
         self.end = self.params.end
 
     def resolve_column_name(self, col: str) -> str:
-        # TODO: when utils/snuba.py becomes typed don't need this extra annotation
-        column_resolver: Callable[[str], str] = resolve_column(self.dataset)
+        if self.builder_config.column_resolver is not None:
+            column_resolver = self.builder_config.column_resolver
+        else:
+            # TODO: when utils/snuba.py becomes typed don't need this extra annotation
+            column_resolver: Callable[[str], str] = resolve_column(self.dataset)
         column_name = column_resolver(col)
         # If the original column was passed in as tag[X], then there won't be a conflict
         # and there's no need to prefix the tag

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -307,11 +307,12 @@ class BaseQueryBuilder:
         self.end = self.params.end
 
     def resolve_column_name(self, col: str) -> str:
-        if self.builder_config.column_resolver is not None:
-            column_resolver = self.builder_config.column_resolver
-        else:
-            # TODO: when utils/snuba.py becomes typed don't need this extra annotation
-            column_resolver: Callable[[str], str] = resolve_column(self.dataset)
+        # TODO: when utils/snuba.py becomes typed don't need this extra annotation
+        column_resolver: Callable[[str], str] = (
+            self.builder_config.column_resolver
+            if self.builder_config.column_resolver is not None
+            else resolve_column(self.dataset)
+        )
         column_name = column_resolver(col)
         # If the original column was passed in as tag[X], then there won't be a conflict
         # and there's no need to prefix the tag

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -260,6 +260,7 @@ class QueryBuilderConfig:
     allow_metric_aggregates: bool | None = False
     # Allow the errors query builder to use the entity prefix for fields
     use_entity_prefix_for_fields: bool = False
+    column_resolver: Callable[[str], str] | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/sentry/issues/endpoints/test_group_event_details.py
+++ b/tests/sentry/issues/endpoints/test_group_event_details.py
@@ -555,3 +555,43 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert response.data["id"] == str(occurrence.event_id)
         assert response.data["previousEventID"] is None
         assert response.data["nextEventID"] is None
+
+    def _store_platform_tag_collision_events(self) -> Any:
+        events = []
+        for i, ts in enumerate(
+            [before_now(seconds=10), before_now(seconds=8), before_now(seconds=6)]
+        ):
+            event = self.store_event(
+                data={
+                    "event_id": f"{i + 1}" * 32,
+                    "timestamp": ts.isoformat(),
+                    "fingerprint": ["platform-collision-group"],
+                    "tags": {"platform": "SJ1"},
+                },
+                project_id=self.project_1.id,
+            )
+            events.append(event)
+        return event.group, events
+
+    def test_platform_tag_collision_without_option(self) -> None:
+        group, _events = self._store_platform_tag_collision_events()
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/recommended/"
+        response = self.client.get(url, {"query": "platform:SJ1"}, format="json")
+        assert response.status_code == 404
+
+    def test_platform_tag_collision_with_option(self) -> None:
+        group, events = self._store_platform_tag_collision_events()
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/recommended/"
+        with self.options({"issues.search.use-tag-aware-condition-resolver": True}):
+            response = self.client.get(url, {"query": "platform:SJ1"}, format="json")
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == events[-1].event_id
+
+    def test_explicit_tag_query_works_regardless_of_option(self) -> None:
+        group, events = self._store_platform_tag_collision_events()
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/recommended/"
+        for option_value in (False, True):
+            with self.options({"issues.search.use-tag-aware-condition-resolver": option_value}):
+                response = self.client.get(url, {"query": "tags[platform]:SJ1"}, format="json")
+            assert response.status_code == 200, response.content
+            assert response.data["id"] == events[-1].event_id

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -7,7 +7,9 @@ from urllib3.connectionpool import ConnectionPool
 from urllib3.exceptions import ReadTimeoutError
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
+from sentry.models.group import Group
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, freeze_time
@@ -614,7 +616,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         response = self.do_request(url)
         assert response.status_code == 504
 
-    def _store_platform_tag_collision_events(self) -> tuple:
+    def _store_platform_tag_collision_events(self) -> tuple[Group, list[Event]]:
         events = []
         for i, ts in enumerate(
             [before_now(seconds=10), before_now(seconds=8), before_now(seconds=6)]

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -613,3 +613,47 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/"
         response = self.do_request(url)
         assert response.status_code == 504
+
+    def _store_platform_tag_collision_events(self) -> tuple:
+        events = []
+        for i, ts in enumerate(
+            [before_now(seconds=10), before_now(seconds=8), before_now(seconds=6)]
+        ):
+            event = self.store_event(
+                data={
+                    "event_id": f"{i + 1}" * 32,
+                    "timestamp": ts.isoformat(),
+                    "fingerprint": ["platform-collision-group"],
+                    "tags": {"platform": "SJ1"},
+                },
+                project_id=self.project.id,
+            )
+            events.append(event)
+        return event.group, events
+
+    def test_platform_tag_collision_without_option(self) -> None:
+        self.login_as(user=self.user)
+        group, _events = self._store_platform_tag_collision_events()
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/?query=platform:SJ1"
+        response = self.do_request(url)
+        assert response.status_code == 200
+        assert len(response.data) == 0
+
+    def test_platform_tag_collision_with_option(self) -> None:
+        self.login_as(user=self.user)
+        group, _events = self._store_platform_tag_collision_events()
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/?query=platform:SJ1"
+        with self.options({"issues.search.use-tag-aware-condition-resolver": True}):
+            response = self.do_request(url)
+        assert response.status_code == 200
+        assert len(response.data) == 3
+
+    def test_explicit_tag_query_works_regardless_of_option(self) -> None:
+        self.login_as(user=self.user)
+        group, _events = self._store_platform_tag_collision_events()
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/?query=tags[platform]:SJ1"
+        for option_value in (False, True):
+            with self.options({"issues.search.use-tag-aware-condition-resolver": option_value}):
+                response = self.do_request(url)
+            assert response.status_code == 200
+            assert len(response.data) == 3


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/114245.

Extends the column name collision fix from the above PR (issue feed search result badges) to the issue details page.

When a custom tag name collides with a Snuba column name (e.g. custom tag `platform` vs. SDK `platform` column), `resolve_column` incorrectly resolves bare `platform` in a search query to the SDK column instead of `tags[platform]`. This caused the Events tab and event navigation (latest/oldest/recommended) to return 0 results when filtering by the colliding tag.

Adds an optional `column_resolver` to `QueryBuilderConfig` so callers can inject `get_snuba_column_name` (which correctly falls back to `tags[name]`) without subclassing the query builder. Applies the fix to `get_query_builder_for_group` (Events tab + Attachments) and `issue_search_query_to_conditions` (event details next/prev navigation), gated behind the same `issues.search.use-tag-aware-condition-resolver` option as the original PR.

[Slack thread for context](https://sentry.slack.com/archives/C04KZQBNQ2U/p1777371987714729)