### PR TITLE
fix(autofix): Read automation settings from detailed project

### DIFF
--- a/static/app/components/events/autofix/claudeCodeIntegrationCta.spec.tsx
+++ b/static/app/components/events/autofix/claudeCodeIntegrationCta.spec.tsx
@@ -9,13 +9,27 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 
 describe('ClaudeCodeIntegrationCta', () => {
   const project = ProjectFixture();
+  const enabledProject = ProjectFixture({
+    ...project,
+    seerScannerAutomation: true,
+    autofixAutomationTuning: 'medium',
+  });
   const organization = OrganizationFixture({
     features: ['integrations-claude-code'],
   });
 
+  function mockDetailedProject(projectBody = enabledProject) {
+    return MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${projectBody.slug}/`,
+      body: projectBody,
+    });
+  }
+
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     localStorage.clear();
+
+    mockDetailedProject();
 
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
@@ -209,6 +223,7 @@ describe('ClaudeCodeIntegrationCta', () => {
         seerScannerAutomation: true,
         autofixAutomationTuning: 'medium',
       });
+      mockDetailedProject(projectWithAutomation);
 
       const projectUpdateMock = MockApiClient.addMockResponse({
         url: `/projects/${organization.slug}/${projectWithAutomation.slug}/`,
@@ -256,6 +271,7 @@ describe('ClaudeCodeIntegrationCta', () => {
         seerScannerAutomation: false,
         autofixAutomationTuning: 'off',
       });
+      mockDetailedProject(projectWithoutAutomation);
 
       const updatedProject = {
         ...projectWithoutAutomation,
@@ -370,6 +386,7 @@ describe('ClaudeCodeIntegrationCta', () => {
         seerScannerAutomation: false,
         autofixAutomationTuning: 'off',
       });
+      mockDetailedProject(projectWithoutAutomation);
 
       render(<ClaudeCodeIntegrationCta project={projectWithoutAutomation} />, {
         organization,
@@ -423,6 +440,7 @@ describe('ClaudeCodeIntegrationCta', () => {
         seerScannerAutomation: true,
         autofixAutomationTuning: 'medium',
       });
+      mockDetailedProject(projectWithAutomation);
 
       render(<ClaudeCodeIntegrationCta project={projectWithAutomation} />, {
         organization,
@@ -440,6 +458,7 @@ describe('ClaudeCodeIntegrationCta', () => {
         seerScannerAutomation: true,
         autofixAutomationTuning: 'medium',
       });
+      mockDetailedProject(projectWithAutomation);
 
       render(<ClaudeCodeIntegrationCta project={projectWithAutomation} />, {
         organization,

--- a/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
+++ b/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
@@ -66,7 +66,7 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
 
     const hasIntegration = Boolean(integration);
     const isAutomationEnabled =
-      projectDetails.seerScannerAutomation === true &&
+      projectDetails.seerScannerAutomation !== false &&
       projectDetails.autofixAutomationTuning !== 'off';
     const isConfigured =
       preference?.automation_handoff?.target === config.target && isAutomationEnabled;
@@ -95,7 +95,7 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
       });
 
       const isAutomationDisabled =
-        projectDetails.seerScannerAutomation !== true ||
+        projectDetails.seerScannerAutomation === false ||
         projectDetails.autofixAutomationTuning === 'off';
 
       if (isAutomationDisabled) {

--- a/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
+++ b/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
@@ -14,6 +14,7 @@ import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
@@ -40,6 +41,16 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
     const organization = useOrganization();
     const user = useUser();
 
+    const hasFeatureFlag =
+      !config.featureFlag || organization.features.includes(config.featureFlag);
+    const {data: projectDetails = project, isPending: isLoadingProject} =
+      useDetailedProject(
+        {
+          orgSlug: organization.slug,
+          projectSlug: project.slug,
+        },
+        {enabled: hasFeatureFlag}
+      );
     const {data, isFetching: isLoadingPreferences} = useProjectSeerPreferences(project);
     const preference = data?.preference;
     const {mutate: updateProjectSeerPreferences, isPending: isUpdatingPreferences} =
@@ -53,12 +64,10 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
       i => i.provider === config.provider
     );
 
-    const hasFeatureFlag =
-      !config.featureFlag || organization.features.includes(config.featureFlag);
     const hasIntegration = Boolean(integration);
     const isAutomationEnabled =
-      project.seerScannerAutomation !== false &&
-      project.autofixAutomationTuning !== 'off';
+      projectDetails.seerScannerAutomation === true &&
+      projectDetails.autofixAutomationTuning !== 'off';
     const isConfigured =
       preference?.automation_handoff?.target === config.target && isAutomationEnabled;
 
@@ -86,8 +95,8 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
       });
 
       const isAutomationDisabled =
-        project.seerScannerAutomation === false ||
-        project.autofixAutomationTuning === 'off';
+        projectDetails.seerScannerAutomation !== true ||
+        projectDetails.autofixAutomationTuning === 'off';
 
       if (isAutomationDisabled) {
         await updateProjectAutomation({
@@ -111,7 +120,12 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
       return null;
     }
 
-    if (isLoadingPreferences || isLoadingIntegrations || isUpdatingPreferences) {
+    if (
+      isLoadingProject ||
+      isLoadingPreferences ||
+      isLoadingIntegrations ||
+      isUpdatingPreferences
+    ) {
       return (
         <Container
           padding="xl"

--- a/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
@@ -9,11 +9,25 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 
 describe('CursorIntegrationCta', () => {
   const project = ProjectFixture();
+  const enabledProject = ProjectFixture({
+    ...project,
+    seerScannerAutomation: true,
+    autofixAutomationTuning: 'medium',
+  });
   const organization = OrganizationFixture();
+
+  function mockDetailedProject(projectBody = enabledProject) {
+    return MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${projectBody.slug}/`,
+      body: projectBody,
+    });
+  }
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     localStorage.clear();
+
+    mockDetailedProject();
 
     // Default mock for seer preferences
     MockApiClient.addMockResponse({
@@ -187,6 +201,7 @@ describe('CursorIntegrationCta', () => {
         seerScannerAutomation: false,
         autofixAutomationTuning: 'off',
       });
+      mockDetailedProject(projectWithoutAutomation);
 
       const updatedProject = {
         ...projectWithoutAutomation,
@@ -271,6 +286,7 @@ describe('CursorIntegrationCta', () => {
         seerScannerAutomation: true,
         autofixAutomationTuning: 'medium',
       });
+      mockDetailedProject(projectWithAutomation);
 
       const projectUpdateMock = MockApiClient.addMockResponse({
         url: `/projects/${organization.slug}/${projectWithAutomation.slug}/`,
@@ -353,6 +369,7 @@ describe('CursorIntegrationCta', () => {
         seerScannerAutomation: false,
         autofixAutomationTuning: 'off',
       });
+      mockDetailedProject(projectWithoutAutomation);
 
       render(<CursorIntegrationCta project={projectWithoutAutomation} />, {
         organization,
@@ -409,6 +426,7 @@ describe('CursorIntegrationCta', () => {
         seerScannerAutomation: true,
         autofixAutomationTuning: 'medium',
       });
+      mockDetailedProject(projectWithAutomation);
 
       render(<CursorIntegrationCta project={projectWithAutomation} />, {
         organization,
@@ -426,6 +444,7 @@ describe('CursorIntegrationCta', () => {
         seerScannerAutomation: true,
         autofixAutomationTuning: 'medium',
       });
+      mockDetailedProject(projectWithAutomation);
 
       render(<CursorIntegrationCta project={projectWithAutomation} />, {
         organization,

--- a/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
@@ -16,18 +16,14 @@ describe('CursorIntegrationCta', () => {
   });
   const organization = OrganizationFixture();
 
-  function mockDetailedProject(projectBody = enabledProject) {
-    return MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${projectBody.slug}/`,
-      body: projectBody,
-    });
-  }
-
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     localStorage.clear();
 
-    mockDetailedProject();
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${enabledProject.slug}/`,
+      body: enabledProject,
+    });
 
     // Default mock for seer preferences
     MockApiClient.addMockResponse({
@@ -201,7 +197,10 @@ describe('CursorIntegrationCta', () => {
         seerScannerAutomation: false,
         autofixAutomationTuning: 'off',
       });
-      mockDetailedProject(projectWithoutAutomation);
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${projectWithoutAutomation.slug}/`,
+        body: projectWithoutAutomation,
+      });
 
       const updatedProject = {
         ...projectWithoutAutomation,
@@ -286,7 +285,10 @@ describe('CursorIntegrationCta', () => {
         seerScannerAutomation: true,
         autofixAutomationTuning: 'medium',
       });
-      mockDetailedProject(projectWithAutomation);
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${projectWithAutomation.slug}/`,
+        body: projectWithAutomation,
+      });
 
       const projectUpdateMock = MockApiClient.addMockResponse({
         url: `/projects/${organization.slug}/${projectWithAutomation.slug}/`,
@@ -369,7 +371,10 @@ describe('CursorIntegrationCta', () => {
         seerScannerAutomation: false,
         autofixAutomationTuning: 'off',
       });
-      mockDetailedProject(projectWithoutAutomation);
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${projectWithoutAutomation.slug}/`,
+        body: projectWithoutAutomation,
+      });
 
       render(<CursorIntegrationCta project={projectWithoutAutomation} />, {
         organization,
@@ -426,7 +431,10 @@ describe('CursorIntegrationCta', () => {
         seerScannerAutomation: true,
         autofixAutomationTuning: 'medium',
       });
-      mockDetailedProject(projectWithAutomation);
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${projectWithAutomation.slug}/`,
+        body: projectWithAutomation,
+      });
 
       render(<CursorIntegrationCta project={projectWithAutomation} />, {
         organization,
@@ -444,7 +452,10 @@ describe('CursorIntegrationCta', () => {
         seerScannerAutomation: true,
         autofixAutomationTuning: 'medium',
       });
-      mockDetailedProject(projectWithAutomation);
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${projectWithAutomation.slug}/`,
+        body: projectWithAutomation,
+      });
 
       render(<CursorIntegrationCta project={projectWithAutomation} />, {
         organization,

--- a/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
@@ -447,6 +447,27 @@ describe('CursorIntegrationCta', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('treats missing scanner automation as enabled when tuning is enabled', async () => {
+      const projectWithAutomation = ProjectFixture({
+        autofixAutomationTuning: 'medium',
+      });
+      delete projectWithAutomation.seerScannerAutomation;
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${projectWithAutomation.slug}/`,
+        body: projectWithAutomation,
+      });
+
+      render(<CursorIntegrationCta project={projectWithAutomation} />, {
+        organization,
+      });
+
+      expect(await screen.findByText('Cursor Agent Integration')).toBeInTheDocument();
+      expect(screen.getByText(/Cursor handoff is active/)).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Set Seer to hand off to Cursor'})
+      ).not.toBeInTheDocument();
+    });
+
     it('does not show setup button in configured stage', async () => {
       const projectWithAutomation = ProjectFixture({
         seerScannerAutomation: true,

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -160,12 +160,12 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   ];
 
   const handleSetupCursorHandoff = async () => {
-    if (!cursorIntegration?.id) {
+    if (!cursorIntegration?.id || !projectDetails) {
       return;
     }
 
     const isAutomationDisabled =
-      projectDetails?.seerScannerAutomation === false ||
+      projectDetails.seerScannerAutomation === false ||
       projectDetails.autofixAutomationTuning === 'off';
 
     if (isAutomationDisabled) {

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -101,7 +101,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   );
   const {starredViews: views} = useStarredIssueViews();
 
-  const {data: projectDetails = project} = useDetailedProject({
+  const {data: projectDetails} = useDetailedProject({
     orgSlug: organization.slug,
     projectSlug: project.slug,
   });
@@ -125,10 +125,11 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const needsRepoSelection =
     repos.length === 0 && !preference?.repositories?.length && !codeMappingRepos?.length;
   const needsAutomation =
-    projectDetails.autofixAutomationTuning === 'off' ||
-    projectDetails.autofixAutomationTuning === undefined ||
-    projectDetails.seerScannerAutomation === false ||
-    projectDetails.seerScannerAutomation === undefined;
+    projectDetails !== undefined &&
+    (projectDetails.autofixAutomationTuning === 'off' ||
+      projectDetails.autofixAutomationTuning === undefined ||
+      projectDetails.seerScannerAutomation === false ||
+      projectDetails.seerScannerAutomation === undefined);
   const needsFixabilityView =
     !views.some(view => view.query.includes(FieldKey.ISSUE_SEER_ACTIONABILITY)) &&
     isStarredViewAllowed;
@@ -165,7 +166,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     }
 
     const isAutomationDisabled =
-      projectDetails.seerScannerAutomation !== true ||
+      projectDetails?.seerScannerAutomation !== true ||
       projectDetails.autofixAutomationTuning === 'off';
 
     if (isAutomationDisabled) {

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -101,7 +101,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   );
   const {starredViews: views} = useStarredIssueViews();
 
-  const detailedProject = useDetailedProject({
+  const {data: projectDetails = project} = useDetailedProject({
     orgSlug: organization.slug,
     projectSlug: project.slug,
   });
@@ -125,11 +125,10 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const needsRepoSelection =
     repos.length === 0 && !preference?.repositories?.length && !codeMappingRepos?.length;
   const needsAutomation =
-    detailedProject?.data &&
-    (detailedProject?.data?.autofixAutomationTuning === 'off' ||
-      detailedProject?.data?.autofixAutomationTuning === undefined ||
-      detailedProject?.data?.seerScannerAutomation === false ||
-      detailedProject?.data?.seerScannerAutomation === undefined);
+    projectDetails.autofixAutomationTuning === 'off' ||
+    projectDetails.autofixAutomationTuning === undefined ||
+    projectDetails.seerScannerAutomation === false ||
+    projectDetails.seerScannerAutomation === undefined;
   const needsFixabilityView =
     !views.some(view => view.query.includes(FieldKey.ISSUE_SEER_ACTIONABILITY)) &&
     isStarredViewAllowed;
@@ -166,8 +165,8 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     }
 
     const isAutomationDisabled =
-      project.seerScannerAutomation === false ||
-      project.autofixAutomationTuning === 'off';
+      projectDetails.seerScannerAutomation !== true ||
+      projectDetails.autofixAutomationTuning === 'off';
 
     if (isAutomationDisabled) {
       await updateProjectAutomation({

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -101,7 +101,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   );
   const {starredViews: views} = useStarredIssueViews();
 
-  const {data: projectDetails} = useDetailedProject({
+  const {data: projectDetails, isPending: isLoadingProject} = useDetailedProject({
     orgSlug: organization.slug,
     projectSlug: project.slug,
   });
@@ -128,8 +128,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     projectDetails !== undefined &&
     (projectDetails.autofixAutomationTuning === 'off' ||
       projectDetails.autofixAutomationTuning === undefined ||
-      projectDetails.seerScannerAutomation === false ||
-      projectDetails.seerScannerAutomation === undefined);
+      projectDetails.seerScannerAutomation === false);
   const needsFixabilityView =
     !views.some(view => view.query.includes(FieldKey.ISSUE_SEER_ACTIONABILITY)) &&
     isStarredViewAllowed;
@@ -166,7 +165,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     }
 
     const isAutomationDisabled =
-      projectDetails?.seerScannerAutomation !== true ||
+      projectDetails?.seerScannerAutomation === false ||
       projectDetails.autofixAutomationTuning === 'off';
 
     if (isAutomationDisabled) {
@@ -197,11 +196,15 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const firstIncompleteIdx = incompleteStepIndices[0];
   const lastIncompleteIdx = incompleteStepIndices[incompleteStepIndices.length - 1];
   const anyStepIncomplete = incompleteStepIndices.length > 0;
+  const showOnboardingSteps =
+    !isLoadingPreferences && !isLoadingProject && anyStepIncomplete;
+  const showCollapsedSummary = showOnboardingSteps && stepsCollapsed;
+  const showFullGuidedSteps = showOnboardingSteps && !stepsCollapsed;
 
   return (
     <Stack align="stretch">
       {/* Collapsed summary */}
-      {!isLoadingPreferences && anyStepIncomplete && stepsCollapsed && (
+      {showCollapsedSummary && (
         <CollapsedSummaryCard onClick={() => setStepsCollapsed(false)}>
           <IconSeer animation="waiting" size="lg" style={{marginRight: 8}} />
           <span>
@@ -215,7 +218,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
         </CollapsedSummaryCard>
       )}
       {/* Full guided steps */}
-      {!isLoadingPreferences && anyStepIncomplete && !stepsCollapsed && (
+      {showFullGuidedSteps && (
         <AnimatePresence>
           <motion.div
             initial={{opacity: 0, y: 10, height: 0}}

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -35,21 +35,13 @@ describe('ProjectSeer', () => {
   let project: Project;
   let organization: Organization;
 
-  function mockDetailedProject({
-    org = organization,
-    projectBody = project,
-  }: {org?: Organization; projectBody?: Project} = {}) {
-    return MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${projectBody.slug}/`,
-      method: 'GET',
-      body: projectBody,
-    });
-  }
-
   beforeEach(() => {
     project = ProjectFixture();
     organization = OrganizationFixture();
-    mockDetailedProject();
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${project.slug}/`,
+      body: project,
+    });
 
     // Mock the seer setup check endpoint
     MockApiClient.addMockResponse({
@@ -728,7 +720,10 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
-      mockDetailedProject({org: orgWithCursorFeature, projectBody: initialProject});
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/`,
+        body: initialProject,
+      });
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
@@ -808,7 +803,10 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
-      mockDetailedProject({org: orgWithCursorFeature, projectBody: initialProject});
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/`,
+        body: initialProject,
+      });
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
@@ -917,7 +915,10 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
-      mockDetailedProject({org: orgWithCursorFeature, projectBody: initialProject});
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/`,
+        body: initialProject,
+      });
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
@@ -1008,7 +1009,10 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
-      mockDetailedProject({org: orgWithCursorFeature, projectBody: initialProject});
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/`,
+        body: initialProject,
+      });
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
@@ -1132,7 +1136,10 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
-      mockDetailedProject({org: orgWithBothFeatures, projectBody: initialProject});
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/`,
+        body: initialProject,
+      });
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithBothFeatures.slug}/seer/setup-check/`,
@@ -1215,7 +1222,10 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
-      mockDetailedProject({org: orgWithCursorFeature, projectBody: initialProject});
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/`,
+        body: initialProject,
+      });
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -35,9 +35,21 @@ describe('ProjectSeer', () => {
   let project: Project;
   let organization: Organization;
 
+  function mockDetailedProject({
+    org = organization,
+    projectBody = project,
+  }: {org?: Organization; projectBody?: Project} = {}) {
+    return MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${projectBody.slug}/`,
+      method: 'GET',
+      body: projectBody,
+    });
+  }
+
   beforeEach(() => {
     project = ProjectFixture();
     organization = OrganizationFixture();
+    mockDetailedProject();
 
     // Mock the seer setup check endpoint
     MockApiClient.addMockResponse({
@@ -716,6 +728,7 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
+      mockDetailedProject({org: orgWithCursorFeature, projectBody: initialProject});
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
@@ -795,6 +808,7 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
+      mockDetailedProject({org: orgWithCursorFeature, projectBody: initialProject});
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
@@ -903,6 +917,7 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
+      mockDetailedProject({org: orgWithCursorFeature, projectBody: initialProject});
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
@@ -993,6 +1008,7 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
+      mockDetailedProject({org: orgWithCursorFeature, projectBody: initialProject});
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
@@ -1116,6 +1132,7 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
+      mockDetailedProject({org: orgWithBothFeatures, projectBody: initialProject});
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithBothFeatures.slug}/seer/setup-check/`,
@@ -1198,6 +1215,7 @@ describe('ProjectSeer', () => {
         autofixAutomationTuning: 'medium',
         seerScannerAutomation: true,
       };
+      mockDetailedProject({org: orgWithCursorFeature, projectBody: initialProject});
 
       MockApiClient.addMockResponse({
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,


### PR DESCRIPTION
Autofix coding agent CTAs were checking detailed project settings from project summary objects, so missing Seer automation fields could look enabled.

Use the detailed project for those reads and keep updates going through useUpdateProject with the original project. Matches the pattern from #115139.

part of #115024