### PR TITLE
ref(feedback): adopt useModal in feedback item

### DIFF
--- a/static/app/components/feedback/feedbackItem/screenshotSection.tsx
+++ b/static/app/components/feedback/feedbackItem/screenshotSection.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
 import {useDeleteEventAttachmentOptimistic} from 'sentry/actionCreators/events';
-import {openModal} from 'sentry/actionCreators/modal';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {FeedbackScreenshot} from 'sentry/components/feedback/feedbackItem/feedbackScreenshot';
 import {
@@ -23,6 +23,8 @@ type Props = {
 };
 
 export function ScreenshotSection({event, organization, projectSlug}: Props) {
+  const {openModal} = useModal();
+
   const {screenshots} = useFeedbackScreenshot({projectSlug, event});
   const {mutate: deleteAttachment} = useDeleteEventAttachmentOptimistic();
 


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.