### PR TITLE
fix: mypy-weaklist-stale-on-delete

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,8 +66,9 @@ repos:
         language: python
       - id: check-mypy-weaklist
         name: check mypy weaklist
-        entry: python3 -m tools.mypy_helpers.check_stronglist
-        files: ^pyproject\.toml$
+        entry: python3 -m tools.mypy_helpers.check_stronglist pyproject.toml
+        files: (^pyproject\.toml$|\.py$)
+        pass_filenames: false
         language: python
       - id: prevent-mypy-weaklist-additions
         name: prevent mypy weaklist additions


### PR DESCRIPTION
addresses the issue in https://github.com/getsentry/sentry/pull/115204

---

The check-mypy-weaklist pre-commit hook only fired when pyproject.toml changed, so deleting a Python file without cleaning up its weaklist entry would slip through locally and break the test_stronglist CI check. Extended the hook to also trigger on .py file changes so the validation runs whenever a file deletion could produce a stale entry.
