### PR TITLE
fix(tracemetrics): Fix palette differences between table and viz

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -177,6 +177,8 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
     return false;
   };
 
+  const topResultsCount = topEvents ? Math.min(result.data?.length ?? 0, topEvents) : 0;
+
   const isPending = result.isPending && !isMetricOptionsEmpty;
 
   return (
@@ -246,7 +248,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
             return (
               <SimpleTable.Row key={i} style={{minHeight: '33px'}}>
                 {topEvents && i < topEvents && (
-                  <StyledTopResultsIndicator count={topEvents} index={i} />
+                  <StyledTopResultsIndicator count={topResultsCount} index={i} />
                 )}
                 {displayFields.map((field, j) => (
                   <AggregatesStyledRowCell


### PR DESCRIPTION
Use actual row count instead of the limit when determining the color palette for top results
