### PR TITLE
ref(dashboards): replace derived state in editAccessSelector

### DIFF
--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -67,16 +67,11 @@ export function EditAccessSelector({
     const teamIdsList: string[] = Object.values(teamsToRender).map(team => team.id);
     return !defined(dashboard.permissions) || dashboard.permissions.isEditableByEveryone
       ? ['_creator', '_allUsers', ...teamIdsList]
-      : [
-          '_creator',
-          ...(dashboard.permissions.teamsWithEditAccess?.map(teamId => String(teamId)) ??
-            []),
-        ];
+      : ['_creator', ...(dashboard.permissions.teamsWithEditAccess?.map(String) ?? [])];
   }, [dashboard.permissions, teamsToRender]);
 
   const [pendingOptions, setPendingOptions] = useState<string[] | null>(null);
   const selectedOptions = pendingOptions ?? derivedOptions;
-  const setSelectedOptions = setPendingOptions;
 
   const [isMenuOpen, setMenuOpen] = useState(false);
   const [isCollapsedAvatarTooltipOpen, setIsCollapsedAvatarTooltipOpen] = useState(false);
@@ -123,7 +118,7 @@ export function EditAccessSelector({
       }
     }
 
-    setSelectedOptions(newSelectedValues);
+    setPendingOptions(newSelectedValues);
   };
 
   // Creates a permissions object based on the options selected
@@ -314,10 +309,9 @@ export function EditAccessSelector({
       onOpenChange={newOpenState => {
         if (newOpenState) {
           trackAnalytics('dashboards2.edit_access.start', {organization});
-        } else {
-          setPendingOptions(null);
         }
 
+        setPendingOptions(null);
         setMenuOpen(newOpenState);
       }}
       menuFooter={

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
@@ -63,8 +63,21 @@ export function EditAccessSelector({
   const {onSearch} = useTeams();
   const teamIds: string[] = Object.values(teamsToRender).map(team => team.id);
 
-  const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
-  const [stagedOptions, setStagedOptions] = useState<string[]>([]);
+  const derivedOptions = useMemo(() => {
+    const teamIdsList: string[] = Object.values(teamsToRender).map(team => team.id);
+    return !defined(dashboard.permissions) || dashboard.permissions.isEditableByEveryone
+      ? ['_creator', '_allUsers', ...teamIdsList]
+      : [
+          '_creator',
+          ...(dashboard.permissions.teamsWithEditAccess?.map(teamId => String(teamId)) ??
+            []),
+        ];
+  }, [dashboard.permissions, teamsToRender]);
+
+  const [pendingOptions, setPendingOptions] = useState<string[] | null>(null);
+  const selectedOptions = pendingOptions ?? derivedOptions;
+  const setSelectedOptions = setPendingOptions;
+
   const [isMenuOpen, setMenuOpen] = useState(false);
   const [isCollapsedAvatarTooltipOpen, setIsCollapsedAvatarTooltipOpen] = useState(false);
   const {teams: selectedTeam} = useTeamsById({
@@ -78,21 +91,6 @@ export function EditAccessSelector({
       option => option !== '_allUsers' && option !== '_creator'
     ),
   });
-
-  // Gets selected options for the dropdown from dashboard object
-  useEffect(() => {
-    const teamIdsList: string[] = Object.values(teamsToRender).map(team => team.id);
-    const selectedOptionsFromDashboard =
-      !defined(dashboard.permissions) || dashboard.permissions.isEditableByEveryone
-        ? ['_creator', '_allUsers', ...teamIdsList]
-        : [
-            '_creator',
-            ...(dashboard.permissions.teamsWithEditAccess?.map(teamId =>
-              String(teamId)
-            ) ?? []),
-          ];
-    setSelectedOptions(selectedOptionsFromDashboard);
-  }, [dashboard, teamsToRender, isMenuOpen]); // isMenuOpen dependency ensures perms are 'refreshed'
 
   // Handles state change when dropdown options are selected
   const onSelectOptions = (newSelectedOptions: any) => {
@@ -253,13 +251,11 @@ export function EditAccessSelector({
       />
     );
 
-  // Sorting function for team options
+  // Sorting function for team options — uses derivedOptions (the saved state)
+  // so the sort order is stable while the user interacts with checkboxes
   const listSort = useCallback(
-    (team: Team) => [
-      !stagedOptions.includes(team.id), // selected teams are shown first
-      team.slug, // sort rest alphabetically
-    ],
-    [stagedOptions]
+    (team: Team) => [!derivedOptions.includes(team.id), team.slug],
+    [derivedOptions]
   );
 
   const allDropdownOptions = useMemo(
@@ -318,15 +314,17 @@ export function EditAccessSelector({
       onOpenChange={newOpenState => {
         if (newOpenState) {
           trackAnalytics('dashboards2.edit_access.start', {organization});
+        } else {
+          setPendingOptions(null);
         }
 
-        setStagedOptions(selectedOptions);
-        setMenuOpen(!isMenuOpen);
+        setMenuOpen(newOpenState);
       }}
       menuFooter={
         <Flex gap="md" justify="end">
           <MenuComponents.CancelButton
             onClick={() => {
+              setPendingOptions(null);
               setMenuOpen(false);
             }}
             disabled={!userCanEditDashboardPermissions}
@@ -353,7 +351,8 @@ export function EditAccessSelector({
 
                 onChangeEditAccess?.(newDashboardPermissions);
               }
-              setMenuOpen(!isMenuOpen);
+              setPendingOptions(null);
+              setMenuOpen(false);
             }}
             disabled={
               disabled ||


### PR DESCRIPTION
## Summary
- Replaces `useState` + `useEffect` derived-state pattern for `selectedOptions` with `useMemo`-derived `derivedOptions`
- Introduces `pendingOptions` state (null when menu is closed, set during user interaction) that falls back to `derivedOptions`
- Removes `stagedOptions` in favor of `derivedOptions` for sort ordering
- Clears `pendingOptions` on cancel, apply, or menu close — no effect needed to reset

The previous pattern used an effect with `[dashboard, teamsToRender, isMenuOpen]` dependencies to sync state from props. Now the derived value is always fresh via `useMemo`, and local edits are scoped to menu-open lifetime.

## Test plan
- [x] All 8 existing tests pass
- [x] Open edit access selector, toggle teams, verify selections work
- [x] Cancel discards changes, Apply saves them
- [x] Sort order shows previously-selected teams first when menu opens

I checked all these cases manually, seems like it's working - ryan953