### PR TITLE
chore(snapshots): Update settings badge from alpha to beta

### DIFF
--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -157,7 +157,7 @@ export function getNavigationConfiguration({
         {
           path: `${pathPrefix}/snapshots/`,
           title: t('Snapshots'),
-          badge: () => 'alpha',
+          badge: () => 'beta',
           show: () => !!organization?.features?.includes('preprod-snapshots'),
           description: t('Configure snapshot status checks and PR comments.'),
         },


### PR DESCRIPTION
Updates the Snapshots settings navigation badge from alpha to beta to
reflect the feature's current maturity stage.

Replaces #115274 (closed due to branch rename).