### PR TITLE
ref(seer): Promote taxonomy routes to stable structured context

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -53,16 +53,15 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/explore/traces/',
   '/explore/traces/trace/:traceSlug/',
   '/issues/',
+  '/issues/errors-outages/',
+  '/issues/breached-metrics/',
+  '/issues/warnings/',
   '/issues/:groupId/',
   '/issues/:groupId/events/',
   '/issues/:groupId/events/:eventId/',
 ]);
 /** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>([
-  '/issues/errors-outages/',
-  '/issues/breached-metrics/',
-  '/issues/warnings/',
-]);
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>();
 
 function supportsStructuredContext(
   referrer: string,


### PR DESCRIPTION
+ Move /issues/errors-outages/, /issues/breached-metrics/, and /issues/warnings/ from NEW_STRUCTURED_CONTEXT_ROUTES to STRUCTURED_CONTEXT_ROUTES.

