### PR TITLE
ref(alerts): remove dead standalone SystemAlerts mount

### DIFF
--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -50,20 +50,11 @@
 {% endif %}
 {% endblock %}
 
-<div id="blk_alerts" class="messages-container"></div>
 <div id="blk_indicators"></div>
 
 {% script %}
 <script>
   window.__onSentryInit = window.__onSentryInit || [];
-  window.__onSentryInit.push({
-    name: 'renderReact',
-    component: 'SystemAlerts',
-    container: '#blk_alerts',
-    props: {
-      className: 'alert-list',
-    },
-  });
   window.__onSentryInit.push({
     name: 'renderReact ',
     component: 'Indicators',


### PR DESCRIPTION
The standalone `<SystemAlerts>` mount at `#blk_alerts` (rendered as a separate React tree on every page that extends `layout.html`) has been dead plumbing since the React+Reflux era began in 2015.

Verified across the full git history (`git log -S` for `AlertStore.addAlert`, `AlertActions.addAlert`, `addAlert` in `*.html`, `SentryApp.AlertStore`, `Sentry.AlertActions`, etc.) — no Django template, plugin, or external code has ever pushed alerts via this mount. Every `AlertStore` producer lives inside the SPA's `<App>` tree, which renders its own `<SystemAlerts>` via `appBodyContent.tsx` / `organizationLayout/index.tsx`. Django flash messages render server-side via the `{% if messages %}` block in this same template, never through React.

The matching frontend cleanup (removing `SYSTEM_ALERTS` from `processInitQueue`'s `COMPONENT_MAP` and the `SentryInitRenderReactComponent` enum, plus the corresponding test) ships as a separate PR per the frontend/backend split rule. Either PR can land first — the frontend gracefully skips unknown component names via `Object.hasOwn(COMPONENT_MAP, ...)`.

The `<Indicators>` standalone mount is intentionally preserved — it is genuinely live and needed by the Setup Wizard flow (a non-SPA page that calls `addErrorMessage` from `wizardProjectSelection.tsx`).