### PR TITLE
ref(onboarding): adopt useModal in onboarding flows

### DIFF
--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -6,13 +6,13 @@ import {TeamFixture} from 'sentry-fixture/team';
 
 import {
   render,
+  renderGlobalModal,
   screen,
   userEvent,
   waitFor,
   within,
 } from 'sentry-test/reactTestingLibrary';
 
-import {openConsoleModal, openModal} from 'sentry/actionCreators/modal';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   OnboardingContextProvider,
@@ -24,8 +24,6 @@ import * as analytics from 'sentry/utils/analytics';
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 import {ScmPlatformFeatures} from './scmPlatformFeatures';
-
-jest.mock('sentry/actionCreators/modal');
 
 // Mock the virtualizer so all items render in JSDOM (no layout engine).
 jest.mock('@tanstack/react-virtual', () => ({
@@ -433,8 +431,6 @@ describe('ScmPlatformFeatures', () => {
   });
 
   it('shows framework suggestion modal when selecting a base language', async () => {
-    const mockOpenModal = openModal as jest.Mock;
-
     render(
       <ScmPlatformFeatures
         onComplete={jest.fn()}
@@ -446,6 +442,7 @@ describe('ScmPlatformFeatures', () => {
         additionalWrapper: makeOnboardingWrapper(),
       }
     );
+    renderGlobalModal();
 
     await screen.findByText('Select a platform');
 
@@ -453,14 +450,10 @@ describe('ScmPlatformFeatures', () => {
     await userEvent.type(screen.getByRole('textbox'), 'JavaScript');
     await userEvent.click(await screen.findByText('Browser JavaScript'));
 
-    await waitFor(() => {
-      expect(mockOpenModal).toHaveBeenCalled();
-    });
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
   it('opens console modal when selecting a disabled gaming platform', async () => {
-    const mockOpenConsoleModal = openConsoleModal as jest.Mock;
-
     render(
       <ScmPlatformFeatures
         onComplete={jest.fn()}
@@ -475,6 +468,7 @@ describe('ScmPlatformFeatures', () => {
         additionalWrapper: makeOnboardingWrapper(),
       }
     );
+    renderGlobalModal();
 
     await screen.findByText('Select a platform');
 
@@ -482,9 +476,7 @@ describe('ScmPlatformFeatures', () => {
     await userEvent.type(screen.getByRole('textbox'), 'Nintendo');
     await userEvent.click(await screen.findByText('Nintendo Switch'));
 
-    await waitFor(() => {
-      expect(mockOpenConsoleModal).toHaveBeenCalled();
-    });
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
   it('disabling tracing auto-disables profiling', async () => {

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -5,11 +5,12 @@ import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 import {Select} from '@sentry/scraps/select';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {closeModal, openConsoleModal, openModal} from 'sentry/actionCreators/modal';
+import {closeModal, openConsoleModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -97,6 +98,8 @@ function getPlatformName(platformKey: PlatformKey | undefined) {
 }
 
 export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const {
     selectedRepository,

--- a/static/app/views/onboarding/useConfigureSdk.spec.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.spec.tsx
@@ -2,7 +2,8 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
-import {openModal} from 'sentry/actionCreators/modal';
+import {useModal} from '@sentry/scraps/modal';
+
 import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
 import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -11,11 +12,12 @@ import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 import {useConfigureSdk} from './useConfigureSdk';
 
+jest.mock('@sentry/scraps/modal');
 jest.mock('sentry/actionCreators/modal');
 jest.mock('sentry/components/onboarding/useCreateProject');
 
 const mockCreateProject = jest.fn();
-const mockOpenModal = openModal as jest.Mock;
+const mockOpenModal = jest.fn();
 
 function mockCreateProjectHook() {
   let isPending = false;
@@ -69,6 +71,12 @@ describe('useConfigureSdk', () => {
 
     createProjectInstance = mockCreateProjectHook();
     mockUseCreateProject.mockReturnValue(createProjectInstance);
+    jest.mocked(useModal).mockReturnValue({
+      openModal: mockOpenModal,
+      closeModal: jest.fn(),
+      isOpen: false,
+      visible: false,
+    });
   });
 
   afterEach(() => {

--- a/static/app/views/onboarding/useConfigureSdk.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.tsx
@@ -1,12 +1,14 @@
 import {useCallback} from 'react';
 import * as Sentry from '@sentry/react';
 
+import {useModal} from '@sentry/scraps/modal';
+
 import {
   addErrorMessage,
   addLoadingMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
-import {openConsoleModal, openModal} from 'sentry/actionCreators/modal';
+import {openConsoleModal} from 'sentry/actionCreators/modal';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
@@ -27,6 +29,8 @@ export function useConfigureSdk({
 }: {
   onComplete: (selectedPlatform: OnboardingSelectedSDK) => void;
 }) {
+  const {openModal} = useModal();
+
   const {teams, fetching: isLoadingTeams} = useTeams();
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const organization = useOrganization();
@@ -147,7 +151,7 @@ export function useConfigureSdk({
         }
       );
     },
-    [createPlatformProject, onboardingContext, organization, createProject]
+    [createPlatformProject, onboardingContext, organization, createProject, openModal]
   );
 
   return {

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -12,7 +12,7 @@ import {useModal} from '@sentry/scraps/modal';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openConsoleModal, openModal} from 'sentry/actionCreators/modal';
+import {openConsoleModal} from 'sentry/actionCreators/modal';
 import {Access} from 'sentry/components/acl/access';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {List} from 'sentry/components/list';
@@ -137,7 +137,7 @@ function getSubmitTooltipText({
 }
 
 export function CreateProject() {
-  const globalModal = useModal();
+  const {openModal, visible: isModalVisible} = useModal();
   const navigate = useNavigate();
   const organization = useOrganization();
   const location = useLocation();
@@ -419,7 +419,7 @@ export function CreateProject() {
         }
       );
     },
-    [configurePlatform, organization]
+    [configurePlatform, organization, openModal]
   );
 
   const debounceHandleProjectCreation = useMemo(
@@ -593,7 +593,7 @@ export function CreateProject() {
               </Tooltip>
             </div>
           </FormFieldGroup>
-          {!globalModal.visible && (
+          {!isModalVisible && (
             <ProjectCreationErrorAlert error={createProjectAndRules.error} />
           )}
         </List>


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.