### PR TITLE
ref(seer): Use send_halt_message for identity linking prompt

### DIFF
--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -4,13 +4,13 @@ import logging
 from collections.abc import Mapping, Sequence
 from typing import Any, NamedTuple
 
-from slack_sdk.models.blocks import ActionsBlock, ButtonElement, LinkButtonElement, MarkdownBlock
+from slack_sdk.models.blocks import MarkdownBlock
 from taskbroker_client.retry import Retry
 
 from sentry import analytics
 from sentry.identity.services.identity import identity_service
+from sentry.integrations.messaging.metrics import SeerSlackHaltReason
 from sentry.integrations.services.integration.model import RpcIntegration
-from sentry.integrations.slack.views.link_identity import build_linking_url
 from sentry.models.organization import Organization
 from sentry.notifications.platform.slack.provider import SlackRenderable
 from sentry.seer.entrypoints.metrics import (
@@ -31,6 +31,7 @@ from sentry.seer.entrypoints.slack.mention import (
     extract_slack_message_links,
     find_message_in_attachments,
 )
+from sentry.seer.entrypoints.slack.messaging import send_halt_message
 from sentry.seer.entrypoints.slack.metrics import (
     ProcessMentionFailureReason,
     ProcessMentionHaltReason,
@@ -121,9 +122,12 @@ def process_mention_for_slack(
         if not user:
             lifecycle.record_halt(ProcessMentionHaltReason.IDENTITY_NOT_LINKED)
             # In a thread, show the prompt in the thread; top-level, show in the channel.
-            _send_link_identity_prompt(
-                entrypoint=entrypoint,
+            send_halt_message(
+                integration=entrypoint.integration,
+                slack_user_id=entrypoint.slack_user_id,
+                channel_id=entrypoint.channel_id,
                 thread_ts=thread_ts if thread_ts else "",
+                halt_reason=SeerSlackHaltReason.IDENTITY_NOT_LINKED,
             )
             entrypoint.install.set_thread_status(
                 channel_id=channel_id,
@@ -287,47 +291,6 @@ def _count_linked_users(
         }
     )
     return len(identities)
-
-
-def _send_link_identity_prompt(
-    *,
-    entrypoint: SlackAgentEntrypoint,
-    thread_ts: str,
-) -> None:
-    """Send an ephemeral message prompting the user to link their Slack identity to Sentry."""
-    associate_url = build_linking_url(
-        integration=entrypoint.integration,
-        slack_id=entrypoint.slack_user_id,
-        channel_id=entrypoint.channel_id,
-        response_url=None,
-    )
-    renderable = _build_link_identity_renderable(associate_url)
-    try:
-        entrypoint.install.send_threaded_ephemeral_message(
-            slack_user_id=entrypoint.slack_user_id,
-            channel_id=entrypoint.channel_id,
-            renderable=renderable,
-            thread_ts=thread_ts,
-        )
-    except Exception as e:
-        _logger.warning("seer.slack.process_mention.send_link_identity_prompt_failed", exc_info=e)
-
-
-def _build_link_identity_renderable(associate_url: str) -> SlackRenderable:
-    """Build a SlackRenderable prompting the user to link their Slack identity to Sentry."""
-    message = "Link your Slack identity to Sentry to use Seer Agent in Slack."
-    return SlackRenderable(
-        blocks=[
-            MarkdownBlock(text=message),
-            ActionsBlock(
-                elements=[
-                    LinkButtonElement(text="Link", url=associate_url),
-                    ButtonElement(text="Cancel", value="ignore"),
-                ]
-            ),
-        ],
-        text=message,
-    )
 
 
 def _send_not_org_member_message(

--- a/tests/sentry/seer/entrypoints/slack/test_tasks.py
+++ b/tests/sentry/seer/entrypoints/slack/test_tasks.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+from sentry.integrations.messaging.metrics import SeerSlackHaltReason
 from sentry.seer.entrypoints.slack.analytics import (
     SlackSeerAgentConversation,
     SlackSeerAgentResponded,
@@ -135,7 +136,7 @@ class ProcessMentionForSlackTest(TestCase):
         assert_failure_metric(mock_record, EntrypointSetupError("not found"))
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    @patch("sentry.seer.entrypoints.slack.tasks._send_link_identity_prompt")
+    @patch("sentry.seer.entrypoints.slack.tasks.send_halt_message")
     @patch("sentry.seer.entrypoints.slack.tasks.SeerAgentOperator")
     @patch("sentry.seer.entrypoints.slack.tasks.SlackAgentEntrypoint")
     @patch("sentry.seer.entrypoints.slack.tasks._resolve_user")
@@ -144,7 +145,7 @@ class ProcessMentionForSlackTest(TestCase):
         mock_resolve_user,
         mock_agent_cls,
         mock_operator_cls,
-        mock_send_link,
+        mock_send_halt,
         mock_record,
     ):
         mock_resolve_user.return_value = None
@@ -156,8 +157,12 @@ class ProcessMentionForSlackTest(TestCase):
 
         self._run_task()
 
-        mock_send_link.assert_called_once_with(
-            entrypoint=mock_entrypoint, thread_ts="1234567890.123456"
+        mock_send_halt.assert_called_once_with(
+            integration=mock_entrypoint.integration,
+            slack_user_id=mock_entrypoint.slack_user_id,
+            channel_id=mock_entrypoint.channel_id,
+            thread_ts="1234567890.123456",
+            halt_reason=SeerSlackHaltReason.IDENTITY_NOT_LINKED,
         )
         mock_operator_cls.assert_not_called()
         assert_halt_metric(mock_record, ProcessMentionHaltReason.IDENTITY_NOT_LINKED)


### PR DESCRIPTION
there was a custom function in slack entrypoint task that would fire when we prompt the user to link their slack account to sentry account. let's just re-use the `send_halt_message`.

note: this technically should _never_ be sent because we already do the check in the control silo level:

https://github.com/getsentry/sentry/blob/cf681d4d26c390cbf79203a963567ee1f1bc6c6a/src/sentry/middleware/integrations/tasks.py#L242-L269

But if we are running on monolith devenvs, this is useful, and we should probably make sure we didn't run into any race conditions or anything, so let's keep the check there as well.