### PR TITLE
fix(spans): release flush lock in done_flush_segments

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -1061,4 +1061,6 @@ class SpansBuffer:
                         for payload_key in flushed_segment.payload_keys:
                             p.unlink(payload_key)
 
+                    p.delete(self._get_flush_lock_key(segment_key))
+
                 p.execute()

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -1044,6 +1044,7 @@ class SpansBuffer:
             with self.client.pipeline(transaction=False) as p:
                 for segment_key, flushed_segment in segment_keys.items():
                     if segment_key in segments_to_skip:
+                        p.delete(self._get_flush_lock_key(segment_key))
                         continue
 
                     # Data keys (set, hrs, ic, ibc) were already deleted

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -1507,6 +1507,35 @@ def test_flush_lock(
         assert len(rv_a) + len(rv_b) == expected_flushed_segments
 
 
+def test_flush_lock_released_after_done_flush(buffer: SpansBuffer) -> None:
+    process_spans(
+        [
+            Span(
+                payload=_payload("b" * 16),
+                trace_id="a" * 32,
+                span_id="b" * 16,
+                parent_span_id=None,
+                segment_id=None,
+                is_segment_span=True,
+                project_id=1,
+            ),
+        ],
+        buffer,
+        now=0,
+    )
+
+    with override_options({"spans.buffer.flusher.flush-lock-ttl": 60}):
+        rv = buffer.flush_segments(now=11)
+        segment_key = next(iter(rv))
+        lock_key = buffer._get_flush_lock_key(segment_key)
+        assert buffer.client.exists(lock_key) == 1
+
+        buffer.done_flush_segments(rv)
+        assert buffer.client.exists(lock_key) == 0
+
+    assert_clean(buffer.client)
+
+
 @pytest.mark.parametrize(
     "flush_lock_ttl, expected_flushed_segments",
     [

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -1536,6 +1536,42 @@ def test_flush_lock_released_after_done_flush(buffer: SpansBuffer) -> None:
     assert_clean(buffer.client)
 
 
+def test_flush_lock_released_when_cleanup_skipped(buffer: SpansBuffer) -> None:
+    process_spans(
+        [
+            Span(
+                payload=_payload("b" * 16),
+                trace_id="a" * 32,
+                span_id="b" * 16,
+                parent_span_id=None,
+                segment_id=None,
+                is_segment_span=True,
+                project_id=1,
+            ),
+        ],
+        buffer,
+        now=0,
+    )
+
+    with override_options({"spans.buffer.flusher.flush-lock-ttl": 60}):
+        rv = buffer.flush_segments(now=11)
+        segment_key = next(iter(rv))
+        flushed_segment = rv[segment_key]
+        lock_key = buffer._get_flush_lock_key(segment_key)
+
+        buffer.client.zadd(flushed_segment.queue_key, {segment_key: flushed_segment.score + 10})
+
+        buffer.done_flush_segments(rv)
+
+        assert buffer.client.exists(lock_key) == 0
+        assert buffer.client.zscore(flushed_segment.queue_key, segment_key) is not None
+
+        rv2 = buffer.flush_segments(now=22)
+        buffer.done_flush_segments(rv2)
+
+    assert_clean(buffer.client)
+
+
 @pytest.mark.parametrize(
     "flush_lock_ttl, expected_flushed_segments",
     [


### PR DESCRIPTION
Refs STREAM-960

When spans from the same segment land in multiple partitions, the same segment key can appear in multiple Redis shard queues. One flusher wins the per-segment lock and flushes/cleans up the segment, while other flushers skip because the lock is still held.

without the fix, the lock remained until TTL expiry even after the winning flusher finished cleanup. With long TTLs, skipped/stale queue entries could be repeatedly selected by ZRANGEBYSCORE, blocking the flusher.