### PR TITLE
ref(billing): adopt useModal in billing views

### DIFF
--- a/static/app/views/admin/adminUserEdit.tsx
+++ b/static/app/views/admin/adminUserEdit.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {openModal} from 'sentry/actionCreators/modal';
 import {RadioGroup} from 'sentry/components/forms/controls/radioGroup';
 import {Form} from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
@@ -116,6 +116,8 @@ function RemoveUserModal({user, onRemove, closeModal}: RemoveModalProps) {
 }
 
 function AdminUserEdit() {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const {id} = useParams<{id: string}>();
   const userEndpoint = getApiUrl('/users/$userId/', {path: {userId: id}});

--- a/static/gsApp/views/legalAndCompliance/gdprPanel.tsx
+++ b/static/gsApp/views/legalAndCompliance/gdprPanel.tsx
@@ -6,6 +6,7 @@ import {z} from 'zod';
 import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
 import {Grid, Stack} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {
@@ -14,7 +15,6 @@ import {
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {openModal} from 'sentry/actionCreators/modal';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
@@ -151,6 +151,8 @@ const sectionTitles = {
 } as const;
 
 export function GDPRPanel({subscription}: GDPRPanelProps) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const activeSuperUser = isActiveSuperuser();
   const hasAccess = organization.access.includes('org:billing');

--- a/static/gsApp/views/legalAndCompliance/policyRow.tsx
+++ b/static/gsApp/views/legalAndCompliance/policyRow.tsx
@@ -6,8 +6,8 @@ import moment from 'moment-timezone';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex, Grid, type FlexProps} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
@@ -37,6 +37,8 @@ export function PolicyRow({
   onAccept,
   subscription,
 }: PolicyRowProps) {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const organization = useOrganization();
 

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -6,10 +6,10 @@ import {Button, LinkButton} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Container, Grid, Stack, type GridProps} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Pagination} from '@sentry/scraps/pagination';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {Confirm} from 'sentry/components/confirm';
 import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -54,6 +54,8 @@ type Props = {
 };
 
 export function SpendAllocationsRoot({organization, subscription}: Props) {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const [errors, setErrors] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.