### PR TITLE
ref(assisted-query): Remove old ai_query analytics events and analyticsSource prop

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
@@ -42,11 +42,6 @@ export function AskSeerOption<T>({state}: {state: ComboBoxState<T>}) {
 
   const handleClick = () => {
     if (optionDisableOverride) return;
-
-    trackAnalytics('trace.explorer.ai_query_interface', {
-      organization,
-      action: 'opened',
-    });
     trackAnalytics('ai_query.interface', {
       organization,
       area: analyticsArea,

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -68,7 +68,6 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization}
@@ -88,7 +87,6 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization}
@@ -107,7 +105,6 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization}
@@ -125,7 +122,6 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          feedbackSource="test"
         />
       ) : (
         <div>
@@ -161,7 +157,6 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization}
@@ -184,7 +179,6 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={applySeerSearchQuery}
-          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {
@@ -221,7 +215,6 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization}
@@ -245,7 +238,6 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>
     );
@@ -259,7 +251,6 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization: {...organization, hideAiFeatures: true}}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -68,7 +68,7 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          analyticsSource="test"
+          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization}
@@ -88,7 +88,7 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          analyticsSource="test"
+          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization}
@@ -107,7 +107,7 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          analyticsSource="test"
+          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization}
@@ -125,7 +125,7 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          analyticsSource="test"
+          feedbackSource="test"
         />
       ) : (
         <div>
@@ -161,7 +161,7 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          analyticsSource="test"
+          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization}
@@ -184,7 +184,7 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={applySeerSearchQuery}
-          analyticsSource="test"
+          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {
@@ -221,7 +221,7 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          analyticsSource="test"
+          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization}
@@ -245,7 +245,7 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          analyticsSource="test"
+          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>
     );
@@ -259,7 +259,7 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
-          analyticsSource="test"
+          feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
       {organization: {...organization, hideAiFeatures: true}}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -88,17 +88,6 @@ interface AskSeerComboBoxProps<T extends QueryTokensProps> extends Omit<
   AriaComboBoxProps<unknown>,
   'children'
 > {
-  /**
-   * The source of the analytics event, must be a dot-separated identifier like "trace.
-   * explorer" or "issue.list"
-   * @example 'trace.explorer'
-   *
-   * The combobox has the following analytic events, that will need to be tracked with your provided analyticsSource:
-   * - `<analyticsSource>.ai_query_rejected`
-   * - `<analyticsSource>.ai_query_interface`
-   * - `<analyticsSource>.ai_query_submitted`
-   */
-  analyticsSource: string;
   applySeerSearchQuery: (item: T) => void;
   askSeerMutationOptions: MutationOptions<
     {
@@ -114,7 +103,6 @@ interface AskSeerComboBoxProps<T extends QueryTokensProps> extends Omit<
 
 export function AskSeerComboBox<T extends QueryTokensProps>({
   initialQuery,
-  analyticsSource,
   ...props
 }: AskSeerComboBoxProps<T>) {
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -210,11 +198,6 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
       if (typeof key !== 'string') return;
 
       if (key === 'none-of-these') {
-        trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
-          organization,
-          natural_language_query: searchQuery,
-          num_queries_returned: data?.queries?.length ?? 0,
-        });
         trackAnalytics('ai_query.rejected', {
           organization,
           area: analyticsArea,
@@ -286,10 +269,6 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
         switch (e.key) {
           case 'Escape':
             if (!state.isOpen) {
-              trackAnalytics(`${analyticsSource}.ai_query_interface`, {
-                organization,
-                action: 'closed',
-              });
               trackAnalytics('ai_query.interface', {
                 organization,
                 area: analyticsArea,
@@ -303,11 +282,6 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
             return;
           case 'Enter':
             if (state.isOpen && state.selectionManager.focusedKey === 'none-of-these') {
-              trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
-                organization,
-                natural_language_query: searchQuery,
-                num_queries_returned: data?.queries?.length ?? 0,
-              });
               trackAnalytics('ai_query.rejected', {
                 organization,
                 area: analyticsArea,
@@ -339,10 +313,6 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
               searchQuery.trim() !== null &&
               searchQuery.trim() !== ''
             ) {
-              trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
-                organization,
-                natural_language_query: searchQuery.trim(),
-              });
               trackAnalytics('ai_query.submitted', {
                 organization,
                 area: analyticsArea,
@@ -408,10 +378,6 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
 
   useLayoutEffect(() => {
     if (autoSubmitSeer && searchQuery.trim()) {
-      trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
-        organization,
-        natural_language_query: searchQuery.trim(),
-      });
       trackAnalytics('ai_query.submitted', {
         organization,
         area: analyticsArea,
@@ -422,7 +388,6 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
     }
   }, [
     analyticsArea,
-    analyticsSource,
     autoSubmitSeer,
     organization,
     searchQuery,
@@ -458,10 +423,6 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
           icon={<IconClose />}
           onFocus={() => !state.isOpen && state.open()}
           onClick={() => {
-            trackAnalytics(`${analyticsSource}.ai_query_interface`, {
-              organization,
-              action: 'closed',
-            });
             trackAnalytics('ai_query.interface', {
               organization,
               area: analyticsArea,

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -88,12 +88,6 @@ interface AskSeerPollingComboBoxProps<T extends QueryTokensProps> extends Omit<
   AriaComboBoxProps<unknown>,
   'children'
 > {
-  /**
-   * The source of the analytics event, must be a dot-separated identifier like "trace.
-   * explorer" or "issue.list"
-   * @example 'trace.explorer'
-   */
-  analyticsSource: string;
   applySeerSearchQuery: (item: T) => void;
   initialQuery: string;
   projectIds: number[];
@@ -117,7 +111,6 @@ interface AskSeerPollingComboBoxProps<T extends QueryTokensProps> extends Omit<
 
 export function AskSeerPollingComboBox<T extends QueryTokensProps>({
   initialQuery,
-  analyticsSource,
   projectIds,
   strategy,
   transformResponse,
@@ -237,11 +230,6 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
       if (typeof key !== 'string') return;
 
       if (key === 'none-of-these') {
-        trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
-          organization,
-          natural_language_query: searchQuery,
-          num_queries_returned: queries.length ?? 0,
-        });
         trackAnalytics('ai_query.rejected', {
           organization,
           area: analyticsArea,
@@ -314,10 +302,6 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
         switch (e.key) {
           case 'Escape':
             if (!state.isOpen) {
-              trackAnalytics(`${analyticsSource}.ai_query_interface`, {
-                organization,
-                action: 'closed',
-              });
               trackAnalytics('ai_query.interface', {
                 organization,
                 area: analyticsArea,
@@ -332,11 +316,6 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
             return;
           case 'Enter':
             if (state.isOpen && state.selectionManager.focusedKey === 'none-of-these') {
-              trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
-                organization,
-                natural_language_query: searchQuery,
-                num_queries_returned: queries.length ?? 0,
-              });
               trackAnalytics('ai_query.rejected', {
                 organization,
                 area: analyticsArea,
@@ -369,10 +348,6 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
               searchQuery.trim() !== null &&
               searchQuery.trim() !== ''
             ) {
-              trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
-                organization,
-                natural_language_query: searchQuery.trim(),
-              });
               trackAnalytics('ai_query.submitted', {
                 organization,
                 area: analyticsArea,
@@ -438,10 +413,6 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
 
   useLayoutEffect(() => {
     if (autoSubmitSeer && searchQuery.trim()) {
-      trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
-        organization,
-        natural_language_query: searchQuery.trim(),
-      });
       trackAnalytics('ai_query.submitted', {
         organization,
         area: analyticsArea,
@@ -452,7 +423,6 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
     }
   }, [
     analyticsArea,
-    analyticsSource,
     autoSubmitSeer,
     organization,
     searchQuery,
@@ -475,7 +445,6 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
         initialQuery={initialQuery}
         askSeerMutationOptions={fallbackMutationOptions}
         applySeerSearchQuery={props.applySeerSearchQuery}
-        analyticsSource={analyticsSource}
       />
     );
   }
@@ -503,10 +472,6 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
           icon={<IconClose />}
           onFocus={() => !state.isOpen && state.open()}
           onClick={() => {
-            trackAnalytics(`${analyticsSource}.ai_query_interface`, {
-              organization,
-              action: 'closed',
-            });
             trackAnalytics('ai_query.interface', {
               organization,
               area: analyticsArea,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -5708,7 +5708,6 @@ describe('SearchQueryBuilder', () => {
           return displayAskSeer ? (
             <AskSeerComboBox
               initialQuery={query}
-              feedbackSource="test"
               applySeerSearchQuery={() => {}}
               askSeerMutationOptions={mutationOptions({
                 mutationFn: async (_value: string) => {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -5708,7 +5708,7 @@ describe('SearchQueryBuilder', () => {
           return displayAskSeer ? (
             <AskSeerComboBox
               initialQuery={query}
-              analyticsSource="test"
+              feedbackSource="test"
               applySeerSearchQuery={() => {}}
               askSeerMutationOptions={mutationOptions({
                 mutationFn: async (_value: string) => {

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -64,10 +64,6 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       const newFilterValueType = getFilterValueType(token, newFieldDef);
 
       if (keyName === ASK_SEER_ITEM_KEY) {
-        trackAnalytics('trace.explorer.ai_query_interface', {
-          organization,
-          action: 'opened',
-        });
         trackAnalytics('ai_query.interface', {
           organization,
           area: analyticsArea,
@@ -85,10 +81,6 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       }
 
       if (keyName === ASK_SEER_CONSENT_ITEM_KEY) {
-        trackAnalytics('trace.explorer.ai_query_interface', {
-          organization,
-          action: 'consent_accepted',
-        });
         trackAnalytics('ai_query.interface', {
           organization,
           area: analyticsArea,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -419,10 +419,6 @@ export function useFilterKeyListBox({filterValue}: UseFilterKeyListBoxArgs) {
   const handleOptionSelected = useCallback(
     (option: FilterKeyItem) => {
       if (option.type === 'ask-seer') {
-        trackAnalytics('trace.explorer.ai_query_interface', {
-          organization,
-          action: 'opened',
-        });
         trackAnalytics('ai_query.interface', {
           organization,
           area: analyticsArea,
@@ -440,10 +436,6 @@ export function useFilterKeyListBox({filterValue}: UseFilterKeyListBoxArgs) {
       }
 
       if (option.type === 'ask-seer-consent') {
-        trackAnalytics('trace.explorer.ai_query_interface', {
-          organization,
-          action: 'consent_accepted',
-        });
         trackAnalytics('ai_query.interface', {
           organization,
           area: analyticsArea,

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -56,9 +56,6 @@ export type IssueEventParameters = {
   'device.classification.unclassified.ios.device': {
     model: string;
   };
-  'errors.ai_query_applied': {
-    query: string;
-  };
   'highlights.edit_modal.add_context_key': Record<string, unknown>;
   'highlights.edit_modal.add_tag': Record<string, unknown>;
   'highlights.edit_modal.cancel_clicked': Record<string, unknown>;
@@ -78,9 +75,6 @@ export type IssueEventParameters = {
     group_id: number;
     issue_type: string;
     project_id: number;
-  };
-  'issue.list.ai_query_applied': {
-    query: string;
   };
   'issue.shared_publicly': Record<string, unknown>;
   'issue_details.activity_drawer.filter_changed': {
@@ -308,7 +302,6 @@ type IssueEventKey = keyof IssueEventParameters;
 
 export const issueEventMap: Record<IssueEventKey, string | null> = {
   'breadcrumbs.issue_details.change_time_display': 'Breadcrumb Time Display Toggled',
-  'errors.ai_query_applied': 'Errors: AI Query Applied',
   'breadcrumbs.issue_details.drawer_opened': 'Breadcrumb Drawer Opened',
   'breadcrumbs.drawer.action': 'Breadcrumb Drawer Action Taken',
   'highlights.edit_modal.add_context_key': 'Highlights: Add Context in Edit Modal',
@@ -373,7 +366,6 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_views.star_view': 'Issue Views: Star View',
   'issue_search.failed': 'Issue Search: Failed',
   'issue_search.empty': 'Issue Search: Empty',
-  'issue.list.ai_query_applied': 'Issue List: AI Query Applied',
   'issues_stream.archived': 'Issues Stream: Archived',
   'issues_stream.updated_priority': 'Issues Stream: Updated Priority',
   'issues_stream.realtime_clicked': 'Issues Stream: Realtime Clicked',

--- a/static/app/utils/analytics/logsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/logsAnalyticsEvent.tsx
@@ -9,11 +9,6 @@ export enum LogsAnalyticsPageSource {
 }
 
 export type LogsAnalyticsEventParameters = {
-  'logs.ai_query_applied': {
-    group_by_count: number;
-    organization: Organization;
-    query: string;
-  };
   'logs.auto_refresh.timeout': {
     organization: Organization;
     page_source: LogsAnalyticsPageSource;
@@ -129,5 +124,4 @@ export const logsAnalyticsEventMap: Record<LogsAnalyticsEventKey, string | null>
   'logs.onboarding_platform_docs_viewed':
     'Logs Explore Empty State (Onboarding) - Platform Docs Viewed',
   'logs.table.row_copied_as_json': 'Logs Row Copied as JSON',
-  'logs.ai_query_applied': 'Logs AI Query Applied',
 };

--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -11,22 +11,6 @@ export type TracingEventParameters = {
   'trace.configurations_docs_link_clicked': {
     title: string;
   };
-
-  'trace.explorer.ai_query_applied': {
-    group_by_count: number;
-    query: string;
-    visualize_count: number;
-  };
-  'trace.explorer.ai_query_interface': {
-    action: 'opened' | 'closed' | 'consent_accepted';
-  };
-  'trace.explorer.ai_query_rejected': {
-    natural_language_query: string;
-    num_queries_returned: number;
-  };
-  'trace.explorer.ai_query_submitted': {
-    natural_language_query: string;
-  };
   'trace.explorer.cross_event_added': {
     type: CrossEventType;
   };
@@ -226,10 +210,6 @@ export const tracingEventMap: Record<TracingEventKey, string | null> = {
   'trace.metadata': 'Trace Load Metadata',
   'trace.load.empty_state': 'Trace Load Empty State',
   'trace.load.error_state': 'Trace Load Error State',
-  'trace.explorer.ai_query_applied': 'Trace Explorer: AI Query Applied',
-  'trace.explorer.ai_query_rejected': 'Trace Explorer: AI Query Rejected',
-  'trace.explorer.ai_query_submitted': 'Trace Explorer: AI Query Submitted',
-  'trace.explorer.ai_query_interface': 'Trace Explorer: AI Query Interface',
   'trace.explorer.metadata': 'Improved Trace Explorer Pageload Metadata',
   'trace.explorer.cross_event_added': 'Trace Explorer: Cross Event Added',
   'trace.explorer.cross_event_changed': 'Trace Explorer: Cross Event Changed',

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -306,7 +306,6 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
       strategy="Errors"
       applySeerSearchQuery={applySeerSearchQuery}
       transformResponse={transformResponse}
-      feedbackSource="errors_ai_query"
       fallbackMutationOptions={issueListAskSeerMutationOptions}
     />
   );

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -233,10 +233,6 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         columns,
       });
 
-      trackAnalytics('errors.ai_query_applied', {
-        organization,
-        query: queryToUse,
-      });
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
@@ -294,8 +290,8 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
       location,
       navigate,
       onSearch,
-      organization,
       pageFilters.selection.datetime,
+      organization,
     ]
   );
 
@@ -310,7 +306,7 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
       strategy="Errors"
       applySeerSearchQuery={applySeerSearchQuery}
       transformResponse={transformResponse}
-      analyticsSource="errors"
+      feedbackSource="errors_ai_query"
       fallbackMutationOptions={issueListAskSeerMutationOptions}
     />
   );

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -242,11 +242,6 @@ export function LogsTabSeerComboBox() {
         mode,
       });
 
-      trackAnalytics('logs.ai_query_applied', {
-        organization,
-        query: queryToUse,
-        group_by_count: groupBys.length,
-      });
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
@@ -322,7 +317,7 @@ export function LogsTabSeerComboBox() {
       strategy="Logs"
       applySeerSearchQuery={applySeerSearchQuery}
       transformResponse={transformResponse}
-      analyticsSource="logs"
+      feedbackSource="logs_ai_query"
       fallbackMutationOptions={logsTabAskSeerMutationOptions}
     />
   );

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -317,7 +317,6 @@ export function LogsTabSeerComboBox() {
       strategy="Logs"
       applySeerSearchQuery={applySeerSearchQuery}
       transformResponse={transformResponse}
-      feedbackSource="logs_ai_query"
       fallbackMutationOptions={logsTabAskSeerMutationOptions}
     />
   );

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -396,7 +396,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         }}
         applySeerSearchQuery={applySeerSearchQuery}
         transformResponse={transformResponse}
-        analyticsSource="metrics"
         fallbackMutationOptions={metricsTabAskSeerMutationOptions}
       />
     );
@@ -407,7 +406,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       initialQuery={initialSeerQuery}
       askSeerMutationOptions={metricsTabAskSeerMutationOptions}
       applySeerSearchQuery={applySeerSearchQuery}
-      analyticsSource="metrics"
     />
   );
 }

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -260,12 +260,6 @@ export function SpansTabSeerComboBox() {
         sort,
         mode,
       });
-      trackAnalytics('trace.explorer.ai_query_applied', {
-        organization,
-        query: queryToUse,
-        group_by_count: groupBys.length,
-        visualize_count: visualizations.length,
-      });
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
@@ -352,7 +346,7 @@ export function SpansTabSeerComboBox() {
         strategy="Traces"
         applySeerSearchQuery={applySeerSearchQuery}
         transformResponse={transformResponse}
-        analyticsSource="trace.explorer"
+        feedbackSource="trace_explorer_ai_query"
         fallbackMutationOptions={spansTabAskSeerMutationOptions}
       />
     );
@@ -363,7 +357,7 @@ export function SpansTabSeerComboBox() {
       initialQuery={initialSeerQuery}
       askSeerMutationOptions={spansTabAskSeerMutationOptions}
       applySeerSearchQuery={applySeerSearchQuery}
-      analyticsSource="trace.explorer"
+      feedbackSource="trace_explorer_ai_query"
     />
   );
 }

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -346,7 +346,6 @@ export function SpansTabSeerComboBox() {
         strategy="Traces"
         applySeerSearchQuery={applySeerSearchQuery}
         transformResponse={transformResponse}
-        feedbackSource="trace_explorer_ai_query"
         fallbackMutationOptions={spansTabAskSeerMutationOptions}
       />
     );
@@ -357,7 +356,6 @@ export function SpansTabSeerComboBox() {
       initialQuery={initialSeerQuery}
       askSeerMutationOptions={spansTabAskSeerMutationOptions}
       applySeerSearchQuery={applySeerSearchQuery}
-      feedbackSource="trace_explorer_ai_query"
     />
   );
 }

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -187,10 +187,6 @@ export function IssueListSeerComboBox() {
         end: resultEnd,
       });
 
-      trackAnalytics('issue.list.ai_query_applied', {
-        organization,
-        query: queryToUse,
-      });
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
@@ -255,7 +251,7 @@ export function IssueListSeerComboBox() {
       strategy="Issues"
       applySeerSearchQuery={applySeerSearchQuery}
       transformResponse={transformResponse}
-      analyticsSource="issue.list"
+      feedbackSource="issue_list_ai_query"
       fallbackMutationOptions={issueListAskSeerMutationOptions}
     />
   );

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -251,7 +251,6 @@ export function IssueListSeerComboBox() {
       strategy="Issues"
       applySeerSearchQuery={applySeerSearchQuery}
       transformResponse={transformResponse}
-      feedbackSource="issue_list_ai_query"
       fallbackMutationOptions={issueListAskSeerMutationOptions}
     />
   );


### PR DESCRIPTION
Reverts getsentry/sentry#112184 (303c904862ab), re-applying the original cleanup from getsentry/sentry#112083.
The dashboard migration that blocked the original removal is now complete

## Summary
- Removes the unnecessary `analyticsSource` prop from `AskSeerComboBox`, `AskSeerPollingComboBox`, and all call sites (discover, logs, spans, issue list)
- Removes the `ai_query` analytics event definitions from `issueAnalyticsEvents.tsx`, `logsAnalyticsEvent.tsx`, and `tracingEventMap.tsx`
