### PR TITLE
ref(performance): adopt useModal in performance views

### DIFF
--- a/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
+++ b/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
@@ -6,9 +6,9 @@ import {
   type SelectOption,
 } from '@sentry/scraps/compactSelect';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {IconSettings} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
@@ -31,6 +31,8 @@ interface TracePreferencesDropdownProps {
 }
 
 export function TracePreferencesDropdown(props: TracePreferencesDropdownProps) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const {projects} = useProjects();
 

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -4,11 +4,11 @@ import type {Location, LocationDescriptorObject} from 'history';
 
 import {Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {GuideAnchor} from 'sentry/components/assistant/guideAnchor';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {GridColumn} from 'sentry/components/tables/gridEditable';
@@ -127,6 +127,8 @@ export function Table({
   eventView,
   theme,
 }: Props) {
+  const {openModal} = useModal();
+
   const [widths, setWidths] = useState<number[]>([]);
   const [transactionData, setTransactionData] = useState<TransactionData>();
   const [tableMetricSet, setTableMetricSet] = useState(false);

--- a/static/app/views/performance/transactionSummary/transactionThresholdButton.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdButton.tsx
@@ -1,9 +1,9 @@
 import {useEffect, useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
 import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -36,6 +36,8 @@ function TransactionThresholdButton({
   projects,
   transactionName,
 }: Props) {
+  const {openModal} = useModal();
+
   const [loadingThreshold, setLoadingThreshold] = useState(false);
   const [transactionThreshold, setTransactionThreshold] = useState<number>();
   const [transactionThresholdMetric, setTransactionThresholdMetric] =


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.