### PR TITLE
ref(mypy): extend prevent-weaklist-additions hook to also guard disable_error_code section

### DIFF
--- a/tests/tools/mypy_helpers/test_prevent_weaklist_additions.py
+++ b/tests/tools/mypy_helpers/test_prevent_weaklist_additions.py
@@ -224,6 +224,39 @@ disable_error_code = ["misc"]
     assert out.index("'p.q.r'") < out.index("'x.y.z'")
 
 
+def test_addition_to_both_sections_reports_all(tmp_path, capsys) -> None:
+    initial = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disallow_untyped_defs = false
+"""
+    updated = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c", "x.y.z"]
+disable_error_code = ["misc"]
+
+[[tool.mypy.overrides]]
+module = ["a.b.c", "p.q.r"]
+disallow_untyped_defs = false
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, initial)
+    tmp_path.joinpath("pyproject.toml").write_text(updated)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 1
+
+    out = capsys.readouterr().out
+    assert "'x.y.z'" in out
+    assert "module ignores list" in out
+    assert "'p.q.r'" in out
+    assert "weaklist" in out
+
+
 def test_multiple_module_ignores_sections_fails_loudly(tmp_path) -> None:
     src = """\
 [[tool.mypy.overrides]]

--- a/tests/tools/mypy_helpers/test_prevent_weaklist_additions.py
+++ b/tests/tools/mypy_helpers/test_prevent_weaklist_additions.py
@@ -129,11 +129,11 @@ disallow_untyped_defs = false
     assert "'d.e.f'" not in out
 
 
-def test_other_overrides_ignored(tmp_path) -> None:
+def test_unrelated_overrides_ignored(tmp_path) -> None:
     initial = """\
 [[tool.mypy.overrides]]
 module = ["a.b.c"]
-disable_error_code = ["misc"]
+disallow_any_generics = false
 
 [[tool.mypy.overrides]]
 module = ["a.b.c"]
@@ -141,8 +141,8 @@ disallow_untyped_defs = false
 """
     updated = """\
 [[tool.mypy.overrides]]
-module = ["a.b.c", "new.module.added.to.allowlist"]
-disable_error_code = ["misc"]
+module = ["a.b.c", "new.module"]
+disallow_any_generics = false
 
 [[tool.mypy.overrides]]
 module = ["a.b.c"]
@@ -154,6 +154,92 @@ disallow_untyped_defs = false
 
     with contextlib.chdir(tmp_path):
         assert main(("pyproject.toml",)) == 0
+
+
+def test_module_ignores_addition_fails(tmp_path, capsys) -> None:
+    initial = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+"""
+    updated = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c", "x.y.z"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, initial)
+    tmp_path.joinpath("pyproject.toml").write_text(updated)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 1
+
+    expected = (
+        "pyproject.toml: 'x.y.z' was added to the mypy module ignores list — "
+        "do not add new modules; fix the type errors instead.\n"
+    )
+    assert capsys.readouterr().out == expected
+
+
+def test_module_ignores_removal_passes(tmp_path) -> None:
+    initial = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c", "d.e.f"]
+disable_error_code = ["misc"]
+"""
+    updated = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, initial)
+    tmp_path.joinpath("pyproject.toml").write_text(updated)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 0
+
+
+def test_module_ignores_multiple_additions_reported_sorted(tmp_path, capsys) -> None:
+    initial = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+"""
+    updated = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c", "x.y.z", "p.q.r"]
+disable_error_code = ["misc"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, initial)
+    tmp_path.joinpath("pyproject.toml").write_text(updated)
+
+    with contextlib.chdir(tmp_path):
+        assert main(("pyproject.toml",)) == 1
+
+    out = capsys.readouterr().out
+    assert "'p.q.r'" in out
+    assert "'x.y.z'" in out
+    assert out.index("'p.q.r'") < out.index("'x.y.z'")
+
+
+def test_multiple_module_ignores_sections_fails_loudly(tmp_path) -> None:
+    src = """\
+[[tool.mypy.overrides]]
+module = ["a.b.c"]
+disable_error_code = ["misc"]
+
+[[tool.mypy.overrides]]
+module = ["d.e.f"]
+disable_error_code = ["attr-defined"]
+"""
+    _init_repo(tmp_path)
+    _commit_pyproject(tmp_path, src)
+
+    with contextlib.chdir(tmp_path):
+        with pytest.raises(SystemExit, match="multiple"):
+            main(("pyproject.toml",))
 
 
 def test_new_file_passes(tmp_path) -> None:

--- a/tools/mypy_helpers/prevent_weaklist_additions.py
+++ b/tools/mypy_helpers/prevent_weaklist_additions.py
@@ -6,24 +6,31 @@ import tomllib
 from collections.abc import Sequence
 
 
-def _weaklist_modules(data: dict[str, object]) -> frozenset[str]:
+def _modules_for_override_key(data: dict[str, object], key: str) -> frozenset[str]:
     try:
         overrides = data["tool"]["mypy"]["overrides"]  # type: ignore[index]
     except KeyError:
         return frozenset()
-    weaklists = [cfg for cfg in overrides if "disallow_untyped_defs" in cfg]
-    if not weaklists:
+    matching = [cfg for cfg in overrides if key in cfg]
+    if not matching:
         return frozenset()
-    if len(weaklists) > 1:
+    if len(matching) > 1:
         raise SystemExit(
-            "pyproject.toml has multiple [tool.mypy.overrides] sections with "
-            "disallow_untyped_defs; expected exactly one weaklist."
+            f"pyproject.toml has multiple [tool.mypy.overrides] sections with "
+            f"{key!r}; expected exactly one."
         )
-    return frozenset(weaklists[0]["module"])
+    return frozenset(matching[0]["module"])  # type: ignore[index]
+
+
+# (override key, human-readable list name, advice suffix)
+_CHECKS = (
+    ("disallow_untyped_defs", "mypy weaklist", "fix the typing issues instead"),
+    ("disable_error_code", "mypy module ignores list", "fix the type errors instead"),
+)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Prevent new additions to the mypy weaklist.")
+    parser = argparse.ArgumentParser(description="Prevent new additions to mypy override lists.")
     parser.add_argument("filenames", nargs="*")
     args = parser.parse_args(argv)
 
@@ -38,18 +45,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             continue
 
         head_data = tomllib.loads(result.stdout.decode())
-        head_modules = _weaklist_modules(head_data)
 
         with open(filename, "rb") as f:
             staged_data = tomllib.load(f)
-        staged_modules = _weaklist_modules(staged_data)
 
-        for mod in sorted(staged_modules - head_modules):
-            print(
-                f"{filename}: '{mod}' was added to the mypy weaklist — "
-                f"do not add new modules; fix the typing issues instead."
-            )
-            retv = 1
+        for key, list_name, advice in _CHECKS:
+            head_modules = _modules_for_override_key(head_data, key)
+            staged_modules = _modules_for_override_key(staged_data, key)
+            for mod in sorted(staged_modules - head_modules):
+                print(
+                    f"{filename}: '{mod}' was added to the {list_name} — "
+                    f"do not add new modules; {advice}."
+                )
+                retv = 1
 
     return retv
 

--- a/tools/mypy_helpers/prevent_weaklist_additions.py
+++ b/tools/mypy_helpers/prevent_weaklist_additions.py
@@ -19,7 +19,7 @@ def _modules_for_override_key(data: dict[str, object], key: str, filename: str) 
             f"{filename}: multiple [tool.mypy.overrides] sections with "
             f"{key!r}; expected exactly one."
         )
-    return frozenset(matching[0]["module"])  # type: ignore[index]
+    return frozenset(matching[0]["module"])  # type: ignore[arg-type]
 
 
 # (override key, human-readable list name, advice suffix)

--- a/tools/mypy_helpers/prevent_weaklist_additions.py
+++ b/tools/mypy_helpers/prevent_weaklist_additions.py
@@ -6,7 +6,7 @@ import tomllib
 from collections.abc import Sequence
 
 
-def _modules_for_override_key(data: dict[str, object], key: str) -> frozenset[str]:
+def _modules_for_override_key(data: dict[str, object], key: str, filename: str) -> frozenset[str]:
     try:
         overrides = data["tool"]["mypy"]["overrides"]  # type: ignore[index]
     except KeyError:
@@ -16,7 +16,7 @@ def _modules_for_override_key(data: dict[str, object], key: str) -> frozenset[st
         return frozenset()
     if len(matching) > 1:
         raise SystemExit(
-            f"pyproject.toml has multiple [tool.mypy.overrides] sections with "
+            f"{filename}: multiple [tool.mypy.overrides] sections with "
             f"{key!r}; expected exactly one."
         )
     return frozenset(matching[0]["module"])  # type: ignore[index]
@@ -50,8 +50,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             staged_data = tomllib.load(f)
 
         for key, list_name, advice in _CHECKS:
-            head_modules = _modules_for_override_key(head_data, key)
-            staged_modules = _modules_for_override_key(staged_data, key)
+            head_modules = _modules_for_override_key(head_data, key, filename)
+            staged_modules = _modules_for_override_key(staged_data, key, filename)
             for mod in sorted(staged_modules - head_modules):
                 print(
                     f"{filename}: '{mod}' was added to the {list_name} — "

--- a/tools/mypy_helpers/prevent_weaklist_additions.py
+++ b/tools/mypy_helpers/prevent_weaklist_additions.py
@@ -19,7 +19,7 @@ def _modules_for_override_key(data: dict[str, object], key: str, filename: str) 
             f"{filename}: multiple [tool.mypy.overrides] sections with "
             f"{key!r}; expected exactly one."
         )
-    return frozenset(matching[0]["module"])  # type: ignore[arg-type]
+    return frozenset(matching[0]["module"])
 
 
 # (override key, human-readable list name, advice suffix)


### PR DESCRIPTION
The `prevent-mypy-weaklist-additions` pre-commit hook previously only checked the `disallow_untyped_defs` weaklist for new entries. The `disable_error_code` override section (the "module ignores" list, generated by `make_module_ignores.py`) had no equivalent guard, meaning developers could silently add new per-module error suppression without any local feedback.

Rather than adding a second parallel hook and script (as proposed in #115212, which is a near-verbatim copy of `prevent_weaklist_additions.py` differing only by the override key), this change parametrizes the existing check to cover both sections in a single pass:

- Rename `_weaklist_modules(data)` → `_modules_for_override_key(data, key)`
- Introduce `_CHECKS`, a tuple of `(override_key, list_name, advice)` pairs for `disallow_untyped_defs` and `disable_error_code`
- `main()` iterates over both checks per file, reporting any net-new module entries relative to HEAD with section-appropriate messaging

This avoids a new pre-commit hook (keeping pre-commit fast), eliminates the code duplication, and ensures both sections are checked in one `pyproject.toml` read.

Tests: updated `test_other_overrides_ignored` (which was asserting that `disable_error_code` additions were silently ignored — now correctly inverted) and added four new cases covering the `disable_error_code` path: addition fails, removal passes, multiple additions sorted, and duplicate sections raise `SystemExit`.