### PR TITLE
ref(seer): Skip events without stacktraces in lightweight RCA clustering

### DIFF
--- a/src/sentry/seer/supergroups/lightweight_rca_cluster.py
+++ b/src/sentry/seer/supergroups/lightweight_rca_cluster.py
@@ -11,6 +11,8 @@ from sentry.seer.signed_seer_api import (
     SeerViewerContext,
     make_lightweight_rca_cluster_request,
 )
+from sentry.utils import metrics
+from sentry.utils.event import has_stacktrace
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,14 @@ def trigger_lightweight_rca_cluster(group: Group) -> None:
             "lightweight_rca_cluster.event_not_ready",
             extra={"group_id": group.id, "event_id": event.event_id},
         )
+        return
+
+    if not has_stacktrace(ready_event.data):
+        logger.info(
+            "lightweight_rca_cluster.no_stacktrace",
+            extra={"group_id": group.id, "event_id": ready_event.event_id},
+        )
+        metrics.incr("sentry.lightweight_rca_cluster.skipped", tags={"reason": "no_stacktrace"})
         return
 
     serialized_event = serialize(ready_event, None, EventSerializer())

--- a/src/sentry/seer/supergroups/lightweight_rca_cluster.py
+++ b/src/sentry/seer/supergroups/lightweight_rca_cluster.py
@@ -11,8 +11,11 @@ from sentry.seer.signed_seer_api import (
     SeerViewerContext,
     make_lightweight_rca_cluster_request,
 )
+from sentry.seer.similarity.utils import (
+    SEER_INELIGIBLE_EVENT_PLATFORMS,
+    event_content_has_stacktrace,
+)
 from sentry.utils import metrics
-from sentry.utils.event import has_stacktrace
 
 logger = logging.getLogger(__name__)
 
@@ -40,12 +43,30 @@ def trigger_lightweight_rca_cluster(group: Group) -> None:
         )
         return
 
-    if not has_stacktrace(ready_event.data):
+    if not event_content_has_stacktrace(ready_event):
         logger.info(
-            "lightweight_rca_cluster.no_stacktrace",
-            extra={"group_id": group.id, "event_id": ready_event.event_id},
+            "lightweight_rca_cluster.event_not_eligible",
+            extra={
+                "group_id": group.id,
+                "event_id": ready_event.event_id,
+                "reason": "no_stacktrace",
+            },
         )
-        metrics.incr("sentry.lightweight_rca_cluster.skipped", tags={"reason": "no_stacktrace"})
+        metrics.incr("seer.lightweight_rca_cluster.skipped", tags={"reason": "no_stacktrace"})
+        return
+
+    if ready_event.platform in SEER_INELIGIBLE_EVENT_PLATFORMS:
+        logger.info(
+            "lightweight_rca_cluster.event_not_eligible",
+            extra={
+                "group_id": group.id,
+                "event_id": ready_event.event_id,
+                "reason": "unsupported_platform",
+            },
+        )
+        metrics.incr(
+            "seer.lightweight_rca_cluster.skipped", tags={"reason": "unsupported_platform"}
+        )
         return
 
     serialized_event = serialize(ready_event, None, EventSerializer())

--- a/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
+++ b/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
@@ -23,6 +23,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.types.group import UNRESOLVED_SUBSTATUS_CHOICES
 from sentry.utils import metrics
+from sentry.utils.event import has_stacktrace
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.snuba import SnubaError, bulk_snuba_queries
 
@@ -316,26 +317,32 @@ def _batch_fetch_events(groups: Sequence[Group], organization_id: int) -> list[t
     # Batch fetch all event data from nodestore in one multi-get
     eventstore.bind_nodes(events)
 
-    # Drop events with empty data and security-report event types (CSP/HPKP/
-    # Expect-CT/Expect-Staple/NEL) — they all roll up under ErrorGroupType but
+    # Drop events with empty data, security-report event types (CSP/HPKP/
+    # Expect-CT/Expect-Staple/NEL), and events without stacktraces — they
     # don't carry the application-code signal that RCA clustering needs.
     valid_groups: list[Group] = []
     valid_events: list[Event] = []
-    skipped_security_reports = 0
     for group, event in zip(matched_groups, events):
         if not event.data:
+            metrics.incr(
+                "seer.supergroups_backfill_lightweight.event_skipped",
+                tags={"reason": "no_data"},
+            )
             continue
         if event.get_event_type() in SECURITY_REPORT_INTERFACES:
-            skipped_security_reports += 1
+            metrics.incr(
+                "seer.supergroups_backfill_lightweight.event_skipped",
+                tags={"reason": "security_report"},
+            )
+            continue
+        if not has_stacktrace(event.data):
+            metrics.incr(
+                "seer.supergroups_backfill_lightweight.event_skipped",
+                tags={"reason": "no_stacktrace"},
+            )
             continue
         valid_groups.append(group)
         valid_events.append(event)
-
-    if skipped_security_reports:
-        metrics.incr(
-            "seer.supergroups_backfill_lightweight.security_reports_skipped",
-            amount=skipped_security_reports,
-        )
 
     if not valid_events:
         return []

--- a/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
+++ b/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
@@ -16,6 +16,10 @@ from sentry.seer.signed_seer_api import (
     SeerViewerContext,
     make_lightweight_rca_cluster_request,
 )
+from sentry.seer.similarity.utils import (
+    SEER_INELIGIBLE_EVENT_PLATFORMS,
+    event_content_has_stacktrace,
+)
 from sentry.services.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
@@ -23,7 +27,6 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.types.group import UNRESOLVED_SUBSTATUS_CHOICES
 from sentry.utils import metrics
-from sentry.utils.event import has_stacktrace
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.snuba import SnubaError, bulk_snuba_queries
 
@@ -317,9 +320,10 @@ def _batch_fetch_events(groups: Sequence[Group], organization_id: int) -> list[t
     # Batch fetch all event data from nodestore in one multi-get
     eventstore.bind_nodes(events)
 
-    # Drop events with empty data, security-report event types (CSP/HPKP/
-    # Expect-CT/Expect-Staple/NEL), and events without stacktraces — they
-    # don't carry the application-code signal that RCA clustering needs.
+    # Drop events that Seer can't meaningfully analyze: empty data, security
+    # reports (CSP/HPKP/Expect-CT/Expect-Staple/NEL), events without
+    # stacktraces, and unsupported platforms.  Aligned with the similar-issues
+    # eligibility checks in grouping/ingest/seer.py.
     valid_groups: list[Group] = []
     valid_events: list[Event] = []
     for group, event in zip(matched_groups, events):
@@ -335,10 +339,16 @@ def _batch_fetch_events(groups: Sequence[Group], organization_id: int) -> list[t
                 tags={"reason": "security_report"},
             )
             continue
-        if not has_stacktrace(event.data):
+        if not event_content_has_stacktrace(event):
             metrics.incr(
                 "seer.supergroups_backfill_lightweight.event_skipped",
                 tags={"reason": "no_stacktrace"},
+            )
+            continue
+        if event.platform in SEER_INELIGIBLE_EVENT_PLATFORMS:
+            metrics.incr(
+                "seer.supergroups_backfill_lightweight.event_skipped",
+                tags={"reason": "unsupported_platform"},
             )
             continue
         valid_groups.append(group)

--- a/tests/sentry/seer/supergroups/test_lightweight_rca_cluster.py
+++ b/tests/sentry/seer/supergroups/test_lightweight_rca_cluster.py
@@ -68,6 +68,7 @@ class TriggerLightweightRCAClusterTest(TestCase):
             data={"message": "no stacktrace here", "level": "error", "fingerprint": ["no-stack"]},
             project_id=self.project.id,
         )
+        assert event.group is not None
 
         trigger_lightweight_rca_cluster(event.group)
 
@@ -79,6 +80,7 @@ class TriggerLightweightRCAClusterTest(TestCase):
             data={**EVENT_DATA_WITH_STACKTRACE, "platform": "other", "fingerprint": ["other-plat"]},
             project_id=self.project.id,
         )
+        assert event.group is not None
 
         trigger_lightweight_rca_cluster(event.group)
 

--- a/tests/sentry/seer/supergroups/test_lightweight_rca_cluster.py
+++ b/tests/sentry/seer/supergroups/test_lightweight_rca_cluster.py
@@ -5,12 +5,35 @@ import pytest
 from sentry.seer.supergroups.lightweight_rca_cluster import trigger_lightweight_rca_cluster
 from sentry.testutils.cases import TestCase
 
+EVENT_DATA_WITH_STACKTRACE = {
+    "message": "test error",
+    "level": "error",
+    "platform": "python",
+    "exception": {
+        "values": [
+            {
+                "type": "ValueError",
+                "value": "test",
+                "stacktrace": {
+                    "frames": [
+                        {
+                            "function": "test_func",
+                            "filename": "test.py",
+                            "lineno": 1,
+                        }
+                    ]
+                },
+            }
+        ]
+    },
+}
+
 
 class TriggerLightweightRCAClusterTest(TestCase):
     def setUp(self):
         super().setUp()
         self.event = self.store_event(
-            data={"message": "test error", "level": "error"},
+            data=EVENT_DATA_WITH_STACKTRACE,
             project_id=self.project.id,
         )
         self.group = self.event.group
@@ -38,3 +61,25 @@ class TriggerLightweightRCAClusterTest(TestCase):
 
         with pytest.raises(Exception):
             trigger_lightweight_rca_cluster(self.group)
+
+    @patch("sentry.seer.supergroups.lightweight_rca_cluster.make_lightweight_rca_cluster_request")
+    def test_skips_event_without_stacktrace(self, mock_request):
+        event = self.store_event(
+            data={"message": "no stacktrace here", "level": "error", "fingerprint": ["no-stack"]},
+            project_id=self.project.id,
+        )
+
+        trigger_lightweight_rca_cluster(event.group)
+
+        mock_request.assert_not_called()
+
+    @patch("sentry.seer.supergroups.lightweight_rca_cluster.make_lightweight_rca_cluster_request")
+    def test_skips_event_with_unsupported_platform(self, mock_request):
+        event = self.store_event(
+            data={**EVENT_DATA_WITH_STACKTRACE, "platform": "other", "fingerprint": ["other-plat"]},
+            project_id=self.project.id,
+        )
+
+        trigger_lightweight_rca_cluster(event.group)
+
+        mock_request.assert_not_called()

--- a/tests/sentry/tasks/seer/test_backfill_supergroups_lightweight.py
+++ b/tests/sentry/tasks/seer/test_backfill_supergroups_lightweight.py
@@ -16,11 +16,39 @@ from sentry.utils.snuba import SnubaError
 TEST_BATCH_SIZE = 5
 
 
+def _make_event_data(message="test error", fingerprint=None):
+    data = {
+        "message": message,
+        "level": "error",
+        "platform": "python",
+        "exception": {
+            "values": [
+                {
+                    "type": "ValueError",
+                    "value": message,
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "test_func",
+                                "filename": "test.py",
+                                "lineno": 1,
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+    }
+    if fingerprint is not None:
+        data["fingerprint"] = fingerprint
+    return data
+
+
 class BackfillSupergroupsLightweightForOrgTest(TestCase):
     def setUp(self):
         super().setUp()
         self.event = self.store_event(
-            data={"message": "test error", "level": "error"},
+            data=_make_event_data(),
             project_id=self.project.id,
         )
         self.group = self.event.group
@@ -54,7 +82,7 @@ class BackfillSupergroupsLightweightForOrgTest(TestCase):
 
         project2 = self.create_project(organization=self.organization)
         event2 = self.store_event(
-            data={"message": "error in project2", "level": "error"},
+            data=_make_event_data("error in project2"),
             project_id=project2.id,
         )
         assert event2.group is not None
@@ -88,11 +116,7 @@ class BackfillSupergroupsLightweightForOrgTest(TestCase):
         # Create enough groups to fill a batch
         for i in range(TEST_BATCH_SIZE):
             evt = self.store_event(
-                data={
-                    "message": f"error {i}",
-                    "level": "error",
-                    "fingerprint": [f"group-{i}"],
-                },
+                data=_make_event_data(f"error {i}", fingerprint=[f"group-{i}"]),
                 project_id=self.project.id,
             )
             assert evt.group is not None
@@ -156,7 +180,7 @@ class BackfillSupergroupsLightweightForOrgTest(TestCase):
     )
     def test_continues_on_individual_group_failure(self, mock_request):
         event2 = self.store_event(
-            data={"message": "second error", "level": "error", "fingerprint": ["group2"]},
+            data=_make_event_data("second error", fingerprint=["group2"]),
             project_id=self.project.id,
         )
         assert event2.group is not None
@@ -297,7 +321,7 @@ class BackfillSupergroupsLightweightForOrgTest(TestCase):
         mock_request.return_value = MagicMock(status=200)
 
         event2 = self.store_event(
-            data={"message": "second error", "level": "error", "fingerprint": ["group2"]},
+            data=_make_event_data("second error", fingerprint=["group2"]),
             project_id=self.project.id,
         )
         assert event2.group is not None
@@ -324,11 +348,7 @@ class BackfillSupergroupsLightweightForOrgTest(TestCase):
         # Create exactly TEST_BATCH_SIZE groups total (setUp already created 1)
         for i in range(TEST_BATCH_SIZE - 1):
             evt = self.store_event(
-                data={
-                    "message": f"error {i}",
-                    "level": "error",
-                    "fingerprint": [f"boundary-{i}"],
-                },
+                data=_make_event_data(f"error {i}", fingerprint=[f"boundary-{i}"]),
                 project_id=self.project.id,
             )
             assert evt.group is not None
@@ -370,3 +390,49 @@ class BackfillSupergroupsLightweightForOrgTest(TestCase):
             backfill_supergroups_lightweight_for_org(self.organization.id, **final_kwargs)
             mock_request.assert_not_called()
             mock_chain.assert_not_called()
+
+    @with_feature("organizations:supergroups-lightweight-rca-clustering-write")
+    @patch(
+        "sentry.tasks.seer.backfill_supergroups_lightweight.make_lightweight_rca_cluster_request"
+    )
+    def test_skips_events_without_stacktrace(self, mock_request):
+        """Events without stacktraces are filtered out before sending to Seer."""
+        original_bind = eventstore.bind_nodes
+
+        def bind_and_strip_stacktrace(events):
+            original_bind(events)
+            for event in events:
+                if event.data:
+                    event.data.pop("exception", None)
+                    event.data.pop("threads", None)
+                    event.data.pop("stacktrace", None)
+
+        with patch(
+            "sentry.tasks.seer.backfill_supergroups_lightweight.eventstore.bind_nodes",
+            side_effect=bind_and_strip_stacktrace,
+        ):
+            backfill_supergroups_lightweight_for_org(self.organization.id)
+
+        mock_request.assert_not_called()
+
+    @with_feature("organizations:supergroups-lightweight-rca-clustering-write")
+    @patch(
+        "sentry.tasks.seer.backfill_supergroups_lightweight.make_lightweight_rca_cluster_request"
+    )
+    def test_skips_events_with_unsupported_platform(self, mock_request):
+        """Events with platform 'other' are filtered out before sending to Seer."""
+        original_bind = eventstore.bind_nodes
+
+        def bind_and_set_platform_other(events):
+            original_bind(events)
+            for event in events:
+                if event.data:
+                    event.data["platform"] = "other"
+
+        with patch(
+            "sentry.tasks.seer.backfill_supergroups_lightweight.eventstore.bind_nodes",
+            side_effect=bind_and_set_platform_other,
+        ):
+            backfill_supergroups_lightweight_for_org(self.organization.id)
+
+        mock_request.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `has_stacktrace()` checks to both the live path (`trigger_lightweight_rca_cluster`) and the backfill path (`backfill_supergroups_lightweight`) before sending events to Seer for lightweight RCA clustering
- Events without stacktraces don't carry the application-code signal needed for meaningful RCA. Filtering on the Sentry side avoids unnecessary serialization, network calls, and LLM invocations in Seer
- Consolidate backfill skip metrics into a single `event_skipped` metric with a `reason` tag (`no_data`, `security_report`, `no_stacktrace`)
- Part of the motivation is bringing down the volume of issues being processed

## Test plan
- [ ] Verify existing tests pass for both paths
- [ ] Confirm events with stacktraces still flow through to Seer
- [ ] Confirm message-only events (no exception/thread/stacktrace interfaces) are skipped with appropriate logging and metrics