### PR TITLE
chore(cells) Remove org_setup_complete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2263,7 +2263,6 @@ module = [
     "tests.sentry.relocation.test_utils",
     "tests.sentry.rules",
     "tests.sentry.rules.actions",
-    "tests.sentry.rules.actions.test_base",
     "tests.sentry.rules.actions.test_create_ticket_utils",
     "tests.sentry.rules.actions.test_notify_event",
     "tests.sentry.rules.actions.test_notify_event_sentry_app",

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -40,7 +40,6 @@ from sentry.services.organization import (
     PostProvisionOptions,
 )
 from sentry.services.organization.provisioning import organization_provisioning_service
-from sentry.signals import org_setup_complete
 from sentry.silo.base import SiloMode
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
@@ -408,10 +407,6 @@ class OrganizationIndexEndpoint(Endpoint):
                 provisioning_options=provision_args,
             )
             org = Organization.objects.get(id=rpc_org.id)
-
-            org_setup_complete.send_robust(
-                instance=org, user=request.user, sender="in-app", referrer="in-app"
-            )
 
         # TODO(hybrid-cloud): We'll need to catch a more generic error
         # when the internal RPC is implemented.

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -90,8 +90,6 @@ class BetterSignal(Signal):
 buffer_incr_complete = BetterSignal()  # ["model", "columns", "extra", "result"]
 pending_delete = BetterSignal()  # ["instance", "actor"]
 event_processed = BetterSignal()  # ["project", "event"]
-# When the organization and initial member have been created
-org_setup_complete = BetterSignal()  # ["organization", "user"]
 
 # This signal should eventually be removed as we should not send
 # transactions through post processing


### PR DESCRIPTION
With all provisioning analytics captured during the provisiong and post-provisioning steps we don't need this signal anymore.

Refs INFRENG-186

This depends on getsentry/getsentry#20259 being shipped.