### PR TITLE
ref(autofix): adopt useModal in autofix views

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -6,9 +6,9 @@ import {AnimatePresence, motion, type MotionNodeAnimationOptions} from 'framer-m
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex, Grid} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {ClippedBox} from 'sentry/components/clippedBox';
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
 import {AutofixHighlightPopup} from 'sentry/components/events/autofix/autofixHighlightPopup';
@@ -678,6 +678,8 @@ function SetupAndCreateBranchButton({
   onProcessingChange: (processing: boolean) => void;
   runId: string;
 }) {
+  const {openModal} = useModal();
+
   const {codebases} = useAutofixRepos(groupId);
 
   if (
@@ -726,6 +728,8 @@ function SetupAndCreatePRsButton({
   onProcessingChange: (processing: boolean) => void;
   runId: string;
 }) {
+  const {openModal} = useModal();
+
   const {codebases} = useAutofixRepos(groupId);
   if (
     !changes.every(

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -1,8 +1,9 @@
 import {useCallback, useMemo, useState} from 'react';
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
+import {useModal} from '@sentry/scraps/modal';
+
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {AutofixCursorGithubAccessModal} from 'sentry/components/events/autofix/autofixCursorGithubAccessModal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {AutofixGithubCopilotPurchaseModal} from 'sentry/components/events/autofix/autofixGithubCopilotPurchaseModal';
@@ -367,6 +368,8 @@ export function needsGitHubAuth(error: RequestError): boolean {
 }
 
 export function useLaunchCodingAgent(groupId: string, runId: string) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const queryClient = useQueryClient();
 

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -1,12 +1,13 @@
 import {useCallback, useRef, useState} from 'react';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 
+import {useModal} from '@sentry/scraps/modal';
+
 import {
   addErrorMessage,
   addLoadingMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {AutofixCursorGithubAccessModal} from 'sentry/components/events/autofix/autofixCursorGithubAccessModal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {AutofixGithubCopilotPurchaseModal} from 'sentry/components/events/autofix/autofixGithubCopilotPurchaseModal';
@@ -509,6 +510,8 @@ export function useExplorerAutofix(
   groupId: string,
   options: UseExplorerAutofixOptions = {}
 ) {
+  const {openModal} = useModal();
+
   const {enabled = true} = options;
   const api = useApi();
   const queryClient = useQueryClient();
@@ -781,7 +784,16 @@ export function useExplorerAutofix(
         setWaitingForCodingAgent(false);
       }
     },
-    [api, orgSlug, groupId, queryClient, organization, user.id, appendCodingAgentErrors]
+    [
+      api,
+      orgSlug,
+      groupId,
+      queryClient,
+      organization,
+      user.id,
+      appendCodingAgentErrors,
+      openModal,
+    ]
   );
 
   // Clear waiting state when we get a response


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.