### PR TITLE
feat(snapshots): Add context.test_file_path to snapshot JSON metadata

### DIFF
--- a/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
@@ -1,6 +1,9 @@
 // Keep in sync with src/sentry/preprod/snapshots/manifest.py
 export interface SnapshotImageMetadata {
   display_name: string;
+  context?: {
+    test_file_path: string;
+  };
   group?: string | null;
   // Skip height, width and image_file_name as they're handled by the CLI
 }

--- a/tests/js/sentry-test/snapshots/snapshot.ts
+++ b/tests/js/sentry-test/snapshots/snapshot.ts
@@ -146,6 +146,7 @@ export async function takeSnapshot({
       display_name: displayName,
       group,
       ...metadata,
+      context: {test_file_path: relativePath},
     };
 
     await Promise.all([


### PR DESCRIPTION
Every snapshot JSON sidecar now includes a `context.test_file_path` field with the project-relative path to the `.snapshots.tsx` file that generated it. This lets downstream consumers trace any snapshot back to its source test without relying on directory conventions.

```json
{
  "display_name": "light / primary / sm / icon-only",
  "group": "light – icon-only",
  "context": {
    "test_file_path": "static/app/components/core/button/button.snapshots.tsx"
  }
}
```

The path is derived from the `relativePath` already computed in `takeSnapshot()`, so no new data plumbing was needed. The Python `ImageMetadata` model uses `extra = "allow"`, so the new key flows through without backend changes.

Refs EME-1125