### PR TITLE
fix(preprod): Get snapshot PR comments from detailed project

### DIFF
--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.spec.tsx
@@ -3,7 +3,6 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {SnapshotPrCommentsToggle} from 'sentry/views/settings/project/preprod/snapshotPrCommentsToggle';
 
 describe('SnapshotPrCommentsToggle', () => {
@@ -21,6 +20,10 @@ describe('SnapshotPrCommentsToggle', () => {
 
   it('renders default values when the project has no preprod options', async () => {
     const project = ProjectFixture({options: {}});
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: project,
+    });
     render(<SnapshotPrCommentsToggle />, {
       organization,
       outletContext: {project},
@@ -39,6 +42,10 @@ describe('SnapshotPrCommentsToggle', () => {
     const project = ProjectFixture({
       options: {},
       preprodSnapshotPrCommentsEnabled: true,
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: project,
     });
     render(<SnapshotPrCommentsToggle />, {
       organization,
@@ -72,6 +79,10 @@ describe('SnapshotPrCommentsToggle', () => {
       preprodSnapshotPrCommentsPostOnChanged: false,
       preprodSnapshotPrCommentsPostOnRenamed: true,
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: project,
+    });
     render(<SnapshotPrCommentsToggle />, {
       organization,
       outletContext: {project},
@@ -98,6 +109,10 @@ describe('SnapshotPrCommentsToggle', () => {
       preprodSnapshotPrCommentsEnabled: true,
     });
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      body: project,
+    });
     const mock = MockApiClient.addMockResponse({
       url: projectEndpoint,
       method: 'PUT',
@@ -131,6 +146,10 @@ describe('SnapshotPrCommentsToggle', () => {
       preprodSnapshotPrCommentsEnabled: true,
     });
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      body: project,
+    });
     const mock = MockApiClient.addMockResponse({
       url: projectEndpoint,
       method: 'PUT',
@@ -163,8 +182,11 @@ describe('SnapshotPrCommentsToggle', () => {
       options: {},
       preprodSnapshotPrCommentsEnabled: true,
     });
-    ProjectsStore.loadInitialData([project]);
     const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      body: project,
+    });
     const mock = MockApiClient.addMockResponse({
       url: projectEndpoint,
       method: 'PUT',
@@ -175,6 +197,12 @@ describe('SnapshotPrCommentsToggle', () => {
       organization,
       outletContext: {project},
       initialRouterConfig,
+    });
+
+    // Setup mock for after the toggle is switched off
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      body: {...project, preprodSnapshotPrCommentsEnabled: false},
     });
 
     await userEvent.click(
@@ -202,6 +230,10 @@ describe('SnapshotPrCommentsToggle', () => {
     const project = ProjectFixture({
       options: {},
       preprodSnapshotPrCommentsEnabled: false,
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: project,
     });
     render(<SnapshotPrCommentsToggle />, {
       organization,

--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
@@ -7,11 +7,9 @@ import {Container} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
-import {ProjectsStore} from 'sentry/stores/projectsStore';
-import type {Project} from 'sentry/types/project';
-import {fetchMutation} from 'sentry/utils/queryClient';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
+import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 import {getSnapshotPrComments} from './getSnapshotPrComments';
@@ -35,32 +33,16 @@ type PrCommentField = {
 export function SnapshotPrCommentsToggle() {
   const organization = useOrganization();
   const {project: outletProject} = useProjectSettingsOutlet();
-  const project = useProjectFromId({project_id: outletProject.id}) ?? outletProject;
+  const {data: project = outletProject} = useDetailedProject({
+    orgSlug: organization.slug,
+    projectSlug: outletProject.slug,
+  });
+  const {mutateAsync: updateProject} = useUpdateProject(outletProject);
   const {enabled, postOnAdded, postOnRemoved, postOnChanged, postOnRenamed} =
     getSnapshotPrComments(project);
 
-  const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
-
   const projectMutationOptions = mutationOptions({
-    mutationFn: (data: Partial<Schema>) =>
-      fetchMutation<Project>({
-        url: projectEndpoint,
-        method: 'PUT',
-        data,
-      }),
-    onMutate: data => {
-      const previous = ProjectsStore.getById(project.id);
-      ProjectsStore.onUpdateSuccess({id: project.id, ...data});
-      return () => {
-        if (previous) {
-          ProjectsStore.onUpdateSuccess(previous);
-        }
-      };
-    },
-    onSuccess: response => ProjectsStore.onUpdateSuccess(response),
-    onError: (_error, _variables, rollback) => {
-      rollback?.();
-    },
+    mutationFn: (data: Partial<Schema>) => updateProject(data),
   });
 
   const postConditionFields = [


### PR DESCRIPTION
Snapshot PR comments had the same project cache issue fixed for status checks in #115139. ProjectsStore usually has the summary shape, the type split between ProjectSummary and DetailedProject will make this more clear soon.