### PR TITLE
fix(ourlogs): add min-height of 20vh or 15rem to page main items

### DIFF
--- a/static/app/views/explore/components/viewportConstrainedPage.tsx
+++ b/static/app/views/explore/components/viewportConstrainedPage.tsx
@@ -13,9 +13,7 @@ interface ViewportConstrainedPageProps extends FlexProps {
  * A page layout that constrains itself to the viewport height to prevent
  * window-level scrolling. Uses CSS size containment so that the page's
  * intrinsic size doesn't bubble up through the flex chain — the flex
- * algorithm sizes it to exactly the remaining space after siblings
- * (TopBar, Footer, etc.), and content within must manage its own
- * overflow (e.g. via scrollable table bodies).
+ * algorithm sizes it to exactly the remaining space after siblings.
  *
  * When constrained, the global footer sibling is hidden on smaller
  * viewport heights and when `hideFooter` is set.
@@ -42,6 +40,7 @@ export function ViewportConstrainedPage({
 
 const ConstrainedPage = styled(Stack)`
   contain: size;
+  overflow-y: auto;
 
   @media (max-height: ${SHORT_VIEWPORT_HEIGHT}px) {
     ~ footer {

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -519,7 +519,7 @@ export function LogsTabContent({datePageFilterProps, tableExpando}: LogsTabProps
                 </TableActionsContainer>
               )}
             </LogsTableActionsContainer>
-            <LogsItemContainer overflowX="auto">
+            <LogsItemContainer minHeight="max(25vh, 20rem)" overflowX="auto">
               {tableTab === 'logs' ? (
                 <LogsInfiniteTable
                   analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}


### PR DESCRIPTION
If the user puts a lot of charts on the logs page then there's no way to avoid needing a vertical scrollbar. This:

* Allows `ViewportConstrainedPage` to have a vertical scrollbar if needed
* Adds a logs table min-height of 25% of the viewport height, or at least 15rem

With every added complexity, I look forward to LOGS-664 (the cleanup task) a little bit more.

Fixes LOGS-791