### PR TITLE
chore(explore): Extract and re-use search sorting logic

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -3694,18 +3694,20 @@ function _getFieldFromMappings(
   }
 }
 
+export type GetFieldDefinitionType =
+  | 'event'
+  | 'replay'
+  | 'replay_click'
+  | 'feedback'
+  | 'preprod'
+  | 'span'
+  | 'log'
+  | 'uptime'
+  | 'tracemetric';
+
 export const getFieldDefinition = (
   key: string,
-  type:
-    | 'event'
-    | 'replay'
-    | 'replay_click'
-    | 'feedback'
-    | 'preprod'
-    | 'span'
-    | 'log'
-    | 'uptime'
-    | 'tracemetric' = 'event',
+  type: GetFieldDefinitionType = 'event',
   kind?: FieldKind
 ): FieldDefinition | null => {
   return _getFieldFromMappings(type, key, kind) ?? null;

--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -13,8 +13,7 @@ import {DragReorderButton} from 'sentry/components/dnd/dragReorderButton';
 import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
-import {getFieldDefinition} from 'sentry/utils/fields';
-import {fzf} from 'sentry/utils/search/fzf';
+import {type GetFieldDefinitionType} from 'sentry/utils/fields';
 import {
   ToolbarFooterButton,
   ToolbarHeader,
@@ -22,6 +21,7 @@ import {
   ToolbarRow,
 } from 'sentry/views/explore/components/toolbar/styles';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
+import {sortSearchedAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 
 export function ToolbarGroupByHeader() {
   return (
@@ -44,7 +44,7 @@ interface ToolbarGroupByDropdownProps {
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
   options: Array<SelectOption<string>>;
-  fieldDefinitionType?: Parameters<typeof getFieldDefinition>[1];
+  fieldDefinitionType?: GetFieldDefinitionType;
   loading?: boolean;
   onClose?: () => void;
   onSearch?: (search: string) => void;
@@ -93,24 +93,11 @@ export function ToolbarGroupByDropdown({
         search={{
           onChange: onSearch,
           filter: (option, search) => {
-            const text =
-              option.textValue ?? (typeof option.label === 'string' ? option.label : '');
-            const normalizedText = text.toLowerCase();
-            const normalizedSearch = search.toLowerCase();
-            // Keep Group By's existing substring filtering behavior while using fzf
-            // only to rank the matched options.
-            if (!normalizedText.includes(normalizedSearch)) {
-              return {score: 0};
-            }
-            const result = fzf(text, normalizedSearch, false);
-            if (result.end === -1) {
-              return {score: 0};
-            }
-            const isKnown =
-              getFieldDefinition(String(option.value), fieldDefinitionType) !== null;
-            const prefixBoost =
-              result.start === 0 && result.end === normalizedSearch.length ? 8 : 0;
-            return {score: Math.max(1, result.score) + prefixBoost + (isKnown ? 2 : 1)};
+            return sortSearchedAttributes({
+              fieldDefinitionType,
+              option,
+              searchText: search,
+            });
           },
         }}
         trigger={triggerProps => (

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -20,6 +20,8 @@ import {
   ToolbarLabel,
   ToolbarRow,
 } from 'sentry/views/explore/components/toolbar/styles';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+import {sortSearchedAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 
 export function ToolbarVisualizeHeader() {
   return (
@@ -93,7 +95,16 @@ export function ToolbarVisualizeDropdown({
         return (
           <FieldCompactSelect
             key={param.name}
-            search={{onChange: onSearch}}
+            search={{
+              onChange: onSearch,
+              filter: (option, searchText) => {
+                return sortSearchedAttributes({
+                  fieldDefinitionType: TraceItemDataset.SPANS,
+                  option,
+                  searchText,
+                });
+              },
+            }}
             options={fieldOptions}
             value={parsedFunction?.arguments[index] ?? param.defaultValue ?? ''}
             onChange={option => onChangeArgument(index, option)}
@@ -105,7 +116,16 @@ export function ToolbarVisualizeDropdown({
       })}
       {aggregateDefinition?.parameters?.length === 0 && ( // for parameterless functions, we want to still show show greyed out spans
         <FieldCompactSelect
-          search={{onChange: onSearch}}
+          search={{
+            onChange: onSearch,
+            filter: (option, searchText) => {
+              return sortSearchedAttributes({
+                fieldDefinitionType: TraceItemDataset.SPANS,
+                option,
+                searchText,
+              });
+            },
+          }}
           options={fieldOptions}
           value={parsedFunction?.arguments[0] ?? ''}
           onChange={option => onChangeArgument(0, option)}

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -13,14 +13,13 @@ import {IconAdd} from 'sentry/icons';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
-import {getFieldDefinition} from 'sentry/utils/fields';
+import {getFieldDefinition, type GetFieldDefinitionType} from 'sentry/utils/fields';
 import {
   ToolbarFooterButton,
   ToolbarHeader,
   ToolbarLabel,
   ToolbarRow,
 } from 'sentry/views/explore/components/toolbar/styles';
-import {TraceItemDataset} from 'sentry/views/explore/types';
 import {sortSearchedAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 
 export function ToolbarVisualizeHeader() {
@@ -45,6 +44,7 @@ interface ToolbarVisualizeDropdownProps {
   onChangeArgument: (index: number, option: SelectOption<SelectKey>) => void;
   parsedFunction: ParsedFunction | null;
   dragColumnId?: number;
+  fieldDefinitionType?: GetFieldDefinitionType;
   label?: ReactNode;
   loading?: boolean;
   onClose?: () => void;
@@ -64,6 +64,7 @@ export function ToolbarVisualizeDropdown({
   parsedFunction,
   label,
   loading,
+  fieldDefinitionType = 'span',
 }: ToolbarVisualizeDropdownProps) {
   const {attributes, listeners, setNodeRef, transform} = useSortable({
     id: dragColumnId ?? 0,
@@ -99,7 +100,7 @@ export function ToolbarVisualizeDropdown({
               onChange: onSearch,
               filter: (option, searchText) => {
                 return sortSearchedAttributes({
-                  fieldDefinitionType: TraceItemDataset.SPANS,
+                  fieldDefinitionType,
                   option,
                   searchText,
                 });
@@ -120,7 +121,7 @@ export function ToolbarVisualizeDropdown({
             onChange: onSearch,
             filter: (option, searchText) => {
               return sortSearchedAttributes({
-                fieldDefinitionType: TraceItemDataset.SPANS,
+                fieldDefinitionType,
                 option,
                 searchText,
               });

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -5,10 +5,11 @@ import type {SelectOption} from '@sentry/scraps/compactSelect';
 
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
-import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
+import {FieldKind} from 'sentry/utils/fields';
 import {buildAttributeOptions} from 'sentry/views/explore/components/attributeOption';
 import {UNGROUPED} from 'sentry/views/explore/contexts/pageParamsContext/groupBys';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {sortKnownAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 
 interface UseGroupByFieldsProps {
   booleanTags: TagCollection;
@@ -46,18 +47,7 @@ export function useGroupByFields({
         seen.add(option.value);
         return true;
       })
-      .toSorted((a, b) => {
-        const aKnown =
-          getFieldDefinition(a.value, TRACE_ITEM_FIELD_DEFINITION_TYPE[traceItemType]) !==
-          null;
-        const bKnown =
-          getFieldDefinition(b.value, TRACE_ITEM_FIELD_DEFINITION_TYPE[traceItemType]) !==
-          null;
-        if (aKnown !== bKnown) return aKnown ? -1 : 1;
-        const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
-        const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');
-        return aLabel.localeCompare(bLabel);
-      });
+      .toSorted((a, b) => sortKnownAttributes(a, b, traceItemType));
 
     return [
       // hard code in an empty option
@@ -74,14 +64,6 @@ export function useGroupByFields({
     ];
   }, [booleanTags, groupBys, hideEmptyOption, numberTags, stringTags, traceItemType]);
 }
-
-const TRACE_ITEM_FIELD_DEFINITION_TYPE: Partial<
-  Record<TraceItemDataset, 'span' | 'log' | 'tracemetric'>
-> = {
-  [TraceItemDataset.SPANS]: 'span',
-  [TraceItemDataset.LOGS]: 'log',
-  [TraceItemDataset.TRACEMETRICS]: 'tracemetric',
-};
 
 // Some fields don't make sense to allow users to group by as they create
 // very high cardinality groupings and is not useful.

--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -45,9 +45,9 @@ describe('useVisualizeFields', () => {
     });
 
     expect(result.current.map(field => field.value)).toEqual([
-      'score.ttfb',
       'span.duration',
       'span.self_time',
+      'score.ttfb',
     ]);
   });
 

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -16,6 +16,7 @@ import {
 } from 'sentry/utils/fields';
 import {optionFromTag} from 'sentry/views/explore/components/attributeOption';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {sortKnownAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 import {SpanFields} from 'sentry/views/insights/types';
 
 interface UseVisualizeFieldsProps {
@@ -67,11 +68,7 @@ export function useVisualizeFields({
         seen.add(option.value);
         return true;
       })
-      .toSorted((a, b) => {
-        const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
-        const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');
-        return aLabel.localeCompare(bLabel);
-      });
+      .toSorted((a, b) => sortKnownAttributes(a, b, traceItemType));
   }, [tags, unknownField, traceItemType]);
 
   return fieldOptions;

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -327,6 +327,7 @@ function VisualizeDropdown({
       onClose={onClose}
       onSearch={onSearch}
       loading={loading}
+      fieldDefinitionType="log"
     />
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -18,6 +18,7 @@ import {
   useSetQueryParamsGroupBys,
 } from 'sentry/views/explore/queryParams/context';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {sortSearchedAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 import {
   selectTraceItemTagCollection,
   traceItemAttributeKeysOptions,
@@ -115,7 +116,15 @@ export function GroupBySelector({
   return (
     <CompactSelect
       multiple
-      search
+      search={{
+        filter: (option, searchText) => {
+          return sortSearchedAttributes({
+            fieldDefinitionType: TraceItemDataset.TRACEMETRICS,
+            option,
+            searchText,
+          });
+        },
+      }}
       clearable
       trigger={triggerProps => (
         <OverlayTrigger.Button

--- a/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
@@ -16,6 +16,7 @@ import {
   SectionLabel,
 } from 'sentry/views/explore/multiQueryMode/queryConstructors/styles';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {sortSearchedAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 
 type Props = {index: number; query: ReadableExploreQueryParts};
 
@@ -51,7 +52,15 @@ export function GroupBySection({query, index}: Props) {
         options={enabledOptions}
         value={query.groupBys}
         clearable
-        search
+        search={{
+          filter: (option, searchText) => {
+            return sortSearchedAttributes({
+              fieldDefinitionType: TraceItemDataset.SPANS,
+              option,
+              searchText,
+            });
+          },
+        }}
         onChange={options =>
           updateGroupBys({groupBys: options.map(value => value.value.toString())})
         }

--- a/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
@@ -23,6 +23,7 @@ import {
   SectionLabel,
 } from 'sentry/views/explore/multiQueryMode/queryConstructors/styles';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {sortSearchedAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 
 type Props = {
   index: number;
@@ -82,7 +83,15 @@ export function VisualizeSection({query, index}: Props) {
             }}
           />
           <CompactSelect
-            search
+            search={{
+              filter: (option, searchText) => {
+                return sortSearchedAttributes({
+                  fieldDefinitionType: TraceItemDataset.SPANS,
+                  option,
+                  searchText,
+                });
+              },
+            }}
             options={options}
             value={parsedFunction?.arguments?.[0] ?? ''}
             onChange={newField => {

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -64,6 +64,7 @@ import {
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {sortSearchedAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 
 interface AggregateColumnEditorModalProps extends ModalRenderProps {
   booleanTags: TagCollection;
@@ -366,7 +367,16 @@ function GroupBySelector({
       options={options}
       value={groupBy.groupBy}
       onChange={handleChange}
-      search={{onChange: setSearch}}
+      search={{
+        onChange: setSearch,
+        filter: (option, searchText) => {
+          return sortSearchedAttributes({
+            fieldDefinitionType: TraceItemDataset.SPANS,
+            option,
+            searchText,
+          });
+        },
+      }}
       loading={isSearchLoading}
       emptyMessage={isSearchLoading ? t('Loading…') : t('No matching attributes')}
       trigger={triggerProps => (
@@ -597,7 +607,16 @@ function AttributeArgumentSelect({
       options={options}
       value={value}
       onChange={onChange}
-      search={{onChange: setSearch}}
+      search={{
+        onChange: setSearch,
+        filter: (option, searchText) => {
+          return sortSearchedAttributes({
+            fieldDefinitionType: TraceItemDataset.SPANS,
+            option,
+            searchText,
+          });
+        },
+      }}
       loading={isSearchLoading}
       emptyMessage={isSearchLoading ? t('Loading…') : t('No matching attributes')}
       // Stay enabled whenever the function supports server-side search so the

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -27,6 +27,10 @@ import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {
+  sortKnownAttributes,
+  sortSearchedAttributes,
+} from 'sentry/views/explore/utils/sortSearchedAttributes';
 
 interface ColumnEditorModalProps extends ModalRenderProps {
   booleanTags: TagCollection;
@@ -299,7 +303,16 @@ function ColumnEditorRow({
         value={column.column ?? ''}
         onChange={handleColumnChange}
         disabled={required}
-        search={{onChange: setSearch}}
+        search={{
+          onChange: setSearch,
+          filter: (option, searchText) => {
+            return sortSearchedAttributes({
+              fieldDefinitionType: traceItemType,
+              option,
+              searchText,
+            });
+          },
+        }}
         loading={isSearchLoading}
         emptyMessage={isSearchLoading ? t('Loading\u2026') : t('No matching attributes')}
         trigger={triggerProps => (
@@ -356,17 +369,7 @@ function buildColumnOptions({
       if (typeof option.label === 'string' && hidden.includes(option.label)) return false;
       return true;
     })
-    .toSorted((a, b) => {
-      const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
-      const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');
-      if (aLabel < bLabel) {
-        return -1;
-      }
-      if (aLabel > bLabel) {
-        return 1;
-      }
-      return 0;
-    });
+    .toSorted((a, b) => sortKnownAttributes(a, b, traceItemType));
 }
 
 const RowContainer = styled('div')`

--- a/static/app/views/explore/utils/sortSearchedAttributes.tsx
+++ b/static/app/views/explore/utils/sortSearchedAttributes.tsx
@@ -17,6 +17,13 @@ interface SortSearchedAttributesProps<Value extends SelectKey> {
   searchText: string;
 }
 
+/**
+ * Scores an attribute option for CompactSelect search results in Explore field pickers.
+ *
+ * Use this as a custom search/filter scorer when the menu should keep the existing
+ * substring-only matching behavior, but rank matches with fzf and prefer known Sentry
+ * field definitions over arbitrary custom attributes.
+ */
 export function sortSearchedAttributes<Value extends SelectKey>({
   fieldDefinitionType,
   option,
@@ -71,6 +78,12 @@ function getFieldDefinitionType(
   }
 }
 
+/**
+ * Sorts attribute options for Explore field pickers before the user enters search text.
+ *
+ * Use this for initial option lists where known Sentry field definitions should appear
+ * before custom attributes, with each group sorted alphabetically by label.
+ */
 export function sortKnownAttributes<Value extends SelectOption<string>>(
   a: Value,
   b: Value,

--- a/static/app/views/explore/utils/sortSearchedAttributes.tsx
+++ b/static/app/views/explore/utils/sortSearchedAttributes.tsx
@@ -1,0 +1,87 @@
+import type {
+  SearchMatchResult,
+  SelectKey,
+  SelectOption,
+  SelectOptionWithKey,
+} from '@sentry/scraps/compactSelect';
+
+import {getFieldDefinition, type GetFieldDefinitionType} from 'sentry/utils/fields';
+import {fzf} from 'sentry/utils/search/fzf';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+type SortFieldDefinitionType = GetFieldDefinitionType | TraceItemDataset;
+
+interface SortSearchedAttributesProps<Value extends SelectKey> {
+  fieldDefinitionType: SortFieldDefinitionType;
+  option: SelectOptionWithKey<Value>;
+  searchText: string;
+}
+
+export function sortSearchedAttributes<Value extends SelectKey>({
+  fieldDefinitionType,
+  option,
+  searchText,
+}: SortSearchedAttributesProps<Value>): SearchMatchResult {
+  const text = option.textValue ?? (typeof option.label === 'string' ? option.label : '');
+  const normalizedText = text.toLowerCase();
+  const normalizedSearch = searchText.toLowerCase();
+  // Keep Group By's existing substring filtering behavior while using fzf
+  // only to rank the matched options.
+  if (!normalizedText.includes(normalizedSearch)) {
+    return {score: 0};
+  }
+
+  const result = fzf(text, normalizedSearch, false);
+  if (result.end === -1) {
+    return {score: 0};
+  }
+
+  const isKnown =
+    getFieldDefinition(
+      String(option.value),
+      getFieldDefinitionType(fieldDefinitionType)
+    ) !== null;
+
+  const prefixBoost =
+    result.start === 0 && result.end === normalizedSearch.length ? 8 : 0;
+  return {score: Math.max(1, result.score) + prefixBoost + (isKnown ? 2 : 1)};
+}
+
+function getFieldDefinitionType(
+  fieldDefinitionType: SortFieldDefinitionType
+): GetFieldDefinitionType {
+  switch (fieldDefinitionType) {
+    case TraceItemDataset.ERRORS:
+    case TraceItemDataset.PROCESSING_ERRORS:
+      return 'event';
+    case TraceItemDataset.LOGS:
+      return 'log';
+    case TraceItemDataset.PREPROD:
+      return 'preprod';
+    case TraceItemDataset.REPLAYS:
+      return 'replay';
+    case TraceItemDataset.SPANS:
+      return 'span';
+    case TraceItemDataset.TRACEMETRICS:
+      return 'tracemetric';
+    case TraceItemDataset.UPTIME_RESULTS:
+      return 'uptime';
+    default:
+      return fieldDefinitionType;
+  }
+}
+
+export function sortKnownAttributes<Value extends SelectOption<string>>(
+  a: Value,
+  b: Value,
+  traceItemType: TraceItemDataset
+) {
+  const aKnown =
+    getFieldDefinition(a.value, getFieldDefinitionType(traceItemType)) !== null;
+  const bKnown =
+    getFieldDefinition(b.value, getFieldDefinitionType(traceItemType)) !== null;
+  if (aKnown !== bKnown) return aKnown ? -1 : 1;
+  const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
+  const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');
+  return aLabel.localeCompare(bLabel);
+}


### PR DESCRIPTION
Continue the work from #115032, and extend it to the visualize dropdown, and column editors.