### PR TITLE
ref(projects): Convert deprecated project redirect to hooks

### DIFF
--- a/static/app/views/projects/redirectDeprecatedProjectRoute.spec.tsx
+++ b/static/app/views/projects/redirectDeprecatedProjectRoute.spec.tsx
@@ -1,0 +1,77 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {redirectDeprecatedProjectRoute} from 'sentry/views/projects/redirectDeprecatedProjectRoute';
+
+jest.mock('sentry/utils/analytics');
+
+describe('redirectDeprecatedProjectRoute', () => {
+  const organization = OrganizationFixture({slug: 'old-org'});
+  const project = ProjectFixture({
+    id: '123',
+    slug: 'old-project',
+    organization: {id: '456', slug: organization.slug},
+  });
+  const pathname = `/${organization.slug}/${project.slug}/`;
+  const initialRouterConfig = {
+    location: {pathname},
+    route: '/:orgId/:projectId/',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
+  it('redirects legacy project routes to the generated route', async () => {
+    const projectRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: project,
+      match: [MockApiClient.matchQuery({collapse: 'organization'})],
+    });
+    const RedirectDeprecatedProjectRoute = redirectDeprecatedProjectRoute(
+      ({orgId, projectId}) => `/organizations/${orgId}/issues/?project=${projectId}`
+    );
+
+    const {router} = render(<RedirectDeprecatedProjectRoute />, {
+      initialRouterConfig,
+    });
+
+    await waitFor(() => {
+      expect(router.location).toEqual(
+        expect.objectContaining({
+          pathname: `/organizations/${organization.slug}/issues/`,
+          query: {project: project.id},
+        })
+      );
+    });
+
+    expect(projectRequest).toHaveBeenCalledTimes(1);
+    expect(trackAnalytics).toHaveBeenCalledWith('deprecated_urls.redirect', {
+      feature: 'global_views',
+      url: pathname,
+      organization: project.organization.id,
+    });
+  });
+
+  it('displays a project not found error on 404s', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      statusCode: 404,
+    });
+    const RedirectDeprecatedProjectRoute = redirectDeprecatedProjectRoute(
+      ({orgId, projectId}) => `/organizations/${orgId}/issues/?project=${projectId}`
+    );
+
+    render(<RedirectDeprecatedProjectRoute />, {
+      initialRouterConfig,
+    });
+
+    expect(
+      await screen.findByText('The project you were looking for was not found.')
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
+++ b/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
@@ -7,7 +7,7 @@ import {Redirect} from 'sentry/components/redirect';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
-import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 
@@ -57,7 +57,7 @@ export const redirectDeprecatedProjectRoute = (generateRedirectRoute: RedirectCa
     }
 
     if (!hasProjectId || !organizationId) {
-      if ((error as RequestError | null)?.status === 404) {
+      if (error instanceof RequestError && error.status === 404) {
         return (
           <Flex flex={1} padding="2xl">
             <Alert.Container>

--- a/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
+++ b/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
@@ -1,113 +1,15 @@
-import {Component} from 'react';
-import styled from '@emotion/styled';
-
 import {Alert} from '@sentry/scraps/alert';
+import {Flex} from '@sentry/scraps/layout';
 
-import type {Client} from 'sentry/api';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Redirect} from 'sentry/components/redirect';
 import {t} from 'sentry/locale';
-import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
-import {withApi} from 'sentry/utils/withApi';
-
-type DetailsProps = {
-  api: Client;
-  children: (props: ChildProps) => React.ReactNode;
-  orgId: string;
-  projectSlug: string;
-};
-
-type DetailsState = {
-  error: null | RequestError;
-  loading: boolean;
-  project: null | Project;
-};
-
-type ChildProps = DetailsState & {
-  hasProjectId: boolean;
-  organizationId: null | string;
-  projectId: null | string;
-};
-
-class ProjectDetailsInner extends Component<DetailsProps, DetailsState> {
-  state: DetailsState = {
-    loading: true,
-    error: null,
-    project: null,
-  };
-
-  componentDidMount() {
-    this.fetchData();
-  }
-
-  fetchData = async () => {
-    this.setState({
-      loading: true,
-      error: null,
-    });
-
-    const {orgId, projectSlug} = this.props;
-
-    try {
-      // TODO: Convert this class component to a functional one and use
-      // `useDetailedProject` so this request shares the same cache and the
-      // `collapse=organization` query option is applied automatically.
-      const project = await this.props.api.requestPromise(
-        `/projects/${orgId}/${projectSlug}/`,
-        {query: {collapse: 'organization'}}
-      );
-
-      this.setState({
-        loading: false,
-        error: null,
-        project,
-      });
-    } catch (error) {
-      this.setState({
-        loading: false,
-        error: error as RequestError,
-        project: null,
-      });
-    }
-  };
-
-  getProjectId() {
-    if (this.state.project) {
-      return this.state.project.id;
-    }
-    return null;
-  }
-
-  hasProjectId() {
-    const projectID = this.getProjectId();
-    return typeof projectID === 'string' && projectID.length > 0;
-  }
-
-  getOrganizationId() {
-    if (this.state.project) {
-      return this.state.project.organization.id;
-    }
-    return null;
-  }
-
-  render() {
-    const childrenProps: ChildProps = {
-      ...this.state,
-      projectId: this.getProjectId(),
-      hasProjectId: this.hasProjectId(),
-      organizationId: this.getOrganizationId(),
-    };
-
-    return this.props.children(childrenProps);
-  }
-}
-
-const ProjectDetails = withApi(ProjectDetailsInner);
 
 type RedirectOptions = {
   orgId: string;
@@ -136,46 +38,49 @@ export const redirectDeprecatedProjectRoute = (generateRedirectRoute: RedirectCa
     }
 
     const {orgId, projectId: projectSlug} = params;
+    const {
+      data: project,
+      error,
+      isPending,
+    } = useDetailedProject({orgSlug: orgId, projectSlug});
+
+    const projectId = project?.id ?? null;
+    const hasProjectId = typeof projectId === 'string' && projectId.length > 0;
+    const organizationId = project?.organization.id ?? null;
+
+    if (isPending) {
+      return (
+        <Flex flex={1} padding="2xl">
+          <LoadingIndicator />
+        </Flex>
+      );
+    }
+
+    if (!hasProjectId || !organizationId) {
+      if ((error as RequestError | null)?.status === 404) {
+        return (
+          <Flex flex={1} padding="2xl">
+            <Alert.Container>
+              <Alert variant="danger" showIcon={false}>
+                {t('The project you were looking for was not found.')}
+              </Alert>
+            </Alert.Container>
+          </Flex>
+        );
+      }
+
+      return (
+        <Flex flex={1} padding="2xl">
+          <LoadingError />
+        </Flex>
+      );
+    }
 
     return (
-      <Wrapper>
-        <ProjectDetails orgId={orgId} projectSlug={projectSlug}>
-          {({loading, error, hasProjectId, projectId, organizationId}) => {
-            if (loading) {
-              return <LoadingIndicator />;
-            }
-
-            if (!hasProjectId || !organizationId) {
-              if (error?.status === 404) {
-                return (
-                  <Alert.Container>
-                    <Alert variant="danger" showIcon={false}>
-                      {t('The project you were looking for was not found.')}
-                    </Alert>
-                  </Alert.Container>
-                );
-              }
-
-              return <LoadingError />;
-            }
-
-            const routeProps: RedirectOptions = {
-              orgId,
-              projectId,
-            };
-
-            return (
-              <Redirect
-                to={trackRedirect(organizationId, generateRedirectRoute(routeProps))}
-              />
-            );
-          }}
-        </ProjectDetails>
-      </Wrapper>
+      <Flex flex={1} padding="2xl">
+        <Redirect
+          to={trackRedirect(organizationId, generateRedirectRoute({orgId, projectId}))}
+        />
+      </Flex>
     );
   };
-
-const Wrapper = styled('div')`
-  flex: 1;
-  padding: ${p => p.theme.space['2xl']};
-`;


### PR DESCRIPTION
The deprecated project redirect route still had a class wrapper doing its own API request. This switches it over to useDetailedProject so it shares the detailed project query cache and keeps collapse=organization behavior in one place.

Adds coverage for the successful redirect path and the project 404 state.