### PR TITLE
feat(typing): Add pre-commit hook to prevent new module ignores additions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,11 @@ repos:
         entry: python3 -m tools.mypy_helpers.prevent_weaklist_additions
         files: ^pyproject\.toml$
         language: python
+      - id: prevent-mypy-module-ignores-additions
+        name: prevent mypy module ignores additions
+        entry: python3 -m tools.mypy_helpers.prevent_module_ignores_additions
+        files: ^pyproject\.toml$
+        language: python
       - id: prevent-push
         name: prevent pushing master
         stages: [pre-push]

--- a/tests/tools/mypy_helpers/test_prevent_module_ignores_additions.py
+++ b/tests/tools/mypy_helpers/test_prevent_module_ignores_additions.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import contextlib
+import subprocess
+
+import pytest
+
+from tools.mypy_helpers.prevent_module_ignores_additions import main
+
+
+def _git(cwd, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _init_repo(tmp_path) -> None:
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "config", "commit.gpgsign", "false")
+
+
+def _commit_pyproject(tmp_path, contents: str) -> None:
+    tmp_path.joinpath("pyproject.toml").write_text(contents)
+    _git(tmp_path, "add", "pyproject.toml")
+    _git(tmp_path, "commit", "-q", "-m", "initial")
+
+
+def test_no_changes_passes(tmp_path) -> None:
+    src = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c", "d.e.f"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, src)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 0
+
+
+def test_removal_passes(tmp_path) -> None:
+    initial = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c", "d.e.f"]
+disable_error_code = ["misc"]
+"""
+    updated = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, initial)
+    tmp_path.joinpath("pyproject.toml").write_text(updated)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 0
+
+
+def test_addition_fails(tmp_path, capsys) -> None:
+    initial = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+"""
+    updated = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c", "x.y.z"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, initial)
+    tmp_path.joinpath("pyproject.toml").write_text(updated)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 1
+
+    expected = (
+        "pyproject.toml: 'x.y.z' was added to the mypy module ignores list — "
+        "do not add new modules; fix the typing issues instead.\n"
+    )
+    assert capsys.readouterr().out == expected
+
+
+def test_multiple_additions_reported_sorted(tmp_path, capsys) -> None:
+    initial = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+"""
+    updated = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c", "x.y.z", "p.q.r"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, initial)
+    tmp_path.joinpath("pyproject.toml").write_text(updated)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 1
+
+    out = capsys.readouterr().out
+    assert "'p.q.r'" in out
+    assert "'x.y.z'" in out
+    assert out.index("'p.q.r'") < out.index("'x.y.z'")
+
+
+def test_addition_and_removal_same_diff_only_addition_fails(tmp_path, capsys) -> None:
+    initial = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c", "d.e.f"]
+disable_error_code = ["misc"]
+"""
+    updated = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c", "x.y.z"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, initial)
+    tmp_path.joinpath("pyproject.toml").write_text(updated)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 1
+
+    out = capsys.readouterr().out
+    assert "'x.y.z'" in out
+    assert "'d.e.f'" not in out
+
+
+def test_other_overrides_ignored(tmp_path) -> None:
+    initial = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disallow_untyped_defs = false
+"""
+    updated = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+
+[[tool.mypy.overrides]]
+module = ["a.b.c", "new.module.added.to.weaklist"]
+disallow_untyped_defs = false
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, initial)
+    tmp_path.joinpath("pyproject.toml").write_text(updated)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 0
+
+
+def test_new_file_passes(tmp_path) -> None:
+    src = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    tmp_path.joinpath("README.md").write_text("hi")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "commit", "-q", "-m", "init")
+    tmp_path.joinpath("pyproject.toml").write_text(src)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 0
+
+
+def test_no_module_ignores_section_treated_as_empty(tmp_path) -> None:
+    src = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disallow_untyped_defs = false
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, src)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 0
+
+
+def test_no_filenames_passes(tmp_path) -> None:
+    _init_repo(tmp_path)
+
+    with contextlib.chdir(tmp_path):
+        assert main(()) == 0
+
+
+def test_missing_overrides_section_treated_as_empty(tmp_path) -> None:
+    initial = """\
+[tool.mypy]
+strict = true
+"""
+    updated = """\
+[tool.mypy]
+strict = true
+
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, initial)
+    tmp_path.joinpath("pyproject.toml").write_text(updated)
+
+    with contextlib.chdir(tmp_path):
+        # HEAD has no overrides at all (treated as empty); staged adds one
+        # module ignores entry — that's still a new addition relative to HEAD.
+        assert main(("pyproject.toml",)) == 1
+
+
+def test_multiple_module_ignores_sections_fails_loudly(tmp_path) -> None:
+    src = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+
+[[tool.mypy.overrides]]
+module = ["d.e.f"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, src)
+
+    with contextlib.chdir(tmp_path):
+        with pytest.raises(SystemExit, match="multiple"):
+            main(("pyproject.toml",))

--- a/tools/mypy_helpers/prevent_module_ignores_additions.py
+++ b/tools/mypy_helpers/prevent_module_ignores_additions.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import tomllib
+from collections.abc import Sequence
+
+
+def _module_ignores_modules(data: dict[str, object]) -> frozenset[str]:
+    try:
+        overrides = data["tool"]["mypy"]["overrides"]  # type: ignore[index]
+    except KeyError:
+        return frozenset()
+    ignores = [cfg for cfg in overrides if "disable_error_code" in cfg]
+    if not ignores:
+        return frozenset()
+    if len(ignores) > 1:
+        raise SystemExit(
+            "pyproject.toml has multiple [tool.mypy.overrides] sections with "
+            "disable_error_code; expected exactly one module ignores list."
+        )
+    return frozenset(ignores[0]["module"])
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Prevent new additions to the mypy module ignores list."
+    )
+    parser.add_argument("filenames", nargs="*")
+    args = parser.parse_args(argv)
+
+    retv = 0
+    for filename in args.filenames:
+        result = subprocess.run(
+            ["git", "show", f"HEAD:{filename}"],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            # File is new (not in HEAD); nothing to compare against.
+            continue
+
+        head_data = tomllib.loads(result.stdout.decode())
+        head_modules = _module_ignores_modules(head_data)
+
+        with open(filename, "rb") as f:
+            staged_data = tomllib.load(f)
+        staged_modules = _module_ignores_modules(staged_data)
+
+        for mod in sorted(staged_modules - head_modules):
+            print(
+                f"{filename}: '{mod}' was added to the mypy module ignores list — "
+                f"do not add new modules; fix the typing issues instead."
+            )
+            retv = 1
+
+    return retv
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `tools/mypy_helpers/prevent_module_ignores_additions.py` — compares the staged `pyproject.toml` `disable_error_code` override (the "sentry modules with typing issues" list generated by `make_module_ignores.py`) against `HEAD` and fails if any net-new module entries appear.
- Wires it up as the `prevent-mypy-module-ignores-additions` pre-commit hook (runs only when `pyproject.toml` is staged).

Mirrors the existing `prevent-mypy-weaklist-additions` hook (#114761), which guards the sibling `disallow_untyped_defs = false` weaklist. Like the weaklist, the module ignores list should only shrink as modules get their typing issues fixed; this hook enforces that policy locally so violations are caught before CI.

## Behaviour

- **Blocked**: adding a module that didn't exist in HEAD's module ignores list
- **Allowed**: removing entries (improvements), or collapsing multiple explicit entries into a wildcard that already existed in HEAD

## Test plan

- [ ] Stage a `pyproject.toml` with a new entry in the `disable_error_code` section → hook should fail with a clear message
- [ ] Stage a `pyproject.toml` with an entry removed → hook should pass
- [ ] Stage an unrelated file → hook is skipped entirely