### PR TITLE
ref(arithmeticBuilder): replace derived state with useMemo in story

### DIFF
--- a/static/app/components/arithmeticBuilder/arithmeticBuilder.stories.tsx
+++ b/static/app/components/arithmeticBuilder/arithmeticBuilder.stories.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
 
 import {ArithmeticBuilder} from 'sentry/components/arithmeticBuilder';
 import {Expression} from 'sentry/components/arithmeticBuilder/expression';
@@ -8,19 +8,17 @@ import * as Storybook from 'sentry/stories';
 export default Storybook.story('ArithmeticBuilder', story => {
   story('With References', () => {
     const [expression, setExpression] = useState('A + B');
-    const [isValid, setIsValid] = useState(true);
     const [references, setReferences] = useState(new Set<string>(['A', 'B', 'C']));
     const [parseError, setParseError] = useState('');
+
+    const isValid = useMemo(
+      () => new Expression(expression, references).isValid,
+      [expression, references]
+    );
 
     const onExpressionChange = useCallback((expr: Expression) => {
       setExpression(expr.text);
     }, []);
-
-    // Explicitly check the new expression for validity since references
-    // changing is a responibility of the caller.
-    useEffect(() => {
-      setIsValid(new Expression(expression, references).isValid);
-    }, [expression, references]);
 
     return (
       <Fragment>


### PR DESCRIPTION
## Summary
- Replace `useState` + `useEffect` derived state with `useMemo` for computing `isValid` in the ArithmeticBuilder story
- Fixes `react-you-might-not-need-an-effect/no-derived-state` lint error

## Test plan
- [ ] Verify the ArithmeticBuilder story renders correctly

--- 

Seems to keep working when i play with it `/stories/product/components/arithmeticbuilder/arithmeticbuilder/`

<img width="834" height="266" alt="SCR-20260507-mxbq" src="https://github.com/user-attachments/assets/e14469f5-f6b3-4257-bba7-a3f340011d9c" />

