### PR TITLE
chore(cross-events): Clean up feature flag

### DIFF
--- a/static/app/views/explore/spans/content.spec.tsx
+++ b/static/app/views/explore/spans/content.spec.tsx
@@ -23,7 +23,7 @@ function TopBarWrapper({children}: {children: ReactNode}) {
 describe('ExploreContent', () => {
   const {organization, project} = initializeOrg({
     organization: {
-      features: ['gen-ai-features', 'traces-page-cross-event-querying'],
+      features: ['gen-ai-features'],
     },
   });
 

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -57,7 +57,7 @@ const datePageFilterProps: DatePageFilterProps = {
 describe('SpansTabContent', () => {
   const {organization, project} = initializeOrg({
     organization: {
-      features: ['gen-ai-features', 'traces-page-cross-event-querying'],
+      features: ['gen-ai-features'],
     },
   });
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -211,10 +211,6 @@ function SpanTabContentSectionInner({
     sortBys: sortBys.map(s => (s.kind === 'desc' ? `-${s.field}` : s.field)),
   });
 
-  const hasCrossEventQueries = organization.features.includes(
-    'traces-page-cross-event-querying'
-  );
-
   const queryType =
     tab === Mode.AGGREGATE
       ? 'aggregate'
@@ -234,7 +230,7 @@ function SpanTabContentSectionInner({
     enabled: isReady && queryType === 'aggregate',
     queryExtras: {
       caseInsensitive,
-      ...(hasCrossEventQueries && defined(crossEventQueries) ? crossEventQueries : {}),
+      ...crossEventQueries,
     },
   });
   const spansTableResult = useExploreSpansTable({
@@ -243,7 +239,7 @@ function SpanTabContentSectionInner({
     enabled: isReady && queryType === 'samples',
     queryExtras: {
       caseInsensitive,
-      ...(hasCrossEventQueries && defined(crossEventQueries) ? crossEventQueries : {}),
+      ...crossEventQueries,
     },
   });
   const tracesTableQuery = useQuery({
@@ -252,7 +248,7 @@ function SpanTabContentSectionInner({
       limit,
       queryExtras: {
         caseInsensitive,
-        ...(hasCrossEventQueries && defined(crossEventQueries) ? crossEventQueries : {}),
+        ...crossEventQueries,
       },
     }),
     select: selectJsonWithHeaders,
@@ -269,7 +265,7 @@ function SpanTabContentSectionInner({
       enabled: isReady,
       queryExtras: {
         caseInsensitive,
-        ...(hasCrossEventQueries && defined(crossEventQueries) ? crossEventQueries : {}),
+        ...crossEventQueries,
       },
     });
 

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -77,12 +77,8 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
   const hasRawSearchReplacement = organization.features.includes(
     'search-query-builder-raw-search-replacement'
   );
-  const hasCrossEventQueryingFlag = organization.features.includes(
-    'traces-page-cross-event-querying'
-  );
 
-  const hasCrossEvents =
-    hasCrossEventQueryingFlag && defined(crossEvents) && crossEvents.length > 0;
+  const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
 
   const {attributes: numberAttributes, isLoading: numberAttributesLoading} =
     useSpanItemAttributes({}, 'number');
@@ -184,7 +180,7 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
                 <SpansSearchBar
                   spanSearchQueryBuilderProps={spanSearchQueryBuilderProps}
                 />
-                {hasCrossEventQueryingFlag ? <CrossEventQueryingDropdown /> : null}
+                <CrossEventQueryingDropdown />
                 {hasCrossEvents ? <SpansTabCrossEventSearchBars /> : null}
               </Grid>
               {hasCrossEvents ? null : (


### PR DESCRIPTION
This PR cleans up the feature flag checks in the UI for cross-event queries, since we've rolled it out fully to GA.