### PR TITLE
fix(mypy): Remove stale weaklist entry for deleted test file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2263,7 +2263,6 @@ module = [
     "tests.sentry.relocation.test_utils",
     "tests.sentry.rules",
     "tests.sentry.rules.actions",
-    "tests.sentry.rules.actions.test_base",
     "tests.sentry.rules.actions.test_create_ticket_utils",
     "tests.sentry.rules.actions.test_notify_event",
     "tests.sentry.rules.actions.test_notify_event_sentry_app",


### PR DESCRIPTION
`tests/sentry/rules/actions/test_base.py` was removed in #115035 but its mypy weaklist entry in `pyproject.toml` was left behind. This causes `test_stronglist` to fail on every CI run, which has been consistently breaking deploys.