### PR TITLE
fix(ourlogs): Hide axis pointer label on collapsed spark line chart

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -803,6 +803,7 @@ const HIDDEN_AXIS = {
   axisLine: {show: false},
   axisTick: {show: false},
   axisLabel: {show: false},
+  axisPointer: {label: {show: false}},
 } satisfies XAXisComponentOption | YAXisComponentOption;
 
 TimeSeriesWidgetVisualization.LoadingPlaceholder = WidgetLoadingPanel;


### PR DESCRIPTION
Hovering the collapsed spark line preview in the logs chart header rendered a small floating value label pinned to the (hidden) y-axis. That's separate from the main mouse-following tooltip. We only want the main one when the y-axis is hidden.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="563" height="241" alt="Screenshot 2026-05-11 at 11 02 14 AM" src="https://github.com/user-attachments/assets/b4fd2b19-05fa-41bd-9a07-7b061604ce91" />
</td>
<td>
<img width="563" height="241" alt="Screenshot 2026-05-11 at 11 01 55 AM" src="https://github.com/user-attachments/assets/0a51b5a9-258c-49dc-906a-ccc68d6689e9" />
</td>
</tr>
</tbody>
</table>

Fixes LOGS-792.

Made with [Cursor](https://cursor.com)