### PR TITLE
feat(preprod): Add auto_approved status to snapshot approval

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -97,7 +97,7 @@ class SnapshotComparisonInfo(BaseModel):
     images_removed: int = 0
     images_changed: int = 0
     images_unchanged: int = 0
-    approval_status: Literal["approved", "requires_approval"] | None = None
+    approval_status: Literal["approved", "auto_approved", "requires_approval"] | None = None
 
 
 class SizeInfoSizeMetric(BaseModel):
@@ -319,7 +319,10 @@ def to_snapshot_comparison_info(head_artifact: PreprodArtifact) -> SnapshotCompa
     approvals.sort(key=lambda a: a.id, reverse=True)
     if approvals:
         if approvals[0].approval_status == PreprodComparisonApproval.ApprovalStatus.APPROVED:
-            approval_status = "approved"
+            if (approvals[0].extras or {}).get("auto_approval") is True:
+                approval_status = "auto_approved"
+            else:
+                approval_status = "approved"
         else:
             approval_status = "requires_approval"
 

--- a/src/sentry/preprod/artifact_search.py
+++ b/src/sentry/preprod/artifact_search.py
@@ -62,6 +62,7 @@ search_config = SearchConfig.create_from(
     allowed_keys={
         "app_id",
         "app_name",
+        "approval_status",
         "build_configuration_name",
         "build_number",
         "build_version",
@@ -159,6 +160,19 @@ def _translate_size_state(value: object) -> int:
             f"Valid values: {', '.join(sorted(SIZE_STATE_VALUES))}"
         )
     return SIZE_STATE_VALUES[raw]
+
+
+APPROVAL_STATUS_VALUES = frozenset({"approved", "auto_approved", "requires_approval"})
+
+
+def _validate_approval_status(value: object) -> str:
+    raw = str(value).lower()
+    if raw not in APPROVAL_STATUS_VALUES:
+        raise InvalidSearchQuery(
+            f"Invalid approval_status value: {value}. "
+            f"Valid values: {', '.join(sorted(APPROVAL_STATUS_VALUES))}"
+        )
+    return raw
 
 
 def _base_searchable_queryset() -> PreprodArtifactQuerySet:
@@ -319,6 +333,59 @@ def apply_filters(
                 queryset = queryset.filter(Exists(approved_exists))
             else:
                 queryset = queryset.filter(~Exists(approved_exists))
+            continue
+
+        if name == "approval_status":
+            values = token.value.value if token.is_in_filter else [token.value.value]
+            validated = [_validate_approval_status(v) for v in values]
+
+            base_qs = PreprodComparisonApproval.objects.filter(
+                preprod_artifact=OuterRef("pk"),
+                preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            )
+            subqueries: list[Q] = []
+            for val in validated:
+                if val == "approved":
+                    subqueries.append(
+                        Q(
+                            Exists(
+                                base_qs.filter(
+                                    approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+                                ).exclude(extras__auto_approval=True)
+                            )
+                        )
+                    )
+                elif val == "auto_approved":
+                    subqueries.append(
+                        Q(
+                            Exists(
+                                base_qs.filter(
+                                    approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+                                    extras__auto_approval=True,
+                                )
+                            )
+                        )
+                    )
+                elif val == "requires_approval":
+                    subqueries.append(
+                        Q(Exists(base_qs))
+                        & ~Q(
+                            Exists(
+                                base_qs.filter(
+                                    approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+                                )
+                            )
+                        )
+                    )
+
+            combined = subqueries[0]
+            for sq in subqueries[1:]:
+                combined |= sq
+
+            if token.is_negation:
+                queryset = queryset.filter(~combined)
+            else:
+                queryset = queryset.filter(combined)
             continue
 
         # We don't have to handle boolean operators or parens here

--- a/src/sentry/preprod/artifact_search.py
+++ b/src/sentry/preprod/artifact_search.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import operator
 from collections.abc import Sequence
+from functools import reduce
 
 from django.db.models import Exists, OuterRef, Q
 
@@ -368,19 +370,16 @@ def apply_filters(
                     )
                 elif val == "requires_approval":
                     subqueries.append(
-                        Q(Exists(base_qs))
-                        & ~Q(
+                        Q(
                             Exists(
-                                base_qs.filter(
+                                base_qs.exclude(
                                     approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
                                 )
                             )
                         )
                     )
 
-            combined = subqueries[0]
-            for sq in subqueries[1:]:
-                combined |= sq
+            combined = reduce(operator.or_, subqueries)
 
             if token.is_negation:
                 queryset = queryset.filter(~combined)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2610,6 +2610,7 @@ class Factories:
         approval_status: int = PreprodComparisonApproval.ApprovalStatus.APPROVED,
         approved_at: datetime | None = None,
         approved_by_id: int | None = None,
+        extras: dict | None = None,
     ) -> PreprodComparisonApproval:
         return PreprodComparisonApproval.objects.create(
             preprod_artifact=preprod_artifact,
@@ -2617,6 +2618,7 @@ class Factories:
             approval_status=approval_status,
             approved_at=approved_at,
             approved_by_id=approved_by_id,
+            extras=extras,
         )
 
     @staticmethod

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -930,6 +930,71 @@ class BuildsEndpointTest(APITestCase):
         app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
         assert app_ids == {"com.approved.app"}
 
+    def test_query_approval_status(self) -> None:
+        manual_artifact = self.create_preprod_artifact(app_id="com.manual.app")
+        self.create_preprod_snapshot_metrics(preprod_artifact=manual_artifact)
+        self.create_preprod_comparison_approval(
+            preprod_artifact=manual_artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        )
+
+        auto_artifact = self.create_preprod_artifact(app_id="com.auto.app")
+        self.create_preprod_snapshot_metrics(preprod_artifact=auto_artifact)
+        self.create_preprod_comparison_approval(
+            preprod_artifact=auto_artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+            extras={"auto_approval": True},
+        )
+
+        pending_artifact = self.create_preprod_artifact(app_id="com.pending.app")
+        self.create_preprod_snapshot_metrics(preprod_artifact=pending_artifact)
+        self.create_preprod_comparison_approval(
+            preprod_artifact=pending_artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+        )
+
+        response = self._request({"display": "snapshot", "query": "approval_status:approved"})
+        self._assert_is_successful(response)
+        app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
+        assert app_ids == {"com.manual.app"}
+
+        response = self._request({"display": "snapshot", "query": "approval_status:auto_approved"})
+        self._assert_is_successful(response)
+        app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
+        assert app_ids == {"com.auto.app"}
+
+        response = self._request(
+            {"display": "snapshot", "query": "approval_status:requires_approval"}
+        )
+        self._assert_is_successful(response)
+        app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
+        assert app_ids == {"com.pending.app"}
+
+    def test_query_approval_status_invalid_value(self) -> None:
+        self.create_preprod_artifact(app_id="com.test.app")
+
+        response = self._request({"display": "snapshot", "query": "approval_status:bogus"})
+        assert response.status_code == 400
+
+    def test_snapshot_comparison_info_auto_approved(self) -> None:
+        artifact = self.create_preprod_artifact(app_id="com.auto.app")
+        self.create_preprod_snapshot_metrics(preprod_artifact=artifact)
+        self.create_preprod_comparison_approval(
+            preprod_artifact=artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+            extras={"auto_approval": True},
+        )
+
+        response = self._request({"display": "snapshot"})
+        self._assert_is_successful(response)
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["snapshot_comparison_info"]["approval_status"] == "auto_approved"
+
 
 class QuerysetForQueryTest(APITestCase):
     """Tests for the queryset_for_query, artifact_in_queryset, and artifact_matches_query functions."""

--- a/tests/sentry/preprod/api/models/test_project_preprod_build_details_models.py
+++ b/tests/sentry/preprod/api/models/test_project_preprod_build_details_models.py
@@ -8,8 +8,13 @@ from sentry.preprod.api.models.project_preprod_build_details_models import (
     SizeInfoPending,
     SizeInfoProcessing,
     to_size_info,
+    to_snapshot_comparison_info,
 )
-from sentry.preprod.models import PreprodArtifactSizeMetrics
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeMetrics,
+    PreprodComparisonApproval,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
 
@@ -241,3 +246,82 @@ class TestToSizeInfo(TestCase):
             ValueError, match="FAILED state requires both error_code and error_message"
         ):
             to_size_info(list([size_metrics]))
+
+
+@cell_silo_test
+class TestToSnapshotComparisonInfoApprovalStatus(TestCase):
+    def _create_artifact_with_snapshot_metrics(self) -> PreprodArtifact:
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_snapshot_metrics(preprod_artifact=artifact, image_count=1)
+        return PreprodArtifact.objects.select_related("preprodsnapshotmetrics").get(pk=artifact.pk)
+
+    def test_manual_approval_returns_approved(self) -> None:
+        artifact = self._create_artifact_with_snapshot_metrics()
+        self.create_preprod_comparison_approval(
+            preprod_artifact=artifact,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        )
+
+        result = to_snapshot_comparison_info(artifact)
+
+        assert result is not None
+        assert result.approval_status == "approved"
+
+    def test_auto_approval_returns_auto_approved(self) -> None:
+        artifact = self._create_artifact_with_snapshot_metrics()
+        self.create_preprod_comparison_approval(
+            preprod_artifact=artifact,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+            extras={"auto_approval": True},
+        )
+
+        result = to_snapshot_comparison_info(artifact)
+
+        assert result is not None
+        assert result.approval_status == "auto_approved"
+
+    def test_needs_approval_returns_requires_approval(self) -> None:
+        artifact = self._create_artifact_with_snapshot_metrics()
+        self.create_preprod_comparison_approval(
+            preprod_artifact=artifact,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+        )
+
+        result = to_snapshot_comparison_info(artifact)
+
+        assert result is not None
+        assert result.approval_status == "requires_approval"
+
+    def test_no_approval_records_returns_none(self) -> None:
+        artifact = self._create_artifact_with_snapshot_metrics()
+
+        result = to_snapshot_comparison_info(artifact)
+
+        assert result is not None
+        assert result.approval_status is None
+
+    def test_extras_none_treated_as_manual(self) -> None:
+        artifact = self._create_artifact_with_snapshot_metrics()
+        self.create_preprod_comparison_approval(
+            preprod_artifact=artifact,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+            extras=None,
+        )
+
+        result = to_snapshot_comparison_info(artifact)
+
+        assert result is not None
+        assert result.approval_status == "approved"
+
+    def test_extras_without_auto_approval_key_treated_as_manual(self) -> None:
+        artifact = self._create_artifact_with_snapshot_metrics()
+        self.create_preprod_comparison_approval(
+            preprod_artifact=artifact,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+            extras={"some_other_key": True},
+        )
+
+        result = to_snapshot_comparison_info(artifact)
+
+        assert result is not None
+        assert result.approval_status == "approved"

--- a/tests/sentry/preprod/test_artifact_search.py
+++ b/tests/sentry/preprod/test_artifact_search.py
@@ -327,3 +327,117 @@ class ArtifactMatchesQueryIsApprovedFilterTest(TestCase):
 
         assert not artifact_matches_query(approved_artifact, "!is_approved:true", self.organization)
         assert artifact_matches_query(pending_artifact, "!is_approved:true", self.organization)
+
+
+class ArtifactMatchesQueryApprovalStatusFilterTest(TestCase):
+    def _create_artifact_with_approval(
+        self,
+        feature_type: int = PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+        status: int = PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        with_approval_row: bool = True,
+        extras: dict | None = None,
+    ) -> PreprodArtifact:
+        artifact = self.create_preprod_artifact(project=self.project)
+        if with_approval_row:
+            self.create_preprod_comparison_approval(
+                preprod_artifact=artifact,
+                preprod_feature_type=feature_type,
+                approval_status=status,
+                extras=extras,
+            )
+        return artifact
+
+    def test_approval_status_approved_matches_manual_only(self) -> None:
+        manual = self._create_artifact_with_approval()
+        auto = self._create_artifact_with_approval(extras={"auto_approval": True})
+        pending = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+        )
+
+        assert artifact_matches_query(manual, "approval_status:approved", self.organization)
+        assert not artifact_matches_query(auto, "approval_status:approved", self.organization)
+        assert not artifact_matches_query(pending, "approval_status:approved", self.organization)
+
+    def test_approval_status_auto_approved(self) -> None:
+        manual = self._create_artifact_with_approval()
+        auto = self._create_artifact_with_approval(extras={"auto_approval": True})
+        pending = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+        )
+
+        assert not artifact_matches_query(
+            manual, "approval_status:auto_approved", self.organization
+        )
+        assert artifact_matches_query(auto, "approval_status:auto_approved", self.organization)
+        assert not artifact_matches_query(
+            pending, "approval_status:auto_approved", self.organization
+        )
+
+    def test_approval_status_requires_approval(self) -> None:
+        manual = self._create_artifact_with_approval()
+        pending = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+        )
+
+        assert not artifact_matches_query(
+            manual, "approval_status:requires_approval", self.organization
+        )
+        assert artifact_matches_query(
+            pending, "approval_status:requires_approval", self.organization
+        )
+
+    def test_approval_status_no_record_matches_nothing(self) -> None:
+        no_row = self._create_artifact_with_approval(with_approval_row=False)
+
+        assert not artifact_matches_query(no_row, "approval_status:approved", self.organization)
+        assert not artifact_matches_query(
+            no_row, "approval_status:auto_approved", self.organization
+        )
+        assert not artifact_matches_query(
+            no_row, "approval_status:requires_approval", self.organization
+        )
+
+    def test_approval_status_scoped_to_snapshots(self) -> None:
+        artifact = self._create_artifact_with_approval(
+            feature_type=PreprodComparisonApproval.FeatureType.SIZE,
+        )
+
+        assert not artifact_matches_query(artifact, "approval_status:approved", self.organization)
+
+    def test_approval_status_in_filter(self) -> None:
+        manual = self._create_artifact_with_approval()
+        auto = self._create_artifact_with_approval(extras={"auto_approval": True})
+        pending = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+        )
+
+        assert artifact_matches_query(
+            manual, "approval_status:[approved, auto_approved]", self.organization
+        )
+        assert artifact_matches_query(
+            auto, "approval_status:[approved, auto_approved]", self.organization
+        )
+        assert not artifact_matches_query(
+            pending, "approval_status:[approved, auto_approved]", self.organization
+        )
+
+    def test_approval_status_negation(self) -> None:
+        manual = self._create_artifact_with_approval()
+        auto = self._create_artifact_with_approval(extras={"auto_approval": True})
+        pending = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+        )
+
+        assert not artifact_matches_query(manual, "!approval_status:approved", self.organization)
+        assert artifact_matches_query(auto, "!approval_status:approved", self.organization)
+        assert artifact_matches_query(pending, "!approval_status:approved", self.organization)
+
+    def test_approval_status_invalid_value(self) -> None:
+        import pytest
+
+        from sentry.exceptions import InvalidSearchQuery
+
+        artifact = self._create_artifact_with_approval()
+
+        with pytest.raises(InvalidSearchQuery):
+            artifact_matches_query(artifact, "approval_status:bogus", self.organization)


### PR DESCRIPTION
Distinguish auto-approved snapshot comparisons from manually approved ones in the builds list API and search.

Previously, both manual and auto-approved artifacts returned `"approved"` as the approval status. Now `SnapshotComparisonInfo.approval_status` returns `"auto_approved"` when the latest approval record has `extras.auto_approval == True`, derived from the existing `PreprodComparisonApproval.extras` JSON field — no schema changes.

**`approval_status` search filter**

Adds a new `approval_status` search key supporting `approved`, `auto_approved`, and `requires_approval` values with IN-filter and negation support. The existing `is_approved` boolean filter is preserved for backwards compatibility during frontend rollout.