### PR TITLE
Revert "chore(objectstore): temporarily disable proxy endpoint in s4s2"

### DIFF
--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -27,7 +27,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
 from sentry.objectstore import parse_accept_encoding
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.types.cell import get_local_cell
 
 
 @cell_silo_endpoint
@@ -77,11 +76,6 @@ class ObjectstoreEndpoint(Endpoint):
         path: str,
     ) -> Response | StreamingHttpResponse:
         assert request.method
-
-        # TODO(FS-300): Re-enable this endpoint in S4S2 after secret versions are fixed
-        if get_local_cell().name == "s4s2":
-            return Response({"detail": "Unauthorized"}, status=401)
-
         target_url = get_target_url(path)
 
         headers = dict(request.headers)


### PR DESCRIPTION
Reverts getsentry/sentry#115031

Depends on k8s revert that re-enables auth enforcement

auth enforcement has been re-enabled in S4S2 so we can re-enable this endpoint