### PR TITLE
ref(replay): Rename Breadcrumbs tab to Activity

### DIFF
--- a/static/app/views/explore/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/explore/replays/detail/layout/focusTabs.tsx
@@ -56,7 +56,7 @@ function getReplayTabs({
           <FeatureBadge type="new" />
         </Flex>
       ) : null,
-    [TabKey.BREADCRUMBS]: t('Breadcrumbs'),
+    [TabKey.BREADCRUMBS]: t('Activity'),
     [TabKey.CONSOLE]: t('Console'),
     [TabKey.LOGS]: hasLogs ? t('Logs') : null,
     [TabKey.NETWORK]: t('Network'),


### PR DESCRIPTION
## Summary

The data under replays breadcrumbs don't match the data under issue breadcrumbs, they shouldn't have the same name otherwise users may expect them to match.

Docs companion PR: https://github.com/getsentry/sentry-docs/pull/17712.

Fixes [REPLAY-690](https://linear.app/getsentry/issue/REPLAY-690/disparity-between-issue-and-replay-breadcrumbs)