### PR TITLE
ref(aci): use addErrorMessage for detector mutation errors

### DIFF
--- a/static/app/views/detectors/hooks/index.ts
+++ b/static/app/views/detectors/hooks/index.ts
@@ -1,7 +1,7 @@
 import {queryOptions, useMutation, useQueryClient} from '@tanstack/react-query';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
-import {AlertStore} from 'sentry/stores/alertStore';
 import type {Organization} from 'sentry/types/organization';
 import {
   type BaseDetectorUpdatePayload,
@@ -131,7 +131,7 @@ export function useCreateDetector<T extends Detector = Detector>() {
       });
     },
     onError: _ => {
-      AlertStore.addAlert({variant: 'danger', message: t('Unable to create monitor')});
+      addErrorMessage(t('Unable to create monitor'));
     },
   });
 }
@@ -165,7 +165,7 @@ export function useUpdateDetector<T extends Detector = Detector>() {
       });
     },
     onError: _ => {
-      AlertStore.addAlert({variant: 'danger', message: t('Unable to update monitor')});
+      addErrorMessage(t('Unable to update monitor'));
     },
   });
 }


### PR DESCRIPTION
These mutation hooks were using `AlertStore.addAlert` as a transient toast, but AlertStore is for persistent system banners. Sibling form-submit hooks (`useCreateDetectorFormSubmit`, `useEditDetectorFormSubmit`, `useSubmitEditDetector`) already toast the same fallback strings via `addErrorMessage`.