### PR TITLE
feat(integrations): add GitLab ticket alert action

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -333,6 +333,7 @@ TICKET_ACTIONS = frozenset(
         "sentry.integrations.vsts.notify_action.AzureDevopsCreateTicketAction",
         "sentry.integrations.github.notify_action.GitHubCreateTicketAction",
         "sentry.integrations.github_enterprise.notify_action.GitHubEnterpriseCreateTicketAction",
+        "sentry.integrations.gitlab.notify_action.GitlabCreateTicketAction",
     ]
 )
 

--- a/src/sentry/integrations/gitlab/__init__.py
+++ b/src/sentry/integrations/gitlab/__init__.py
@@ -1,0 +1,5 @@
+from sentry.rules import rules
+
+from .actions.create_ticket import GitlabCreateTicketAction
+
+rules.add(GitlabCreateTicketAction)

--- a/src/sentry/integrations/gitlab/actions/__init__.py
+++ b/src/sentry/integrations/gitlab/actions/__init__.py
@@ -1,0 +1,3 @@
+from .create_ticket import GitlabCreateTicketAction
+
+__all__ = ("GitlabCreateTicketAction",)

--- a/src/sentry/integrations/gitlab/actions/create_ticket.py
+++ b/src/sentry/integrations/gitlab/actions/create_ticket.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.rules.actions import TicketEventAction
+from sentry.utils.http import absolute_uri
+
+
+class GitlabCreateTicketAction(TicketEventAction):
+    id = "sentry.integrations.gitlab.notify_action.GitlabCreateTicketAction"
+    label = "Create a GitLab issue in {integration} with these "
+    ticket_type = "a GitLab issue"
+    link = "https://docs.sentry.io/product/integrations/source-code-mgmt/gitlab/#issue-management"
+    provider = IntegrationProviderSlug.GITLAB.value
+
+    def generate_footer(self, rule_url: str) -> str:
+        return f"\nThis issue was automatically created by Sentry via [{self.rule.label}]({absolute_uri(rule_url)})"

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -15,7 +15,6 @@ from snuba_sdk import Request as SnubaRequest
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.integrations.errors import OrganizationIntegrationNotFound
-from sentry.integrations.gitlab.constants import GITLAB_CLOUD_BASE_URL
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.integration.model import RpcOrganizationIntegration
 from sentry.integrations.source_code_management.metrics import (
@@ -196,6 +195,8 @@ class CommitContextIntegration(ABC):
                 # Ignore retry errors for GitLab
                 # Ignore host error errors for GitLab
                 # TODO(ecosystem): Remove this once we have a better way to handle this
+                from sentry.integrations.gitlab.constants import GITLAB_CLOUD_BASE_URL
+
                 if (
                     self.integration_name == ExternalProviderEnum.GITLAB.value
                     and client.base_url != GITLAB_CLOUD_BASE_URL

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -10,7 +10,6 @@ import sentry_sdk
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.integrations.base import IntegrationInstallation
-from sentry.integrations.gitlab.constants import GITLAB_CLOUD_BASE_URL
 from sentry.integrations.services.repository import RpcRepository
 from sentry.integrations.source_code_management.metrics import (
     SCMIntegrationInteractionEvent,
@@ -286,6 +285,8 @@ class RepositoryIntegration(
             except ApiRetryError as e:
                 # Ignore retry errors for GitLab
                 # TODO(ecosystem): Remove this once we have a better way to handle this
+                from sentry.integrations.gitlab.constants import GITLAB_CLOUD_BASE_URL
+
                 if (
                     self.integration_name == IntegrationProviderSlug.GITLAB.value
                     and client.base_url != GITLAB_CLOUD_BASE_URL

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -32,7 +32,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         self.create_project(teams=[team], name="baz")
 
         response = self.get_success_response(self.organization.slug, project1.slug)
-        assert len(response.data["actions"]) == 13
+        assert len(response.data["actions"]) == 14
         assert len(response.data["conditions"]) == 10
         assert len(response.data["filters"]) == 10
 
@@ -134,7 +134,7 @@ class ProjectRuleConfigurationTest(APITestCase):
 
         response = self.get_success_response(self.organization.slug, project1.slug)
 
-        assert len(response.data["actions"]) == 14
+        assert len(response.data["actions"]) == 15
         assert {
             "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
             "label": "Send a notification via {service}",
@@ -164,7 +164,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         )
         response = self.get_success_response(self.organization.slug, project1.slug)
 
-        assert len(response.data["actions"]) == 14
+        assert len(response.data["actions"]) == 15
         assert {
             "id": SENTRY_APP_ALERT_ACTION,
             "service": sentry_app.slug,
@@ -180,7 +180,7 @@ class ProjectRuleConfigurationTest(APITestCase):
 
     def test_issue_type_and_category_filter_feature(self) -> None:
         response = self.get_success_response(self.organization.slug, self.project.slug)
-        assert len(response.data["actions"]) == 13
+        assert len(response.data["actions"]) == 14
         assert len(response.data["conditions"]) == 10
         assert len(response.data["filters"]) == 10
 

--- a/tests/sentry/integrations/gitlab/test_ticket_action.py
+++ b/tests/sentry/integrations/gitlab/test_ticket_action.py
@@ -1,0 +1,171 @@
+from time import time
+
+import orjson
+import responses
+from django.urls import reverse
+from rest_framework.test import APITestCase as BaseAPITestCase
+
+from sentry.integrations.gitlab.actions.create_ticket import GitlabCreateTicketAction
+from sentry.integrations.gitlab.integration import GitlabIntegration
+from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.integrations.models.integration import Integration
+from sentry.models.rule import Rule
+from sentry.services.eventstore.models import GroupEvent
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import RuleTestCase
+from sentry.testutils.helpers.integrations import get_installation_of_type
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.testutils.skips import requires_snuba
+from sentry.types.rules import RuleFuture
+from sentry.users.models.identity import Identity, IdentityProvider
+
+pytestmark = [requires_snuba]
+
+
+class GitlabTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
+    rule_cls = GitlabCreateTicketAction
+    project_id = "10"
+    project_name = "getsentry/sentry"
+    issue_iid = "1"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = Integration.objects.create(
+                provider="gitlab",
+                name="Example Gitlab",
+                external_id="example.gitlab.com:group-x",
+                metadata={
+                    "instance": "example.gitlab.com",
+                    "base_url": "https://example.gitlab.com",
+                    "domain_name": "example.gitlab.com/group-x",
+                    "verify_ssl": False,
+                    "webhook_secret": "secret-token-value",
+                    "group_id": 1,
+                },
+            )
+            identity = Identity.objects.create(
+                idp=IdentityProvider.objects.create(type="gitlab", config={}),
+                user=self.user,
+                external_id="gitlab123",
+                data={
+                    "access_token": "123456789",
+                    "created_at": time(),
+                    "refresh_token": "0987654321",
+                },
+            )
+            self.integration.add_organization(self.organization, self.user, identity.id)
+        self.installation = get_installation_of_type(
+            GitlabIntegration, self.integration, self.organization.id
+        )
+
+    def trigger(self, event, rule_object):
+        action = rule_object.data.get("actions", ())[0]
+        action_inst = self.get_rule(data=action, rule=rule_object)
+        results = list(action_inst.after(event=event))
+        assert len(results) == 1
+
+        rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)
+        return results[0].callback(event, futures=[rule_future])
+
+    def get_key(self, event: GroupEvent):
+        return ExternalIssue.objects.get_linked_issues(event, self.integration).values_list(
+            "key", flat=True
+        )[0]
+
+    @responses.activate
+    def test_ticket_rules(self) -> None:
+        responses.add(
+            responses.POST,
+            f"https://example.gitlab.com/api/v4/projects/{self.project_id}/issues",
+            json={
+                "id": 8,
+                "iid": self.issue_iid,
+                "title": "sample title",
+                "description": "sample bug report",
+                "web_url": f"https://example.gitlab.com/{self.project_name}/issues/{self.issue_iid}",
+            },
+            status=201,
+        )
+        responses.add(
+            responses.GET,
+            f"https://example.gitlab.com/api/v4/projects/{self.project_id}",
+            json={"path_with_namespace": self.project_name, "id": int(self.project_id)},
+        )
+
+        response = self.client.post(
+            reverse(
+                "sentry-api-0-project-rules",
+                kwargs={
+                    "organization_id_or_slug": self.organization.slug,
+                    "project_id_or_slug": self.project.slug,
+                },
+            ),
+            format="json",
+            data={
+                "name": "hello world",
+                "owner": self.user.id,
+                "environment": None,
+                "actionMatch": "any",
+                "frequency": 5,
+                "actions": [
+                    {
+                        "id": "sentry.integrations.gitlab.notify_action.GitlabCreateTicketAction",
+                        "integration": self.integration.id,
+                        "dynamic_form_fields": [{"name": "project"}],
+                        "project": self.project_id,
+                    }
+                ],
+                "conditions": [],
+            },
+        )
+        assert response.status_code == 200
+
+        rule_object = Rule.objects.get(id=response.data["id"])
+        event = self.get_group_event()
+
+        self.trigger(event, rule_object)
+
+        key = self.get_key(event)
+        assert key == f"example.gitlab.com/group-x:{self.project_name}#{self.issue_iid}"
+        external_issue_count = len(ExternalIssue.objects.filter(key=key))
+        assert external_issue_count == 1
+
+        request_data = orjson.loads(responses.calls[0].request.body)
+        assert request_data["title"] == event.title
+        assert "This issue was automatically created by Sentry" in request_data["description"]
+
+        self.trigger(event, rule_object)
+
+        assert ExternalIssue.objects.count() == external_issue_count
+
+    @responses.activate
+    def test_fails_validation(self) -> None:
+        response = self.client.post(
+            reverse(
+                "sentry-api-0-project-rules",
+                kwargs={
+                    "organization_id_or_slug": self.organization.slug,
+                    "project_id_or_slug": self.project.slug,
+                },
+            ),
+            format="json",
+            data={
+                "name": "hello world",
+                "owner": self.user.id,
+                "environment": None,
+                "actionMatch": "any",
+                "frequency": 5,
+                "actions": [
+                    {
+                        "id": "sentry.integrations.gitlab.notify_action.GitlabCreateTicketAction",
+                        "integration": self.integration.id,
+                        "project": self.project_id,
+                    }
+                ],
+                "conditions": [],
+            },
+        )
+        assert response.status_code == 400
+        assert response.data["actions"][0] == "Must configure issue link settings."


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds GitLab as a ticket-creation action for issue alerts.

This introduces the GitLab create-ticket action, registers it in issue alert configuration, and adds coverage for rule configuration and GitLab ticket action behavior.
 
Closes #50309

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
