### PR TITLE
ref(alerts): adopt useModal in issue rule actions

### DIFF
--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -6,9 +6,9 @@ import {Button} from '@sentry/scraps/button';
 import {Input, NumberInput} from '@sentry/scraps/input';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {Select} from '@sentry/scraps/select';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import type {JsonFormAdapterFieldConfig} from 'sentry/components/backendJsonFormAdapter/types';
 import {transformChoices} from 'sentry/components/backendJsonFormAdapter/utils';
 import {TicketRuleModal} from 'sentry/components/externalIssues/ticketRuleModal';
@@ -324,6 +324,8 @@ export function RuleNode({
   incompatibleRule,
   incompatibleBanner,
 }: Props) {
+  const {openModal} = useModal();
+
   const handleDelete = useCallback(() => {
     onDelete(index);
   }, [index, onDelete]);

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
@@ -2,16 +2,18 @@ import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegration
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {HookStore} from 'sentry/stores/hookStore';
 import {
   MessagingIntegrationAnalyticsView,
   SetupMessagingIntegrationButton,
 } from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
-
-jest.mock('sentry/actionCreators/modal');
 
 describe('SetupAlertIntegrationButton', () => {
   const organization = OrganizationFixture();
@@ -86,9 +88,10 @@ describe('SetupAlertIntegrationButton', () => {
     mockResponses.forEach(mock => {
       expect(mock).toHaveBeenCalled();
     });
+    renderGlobalModal();
     const button = await screen.findByRole('button', {name: /connect to messaging/i});
     await userEvent.click(button);
-    expect(openModal).toHaveBeenCalled();
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
   it('does not render button if API errors', () => {

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -2,8 +2,8 @@ import {useQueries, useQuery} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {t} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import type {
@@ -31,6 +31,8 @@ export function SetupMessagingIntegrationButton({
   analyticsView,
   projectId,
 }: Props) {
+  const {openModal} = useModal();
+
   const providerKeys = ['slack', 'discord', 'msteams'];
   const organization = useOrganization();
 


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.