### PR TITLE
feat(onboarding): Render info-only feature cards for wizard-driven platforms

### DIFF
--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -1,5 +1,5 @@
 import {Tag} from '@sentry/scraps/badge';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -35,7 +35,7 @@ export function ScmFeatureInfoCards({
           {t('Features available for this platform')}
         </Heading>
       </Flex>
-      <Stack gap="md">
+      <Grid gap="md" columns="1fr 1fr">
         {availableFeatures.map(feature => {
           const meta = featureMeta[feature];
           return (
@@ -62,7 +62,7 @@ export function ScmFeatureInfoCards({
             </Container>
           );
         })}
-      </Stack>
+      </Grid>
     </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -14,8 +14,8 @@ interface ScmFeatureInfoCardsProps {
   availableFeatures: ProductSolution[];
   disabledProducts: DisabledProducts;
   featureMeta: Record<ProductSolution, FeatureMeta>;
-  platformName: string;
   isVolumeLoading?: boolean;
+  platformName?: string;
 }
 
 // Informational variant of the SCM feature card list. Renders the products
@@ -33,15 +33,17 @@ export function ScmFeatureInfoCards({
   return (
     <Stack gap="xl" width="100%" justify="center">
       <Stack gap="md">
-        <Heading as="h3" size="xl">
-          {tct('Available with [platformName]', {
-            platformName: (
-              <Text as="span" bold variant="accent">
-                {platformName}
-              </Text>
-            ),
-          })}
-        </Heading>
+        {platformName ? (
+          <Heading as="h3" size="xl">
+            {tct('Available with [platformName]', {
+              platformName: (
+                <Text as="span" bold variant="accent">
+                  {platformName}
+                </Text>
+              ),
+            })}
+          </Heading>
+        ) : null}
         <Text size="lg" variant="secondary" density="comfortable">
           {t('In the next step, run our setup wizard to choose what to instrument')}
         </Text>

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -13,6 +13,7 @@ interface ScmFeatureInfoCardsProps {
   availableFeatures: ProductSolution[];
   disabledProducts: DisabledProducts;
   featureMeta: Record<ProductSolution, FeatureMeta>;
+  platformName: string;
   isVolumeLoading?: boolean;
 }
 
@@ -24,16 +25,17 @@ interface ScmFeatureInfoCardsProps {
 export function ScmFeatureInfoCards({
   availableFeatures,
   featureMeta,
+  platformName,
   isVolumeLoading,
 }: ScmFeatureInfoCardsProps) {
   return (
     <Stack gap="xl" width="100%" justify="center">
       <Stack gap="md">
         <Heading as="h3" size="xl">
-          {tct('Available with [bold:platform]', {
-            bold: (
+          {tct('Available with [platformName]', {
+            platformName: (
               <Text as="span" bold variant="accent">
-                {null}
+                {platformName}
               </Text>
             ),
           })}

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -1,13 +1,11 @@
-import {Tag} from '@sentry/scraps/badge';
-import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {DisabledProducts} from 'sentry/components/onboarding/productSelection';
 import {Placeholder} from 'sentry/components/placeholder';
-import {IconInfo} from 'sentry/icons/iconInfo';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 
 import type {FeatureMeta} from './useScmFeatureMeta';
 
@@ -30,36 +28,72 @@ export function ScmFeatureInfoCards({
 }: ScmFeatureInfoCardsProps) {
   return (
     <Stack gap="xl" width="100%" justify="center">
-      <Flex justify="between" align="center">
+      <Stack gap="md">
         <Heading as="h3" size="xl">
-          {t('Features available for this platform')}
+          {tct('Available with [bold:platform]', {
+            bold: (
+              <Text as="span" bold variant="accent">
+                {null}
+              </Text>
+            ),
+          })}
         </Heading>
-      </Flex>
-      <Grid gap="md" columns="1fr 1fr">
+        <Text size="lg" variant="secondary" density="comfortable">
+          {t('In the next step, run our setup wizard to choose what to instrument')}
+        </Text>
+      </Stack>
+      <Grid
+        gap="2xl"
+        columns={{xs: '1fr', sm: '1fr 1fr'}}
+        border="secondary"
+        radius="lg"
+        padding="2xl"
+      >
         {availableFeatures.map(feature => {
           const meta = featureMeta[feature];
+          const Icon = meta.icon;
           return (
-            <Container key={feature} padding="lg" border="primary" radius="md">
-              <Flex justify="between" align="start" gap="md">
-                <Stack gap="xs">
-                  <Text bold size="md">
-                    {meta.label}
-                  </Text>
-                  <Text variant="secondary">{meta.description}</Text>
-                </Stack>
-                <Flex align="start" gap="sm">
+            <Grid
+              key={feature}
+              columns="min-content 1fr"
+              rows="min-content min-content"
+              gap={{xs: 'xs md', sm: 'xs lg'}}
+              align="center"
+              areas={`
+                    "icon label"
+                    ". description"
+                  `}
+            >
+              <Container area="icon">
+                {containerProps => <Icon {...containerProps} size="md" />}
+              </Container>
+              <Container area="label">
+                <Text bold size="md">
+                  {meta.label}
+                </Text>
+              </Container>
+              <Stack gap="md" area="description">
+                <Text variant="secondary" density="comfortable">
+                  {meta.description}
+                </Text>
+                <Container>
                   {isVolumeLoading ? (
-                    <Placeholder height="22px" width="100px" />
+                    <Placeholder height="20px" width="100px" />
                   ) : (
                     <Tooltip title={meta.volumeTooltip} delay={100}>
-                      <Tag variant="muted" icon={<IconInfo size="sm" />}>
+                      <Text
+                        variant="muted"
+                        underline="dotted"
+                        size="sm"
+                        density="comfortable"
+                      >
                         {meta.volume}
-                      </Tag>
+                      </Text>
                     </Tooltip>
                   )}
-                </Flex>
-              </Flex>
-            </Container>
+                </Container>
+              </Stack>
+            </Grid>
           );
         })}
       </Grid>

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -1,0 +1,68 @@
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {DisabledProducts} from 'sentry/components/onboarding/productSelection';
+import {Placeholder} from 'sentry/components/placeholder';
+import {IconInfo} from 'sentry/icons/iconInfo';
+import {t} from 'sentry/locale';
+
+import type {FeatureMeta} from './useScmFeatureMeta';
+
+interface ScmFeatureInfoCardsProps {
+  availableFeatures: ProductSolution[];
+  disabledProducts: DisabledProducts;
+  featureMeta: Record<ProductSolution, FeatureMeta>;
+  isVolumeLoading?: boolean;
+}
+
+// Informational variant of the SCM feature card list. Renders the products
+// applicable to the user-selected platform without offering toggles, used for
+// platforms whose onboarding is wizard-driven (the wizard CLI handles
+// configuration; toggles aren't actionable). Visual treatment is a placeholder;
+// designer iterates on this separately.
+export function ScmFeatureInfoCards({
+  availableFeatures,
+  featureMeta,
+  isVolumeLoading,
+}: ScmFeatureInfoCardsProps) {
+  return (
+    <Stack gap="xl" width="100%" justify="center">
+      <Flex justify="between" align="center">
+        <Heading as="h3" size="xl">
+          {t('Features available for this platform')}
+        </Heading>
+      </Flex>
+      <Stack gap="md">
+        {availableFeatures.map(feature => {
+          const meta = featureMeta[feature];
+          return (
+            <Container key={feature} padding="lg" border="primary" radius="md">
+              <Flex justify="between" align="start" gap="md">
+                <Stack gap="xs">
+                  <Text bold size="md">
+                    {meta.label}
+                  </Text>
+                  <Text variant="secondary">{meta.description}</Text>
+                </Stack>
+                <Flex align="start" gap="sm">
+                  {isVolumeLoading ? (
+                    <Placeholder height="22px" width="100px" />
+                  ) : (
+                    <Tooltip title={meta.volumeTooltip} delay={100}>
+                      <Tag variant="muted" icon={<IconInfo size="sm" />}>
+                        {meta.volume}
+                      </Tag>
+                    </Tooltip>
+                  )}
+                </Flex>
+              </Flex>
+            </Container>
+          );
+        })}
+      </Stack>
+    </Stack>
+  );
+}

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -1,4 +1,5 @@
-import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -83,11 +84,14 @@ export function ScmFeatureInfoCards({
                     />
                   )}
                 </Container>
-                <Container area="label">
+                <Flex area="label" gap="sm" align="center">
                   <Text bold size="md" variant={isDisabled ? 'muted' : undefined}>
                     {meta.label}
                   </Text>
-                </Container>
+                  {meta.alwaysEnabled ? (
+                    <Tag variant="muted">{t('Always on')}</Tag>
+                  ) : null}
+                </Flex>
                 <Stack gap="md" area="description">
                   <Text
                     variant={isDisabled ? 'muted' : 'secondary'}
@@ -106,7 +110,7 @@ export function ScmFeatureInfoCards({
                       >
                         <Text
                           variant="muted"
-                          underline={isDisabled ? undefined : 'dotted'}
+                          underline="dotted"
                           size="sm"
                           density="comfortable"
                         >

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -24,6 +24,7 @@ interface ScmFeatureInfoCardsProps {
 // designer iterates on this separately.
 export function ScmFeatureInfoCards({
   availableFeatures,
+  disabledProducts,
   featureMeta,
   platformName,
   isVolumeLoading,
@@ -54,48 +55,69 @@ export function ScmFeatureInfoCards({
         {availableFeatures.map(feature => {
           const meta = featureMeta[feature];
           const Icon = meta.icon;
+          const disabledProduct = disabledProducts[feature];
+          const isDisabled = !meta.alwaysEnabled && !!disabledProduct;
           return (
-            <Grid
+            <Tooltip
               key={feature}
-              columns="min-content 1fr"
-              rows="min-content min-content"
-              gap={{xs: 'xs md', sm: 'xs lg'}}
-              align="center"
-              areas={`
+              title={disabledProduct?.reason}
+              disabled={!isDisabled}
+              delay={100}
+            >
+              <Grid
+                columns="min-content 1fr"
+                rows="min-content min-content"
+                gap={{xs: 'xs md', sm: 'xs lg'}}
+                align="center"
+                areas={`
                     "icon label"
                     ". description"
                   `}
-            >
-              <Container area="icon">
-                {containerProps => <Icon {...containerProps} size="md" />}
-              </Container>
-              <Container area="label">
-                <Text bold size="md">
-                  {meta.label}
-                </Text>
-              </Container>
-              <Stack gap="md" area="description">
-                <Text variant="secondary" density="comfortable">
-                  {meta.description}
-                </Text>
-                <Container>
-                  {isVolumeLoading ? (
-                    <Placeholder height="20px" width="100px" />
-                  ) : (
-                    <Tooltip title={meta.volumeTooltip} delay={100}>
-                      <Text
-                        variant="muted"
-                        underline="dotted"
-                        size="sm"
-                        density="comfortable"
-                      >
-                        {meta.volume}
-                      </Text>
-                    </Tooltip>
+              >
+                <Container area="icon">
+                  {containerProps => (
+                    <Icon
+                      {...containerProps}
+                      size="md"
+                      variant={isDisabled ? 'muted' : undefined}
+                    />
                   )}
                 </Container>
-              </Stack>
-            </Grid>
+                <Container area="label">
+                  <Text bold size="md" variant={isDisabled ? 'muted' : undefined}>
+                    {meta.label}
+                  </Text>
+                </Container>
+                <Stack gap="md" area="description">
+                  <Text
+                    variant={isDisabled ? 'muted' : 'secondary'}
+                    density="comfortable"
+                  >
+                    {meta.description}
+                  </Text>
+                  <Container>
+                    {isVolumeLoading ? (
+                      <Placeholder height="20px" width="100px" />
+                    ) : (
+                      <Tooltip
+                        title={meta.volumeTooltip}
+                        delay={100}
+                        disabled={isDisabled}
+                      >
+                        <Text
+                          variant="muted"
+                          underline={isDisabled ? undefined : 'dotted'}
+                          size="sm"
+                          density="comfortable"
+                        >
+                          {meta.volume}
+                        </Text>
+                      </Tooltip>
+                    )}
+                  </Container>
+                </Stack>
+              </Grid>
+            </Tooltip>
           );
         })}
       </Grid>

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -31,9 +31,11 @@ export function ScmFeatureSelectionCards({
         <Heading as="h3" size="xl">
           {t('What do you want to instrument?')}
         </Heading>
-        <Text size="sm" variant="secondary">
-          {t('Choose one or more')}
-        </Text>
+        {availableFeatures.length > 1 ? (
+          <Text size="sm" variant="secondary">
+            {t('Choose one or more')}
+          </Text>
+        ) : null}
       </Flex>
       <Stack gap="md">
         {availableFeatures.map(feature => {

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -4,7 +4,13 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 import {TeamFixture} from 'sentry-fixture/team';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import {openConsoleModal, openModal} from 'sentry/actionCreators/modal';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -113,8 +119,9 @@ describe('ScmPlatformFeatures', () => {
       }
     );
 
-    expect(await screen.findByText('Next.js')).toBeInTheDocument();
-    expect(screen.getByText('Django')).toBeInTheDocument();
+    const radioGroup = await screen.findByRole('radiogroup');
+    expect(within(radioGroup).getByText('Next.js')).toBeInTheDocument();
+    expect(within(radioGroup).getByText('Django')).toBeInTheDocument();
   });
 
   it('auto-selects first detected platform', async () => {
@@ -147,7 +154,7 @@ describe('ScmPlatformFeatures', () => {
     );
 
     expect(
-      await screen.findByText('Features available for this platform')
+      await screen.findByRole('heading', {level: 3, name: 'Available with Next.js'})
     ).toBeInTheDocument();
   });
 
@@ -569,7 +576,7 @@ describe('ScmPlatformFeatures', () => {
         }
       );
 
-      await screen.findByText('Features available for this platform');
+      await screen.findByRole('heading', {level: 3, name: 'Available with Next.js'});
 
       const detectedCalls = trackAnalyticsSpy.mock.calls.filter(
         ([event, params]) =>

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -147,7 +147,7 @@ describe('ScmPlatformFeatures', () => {
     );
 
     expect(
-      await screen.findByText('What do you want to instrument?')
+      await screen.findByText('Features available for this platform')
     ).toBeInTheDocument();
   });
 
@@ -569,7 +569,7 @@ describe('ScmPlatformFeatures', () => {
         }
       );
 
-      await screen.findByText('What do you want to instrument?');
+      await screen.findByText('Features available for this platform');
 
       const detectedCalls = trackAnalyticsSpy.mock.calls.filter(
         ([event, params]) =>

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -158,6 +158,110 @@ describe('ScmPlatformFeatures', () => {
     ).toBeInTheDocument();
   });
 
+  describe('feature card variants', () => {
+    it('renders informational cards for wizard-driven platforms (no toggles)', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {platforms: [DetectedPlatformFixture()]},
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+          }),
+        }
+      );
+
+      expect(
+        await screen.findByRole('heading', {level: 3, name: 'Available with Next.js'})
+      ).toBeInTheDocument();
+      expect(screen.getByText('Error monitoring')).toBeInTheDocument();
+      expect(screen.getByText('Tracing')).toBeInTheDocument();
+      expect(screen.getByText('Session replay')).toBeInTheDocument();
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('What do you want to instrument?')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders toggleable cards for curated platforms', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {
+          platforms: [DetectedPlatformFixture({platform: 'python', language: 'Python'})],
+        },
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+          }),
+        }
+      );
+
+      expect(
+        await screen.findByText('What do you want to instrument?')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', {name: /Tracing/})).toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', {level: 3, name: /^Available with /})
+      ).not.toBeInTheDocument();
+    });
+
+    it('skips the feature-cards block for platforms in neither map', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {platforms: []},
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+            selectedPlatform: {
+              key: 'nintendo-switch',
+              name: 'Nintendo Switch',
+              language: 'nintendo-switch',
+              type: 'console',
+              link: null,
+              category: 'all',
+            },
+          }),
+        }
+      );
+
+      await screen.findByRole('button', {name: 'Continue'});
+
+      expect(
+        screen.queryByRole('heading', {level: 3, name: /^Available with /})
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('What do you want to instrument?')
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/unlimited volume for 14 days/)).not.toBeInTheDocument();
+    });
+  });
+
   it('clicking "Change platform" shows manual picker', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/42/platforms/`,

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -91,6 +91,11 @@ function shouldSuggestFramework(platformKey: PlatformKey): boolean {
   );
 }
 
+function getPlatformName(platformKey: PlatformKey | undefined) {
+  if (!platformKey) return;
+  return getPlatformInfo(platformKey)?.name;
+}
+
 export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
   const organization = useOrganization();
   const {
@@ -161,6 +166,8 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
   const detectedPlatformKey = resolvedPlatforms[0]?.platform;
   // Derive platform from explicit selection, falling back to first detected
   const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
+
+  const currentPlatformName = getPlatformName(currentPlatformKey);
 
   // Fire scm_platform_selected once when detection auto-resolves a platform
   // and the user hasn't explicitly chosen one. Otherwise a user who accepts
@@ -628,12 +635,7 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
                     availableFeatures={availableFeatures}
                     disabledProducts={disabledProducts}
                     featureMeta={featureMeta}
-                    platformName={
-                      currentPlatformKey
-                        ? (getPlatformInfo(currentPlatformKey)?.name ??
-                          currentPlatformKey)
-                        : ''
-                    }
+                    platformName={currentPlatformName}
                     isVolumeLoading={isFeatureMetaLoading}
                   />
                 )}

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -19,6 +19,7 @@ import {
   platformProductAvailability,
 } from 'sentry/components/onboarding/productSelection';
 import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
+import {PLATFORM_PRODUCT_INFO} from 'sentry/data/platformProductInfo.generated';
 import {platforms} from 'sentry/data/platforms';
 import {IconBroadcast, IconBusiness, IconGeneric} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -31,6 +32,7 @@ import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
+import {ScmFeatureInfoCards} from 'sentry/views/onboarding/components/scmFeatureInfoCards';
 import {ScmFeatureSelectionCards} from 'sentry/views/onboarding/components/scmFeatureSelectionCards';
 import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCard';
 import {useScmFeatureMeta} from 'sentry/views/onboarding/components/useScmFeatureMeta';
@@ -181,16 +183,40 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
     });
   }, [detectedPlatformKey, selectedPlatform?.key, organization]);
 
-  const availableFeatures = useMemo(() => {
+  // Pick which feature-card variant to render for the selected platform.
+  //   toggleable    — platform has a curated entry in `platformProductAvailability`;
+  //                   render `ScmFeatureSelectionCards` (user can toggle products).
+  //   informational — platform has a generated entry in `PLATFORM_PRODUCT_INFO`
+  //                   (wizard-driven onboarding); render `ScmFeatureInfoCards`
+  //                   (informational, no toggles since the wizard handles config).
+  //   none          — platform isn't covered by either map; render no feature cards.
+  const featureMode = useMemo<'toggleable' | 'informational' | 'none'>(() => {
     if (!currentPlatformKey) {
+      return 'none';
+    }
+    if (currentPlatformKey in platformProductAvailability) {
+      return 'toggleable';
+    }
+    if (currentPlatformKey in PLATFORM_PRODUCT_INFO) {
+      return 'informational';
+    }
+    return 'none';
+  }, [currentPlatformKey]);
+
+  const availableFeatures = useMemo(() => {
+    if (!currentPlatformKey || featureMode === 'none') {
       return [];
     }
-    const features = new Set([
+    const sourceProducts =
+      featureMode === 'toggleable'
+        ? platformProductAvailability[currentPlatformKey]
+        : PLATFORM_PRODUCT_INFO[currentPlatformKey];
+    const features = new Set<ProductSolution>([
       ProductSolution.ERROR_MONITORING,
-      ...(platformProductAvailability[currentPlatformKey] ?? []),
+      ...(sourceProducts ?? []),
     ]);
     return FEATURE_DISPLAY_ORDER.filter(f => features.has(f));
-  }, [currentPlatformKey]);
+  }, [currentPlatformKey, featureMode]);
 
   const disabledProducts = useMemo(
     () => getDisabledProducts(organization),
@@ -567,8 +593,8 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
               />
             </MotionStack>
           )}
-          <MotionStack layout="position" width="100%">
-            {availableFeatures.length > 0 && (
+          {featureMode !== 'none' && (
+            <MotionStack layout="position" width="100%">
               <Stack gap="2xl" paddingTop="xs">
                 <Flex
                   padding="lg"
@@ -591,17 +617,26 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
                     )}
                   </Text>
                 </Flex>
-                <ScmFeatureSelectionCards
-                  availableFeatures={availableFeatures}
-                  selectedFeatures={currentFeatures}
-                  disabledProducts={disabledProducts}
-                  onToggleFeature={handleToggleFeature}
-                  featureMeta={featureMeta}
-                  isVolumeLoading={isFeatureMetaLoading}
-                />
+                {featureMode === 'toggleable' ? (
+                  <ScmFeatureSelectionCards
+                    availableFeatures={availableFeatures}
+                    selectedFeatures={currentFeatures}
+                    disabledProducts={disabledProducts}
+                    onToggleFeature={handleToggleFeature}
+                    featureMeta={featureMeta}
+                    isVolumeLoading={isFeatureMetaLoading}
+                  />
+                ) : (
+                  <ScmFeatureInfoCards
+                    availableFeatures={availableFeatures}
+                    disabledProducts={disabledProducts}
+                    featureMeta={featureMeta}
+                    isVolumeLoading={isFeatureMetaLoading}
+                  />
+                )}
               </Stack>
-            )}
-          </MotionStack>
+            </MotionStack>
+          )}
           <MotionFlex
             layout="position"
             align="center"

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -634,7 +634,8 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
                     disabledProducts={disabledProducts}
                     featureMeta={featureMeta}
                     platformName={
-                      platforms.find(p => p.id === currentPlatformKey)?.name ?? ''
+                      (currentPlatformKey && getPlatformInfo(currentPlatformKey)?.name) ||
+                      ''
                     }
                     isVolumeLoading={isFeatureMetaLoading}
                   />

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -4,7 +4,7 @@ import {LayoutGroup, motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -484,14 +484,16 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
         </Heading>
         <LayoutGroup>
           <Stack gap="md" paddingTop="sm">
-            <Heading as="h3" size="xl">
+            <Heading as="h3" size="lg">
               {t('Choose your SDK')}
             </Heading>
-            <Text variant="muted" size="lg" density="comfortable">
-              {t(
-                'Each Sentry project collects data from one service or app. Select a language or framework you want to get started monitoring with our SDKs.'
-              )}
-            </Text>
+            <Container>
+              <Text variant="muted" size="md" density="comfortable">
+                {t(
+                  'Each Sentry project collects data from one service or app. Select a language or framework you want to get started monitoring with our SDKs.'
+                )}
+              </Text>
+            </Container>
           </Stack>
           {showDetectedPlatforms ? (
             <MotionStack

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -183,13 +183,8 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
     });
   }, [detectedPlatformKey, selectedPlatform?.key, organization]);
 
-  // Pick which feature-card variant to render for the selected platform.
-  //   toggleable    — platform has a curated entry in `platformProductAvailability`;
-  //                   render `ScmFeatureSelectionCards` (user can toggle products).
-  //   informational — platform has a generated entry in `PLATFORM_PRODUCT_INFO`
-  //                   (wizard-driven onboarding); render `ScmFeatureInfoCards`
-  //                   (informational, no toggles since the wizard handles config).
-  //   none          — platform isn't covered by either map; render no feature cards.
+  // Wizard-driven platforms render an informational variant since the wizard CLI
+  // owns product configuration and toggles aren't actionable.
   const featureMode = useMemo<'toggleable' | 'informational' | 'none'>(() => {
     if (!currentPlatformKey) {
       return 'none';
@@ -634,8 +629,10 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
                     disabledProducts={disabledProducts}
                     featureMeta={featureMeta}
                     platformName={
-                      (currentPlatformKey && getPlatformInfo(currentPlatformKey)?.name) ||
-                      ''
+                      currentPlatformKey
+                        ? (getPlatformInfo(currentPlatformKey)?.name ??
+                          currentPlatformKey)
+                        : ''
                     }
                     isVolumeLoading={isFeatureMetaLoading}
                   />

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -633,6 +633,9 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
                     availableFeatures={availableFeatures}
                     disabledProducts={disabledProducts}
                     featureMeta={featureMeta}
+                    platformName={
+                      platforms.find(p => p.id === currentPlatformKey)?.name ?? ''
+                    }
                     isVolumeLoading={isFeatureMetaLoading}
                   />
                 )}


### PR DESCRIPTION
Wire the SCM platform-features step to the generated `PLATFORM_PRODUCT_INFO` map. The step now selects between three render modes per platform.

**Render modes**

- **toggleable** — platform has a curated entry in `platformProductAvailability`. Existing `ScmFeatureSelectionCards` with checkbox switches.
- **informational** — platform has a generated entry in `PLATFORM_PRODUCT_INFO` (i.e. wizard-driven onboarding). New `ScmFeatureInfoCards` placeholder; describes applicable products without toggle affordances, since the wizard CLI handles configuration.
- **none** — neither map covers the platform. The entire feature-cards block is omitted.

**Visual placeholder for informational mode**

`ScmFeatureInfoCards` ships with a minimal layout (heading, label, description, free-tier volume tag in plain containers). Designer iterates on the visual treatment in a follow-up; this PR provides the structural scaffolding only.

**Tests**

Two existing tests assert the toggleable heading on the default detected platform (`javascript-nextjs`). `javascript-nextjs` is now in info mode, so those two assertions switch to the info-mode heading. The other 20 tests are untouched and pass.

**Stack**
- [PR 1](https://github.com/getsentry/sentry/pull/115177): Add platformProductInfo codegen script
- [PR 2](https://github.com/getsentry/sentry/pull/115092): Add platformProductInfo.generated.ts for SCM info-only platforms
- **PR 3 (this):** Render info-only feature cards for wizard-driven platforms