### PR TITLE
feat(preprod): Add timeout warning for image optimization insights

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -12,6 +12,7 @@ import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AppSizeInsightsSidebar} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar';
 import {formatUpside} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow';
+import {InsightTimedOutWarning} from 'sentry/views/preprod/buildDetails/main/insights/insightTimedOutWarning';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 import {type ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 
@@ -88,9 +89,12 @@ export function AppSizeInsights({
             height="22px"
             padding="xs sm"
           >
-            <Text size="sm" bold>
-              {insight.name}
-            </Text>
+            <Flex align="center" gap="xs">
+              <Text size="sm" bold>
+                {insight.name}
+              </Text>
+              <InsightTimedOutWarning insight={insight} />
+            </Flex>
             <Flex align="center" gap="sm">
               <Text variant="muted" size="sm" tabular>
                 -{formatBytesBase10(insight.totalSavings)}

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -16,6 +16,7 @@ import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {openAlternativeIconsInsightModal} from 'sentry/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal';
+import {InsightTimedOutWarning} from 'sentry/views/preprod/buildDetails/main/insights/insightTimedOutWarning';
 import {openMainBinaryExportedSymbolsModal} from 'sentry/views/preprod/buildDetails/main/insights/mainBinaryExportedSymbolsModal';
 import {openMinifyLocalizedStringsModal} from 'sentry/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal';
 import {openOptimizeImagesModal} from 'sentry/views/preprod/buildDetails/main/insights/optimizeImagesModal';
@@ -126,9 +127,12 @@ export function AppSizeInsightsSidebarRow({
   return (
     <Flex border="muted" radius="md" padding="xl" direction="column" gap="md">
       <Flex align="start" justify="between">
-        <Text variant="primary" size="md" bold>
-          {insight.name}
-        </Text>
+        <Flex align="center" gap="xs">
+          <Text variant="primary" size="md" bold>
+            {insight.name}
+          </Text>
+          <InsightTimedOutWarning insight={insight} />
+        </Flex>
         <Flex align="center" gap="sm" flexShrink={0}>
           <Text size="sm" tabular>
             {t('Potential savings %s', formatBytesBase10(insight.totalSavings))}

--- a/static/app/views/preprod/buildDetails/main/insights/insightTimedOutWarning.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/insightTimedOutWarning.tsx
@@ -30,7 +30,7 @@ export function InsightTimedOutWarning({insight}: {insight: ProcessedInsight}) {
           <br />
           <br />
           {t(
-            'Consider running your app through Launchpad locally for complete results: github.com/getsentry/launchpad'
+            'For complete results, run your app through Launchpad locally: github.com/getsentry/launchpad'
           )}
         </span>
       }

--- a/static/app/views/preprod/buildDetails/main/insights/insightTimedOutWarning.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/insightTimedOutWarning.tsx
@@ -1,0 +1,43 @@
+import {Flex} from '@sentry/scraps/layout';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {IconWarning} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
+
+const IMAGE_INSIGHT_KEYS = new Set([
+  'image_optimization',
+  'alternate_icons_optimization',
+]);
+
+function isImageInsightTimedOut(insight: ProcessedInsight): boolean {
+  return !!insight.timedOut && IMAGE_INSIGHT_KEYS.has(insight.key);
+}
+
+export function InsightTimedOutWarning({insight}: {insight: ProcessedInsight}) {
+  if (!isImageInsightTimedOut(insight)) {
+    return null;
+  }
+
+  return (
+    <Tooltip
+      isHoverable
+      title={
+        <span>
+          {t(
+            'This app has a high amount of images and our analysis timed out before all of them could be processed!'
+          )}
+          <br />
+          <br />
+          {t(
+            'Consider running your app through Launchpad locally for complete results: github.com/getsentry/launchpad'
+          )}
+        </span>
+      }
+    >
+      <Flex align="center">
+        <IconWarning size="sm" variant="warning" />
+      </Flex>
+    </Tooltip>
+  );
+}

--- a/static/app/views/preprod/buildDetails/main/insights/insightTimedOutWarning.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/insightTimedOutWarning.tsx
@@ -25,7 +25,7 @@ export function InsightTimedOutWarning({insight}: {insight: ProcessedInsight}) {
       title={
         <span>
           {t(
-            'This app has a high amount of images and our analysis timed out before all of them could be processed!'
+            'This app has a high number of images and was not fully analyzed. Only a subset of results are shown.'
           )}
           <br />
           <br />

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -181,6 +181,7 @@ export interface OptimizableImageFile {
 
 interface ImageOptimizationInsightResult extends BaseInsightResult {
   optimizable_files: OptimizableImageFile[];
+  timed_out?: boolean;
 }
 
 export interface StripBinaryFileInfo {

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -35,6 +35,7 @@ export interface ProcessedInsight {
   name: string;
   percentage: number;
   totalSavings: number;
+  timedOut?: boolean;
 }
 
 interface InsightConfig {
@@ -211,6 +212,7 @@ export function processInsights(
         description: config.description,
         totalSavings: insight.total_savings,
         percentage: (insight.total_savings / totalSize) * 100,
+        timedOut: insight.timed_out ?? false,
         files: optimizableFiles.map((file: OptimizableImageFile) => {
           const maxSavings = Math.max(
             file.minify_savings || 0,
@@ -247,6 +249,7 @@ export function processInsights(
         description: config.description,
         totalSavings: insight.total_savings,
         percentage: (insight.total_savings / totalSize) * 100,
+        timedOut: insight.timed_out ?? false,
         files: optimizableFiles.map((file: OptimizableImageFile) => {
           const maxSavings = Math.max(
             file.minify_savings || 0,


### PR DESCRIPTION
Screenshots:
<img width="1880" height="358" alt="image" src="https://github.com/user-attachments/assets/0821932c-ca06-43bd-94c1-86bd1ec2a554" />

<img width="1428" height="496" alt="image" src="https://github.com/user-attachments/assets/260a5f85-cc0a-4c2f-b3bd-f27ff30dd5f7" />



Surface a warning icon with tooltip when image optimization or alternate icons
analysis times out before completing. This lets users know that results may be
incomplete and directs them to run Launchpad locally for full results.

**Changes:**
- Add `timed_out` optional boolean to `ImageOptimizationInsightResult` type
- Propagate `timedOut` through `ProcessedInsight` during insight processing
- Extract shared `InsightTimedOutWarning` component (tooltip + warning icon)
  used by both the insights summary table and the sidebar detail row
- Previously the tooltip was duplicated inline in both `appSizeInsights.tsx`
  and `appSizeInsightsSidebarRow.tsx` — now lives in one place