### PR TITLE
fix(seer): Use hash-based jitter for night shift org dispatch

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -44,12 +44,12 @@ from sentry.tasks.seer.night_shift.tweaks import (
     get_night_shift_tweaks,
 )
 from sentry.taskworker.namespaces import seer_tasks
+from sentry.utils.hashlib import md5_text
 from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapper
 
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
-NIGHT_SHIFT_DISPATCH_STEP_SECONDS = 37
 NIGHT_SHIFT_SPREAD_DURATION = timedelta(hours=4)
 
 BATCH_FEATURE_NAMES = [
@@ -146,7 +146,7 @@ def schedule_night_shift(
         )
         eligible = _get_eligible_orgs_from_batch(org_batch)
         for org in eligible:
-            delay = (batch_index * NIGHT_SHIFT_DISPATCH_STEP_SECONDS) % spread_seconds
+            delay = int(md5_text(str(org.id)).hexdigest(), 16) % spread_seconds
             run_night_shift_for_org.apply_async(args=[org.id], kwargs=task_kwargs, countdown=delay)
             batch_index += 1
 


### PR DESCRIPTION
## Summary
- The previous jitter used `batch_index * 37 % spread_seconds`, which only distributes well when the eligible org count is large enough to wrap around the 14,400-second window. With heavy filtering reducing the eligible set to ~50 orgs, runs clustered in the first ~30 minutes.
- Switch to `md5(org.id) % spread_seconds` so each org gets a deterministic, uniformly distributed delay regardless of eligible count.

## Test plan
- [x] Existing `TestScheduleNightShift` tests pass (32/32)
- [ ] Verify in next nightly run that org dispatch times are spread across the full 4-hour window