### PR TITLE
fix(slack): Drop empty list filter values when unfurling dashboards

### DIFF
--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -309,7 +309,7 @@ def _apply_page_filters(
     # project: URL wins. Otherwise fall back to the dashboard's projects.
     # An unconfigured dashboard (no projects, no all_projects) omits the
     # param so the API defaults to "My Projects", matching the dashboard FE.
-    project_values = url_params.getlist("project")
+    project_values = [project for project in url_params.getlist("project") if project]
     if not project_values:
         project_values = [str(p) for p in dashboard_filters.get("projects") or []]
     if project_values:
@@ -317,7 +317,7 @@ def _apply_page_filters(
 
     # environment: URL wins. Otherwise fall back to dashboard, or omit (no
     # filter) to match the FE default of "All Environments".
-    env_values = url_params.getlist("environment")
+    env_values = [environment for environment in url_params.getlist("environment") if environment]
     if not env_values:
         env_values = list(dashboard_filters.get("environment") or [])
     if env_values:
@@ -370,10 +370,12 @@ def _dashboard_filter_conditions(
     Storage uses snake_case (``global_filter``); URL params use camelCase
     (``globalFilter``), each value JSON-encoded.
     """
-    url_release = url_params.getlist("release")
+    url_release = [release for release in url_params.getlist("release") if release]
     release = url_release if url_release else list(dashboard_filters.get("release") or [])
 
-    url_global = url_params.getlist("globalFilter")
+    url_global = [
+        global_filter for global_filter in url_params.getlist("globalFilter") if global_filter
+    ]
     if url_global:
         global_filters: list[dict[str, Any]] = []
         for raw in url_global:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -3179,6 +3179,40 @@ class BuildWidgetTimeseriesParamsTest(TestCase):
 
         assert params["query"] == 'release:["v1.0.0","v2.0.0"]'
 
+    def test_url_empty_release_falls_back_to_dashboard_release(self) -> None:
+        widget = self._make_widget()
+        widget.dashboard.filters = {"release": ["v1.0.0"]}
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict("release="))[0]
+
+        assert params["query"] == 'release:"v1.0.0"'
+
+    def test_url_empty_release_with_no_dashboard_release_omits_query(self) -> None:
+        widget = self._make_widget()
+
+        params = build_widget_timeseries_params(widget, QueryDict("release="))[0]
+
+        assert "query" not in params
+
+    def test_url_empty_project_falls_back_to_dashboard_projects(self) -> None:
+        project_a = self.create_project(organization=self.organization)
+        widget = self._make_widget()
+        widget.dashboard.projects.set([project_a])
+
+        params = build_widget_timeseries_params(widget, QueryDict("project="))[0]
+
+        assert params["project"] == str(project_a.id)
+
+    def test_url_empty_environment_falls_back_to_dashboard_environment(self) -> None:
+        widget = self._make_widget()
+        widget.dashboard.filters = {"environment": ["prod"]}
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict("environment="))[0]
+
+        assert params["environment"] == "prod"
+
     def test_dashboard_global_filter_applied_when_dataset_matches(self) -> None:
         widget = self._make_widget(widget_type=DashboardWidgetTypes.SPANS)
         widget.dashboard.filters = {
@@ -3247,6 +3281,19 @@ class BuildWidgetTimeseriesParamsTest(TestCase):
         params = build_widget_timeseries_params(widget, QueryDict(f"globalFilter={url_filter}"))[0]
 
         assert params["query"] == "env:prod"
+
+    def test_url_empty_global_filter_falls_back_to_dashboard_global_filter(self) -> None:
+        widget = self._make_widget(widget_type=DashboardWidgetTypes.SPANS)
+        widget.dashboard.filters = {
+            "global_filter": [
+                {"dataset": "spans", "tag": {"key": "span.op"}, "value": "span.op:http"},
+            ],
+        }
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict("globalFilter="))[0]
+
+        assert params["query"] == "span.op:http"
 
     def test_url_global_filter_invalid_json_is_skipped(self) -> None:
         widget = self._make_widget(widget_type=DashboardWidgetTypes.SPANS)


### PR DESCRIPTION
## Summary

A dashboard widget link like `?release=&project=1&environment=` produced a blank chart even when the dashboard had a saved release/environment to fall back on. `QueryDict.getlist("release")` returns `['']` for `release=` — a truthy single-element list — so the unfurl code emitted `release:""` into the query, matching nothing.

Filter out empty strings from the URL getlists so `release=` / `project=` / `environment=` / `globalFilter=` cleanly fall through to the dashboard's saved values, matching how the dashboard FE renders the widget.