### PR TITLE
ref(monitors): Singularize Monitor Type labels

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -508,16 +508,13 @@ export function GlobalCommandPaletteActions() {
               display={{label: t('My Monitors')}}
               to={`${prefix}/monitors/my-monitors/`}
             />
+            <CMDKAction display={{label: t('Error')}} to={`${prefix}/monitors/errors/`} />
             <CMDKAction
-              display={{label: t('Errors')}}
-              to={`${prefix}/monitors/errors/`}
-            />
-            <CMDKAction
-              display={{label: t('Metrics')}}
+              display={{label: t('Metric')}}
               to={`${prefix}/monitors/metrics/`}
             />
             <CMDKAction
-              display={{label: t('Crons')}}
+              display={{label: t('Cron')}}
               keywords={[t('jobs'), t('cron jobs')]}
               to={`${prefix}/monitors/crons/`}
             />
@@ -530,7 +527,7 @@ export function GlobalCommandPaletteActions() {
             )}
             {organization.features.includes('preprod-size-monitors-frontend') && (
               <CMDKAction
-                display={{label: t('Mobile Builds')}}
+                display={{label: t('Mobile Build')}}
                 to={`${prefix}/monitors/mobile-builds/`}
               />
             )}

--- a/static/app/views/detectors/utils/detectorTypeConfig.tsx
+++ b/static/app/views/detectors/utils/detectorTypeConfig.tsx
@@ -42,7 +42,7 @@ const DETECTOR_TYPE_CONFIG: Record<DetectorType, DetectorTypeConfig> = {
     systemCreatedNotice: () => t('This monitor is managed by Sentry'),
   },
   preprod_size_analysis: {
-    label: t('Mobile Builds'),
+    label: t('Mobile Build'),
     path: 'mobile-builds',
     userCreateable: true,
   },

--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -384,13 +384,13 @@ describe('desktop navigation', () => {
           [`${ORG}/insights/mobile/`, 'Insights', 'Mobile'],
           [`${ORG}/insights/ai-agents/`, 'Insights', 'Agents'],
           [`${ORG}/insights/mcp/`, 'Insights', 'MCP'],
-          [`${ORG}/monitors/crons/?insightsRedirect=true`, 'Monitors', 'Crons'],
+          [`${ORG}/monitors/crons/?insightsRedirect=true`, 'Monitors', 'Cron'],
           // Monitors
           [`${ORG}/monitors/`, 'Monitors', 'All Monitors'],
           [`${ORG}/monitors/my-monitors/`, 'Monitors', 'My Monitors'],
-          [`${ORG}/monitors/errors/`, 'Monitors', 'Errors'],
-          [`${ORG}/monitors/metrics/`, 'Monitors', 'Metrics'],
-          [`${ORG}/monitors/crons/`, 'Monitors', 'Crons'],
+          [`${ORG}/monitors/errors/`, 'Monitors', 'Error'],
+          [`${ORG}/monitors/metrics/`, 'Monitors', 'Metric'],
+          [`${ORG}/monitors/crons/`, 'Monitors', 'Cron'],
           [`${ORG}/monitors/alerts/`, 'Monitors', 'Alerts'],
           // Settings
           ['/settings/org-slug/', 'Settings', 'General Settings'],

--- a/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
@@ -45,7 +45,7 @@ export function MonitorsSecondaryNavigation() {
                 to={`${baseUrl}/errors/`}
                 analyticsItemName="monitors_errors"
               >
-                {t('Errors')}
+                {t('Error')}
               </SecondaryNavigation.Link>
             </SecondaryNavigation.ListItem>
             <SecondaryNavigation.ListItem>
@@ -53,7 +53,7 @@ export function MonitorsSecondaryNavigation() {
                 to={`${baseUrl}/metrics/`}
                 analyticsItemName="monitors_metrics"
               >
-                {t('Metrics')}
+                {t('Metric')}
               </SecondaryNavigation.Link>
             </SecondaryNavigation.ListItem>
             <SecondaryNavigation.ListItem>
@@ -61,7 +61,7 @@ export function MonitorsSecondaryNavigation() {
                 to={`${baseUrl}/crons/`}
                 analyticsItemName="monitors_crons"
               >
-                {t('Crons')}
+                {t('Cron')}
               </SecondaryNavigation.Link>
             </SecondaryNavigation.ListItem>
             <Feature features={['uptime']}>
@@ -80,7 +80,7 @@ export function MonitorsSecondaryNavigation() {
                   to={`${baseUrl}/mobile-builds/`}
                   analyticsItemName="monitors_mobile_builds"
                 >
-                  {t('Mobile Builds')}
+                  {t('Mobile Build')}
                 </SecondaryNavigation.Link>
               </SecondaryNavigation.ListItem>
             </Feature>


### PR DESCRIPTION
Update the Monitor Type entries in the Monitors inner-nav from plural to
singular: Errors → Error, Metrics → Metric, Crons → Cron, Mobile Builds →
Mobile Build. The labels describe the type of monitor (singular noun
modifier) rather than a count, so the singular form reads more naturally
in the "By Monitor Type" list.

Also updates the same labels in the two surfaces that hardcode them
in parallel with the inner-nav so the names stay consistent:

- Cmd+K palette Monitors submenu (`commandPaletteGlobalActions.tsx`)
- Detector type config (`detectorTypeConfig.tsx`) — `preprod_size_analysis`
  is the only entry there that was still plural

Uptime is left as-is. Legacy "Crons" / "Metrics" labels under Insights and
Explore reference different products (the moved-Insights redirect entry
and the Application Metrics product respectively) and are intentionally
unchanged.