### PR TITLE
ref(crons): adopt useModal in upgrade CTA

### DIFF
--- a/static/gsApp/components/crons/cronsBannerUpgradeCTA.tsx
+++ b/static/gsApp/components/crons/cronsBannerUpgradeCTA.tsx
@@ -1,6 +1,6 @@
 import {Button, LinkButton} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {t} from 'sentry/locale';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
@@ -56,6 +56,8 @@ export function CronsBannerOnDemandCTA({
   hasBillingAccess,
   subscription,
 }: OnDemandCTAProps) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
 
   const openOnDemandBudgetEditModal = () => {


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.