### PR TITLE
feat(seer): Add structured LLM context for issue taxonomy pages

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -887,7 +887,9 @@ function IssueListOverviewInner({
 
   const hasPageFrame = useHasPageFrameFeature();
 
-  const isTaxonomyView = initialQuery.includes('issue.category:');
+  // Derive from query (URL state) not initialQuery (prop) so the hint
+  // stays accurate if the user edits the search bar.
+  const isTaxonomyView = query.includes('issue.category:');
 
   useLLMContext({
     contextHint:

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -887,9 +887,14 @@ function IssueListOverviewInner({
 
   const hasPageFrame = useHasPageFrameFeature();
 
+  const isTaxonomyView = initialQuery.includes('issue.category:');
+
   useLLMContext({
     contextHint:
-      'Sentry issue list page. Shows a filterable, sortable list of grouped issues. ' +
+      (isTaxonomyView
+        ? 'Sentry issue feed — filtered taxonomy view. The query below contains the active category filter. '
+        : 'Sentry issue list page. ') +
+      'Shows a filterable, sortable list of grouped issues. ' +
       'query is the current search filter (Sentry search syntax). ' +
       'displayedIssues is a pipe-delimited CSV with header row (shortId|title|issueType|level|priority|events|users|firstSeen) of the visible issues on the current page. ' +
       'issueCount is the total matching issues — there may be more than what is displayed. ' +

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -58,7 +58,11 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/issues/:groupId/events/:eventId/',
 ]);
 /** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>();
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>([
+  '/issues/errors-outages/',
+  '/issues/breached-metrics/',
+  '/issues/warnings/',
+]);
 
 function supportsStructuredContext(
   referrer: string,


### PR DESCRIPTION
+ Register /issues/errors-outages/, /issues/breached-metrics/, and /issues/warnings/ in NEW_STRUCTURED_CONTEXT_ROUTES so the Seer context engine uses structured page context on taxonomy views.
+ Adjust the contextHint in IssueListOverview to tell the LLM when the user is on a filtered taxonomy view vs the main issue list.
