### PR TITLE
feat(seer): Add feature flag to enable Code Mode for Slack Explorer

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -286,6 +286,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code mode tools (sentry_api_search/execute) in Seer Agent
     manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable code mode tools for Slack-initiated Explorer sessions
+    manager.add("organizations:seer-slack-code-mode", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the thinking blocks toggle in the Seer Agent top bar
     manager.add("organizations:seer-explorer-thinking-blocks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable client-side UI tools for Seer Agent

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -610,6 +610,12 @@ class SeerAgentOperator[CachePayloadT]:
                 }
             )
 
+            enable_code_mode_tools = "off"
+            if category_key == "slack_thread" and features.has(
+                "organizations:seer-slack-code-mode", organization
+            ):
+                enable_code_mode_tools = "only"
+
             try:
                 # RpcUser is not in SeerAgentClient's type signature but works at runtime
                 client = SeerAgentClient(
@@ -620,6 +626,7 @@ class SeerAgentOperator[CachePayloadT]:
                     on_completion_hook=SeerOperatorCompletionHook,
                     is_interactive=True,
                     enable_coding=False,
+                    enable_code_mode_tools=enable_code_mode_tools,
                 )
             except SeerPermissionError as e:
                 with SeerOperatorEventLifecycleMetric(

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -24,6 +24,7 @@ from sentry.seer.autofix.utils import (
 from sentry.seer.autofix.utils import CodingAgentState as LegacyCodingAgentState
 from sentry.seer.entrypoints.operator import (
     AUTOFIX_FALLBACK_CAUSE_ID,
+    SeerAgentOperator,
     SeerAutofixOperator,
     SeerOperatorCompletionHook,
     get_autofix_explorer_status,
@@ -1161,3 +1162,65 @@ class TestSeerOperatorCompletionHook(TestCase):
             summary=None,
             run_id=MOCK_RUN_ID,
         )
+
+
+class TestSeerAgentOperatorCodeMode(TestCase):
+    def setUp(self) -> None:
+        self.entrypoint = MockAgentEntrypoint()
+        self.operator = SeerAgentOperator(self.entrypoint)
+
+    @patch("sentry.seer.entrypoints.operator.SeerAgentClient")
+    def test_slack_code_mode_enabled(self, mock_client_cls):
+        mock_client = Mock()
+        mock_client.get_runs.return_value = []
+        mock_client.start_run.return_value = 1
+        mock_client_cls.return_value = mock_client
+
+        with self.feature("organizations:seer-slack-code-mode"):
+            self.operator.trigger_agent(
+                organization=self.organization,
+                user=self.user,
+                prompt="hi",
+                category_key="slack_thread",
+                category_value="thread-123",
+            )
+
+        mock_client_cls.assert_called_once()
+        assert mock_client_cls.call_args.kwargs["enable_code_mode_tools"] == "only"
+
+    @patch("sentry.seer.entrypoints.operator.SeerAgentClient")
+    def test_slack_code_mode_disabled(self, mock_client_cls):
+        mock_client = Mock()
+        mock_client.get_runs.return_value = []
+        mock_client.start_run.return_value = 1
+        mock_client_cls.return_value = mock_client
+
+        self.operator.trigger_agent(
+            organization=self.organization,
+            user=self.user,
+            prompt="hi",
+            category_key="slack_thread",
+            category_value="thread-123",
+        )
+
+        mock_client_cls.assert_called_once()
+        assert mock_client_cls.call_args.kwargs["enable_code_mode_tools"] == "off"
+
+    @patch("sentry.seer.entrypoints.operator.SeerAgentClient")
+    def test_non_slack_category_ignores_flag(self, mock_client_cls):
+        mock_client = Mock()
+        mock_client.get_runs.return_value = []
+        mock_client.start_run.return_value = 1
+        mock_client_cls.return_value = mock_client
+
+        with self.feature("organizations:seer-slack-code-mode"):
+            self.operator.trigger_agent(
+                organization=self.organization,
+                user=self.user,
+                prompt="hi",
+                category_key="other_category",
+                category_value="val-123",
+            )
+
+        mock_client_cls.assert_called_once()
+        assert mock_client_cls.call_args.kwargs["enable_code_mode_tools"] == "off"


### PR DESCRIPTION
Add `organizations:seer-slack-code-mode` FlagPole flag that enables Code Mode for Slack-initiated Explorer sessions. When the flag is active and the category_key is `"slack_thread"`, `SeerAgentOperator.trigger_agent()` passes `enable_code_mode_tools="only"` to `SeerAgentClient`.

This gives the Slack Explorer agent access to the full Sentry API surface (200+ endpoints) via sandboxed search/execute tools, rather than the default tool set. The flag is separate from the web UI code mode flag (`seer-explorer-code-mode-tools`) so it can be rolled out independently.

No Seer-side changes needed — the `enable_code_mode_tools` field already flows through `ExplorerChatRequest` → `ExplorerState` → tool selection. Companion Seer PRs for context engine filesystem hydration: getsentry/seer#6335 (context blocks as `/tmp` files in code mode).