### PR TITLE
chore(alerts): Remove unused incident endpoint code

### DIFF
--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -72,11 +72,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
 
-        has_workflow_engine_flags = features.has(
-            "organizations:workflow-engine-metric-alert-endpoints-get", organization
-        ) or features.has("organizations:workflow-engine-rule-serializers", organization)
-
-        if request.method == "GET" and has_workflow_engine_flags:
+        if request.method == "GET":
             gop: GroupOpenPeriod | None = None
 
             # Try the association table first (dual-written data).
@@ -112,7 +108,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
             kwargs["incident"] = gop
             return args, kwargs
 
-        # Legacy path (flag off): replicate IncidentEndpoint.convert_args lookup.
+        # PUT: update_incident_status operates on the legacy Incident model.
         try:
             incident = kwargs["incident"] = Incident.objects.get(
                 organization=organization, identifier=int_id
@@ -137,15 +133,12 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
         ``````````````````
         :auth: required
         """
-        if isinstance(incident, GroupOpenPeriod):
-            expand = request.GET.getlist("expand", [])
-            return Response(
-                serialize(
-                    incident, request.user, WorkflowEngineDetailedIncidentSerializer(expand=expand)
-                )
+        expand = request.GET.getlist("expand", [])
+        return Response(
+            serialize(
+                incident, request.user, WorkflowEngineDetailedIncidentSerializer(expand=expand)
             )
-
-        return Response(serialize(incident, request.user, DetailedIncidentSerializer()))
+        )
 
     @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-incident-details")
     def put(self, request: Request, organization: Organization, incident) -> Response:

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -19,14 +19,11 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.exceptions import InvalidParams
-from sentry.incidents.endpoints.serializers.incident import IncidentSerializer
 from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineIncidentSerializer,
 )
 from sentry.incidents.grouptype import MetricIssue
-from sentry.incidents.models.alert_rule import AlertRuleActivity, AlertRuleActivityType
-from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.models.environment import Environment
 from sentry.models.groupopenperiod import GroupOpenPeriod
@@ -40,10 +37,7 @@ from sentry.utils.dates import ensure_aware
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.models import AlertRuleDetector, DataSourceDetector
 from sentry.workflow_engine.models.detector_group import DetectorGroup
-from sentry.workflow_engine.utils.legacy_metric_tracking import (
-    report_used_legacy_models,
-    track_alert_endpoint_execution,
-)
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 from .utils import parse_team_params
 
@@ -80,89 +74,19 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
         query_status = request.GET.get("status")
         teams = request.GET.getlist("team", [])
 
-        use_workflow_engine = features.has(
-            "organizations:workflow-engine-rule-serializers", organization
-        ) or features.has("organizations:workflow-engine-metric-alert-endpoints-get", organization)
-
-        if use_workflow_engine:
-            return self._get_workflow_engine(
-                request,
-                organization,
-                projects=projects,
-                envs=envs,
-                expand=expand,
-                title=title,
-                query_alert_rule=query_alert_rule,
-                query_include_snapshots=query_include_snapshots,
-                query_start_s=query_start_s,
-                query_end_s=query_end_s,
-                query_status=query_status,
-                teams=teams,
-            )
-
-        incidents = Incident.objects.fetch_for_organization(organization, projects)
-        report_used_legacy_models()
-
-        if envs:
-            incidents = incidents.filter(alert_rule__snuba_query__environment__in=envs)
-        if query_alert_rule is not None:
-            query_alert_rule_id = to_valid_int_id("alertRule", query_alert_rule)
-            alert_rule_ids = [query_alert_rule_id]
-            if query_include_snapshots:
-                snapshot_alerts = AlertRuleActivity.objects.filter(
-                    previous_alert_rule=query_alert_rule_id,
-                    type=AlertRuleActivityType.SNAPSHOT.value,
-                )
-                for snapshot_alert in snapshot_alerts:
-                    alert_rule_ids.append(snapshot_alert.alert_rule_id)
-            incidents = incidents.filter(alert_rule__in=alert_rule_ids)
-
-        if query_start_s is not None:
-            # exclude incidents closed before the window
-            query_start = ensure_aware(parse_date(query_start_s))
-            incidents = incidents.exclude(date_closed__lt=query_start)
-
-        if query_end_s is not None:
-            # exclude incidents started after the window
-            query_end = ensure_aware(parse_date(query_end_s))
-            incidents = incidents.exclude(date_started__gt=query_end)
-
-        if query_status is not None:
-            if query_status == "open":
-                incidents = incidents.exclude(status=IncidentStatus.CLOSED.value)
-            elif query_status == "warning":
-                incidents = incidents.filter(status=IncidentStatus.WARNING.value)
-            elif query_status == "critical":
-                incidents = incidents.filter(status=IncidentStatus.CRITICAL.value)
-            elif query_status == "closed":
-                incidents = incidents.filter(status=IncidentStatus.CLOSED.value)
-
-        if teams:
-            try:
-                teams_query, unassigned = parse_team_params(request, organization, teams)
-            except InvalidParams as err:
-                return Response(str(err), status=status.HTTP_400_BAD_REQUEST)
-
-            team_filter_query = Q(alert_rule__team_id__in=teams_query.values_list("id", flat=True))
-            if unassigned:
-                team_filter_query = team_filter_query | Q(alert_rule__team_id__isnull=True)
-
-            incidents = incidents.filter(team_filter_query)
-
-        if title:
-            incidents = incidents.filter(Q(title__icontains=title))
-
-        if not features.has("organizations:performance-view", organization):
-            # Filter to only error alerts
-            incidents = incidents.filter(alert_rule__snuba_query__dataset=Dataset.Events.value)
-
-        return self.paginate(
+        return self._get_workflow_engine(
             request,
-            queryset=incidents,
-            order_by="-date_started",
-            paginator_cls=OffsetPaginator,
-            on_results=lambda x: serialize(x, request.user, IncidentSerializer(expand=expand)),
-            default_per_page=25,
+            organization,
+            projects=projects,
+            envs=envs,
+            expand=expand,
+            title=title,
+            query_alert_rule=query_alert_rule,
+            query_include_snapshots=query_include_snapshots,
+            query_start_s=query_start_s,
+            query_end_s=query_end_s,
+            query_status=query_status,
+            teams=teams,
         )
 
     def _get_workflow_engine(

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -1,9 +1,14 @@
 from django.utils import timezone
 
+from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
+from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.silo import no_silo_test
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
+from sentry.workflow_engine.models import IncidentGroupOpenPeriod
 
 FEATURE_NAME = ["organizations:incidents", "organizations:performance-view"]
 
@@ -17,6 +22,13 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
 
     def test_incidents_list(self) -> None:
         alert_rule = self.create_alert_rule(name="Alert Rule #1")
+        _, _, _, detector, _, _, _, _ = migrate_alert_rule(alert_rule)
+
+        group = self.create_group(type=MetricIssue.type_id, project=self.project)
+        group.update(priority=PriorityLevel.HIGH.value)
+        self.create_detector_group(detector=detector, group=group)
+        gop = GroupOpenPeriod.objects.get(group=group, project=self.project)
+
         incident = self.create_incident(
             self.organization,
             title="Incident #1",
@@ -24,6 +36,11 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
             date_detected=timezone.now(),
             projects=[self.project],
             alert_rule=alert_rule,
+        )
+        IncidentGroupOpenPeriod.objects.create(
+            group_open_period=gop,
+            incident_id=incident.id,
+            incident_identifier=incident.identifier,
         )
         update_incident_status(
             incident, IncidentStatus.CRITICAL, status_method=IncidentStatusMethod.RULE_TRIGGERED

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -1,21 +1,15 @@
 from functools import cached_property
 
-from sentry.api.serializers import serialize
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
 from sentry.workflow_engine.models import IncidentGroupOpenPeriod
-from tests.sentry.incidents.serializers.test_workflow_engine_base import (
-    TestWorkflowEngineSerializer,
-)
 
 
 class BaseIncidentDetailsTest(APITestCase):
@@ -52,64 +46,7 @@ class BaseIncidentDetailsTest(APITestCase):
         assert resp.status_code == 404
 
 
-class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest):
-    @freeze_time()
-    def test_simple(self) -> None:
-        incident = self.create_incident()
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(incident.organization.slug, incident.identifier)
-
-        expected = serialize(incident)
-
-        assert resp.data["id"] == expected["id"]
-        assert resp.data["identifier"] == expected["identifier"]
-        assert resp.data["projects"] == expected["projects"]
-        assert resp.data["dateDetected"] == expected["dateDetected"]
-        assert resp.data["dateCreated"] == expected["dateCreated"]
-        assert resp.data["projects"] == expected["projects"]
-
-    def test_workflow_engine_flag_off_uses_legacy_path(self) -> None:
-        incident = self.create_incident()
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, incident.identifier)
-        assert resp.data["id"] == str(incident.id)
-
-
-class OrganizationIncidentUpdateStatusTest(BaseIncidentDetailsTest):
-    method = "put"
-
-    def get_success_response(self, *args, **params):
-        params.setdefault("status", IncidentStatus.CLOSED.value)
-        return super().get_success_response(*args, **params)
-
-    def test_simple(self) -> None:
-        incident = self.create_incident()
-        with self.feature("organizations:incidents"):
-            self.get_success_response(
-                incident.organization.slug, incident.identifier, status=IncidentStatus.CLOSED.value
-            )
-
-        incident = Incident.objects.get(id=incident.id)
-        assert incident.status == IncidentStatus.CLOSED.value
-
-    def test_cannot_open(self) -> None:
-        incident = self.create_incident()
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(
-                incident.organization.slug, incident.identifier, status=IncidentStatus.OPEN.value
-            )
-            assert resp.status_code == 400
-            assert resp.data.startswith("Status cannot be changed")
-
-    def test_invalid_status(self) -> None:
-        incident = self.create_incident()
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(incident.organization.slug, incident.identifier, status=5000)
-            assert resp.status_code == 400
-            assert resp.data["status"][0].startswith("Invalid value for status")
-
-
-@with_feature(["organizations:incidents", "organizations:workflow-engine-rule-serializers"])
+@with_feature(["organizations:incidents"])
 class WorkflowEngineIncidentDetailsTest(APITestCase):
     endpoint = "sentry-api-0-organization-incident-details"
 
@@ -165,48 +102,35 @@ class WorkflowEngineIncidentDetailsTest(APITestCase):
         assert resp.status_code == 404
 
 
-class IncidentDetailsDeltaTest(APITestCase, TestWorkflowEngineSerializer):
-    endpoint = "sentry-api-0-organization-incident-details"
+class OrganizationIncidentUpdateStatusTest(BaseIncidentDetailsTest):
+    method = "put"
 
-    def setUp(self) -> None:
-        super().setUp()
-        self.add_warning_trigger()
-        self.add_incident_data()
-        self.login_as(self.user)
+    def get_success_response(self, *args, **params):
+        params.setdefault("status", IncidentStatus.CLOSED.value)
+        return super().get_success_response(*args, **params)
 
-    @with_feature("organizations:incidents")
-    def test_serializer_parity(self) -> None:
-        old_resp = self.get_success_response(self.organization.slug, self.incident.identifier)
+    def test_simple(self) -> None:
+        incident = self.create_incident()
+        with self.feature("organizations:incidents"):
+            self.get_success_response(
+                incident.organization.slug, incident.identifier, status=IncidentStatus.CLOSED.value
+            )
 
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            new_resp = self.get_success_response(self.organization.slug, self.incident.identifier)
+        incident = Incident.objects.get(id=incident.id)
+        assert incident.status == IncidentStatus.CLOSED.value
 
-        old_data = dict(old_resp.data)
-        new_data = dict(new_resp.data)
+    def test_cannot_open(self) -> None:
+        incident = self.create_incident()
+        with self.feature("organizations:incidents"):
+            resp = self.get_response(
+                incident.organization.slug, incident.identifier, status=IncidentStatus.OPEN.value
+            )
+            assert resp.status_code == 400
+            assert resp.data.startswith("Status cannot be changed")
 
-        # Sort triggers for order-independent comparison.
-        for data in (old_data, new_data):
-            if isinstance(data.get("alertRule"), dict):
-                data["alertRule"] = {
-                    **data["alertRule"],
-                    "triggers": sorted(
-                        data["alertRule"].get("triggers", []), key=lambda t: t.get("label", "")
-                    ),
-                }
-
-        assert_serializer_parity(
-            old=old_data,
-            new=new_data,
-            known_differences={
-                # migration always creates a resolve condition; the old serializer can
-                # return None when AlertRule.resolve_threshold is unset.
-                "alertRule.resolveThreshold",
-                "alertRule.triggers.resolveThreshold",
-                # WE derives status from group priority (HIGH→CRITICAL); legacy preserves
-                # the incident's own status field which starts as OPEN.
-                "status",
-                # WE uses the live group title; legacy preserves the incident title
-                # as it was at creation time.
-                "title",
-            },
-        )
+    def test_invalid_status(self) -> None:
+        incident = self.create_incident()
+        with self.feature("organizations:incidents"):
+            resp = self.get_response(incident.organization.slug, incident.identifier, status=5000)
+            assert resp.status_code == 400
+            assert resp.data["status"][0].startswith("Invalid value for status")

--- a/tests/sentry/incidents/endpoints/test_organization_incident_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_index.py
@@ -1,369 +1,31 @@
 from datetime import timedelta
 from functools import cached_property
 
-from django.utils import timezone
-
-from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.incidents.grouptype import MetricIssue
-from sentry.incidents.logic import update_incident_status
-from sentry.incidents.models.incident import IncidentActivity, IncidentActivityType, IncidentStatus
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
-from sentry.models.groupopenperiod import GroupOpenPeriod
-from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenPeriodActivityType
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.types.actor import Actor
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.migration_helpers.alert_rule import (
     migrate_alert_rule,
     migrate_metric_data_conditions,
     migrate_resolve_threshold_data_condition,
 )
-from sentry.workflow_engine.models import Detector, DetectorGroup, IncidentGroupOpenPeriod
+from sentry.workflow_engine.models import Detector, DetectorGroup
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
-class IncidentListEndpointTest(APITestCase):
-    endpoint = "sentry-api-0-organization-incident-index"
-
-    @cached_property
-    def organization(self):
-        return self.create_organization()
-
-    @cached_property
-    def project(self):
-        return self.create_project(organization=self.organization)
-
-    @cached_property
-    def user(self):
-        return self.create_user()
-
-    def test_simple(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        incident = self.create_incident()
-        other_incident = self.create_incident(status=IncidentStatus.CLOSED.value)
-
-        self.login_as(self.user)
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_success_response(self.organization.slug)
-
-        assert resp.data == serialize([other_incident, incident])
-
-    def test_filter_status(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        incident = self.create_incident()
-        closed_incident = self.create_incident(status=IncidentStatus.CLOSED.value)
-        self.login_as(self.user)
-
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp_closed = self.get_success_response(self.organization.slug, status="closed")
-            resp_open = self.get_success_response(self.organization.slug, status="open")
-
-        assert len(resp_closed.data) == 1
-        assert len(resp_open.data) == 1
-        assert resp_closed.data == serialize([closed_incident])
-        assert resp_open.data == serialize([incident])
-
-    def test_filter_env(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        env = self.create_environment(self.project)
-        rule = self.create_alert_rule(projects=[self.project], environment=env)
-
-        incident = self.create_incident(alert_rule=rule)
-        self.create_incident()
-
-        self.login_as(self.user)
-
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp_filter_env = self.get_success_response(
-                self.organization.slug, environment=env.name
-            )
-            resp_no_env_filter = self.get_success_response(self.organization.slug)
-
-        # The alert without an environment assigned should not be selected
-        assert len(resp_filter_env.data) == 1
-        assert resp_filter_env.data == serialize([incident])
-
-        # No filter returns both incidents
-        assert len(resp_no_env_filter.data) == 2
-
-    def test_no_feature(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-        resp = self.get_response(self.organization.slug)
-        assert resp.status_code == 404
-
-    def test_no_perf_alerts(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        # alert_rule = self.create_alert_rule()
-        perf_alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
-
-        perf_incident = self.create_incident(alert_rule=perf_alert_rule)
-        incident = self.create_incident()
-
-        self.login_as(self.user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug)
-            assert resp.data == serialize([incident])
-
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_success_response(self.organization.slug)
-            assert resp.data == serialize([incident, perf_incident])
-
-    def test_filter_start_end_times(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        old_incident = self.create_incident(date_started=timezone.now() - timedelta(hours=26))
-        update_incident_status(
-            incident=old_incident,
-            status=IncidentStatus.CLOSED,
-            date_closed=timezone.now() - timedelta(hours=25),
-        )
-        new_incident = self.create_incident(date_started=timezone.now() - timedelta(hours=2))
-        update_incident_status(
-            incident=new_incident,
-            status=IncidentStatus.CLOSED,
-            date_closed=timezone.now() - timedelta(hours=1),
-        )
-        self.login_as(self.user)
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp_all = self.get_success_response(self.organization.slug)
-            resp_new = self.get_success_response(
-                self.organization.slug,
-                start=(timezone.now() - timedelta(hours=12)).isoformat(),
-                end=timezone.now().isoformat(),
-            )
-            resp_old = self.get_success_response(
-                self.organization.slug,
-                start=(timezone.now() - timedelta(hours=36)).isoformat(),
-                end=(timezone.now() - timedelta(hours=24)).isoformat(),
-            )
-
-        assert resp_all.data == serialize([new_incident, old_incident])
-        assert resp_new.data == serialize([new_incident])
-        assert resp_old.data == serialize([old_incident])
-
-    def test_filter_name(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        incident = self.create_incident(title="yet another alert rule")
-        self.login_as(self.user)
-
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            results = self.get_success_response(self.organization.slug, title="yet")
-            no_results = self.get_success_response(self.organization.slug, title="no results")
-
-        assert len(results.data) == 1
-        assert len(no_results.data) == 0
-        assert results.data == serialize([incident])
-
-    def test_rule_teams(self) -> None:
-        team = self.create_team(organization=self.organization, members=[self.user])
-        alert_rule = self.create_alert_rule(
-            name="alert rule",
-            organization=self.organization,
-            projects=[self.project],
-            owner=Actor.from_id(user_id=None, team_id=team.id),
-        )
-        other_team = self.create_team(organization=self.organization, members=[self.user])
-        other_alert_rule = self.create_alert_rule(
-            name="rule 2",
-            organization=self.organization,
-            projects=[self.project],
-            owner=Actor.from_id(user_id=None, team_id=other_team.id),
-        )
-        unassigned_alert_rule = self.create_alert_rule(
-            name="rule 66",
-            organization=self.organization,
-            projects=[self.project],
-        )
-        self.create_incident(alert_rule=alert_rule)
-        self.create_incident(alert_rule=other_alert_rule)
-        self.create_incident(alert_rule=unassigned_alert_rule)
-        self.login_as(self.user)
-
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            results = self.get_success_response(self.organization.slug, project=[self.project.id])
-        assert len(results.data) == 3
-
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            results = self.get_success_response(
-                self.organization.slug, project=[self.project.id], team=[team.id]
-            )
-        assert len(results.data) == 1
-
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            results = self.get_success_response(
-                self.organization.slug, project=[self.project.id], team=[team.id, other_team.id]
-            )
-        assert len(results.data) == 2
-
-
-class IncidentListDeltaTest(APITestCase):
-    endpoint = "sentry-api-0-organization-incident-index"
-
-    @cached_property
-    def organization(self):
-        return self.create_organization()
-
-    @cached_property
-    def project(self):
-        return self.create_project(organization=self.organization)
-
-    @cached_property
-    def user(self):
-        return self.create_user()
-
-    @freeze_time("2024-12-11 03:21:34")
-    def test_workflow_engine_serializer_matches_old_serializer(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-
-        alert_rule = self.create_alert_rule()
-        trigger = self.create_alert_rule_trigger(alert_rule=alert_rule)
-        _, _, _, detector, _, _, _, _ = migrate_alert_rule(alert_rule)
-        migrate_metric_data_conditions(trigger)
-        migrate_resolve_threshold_data_condition(alert_rule)
-
-        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CRITICAL.value)
-
-        with assume_test_silo_mode(SiloMode.CELL):
-            group = self.create_group(type=MetricIssue.type_id, project=self.project)
-            group.priority = PriorityLevel.HIGH.value
-            group.save()
-            DetectorGroup.objects.create(detector=detector, group=group)
-
-            group_open_period = GroupOpenPeriod.objects.get(group=group, project=self.project)
-            group_open_period.update(date_started=incident.date_started)
-
-            IncidentGroupOpenPeriod.objects.create(
-                group_open_period=group_open_period,
-                incident_id=incident.id,
-                incident_identifier=incident.identifier,
-            )
-
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            old_resp = self.get_success_response(self.organization.slug)
-        old_data = old_resp.data
-        assert len(old_data) > 0
-
-        with self.feature(
-            [
-                "organizations:incidents",
-                "organizations:performance-view",
-                "organizations:workflow-engine-rule-serializers",
-            ]
-        ):
-            new_resp = self.get_success_response(self.organization.slug)
-        new_data = new_resp.data
-        assert len(new_data) == len(old_data)
-
-        for old_incident, new_incident in zip(old_data, new_data):
-            assert_serializer_parity(
-                old=old_incident,
-                new=new_incident,
-                known_differences={
-                    # resolveThreshold: WE serializer always creates a resolve condition during migration;
-                    # legacy serializer returns None when AlertRule.resolve_threshold is None.
-                    "alertRule.resolveThreshold",
-                    # triggers.resolveThreshold: same reason as alertRule.resolveThreshold.
-                    "alertRule.triggers.resolveThreshold",
-                    # triggers.label: legacy uses the user-defined trigger name; WE uses "critical"/"warning".
-                    "alertRule.triggers.label",
-                    # title: Old system uses Incident.title (set from AlertRule.name at incident creation time),
-                    # WE system uses Group.title (the issue title). These are typically different strings.
-                    "title",
-                },
-            )
-
-    @freeze_time("2024-12-11 03:21:34")
-    def test_activity_serialization_parity(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-
-        alert_rule = self.create_alert_rule()
-        trigger = self.create_alert_rule_trigger(alert_rule=alert_rule)
-        _, _, _, detector, _, _, _, _ = migrate_alert_rule(alert_rule)
-        migrate_metric_data_conditions(trigger)
-        migrate_resolve_threshold_data_condition(alert_rule)
-
-        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CRITICAL.value)
-
-        with assume_test_silo_mode(SiloMode.CELL):
-            group = self.create_group(type=MetricIssue.type_id, project=self.project)
-            group.priority = PriorityLevel.HIGH.value
-            group.save()
-            DetectorGroup.objects.create(detector=detector, group=group)
-
-            group_open_period = GroupOpenPeriod.objects.get(group=group, project=self.project)
-            group_open_period.update(date_started=incident.date_started)
-
-            IncidentGroupOpenPeriod.objects.create(
-                group_open_period=group_open_period,
-                incident_id=incident.id,
-                incident_identifier=incident.identifier,
-            )
-
-            # Legacy activity: STATUS_CHANGE to CRITICAL
-            IncidentActivity.objects.create(
-                incident=incident,
-                type=IncidentActivityType.STATUS_CHANGE.value,
-                value=str(IncidentStatus.CRITICAL.value),
-                previous_value=None,
-            )
-
-            # Matching WE activity: OPENED with HIGH priority (maps to CRITICAL)
-            GroupOpenPeriodActivity.objects.create(
-                group_open_period=group_open_period,
-                type=OpenPeriodActivityType.OPENED,
-                value=PriorityLevel.HIGH,
-                date_added=incident.date_started,
-            )
-
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            old_resp = self.get_success_response(self.organization.slug, expand="activities")
-        old_data = old_resp.data
-        assert len(old_data) > 0
-
-        with self.feature(
-            [
-                "organizations:incidents",
-                "organizations:performance-view",
-                "organizations:workflow-engine-rule-serializers",
-            ]
-        ):
-            new_resp = self.get_success_response(self.organization.slug, expand="activities")
-        new_data = new_resp.data
-        assert len(new_data) == len(old_data)
-
-        for old_incident_data, new_incident_data in zip(old_data, new_data):
-            assert_serializer_parity(
-                old=old_incident_data,
-                new=new_incident_data,
-                known_differences={
-                    "alertRule.resolveThreshold",
-                    "alertRule.triggers.resolveThreshold",
-                    "alertRule.triggers.label",
-                    "title",
-                    # Legacy activities include fields the WE path intentionally omits
-                    "activities.incidentIdentifier",
-                    "activities.user",
-                    "activities.comment",
-                },
-                # Different tables with independent auto-increment sequences
-                unreliable={"activities.id"},
-            )
-
-
+@with_feature(["organizations:incidents", "organizations:performance-view"])
 class WorkflowEngineIncidentListTest(APITestCase):
     endpoint = "sentry-api-0-organization-incident-index"
 
@@ -395,33 +57,15 @@ class WorkflowEngineIncidentListTest(APITestCase):
             group.save()
             DetectorGroup.objects.create(detector=detector, group=group)
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            old_resp = self.get_success_response(self.organization.slug)
-        assert len(old_resp.data) == 0
+        resp = self.get_success_response(self.organization.slug)
+        assert len(resp.data) == 1
 
-        with self.feature(
-            [
-                "organizations:incidents",
-                "organizations:performance-view",
-                "organizations:workflow-engine-rule-serializers",
-            ]
-        ):
-            new_resp = self.get_success_response(self.organization.slug)
-        assert len(new_resp.data) == 1
-
-        incident_data = new_resp.data[0]
+        incident_data = resp.data[0]
         assert incident_data["status"] == IncidentStatus.CRITICAL.value
         assert incident_data["organizationId"] == str(self.organization.id)
         assert incident_data["projects"] == [self.project.slug]
         assert incident_data["id"] is not None
 
-    @with_feature(
-        [
-            "organizations:incidents",
-            "organizations:performance-view",
-            "organizations:workflow-engine-rule-serializers",
-        ]
-    )
     def test_single_written_metric_issue(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
@@ -485,13 +129,6 @@ class WorkflowEngineIncidentListTest(APITestCase):
         assert incident_data["alertRule"] is not None
         assert incident_data["alertRule"]["id"] == str(get_fake_id_from_object_id(detector.id))
 
-    @with_feature(
-        [
-            "organizations:incidents",
-            "organizations:performance-view",
-            "organizations:workflow-engine-rule-serializers",
-        ]
-    )
     def test_filter_by_fake_alert_rule_id(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
@@ -525,13 +162,6 @@ class WorkflowEngineIncidentListTest(APITestCase):
 
         assert len(resp_empty.data) == 0
 
-    @with_feature(
-        [
-            "organizations:incidents",
-            "organizations:performance-view",
-            "organizations:workflow-engine-rule-serializers",
-        ]
-    )
     def test_filter_by_alert_rule_excludes_pending_deletion_detector(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -234,44 +234,46 @@ class FetchOpenPeriodsTest(BaseMetricIssueTest):
     @freeze_time(frozen_time)
     @with_feature("organizations:incidents")
     def test_get_incidents_from_detector(self) -> None:
-        self.create_detector()  # dummy so detector ID != alert rule ID
-        detector = self.create_detector(project=self.project)
-        alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
-        self.create_alert_rule_detector(detector=detector, alert_rule_id=alert_rule.id)
-        incident = self.create_incident(
-            date_started=must_parse_datetime("2022-05-16T18:55:00Z"),
-            status=IncidentStatus.CRITICAL.value,
-            alert_rule=alert_rule,
+        group = self.create_group(
+            project=self.project, type=MetricIssue.type_id, priority=PriorityLevel.HIGH
         )
-        # create incident activity the same way we do in logic.py create_incident
-        detected_activity = self.create_incident_activity(
-            incident,
-            IncidentActivityType.DETECTED.value,
-            date_added=incident.date_started,
+        DetectorGroup.objects.create(detector=self.detector, group=group)
+        group_open_period = GroupOpenPeriod.objects.get(group=group)
+
+        opened_gopa = GroupOpenPeriodActivity.objects.create(
+            date_added=group_open_period.date_added,
+            group_open_period=group_open_period,
+            type=OpenPeriodActivityType.OPENED,
+            value=group.priority,
         )
-        created_activity = self.create_incident_activity(
-            incident,
-            IncidentActivityType.CREATED.value,
+        closed_gopa = GroupOpenPeriodActivity.objects.create(
+            date_added=group_open_period.date_added + datetime.timedelta(minutes=5),
+            group_open_period=group_open_period,
+            type=OpenPeriodActivityType.CLOSED,
         )
 
-        time_period = incident_date_range(60, incident.date_started, incident.date_closed)
+        time_period = incident_date_range(
+            60, group_open_period.date_started, group_open_period.date_ended
+        )
 
-        chart_data = fetch_metric_issue_open_periods(self.organization, detector.id, time_period)
-        assert chart_data[0]["alertRule"]["id"] == str(alert_rule.id)
+        chart_data = fetch_metric_issue_open_periods(
+            self.organization, self.detector.id, time_period
+        )
+        assert chart_data[0]["alertRule"]["id"] == str(self.alert_rule.id)
         assert chart_data[0]["projects"] == [self.project.slug]
-        assert chart_data[0]["dateStarted"] == incident.date_started
+        assert chart_data[0]["dateStarted"] == group_open_period.date_started
 
         assert len(chart_data[0]["activities"]) == 2
-        detected_activity_resp = chart_data[0]["activities"][0]
-        created_activity_resp = chart_data[0]["activities"][1]
+        opened_activity_resp = chart_data[0]["activities"][0]
+        closed_activity_resp = chart_data[0]["activities"][1]
 
-        assert detected_activity_resp["incidentIdentifier"] == str(incident.identifier)
-        assert detected_activity_resp["type"] == IncidentActivityType.DETECTED.value
-        assert detected_activity_resp["dateCreated"] == detected_activity.date_added
+        assert opened_activity_resp["id"] == str(opened_gopa.id)
+        assert opened_activity_resp["type"] == IncidentActivityType.STATUS_CHANGE.value
+        assert opened_activity_resp["dateCreated"] == opened_gopa.date_added
 
-        assert created_activity_resp["incidentIdentifier"] == str(incident.identifier)
-        assert created_activity_resp["type"] == IncidentActivityType.CREATED.value
-        assert created_activity_resp["dateCreated"] == created_activity.date_added
+        assert closed_activity_resp["id"] == str(closed_gopa.id)
+        assert closed_activity_resp["type"] == IncidentActivityType.STATUS_CHANGE.value
+        assert closed_activity_resp["dateCreated"] == closed_gopa.date_added
 
     @freeze_time(frozen_time)
     @with_feature("organizations:incidents")

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -9,7 +9,9 @@ from django.utils import timezone
 
 from sentry.charts.types import ChartType
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
+from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
+from sentry.incidents.models.incident import Incident
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.integrations.slack.message_builder.discover import SlackDiscoverMessageBuilder
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
@@ -18,6 +20,7 @@ from sentry.integrations.slack.unfurl.dashboards import build_widget_timeseries_
 from sentry.integrations.slack.unfurl.handlers import link_handlers, match_link
 from sentry.integrations.slack.unfurl.types import LinkType, UnfurlableUrl
 from sentry.models.dashboard_widget import DashboardWidgetDisplayTypes, DashboardWidgetTypes
+from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.search.eap.types import SupportedTraceItemType
 from sentry.snuba import discover, errors, transactions
 from sentry.snuba.dataset import Dataset
@@ -28,6 +31,9 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
+from sentry.workflow_engine.models import IncidentGroupOpenPeriod
 
 pytestmark = [requires_snuba, pytest.mark.sentry_metrics]
 
@@ -325,6 +331,29 @@ class UnfurlTest(TestCase):
     def tearDown(self) -> None:
         self.frozen_time.stop()
 
+    def _wire_workflow_engine_for_incident(self, alert_rule, incident: Incident) -> None:
+        """
+        Wire up the workflow engine fixtures so that the /incidents/ endpoint
+        (which always routes through _get_workflow_engine) returns this incident.
+        """
+        _, _, _, detector, _, _, _, _ = migrate_alert_rule(alert_rule)
+        group = self.create_group(
+            project=self.project,
+            type=MetricIssue.type_id,
+            priority=PriorityLevel.HIGH,
+            first_seen=incident.date_started,
+        )
+        self.create_detector_group(detector=detector, group=group)
+        gop = GroupOpenPeriod.objects.get(group=group)
+        # Align the open period's date_started with the incident's so the chart's
+        # time-window query (which truncates to seconds via strftime) includes it.
+        gop.update(date_started=incident.date_started)
+        IncidentGroupOpenPeriod.objects.create(
+            group_open_period=gop,
+            incident_id=incident.id,
+            incident_identifier=incident.identifier,
+        )
+
     def test_unfurl_issues(self) -> None:
         min_ago = before_now(minutes=1).isoformat()
         event = self.store_event(
@@ -451,6 +480,7 @@ class UnfurlTest(TestCase):
         self.create_alert_rule_trigger_action(
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
+        self._wire_workflow_engine_for_incident(alert_rule, incident)
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/issues/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}"
         links = [
@@ -502,6 +532,7 @@ class UnfurlTest(TestCase):
             alert_rule=alert_rule,
             date_started=timezone.now() - timedelta(minutes=2),
         )
+        self._wire_workflow_engine_for_incident(alert_rule, incident)
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/issues/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}"
         links = [
@@ -559,6 +590,7 @@ class UnfurlTest(TestCase):
         self.create_alert_rule_trigger_action(
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
+        self._wire_workflow_engine_for_incident(alert_rule, incident)
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/issues/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}"
         links = [


### PR DESCRIPTION
Remove unused incident code - this is part of me prepping to remove `IncidentActivity` and there are more pieces to it but the last PR got very large so I broke this part out. `organizations:workflow-engine-metric-alert-endpoints-get` has been GA'd for a couple weeks.