### PR TITLE
fix(preprod): Get snapshot status checks from detailed project

### DIFF
--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
@@ -3,7 +3,6 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {SnapshotStatusChecks} from 'sentry/views/settings/project/preprod/snapshotStatusChecks';
 
 describe('SnapshotStatusChecks', () => {
@@ -135,7 +134,6 @@ describe('SnapshotStatusChecks', () => {
 
   it('immediately hides failure condition toggles when status checks are disabled', async () => {
     const project = ProjectFixture({options: {}});
-    ProjectsStore.loadInitialData([project]);
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
     const mock = MockApiClient.addMockResponse({
       url: projectEndpoint,

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
@@ -132,7 +132,7 @@ describe('SnapshotStatusChecks', () => {
     );
   });
 
-  it('immediately hides failure condition toggles when status checks are disabled', async () => {
+  it('saves status checks enabled flag when toggled off', async () => {
     const project = ProjectFixture({options: {}});
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
     const mock = MockApiClient.addMockResponse({
@@ -151,12 +151,6 @@ describe('SnapshotStatusChecks', () => {
       await screen.findByRole('checkbox', {name: 'Enable Snapshot Status Checks'})
     );
 
-    expect(
-      await screen.findByText('Enable status checks to configure failure conditions')
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('checkbox', {name: 'Fail on Changed Snapshots'})
-    ).not.toBeInTheDocument();
     await waitFor(() =>
       expect(mock).toHaveBeenCalledWith(
         projectEndpoint,

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
@@ -132,7 +132,7 @@ describe('SnapshotStatusChecks', () => {
     );
   });
 
-  it('saves status checks enabled flag when toggled off', async () => {
+  it('immediately hides failure condition toggles when status checks are disabled', async () => {
     const project = ProjectFixture({options: {}});
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
     const mock = MockApiClient.addMockResponse({
@@ -151,6 +151,12 @@ describe('SnapshotStatusChecks', () => {
       await screen.findByRole('checkbox', {name: 'Enable Snapshot Status Checks'})
     );
 
+    expect(
+      await screen.findByText('Enable status checks to configure failure conditions')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Fail on Changed Snapshots'})
+    ).not.toBeInTheDocument();
     await waitFor(() =>
       expect(mock).toHaveBeenCalledWith(
         projectEndpoint,

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
@@ -20,6 +20,10 @@ describe('SnapshotStatusChecks', () => {
 
   it('renders default values when the project has no preprod options', async () => {
     const project = ProjectFixture({options: {}});
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: project,
+    });
     render(<SnapshotStatusChecks />, {
       organization,
       outletContext: {project},
@@ -52,6 +56,10 @@ describe('SnapshotStatusChecks', () => {
       preprodSnapshotStatusChecksFailOnChanged: false,
       preprodSnapshotStatusChecksFailOnRenamed: true,
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: project,
+    });
     render(<SnapshotStatusChecks />, {
       organization,
       outletContext: {project},
@@ -75,6 +83,10 @@ describe('SnapshotStatusChecks', () => {
   it('saves fail_on_changed when toggled off', async () => {
     const project = ProjectFixture({options: {}});
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      body: project,
+    });
     const mock = MockApiClient.addMockResponse({
       url: projectEndpoint,
       method: 'PUT',
@@ -105,6 +117,10 @@ describe('SnapshotStatusChecks', () => {
   it('saves fail_on_renamed when toggled on', async () => {
     const project = ProjectFixture({options: {}});
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      body: project,
+    });
     const mock = MockApiClient.addMockResponse({
       url: projectEndpoint,
       method: 'PUT',
@@ -135,6 +151,10 @@ describe('SnapshotStatusChecks', () => {
   it('immediately hides failure condition toggles when status checks are disabled', async () => {
     const project = ProjectFixture({options: {}});
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      body: project,
+    });
     const mock = MockApiClient.addMockResponse({
       url: projectEndpoint,
       method: 'PUT',
@@ -147,8 +167,16 @@ describe('SnapshotStatusChecks', () => {
       initialRouterConfig,
     });
 
+    // Setup mock for after the toggle is switched off
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      body: {...project, preprodSnapshotStatusChecksEnabled: false},
+    });
+
     await userEvent.click(
-      await screen.findByRole('checkbox', {name: 'Enable Snapshot Status Checks'})
+      await screen.findByRole('checkbox', {
+        name: 'Enable Snapshot Status Checks',
+      })
     );
 
     expect(
@@ -172,6 +200,10 @@ describe('SnapshotStatusChecks', () => {
     const project = ProjectFixture({
       options: {},
       preprodSnapshotStatusChecksEnabled: false,
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: project,
     });
     render(<SnapshotStatusChecks />, {
       organization,

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -66,23 +66,18 @@ export function SnapshotStatusChecks() {
     onMutate: data => {
       const previousProject = currentProject;
       queryClient.setQueryData(projectQueryKey, prev => {
-        return {
-          headers: prev?.headers ?? {},
-          json: {...(prev?.json ?? previousProject), ...data},
-        };
+        return prev ? {...prev, json: {...prev.json, ...data}} : undefined;
       });
       return () => {
-        queryClient.setQueryData(projectQueryKey, prev => ({
-          headers: prev?.headers ?? {},
-          json: previousProject,
-        }));
+        queryClient.setQueryData(projectQueryKey, prev => {
+          return prev ? {...prev, json: previousProject} : undefined;
+        });
       };
     },
     onSuccess: response => {
-      queryClient.setQueryData(projectQueryKey, prev => ({
-        headers: prev?.headers ?? {},
-        json: {...(prev?.json ?? project), ...response},
-      }));
+      queryClient.setQueryData(projectQueryKey, prev => {
+        return prev ? {...prev, json: response} : undefined;
+      });
     },
     onError: (_error, _variables, rollback) => {
       rollback?.();

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -7,7 +7,9 @@ import {Container} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 import {getSnapshotStatusChecks} from './getSnapshotStatusChecks';
@@ -29,8 +31,13 @@ type SnapshotStatusCheckField = {
 };
 
 export function SnapshotStatusChecks() {
-  const {project} = useProjectSettingsOutlet();
-  const {mutateAsync: updateProject} = useUpdateProject(project);
+  const organization = useOrganization();
+  const {project: outletProject} = useProjectSettingsOutlet();
+  const {data: project = outletProject} = useDetailedProject({
+    orgSlug: organization.slug,
+    projectSlug: outletProject.slug,
+  });
+  const {mutateAsync: updateProject} = useUpdateProject(outletProject);
   const {enabled, failOnAdded, failOnRemoved, failOnChanged, failOnRenamed} =
     getSnapshotStatusChecks(project);
 

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {mutationOptions} from '@tanstack/react-query';
+import {mutationOptions, useQueryClient} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
@@ -7,11 +7,13 @@ import {Container} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
-import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
+import {
+  makeDetailedProjectQueryKey,
+  useDetailedProject,
+} from 'sentry/utils/project/useDetailedProject';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 import {getSnapshotStatusChecks} from './getSnapshotStatusChecks';
@@ -34,12 +36,20 @@ type SnapshotStatusCheckField = {
 
 export function SnapshotStatusChecks() {
   const organization = useOrganization();
-  const {project: outletProject} = useProjectSettingsOutlet();
-  const project = useProjectFromId({project_id: outletProject.id}) ?? outletProject;
-  const {enabled, failOnAdded, failOnRemoved, failOnChanged, failOnRenamed} =
-    getSnapshotStatusChecks(project);
-
+  const {project} = useProjectSettingsOutlet();
+  const queryClient = useQueryClient();
   const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+  const projectQueryKey = makeDetailedProjectQueryKey({
+    orgSlug: organization.slug,
+    projectSlug: project.slug,
+  });
+  const {data: detailedProject} = useDetailedProject(
+    {orgSlug: organization.slug, projectSlug: project.slug},
+    {enabled: false}
+  );
+  const currentProject = detailedProject ?? project;
+  const {enabled, failOnAdded, failOnRemoved, failOnChanged, failOnRenamed} =
+    getSnapshotStatusChecks(currentProject);
 
   const projectMutationOptions = mutationOptions({
     mutationFn: (data: Partial<Schema>) =>
@@ -49,17 +59,30 @@ export function SnapshotStatusChecks() {
         data,
       }),
     onMutate: data => {
-      const previous = ProjectsStore.getById(project.id);
-      ProjectsStore.onUpdateSuccess({id: project.id, ...data});
-      return () => {
-        if (previous) {
-          ProjectsStore.onUpdateSuccess(previous);
-        }
-      };
+      const previousProject = currentProject;
+      queryClient.setQueryData(projectQueryKey, prev => {
+        return {
+          headers: prev?.headers ?? {},
+          json: {...(prev?.json ?? previousProject), ...data},
+        };
+      });
+      return previousProject;
     },
-    onSuccess: response => ProjectsStore.onUpdateSuccess(response),
-    onError: (_error, _variables, rollback) => {
-      rollback?.();
+    onSuccess: response => {
+      queryClient.setQueryData(projectQueryKey, prev => ({
+        headers: prev?.headers ?? {},
+        json: {...(prev?.json ?? project), ...response},
+      }));
+    },
+    onError: (_error, _variables, previousProject) => {
+      if (!previousProject) {
+        return;
+      }
+
+      queryClient.setQueryData(projectQueryKey, prev => ({
+        headers: prev?.headers ?? {},
+        json: previousProject,
+      }));
     },
   });
 

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -8,6 +8,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {
   makeDetailedProjectQueryKey,
   useDetailedProject,
@@ -38,7 +39,6 @@ export function SnapshotStatusChecks() {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
   const queryClient = useQueryClient();
-  const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
   const projectQueryKey = makeDetailedProjectQueryKey({
     orgSlug: organization.slug,
     projectSlug: project.slug,
@@ -54,7 +54,12 @@ export function SnapshotStatusChecks() {
   const projectMutationOptions = mutationOptions({
     mutationFn: (data: Partial<Schema>) =>
       fetchMutation<Project>({
-        url: projectEndpoint,
+        url: getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            projectIdOrSlug: project.slug,
+          },
+        }),
         method: 'PUT',
         data,
       }),

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -71,7 +71,12 @@ export function SnapshotStatusChecks() {
           json: {...(prev?.json ?? previousProject), ...data},
         };
       });
-      return previousProject;
+      return () => {
+        queryClient.setQueryData(projectQueryKey, prev => ({
+          headers: prev?.headers ?? {},
+          json: previousProject,
+        }));
+      };
     },
     onSuccess: response => {
       queryClient.setQueryData(projectQueryKey, prev => ({
@@ -79,15 +84,8 @@ export function SnapshotStatusChecks() {
         json: {...(prev?.json ?? project), ...response},
       }));
     },
-    onError: (_error, _variables, previousProject) => {
-      if (!previousProject) {
-        return;
-      }
-
-      queryClient.setQueryData(projectQueryKey, prev => ({
-        headers: prev?.headers ?? {},
-        json: previousProject,
-      }));
+    onError: (_error, _variables, rollback) => {
+      rollback?.();
     },
   });
 

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -7,9 +7,7 @@ import {Container} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
-import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 import {getSnapshotStatusChecks} from './getSnapshotStatusChecks';
@@ -31,16 +29,10 @@ type SnapshotStatusCheckField = {
 };
 
 export function SnapshotStatusChecks() {
-  const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
-  const {data: detailedProject} = useDetailedProject(
-    {orgSlug: organization.slug, projectSlug: project.slug},
-    {enabled: false}
-  );
   const {mutateAsync: updateProject} = useUpdateProject(project);
-  const currentProject = detailedProject ?? project;
   const {enabled, failOnAdded, failOnRemoved, failOnChanged, failOnRenamed} =
-    getSnapshotStatusChecks(currentProject);
+    getSnapshotStatusChecks(project);
 
   const projectMutationOptions = mutationOptions({
     mutationFn: (data: Partial<Schema>) => updateProject(data),

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {mutationOptions, useQueryClient} from '@tanstack/react-query';
+import {mutationOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
@@ -7,13 +7,8 @@ import {Container} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
-import type {Project} from 'sentry/types/project';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {
-  makeDetailedProjectQueryKey,
-  useDetailedProject,
-} from 'sentry/utils/project/useDetailedProject';
-import {fetchMutation} from 'sentry/utils/queryClient';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
+import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -38,50 +33,17 @@ type SnapshotStatusCheckField = {
 export function SnapshotStatusChecks() {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
-  const queryClient = useQueryClient();
-  const projectQueryKey = makeDetailedProjectQueryKey({
-    orgSlug: organization.slug,
-    projectSlug: project.slug,
-  });
   const {data: detailedProject} = useDetailedProject(
     {orgSlug: organization.slug, projectSlug: project.slug},
     {enabled: false}
   );
+  const {mutateAsync: updateProject} = useUpdateProject(project);
   const currentProject = detailedProject ?? project;
   const {enabled, failOnAdded, failOnRemoved, failOnChanged, failOnRenamed} =
     getSnapshotStatusChecks(currentProject);
 
   const projectMutationOptions = mutationOptions({
-    mutationFn: (data: Partial<Schema>) =>
-      fetchMutation<Project>({
-        url: getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
-          path: {
-            organizationIdOrSlug: organization.slug,
-            projectIdOrSlug: project.slug,
-          },
-        }),
-        method: 'PUT',
-        data,
-      }),
-    onMutate: data => {
-      const previousProject = currentProject;
-      queryClient.setQueryData(projectQueryKey, prev => {
-        return prev ? {...prev, json: {...prev.json, ...data}} : prev;
-      });
-      return () => {
-        queryClient.setQueryData(projectQueryKey, prev => {
-          return prev ? {...prev, json: previousProject} : prev;
-        });
-      };
-    },
-    onSuccess: response => {
-      queryClient.setQueryData(projectQueryKey, prev => {
-        return prev ? {...prev, json: response} : prev;
-      });
-    },
-    onError: (_error, _variables, rollback) => {
-      rollback?.();
-    },
+    mutationFn: (data: Partial<Schema>) => updateProject(data),
   });
 
   const failureConditionFields = [

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -66,17 +66,17 @@ export function SnapshotStatusChecks() {
     onMutate: data => {
       const previousProject = currentProject;
       queryClient.setQueryData(projectQueryKey, prev => {
-        return prev ? {...prev, json: {...prev.json, ...data}} : undefined;
+        return prev ? {...prev, json: {...prev.json, ...data}} : prev;
       });
       return () => {
         queryClient.setQueryData(projectQueryKey, prev => {
-          return prev ? {...prev, json: previousProject} : undefined;
+          return prev ? {...prev, json: previousProject} : prev;
         });
       };
     },
     onSuccess: response => {
       queryClient.setQueryData(projectQueryKey, prev => {
-        return prev ? {...prev, json: response} : undefined;
+        return prev ? {...prev, json: response} : prev;
       });
     },
     onError: (_error, _variables, rollback) => {


### PR DESCRIPTION
Snapshot status checks was setting DetailedProject properties in ProjectStore. useUpdateProject to update detailed project and project store (as a backup). The project store typically only contains ProjectSummary objects.  This will be split further in #115024 