### PR TITLE
feat(preprod): Add description and tags fields to ImageMetadata

### DIFF
--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -12,6 +12,8 @@ class ImageMetadata(BaseModel):
     width: int = Field(ge=0)
     height: int = Field(ge=0)
     diff_threshold: float | None = Field(default=None, ge=0.0, lt=1.0)
+    description: str | None = None
+    tags: list[str] | None = None
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
Add optional `description` and `tags` fields to `ImageMetadata` in the
snapshot manifest model. These allow richer annotation of snapshot images
with free-text descriptions and categorical tags.

Both fields are optional and default to `None`, so existing manifests
remain fully compatible.