### PR TITLE
ref(cells): Rename SENTRY_OUTBOX_MODELS key from REGION to CELL

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -435,7 +435,7 @@ TEMPLATES = [
 
 SENTRY_OUTBOX_MODELS: Mapping[str, list[str]] = {
     "CONTROL": ["sentry.ControlOutbox"],
-    "REGION": ["sentry.CellOutbox"],
+    "CELL": ["sentry.CellOutbox"],
 }
 
 # Do not modify reordering

--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -74,7 +74,7 @@ def schedule_batch(
     if not concurrency:
         concurrency = CONCURRENCY
     try:
-        for outbox_name in settings.SENTRY_OUTBOX_MODELS[silo_mode.value]:
+        for outbox_name in settings.SENTRY_OUTBOX_MODELS[silo_mode.name]:
             outbox_model: type[OutboxBase] = OutboxBase.from_outbox_name(outbox_name)
 
             aggregates = outbox_model.objects.all().aggregate(Min("id"), Max("id"))
@@ -143,7 +143,7 @@ def drain_outbox_shards(
 ) -> None:
     try:
         if outbox_name is None:
-            outbox_name = settings.SENTRY_OUTBOX_MODELS["REGION"][0]
+            outbox_name = settings.SENTRY_OUTBOX_MODELS["CELL"][0]
 
         assert outbox_name, "Could not determine outbox name"
         outbox_model: type[CellOutboxBase] = CellOutboxBase.from_outbox_name(outbox_name)

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -677,7 +677,7 @@ def validate_outbox_config() -> None:
     for outbox_name in settings.SENTRY_OUTBOX_MODELS["CONTROL"]:
         ControlOutboxBase.from_outbox_name(outbox_name)
 
-    for outbox_name in settings.SENTRY_OUTBOX_MODELS["REGION"]:
+    for outbox_name in settings.SENTRY_OUTBOX_MODELS["CELL"]:
         CellOutboxBase.from_outbox_name(outbox_name)
 
 


### PR DESCRIPTION
Part of the region -> cell rename.

Getsentry config has been updated to support both keys https://github.com/getsentry/getsentry/pull/20281
