### PR TITLE
ref(seer): Skip events without stacktraces in lightweight RCA clustering

### DIFF
--- a/src/sentry/seer/supergroups/lightweight_rca_cluster.py
+++ b/src/sentry/seer/supergroups/lightweight_rca_cluster.py
@@ -11,6 +11,8 @@ from sentry.seer.signed_seer_api import (
     SeerViewerContext,
     make_lightweight_rca_cluster_request,
 )
+from sentry.utils import metrics
+from sentry.utils.event import has_stacktrace
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,14 @@ def trigger_lightweight_rca_cluster(group: Group) -> None:
             "lightweight_rca_cluster.event_not_ready",
             extra={"group_id": group.id, "event_id": event.event_id},
         )
+        return
+
+    if not has_stacktrace(ready_event.data):
+        logger.info(
+            "lightweight_rca_cluster.no_stacktrace",
+            extra={"group_id": group.id, "event_id": ready_event.event_id},
+        )
+        metrics.incr("sentry.lightweight_rca_cluster.skipped", tags={"reason": "no_stacktrace"})
         return
 
     serialized_event = serialize(ready_event, None, EventSerializer())

--- a/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
+++ b/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
@@ -23,6 +23,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.types.group import UNRESOLVED_SUBSTATUS_CHOICES
 from sentry.utils import metrics
+from sentry.utils.event import has_stacktrace
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.snuba import SnubaError, bulk_snuba_queries
 
@@ -316,26 +317,32 @@ def _batch_fetch_events(groups: Sequence[Group], organization_id: int) -> list[t
     # Batch fetch all event data from nodestore in one multi-get
     eventstore.bind_nodes(events)
 
-    # Drop events with empty data and security-report event types (CSP/HPKP/
-    # Expect-CT/Expect-Staple/NEL) — they all roll up under ErrorGroupType but
+    # Drop events with empty data, security-report event types (CSP/HPKP/
+    # Expect-CT/Expect-Staple/NEL), and events without stacktraces — they
     # don't carry the application-code signal that RCA clustering needs.
     valid_groups: list[Group] = []
     valid_events: list[Event] = []
-    skipped_security_reports = 0
     for group, event in zip(matched_groups, events):
         if not event.data:
+            metrics.incr(
+                "seer.supergroups_backfill_lightweight.event_skipped",
+                tags={"reason": "no_data"},
+            )
             continue
         if event.get_event_type() in SECURITY_REPORT_INTERFACES:
-            skipped_security_reports += 1
+            metrics.incr(
+                "seer.supergroups_backfill_lightweight.event_skipped",
+                tags={"reason": "security_report"},
+            )
+            continue
+        if not has_stacktrace(event.data):
+            metrics.incr(
+                "seer.supergroups_backfill_lightweight.event_skipped",
+                tags={"reason": "no_stacktrace"},
+            )
             continue
         valid_groups.append(group)
         valid_events.append(event)
-
-    if skipped_security_reports:
-        metrics.incr(
-            "seer.supergroups_backfill_lightweight.security_reports_skipped",
-            amount=skipped_security_reports,
-        )
 
     if not valid_events:
         return []


### PR DESCRIPTION
## Summary
- Add `has_stacktrace()` checks to both the live path (`trigger_lightweight_rca_cluster`) and the backfill path (`backfill_supergroups_lightweight`) before sending events to Seer for lightweight RCA clustering
- Events without stacktraces don't carry the application-code signal needed for meaningful RCA. Filtering on the Sentry side avoids unnecessary serialization, network calls, and LLM invocations in Seer
- Consolidate backfill skip metrics into a single `event_skipped` metric with a `reason` tag (`no_data`, `security_report`, `no_stacktrace`)

## Test plan
- [ ] Verify existing tests pass for both paths
- [ ] Confirm events with stacktraces still flow through to Seer
- [ ] Confirm message-only events (no exception/thread/stacktrace interfaces) are skipped with appropriate logging and metrics