### PR TITLE
ref(relocation): adopt useModal in relocation admin

### DIFF
--- a/static/gsAdmin/views/relocationDetails.tsx
+++ b/static/gsAdmin/views/relocationDetails.tsx
@@ -3,6 +3,7 @@ import moment from 'moment-timezone';
 
 import {OrganizationAvatar} from '@sentry/scraps/avatar';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
 import {
   addErrorMessage,
@@ -10,7 +11,6 @@ import {
   addSuccessMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {Client} from 'sentry/api';
 import {UserBadge} from 'sentry/components/idBadge/userBadge';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -172,6 +172,8 @@ const getUserRow = (row: any) => [
 ];
 
 export function RelocationDetails() {
+  const {openModal} = useModal();
+
   const {regionName, relocationUuid} = useParams<{
     regionName: string;
     relocationUuid: string;


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.