### PR TITLE
ref(feedback): replace derived state in useFeedbackHasNewItems

### DIFF
--- a/static/app/components/feedback/useFeedbackHasNewItems.tsx
+++ b/static/app/components/feedback/useFeedbackHasNewItems.tsx
@@ -1,4 +1,3 @@
-import {useEffect, useState} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import type {useFeedbackListApiOptions} from 'sentry/components/feedback/useFeedbackListApiOptions';
@@ -12,24 +11,12 @@ interface Props {
 const POLLING_INTERVAL_MS = 10_000;
 
 export function useFeedbackHasNewItems({listPrefetchApiOptions}: Props) {
-  const [foundData, setFoundData] = useState(false);
-
   const {data} = useQuery({
     ...listPrefetchApiOptions,
-    refetchInterval: POLLING_INTERVAL_MS,
+    refetchInterval: query =>
+      query.state.data?.json?.length ? false : POLLING_INTERVAL_MS,
     staleTime: 0,
-    enabled: !foundData,
   });
-
-  useEffect(() => {
-    // Once we found something, no need to keep polling.
-    setFoundData(Boolean(data?.length));
-  }, [data]);
-
-  useEffect(() => {
-    // New key, start polling again
-    setFoundData(false);
-  }, [listPrefetchApiOptions]);
 
   return Boolean(data?.length);
 }


### PR DESCRIPTION
## Summary
- Removes the `useState` + `useEffect` derived-state pattern from `useFeedbackHasNewItems`
- Uses `refetchInterval` as a callback that checks `query.state.data?.json?.length` to stop polling once items are found
- When query key changes (e.g. filter change), the query resets automatically so polling resumes — no reset effect needed

This is a redo of #114876 which was reverted because `query.state.data` in the `refetchInterval` callback is the raw `ApiResponse` (`{json, headers}`), not the selected array. That PR checked `.length` on the raw object which was always `undefined`, so polling never stopped. This PR correctly accesses `.json?.length`.

## Test plan
- [ ] Open feedback list, verify "Load new feedback" button appears when new items arrive
- [ ] Verify polling stops after items are found (network tab shows no more requests to the issues endpoint)
- [ ] Change filters, verify polling resumes for the new query