### PR TITLE
fix(workflows): Don't report timeouts as errors in process_workflow_event or delayed_workflows

### DIFF
--- a/src/sentry/utils/exceptions.py
+++ b/src/sentry/utils/exceptions.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from typing import Any, Literal
 
 import sentry_sdk
+from taskbroker_client.retry import RetryTaskError
 from taskbroker_client.state import current_task
 from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
@@ -94,6 +95,26 @@ def timeout_grouping_context(*refinements: str) -> Generator[None]:
         {ProcessingDeadlineExceeded: "task.processing_deadline_exceeded"}, *refinements
     ):
         yield
+
+
+@contextmanager
+def quiet_retriable_timeouts() -> Generator[None]:
+    """
+    Context manager for tasks where ProcessingDeadlineExceeded is occasionally expected
+    and safe to retry. When retries remain, the timeout is silently retried with no Sentry
+    event. On the final attempt, the exception propagates normally so it is reported as an
+    error by the framework.
+
+    Must be used inside a task with retries configured.
+    """
+    try:
+        yield
+    except ProcessingDeadlineExceeded:
+        task_state = current_task()
+        if task_state and task_state.retries_remaining:
+            raise RetryTaskError()
+        else:
+            raise
 
 
 @contextmanager

--- a/src/sentry/workflow_engine/tasks/delayed_workflows.py
+++ b/src/sentry/workflow_engine/tasks/delayed_workflows.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from typing import Any
 
 from taskbroker_client.retry import Retry
-from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import workflow_engine_tasks
-from sentry.utils.exceptions import quiet_redis_noise
+from sentry.utils.exceptions import quiet_redis_noise, quiet_retriable_timeouts
 from sentry.workflow_engine.utils import log_context
 
 logger = log_context.get_logger("sentry.workflow_engine.tasks.delayed_workflows")
@@ -21,10 +20,7 @@ logger = log_context.get_logger("sentry.workflow_engine.tasks.delayed_workflows"
     retry=Retry(
         times=5,
         delay=5,
-        on=(
-            Exception,
-            ProcessingDeadlineExceeded,
-        ),
+        on=(Exception,),
     ),
     silo_mode=SiloMode.CELL,
 )
@@ -43,5 +39,5 @@ def process_delayed_workflows(
     log_context.add_extras(project_id=project_id)
     batch_client = DelayedWorkflowClient()
 
-    with quiet_redis_noise():
+    with quiet_retriable_timeouts(), quiet_redis_noise():
         _process_delayed_workflows(batch_client, project_id, batch_key)

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -6,7 +6,6 @@ from typing import Any
 from django.db import router, transaction
 from google.api_core.exceptions import RetryError
 from taskbroker_client.retry import Retry, retry_task
-from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry.eventstream.base import GroupState
 from sentry.locks import locks
@@ -19,7 +18,7 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker import namespaces
 from sentry.utils import metrics
-from sentry.utils.exceptions import quiet_redis_noise
+from sentry.utils.exceptions import quiet_redis_noise, quiet_retriable_timeouts
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 from sentry.workflow_engine.models import DataConditionGroup, Detector
@@ -92,7 +91,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
     retry=Retry(
         times=3,
         delay=5,
-        on=(Exception, ProcessingDeadlineExceeded),
+        on=(Exception,),
         ignore=(
             EventNotFoundError,
             Group.DoesNotExist,
@@ -117,6 +116,25 @@ def process_workflows_event(
     has_escalated: bool,
     start_timestamp_seconds: float | None = None,
     **kwargs: dict[str, Any],
+) -> None:
+    with quiet_retriable_timeouts():
+        _process_workflows_event(
+            event_id=event_id,
+            group_id=group_id,
+            occurrence_id=occurrence_id,
+            group_state=group_state,
+            has_escalated=has_escalated,
+            start_timestamp_seconds=start_timestamp_seconds,
+        )
+
+
+def _process_workflows_event(
+    event_id: str,
+    group_id: int,
+    occurrence_id: str | None,
+    group_state: GroupState,
+    has_escalated: bool,
+    start_timestamp_seconds: float | None = None,
 ) -> None:
     from sentry.workflow_engine.processors.workflow import process_workflows
 

--- a/tests/sentry/utils/test_exceptions.py
+++ b/tests/sentry/utils/test_exceptions.py
@@ -2,13 +2,16 @@ from collections.abc import Callable
 from typing import Any
 from unittest.mock import Mock, patch
 
+import pytest
 from rediscluster.exceptions import RedisClusterException  # type: ignore[attr-defined]
+from taskbroker_client.retry import RetryTaskError
 from taskbroker_client.state import CurrentTaskState
 from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry.utils.exceptions import (
     exception_grouping_context,
     quiet_redis_noise,
+    quiet_retriable_timeouts,
     set_sentry_exception_levels,
     timeout_grouping_context,
 )
@@ -472,3 +475,44 @@ class TestQuietRedisNoise:
                 mock_capture.assert_not_called()
             else:
                 assert False, "ValueError was not re-raised"
+
+
+@patch(
+    "sentry.utils.exceptions.current_task",
+    return_value=CurrentTaskState(
+        id="test_id",
+        namespace="test_namespace",
+        taskname="test_task",
+        attempt=1,
+        processing_deadline_duration=30,
+        retries_remaining=True,
+    ),
+)
+class TestQuietRetriableTimeouts:
+    def test_retries_remaining_raises_retry_silently(self, mock_current_task: Mock) -> None:
+        with pytest.raises(RetryTaskError):
+            with quiet_retriable_timeouts():
+                raise ProcessingDeadlineExceeded("timed out")
+
+    def test_no_retries_remaining_propagates_pde(self, mock_current_task: Mock) -> None:
+        mock_current_task.return_value.retries_remaining = False
+
+        with pytest.raises(ProcessingDeadlineExceeded):
+            with quiet_retriable_timeouts():
+                raise ProcessingDeadlineExceeded("timed out")
+
+    def test_no_task_state_propagates_pde(self, mock_current_task: Mock) -> None:
+        mock_current_task.return_value = None
+
+        with pytest.raises(ProcessingDeadlineExceeded):
+            with quiet_retriable_timeouts():
+                raise ProcessingDeadlineExceeded("timed out")
+
+    def test_non_pde_exceptions_propagate_unchanged(self, mock_current_task: Mock) -> None:
+        with pytest.raises(ValueError, match="other error"):
+            with quiet_retriable_timeouts():
+                raise ValueError("other error")
+
+    def test_no_exception_passes_through(self, mock_current_task: Mock) -> None:
+        with quiet_retriable_timeouts():
+            pass


### PR DESCRIPTION
For these tasks, timeouts are expected, and we can usually solve them by simply retrying the task.
In general, we count retries as business-as-usual but want an exception and a failed task when we can't retry our way out of the problem.
The existing task infra supports retrying timeouts and not reporting timeouts, but not only reporting timeouts if they can't be retried, so this adds a new context manager to support that.