### PR TITLE
fix(api): Return forbidden for gated events endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -5,6 +5,7 @@ from typing import Any, NotRequired, TypedDict
 
 import sentry_sdk
 from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -161,7 +162,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 "OrganizationEventsResponseDict", EventsApiResponse
             ),
             400: OpenApiResponse(description="Invalid Query"),
-            404: api_constants.RESPONSE_NOT_FOUND,
+            403: api_constants.RESPONSE_FORBIDDEN,
         },
         examples=DiscoverAndPerformanceExamples.QUERY_DISCOVER_EVENTS,
     )
@@ -177,7 +178,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         - The `meta` key contains information about the response, including the unit or type of the fields requested
         """
         if not self.has_feature(organization, request):
-            return Response(status=404)
+            return Response(status=status.HTTP_403_FORBIDDEN)
 
         referrer = request.GET.get("referrer")
 

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -178,7 +178,12 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         - The `meta` key contains information about the response, including the unit or type of the fields requested
         """
         if not self.has_feature(organization, request):
-            return Response(status=status.HTTP_403_FORBIDDEN)
+            return Response(
+                {
+                    "detail": "Discover, Performance, or Explore is required to access this endpoint."
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         referrer = request.GET.get("referrer")
 

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -37,6 +37,21 @@ class OrganizationEventsEndpointTest(APITestCase):
         with self.feature(features):
             return self.client_get(self.reverse_url(), query, format="json", **kwargs)
 
+    def test_missing_discover_feature_returns_forbidden(self) -> None:
+        query = {
+            "field": ["user"],
+            "project": [self.project.id],
+        }
+        features = {
+            "organizations:discover-basic": False,
+            "organizations:performance-view": False,
+            "organizations:visibility-explore-view": False,
+        }
+
+        response = self.do_request(query, features=features)
+
+        assert response.status_code == 403
+
     def test_api_key_request(self) -> None:
         self.store_event(
             data={

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -51,6 +51,9 @@ class OrganizationEventsEndpointTest(APITestCase):
         response = self.do_request(query, features=features)
 
         assert response.status_code == 403
+        assert response.data == {
+            "detail": "Discover, Performance, or Explore is required to access this endpoint."
+        }
 
     def test_api_key_request(self) -> None:
         self.store_event(


### PR DESCRIPTION
The events endpoint now returns 403 when an organization lacks all of the Discover, Performance, and Explore feature gates.

Previously this path returned an empty 403, which kept the endpoint from looking like a missing route but still left API clients without a useful reason. The response now includes a detail message naming the required product access, and the regression test asserts both the status and response body.

Refs https://github.com/getsentry/sentry-mcp#937