### PR TITLE
fix(spans) Trim environment names to prevent overflows

### DIFF
--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -36,16 +36,13 @@ class EnvironmentProject(Model):
         unique_together = (("project", "environment"),)
 
 
-NAME_LENGTH = 64
-
-
 @cell_silo_model
 class Environment(Model):
     __relocation_scope__ = RelocationScope.Organization
 
     organization_id = BoundedBigIntegerField()
     projects = models.ManyToManyField("sentry.Project", through=EnvironmentProject)
-    name = models.CharField(max_length=NAME_LENGTH)
+    name = models.CharField(max_length=ENVIRONMENT_NAME_MAX_LENGTH)
     date_added = models.DateTimeField(default=timezone.now)
 
     objects: ClassVar[BaseManager[Self]] = BaseManager(cache_fields=["pk"])
@@ -74,7 +71,7 @@ class Environment(Model):
     @classmethod
     def get_name_or_default(cls, name):
         if name:
-            return name[:NAME_LENGTH]
+            return name[:ENVIRONMENT_NAME_MAX_LENGTH]
         return ""
 
     @classmethod

--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -36,13 +36,16 @@ class EnvironmentProject(Model):
         unique_together = (("project", "environment"),)
 
 
+NAME_LENGTH = 64
+
+
 @cell_silo_model
 class Environment(Model):
     __relocation_scope__ = RelocationScope.Organization
 
     organization_id = BoundedBigIntegerField()
     projects = models.ManyToManyField("sentry.Project", through=EnvironmentProject)
-    name = models.CharField(max_length=64)
+    name = models.CharField(max_length=NAME_LENGTH)
     date_added = models.DateTimeField(default=timezone.now)
 
     objects: ClassVar[BaseManager[Self]] = BaseManager(cache_fields=["pk"])
@@ -70,7 +73,9 @@ class Environment(Model):
 
     @classmethod
     def get_name_or_default(cls, name):
-        return name or ""
+        if name:
+            return name[:NAME_LENGTH]
+        return ""
 
     @classmethod
     def get_for_organization_id(cls, organization_id, name):

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -140,6 +140,17 @@ class TestSpansTask(TestCase):
         )
         assert release.date_added.timestamp() == spans[0]["end_timestamp"]
 
+    def test_create_models_trim_environment_name(self) -> None:
+        spans = self.generate_basic_spans()
+        spans[1]["attributes"]["sentry.environment"]["value"] = "a" * 100
+        assert process_segment(spans)
+
+        # Environment is trimmed
+        Environment.objects.get(
+            organization_id=self.organization.id,
+            name="a" * 64,
+        )
+
     @override_options({"spans.process-segments.detect-performance-problems.enable": True})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     def test_n_plus_one_issue_detection(self, mock_eventstream: mock.MagicMock) -> None:


### PR DESCRIPTION
The environment model has a max name length of 64 characters. Currently if a span contains a longer name, saving segment relations will fail.

Trimming the environment name to prevent overflows preserves as much data as we can. This change will also impact environments created by errors and transactions.

Fixes SENTRY-5HBE