### PR TITLE
ref(replay): adopt useModal in replay components

### DIFF
--- a/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
@@ -2,8 +2,8 @@ import {Fragment, lazy, Suspense, type ReactNode} from 'react';
 import {css} from '@emotion/react';
 
 import {Button, type ButtonProps} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -34,6 +34,8 @@ export function OpenReplayComparisonButton({
   size,
   surface,
 }: Props) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
 
   return (

--- a/static/app/utils/replays/hooks/useShareReplayAtTimestamp.tsx
+++ b/static/app/utils/replays/hooks/useShareReplayAtTimestamp.tsx
@@ -4,8 +4,8 @@ import styled from '@emotion/styled';
 
 import {Input} from '@sentry/scraps/input';
 import {Stack} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {RadioGroup} from 'sentry/components/forms/controls/radioGroup';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {TextCopyInput} from 'sentry/components/textCopyInput';
@@ -74,6 +74,8 @@ function ShareModal({currentTimeSec, Header, Body}: any) {
 }
 
 export function useShareReplayAtTimestamp() {
+  const {openModal} = useModal();
+
   const {currentTime} = useReplayContext();
 
   const handleShare = useCallback(() => {
@@ -81,7 +83,7 @@ export function useShareReplayAtTimestamp() {
     const currentTimeSec = Math.floor(currentTime / 1000);
 
     openModal(deps => <ShareModal currentTimeSec={currentTimeSec} {...deps} />);
-  }, [currentTime]);
+  }, [currentTime, openModal]);
   return handleShare;
 }
 


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.