### PR TITLE
ref(events): adopt useModal in events interfaces

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -13,9 +13,10 @@ import {useVirtualizer} from '@tanstack/react-virtual';
 import {Button} from '@sentry/scraps/button';
 import type {SelectOption, SelectSection} from '@sentry/scraps/compactSelect';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 import {Text} from '@sentry/scraps/text';
 
-import {openModal, openReprocessEventModal} from 'sentry/actionCreators/modal';
+import {openReprocessEventModal} from 'sentry/actionCreators/modal';
 import {
   DebugImageDetails,
   modalCss,
@@ -107,6 +108,8 @@ interface DebugMetaProps {
 type FilterSelections = Array<SelectOption<string>>;
 
 export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const organization = useOrganization();
 
@@ -215,7 +218,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
         {modalCss: modalCss(theme)}
       );
     },
-    [event, groupId, organization, projectSlug, theme]
+    [event, groupId, organization, projectSlug, theme, openModal]
   );
 
   if (shouldSkipSection(filteredImages, data.images)) {

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -6,8 +6,8 @@ import classNames from 'classnames';
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {analyzeFrameForRootCause} from 'sentry/components/events/interfaces/analyzeFrames';
 import {LeadHint} from 'sentry/components/events/interfaces/frame/leadHint';
@@ -110,6 +110,8 @@ function DeprecatedLine({
   registersMeta,
   components,
 }: Props) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const {hasScmSourceContext} = useStacktraceContext();
   const [isHovering, setIsHovering] = useState(false);

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 
 import {Button, LinkButton, type LinkButtonProps} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {useStacktraceCoverage} from 'sentry/components/events/interfaces/frame/useStacktraceCoverage';
 import {hasFileExtension} from 'sentry/components/events/interfaces/frame/utils';
 import {Placeholder} from 'sentry/components/placeholder';
@@ -44,6 +44,8 @@ interface StacktraceLinkProps {
 }
 
 export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLinkProps) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const {projects} = useProjects();
   const project = useMemo(

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -11,10 +11,10 @@ import {LinkButton} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {openModal} from 'sentry/actionCreators/modal';
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {sourceMapSdkDocsMap} from 'sentry/components/events/interfaces/crashContent/exception/utils';
 import {FeedbackModal} from 'sentry/components/featureFeedback/feedbackModal';
@@ -503,6 +503,8 @@ export function SourceMapsDebuggerModal({
   organization,
   projectId,
 }: SourceMapsDebuggerModalProps) {
+  const {openModal} = useModal();
+
   const theme = useTheme();
 
   const {projects} = useProjects();


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.