### PR TITLE
ref(issues): adopt useModal in issue views

### DIFF
--- a/static/app/components/events/highlights/highlightsDataSection.spec.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.spec.tsx
@@ -4,13 +4,13 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {
   render,
+  renderGlobalModal,
   screen,
   userEvent,
   waitFor,
   within,
 } from 'sentry-test/reactTestingLibrary';
 
-import * as modal from 'sentry/actionCreators/modal';
 import {HighlightsDataSection} from 'sentry/components/events/highlights/highlightsDataSection';
 import {EMPTY_HIGHLIGHT_DEFAULT} from 'sentry/components/events/highlights/util';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -36,7 +36,6 @@ describe('HighlightsDataSection', () => {
   };
   const highlightContextTitles = ['User: email', 'Browser: name', 'Browser: version'];
   const analyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
-  const modalSpy = jest.spyOn(modal, 'openModal');
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -55,6 +54,7 @@ describe('HighlightsDataSection', () => {
       body: {},
     });
     render(<HighlightsDataSection event={event} project={project} />, {organization});
+    renderGlobalModal();
     expect(screen.getByText('Highlights')).toBeInTheDocument();
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(await screen.findByText("There's nothing here...")).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('HighlightsDataSection', () => {
       'highlights.issue_details.edit_clicked',
       expect.anything()
     );
-    expect(modalSpy).toHaveBeenCalled();
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
   it('renders highlights from the detailed project API response', async () => {

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -4,8 +4,8 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {ContextCardContent} from 'sentry/components/events/contexts/contextCard';
@@ -48,6 +48,8 @@ function useOpenEditHighlightsModal({
   event: Event;
   detailedProject?: Project;
 }) {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const organization = useOrganization();
   const isProjectAdmin = hasEveryAccess(['project:admin'], {

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {useFetchEventAttachments} from 'sentry/actionCreators/events';
-import {openModal} from 'sentry/actionCreators/modal';
 import {getOrderedContextItems} from 'sentry/components/events/contexts';
 import {
   getContextIcon,
@@ -39,6 +39,8 @@ interface HighlightsIconSummaryProps {
 }
 
 export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps) {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const organization = useOrganization();
 

--- a/static/app/components/stackTrace/issueStackTrace/issueSourceMapsDebuggerAction.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/issueSourceMapsDebuggerAction.tsx
@@ -2,8 +2,8 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {
   prepareSourceMapDebuggerFrameInformation,
   useSourceMapDebugQuery,
@@ -20,6 +20,8 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function IssueSourceMapsDebuggerAction() {
+  const {openModal} = useModal();
+
   const {frame, event, frameIndex} = useStackTraceFrameContext();
   const {exceptionIndex, hideSourceMapDebugger, project} = useStackTraceContext();
   const organization = useOrganization({allowNull: true});

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -6,6 +6,7 @@ import {useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
 import {bulkDelete, bulkUpdate} from 'sentry/actionCreators/group';
 import {
@@ -14,7 +15,7 @@ import {
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {openModal, openReprocessEventModal} from 'sentry/actionCreators/modal';
+import {openReprocessEventModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
 import {FeatureDisabled} from 'sentry/components/acl/featureDisabled';
 import {ArchiveActions} from 'sentry/components/actions/archive';
@@ -107,6 +108,8 @@ interface GroupActionsProps {
 }
 
 export function GroupActions({group, project, disabled, event}: GroupActionsProps) {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const api = useApi({persistInFlight: true});
   const organization = useOrganization();

--- a/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
@@ -4,9 +4,9 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {Card} from 'sentry/components/card';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {DateTime} from 'sentry/components/dateTime';
@@ -44,6 +44,8 @@ export function ScreenshotCard({
   eventId,
   onDelete,
 }: Props) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const [loadingImage, setLoadingImage] = useState(true);
 

--- a/static/app/views/issueDetails/streamline/header/issueIdBreadcrumb.tsx
+++ b/static/app/views/issueDetails/streamline/header/issueIdBreadcrumb.tsx
@@ -4,9 +4,9 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {ShortId} from 'sentry/components/shortId';
 import {IconCopy, IconGlobe} from 'sentry/icons';
@@ -25,6 +25,8 @@ interface ShortIdBreadcrumbProps {
 }
 
 export function IssueIdBreadcrumb({project, group}: ShortIdBreadcrumbProps) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const [isHovered, setIsHovered] = useState(false);
   const shareUrl = group?.shareId ? getShareUrl(organization, group) : null;

--- a/static/app/views/issueList/issueListCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListCommandPaletteActions.tsx
@@ -2,9 +2,9 @@ import {Fragment, useMemo} from 'react';
 import orderBy from 'lodash/orderBy';
 
 import {UserAvatar} from '@sentry/scraps/avatar';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {fetchFeatureFlagValues, fetchTagValues} from 'sentry/actionCreators/tags';
 import {cmdkQueryOptions} from 'sentry/components/commandPalette/types';
 import {
@@ -305,6 +305,8 @@ function SaveViewActions({
   query,
   sort,
 }: Pick<IssueListCommandPaletteActionsProps, 'query' | 'sort'>) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const user = useUser();
   const {viewId} = useParams();

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
 import {Button, ButtonBar} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
 import {FeatureDisabled} from 'sentry/components/acl/featureDisabled';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -154,6 +154,8 @@ function SegmentedIssueViewSaveButton({
 }
 
 export function IssueViewSaveButton({query, sort}: IssueViewSaveButtonProps) {
+  const {openModal} = useModal();
+
   const {viewId} = useParams();
   const {selection} = usePageFilters();
   const {data: view} = useSelectedGroupSearchView();

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
@@ -1,7 +1,8 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {openModal} from 'sentry/actionCreators/modal';
+import {useModal} from '@sentry/scraps/modal';
+
 import {SavedEntityTable} from 'sentry/components/savedEntityTable';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -40,6 +41,8 @@ export function IssueViewsTable({
   type,
   hideCreatedBy = false,
 }: IssueViewsTableProps) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const user = useUser();
   const hasIssueViews = useHasIssueViews();


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.