### PR TITLE
ref(seer): adopt useModal in seer automation views

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.tsx
@@ -6,10 +6,10 @@ import seerConfigBug1 from 'getsentry-images/spot/seer-config-bug-1.svg';
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {Heading} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import type {
   ProjectSeerPreferences,
@@ -61,6 +61,8 @@ const getTableHeaders = (organization: Organization): React.ReactNode[] => [
 ];
 
 export function AutofixRepositories({canWrite, preference, project}: Props) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
 
   const repositoriesQuery = useInfiniteQuery({

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -16,10 +16,10 @@ import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Image} from '@sentry/scraps/image';
 import {InputGroup} from '@sentry/scraps/input';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {
   bulkAutofixAutomationSettingsInfiniteOptions,
   useUpdateBulkAutofixAutomationSettings,
@@ -368,6 +368,8 @@ const SimpleTableWithColumns = styled(SimpleTable)`
 `;
 
 function AddProjectButton() {
+  const {openModal} = useModal();
+
   const [isLoadingModal, setIsLoadingModal] = useState(false);
 
   return (

--- a/static/gsApp/views/seerAutomation/onboarding/onboardingLegacy.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/onboardingLegacy.tsx
@@ -8,13 +8,13 @@ import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
 import {
   addErrorMessage,
   addLoadingMessage,
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {ClippedBox} from 'sentry/components/clippedBox';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
@@ -121,6 +121,8 @@ function ProjectRowWithUpdate({
   projectStates: ProjectStateMap;
   repositories: Repository[];
 }) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
 
   const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
@@ -167,6 +169,7 @@ function ProjectRowWithUpdate({
     project.slug,
     onSuccess,
     onUpdateProjectState,
+    openModal,
   ]);
 
   return <ProjectRow onClick={handleProjectClick} project={project} />;


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.