### PR TITLE
fix(charts): Wire up `visualMap` prop in BaseChart

### DIFF
--- a/static/app/chartcuterie/performance.tsx
+++ b/static/app/chartcuterie/performance.tsx
@@ -48,7 +48,6 @@ export function makePerformanceCharts(theme: Theme): Array<RenderDescriptor<Char
     return {
       ...options,
       grid: performanceChartDefaults.grid,
-      visualMap: options.options?.visualMap,
       backgroundColor: theme.tokens.background.primary,
     };
   }

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -2,6 +2,7 @@ import 'echarts/lib/component/grid';
 import 'echarts/lib/component/graphic';
 import 'echarts/lib/component/toolbox';
 import 'echarts/lib/component/brush';
+import 'echarts/lib/component/visualMap';
 import 'echarts/theme/v5.js';
 import 'zrender/lib/svg/svg';
 
@@ -342,6 +343,7 @@ export function BaseChart({
   dataZoom,
   toolBox,
   graphic,
+  visualMap,
   axisPointer,
   previousPeriod,
   echartsTheme,
@@ -575,6 +577,7 @@ export function BaseChart({
       axisPointer,
       dataZoom,
       graphic,
+      visualMap,
       aria,
       brush,
     };
@@ -598,6 +601,7 @@ export function BaseChart({
     axisPointer,
     dataZoom,
     graphic,
+    visualMap,
     isGroupedByDate,
     useShortDate,
     useMultilineDate,

--- a/static/app/components/charts/heatMapChart.tsx
+++ b/static/app/components/charts/heatMapChart.tsx
@@ -1,5 +1,3 @@
-import './components/visualMap';
-
 import type {HeatmapSeriesOption, VisualMapComponentOption} from 'echarts';
 
 import type {Series} from 'sentry/types/echarts';
@@ -24,9 +22,7 @@ export function HeatMapChart({ref, ...props}: HeatmapProps) {
   return (
     <BaseChart
       ref={ref}
-      options={{
-        visualMap: visualMaps,
-      }}
+      visualMap={visualMaps}
       {...otherProps}
       series={series.map(({seriesName, data, dataArray, ...options}) =>
         HeatMapSeries({

--- a/static/app/components/charts/series/heatMapSeries.tsx
+++ b/static/app/components/charts/series/heatMapSeries.tsx
@@ -1,5 +1,4 @@
 import 'echarts/lib/chart/heatmap';
-import 'echarts/lib/component/visualMap';
 
 import type {HeatmapSeriesOption} from 'echarts';
 

--- a/static/app/components/events/eventStatisticalDetector/breakpointChartOptions.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChartOptions.tsx
@@ -125,25 +125,23 @@ export function getBreakpointChartOptionsFromData(
           axisLabelFormatter(value, 'duration', undefined, durationUnit),
       },
     },
-    options: {
-      visualMap: VisualMap({
-        show: false,
-        type: 'piecewise',
-        selectedMode: false,
-        dimension: 0,
-        pieces: [
-          {
-            gte: 0,
-            lt: breakpointMs,
-            color: theme.colors.gray800,
-          },
-          {
-            gte: breakpointMs,
-            color: theme.colors.red400,
-          },
-        ],
-      }),
-    },
+    visualMap: VisualMap({
+      show: false,
+      type: 'piecewise',
+      selectedMode: false,
+      dimension: 0,
+      pieces: [
+        {
+          gte: 0,
+          lt: breakpointMs,
+          color: theme.colors.gray800,
+        },
+        {
+          gte: breakpointMs,
+          color: theme.colors.red400,
+        },
+      ],
+    }),
   } satisfies BaseChartProps;
   return {
     series,

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -1,5 +1,4 @@
 import 'echarts/lib/chart/heatmap';
-import 'echarts/lib/component/visualMap';
 
 import {useTheme} from '@emotion/react';
 
@@ -108,33 +107,31 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
             show: false,
           },
         }}
-        options={{
-          visualMap: [
-            // Zero values are transparent (empty buckets)
-            {
-              type: 'piecewise',
-              show: false,
-              dimension: 2,
-              seriesIndex: 0,
-              pieces: [
-                {value: 0, opacity: 0},
-                {gt: 0, opacity: 1},
-              ],
+        visualMap={[
+          // Zero values are transparent (empty buckets)
+          {
+            type: 'piecewise',
+            show: false,
+            dimension: 2,
+            seriesIndex: 0,
+            pieces: [
+              {value: 0, opacity: 0},
+              {gt: 0, opacity: 1},
+            ],
+          },
+          // All values are plotted against a palette
+          {
+            type: 'continuous',
+            show: false,
+            dimension: 2,
+            seriesIndex: 0,
+            min: 0,
+            max: Zmax,
+            inRange: {
+              color: [...HEATMAP_COLORS],
             },
-            // All values are plotted against a palette
-            {
-              type: 'continuous',
-              show: false,
-              dimension: 2,
-              seriesIndex: 0,
-              min: 0,
-              max: Zmax,
-              inRange: {
-                color: [...HEATMAP_COLORS],
-              },
-            },
-          ],
-        }}
+          },
+        ]}
         start={start ? new Date(start) : undefined}
         end={end ? new Date(end) : undefined}
         period={period}


### PR DESCRIPTION
`BaseChart` accepts a `visualMap` prop but never destructured or passed it to the echarts option object, so any caller passing it as a prop (e.g. `appSizeTreemap`) had it silently dropped.

This registers the echarts `visualMap` component in `BaseChart` (alongside `grid`, `graphic`, `toolbox`, `brush`) and wires the prop through to the chart options. All existing callers that passed `visualMap` via `options={{ visualMap }}` are migrated to use the dedicated prop for consistency.

The `modifyOptionsForSlack` function in chartcuterie no longer needs to explicitly extract `visualMap` from a nested `options` key since it now lives at the top level and is included via the spread.

Fixes DAIN-1649