### PR TITLE
fix(releases): Handle integration token states in releases promo

### DIFF
--- a/static/app/views/explore/releases/list/releasesPromo.tsx
+++ b/static/app/views/explore/releases/list/releasesPromo.tsx
@@ -109,9 +109,15 @@ export function ReleasesPromo({organization, project}: Props) {
 
   const api = useApi();
   const containerRef = useRef<HTMLDivElement>(null);
-  const [token, setToken] = useState<string | null>(null);
+  const [tokenForApp, setTokenForApp] = useState<{slug: string; token: string} | null>(
+    null
+  );
   const [apps, setApps] = useState<SentryApp[]>([]);
   const [selectedApp, setSelectedApp] = useState<SentryApp | null>(null);
+  const inflightSlugRef = useRef<string | null>(null);
+
+  const token =
+    tokenForApp && tokenForApp.slug === selectedApp?.slug ? tokenForApp.token : null;
 
   useEffect(() => {
     if (!isPending && data) {
@@ -161,11 +167,17 @@ export function ReleasesPromo({organization, project}: Props) {
   }, [organization, project.id]);
 
   const generateAndSetNewToken = async (sentryAppSlug: string) => {
-    setToken(null);
+    inflightSlugRef.current = sentryAppSlug;
     try {
       const newToken = await generateToken(sentryAppSlug);
-      setToken(newToken);
+      if (inflightSlugRef.current !== sentryAppSlug) {
+        return;
+      }
+      setTokenForApp({slug: sentryAppSlug, token: newToken});
     } catch {
+      if (inflightSlugRef.current !== sentryAppSlug) {
+        return;
+      }
       const app = apps.find(a => a.slug === sentryAppSlug);
       addErrorMessage(
         tct('Unable to generate token for [name].', {name: app?.name ?? sentryAppSlug})

--- a/static/app/views/explore/releases/list/releasesPromo.tsx
+++ b/static/app/views/explore/releases/list/releasesPromo.tsx
@@ -161,6 +161,7 @@ export function ReleasesPromo({organization, project}: Props) {
   }, [organization, project.id]);
 
   const generateAndSetNewToken = async (sentryAppSlug: string) => {
+    setToken(null);
     try {
       const newToken = await generateToken(sentryAppSlug);
       setToken(newToken);

--- a/static/app/views/explore/releases/list/releasesPromo.tsx
+++ b/static/app/views/explore/releases/list/releasesPromo.tsx
@@ -17,7 +17,6 @@ import {
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
-import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openCreateReleaseIntegration} from 'sentry/actionCreators/modal';
@@ -293,14 +292,15 @@ sentry-cli releases finalize "$VERSION"`;
               </MenuComponents.CTAButton>
             )}
             trigger={triggerProps => (
-              <Tooltip title={generateTokenDisabledReason} disabled={canGenerateToken}>
-                <OverlayTrigger.Button
-                  {...triggerProps}
-                  prefix={selectedApp ? t('Token From') : undefined}
-                >
-                  {selectedApp ? triggerProps.children : t('Select Integration')}
-                </OverlayTrigger.Button>
-              </Tooltip>
+              <OverlayTrigger.Button
+                {...triggerProps}
+                prefix={selectedApp ? t('Token From') : undefined}
+                tooltipProps={{
+                  title: canGenerateToken ? undefined : generateTokenDisabledReason,
+                }}
+              >
+                {selectedApp ? triggerProps.children : t('Select Integration')}
+              </OverlayTrigger.Button>
             )}
             onChange={option => {
               const app = apps.find(i => i.slug === option.value)!;

--- a/static/app/views/explore/releases/list/releasesPromo.tsx
+++ b/static/app/views/explore/releases/list/releasesPromo.tsx
@@ -17,7 +17,9 @@ import {
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openCreateReleaseIntegration} from 'sentry/actionCreators/modal';
 import {sentryAppsApiOptions} from 'sentry/actionCreators/sentryApps';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -29,7 +31,7 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {simpleHtmlToMarkdown} from 'sentry/components/onboarding/utils/stepsToMarkdown';
 import {Panel} from 'sentry/components/panels/panel';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {SentryApp} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -159,8 +161,16 @@ export function ReleasesPromo({organization, project}: Props) {
   }, [organization, project.id]);
 
   const generateAndSetNewToken = async (sentryAppSlug: string) => {
-    const newToken = await generateToken(sentryAppSlug);
-    return setToken(newToken);
+    try {
+      const newToken = await generateToken(sentryAppSlug);
+      setToken(newToken);
+    } catch {
+      const app = apps.find(a => a.slug === sentryAppSlug);
+      addErrorMessage(
+        tct('Unable to generate token for [name].', {name: app?.name ?? sentryAppSlug})
+      );
+      setSelectedApp(null);
+    }
   };
 
   const generateToken = async (sentryAppSlug: string) => {
@@ -189,7 +199,9 @@ curl -sL https://sentry.io/get-cli/ | bash
 export SENTRY_AUTH_TOKEN=${
     token && selectedApp
       ? `${token} # From internal integration: ${selectedApp.name}`
-      : '[select an integration above]'
+      : selectedApp
+        ? '[generating token...]'
+        : '[select an integration above]'
   }
 export SENTRY_ORG=${organization.slug}
 export SENTRY_PROJECT=${project.slug}
@@ -205,6 +217,10 @@ sentry-cli releases finalize "$VERSION"`;
   }
 
   const canMakeIntegration = organization.access.includes('org:integrations');
+  const canGenerateToken = organization.access.includes('org:write');
+  const generateTokenDisabledReason = t(
+    'You must be an organization owner or manager to generate an integration token.'
+  );
 
   return (
     <Panel>
@@ -234,7 +250,7 @@ sentry-cli releases finalize "$VERSION"`;
             value={selectedApp?.slug}
             emptyMessage={t('No Integrations')}
             search
-            disabled={false}
+            disabled={!canGenerateToken}
             menuFooter={({closeOverlay}) => (
               <MenuComponents.CTAButton
                 tooltipProps={{
@@ -264,12 +280,14 @@ sentry-cli releases finalize "$VERSION"`;
               </MenuComponents.CTAButton>
             )}
             trigger={triggerProps => (
-              <OverlayTrigger.Button
-                {...triggerProps}
-                prefix={selectedApp ? t('Token From') : undefined}
-              >
-                {selectedApp ? triggerProps.children : t('Select Integration')}
-              </OverlayTrigger.Button>
+              <Tooltip title={generateTokenDisabledReason} disabled={canGenerateToken}>
+                <OverlayTrigger.Button
+                  {...triggerProps}
+                  prefix={selectedApp ? t('Token From') : undefined}
+                >
+                  {selectedApp ? triggerProps.children : t('Select Integration')}
+                </OverlayTrigger.Button>
+              </Tooltip>
             )}
             onChange={option => {
               const app = apps.find(i => i.slug === option.value)!;


### PR DESCRIPTION
We have a funky little Releases empty state:
<img width="646" height="311" alt="Screenshot 2026-05-10 at 11 00 37 PM" src="https://github.com/user-attachments/assets/ce37977f-509d-40c1-a5fc-da71e660b866" />

There's an odd behaviour here where selecting an integration from the dropdown immediately fires off a request to make a new integration token. There's a bug filed against this UI in EXP-871 where the snippet never updates.

It never updates because the token creation might silently fail! This PR first of all guards against the most common failure (checking permissions) and secondly fires off a little error toast so people can at least know what's going on. Also, there's now a little loading state.