### PR TITLE
fix(dashboards): Exempt details widgets from limit validation

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -533,12 +533,13 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         # Validate limit on chart widgets with group-by columns:
         # if there are too many groups the server cannot serve the
         # request to get widget data and hence the chart fails to load.
-        # WHEEL widgets render a single aggregated row and don't use `limit`,
+        # WHEEL and DETAILS widgets render a single row and don't use `limit`,
         # so they're exempted from this check.
         if (
             data.get("display_type") != DashboardWidgetDisplayTypes.TABLE
             and data.get("display_type") != DashboardWidgetDisplayTypes.BIG_NUMBER
             and data.get("display_type") != DashboardWidgetDisplayTypes.WHEEL
+            and data.get("display_type") != DashboardWidgetDisplayTypes.DETAILS
             and data.get("limit") is None
             and has_columns
         ):


### PR DESCRIPTION
Update dashboards endpoint to allow details widget to be saved without `limit`. The frontend doesn't require it to have a limit. This has been preventing some users from saving or duplicating dashboards with a `limit is required` error message