### PR TITLE
ref(scraps): adopt useModal in remaining call sites

### DIFF
--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -4,9 +4,9 @@ import styled from '@emotion/styled';
 
 import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {CustomCommitsResolutionModal} from 'sentry/components/customCommitsResolutionModal';
 import {CustomResolutionModal} from 'sentry/components/customResolutionModal';
@@ -88,6 +88,8 @@ export function ResolveActions({
   hasSemverReleaseFeature,
   onUpdate,
 }: ResolveActionsProps) {
+  const {openModal} = useModal();
+
   const organization = useOrganization();
 
   // resolve in semver release is eligible if the flag is enabled,

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx
@@ -1,12 +1,12 @@
 import {useState} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
 import {
   useDeleteEventAttachmentOptimistic,
   useFetchEventAttachments,
 } from 'sentry/actionCreators/events';
-import {openModal} from 'sentry/actionCreators/modal';
 import {Screenshot} from 'sentry/components/events/eventTagsAndScreenshot/screenshot';
 import {
   modalCss,
@@ -36,6 +36,8 @@ export function ScreenshotDataSection({
   isShare,
   ...props
 }: ScreenshotDataSectionProps) {
+  const {openModal} = useModal();
+
   const location = useLocation();
   const organization = useOrganization();
   const {data: attachments} = useFetchEventAttachments(

--- a/static/app/components/featureFeedback/index.tsx
+++ b/static/app/components/featureFeedback/index.tsx
@@ -1,7 +1,7 @@
 import type {ButtonProps} from '@sentry/scraps/button';
 import {Button} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import type {FeedbackModalProps} from 'sentry/components/featureFeedback/feedbackModal';
 import {FeedbackModal, modalCss} from 'sentry/components/featureFeedback/feedbackModal';
 import type {Data} from 'sentry/components/forms/types';
@@ -23,6 +23,8 @@ export function FeatureFeedback<T extends Data>({
   buttonProps = {},
   ...props
 }: FeatureFeedbackProps<T>) {
+  const {openModal} = useModal();
+
   function handleClick(e: React.MouseEvent<HTMLButtonElement>) {
     openModal(modalProps => <FeedbackModal {...modalProps} {...props} />, {
       modalCss,

--- a/static/app/components/pickProjectToContinue.tsx
+++ b/static/app/components/pickProjectToContinue.tsx
@@ -1,9 +1,9 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import type {LocationDescriptor, LocationDescriptorObject} from 'history';
 
 import {Container} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {ContextPickerModalContainer as ContextPickerModal} from 'sentry/components/contextPickerModal';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
@@ -33,9 +33,11 @@ export function PickProjectToContinue({
   projects,
   allowAllProjectsSelection = false,
 }: Props) {
+  const {openModal} = useModal();
   const navigate = useNavigate();
   const nextPathQuery = nextPath.query;
-  let navigating = false;
+  const navigating = useRef(false);
+
   let path = `${nextPath.pathname}?project=`;
 
   if (nextPathQuery) {
@@ -56,36 +58,50 @@ export function PickProjectToContinue({
     }
   }, [shouldRedirect, navigate, path, projects]);
 
+  useEffect(() => {
+    if (shouldRedirect) {
+      return;
+    }
+    navigating.current = false;
+    openModal(
+      modalProps => (
+        <ContextPickerModal
+          {...modalProps}
+          needOrg={false}
+          needProject
+          nextPath={`${path}:project`}
+          onFinish={to => {
+            navigating.current = true;
+            navigate(to, {replace: true});
+            modalProps.closeModal();
+          }}
+          projectSlugs={projects.map(p => p.slug)}
+          allowAllProjectsSelection={allowAllProjectsSelection}
+        />
+      ),
+      {
+        onClose() {
+          // we want this to be executed only if the user didn't select any project
+          // (closed modal either via button, Esc, clicking outside, ...)
+          if (!navigating.current) {
+            navigate(noProjectRedirectPath);
+          }
+        },
+      }
+    );
+  }, [
+    shouldRedirect,
+    openModal,
+    navigate,
+    noProjectRedirectPath,
+    path,
+    projects,
+    allowAllProjectsSelection,
+  ]);
+
   if (shouldRedirect) {
     return null;
   }
-
-  openModal(
-    modalProps => (
-      <ContextPickerModal
-        {...modalProps}
-        needOrg={false}
-        needProject
-        nextPath={`${path}:project`}
-        onFinish={to => {
-          navigating = true;
-          navigate(to, {replace: true});
-          modalProps.closeModal();
-        }}
-        projectSlugs={projects.map(p => p.slug)}
-        allowAllProjectsSelection={allowAllProjectsSelection}
-      />
-    ),
-    {
-      onClose() {
-        // we want this to be executed only if the user didn't select any project
-        // (closed modal either via button, Esc, clicking outside, ...)
-        if (!navigating) {
-          navigate(noProjectRedirectPath);
-        }
-      },
-    }
-  );
 
   return <Container width="100%" height="100vh" />;
 }

--- a/static/gsAdmin/components/changeARRAction.tsx
+++ b/static/gsAdmin/components/changeARRAction.tsx
@@ -1,9 +1,9 @@
 import {Component, Fragment} from 'react';
 
 import {Button, ButtonBar} from '@sentry/scraps/button';
+import {useModal} from '@sentry/scraps/modal';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {openModal} from 'sentry/actionCreators/modal';
 import {NumberField} from 'sentry/components/forms/fields/numberField';
 
 type Props = {
@@ -13,6 +13,8 @@ type Props = {
 };
 
 export function ChangeARRAction(props: Props) {
+  const {openModal} = useModal();
+
   return (
     <Button
       variant="link"

--- a/static/gsAdmin/components/users/userCustomers.tsx
+++ b/static/gsAdmin/components/users/userCustomers.tsx
@@ -1,6 +1,5 @@
 import {Button} from '@sentry/scraps/button';
-
-import {openModal} from 'sentry/actionCreators/modal';
+import {useModal} from '@sentry/scraps/modal';
 
 import {AddToOrgModal, RemoveFromOrgModal} from 'admin/components/addOrRemoveOrgModal';
 import {CustomerGrid} from 'admin/components/customerGrid';
@@ -10,6 +9,8 @@ type Props = {
 };
 
 export function UserCustomers({userId}: Props) {
+  const {openModal} = useModal();
+
   const openAddToOrgModal = () => {
     openModal(modalProps => <AddToOrgModal {...modalProps} userId={userId} />);
   };

--- a/static/gsAdmin/views/broadcasts.tsx
+++ b/static/gsAdmin/views/broadcasts.tsx
@@ -2,8 +2,8 @@ import moment from 'moment-timezone';
 
 import {Button} from '@sentry/scraps/button';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {ConfigStore} from 'sentry/stores/configStore';
 
 import {CreateBroadcastModal} from 'admin/components/createBroadcastModal';
@@ -36,6 +36,8 @@ const getRow = (row: any) => [
 ];
 
 export function Broadcasts() {
+  const {openModal} = useModal();
+
   const hasPermission = ConfigStore.get('user').permissions.has('broadcasts.admin');
   const fields = getBroadcastSchema();
 

--- a/static/gsAdmin/views/docIntegrationDetails.tsx
+++ b/static/gsAdmin/views/docIntegrationDetails.tsx
@@ -3,6 +3,7 @@ import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {DocIntegrationAvatar} from '@sentry/scraps/avatar';
 import {Tag} from '@sentry/scraps/badge';
 import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
 import {
   addErrorMessage,
@@ -10,7 +11,6 @@ import {
   addSuccessMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {DocIntegration} from 'sentry/types/integrations';
@@ -28,6 +28,8 @@ import {DetailsPage} from 'admin/components/detailsPage';
 import {DocIntegrationModal} from 'admin/components/docIntegrationModal';
 
 export function DocIntegrationDetails() {
+  const {openModal} = useModal();
+
   const {docIntegrationSlug} = useParams<{docIntegrationSlug: string}>();
   const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();

--- a/static/gsAdmin/views/docIntegrations.tsx
+++ b/static/gsAdmin/views/docIntegrations.tsx
@@ -3,8 +3,8 @@ import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import type {DocIntegration} from 'sentry/types/integrations';
 
 import {DocIntegrationModal} from 'admin/components/docIntegrationModal';
@@ -35,6 +35,8 @@ const getRow = (doc: DocIntegration) => [
 ];
 
 export function DocIntegrations() {
+  const {openModal} = useModal();
+
   return (
     <div>
       <PageHeader title="Document Integrations">

--- a/static/gsAdmin/views/instanceLevelOAuth/components/newInstanceLevelOAuthClient.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/components/newInstanceLevelOAuthClient.tsx
@@ -1,7 +1,8 @@
 import {Fragment} from 'react';
 
+import {useModal} from '@sentry/scraps/modal';
+
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {openModal} from 'sentry/actionCreators/modal';
 import {CheckboxField} from 'sentry/components/forms/fields/checkboxField';
 import {TextField} from 'sentry/components/forms/fields/textField';
 import {Form} from 'sentry/components/forms/form';
@@ -21,6 +22,8 @@ const fieldProps = {
 } as const;
 
 export function NewInstanceLevelOAuthClient({Body, Header}: ModalRenderProps) {
+  const {openModal} = useModal();
+
   const systemFeatures = ConfigStore.get('features');
   const formModel = new InstanceLevelOAuthClientModel();
 

--- a/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuth.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuth.tsx
@@ -1,7 +1,7 @@
 import {Button} from '@sentry/scraps/button';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {DateTime} from 'sentry/components/dateTime';
 
 import {PageHeader} from 'admin/components/pageHeader';
@@ -23,6 +23,8 @@ const getRow = (row: any) => [
 ];
 
 export function InstanceLevelOAuth() {
+  const {openModal} = useModal();
+
   return (
     <div>
       <PageHeader title="Instance Level OAuth Clients">

--- a/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {ApiForm} from 'sentry/components/forms/apiForm';
 import {TextField} from 'sentry/components/forms/fields/textField';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -39,6 +39,8 @@ const fieldProps = {
 } as const;
 
 export function InstanceLevelOAuthDetails() {
+  const {openModal} = useModal();
+
   const api = useApi();
   const params = useParams<{clientID: string}>();
 

--- a/static/gsAdmin/views/options.tsx
+++ b/static/gsAdmin/views/options.tsx
@@ -4,8 +4,8 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {IconEdit, IconStack} from 'sentry/icons';
 
 import {EditAdminOptionModal} from 'admin/components/editAdminOptionModal';
@@ -35,6 +35,8 @@ function EditableOption({
   path: string;
   row: SerializedOption;
 }) {
+  const {openModal} = useModal();
+
   if (row.groupingInfo && row.groupingInfo.order !== 0) {
     return null;
   }

--- a/static/gsAdmin/views/policies.tsx
+++ b/static/gsAdmin/views/policies.tsx
@@ -2,8 +2,8 @@ import moment from 'moment-timezone';
 
 import {Button} from '@sentry/scraps/button';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {ConfigStore} from 'sentry/stores/configStore';
 
 import {PageHeader} from 'admin/components/pageHeader';
@@ -25,6 +25,8 @@ const getRow = (row: any) => [
 ];
 
 export function Policies() {
+  const {openModal} = useModal();
+
   const hasPermission = ConfigStore.get('user').permissions.has('policies.admin');
 
   return (

--- a/static/gsAdmin/views/policyDetails.tsx
+++ b/static/gsAdmin/views/policyDetails.tsx
@@ -1,9 +1,9 @@
 import moment from 'moment-timezone';
 
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ConfigStore} from 'sentry/stores/configStore';
@@ -22,6 +22,8 @@ import {PolicyRevisions} from 'admin/components/policies/policyRevisions';
 import type {Policy, PolicyRevision} from 'getsentry/types';
 
 export function PolicyDetails() {
+  const {openModal} = useModal();
+
   const api = useApi();
   const {policySlug} = useParams<{policySlug: string}>();
 

--- a/static/gsAdmin/views/promoCodeDetails.tsx
+++ b/static/gsAdmin/views/promoCodeDetails.tsx
@@ -1,13 +1,14 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import moment from 'moment-timezone';
 
+import {useModal} from '@sentry/scraps/modal';
+
 import {
   addErrorMessage,
   addLoadingMessage,
   addSuccessMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -25,6 +26,8 @@ import type {PromoCode} from 'admin/types';
 import {titleCase} from 'getsentry/utils/titleCase';
 
 export function PromoCodeDetails() {
+  const {openModal} = useModal();
+
   const {codeId} = useParams<{codeId: string}>();
   const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();

--- a/static/gsAdmin/views/promoCodes.tsx
+++ b/static/gsAdmin/views/promoCodes.tsx
@@ -3,8 +3,7 @@ import moment from 'moment-timezone';
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Link} from '@sentry/scraps/link';
-
-import {openModal} from 'sentry/actionCreators/modal';
+import {useModal} from '@sentry/scraps/modal';
 
 import {PageHeader} from 'admin/components/pageHeader';
 import {AddPromoCodeModal as PromoCodeModal} from 'admin/components/promoCodes/promoCodeModal';
@@ -44,6 +43,8 @@ const getRow = (row: any) => [
 ];
 
 export function PromoCodes() {
+  const {openModal} = useModal();
+
   return (
     <div>
       <PageHeader title="Promo Codes">

--- a/static/gsAdmin/views/sentryAppDetails.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.tsx
@@ -3,6 +3,7 @@ import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {SentryAppAvatar} from '@sentry/scraps/avatar';
 import {Tag} from '@sentry/scraps/badge';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
 import {
   addErrorMessage,
@@ -10,7 +11,6 @@ import {
   addSuccessMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -26,6 +26,8 @@ import {DetailsPage} from 'admin/components/detailsPage';
 import {SentryAppUpdateModal} from 'admin/components/sentryAppUpdateModal';
 
 export function SentryAppDetails() {
+  const {openModal} = useModal();
+
   const {sentryAppSlug} = useParams<{sentryAppSlug: string}>();
   const ENDPOINT = getApiUrl('/sentry-apps/$sentryAppIdOrSlug/', {
     path: {sentryAppIdOrSlug: sentryAppSlug},

--- a/static/gsAdmin/views/sentryEmployees.tsx
+++ b/static/gsAdmin/views/sentryEmployees.tsx
@@ -1,7 +1,7 @@
 import {Button} from '@sentry/scraps/button';
 import {Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {UserBadge} from 'sentry/components/idBadge/userBadge';
 import {Truncate} from 'sentry/components/truncate';
 import {IconEdit} from 'sentry/icons';
@@ -12,6 +12,8 @@ import ResultGrid from 'admin/components/resultGrid';
 import {UserPermissionsModal} from 'admin/components/users/userPermissionsModal';
 
 export function SentryEmployees() {
+  const {openModal} = useModal();
+
   const gridColumns = [
     <th key="user">User</th>,
     <th key="email" style={{width: 100, textAlign: 'center'}}>

--- a/static/gsAdmin/views/userDetails.tsx
+++ b/static/gsAdmin/views/userDetails.tsx
@@ -1,12 +1,13 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
+import {useModal} from '@sentry/scraps/modal';
+
 import {
   addErrorMessage,
   addLoadingMessage,
   addSuccessMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
-import {openModal} from 'sentry/actionCreators/modal';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -30,6 +31,8 @@ import {UserOverview} from 'admin/components/users/userOverview';
 import {UserPermissionsModal} from 'admin/components/users/userPermissionsModal';
 
 export function UserDetails() {
+  const {openModal} = useModal();
+
   const api = useApi({persistInFlight: true});
   const {userId} = useParams<{userId: string}>();
   const queryClient = useQueryClient();


### PR DESCRIPTION
Adopts the `useModal` hook from `@sentry/scraps/modal` in place of importing `openModal` from `sentry/actionCreators/modal`, following up on the GlobalModal adoption in #114447.

The migration was applied by an `ast-grep` codemod that:

- Inserts `const {openModal} = useModal();` at the top of each enclosing function component or custom hook.
- Updates the import (or merges into an existing `@sentry/scraps/modal` import).
- Appends `openModal` to any wrapping `useCallback` / `useEffect` / `useMemo` dependency array, since the destructured value is no longer module-stable.

Action-creator helpers (e.g. `openInviteModal`) and other call sites where a hook can't be used are left alone. This PR is one of several split per CODEOWNERS group.