### PR TITLE
ref(automations): adopt useModal in action settings

### DIFF
--- a/static/app/views/automations/components/actions/sentryApp.tsx
+++ b/static/app/views/automations/components/actions/sentryApp.tsx
@@ -1,8 +1,8 @@
 import {Fragment} from 'react';
 
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {IconSettings} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {ActionHandler} from 'sentry/types/workflowEngine/actions';
@@ -31,6 +31,8 @@ export function SentryAppNode() {
 }
 
 function SentryAppActionSettingsButton() {
+  const {openModal} = useModal();
+
   const {action, handler, onUpdate} = useActionNodeContext();
   const sentryApp = handler.sentryApp;
 

--- a/static/app/views/automations/components/actions/ticketActionSettingsButton.tsx
+++ b/static/app/views/automations/components/actions/ticketActionSettingsButton.tsx
@@ -1,8 +1,8 @@
 import {useMemo} from 'react';
 
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {TicketRuleModal} from 'sentry/components/externalIssues/ticketRuleModal';
 import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -16,6 +16,8 @@ import {
 import {useAutomationFormContext} from 'sentry/views/automations/components/forms/context';
 
 export function TicketActionSettingsButton() {
+  const {openModal} = useModal();
+
   const {action, onUpdate} = useActionNodeContext();
   const {automation} = useAutomationFormContext();
 


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.