### PR TITLE
fix(search): Prevent AI query feedback button from dismissing dropdown in Safari

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -515,7 +515,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
             </Stack>
           )}
           {openForm && (
-            <SeerFooter>
+            <SeerFooter onMouseDown={e => e.preventDefault()}>
               <Button
                 size="xs"
                 icon={<IconMegaphone />}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -564,7 +564,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
             </SeerContent>
           )}
           {openForm && (
-            <SeerFooter>
+            <SeerFooter onMouseDown={e => e.preventDefault()}>
               <Button
                 size="xs"
                 icon={<IconMegaphone />}


### PR DESCRIPTION
## Summary
- Safari does not focus `<button>` elements on click, so `e.relatedTarget` is `null` in the blur handler of `useSearchTokenCombobox`. This causes the AI query dropdown to close before the "Give Feedback" button's `onClick` fires.
- Adds `onMouseDown={e => e.preventDefault()}` to the `SeerFooter` in both `askSeerComboBox.tsx` and `askSeerPollingComboBox.tsx`, preventing the input blur on click. This matches the existing pattern in `filterKeyListBox/index.tsx:355-358`.
- Cross-browser safe: in Chrome/Firefox the blur handler already handles this via `blurIntoPopover`, so the fix is a no-op there.

Fixes JAVASCRIPT-39GZ

## Test plan
- [ ] Open Sentry in Safari, navigate to Discover → AI query input
- [ ] Click the "Give Feedback" button in the dropdown footer
- [ ] Verify the feedback form opens without the dropdown dismissing
- [x] Verify the same flow still works in Chrome/Firefox (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)