### PR TITLE
fix(feedback): Disallow OR/AND operators in feedback search

### DIFF
--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -303,6 +303,7 @@ export function FeedbackSearch() {
       searchSource="feedback-list"
       placeholder={t('Search Feedback')}
       matchKeySuggestions={[{key: 'user.email', valuePattern: EMAIL_REGEX}]}
+      disallowLogicalOperators
     />
   );
 }


### PR DESCRIPTION
The feedback search bar accepted boolean operators in the input even though issue search (which feedback queries hit on the backend) rejects them with InvalidSearchQuery. Pass disallowLogicalOperators to the SearchQueryBuilder so AND/OR/parens are flagged as invalid before submission, matching the issue list search.

This will make any existing queries with `AND` operators invalid but that shouldn't be a problem since these can't be saved from the UI.

Refs ISWF-2613