### PR TITLE
feat(insights): Show source frames for slow DB spans

### DIFF
--- a/static/app/components/events/interfaces/frame/copyFrameLink.tsx
+++ b/static/app/components/events/interfaces/frame/copyFrameLink.tsx
@@ -1,0 +1,61 @@
+import type {MouseEvent} from 'react';
+
+import {Button, type ButtonProps} from '@sentry/scraps/button';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {IconCopy} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Frame} from 'sentry/types/event';
+import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
+
+const DEFAULT_BUTTON_SIZE = 'xs';
+
+interface CopyFrameLinkProps {
+  frame: Partial<Pick<Frame, 'filename' | 'lineNo'>>;
+  analyticsParams?: ButtonProps['analyticsParams'];
+}
+
+export function CopyFrameLink({analyticsParams, frame}: CopyFrameLinkProps) {
+  const filePath =
+    frame.filename && frame.lineNo !== null && frame.lineNo !== undefined
+      ? `${frame.filename}:${frame.lineNo}`
+      : frame.filename || '';
+
+  const {copy} = useCopyToClipboard();
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+
+    // Strip away relative path segments to make it easier for editors to actually find the file (like VSCode cmd+p)
+    const cleanedFilepath = filePath.replace(/^(\.\/)?(\.\.\/)*/g, '');
+
+    copy(cleanedFilepath, {
+      successMessage: t('File path copied to clipboard'),
+      errorMessage: t('Failed to copy file path'),
+    });
+  };
+
+  // Don't render if there's no valid file path to copy
+  if (!filePath) {
+    return null;
+  }
+
+  return (
+    <Tooltip title={t('Copy file path')} skipWrapper>
+      <Button
+        size={DEFAULT_BUTTON_SIZE}
+        variant="transparent"
+        aria-label={t('Copy file path')}
+        icon={<IconCopy />}
+        onClick={handleClick}
+        {...(analyticsParams
+          ? {
+              analyticsEventKey: 'stacktrace_link_copy_file_path',
+              analyticsEventName: 'Stacktrace Link Copy File Path',
+              analyticsParams,
+            }
+          : {})}
+      />
+    </Tooltip>
+  );
+}

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -8,10 +8,11 @@ import {useModal} from '@sentry/scraps/modal';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {CopyFrameLink} from 'sentry/components/events/interfaces/frame/copyFrameLink';
 import {useStacktraceCoverage} from 'sentry/components/events/interfaces/frame/useStacktraceCoverage';
 import {hasFileExtension} from 'sentry/components/events/interfaces/frame/utils';
 import {Placeholder} from 'sentry/components/placeholder';
-import {IconCopy, IconWarning} from 'sentry/icons';
+import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event, Frame} from 'sentry/types/event';
 import type {StacktraceLinkResult} from 'sentry/types/integrations';
@@ -21,7 +22,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForEvent} from 'sentry/utils/events';
 import {getIntegrationIcon, getIntegrationSourceUrl} from 'sentry/utils/integrationUtil';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
-import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 
@@ -118,6 +118,11 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
       : {}
   );
 
+  const copyFrameLinkAnalyticsParams = {
+    group_id: event.groupID ? parseInt(event.groupID, 10) : -1,
+    ...getAnalyticsDataForEvent(event),
+  };
+
   const onOpenLink = (e: React.MouseEvent, sourceLink: Frame['sourceLink'] = null) => {
     e.stopPropagation();
     const provider = match?.config?.provider;
@@ -162,7 +167,7 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
   if (!match && hasGithubSourceLink && !frame.inApp && frame.sourceLink) {
     return (
       <StacktraceLinkWrapper>
-        <CopyFrameLink event={event} frame={frame} />
+        <CopyFrameLink frame={frame} analyticsParams={copyFrameLinkAnalyticsParams} />
         <Tooltip title={t('Open this line in GitHub')} skipWrapper>
           <ProviderLink
             onClick={e => onOpenLink(e, frame.sourceLink)}
@@ -184,7 +189,7 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
     const label = t('Open this line in %s', match.config.provider.name);
     return (
       <StacktraceLinkWrapper>
-        <CopyFrameLink event={event} frame={frame} />
+        <CopyFrameLink frame={frame} analyticsParams={copyFrameLinkAnalyticsParams} />
         <Tooltip title={label} skipWrapper>
           <ProviderLink
             onClick={onOpenLink}
@@ -226,7 +231,7 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
   ) {
     return (
       <StacktraceLinkWrapper>
-        <CopyFrameLink event={event} frame={frame} />
+        <CopyFrameLink frame={frame} analyticsParams={copyFrameLinkAnalyticsParams} />
         <Tooltip title={t('GitHub')} skipWrapper>
           <ProviderLink
             onClick={onOpenLink}
@@ -261,7 +266,7 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
     );
     return (
       <StacktraceLinkWrapper data-has-setup="true">
-        <CopyFrameLink event={event} frame={frame} />
+        <CopyFrameLink frame={frame} analyticsParams={copyFrameLinkAnalyticsParams} />
         <Button
           size={DEFAULT_BUTTON_SIZE}
           variant="transparent"
@@ -378,55 +383,6 @@ function CodecovLink({
     </Tooltip>
   );
 }
-interface CopyFrameLinkProps {
-  event: Event;
-  frame: Frame;
-}
-
-function CopyFrameLink({event, frame}: CopyFrameLinkProps) {
-  const filePath =
-    frame.filename && frame.lineNo !== null
-      ? `${frame.filename}:${frame.lineNo}`
-      : frame.filename || '';
-
-  const {copy} = useCopyToClipboard();
-
-  const handleClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-
-    // Strip away relative path segments to make it easier for editors to actually find the file (like VSCode cmd+p)
-    const cleanedFilepath = filePath.replace(/^(\.\/)?(\.\.\/)*/g, '');
-
-    copy(cleanedFilepath, {
-      successMessage: t('File path copied to clipboard'),
-      errorMessage: t('Failed to copy file path'),
-    });
-  };
-
-  // Don't render if there's no valid file path to copy
-  if (!filePath) {
-    return null;
-  }
-
-  return (
-    <Tooltip title={t('Copy file path')} skipWrapper>
-      <Button
-        size={DEFAULT_BUTTON_SIZE}
-        variant="transparent"
-        aria-label={t('Copy file path')}
-        icon={<IconCopy />}
-        onClick={handleClick}
-        analyticsEventKey="stacktrace_link_copy_file_path"
-        analyticsEventName="Stacktrace Link Copy File Path"
-        analyticsParams={{
-          group_id: event.groupID ? parseInt(event.groupID, 10) : -1,
-          ...getAnalyticsDataForEvent(event),
-        }}
-      />
-    </Tooltip>
-  );
-}
-
 const fadeIn = keyframes`
 from { opacity: 0; }
 to { opacity: 1; }

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -657,6 +657,58 @@ describe('SpanEvidenceKeyValueList', () => {
 
       expect(screen.getByRole('link', {name: 'More Samples'})).toBeInTheDocument();
     });
+
+    it('renders span-specific missing query source copy', () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/',
+        body: [],
+      });
+
+      const builderWithoutCodeLocation = new TransactionEventBuilder(
+        'a1',
+        '/',
+        IssueType.PERFORMANCE_SLOW_DB_QUERY
+      );
+      builderWithoutCodeLocation.getEventFixture().projectID = '123';
+
+      const parentSpanWithoutCodeLocation = new MockSpan({
+        startTimestamp: 0,
+        endTimestamp: 200,
+        op: 'pageload',
+        problemSpan: ProblemSpan.PARENT,
+      });
+
+      parentSpanWithoutCodeLocation.addChild({
+        startTimestamp: 10,
+        endTimestamp: 10100,
+        op: 'db',
+        description: 'SELECT pokemon FROM pokedex',
+        problemSpan: ProblemSpan.OFFENDER,
+      });
+
+      builderWithoutCodeLocation.addSpan(parentSpanWithoutCodeLocation);
+
+      render(
+        <SpanEvidenceKeyValueList
+          event={builderWithoutCodeLocation.getEventFixture()}
+          projectSlug={projectSlug}
+        />,
+        {
+          organization: OrganizationFixture({
+            features: ['visibility-explore-view'],
+          }),
+        }
+      );
+
+      const slowDbQuery = screen.getByTestId(
+        'span-evidence-key-value-list.slow-db-query'
+      );
+
+      expect(slowDbQuery).toHaveTextContent(
+        'Query source is not available for this span.'
+      );
+      expect(slowDbQuery).not.toHaveTextContent('selected date range');
+    });
   });
 
   describe('Render Blocking Asset', () => {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -605,6 +605,11 @@ describe('SpanEvidenceKeyValueList', () => {
       description: 'SELECT pokemon FROM pokedex',
       problemSpan: ProblemSpan.OFFENDER,
     });
+    parentSpan.children[0]!.span.data = {
+      'code.filepath': '/app/pokedex/queries.py',
+      'code.function': 'fetchPokemon',
+      'code.lineno': 42,
+    };
 
     builder.addSpan(parentSpan);
 
@@ -645,6 +650,9 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.slow-db-query')
       ).toHaveTextContent('SELECT pokemon FROM pokedex');
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.slow-db-query')
+      ).toHaveTextContent('/app/pokedex/queries.py in fetchPokemon at line 42');
       expect(screen.getByRole('cell', {name: 'Duration Impact'})).toBeInTheDocument();
 
       expect(screen.getByRole('link', {name: 'More Samples'})).toBeInTheDocument();

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -8,7 +8,7 @@ import mapValues from 'lodash/mapValues';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -45,6 +45,10 @@ import {SQLishFormatter} from 'sentry/utils/sqlish';
 import {safeURL} from 'sentry/utils/url/safeURL';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  MissingFrame,
+  StackTraceMiniFrame,
+} from 'sentry/views/insights/database/components/stackTraceMiniFrame';
 import {SpanFields} from 'sentry/views/insights/types';
 import {SpanSummaryLink} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/components/spanSummaryLink';
 import {
@@ -505,12 +509,27 @@ function SlowDBQueryEvidence({
 
   const queryValue = (
     <QueryCard>
-      <NoPaddingClippedBox clipHeight={200}>
-        <StyledCodeSnippet language="sql">
-          {formatter.toString(span.description ?? '')}
-        </StyledCodeSnippet>
-      </NoPaddingClippedBox>
-      <Flex gap="md" padding="sm lg" borderTop="muted">
+      <Stack>
+        <NoPaddingClippedBox clipHeight={200}>
+          <StyledCodeSnippet language="sql">
+            {formatter.toString(span.description ?? '')}
+          </StyledCodeSnippet>
+        </NoPaddingClippedBox>
+        {span.data?.['code.filepath'] ? (
+          <StackTraceMiniFrame
+            projectId={event.projectID}
+            event={event}
+            frame={{
+              filename: span.data['code.filepath'],
+              lineNo: span.data['code.lineno'],
+              function: span.data['code.function'],
+            }}
+          />
+        ) : (
+          <MissingFrame />
+        )}
+      </Stack>
+      <Flex gap="md" padding="md lg" borderTop="muted">
         <SpanSummaryLink
           op={span.op}
           category={sentryTags?.category}
@@ -912,5 +931,6 @@ const QueryCard = styled('div')`
   border: 1px solid ${p => p.theme.tokens.border.secondary};
   pre {
     margin: 0 !important;
+    padding-top: ${p => p.theme.space.md} !important;
   }
 `;

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -526,7 +526,7 @@ function SlowDBQueryEvidence({
             }}
           />
         ) : (
-          <MissingFrame />
+          <MissingFrame source="span" />
         )}
       </Stack>
       <Flex gap="md" padding="md lg" borderTop="muted">

--- a/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
@@ -1,9 +1,12 @@
 import {Fragment} from 'react';
-import styled from '@emotion/styled';
 
-import {ProjectAvatar} from '@sentry/scraps/avatar';
+import {LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {CopyFrameLink} from 'sentry/components/events/interfaces/frame/copyFrameLink';
 import {useStacktraceLink} from 'sentry/components/events/interfaces/frame/useStacktraceLink';
 import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
@@ -12,10 +15,13 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {MODULE_DOC_LINK} from 'sentry/views/insights/database/settings';
 
+const DEFAULT_ICON_SIZE = 'xs';
+const DEFAULT_BUTTON_SIZE = 'xs';
+
 interface Props {
+  event: Parameters<typeof useStacktraceLink>[0]['event'] | undefined;
   frame: Parameters<typeof useStacktraceLink>[0]['frame'];
-  event?: Parameters<typeof useStacktraceLink>[0]['event'];
-  projectId?: string;
+  projectId: string | undefined;
 }
 
 export function StackTraceMiniFrame({frame, event, projectId}: Props) {
@@ -23,32 +29,39 @@ export function StackTraceMiniFrame({frame, event, projectId}: Props) {
   const project = projects.find(p => p.id === projectId);
 
   return (
-    <FrameContainer>
-      {project && (
-        <ProjectAvatarContainer>
-          <ProjectAvatar project={project} size={16} />
-        </ProjectAvatarContainer>
-      )}
-      {frame.filename && <Emphasize>{frame?.filename}</Emphasize>}
-      {frame.function && (
-        <Fragment>
-          <Deemphasize> {t('in')} </Deemphasize>
-          <Emphasize>{frame?.function}</Emphasize>
-        </Fragment>
-      )}
-      {frame.lineNo && (
-        <Fragment>
-          <Deemphasize> {t('at line')} </Deemphasize>
-          <Emphasize>{frame?.lineNo}</Emphasize>
-        </Fragment>
-      )}
+    <Flex
+      align="center"
+      background="secondary"
+      borderTop="secondary"
+      gap="xs"
+      justify="between"
+      padding="md lg"
+    >
+      <Flex as="span" align="center" flex="1 1 0" gap="xs" minWidth={0} wrap="wrap">
+        {frame.filename && <Text>{frame.filename}</Text>}
+        {frame.function && (
+          <Fragment>
+            <Text variant="muted"> {t('in')} </Text>
+            <Text>{frame.function}</Text>
+          </Fragment>
+        )}
+        {frame.lineNo && (
+          <Fragment>
+            <Text variant="muted"> {t('at line')} </Text>
+            <Text>{frame.lineNo}</Text>
+          </Fragment>
+        )}
+      </Flex>
 
-      {event && project && (
-        <PushRight>
-          <SourceCodeIntegrationLink event={event} project={project} frame={frame} />
-        </PushRight>
+      {frame.filename && (
+        <Flex as="span" align="center" flexShrink={0} gap="sm">
+          <CopyFrameLink frame={frame} />
+          {event && project ? (
+            <SourceCodeIntegrationLink event={event} project={project} frame={frame} />
+          ) : null}
+        </Flex>
       )}
-    </FrameContainer>
+    </Flex>
   );
 }
 
@@ -71,42 +84,11 @@ export function MissingFrame({system}: MissingFrameProps) {
         );
 
   return (
-    <FrameContainer>
-      <Deemphasize>{errorMessage}</Deemphasize>
-    </FrameContainer>
+    <Flex background="secondary" borderTop="secondary" padding="md lg">
+      <Text variant="muted">{errorMessage}</Text>
+    </Flex>
   );
 }
-
-const FrameContainer = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
-
-  font-family: ${p => p.theme.font.family.sans};
-  font-size: ${p => p.theme.font.size.md};
-
-  border-top: 1px solid ${p => p.theme.tokens.border.primary};
-
-  background: ${p => p.theme.tokens.background.tertiary};
-`;
-
-const ProjectAvatarContainer = styled('div')`
-  margin-right: ${p => p.theme.space.md};
-`;
-
-const Emphasize = styled('span')`
-  color: ${p => p.theme.colors.gray800};
-`;
-
-const Deemphasize = styled('span')`
-  color: ${p => p.theme.tokens.content.secondary};
-`;
-
-const PushRight = styled('span')`
-  margin-left: auto;
-`;
 
 interface SourceCodeIntegrationLinkProps {
   event: Parameters<typeof useStacktraceLink>[0]['event'];
@@ -128,34 +110,25 @@ function SourceCodeIntegrationLink({
   });
 
   if (match?.config && match.sourceUrl && frame.lineNo && !isPending) {
+    const label = t('Open this line in %s', match.config.provider.name);
+
     return (
-      <DeemphasizedExternalLink
-        href={getIntegrationSourceUrl(
-          match.config.provider.key,
-          match.sourceUrl,
-          frame.lineNo
-        )}
-        openInNewTab
-      >
-        <StyledIconWrapper>
-          {getIntegrationIcon(match.config.provider.key, 'sm')}
-        </StyledIconWrapper>
-        {t('Open this line in %s', match.config.provider.name)}
-      </DeemphasizedExternalLink>
+      <Tooltip title={label} skipWrapper>
+        <LinkButton
+          size={DEFAULT_BUTTON_SIZE}
+          variant="transparent"
+          external
+          href={getIntegrationSourceUrl(
+            match.config.provider.key,
+            match.sourceUrl,
+            frame.lineNo
+          )}
+          aria-label={label}
+          icon={getIntegrationIcon(match.config.provider.key, DEFAULT_ICON_SIZE)}
+        />
+      </Tooltip>
     );
   }
 
   return null;
 }
-
-const DeemphasizedExternalLink = styled(ExternalLink)`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.sm};
-  color: ${p => p.theme.tokens.content.secondary};
-`;
-
-const StyledIconWrapper = styled('span')`
-  color: inherit;
-  line-height: 0;
-`;

--- a/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
@@ -66,10 +66,11 @@ export function StackTraceMiniFrame({frame, event, projectId}: Props) {
 }
 
 type MissingFrameProps = {
+  source?: 'dateRange' | 'span';
   system?: string;
 };
 
-export function MissingFrame({system}: MissingFrameProps) {
+export function MissingFrame({source = 'dateRange', system}: MissingFrameProps) {
   const documentation = <ExternalLink href={`${MODULE_DOC_LINK}#query-sources`} />;
 
   const errorMessage =
@@ -78,10 +79,15 @@ export function MissingFrame({system}: MissingFrameProps) {
           'Query sources are not currently supported for MongoDB queries. Learn more in our [documentation:documentation].',
           {documentation}
         )
-      : tct(
-          'Could not find query source in the selected date range. Learn more in our [documentation:documentation].',
-          {documentation}
-        );
+      : source === 'span'
+        ? tct(
+            'Query source is not available for this span. Learn more in our [documentation:documentation].',
+            {documentation}
+          )
+        : tct(
+            'Could not find query source in the selected date range. Learn more in our [documentation:documentation].',
+            {documentation}
+          );
 
   return (
     <Flex background="secondary" borderTop="secondary" padding="md lg">

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -189,7 +189,7 @@ export function SpanDescription({
             }}
           />
         ) : (
-          <MissingFrame />
+          <MissingFrame source="span" />
         )}
       </Stack>
     ) : resolvedModule === ModuleName.HTTP && span.op === 'http.client' && spanURL ? (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -154,7 +154,7 @@ export function SpanDescription({
             }}
           />
         ) : (
-          <MissingFrame />
+          <MissingFrame source="span" />
         )}
       </Stack>
     ) : hasInsightModules &&


### PR DESCRIPTION
shows the source frame under slow DB query evidence when span data includes code.filepath, code.function, and code.lineno, these are provided automatically by some sdks.

Also pulls the stacktrace copy-file-path button into a shared component so the compact database frame gets the same copy behavior without duplicating it.

removes the platform icon and the text "open this line in github" from traces, which helps with wrapping.

before

<img width="1022" height="268" alt="image" src="https://github.com/user-attachments/assets/c084ee23-f062-457c-92fe-40c1e1131fbe" />


after

<img width="1025" height="312" alt="image" src="https://github.com/user-attachments/assets/9cf125f9-1919-4766-8da2-a6b1a4d63c92" />
