### PR TITLE
fix(feature-flags): use sm text in tooltip date

### DIFF
--- a/static/app/components/featureFlags/hooks/useFlagSeries.tsx
+++ b/static/app/components/featureFlags/hooks/useFlagSeries.tsx
@@ -77,7 +77,7 @@ export function useFlagSeries({event, flags}: FlagSeriesProps) {
             </Stack>
             <Separator orientation="horizontal" padding="0" />
             <Flex padding="0 lg">
-              <Text size="xs" variant="muted">
+              <Text size="sm" variant="muted">
                 {time}
                 {event?.dateCreated && suffix}
               </Text>


### PR DESCRIPTION
Bumps the tooltip date line in the feature flag chart series from `size="xs"` to `size="sm"` so it matches the rest of the tooltip text and stays legible.