### PR TITLE
fix(preprod): Improve snapshot status filter behavior

### DIFF
--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -209,6 +209,12 @@ export default function SnapshotsPage() {
   );
   const activeStatuses = useMemo(() => new Set(activeStatusList), [activeStatusList]);
 
+  const availableStatuses = useMemo(
+    () =>
+      new Set((Object.values(DiffStatus) as DiffStatus[]).filter(s => data?.[s]?.length)),
+    [data]
+  );
+
   const handleToggleStatus = useCallback(
     (status: DiffStatus) => {
       startTransition(() => {
@@ -219,13 +225,21 @@ export default function SnapshotsPage() {
           if (prev.length === 1 && prev[0] === status) {
             return [];
           }
-          return prev.includes(status)
+          const next = prev.includes(status)
             ? prev.filter(s => s !== status)
             : [...prev, status];
+          if (
+            availableStatuses.size > 0 &&
+            next.length === availableStatuses.size &&
+            next.every(s => availableStatuses.has(s))
+          ) {
+            return [];
+          }
+          return next;
         });
       });
     },
-    [setActiveStatusList]
+    [setActiveStatusList, availableStatuses]
   );
 
   const {
@@ -346,7 +360,7 @@ export default function SnapshotsPage() {
   }, [sidebarItems, memberSearchKeys, searchQuery]);
 
   const filteredItems = useMemo(() => {
-    const hasStatusFilter = activeStatuses.size > 0;
+    const hasStatusFilter = activeStatuses.size > 0 && comparisonType === 'diff';
     const base = hasStatusFilter
       ? searchFilteredItems.filter(item => activeStatuses.has(item.type as DiffStatus))
       : searchFilteredItems;
@@ -364,7 +378,7 @@ export default function SnapshotsPage() {
       }
       return a.name.localeCompare(b.name);
     });
-  }, [searchFilteredItems, activeStatuses, sortBy]);
+  }, [searchFilteredItems, activeStatuses, sortBy, comparisonType]);
 
   const sidebarSections = useMemo<SidebarSection[]>(() => {
     function toGroup(item: SidebarItem) {

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -217,6 +217,9 @@ export default function SnapshotsPage() {
 
   const handleToggleStatus = useCallback(
     (status: DiffStatus) => {
+      if (availableStatuses.size <= 1) {
+        return;
+      }
       startTransition(() => {
         setActiveStatusList(prev => {
           if (prev.length === 0) {


### PR DESCRIPTION
Clear `selectedTypes` when all available statuses are selected, since
selecting everything is equivalent to the default empty state (show all).
This avoids a confusing URL parameter that has no visible effect.

Also skip status filtering when viewing in "Head only" (solo) mode.
Previously, leftover `selectedTypes` from diff mode would cause the
sidebar to show "No snapshots found" when switching to head-only view,
because solo-mode items have type `'solo'` which never matches any
`DiffStatus` filter value.