### PR TITLE
ref(api): Remove unused fileNameBlocklist constant

### DIFF
--- a/src/sentry/api/helpers/actionable_items_helper.py
+++ b/src/sentry/api/helpers/actionable_items_helper.py
@@ -9,8 +9,6 @@ class ActionPriority:
     UNKNOWN = 4
 
 
-fileNameBlocklist = ["@webkit-masked-url"]
-
 priority_ranking = {
     # Low Priority
     EventErrorType.CLOCK_DRIFT: ActionPriority.LOW,


### PR DESCRIPTION
fileNameBlocklist was defined in actionable_items_helper.py but never referenced anywhere. Drop it.

Ran case-insensitive grep across sentry and getsentry working trees: `grep -rni 'fileNameBlocklist\|file_name_blocklist\|filename_blocklist' \ src/ tests/ static/ ../getsentry` Only the definition line itself was returned — no usages in src/, tests/, static/, or getsentry.