### PR TITLE
fix(issues): Reject mismatched status/substatus on group update

### DIFF
--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -7,9 +7,14 @@ from rest_framework import serializers
 from sentry.api.fields.actor import ActorField
 from sentry.api.helpers.group_index.validators.inbox_details import InboxDetailsValidator
 from sentry.api.helpers.group_index.validators.status_details import StatusDetailsValidator
-from sentry.models.group import STATUS_UPDATE_CHOICES, Group
+from sentry.models.group import STATUS_UPDATE_CHOICES, Group, GroupStatus
 from sentry.types.actor import Actor
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, PriorityLevel
+from sentry.types.group import (
+    IGNORED_SUBSTATUS_CHOICES,
+    SUBSTATUS_UPDATE_CHOICES,
+    UNRESOLVED_SUBSTATUS_CHOICES,
+    PriorityLevel,
+)
 
 
 @extend_schema_serializer(
@@ -113,4 +118,28 @@ class GroupValidator(serializers.Serializer[Group]):
         attrs = super().validate(attrs)
         if len(attrs) > 1 and "discard" in attrs:
             raise serializers.ValidationError("Other attributes cannot be updated when discarding")
+
+        status = attrs.get("status")
+        substatus = attrs.get("substatus")
+        if status is not None and substatus is not None:
+            new_status = STATUS_UPDATE_CHOICES[status]
+            new_substatus = SUBSTATUS_UPDATE_CHOICES[substatus]
+            if new_status == GroupStatus.IGNORED:
+                if new_substatus not in IGNORED_SUBSTATUS_CHOICES:
+                    raise serializers.ValidationError(
+                        {
+                            "substatus": f"'{substatus}' is not a valid substatus for status '{status}'."
+                        }
+                    )
+            elif new_status == GroupStatus.UNRESOLVED:
+                if new_substatus not in UNRESOLVED_SUBSTATUS_CHOICES:
+                    raise serializers.ValidationError(
+                        {
+                            "substatus": f"'{substatus}' is not a valid substatus for status '{status}'."
+                        }
+                    )
+            else:
+                raise serializers.ValidationError(
+                    {"substatus": f"Substatus is not allowed for status '{status}'."}
+                )
         return attrs

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -21,7 +21,11 @@ from sentry.models.project import Project
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import issue_ignored, issue_unignored, issue_unresolved
 from sentry.types.activity import ActivityType
-from sentry.types.group import GroupSubStatus
+from sentry.types.group import (
+    IGNORED_SUBSTATUS_CHOICES,
+    UNRESOLVED_SUBSTATUS_CHOICES,
+    GroupSubStatus,
+)
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.utils import json
@@ -36,7 +40,11 @@ def infer_substatus(
     group_list: Sequence[Group],
 ) -> int | None:
     if new_substatus is not None:
-        return new_substatus
+        if new_status == GroupStatus.IGNORED and new_substatus in IGNORED_SUBSTATUS_CHOICES:
+            return new_substatus
+        if new_status == GroupStatus.UNRESOLVED and new_substatus in UNRESOLVED_SUBSTATUS_CHOICES:
+            return new_substatus
+        new_substatus = None
 
     if new_status == GroupStatus.IGNORED:
         if status_details.get("untilEscalating"):

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -417,7 +417,7 @@ class UpdateGroupsTest(TestCase):
         group.refresh_from_db()
         assert group.status == GroupStatus.RESOLVED
 
-    def test_rejects_substatus_mismatched_with_status(self) -> None:
+    def test_rejects_mismatched_status_and_substatus(self) -> None:
         group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         request = self.make_request(user=self.user, method="GET")
@@ -431,18 +431,6 @@ class UpdateGroupsTest(TestCase):
 
         group.refresh_from_db()
         assert group.status == GroupStatus.UNRESOLVED
-
-    def test_rejects_substatus_for_resolved_status(self) -> None:
-        group = self.create_group(status=GroupStatus.UNRESOLVED)
-
-        request = self.make_request(user=self.user, method="GET")
-        request.user = self.user
-        request.data = {"status": "resolved", "substatus": "ongoing"}
-        request.GET = QueryDict(query_string=f"id={group.id}")
-        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
-
-        with pytest.raises(serializers.ValidationError):
-            update_groups(request, group_list)
 
     def test_resolve_in_next_release_ignores_archived_releases(self) -> None:
         open_release = self.create_release(

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from django.http import QueryDict
+from rest_framework import serializers
 
 from sentry.analytics.events.advanced_search_feature_gated import AdvancedSearchFeatureGateEvent
 from sentry.analytics.events.manual_issue_assignment import ManualIssueAssignment
@@ -415,6 +416,33 @@ class UpdateGroupsTest(TestCase):
 
         group.refresh_from_db()
         assert group.status == GroupStatus.RESOLVED
+
+    def test_rejects_substatus_mismatched_with_status(self) -> None:
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        request = self.make_request(user=self.user, method="GET")
+        request.user = self.user
+        request.data = {"status": "ignored", "substatus": "ongoing"}
+        request.GET = QueryDict(query_string=f"id={group.id}")
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+
+        with pytest.raises(serializers.ValidationError):
+            update_groups(request, group_list)
+
+        group.refresh_from_db()
+        assert group.status == GroupStatus.UNRESOLVED
+
+    def test_rejects_substatus_for_resolved_status(self) -> None:
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        request = self.make_request(user=self.user, method="GET")
+        request.user = self.user
+        request.data = {"status": "resolved", "substatus": "ongoing"}
+        request.GET = QueryDict(query_string=f"id={group.id}")
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+
+        with pytest.raises(serializers.ValidationError):
+            update_groups(request, group_list)
 
     def test_resolve_in_next_release_ignores_archived_releases(self) -> None:
         open_release = self.create_release(

--- a/tests/sentry/issues/test_status_change.py
+++ b/tests/sentry/issues/test_status_change.py
@@ -90,6 +90,30 @@ class InferSubstatusTest(TestCase):
             == GroupSubStatus.REGRESSED
         )
 
+    def test_drops_incompatible_substatus_for_ignored(self) -> None:
+        assert (
+            infer_substatus(
+                new_status=GroupStatus.IGNORED,
+                new_substatus=GroupSubStatus.ONGOING,
+                status_details={},
+                group_list=[],
+            )
+            == GroupSubStatus.FOREVER
+        )
+
+    def test_drops_incompatible_substatus_for_unresolved(self) -> None:
+        assert (
+            infer_substatus(
+                new_status=GroupStatus.UNRESOLVED,
+                new_substatus=GroupSubStatus.FOREVER,
+                status_details={},
+                group_list=[
+                    self.create_group(first_seen=datetime.now(timezone.utc) - timedelta(days=10))
+                ],
+            )
+            == GroupSubStatus.ONGOING
+        )
+
 
 class HandleStatusChangeTest(TestCase):
     def create_issue(self, status: int, substatus: int | None = None) -> None:


### PR DESCRIPTION
A PUT /api/0/issues/{id}/ body with valid-but-mismatched status and substatus (e.g. {status: ignored, substatus: ongoing}) used to issue an UPDATE that violated the substatus_is_valid_for_status DB check constraint and surfaced as a 500.

GroupValidator.validate() now rejects mismatched pairs with a 400. infer_substatus drops a caller-supplied substatus that doesn't match new_status as a backstop, falling through to inference instead.

Fixes SENTRY-5MW7