### PR TITLE
fix(ui): Remove 'Unselect All' label from team selector toggle button

### DIFF
--- a/static/app/components/core/compactSelect/types.tsx
+++ b/static/app/components/core/compactSelect/types.tsx
@@ -28,7 +28,7 @@ export interface SelectSection<Value extends SelectKey> {
    */
   label?: React.ReactNode;
   /**
-   * Whether to show a "Select All"/"Unselect All" button in the section header (only
+   * Whether to show a "Select All" button in the section header (only
    * applicable in multiple-selection mode).
    */
   showToggleAllButton?: boolean;

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -351,7 +351,7 @@ export function SectionToggle({item, listState, onToggle}: SectionToggleProps) {
       tabIndex={-1}
       onClick={toggleAllOptions}
     >
-      {allOptionsSelected ? t('Unselect All') : t('Select All')}
+      {t('Select All')}
     </SectionToggleButton>
   );
 }
@@ -419,7 +419,7 @@ export function HiddenSectionToggle({
         aria-controls={listId}
         id={`${listId}-section-toggle-${item.key}`}
       >
-        {allOptionsSelected ? t('Unselect All in ') : t('Select All in ')}
+        {t('Select All in ')}
         {item.textValue || item.rendered}
       </button>
     </VisuallyHidden>

--- a/static/app/utils/discover/teamKeyTransactionField.spec.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.spec.tsx
@@ -353,7 +353,7 @@ describe('TeamKeyTransactionField', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Toggle star for team'}));
 
-    await userEvent.click(screen.getByRole('button', {name: 'Unselect All in My Teams'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Select All in My Teams'}));
 
     expect(deleteTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
     await waitFor(() => {

--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
@@ -325,7 +325,7 @@ describe('TeamKeyTransactionButton', () => {
 
     await clickTeamKeyTransactionDropdown();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Unselect All in My Teams'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Select All in My Teams'}));
 
     // all teams should be checked now
     expect(screen.getByRole('option', {name: `#${teams[0]!.slug}`})).toHaveAttribute(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR removes the "Unselect All" label from the team selector toggle button in the CompactSelect component, making it always display "Select All" instead.

## Changes

- Updated `SectionToggle` component to always show "Select All" instead of toggling between "Select All" and "Unselect All"
- Updated `HiddenSectionToggle` (keyboard-accessible version) with the same behavior
- Updated test files that referenced the old "Unselect All in My Teams" button label
- Updated TypeScript type comment to reflect the change

## Context

This change was requested in the #discuss-dashboards Slack channel. The toggle button functionality remains unchanged - clicking it still toggles all options on/off. Only the label text has been simplified to always show "Select All" for consistency.

## Testing

- Updated existing tests in:
  - `static/app/utils/discover/teamKeyTransactionField.spec.tsx`
  - `static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx`

The component is used in various places throughout the app, including the dashboard Edit Access Selector (Teams section).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C01MYDW8Y7K/p1778193824851429?thread_ts=1778193824.851429&cid=C01MYDW8Y7K)

<div><a href="https://cursor.com/agents/bc-1aa8d00a-4476-5e78-bb8d-cd1a69f6cbc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1aa8d00a-4476-5e78-bb8d-cd1a69f6cbc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

