### PR TITLE
fix(slack): Hash arg values when deduping unfurled links

### DIFF
--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import orjson
 import sentry_sdk
+from django.http.request import QueryDict
 from rest_framework.request import Request
 from rest_framework.response import Response
 from slack_sdk.errors import SlackApiError
@@ -250,8 +251,16 @@ class SlackEventEndpoint(SlackDMEndpoint):
                     )
                     return {}
 
-                # Don't unfurl the same thing multiple times
-                seen_marker = hash(orjson.dumps((link_type, list(args))).decode())
+                # `list(args)` only captures keys, so links sharing the same
+                # arg shape (explore URLs, dashboard widgets on the same
+                # dashboard, etc.) all collided to one marker and only the
+                # first survived. Fold each value into the marker — QueryDicts
+                # via .urlencode(), everything else as-is — so unique values
+                # produce unique markers.
+                marker_args = sorted(
+                    (k, v.urlencode() if isinstance(v, QueryDict) else v) for k, v in args.items()
+                )
+                seen_marker = hash(orjson.dumps((link_type, marker_args)).decode())
                 if seen_marker in links_seen:
                     continue
 

--- a/tests/sentry/integrations/slack/webhooks/events/test_discover_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_discover_link_shared.py
@@ -72,7 +72,7 @@ class DiscoverLinkSharedEvent(BaseEventTest):
         # two unique links and one duplicate.
         side_effect=[
             (LinkType.DISCOVER, {"arg1": "value1"}),
-            (LinkType.DISCOVER, {"arg1", "value2"}),
+            (LinkType.DISCOVER, {"arg2": "value2"}),
             (LinkType.DISCOVER, {"arg1": "value1"}),
         ],
     )
@@ -103,7 +103,7 @@ class DiscoverLinkSharedEvent(BaseEventTest):
         # two unique links and one duplicate.
         side_effect=[
             (LinkType.DISCOVER, {"arg1": "value1"}),
-            (LinkType.DISCOVER, {"arg1", "value2"}),
+            (LinkType.DISCOVER, {"arg2": "value2"}),
             (LinkType.DISCOVER, {"arg1": "value1"}),
         ],
     )
@@ -130,7 +130,7 @@ class DiscoverLinkSharedEvent(BaseEventTest):
         # two unique links and one duplicate.
         side_effect=[
             (LinkType.DISCOVER, {"arg1": "value1"}),
-            (LinkType.DISCOVER, {"arg1", "value2"}),
+            (LinkType.DISCOVER, {"arg2": "value2"}),
             (LinkType.DISCOVER, {"arg1": "value1"}),
         ],
     )

--- a/tests/sentry/integrations/slack/webhooks/events/test_explore_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_explore_link_shared.py
@@ -118,9 +118,7 @@ class ExploreLinkSharedEvent(BaseEventTest):
 
     def test_unique_explore_links_with_same_arg_shape(self) -> None:
         """Three explore URLs whose args dicts share the same key set but
-        carry different QueryDicts must each unfurl separately. Pre-fix the
-        dedup hashed only args.keys(), so all three collided and only the
-        first reached the handler."""
+        carry different QueryDicts must each unfurl separately."""
         self.link_identity(slack_user_id=LINK_SHARED_EVENT["user"])
 
         handler_fn = Mock(return_value={"l1": "u1", "l2": "u2", "l3": "u3"})

--- a/tests/sentry/integrations/slack/webhooks/events/test_explore_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_explore_link_shared.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import orjson
 import pytest
+from django.http.request import QueryDict
 from slack_sdk.web import SlackResponse
 
 from sentry.integrations.slack.unfurl.types import Handler, LinkType, make_type_coercer
@@ -47,7 +48,7 @@ class ExploreLinkSharedEvent(BaseEventTest):
         "sentry.integrations.slack.webhooks.event.match_link",
         side_effect=[
             (LinkType.EXPLORE, {"arg1": "value1"}),
-            (LinkType.EXPLORE, {"arg1", "value2"}),
+            (LinkType.EXPLORE, {"arg2": "value2"}),
             (LinkType.EXPLORE, {"arg1": "value1"}),
         ],
     )
@@ -71,7 +72,7 @@ class ExploreLinkSharedEvent(BaseEventTest):
         "sentry.integrations.slack.webhooks.event.match_link",
         side_effect=[
             (LinkType.EXPLORE, {"arg1": "value1"}),
-            (LinkType.EXPLORE, {"arg1", "value2"}),
+            (LinkType.EXPLORE, {"arg2": "value2"}),
             (LinkType.EXPLORE, {"arg1": "value1"}),
         ],
     )
@@ -114,3 +115,47 @@ class ExploreLinkSharedEvent(BaseEventTest):
         assert len(unfurls) == 2
         assert unfurls["link1"] == "unfurl"
         assert unfurls["link2"] == "unfurl"
+
+    def test_unique_explore_links_with_same_arg_shape(self) -> None:
+        """Three explore URLs whose args dicts share the same key set but
+        carry different QueryDicts must each unfurl separately. Pre-fix the
+        dedup hashed only args.keys(), so all three collided and only the
+        first reached the handler."""
+        self.link_identity(slack_user_id=LINK_SHARED_EVENT["user"])
+
+        handler_fn = Mock(return_value={"l1": "u1", "l2": "u2", "l3": "u3"})
+
+        with (
+            patch(
+                "sentry.integrations.slack.webhooks.event.match_link",
+                side_effect=[
+                    (LinkType.EXPLORE, {"org_slug": "o", "query": QueryDict("q=foo")}),
+                    (LinkType.EXPLORE, {"org_slug": "o", "query": QueryDict("q=bar")}),
+                    (LinkType.EXPLORE, {"org_slug": "o", "query": QueryDict("q=baz")}),
+                ],
+            ),
+            patch(
+                "sentry.integrations.slack.requests.event.has_explore_links",
+                return_value=True,
+            ),
+            patch(
+                "sentry.integrations.slack.webhooks.event.link_handlers",
+                {
+                    LinkType.EXPLORE: Handler(
+                        matcher=[re.compile(r"test")],
+                        arg_mapper=make_type_coercer({}),
+                        fn=handler_fn,
+                    )
+                },
+            ),
+        ):
+            resp = self.post_webhook(event_data=LINK_SHARED_EVENT)
+            assert resp.status_code == 200, resp.content
+
+        passed_links = handler_fn.call_args.args[1]
+        assert len(passed_links) == 3
+        assert {link.args["query"].urlencode() for link in passed_links} == {
+            "q=foo",
+            "q=bar",
+            "q=baz",
+        }

--- a/tests/sentry/integrations/slack/webhooks/events/test_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_link_shared.py
@@ -38,7 +38,7 @@ class LinkSharedEventTest(BaseEventTest):
         # two unique links and one duplicate.
         side_effect=[
             ("mock_link", {"arg1": "value1"}),
-            ("mock_link", {"arg1", "value2"}),
+            ("mock_link", {"arg2": "value2"}),
             ("mock_link", {"arg1": "value1"}),
         ],
     )
@@ -71,7 +71,7 @@ class LinkSharedEventTest(BaseEventTest):
         # two unique links and one duplicate.
         side_effect=[
             ("mock_link", {"arg1": "value1"}),
-            ("mock_link", {"arg1", "value2"}),
+            ("mock_link", {"arg2": "value2"}),
             ("mock_link", {"arg1": "value1"}),
         ],
     )
@@ -115,7 +115,7 @@ class LinkSharedEventTest(BaseEventTest):
         # two unique links and one duplicate.
         side_effect=[
             ("mock_link", {"arg1": "value1"}),
-            ("mock_link", {"arg1", "value2"}),
+            ("mock_link", {"arg2": "value2"}),
             ("mock_link", {"arg1": "value1"}),
         ],
     )


### PR DESCRIPTION
## Summary

Multiple distinct explore and dashboards links in a single Slack message weren't unfurling — they all hashed to the same dedup marker, so only the first reached its handler. The marker hashed `list(args)` (just the dict keys), missing the values that actually distinguished them.

Fixes DAIN-1656