### PR TITLE
ref(settings): adopt useModal in settings views

### DIFF
--- a/static/app/views/navigation/navigationTour.tsx
+++ b/static/app/views/navigation/navigationTour.tsx
@@ -10,7 +10,8 @@ import {
 
 import NavigationTourSvg from 'sentry-images/spot/stacked-nav-tour.svg';
 
-import {openModal} from 'sentry/actionCreators/modal';
+import {useModal} from '@sentry/scraps/modal';
+
 import {
   TourAction,
   TourContextProvider,
@@ -301,6 +302,8 @@ export function NavigationTourReminder(props: NavigationTourReminderProps) {
 
 // Displays the introductory tour modal when a user is entering the experience for the first time.
 export function useNavigationTourModal() {
+  const {openModal} = useModal();
+
   const user = useUser();
   const organization = useOrganization();
   const hasOpenedTourModal = useRef(false);
@@ -371,6 +374,7 @@ export function useNavigationTourModal() {
     endTour,
     organization,
     dismissTour,
+    openModal,
   ]);
 }
 

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -3,12 +3,12 @@ import {useMutation} from '@tanstack/react-query';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex, Grid} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 import {Switch} from '@sentry/scraps/switch';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {openModal} from 'sentry/actionCreators/modal';
 import {fetchOrganizations} from 'sentry/actionCreators/organizations';
 import {HookOrDefault} from 'sentry/components/hookOrDefault';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -54,6 +54,8 @@ type OwnedOrg = {
 };
 
 function AccountClose() {
+  const {openModal} = useModal();
+
   const api = useApi();
 
   const [organizations, setOrganizations] = useState<OwnedOrg[]>([]);

--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -12,9 +12,9 @@ import {
   FieldGroup as FormFieldGroup,
   FormSearch,
 } from '@sentry/scraps/form';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {Confirm} from 'sentry/components/confirm';
 import {FieldGroup} from 'sentry/components/forms/fieldGroup';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -60,6 +60,8 @@ const schema = z.object({
 });
 
 function ApiApplicationsDetails() {
+  const {openModal} = useModal();
+
   const api = useApi();
   const {appId} = useParams<{appId: string}>();
   const queryClient = useQueryClient();

--- a/static/app/views/settings/account/apiApplications/index.tsx
+++ b/static/app/views/settings/account/apiApplications/index.tsx
@@ -4,13 +4,14 @@ import {useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Grid} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
 import {
   addErrorMessage,
   addLoadingMessage,
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
-import {openModal, type ModalRenderProps} from 'sentry/actionCreators/modal';
+import {type ModalRenderProps} from 'sentry/actionCreators/modal';
 import {RadioGroup} from 'sentry/components/forms/controls/radioGroup';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -31,6 +32,8 @@ import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageH
 const ROUTE_PREFIX = '/settings/account/api/';
 
 export default function ApiApplications() {
+  const {openModal} = useModal();
+
   const api = useApi();
   const hasPageFrame = useHasPageFrameFeature();
   const queryClient = useQueryClient();

--- a/static/app/views/settings/components/dataScrubbing/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelAlert} from 'sentry/components/panels/panelAlert';
@@ -50,6 +50,8 @@ export function DataScrubbing({
   additionalContext,
   relayPiiConfig,
 }: Props) {
+  const {openModal} = useModal();
+
   const api = useApi();
   const [rules, setRules] = useState<Rule[]>([]);
   const navigate = useNavigate();
@@ -110,6 +112,7 @@ export function DataScrubbing({
     organization.slug,
     successfullySaved,
     handleCloseModal,
+    openModal,
   ]);
 
   useEffect(() => {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -8,6 +8,7 @@ import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {
@@ -15,7 +16,6 @@ import {
   addLoadingMessage,
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {
   sentryAppApiOptions,
   sentryAppsApiOptions,
@@ -221,6 +221,8 @@ function getSchemaFieldValue(schema: SentryApp['schema'] | null | undefined) {
 }
 
 export default function SentryApplicationDetails() {
+  const {openModal} = useModal();
+
   const navigate = useNavigate();
   const location = useLocation();
   const {appSlug} = useParams<{appSlug: string}>();

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
@@ -3,8 +3,8 @@ import styled from '@emotion/styled';
 import {SentryAppAvatar} from '@sentry/scraps/avatar';
 import {Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {SentryAppPublishRequestModal} from 'sentry/components/modals/sentryAppPublishRequestModal/sentryAppPublishRequestModal';
 import {PanelItem} from 'sentry/components/panels/panelItem';
 import type {SentryApp} from 'sentry/types/integrations';
@@ -25,6 +25,8 @@ export function SentryApplicationRow({
   onPublishSubmission,
   onRemoveApp,
 }: Props) {
+  const {openModal} = useModal();
+
   const isInternal = app.status === 'internal';
 
   // no publishing for internal apps so hide the status on the developer

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
@@ -6,10 +6,10 @@ import sortBy from 'lodash/sortBy';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {Pagination} from '@sentry/scraps/pagination';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -129,6 +129,8 @@ function useDeletePathConfig({
 }
 
 export function IntegrationCodeMappings({integration}: {integration: Integration}) {
+  const {openModal} = useModal();
+
   const queryClient = useQueryClient();
   useRouteAnalyticsEventNames(
     'integrations.code_mappings_viewed',

--- a/static/app/views/settings/organizationIntegrations/integrationExternalTeamMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalTeamMappings.tsx
@@ -1,8 +1,9 @@
 import {useQuery} from '@tanstack/react-query';
 import {useMutation} from '@tanstack/react-query';
 
+import {useModal} from '@sentry/scraps/modal';
+
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -25,6 +26,8 @@ type Props = {
 };
 
 export function IntegrationExternalTeamMappings(props: Props) {
+  const {openModal} = useModal();
+
   const {integration} = props;
   const organization = useOrganization();
   const location = useLocation();

--- a/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -2,8 +2,9 @@ import {Fragment} from 'react';
 import {useQuery} from '@tanstack/react-query';
 import {useMutation} from '@tanstack/react-query';
 
+import {useModal} from '@sentry/scraps/modal';
+
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -27,6 +28,8 @@ type Props = {
 };
 
 export function IntegrationExternalUserMappings(props: Props) {
+  const {openModal} = useModal();
+
   const {integration} = props;
   const organization = useOrganization();
 

--- a/static/app/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton.tsx
@@ -2,8 +2,8 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {t} from 'sentry/locale';
 import type {IntegrationType} from 'sentry/types/integrations';
 
@@ -16,6 +16,8 @@ type Props = {
 };
 
 export function RequestIntegrationButton(props: Props) {
+  const {openModal} = useModal();
+
   const [isOpen, setIsOpen] = useState(false);
   const [isSent, setIsSent] = useState(false);
 

--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {ContextPickerModalContainer as ContextPickerModal} from 'sentry/components/contextPickerModal';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -56,6 +56,8 @@ function makePluginQueryKey({
 }
 
 function PluginDetailedView() {
+  const {openModal} = useModal();
+
   const tabs: IntegrationTab[] = ['overview', 'configurations'];
   const {activeTab, setActiveTab} = useIntegrationTabs<IntegrationTab>({
     initialTab: 'overview',
@@ -219,7 +221,7 @@ function PluginDetailedView() {
       ),
       {closeEvents: 'escape-key'}
     );
-  }, [integrationSlug, installationStatus, navigate, organization, plugin]);
+  }, [integrationSlug, installationStatus, navigate, organization, plugin, openModal]);
 
   const renderTopButton = useCallback(
     (disabledFromFeatures: boolean, userHasAccess: boolean) => {

--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
@@ -6,9 +6,9 @@ import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {SentryAppAvatar} from '@sentry/scraps/avatar';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {
   installSentryApp,
   uninstallSentryApp,
@@ -49,6 +49,8 @@ function makeSentryAppInstallationsQueryKey({orgSlug}: {orgSlug: string}): ApiQu
 }
 
 export default function SentryAppDetailedView() {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const tabs: IntegrationTab[] = ['overview'];
   const api = useApi({persistInFlight: true});
@@ -227,6 +229,7 @@ export default function SentryAppDetailedView() {
     installationStatus,
     integrationSlug,
     redirectUser,
+    openModal,
   ]);
 
   const handleUninstall = useCallback(

--- a/static/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -6,9 +6,9 @@ import {Button} from '@sentry/scraps/button';
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -37,6 +37,8 @@ const relaySchema = z.object({
 });
 
 export function RelayWrapper() {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
   const api = useApi();
   const [relays, setRelays] = useState(organization.trustedRelays);
@@ -176,6 +178,8 @@ function RelayUsageList({
   relays: Relay[];
   registerKeyAction?: React.ReactNode;
 }) {
+  const {openModal} = useModal();
+
   const {isPending, isError, refetch, data} = useApiQuery<RelayActivity[]>(
     [
       getApiUrl('/organizations/$organizationIdOrSlug/relay_usage/', {

--- a/static/app/views/settings/project/projectOwnership/codeOwnerFileTable.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeOwnerFileTable.tsx
@@ -4,9 +4,9 @@ import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import {TimeSince} from 'sentry/components/timeSince';
@@ -39,6 +39,8 @@ export function CodeOwnerFileTable({
   onDelete,
   disabled,
 }: CodeOwnerFileTableProps) {
+  const {openModal} = useModal();
+
   const api = useApi();
   const theme = useTheme();
   const organization = useOrganization();

--- a/static/app/views/settings/project/projectOwnership/index.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.spec.tsx
@@ -3,12 +3,15 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import ProjectOwnership from 'sentry/views/settings/project/projectOwnership';
-
-jest.mock('sentry/actionCreators/modal');
 
 describe('Project Ownership', () => {
   const {organization, project} = initializeOrg();
@@ -86,9 +89,23 @@ describe('Project Ownership', () => {
         await screen.findByRole('button', {name: 'Import CODEOWNERS'})
       ).toBeInTheDocument();
 
+      // The Add CODEOWNERS modal fetches unfiltered code mappings and
+      // integrations on mount.
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/code-mappings/`,
+        method: 'GET',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/integrations/`,
+        method: 'GET',
+        body: [GitHubIntegrationConfigFixture()],
+      });
+
       // Opens modal
+      renderGlobalModal();
       await userEvent.click(screen.getByRole('button', {name: 'Import CODEOWNERS'}));
-      expect(openModal).toHaveBeenCalled();
+      expect(await screen.findByRole('dialog')).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -7,8 +7,9 @@ import {Button} from '@sentry/scraps/button';
 import {AutoSaveForm, FieldGroup, FormSearch} from '@sentry/scraps/form';
 import {Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
-import {closeModal, openEditOwnershipRules, openModal} from 'sentry/actionCreators/modal';
+import {closeModal, openEditOwnershipRules} from 'sentry/actionCreators/modal';
 import {Access, hasEveryAccess} from 'sentry/components/acl/access';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -41,6 +42,8 @@ const ownershipSchema = z.object({
 });
 
 export default function ProjectOwnership() {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const organization = useOrganization();
   const queryClient = useQueryClient();

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -7,9 +7,9 @@ import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
@@ -41,6 +41,8 @@ interface ProjectSeerProps {
 }
 
 export function AutofixRepositories({project}: ProjectSeerProps) {
+  const {openModal} = useModal();
+
   const theme = useTheme();
   const organization = useOrganization();
   const repositoriesQuery = useInfiniteQuery({


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.