### PR TITLE
feat(preprod): Add CSV download to size compare items changed table

### DIFF
--- a/static/app/views/preprod/buildComparison/main/downloadSizeCompareItemsAsCsv.ts
+++ b/static/app/views/preprod/buildComparison/main/downloadSizeCompareItemsAsCsv.ts
@@ -1,0 +1,34 @@
+import Papa from 'papaparse';
+
+import {downloadFromHref} from 'sentry/utils/downloadFromHref';
+import type {DiffItem} from 'sentry/views/preprod/types/appSizeTypes';
+
+function disableMacros(value: string | null | boolean | number | undefined) {
+  if (
+    typeof value === 'string' &&
+    (value.charAt(0) === '=' ||
+      value.charAt(0) === '+' ||
+      value.charAt(0) === '-' ||
+      value.charAt(0) === '@')
+  ) {
+    return `'${value}`;
+  }
+  return value ?? '';
+}
+
+export function downloadSizeCompareItemsAsCsv(diffItems: DiffItem[], filename: string) {
+  const csvContent = Papa.unparse({
+    fields: ['Change', 'File Path', 'Item Type', 'Size (bytes)', 'Size Diff (bytes)'],
+    data: diffItems.map(item => [
+      disableMacros(item.type),
+      disableMacros(item.path),
+      disableMacros(item.item_type ?? ''),
+      item.head_size ?? item.base_size ?? '',
+      item.size_diff,
+    ]),
+  });
+
+  const encodedDataUrl = `data:text/csv;charset=utf8,${encodeURIComponent(csvContent)}`;
+
+  downloadFromHref(`${filename}.csv`, encodedDataUrl);
+}

--- a/static/app/views/preprod/buildComparison/main/downloadSizeCompareItemsAsCsv.ts
+++ b/static/app/views/preprod/buildComparison/main/downloadSizeCompareItemsAsCsv.ts
@@ -1,5 +1,7 @@
 import Papa from 'papaparse';
 
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
 import {downloadFromHref} from 'sentry/utils/downloadFromHref';
 import type {DiffItem} from 'sentry/views/preprod/types/appSizeTypes';
 
@@ -16,10 +18,13 @@ function disableMacros(value: string | null | boolean | number | undefined) {
   return value ?? '';
 }
 
+const CSV_ROW_LIMIT = 10_000;
+
 export function downloadSizeCompareItemsAsCsv(diffItems: DiffItem[], filename: string) {
+  const rows = diffItems.slice(0, CSV_ROW_LIMIT);
   const csvContent = Papa.unparse({
     fields: ['Change', 'File Path', 'Item Type', 'Size (bytes)', 'Size Diff (bytes)'],
-    data: diffItems.map(item => [
+    data: rows.map(item => [
       disableMacros(item.type),
       disableMacros(item.path),
       disableMacros(item.item_type ?? ''),
@@ -31,4 +36,10 @@ export function downloadSizeCompareItemsAsCsv(diffItems: DiffItem[], filename: s
   const encodedDataUrl = `data:text/csv;charset=utf8,${encodeURIComponent(csvContent)}`;
 
   downloadFromHref(`${filename}.csv`, encodedDataUrl);
+
+  if (diffItems.length > CSV_ROW_LIMIT) {
+    addSuccessMessage(
+      t('Downloaded first %s of %s items', CSV_ROW_LIMIT, diffItems.length)
+    );
+  }
 }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -318,12 +318,7 @@ export function SizeCompareMainContent() {
       <Container background="primary" radius="lg" padding="0" border="primary">
         <Flex direction="column" gap="0">
           <Flex align="center" justify="between" padding="xl">
-            <Flex align="center" gap="sm">
-              <Heading as="h2">
-                {t('Items Changed: %s', comparisonDataQuery.data?.diff_items.length)}
-              </Heading>
-            </Flex>
-            <Flex align="center" gap="sm">
+            <Flex align="center">
               <Button
                 variant="transparent"
                 size="sm"
@@ -338,7 +333,24 @@ export function SizeCompareMainContent() {
                   }}
                 />
               </Button>
+              <Heading as="h2">
+                {t('Items Changed: %s', comparisonDataQuery.data?.diff_items.length)}
+              </Heading>
             </Flex>
+            <Button
+              size="sm"
+              icon={<IconDownload />}
+              disabled={filteredDiffItems.length === 0}
+              onClick={() =>
+                downloadSizeCompareItemsAsCsv(
+                  filteredDiffItems,
+                  t('Size Compare Items Changed')
+                )
+              }
+              aria-label={t('Download CSV')}
+            >
+              {t('Download CSV')}
+            </Button>
           </Flex>
           {isFilesExpanded && (
             <Stack>
@@ -353,35 +365,17 @@ export function SizeCompareMainContent() {
                     onChange={e => setSearchQuery(e.target.value)}
                   />
                 </InputGroup>
-                <Flex align="center" justify="between">
-                  <Flex align="center" gap="lg" wrap="nowrap">
-                    <Text wrap="nowrap">{t('Hide changes < 500B')}</Text>
-                    <Switch
-                      checked={hideSmallChanges}
-                      size="sm"
-                      title={t('Hide < 500B')}
-                      onChange={() => setHideSmallChanges(!hideSmallChanges)}
-                      aria-label={
-                        hideSmallChanges
-                          ? t('Show small changes')
-                          : t('Hide small changes')
-                      }
-                    />
-                  </Flex>
-                  <Button
+                <Flex align="center" gap="lg" wrap="nowrap">
+                  <Text wrap="nowrap">{t('Hide changes < 500B')}</Text>
+                  <Switch
+                    checked={hideSmallChanges}
                     size="sm"
-                    icon={<IconDownload />}
-                    disabled={filteredDiffItems.length === 0}
-                    onClick={() =>
-                      downloadSizeCompareItemsAsCsv(
-                        filteredDiffItems,
-                        t('Size Compare Items Changed')
-                      )
+                    title={t('Hide < 500B')}
+                    onChange={() => setHideSmallChanges(!hideSmallChanges)}
+                    aria-label={
+                      hideSmallChanges ? t('Show small changes') : t('Hide small changes')
                     }
-                    aria-label={t('Download CSV')}
-                  >
-                    {t('Download CSV')}
-                  </Button>
+                  />
                 </Flex>
               </Stack>
               <SizeCompareItemDiffTable

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -12,7 +12,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {IconChevron, IconRefresh, IconSearch} from 'sentry/icons';
+import {IconChevron, IconDownload, IconRefresh, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {parseApiError} from 'sentry/utils/parseApiError';
@@ -22,6 +22,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildComparisonMetricCards} from 'sentry/views/preprod/buildComparison/main/buildComparisonMetricCards';
+import {downloadSizeCompareItemsAsCsv} from 'sentry/views/preprod/buildComparison/main/downloadSizeCompareItemsAsCsv';
 import {InsightComparisonSection} from 'sentry/views/preprod/buildComparison/main/insightComparisonSection';
 import {SizeCompareItemDiffTable} from 'sentry/views/preprod/buildComparison/main/sizeCompareItemDiffTable';
 import {SizeCompareSelectedBuilds} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectedBuilds';
@@ -341,15 +342,8 @@ export function SizeCompareMainContent() {
           </Flex>
           {isFilesExpanded && (
             <Stack>
-              <Flex
-                align="center"
-                gap="xl"
-                paddingLeft="xl"
-                paddingRight="xl"
-                paddingBottom="xl"
-                wrap="wrap"
-              >
-                <InputGroup style={{width: '100%', minWidth: '200px'}}>
+              <Stack gap="md" paddingLeft="xl" paddingRight="xl" paddingBottom="xl">
+                <InputGroup>
                   <InputGroup.LeadingItems>
                     <IconSearch />
                   </InputGroup.LeadingItems>
@@ -359,19 +353,37 @@ export function SizeCompareMainContent() {
                     onChange={e => setSearchQuery(e.target.value)}
                   />
                 </InputGroup>
-                <Flex align="center" gap="lg" wrap="nowrap">
-                  <Text wrap="nowrap">{t('Hide changes < 500B')}</Text>
-                  <Switch
-                    checked={hideSmallChanges}
+                <Flex align="center" justify="between">
+                  <Flex align="center" gap="lg" wrap="nowrap">
+                    <Text wrap="nowrap">{t('Hide changes < 500B')}</Text>
+                    <Switch
+                      checked={hideSmallChanges}
+                      size="sm"
+                      title={t('Hide < 500B')}
+                      onChange={() => setHideSmallChanges(!hideSmallChanges)}
+                      aria-label={
+                        hideSmallChanges
+                          ? t('Show small changes')
+                          : t('Hide small changes')
+                      }
+                    />
+                  </Flex>
+                  <Button
                     size="sm"
-                    title={t('Hide < 500B')}
-                    onChange={() => setHideSmallChanges(!hideSmallChanges)}
-                    aria-label={
-                      hideSmallChanges ? t('Show small changes') : t('Hide small changes')
+                    icon={<IconDownload />}
+                    disabled={filteredDiffItems.length === 0}
+                    onClick={() =>
+                      downloadSizeCompareItemsAsCsv(
+                        filteredDiffItems,
+                        t('Size Compare Items Changed')
+                      )
                     }
-                  />
+                    aria-label={t('Download CSV')}
+                  >
+                    {t('Download CSV')}
+                  </Button>
                 </Flex>
-              </Flex>
+              </Stack>
               <SizeCompareItemDiffTable
                 diffItems={filteredDiffItems}
                 originalItemCount={comparisonDataQuery.data?.diff_items.length ?? 0}


### PR DESCRIPTION
Add a Download CSV button to the Items Changed section of the size comparison view. The export respects the current search query and the hide-small-changes toggle, and includes all matching rows regardless of pagination.

**Download Utility**

Uses PapaParse for CSV generation with formula injection protection (same pattern as Discover and Logs exports). Exports raw byte values for Change, File Path, Item Type, Size, and Size Diff columns. Data is already fully loaded client-side, so no backend changes needed.

**Layout**

The expand/collapse chevron moves to the left of the "Items Changed" heading. The Download CSV button sits in the always-visible header row on the right, so it's accessible even when the table is collapsed.

REFS EME-209