### PR TITLE
ref(alerts): drop SystemAlerts from the init queue component map

### DIFF
--- a/static/app/bootstrap/processInitQueue.spec.tsx
+++ b/static/app/bootstrap/processInitQueue.spec.tsx
@@ -10,7 +10,6 @@ import {TeamFixture} from 'sentry-fixture/team';
 import {screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {processInitQueue} from 'sentry/bootstrap/processInitQueue';
-import {AlertStore} from 'sentry/stores/alertStore';
 import {IndicatorStore} from 'sentry/stores/indicatorStore';
 import {SentryInitRenderReactComponent} from 'sentry/types/system';
 
@@ -60,24 +59,6 @@ describe('processInitQueue', () => {
       render(<div id="indicator-container" />);
       processInitQueue();
       expect(await screen.findByText('Indicator Alert')).toBeInTheDocument();
-    });
-    it('renders system alerts', async () => {
-      window.__onSentryInit = [
-        {
-          component: SentryInitRenderReactComponent.SYSTEM_ALERTS,
-          container: '#system-alerts-container',
-          name: 'renderReact',
-        },
-      ];
-
-      AlertStore.addAlert({
-        message: 'System Alert',
-        variant: 'success',
-      });
-
-      render(<div id="system-alerts-container" />);
-      processInitQueue();
-      expect(await screen.findByText('System Alert')).toBeInTheDocument();
     });
     it('renders setup wizard', async () => {
       window.__onSentryInit = [

--- a/static/app/bootstrap/processInitQueue.tsx
+++ b/static/app/bootstrap/processInitQueue.tsx
@@ -21,8 +21,6 @@ const queryClient = new QueryClient(DEFAULT_QUERY_CLIENT_CONFIG);
 const COMPONENT_MAP = {
   [SentryInitRenderReactComponent.INDICATORS]: () =>
     import(/* webpackChunkName: "Indicators" */ 'sentry/components/indicators'),
-  [SentryInitRenderReactComponent.SYSTEM_ALERTS]: () =>
-    import(/* webpackChunkName: "SystemAlerts" */ 'sentry/views/app/systemAlerts'),
   [SentryInitRenderReactComponent.SETUP_WIZARD]: () =>
     import(/* webpackChunkName: "SetupWizard" */ 'sentry/views/setupWizard'),
   [SentryInitRenderReactComponent.WEB_AUTHN_ASSSERT]: () =>

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -9,7 +9,6 @@ import type {User} from './user';
 export enum SentryInitRenderReactComponent {
   INDICATORS = 'Indicators',
   SETUP_WIZARD = 'SetupWizard',
-  SYSTEM_ALERTS = 'SystemAlerts',
   WEB_AUTHN_ASSSERT = 'WebAuthnAssert',
   SU_STAFF_ACCESS_FORM = 'SuperuserStaffAccessForm',
 }

--- a/static/app/views/app/appBodyContent.tsx
+++ b/static/app/views/app/appBodyContent.tsx
@@ -3,7 +3,7 @@ import {Outlet} from 'react-router-dom';
 
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
-import SystemAlerts from './systemAlerts';
+import {SystemAlerts} from './systemAlerts';
 
 interface AppContentProps {
   children: React.ReactNode;

--- a/static/app/views/app/systemAlerts.tsx
+++ b/static/app/views/app/systemAlerts.tsx
@@ -7,7 +7,7 @@ import {AlertMessage} from './alertMessage';
 
 type Props = {className?: string};
 
-function SystemAlerts(props: Props) {
+export function SystemAlerts(props: Props) {
   const alerts = useLegacyStore(AlertStore);
 
   return (
@@ -18,5 +18,3 @@ function SystemAlerts(props: Props) {
     </Container>
   );
 }
-
-export default SystemAlerts;

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -23,7 +23,7 @@ import {useRouteAnalyticsHookSetup} from 'sentry/utils/routeAnalytics/useRouteAn
 import {useInitSentryToolbar} from 'sentry/utils/useInitSentryToolbar';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AppBodyContent} from 'sentry/views/app/appBodyContent';
-import SystemAlerts from 'sentry/views/app/systemAlerts';
+import {SystemAlerts} from 'sentry/views/app/systemAlerts';
 import {useReleasesDrawer} from 'sentry/views/explore/releases/drawer/useReleasesDrawer';
 import {useRegisterDomainViewUsage} from 'sentry/views/insights/common/utils/domainRedirect';
 import {Navigation} from 'sentry/views/navigation';

--- a/static/gsAdmin/views/layout.tsx
+++ b/static/gsAdmin/views/layout.tsx
@@ -14,7 +14,7 @@ import {ScrapsProviders} from 'sentry/scrapsProviders';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
 // eslint-disable-next-line no-restricted-imports
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
-import SystemAlerts from 'sentry/views/app/systemAlerts';
+import {SystemAlerts} from 'sentry/views/app/systemAlerts';
 
 import {GlobalStyles} from 'admin/globalStyles';
 


### PR DESCRIPTION
The Django template `partial/alerts.html` no longer pushes a `SystemAlerts` `renderReact` config onto `window.__onSentryInit` (see #115222). Drop the corresponding frontend entry from `processInitQueue`'s `COMPONENT_MAP`, the `SentryInitRenderReactComponent` enum, and the now-orphaned test.

The standalone `<SystemAlerts>` mount has been dead plumbing since the React/Reflux era began in 2015 — see the linked backend PR for the full history trek. Every `AlertStore` producer lives inside the SPA's `<App>` tree, which renders its own `<SystemAlerts>`.

`SystemAlerts` itself stays — only its registration in the init queue is removed. The component continues to be mounted in-tree by `appBodyContent.tsx` and `organizationLayout/index.tsx`.