### PR TITLE
chore(jest): Update flaky test markers based on recent CI data

### DIFF
--- a/static/app/bootstrap/boostrapRequests.spec.tsx
+++ b/static/app/bootstrap/boostrapRequests.spec.tsx
@@ -128,7 +128,7 @@ describe('useBootstrapTeamsQuery', () => {
     TeamStore.reset();
   });
 
-  it.isKnownFlake('updates team store with fetched data', async () => {
+  it('updates team store with fetched data', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${orgSlug}/teams/`,
       body: mockTeams,

--- a/static/app/components/actions/archive.spec.tsx
+++ b/static/app/components/actions/archive.spec.tsx
@@ -25,7 +25,7 @@ describe('ArchiveActions', () => {
     });
   });
 
-  it.isKnownFlake('archives forever', async () => {
+  it('archives forever', async () => {
     render(<ArchiveActions onUpdate={onUpdate} />);
 
     await userEvent.click(screen.getByRole('button', {name: 'Archive options'}));

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
@@ -212,36 +212,33 @@ describe('GlobalCommandPaletteActions - project settings ordering', () => {
     expect(screen.getByText('Current')).toBeInTheDocument();
   });
 
-  it.isKnownFlake(
-    'highlights all projects when multiple ?project= params are set',
-    async () => {
-      render(
-        <CommandPaletteProvider>
-          <GlobalCommandPaletteActions />
-          <SlotOutlets />
-          <CommandPalette {...makeRenderProps(jest.fn())} />
-        </CommandPaletteProvider>,
-        {
-          organization,
-          initialRouterConfig: {
-            location: {
-              pathname: `/organizations/${organization.slug}/issues/`,
-              query: {project: [projectA.id, projectB.id]},
-            },
+  it('highlights all projects when multiple ?project= params are set', async () => {
+    render(
+      <CommandPaletteProvider>
+        <GlobalCommandPaletteActions />
+        <SlotOutlets />
+        <CommandPalette {...makeRenderProps(jest.fn())} />
+      </CommandPaletteProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {project: [projectA.id, projectB.id]},
           },
-        }
-      );
+        },
+      }
+    );
 
-      await drillIntoGeneralSettings();
+    await drillIntoGeneralSettings();
 
-      // Both selected projects should appear with the Current tag
-      expect(await screen.findByRole('option', {name: 'project-a'})).toBeInTheDocument();
-      expect(screen.getByRole('option', {name: 'project-b'})).toBeInTheDocument();
-      expect(screen.getAllByText('Current')).toHaveLength(2);
-      // Unselected project should still be present but without a tag
-      expect(screen.getByRole('option', {name: 'project-c'})).toBeInTheDocument();
-    }
-  );
+    // Both selected projects should appear with the Current tag
+    expect(await screen.findByRole('option', {name: 'project-a'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'project-b'})).toBeInTheDocument();
+    expect(screen.getAllByText('Current')).toHaveLength(2);
+    // Unselected project should still be present but without a tag
+    expect(screen.getByRole('option', {name: 'project-c'})).toBeInTheDocument();
+  });
 
   it('shows all projects without priority when not on a :projectId route', async () => {
     render(

--- a/static/app/components/events/autofix/autofixOutputStream.spec.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.spec.tsx
@@ -21,7 +21,7 @@ describe('AutofixOutputStream', () => {
     });
   });
 
-  it.isKnownFlake('renders basic stream content', async () => {
+  it('renders basic stream content', async () => {
     render(
       <AutofixOutputStream
         stream="Hello World"

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -41,7 +41,7 @@ describe('StacktraceLink', () => {
     HookStore.init?.();
   });
 
-  it.isKnownFlake('renders setup CTA with integration but no configs', async () => {
+  it('renders setup CTA with integration but no configs', async () => {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       body: {config: null, sourceUrl: null, integrations: [integration]},

--- a/static/app/gettingStartedDocs/java-log4j2/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java-log4j2/onboarding.spec.tsx
@@ -29,7 +29,7 @@ describe('getting started with log4j2', () => {
     ).toBeInTheDocument();
   });
 
-  it.isKnownFlake('renders maven docs correctly', async () => {
+  it('renders maven docs correctly', async () => {
     renderWithOnboardingLayout(docs, {
       releaseRegistry: {
         'sentry.java.maven-plugin': {

--- a/static/app/gettingStartedDocs/react-native/logs.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/logs.spec.tsx
@@ -38,7 +38,7 @@ function renderMockRequests({
 }
 
 describe('getting started with react-native', () => {
-  it.isKnownFlake('shows React Native logs onboarding content', async () => {
+  it('shows React Native logs onboarding content', async () => {
     const organization = OrganizationFixture();
     const project = ProjectFixture({platform: 'react-native'});
     renderMockRequests({organization, project});

--- a/static/app/views/alerts/rules/issue/ruleNode.spec.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.spec.tsx
@@ -147,7 +147,7 @@ describe('RuleNode', () => {
     expect(onDelete).toHaveBeenCalledWith(index);
   });
 
-  it.isKnownFlake('renders choice string choice fields correctly', async () => {
+  it('renders choice string choice fields correctly', async () => {
     const fieldName = 'exampleStringChoiceField';
     const label = `Here is a string choice field {${fieldName}}`;
     renderRuleNode(formNode(label));

--- a/static/app/views/auth/registerForm.spec.tsx
+++ b/static/app/views/auth/registerForm.spec.tsx
@@ -35,7 +35,7 @@ describe('Register', () => {
     });
   }
 
-  it.isKnownFlake('handles errors', async () => {
+  it('handles errors', async () => {
     const mockRequest = MockApiClient.addMockResponse({
       url: '/auth/register/',
       method: 'POST',
@@ -52,7 +52,7 @@ describe('Register', () => {
     expect(await screen.findByText('Registration failed')).toBeInTheDocument();
   });
 
-  it.isKnownFlake('handles success', async () => {
+  it('handles success', async () => {
     const userObject = {
       id: 1,
       name: 'Joe',

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -126,7 +126,7 @@ describe('SpansSearchBar', () => {
     await screen.findByLabelText('span.op:function');
   });
 
-  it.isKnownFlake('calls onSearch with the correct query', async () => {
+  it('calls onSearch with the correct query', async () => {
     const onSearch = jest.fn();
 
     renderWithProvider({

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -33,7 +33,7 @@ describe('ResultsSearchQueryBuilder', () => {
     });
   });
 
-  it.isKnownFlake('does not show function tags in has: dropdown', async () => {
+  it('does not show function tags in has: dropdown', async () => {
     render(
       <ResultsSearchQueryBuilder
         query=""
@@ -70,7 +70,7 @@ describe('ResultsSearchQueryBuilder', () => {
     });
   });
 
-  it.isKnownFlake('shows normal tags, e.g. transaction, in the dropdown', async () => {
+  it('shows normal tags, e.g. transaction, in the dropdown', async () => {
     render(
       <ResultsSearchQueryBuilder
         query=""

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -161,7 +161,7 @@ describe('MetricsTabContent', () => {
     });
   });
 
-  it.isKnownFlake('should add a metric when Add Metric button is clicked', async () => {
+  it('should add a metric when Add Metric button is clicked', async () => {
     render(
       <ProviderWrapper>
         <MetricsTabContent datePageFilterProps={datePageFilterProps} />
@@ -536,74 +536,67 @@ describe('MetricsTabContent', () => {
     expect(trackAnalyticsMock).toHaveBeenCalledTimes(1);
   });
 
-  it.isKnownFlake(
-    'should switch to aggregate mode when a group by is added',
-    async () => {
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/trace-items/attributes/`,
-        method: 'GET',
-        body: [
-          {
-            attributeType: 'string',
-            key: 'test.region',
-            name: 'test.region',
-          },
-          {
-            attributeType: 'string',
-            key: 'test.service',
-            name: 'test.service',
-          },
-        ],
-        match: [
-          MockApiClient.matchQuery({attributeType: ['string', 'number', 'boolean']}),
-        ],
-      });
-
-      const {router} = render(
-        <ProviderWrapper>
-          <MetricsTabContent datePageFilterProps={datePageFilterProps} />
-        </ProviderWrapper>,
+  it('should switch to aggregate mode when a group by is added', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [
         {
-          initialRouterConfig,
-          organization,
-        }
-      );
+          attributeType: 'string',
+          key: 'test.region',
+          name: 'test.region',
+        },
+        {
+          attributeType: 'string',
+          key: 'test.service',
+          name: 'test.service',
+        },
+      ],
+      match: [MockApiClient.matchQuery({attributeType: ['string', 'number', 'boolean']})],
+    });
 
-      const toolbars = screen.getAllByTestId('metric-toolbar');
-      expect(toolbars).toHaveLength(1);
+    const {router} = render(
+      <ProviderWrapper>
+        <MetricsTabContent datePageFilterProps={datePageFilterProps} />
+      </ProviderWrapper>,
+      {
+        initialRouterConfig,
+        organization,
+      }
+    );
 
-      // Wait for the toolbar to load
-      await waitFor(() => {
-        expect(
-          within(toolbars[0]!).getByRole('button', {name: 'bar'})
-        ).toBeInTheDocument();
-      });
+    const toolbars = screen.getAllByTestId('metric-toolbar');
+    expect(toolbars).toHaveLength(1);
 
-      // Verify initial state is samples mode
-      const initialMetricQuery = JSON.parse(router.location.query.metric as string);
-      expect(initialMetricQuery.mode).toBe('samples');
+    // Wait for the toolbar to load
+    await waitFor(() => {
+      expect(within(toolbars[0]!).getByRole('button', {name: 'bar'})).toBeInTheDocument();
+    });
 
-      // Click on the Group by selector - use text content since prefix renders differently
-      const groupByButton = within(toolbars[0]!).getByText('Group by');
-      await userEvent.click(groupByButton);
+    // Verify initial state is samples mode
+    const initialMetricQuery = JSON.parse(router.location.query.metric as string);
+    expect(initialMetricQuery.mode).toBe('samples');
 
-      // Select a group by option (test.region)
-      const regionOption = await screen.findByRole('option', {name: 'test.region'});
-      await userEvent.click(regionOption);
+    // Click on the Group by selector - use text content since prefix renders differently
+    const groupByButton = within(toolbars[0]!).getByText('Group by');
+    await userEvent.click(groupByButton);
 
-      let metricQuery = router.location.query.metric;
-      expect(metricQuery).toBeDefined();
+    // Select a group by option (test.region)
+    const regionOption = await screen.findByRole('option', {name: 'test.region'});
+    await userEvent.click(regionOption);
 
-      // Verify that the mode switched to aggregate in the URL
-      let parsedQuery: ReturnType<typeof JSON.parse>;
-      await waitFor(() => {
-        metricQuery = router.location.query.metric;
-        parsedQuery = JSON.parse(metricQuery as string);
-        expect(parsedQuery.mode).toBe('aggregate');
-      });
-      expect(parsedQuery.aggregateFields).toContainEqual({groupBy: 'test.region'});
-    }
-  );
+    let metricQuery = router.location.query.metric;
+    expect(metricQuery).toBeDefined();
+
+    // Verify that the mode switched to aggregate in the URL
+    let parsedQuery: ReturnType<typeof JSON.parse>;
+    await waitFor(() => {
+      metricQuery = router.location.query.metric;
+      parsedQuery = JSON.parse(metricQuery as string);
+      expect(parsedQuery.mode).toBe('aggregate');
+    });
+    expect(parsedQuery.aggregateFields).toContainEqual({groupBy: 'test.region'});
+  });
 
   it('does not show the Add Equation button when the feature flag is disabled', async () => {
     render(

--- a/static/app/views/issueList/searchBar.spec.tsx
+++ b/static/app/views/issueList/searchBar.spec.tsx
@@ -44,7 +44,7 @@ describe('IssueListSearchBar', () => {
       onSearch: jest.fn(),
     };
 
-    it.isKnownFlake('displays the correct options for the is tag', async () => {
+    it('displays the correct options for the is tag', async () => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/tags/',
         body: [],

--- a/static/app/views/navigation/primary/whatsNew.spec.tsx
+++ b/static/app/views/navigation/primary/whatsNew.spec.tsx
@@ -22,7 +22,7 @@ describe('WhatsNew', () => {
     jest.useRealTimers();
   });
 
-  it.isKnownFlake('renders empty state when API returns no broadcasts', async () => {
+  it('renders empty state when API returns no broadcasts', async () => {
     render(<PrimaryNavigationWhatsNew />);
 
     await userEvent.click(screen.getByRole('button', {name: "What's New"}));

--- a/static/app/views/projectDetail/projectQuickLinks.spec.tsx
+++ b/static/app/views/projectDetail/projectQuickLinks.spec.tsx
@@ -12,7 +12,7 @@ describe('ProjectDetail > ProjectQuickLinks', () => {
     jest.clearAllMocks();
   });
 
-  it.isKnownFlake('renders a list', async () => {
+  it('renders a list', async () => {
     const {router} = render(
       <ProjectQuickLinks organization={organization} project={ProjectFixture()} />
     );
@@ -36,7 +36,7 @@ describe('ProjectDetail > ProjectQuickLinks', () => {
     });
   });
 
-  it.isKnownFlake('disables link if feature is missing', async () => {
+  it('disables link if feature is missing', async () => {
     render(
       <ProjectQuickLinks
         organization={{...organization, features: []}}

--- a/static/app/views/settings/account/apiTokenDetails.spec.tsx
+++ b/static/app/views/settings/account/apiTokenDetails.spec.tsx
@@ -125,7 +125,7 @@ describe('ApiTokenDetails', () => {
     expect(indicators.addSuccessMessage).toHaveBeenCalled();
   });
 
-  it.isKnownFlake('does not accept long name', async () => {
+  it('does not accept long name', async () => {
     MockApiClient.clearMockResponses();
     jest.spyOn(indicators, 'addErrorMessage');
 

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.spec.tsx
@@ -65,7 +65,7 @@ describe('AddCodeOwnerModal', () => {
     );
   });
 
-  it('renders codeowner file', async () => {
+  it.isKnownFlake('renders codeowner file', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/code-mappings/${codeMapping.id}/codeowners/`,
       method: 'GET',


### PR DESCRIPTION
## Summary
- Marked 1 newly flaky test with `it.isKnownFlake()` based on ≥2 failures on master in the last 7 days
- Un-marked 20 tests that are no longer flaky (0 or 1 failures in the last 7 days)

Dashboard: https://sentry.sentry.io/dashboard/4627175/?environment=ci%3Amaster&project=4857230&statsPeriod=7d

## Newly marked as flaky

| File | Test Name |
|------|-----------|
| `addCodeOwnerModal.spec.tsx` | renders codeowner file |

## Un-marked (no longer flaky)

| File | Test Name |
|------|-----------|
| `boostrapRequests.spec.tsx` | updates team store with fetched data |
| `archive.spec.tsx` | archives forever |
| `commandPaletteGlobalActions.spec.tsx` | highlights all projects when multiple ?project= params are set |
| `autofixOutputStream.spec.tsx` | renders basic stream content |
| `stacktraceLink.spec.tsx` | renders setup CTA with integration but no configs |
| `onboarding.spec.tsx` (java-log4j2) | renders maven docs correctly |
| `logs.spec.tsx` (react-native) | shows React Native logs onboarding content |
| `apiTokenDetails.spec.tsx` | does not accept long name |
| `resultsSearchQueryBuilder.spec.tsx` | does not show function tags in has: dropdown |
| `resultsSearchQueryBuilder.spec.tsx` | shows normal tags, e.g. transaction, in the dropdown |
| `registerForm.spec.tsx` | handles errors |
| `registerForm.spec.tsx` | handles success |
| `whatsNew.spec.tsx` | renders empty state when API returns no broadcasts |
| `projectQuickLinks.spec.tsx` | renders a list |
| `projectQuickLinks.spec.tsx` | disables link if feature is missing |
| `metricsTab.spec.tsx` | should add a metric when Add Metric button is clicked |
| `metricsTab.spec.tsx` | should switch to aggregate mode when a group by is added |
| `ruleNode.spec.tsx` | renders choice string choice fields correctly |
| `spansSearchBar.spec.tsx` | calls onSearch with the correct query |
| `searchBar.spec.tsx` | displays the correct options for the is tag |

## Test plan
- CI passes with the updated flaky markers