### PR TITLE
fix(seer-slack): change thinking status

### DIFF
--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -414,7 +414,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
                 installation.set_thread_status(
                     channel_id=channel_id,
                     thread_ts=thread_ts or ts,
-                    status="Thinking...",
+                    status="is thinking...",
                     loading_messages=_SEER_LOADING_MESSAGES,
                 )
             except Exception:


### PR DESCRIPTION
<img width="238" height="84" alt="image" src="https://github.com/user-attachments/assets/3bb127d7-50b4-451c-aa16-3374c08ff143" />

we should change it so the thinking status is shown as "Sentry is thinking..." instead of just "Sentry Thinking..."

completes ISWF-2626