### PR TITLE
chore: clean up explorer index flags

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -367,9 +367,6 @@ class SeerAgentClient:
         has_org_project_context: bool | None,
     ) -> None:
         """Trigger explorer indexing for the org if Seer reports missing indexes."""
-        if not options.get("seer.explorer_index.enable"):
-            return
-
         if options.get("seer.explorer_index.killswitch.enable"):
             logger.info("seer.explorer_index.killswitch.enable flag enabled, skipping")
             return

--- a/src/sentry/tasks/seer/explorer_index.py
+++ b/src/sentry/tasks/seer/explorer_index.py
@@ -10,7 +10,6 @@ from django.utils import timezone as django_timezone
 from sentry import features, options
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
-from sentry.options.rollout import in_rollout_group
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     AgentIndexProject,
@@ -54,10 +53,6 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
         projects,
         result_value_getter=lambda p: p.id,
     ):
-        if options.get("seer.explorer_index.killswitch.enable"):
-            logger.info("seer.explorer_index.killswitch.enable flag enabled, skipping")
-            return
-
         if project.id % 23 != current_hour:
             continue
 
@@ -90,8 +85,7 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
                 ) or org_features.get("organizations:seer-added", False)
 
                 if has_seer_plan and has_gen_ai:
-                    if in_rollout_group("seer.explorer-index.rollout", project.organization_id):
-                        is_eligible = True
+                    is_eligible = True
 
             else:
                 has_gen_ai = features.has("organizations:gen-ai-features", project.organization)
@@ -107,8 +101,7 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
                 ) or features.has("organizations:seer-added", project.organization)
 
                 if has_seer_plan and has_gen_ai:
-                    if in_rollout_group("seer.explorer-index.rollout", project.organization_id):
-                        is_eligible = True
+                    is_eligible = True
 
         if not is_eligible:
             continue
@@ -128,8 +121,8 @@ def schedule_explorer_index() -> None:
     """
     logger.info("Started schedule_explorer_index task")
 
-    if not options.get("seer.explorer_index.enable"):
-        logger.info("seer.explorer_index.enable flag is disabled")
+    if options.get("seer.explorer_index.killswitch.enable"):
+        logger.info("seer.explorer_index.killswitch.enable flag enabled, skipping")
         return
 
     now = django_timezone.now()
@@ -218,7 +211,9 @@ def run_explorer_index_for_projects(
         projects: List of (project_id, organization_id) tuples
         start: ISO format timestamp string for when this batch was scheduled
     """
-    if not options.get("seer.explorer_index.enable"):
+
+    if options.get("seer.explorer_index.killswitch.enable"):
+        logger.info("seer.explorer_index.killswitch.enable flag enabled, skipping")
         return
 
     if not projects:

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -989,9 +989,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         project.save()
 
         client = SeerAgentClient(self.organization, self.user)
-        with self.options(
-            {"seer.explorer_index.enable": True, "seer.explorer_index.killswitch.enable": False}
-        ):
+        with self.options({"seer.explorer_index.killswitch.enable": False}):
             run_id = client.start_run("Why are my errors spiking?")
 
         assert run_id == 123
@@ -1015,7 +1013,6 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         client = SeerAgentClient(self.organization, self.user)
         with self.options(
             {
-                "seer.explorer_index.enable": True,
                 "seer.explorer_index.killswitch.enable": False,
                 "explorer.context_engine_indexing.enable": True,
             }
@@ -1038,9 +1035,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         project_without_txns = self.create_project(organization=self.organization)
 
         client = SeerAgentClient(self.organization, self.user)
-        with self.options(
-            {"seer.explorer_index.enable": True, "seer.explorer_index.killswitch.enable": False}
-        ):
+        with self.options({"seer.explorer_index.killswitch.enable": False}):
             client.start_run("Why are my errors spiking?")
 
         projects_batch = list(mock_dispatch.call_args[0][0])
@@ -1055,8 +1050,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         )
 
         client = SeerAgentClient(self.organization, self.user)
-        with self.options({"seer.explorer_index.enable": True}):
-            run_id = client.start_run("Why are my errors spiking?")
+        run_id = client.start_run("Why are my errors spiking?")
 
         assert run_id == 123
         mock_dispatch.assert_not_called()
@@ -1067,35 +1061,10 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         mock_chat.return_value = self._mock_chat_response()
 
         client = SeerAgentClient(self.organization, self.user)
-        with self.options({"seer.explorer_index.enable": True}):
-            run_id = client.start_run("Why are my errors spiking?")
+        run_id = client.start_run("Why are my errors spiking?")
 
         assert run_id == 123
         mock_dispatch.assert_not_called()
-
-    @patch("sentry.seer.agent.client.index_org_project_knowledge")
-    @patch("sentry.seer.agent.client.build_service_map")
-    @patch("sentry.seer.agent.client.dispatch_explorer_index_projects")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
-    def test_skips_indexing_when_enable_option_off(
-        self, mock_chat, mock_dispatch, mock_build_service_map, mock_index_knowledge
-    ):
-        mock_chat.return_value = self._mock_chat_response(
-            has_explorer_index=False, has_org_project_context=False
-        )
-        project = self.create_project(organization=self.organization)
-        project.flags.has_transactions = True
-        project.save()
-
-        client = SeerAgentClient(self.organization, self.user)
-        with self.options(
-            {"seer.explorer_index.enable": False, "explorer.context_engine_indexing.enable": True}
-        ):
-            client.start_run("Why are my errors spiking?")
-
-        mock_dispatch.assert_not_called()
-        mock_index_knowledge.apply_async.assert_not_called()
-        mock_build_service_map.apply_async.assert_not_called()
 
     @patch("sentry.seer.agent.client.index_org_project_knowledge")
     @patch("sentry.seer.agent.client.build_service_map")
@@ -1114,7 +1083,6 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         client = SeerAgentClient(self.organization, self.user)
         with self.options(
             {
-                "seer.explorer_index.enable": True,
                 "seer.explorer_index.killswitch.enable": True,
                 "explorer.context_engine_indexing.enable": True,
             }
@@ -1132,9 +1100,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         self.create_project(organization=self.organization)
 
         client = SeerAgentClient(self.organization, self.user)
-        with self.options(
-            {"seer.explorer_index.enable": True, "seer.explorer_index.killswitch.enable": False}
-        ):
+        with self.options({"seer.explorer_index.killswitch.enable": False}):
             client.start_run("Why are my errors spiking?")
 
         mock_dispatch.assert_not_called()

--- a/tests/sentry/tasks/seer/test_explorer_index.py
+++ b/tests/sentry/tasks/seer/test_explorer_index.py
@@ -103,34 +103,6 @@ class TestGetSeerAgentEnabledProjects(TestCase):
             assert active_project.id in project_ids
         assert inactive_project.id not in project_ids
 
-    @freeze_time("2024-01-15 12:00:00")
-    def test_returns_empty_without_feature_flag(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-
-        project.flags.has_transactions = True
-        project.save()
-
-        PromptsActivity.objects.create(
-            organization_id=org.id,
-            project_id=0,
-            user_id=self.user.id,
-            feature="seer_autofix_setup_acknowledged",
-        )
-
-        with self.feature(
-            {
-                "organizations:gen-ai-features": [org.slug],
-                "organizations:seat-based-seer-enabled": [org.slug],
-            }
-        ):
-            with mock.patch(
-                "sentry.tasks.seer.explorer_index.in_rollout_group", return_value=False
-            ):
-                result = list(get_seer_explorer_enabled_projects())
-
-        assert len(result) == 0
-
     def test_excludes_projects_with_hide_ai_features(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
@@ -260,7 +232,7 @@ class TestGetSeerAgentEnabledProjects(TestCase):
         assert project.id not in [p[0] for p in result]
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_includes_projects_with_legacy_seer_plan_via_rollout(self) -> None:
+    def test_includes_projects_with_legacy_seer_plan(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -280,15 +252,14 @@ class TestGetSeerAgentEnabledProjects(TestCase):
                 "organizations:seer-added": [org.slug],
             }
         ):
-            with mock.patch("sentry.tasks.seer.explorer_index.in_rollout_group", return_value=True):
-                result = list(get_seer_explorer_enabled_projects())
+            result = list(get_seer_explorer_enabled_projects())
 
         project_ids = [p[0] for p in result]
         if project.id % 23 == 12:
             assert project.id in project_ids
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_includes_projects_with_seat_based_plan_via_rollout(self) -> None:
+    def test_includes_projects_with_seat_based_plan(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -308,47 +279,17 @@ class TestGetSeerAgentEnabledProjects(TestCase):
                 "organizations:seat-based-seer-enabled": [org.slug],
             }
         ):
-            with mock.patch("sentry.tasks.seer.explorer_index.in_rollout_group", return_value=True):
-                result = list(get_seer_explorer_enabled_projects())
+            result = list(get_seer_explorer_enabled_projects())
 
         project_ids = [p[0] for p in result]
         if project.id % 23 == 12:
             assert project.id in project_ids
-
-    @freeze_time("2024-01-15 12:00:00")
-    def test_excludes_projects_with_billing_plan_not_in_rollout(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-
-        project.flags.has_transactions = True
-        project.save()
-
-        PromptsActivity.objects.create(
-            organization_id=org.id,
-            project_id=0,
-            user_id=self.user.id,
-            feature="seer_autofix_setup_acknowledged",
-        )
-
-        with self.feature(
-            {
-                "organizations:gen-ai-features": [org.slug],
-                "organizations:seat-based-seer-enabled": [org.slug],
-            }
-        ):
-            with mock.patch(
-                "sentry.tasks.seer.explorer_index.in_rollout_group", return_value=False
-            ):
-                result = list(get_seer_explorer_enabled_projects())
-
-        assert len(result) == 0
-        assert project.id not in [p[0] for p in result]
 
 
 @django_db_all
 class TestScheduleExplorerIndex(TestCase):
-    def test_skips_when_option_disabled(self) -> None:
-        with self.options({"seer.explorer_index.enable": False}):
+    def test_skips_when_killswitch_enabled(self) -> None:
+        with self.options({"seer.explorer_index.killswitch.enable": True}):
             with mock.patch(
                 "sentry.tasks.seer.explorer_index.get_seer_explorer_enabled_projects"
             ) as mock_get_projects:
@@ -356,7 +297,7 @@ class TestScheduleExplorerIndex(TestCase):
                 mock_get_projects.assert_not_called()
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_schedules_projects_with_option_enabled(self) -> None:
+    def test_schedules_projects(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -370,19 +311,18 @@ class TestScheduleExplorerIndex(TestCase):
             feature="seer_autofix_setup_acknowledged",
         )
 
-        with self.options({"seer.explorer_index.enable": True}):
-            with self.feature(
-                {
-                    "organizations:gen-ai-features": [org.slug],
-                    "organizations:seer-explorer-index": [org.slug],
-                }
-            ):
-                with mock.patch(
-                    "sentry.tasks.seer.explorer_index.dispatch_explorer_index_projects"
-                ) as mock_dispatch:
-                    mock_dispatch.return_value = iter([])
-                    schedule_explorer_index()
-                    mock_dispatch.assert_called_once()
+        with self.feature(
+            {
+                "organizations:gen-ai-features": [org.slug],
+                "organizations:seer-explorer-index": [org.slug],
+            }
+        ):
+            with mock.patch(
+                "sentry.tasks.seer.explorer_index.dispatch_explorer_index_projects"
+            ) as mock_dispatch:
+                mock_dispatch.return_value = iter([])
+                schedule_explorer_index()
+                mock_dispatch.assert_called_once()
 
 
 @django_db_all
@@ -418,8 +358,7 @@ class TestRunExplorerIndexForProjects(TestCase):
         projects = [(1, 100), (2, 100), (3, 200)]
         start = "2024-01-15T12:00:00+00:00"
 
-        with self.options({"seer.explorer_index.enable": True}):
-            run_explorer_index_for_projects(projects, start)
+        run_explorer_index_for_projects(projects, start)
 
         mock_request.assert_called_once()
         body = mock_request.call_args[0][0]
@@ -436,12 +375,11 @@ class TestRunExplorerIndexForProjects(TestCase):
         projects = [(1, 100)]
         start = "2024-01-15T12:00:00+00:00"
 
-        with self.options({"seer.explorer_index.enable": True}):
-            with pytest.raises(Exception):
-                run_explorer_index_for_projects(projects, start)
+        with pytest.raises(Exception):
+            run_explorer_index_for_projects(projects, start)
 
-    def test_skips_when_option_disabled(self) -> None:
-        with self.options({"seer.explorer_index.enable": False}):
+    def test_skips_when_killswitch_enabled(self) -> None:
+        with self.options({"seer.explorer_index.killswitch.enable": True}):
             with mock.patch(
                 "sentry.tasks.seer.explorer_index.make_agent_index_request"
             ) as mock_request:


### PR DESCRIPTION
cleaning up some rollout flags:
- seer.explorer_index.enable
- seer.explorer-index.rollout

since they are both rolled out. leaving the killswitch in,
incase we need it