### PR TITLE
ref(explore): adopt useModal in explore views

### DIFF
--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -6,9 +6,9 @@ import * as Sentry from '@sentry/react';
 import type {Location, LocationDescriptorObject} from 'history';
 
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {COL_WIDTH_MINIMUM, GridEditable} from 'sentry/components/tables/gridEditable';
 import {SortLink} from 'sentry/components/tables/gridEditable/sortLink';
 import {useQueryBasedColumnResize} from 'sentry/components/tables/gridEditable/useQueryBasedColumnResize';
@@ -104,6 +104,8 @@ type TableViewProps = {
  * object. The new EventView object is pushed to the location object.
  */
 export function TableView(props: TableViewProps) {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const navigate = useNavigate();
   const {projects} = useProjects();

--- a/static/app/views/explore/logs/exports/logsExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModalButton.tsx
@@ -1,6 +1,6 @@
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {type LogsQueryInfo} from 'sentry/components/exports/dataExport';
 import {IconDownload} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -31,6 +31,8 @@ export function LogsExportModalButton({
   queryInfo,
   tableData,
 }: LogsExportModalButtonProps) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const disabledTooltip = getExportDisabledTooltip({
     isDataEmpty: !tableData?.length,

--- a/static/app/views/explore/logs/logsExportModalButton.spec.tsx
+++ b/static/app/views/explore/logs/logsExportModalButton.spec.tsx
@@ -1,9 +1,14 @@
 import {LogFixture} from 'sentry-fixture/log';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import type {LogsQueryInfo} from 'sentry/components/exports/dataExport';
 import {LogsExportModalButton} from 'sentry/views/explore/logs/exports/logsExportModalButton';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
@@ -12,10 +17,6 @@ const mockTrackAnalytics = jest.fn();
 
 jest.mock('sentry/utils/analytics', () => ({
   trackAnalytics: (...args: unknown[]) => mockTrackAnalytics(...args),
-}));
-
-jest.mock('sentry/actionCreators/modal', () => ({
-  openModal: jest.fn(),
 }));
 
 describe('LogsExportModalButton', () => {
@@ -38,10 +39,17 @@ describe('LogsExportModalButton', () => {
   ];
 
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
     jest.clearAllMocks();
+    // The export modal estimates row counts from a timeseries query.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: {timeSeries: []},
+    });
   });
 
-  async function clickExportDataAndGetOnClose() {
+  async function renderAndOpen() {
     render(
       <LogsExportModalButton
         error={null}
@@ -51,49 +59,50 @@ describe('LogsExportModalButton', () => {
       />,
       {organization}
     );
-
+    renderGlobalModal();
     await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-
-    expect(openModal).toHaveBeenCalled();
-    const openOptions = (openModal as jest.Mock).mock.calls[0]?.[1];
-    expect(openOptions?.onClose).toEqual(expect.any(Function));
-
-    return openOptions.onClose;
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
   }
 
-  it('tracks cancel analytics when onClose receives escape-key', async () => {
-    const onClose = await clickExportDataAndGetOnClose();
+  it('opens the export modal and tracks open analytics', async () => {
+    await renderAndOpen();
 
     expect(mockTrackAnalytics).toHaveBeenCalledWith(
       'logs.export_modal',
-      expect.objectContaining({
-        action: 'open',
-      })
-    );
-
-    onClose('escape-key');
-    expect(mockTrackAnalytics).toHaveBeenCalledWith(
-      'logs.export_modal',
-      expect.objectContaining({
-        action: 'cancel',
-        close_reason: 'escape_key',
-      })
+      expect.objectContaining({action: 'open'})
     );
   });
 
-  it('does not track cancel analytics when onClose receives undefined reason', async () => {
-    const onClose = await clickExportDataAndGetOnClose();
+  it('tracks cancel analytics with escape_key when closed via Escape', async () => {
+    await renderAndOpen();
 
-    expect(mockTrackAnalytics).toHaveBeenCalledTimes(1);
-    expect(mockTrackAnalytics).toHaveBeenCalledWith(
-      'logs.export_modal',
-      expect.objectContaining({
-        action: 'open',
-      })
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(mockTrackAnalytics).toHaveBeenCalledWith(
+        'logs.export_modal',
+        expect.objectContaining({action: 'cancel', close_reason: 'escape_key'})
+      );
+    });
+  });
+
+  it('does not double-fire cancel analytics when closed via the Cancel button', async () => {
+    await renderAndOpen();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Cancel'}));
+
+    // The Cancel button itself fires cancel/cancel_button. The onClose
+    // callback receives no reason in the programmatic-close path and must
+    // skip its own cancel event so we don't get a duplicate.
+    await waitFor(() => {
+      expect(mockTrackAnalytics).toHaveBeenCalledWith(
+        'logs.export_modal',
+        expect.objectContaining({action: 'cancel', close_reason: 'cancel_button'})
+      );
+    });
+    const cancelCalls = mockTrackAnalytics.mock.calls.filter(
+      ([event, payload]) => event === 'logs.export_modal' && payload?.action === 'cancel'
     );
-
-    onClose(undefined);
-
-    expect(mockTrackAnalytics).toHaveBeenCalledTimes(1);
+    expect(cancelCalls).toHaveLength(1);
   });
 });

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -3,10 +3,10 @@ import styled from '@emotion/styled';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import * as Layout from 'sentry/components/layouts/thirds';
 import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/datePageFilter';
@@ -241,6 +241,8 @@ const LogsSearchSection = memo(function LogsSearchSection({
 });
 
 export function LogsTabContent({datePageFilterProps, tableExpando}: LogsTabProps) {
+  const {openModal} = useModal();
+
   const pageFilters = usePageFilters();
   const fields = useQueryParamsFields();
   const mode = useQueryParamsMode();

--- a/static/app/views/explore/spans/tour.tsx
+++ b/static/app/views/explore/spans/tour.tsx
@@ -3,7 +3,8 @@ import styled from '@emotion/styled';
 
 import exploreSpansTourSvg from 'sentry-images/spot/explore-spans-tour.svg';
 
-import {openModal} from 'sentry/actionCreators/modal';
+import {useModal} from '@sentry/scraps/modal';
+
 import {StartTourModal, startTourModalCss} from 'sentry/components/tours/startTour';
 import type {TourContextType} from 'sentry/components/tours/tourContext';
 import {useAssistant, useMutateAssistant} from 'sentry/components/tours/useAssistant';
@@ -40,6 +41,8 @@ function useExploreSpansTour(): TourContextType<ExploreSpansTour> {
 
 // Displays the introductory tour modal when a user is entering the experience for the first time.
 export function useExploreSpansTourModal() {
+  const {openModal} = useModal();
+
   const hasOpenedTourModal = useRef(false);
   const {isRegistered, startTour, endTour} = useExploreSpansTour();
   const {data: assistantData} = useAssistant({
@@ -108,6 +111,7 @@ export function useExploreSpansTourModal() {
     mutateAssistant,
     endTour,
     isNavTourActive,
+    openModal,
   ]);
 }
 

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -3,10 +3,10 @@ import {Fragment, useEffect} from 'react';
 import {Badge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {IconEdit} from 'sentry/icons/iconEdit';
 import {t} from 'sentry/locale';
 import type {Confidence} from 'sentry/types/organization';
@@ -43,6 +43,8 @@ interface ExploreTablesProps extends BaseExploreTablesProps {
 }
 
 export function ExploreTables(props: ExploreTablesProps) {
+  const {openModal} = useModal();
+
   const {setTab, tab} = props;
   const crossEvents = useQueryParamsCrossEvents();
   const hasCrossEvents = !!crossEvents?.length;


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.