### PR TITLE
fix(conversations): Quote conversation ID in explore query

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -124,7 +124,7 @@ export function ConversationAggregatesBar({
   const errorsUrl = getExploreUrl({
     organization,
     selection,
-    query: `gen_ai.conversation.id:"${conversationId}" span.status:internal_error`,
+    query: `gen_ai.conversation.id:"${conversationId.replace(/"/g, '\\"')}" span.status:internal_error`,
   });
 
   return (

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -124,7 +124,7 @@ export function ConversationAggregatesBar({
   const errorsUrl = getExploreUrl({
     organization,
     selection,
-    query: `gen_ai.conversation.id:${conversationId} span.status:internal_error`,
+    query: `gen_ai.conversation.id:"${conversationId}" span.status:internal_error`,
   });
 
   return (


### PR DESCRIPTION
Conversation IDs containing colons (e.g. `slack:D0AP8S33J2D:1777059410.613279`) break the Explore page because the search query `gen_ai.conversation.id:slack:D0A18S33J2D:...` is parsed as multiple `attribute:value` pairs. Wrapping the value in double quotes prevents the colon-delimited ID from being split by the query parser.

Fixes TET-2338