### PR TITLE
feat(seer): Add structured LLM context for logs and releases pages

### DIFF
--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -94,6 +94,8 @@ import {
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useRawCounts} from 'sentry/views/explore/useRawCounts';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
+import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
 // eslint-disable-next-line boundaries/dependencies
 import QuotaExceededAlert from 'getsentry/components/performance/quotaExceededAlert';
@@ -244,12 +246,13 @@ const LogsSearchSection = memo(function LogsSearchSection({
   );
 });
 
-export function LogsTabContent({datePageFilterProps, tableExpando}: LogsTabProps) {
+function LogsTabContentInner({datePageFilterProps, tableExpando}: LogsTabProps) {
   const {openModal} = useModal();
 
   const pageFilters = usePageFilters();
   const fields = useQueryParamsFields();
   const mode = useQueryParamsMode();
+  const groupBys = useQueryParamsGroupBys();
   const topEventsLimit = useQueryParamsTopEventsLimit();
   const queryClient = useQueryClient();
   const sortBys = useQueryParamsSortBys();
@@ -258,6 +261,20 @@ export function LogsTabContent({datePageFilterProps, tableExpando}: LogsTabProps
   const setFields = useSetQueryParamsFields();
   const tableData = useLogsPageDataQueryResult();
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
+  const searchQuery = useQueryParamsSearch().formatString();
+  const visualizes = useQueryParamsVisualizes();
+
+  useLLMContext({
+    contextHint:
+      'Sentry logs explorer page. Users search log entries by attributes and view samples or aggregates. ' +
+      'You can search live telemetry for logs, get detailed log attributes by trace ID, and discover attribute names via the telemetry index.',
+    searchQuery,
+    mode,
+    fields,
+    sortBys: sortBys.map(s => (s.kind === 'desc' ? `-${s.field}` : s.field)),
+    groupBys: groupBys.filter(g => g !== ''),
+    visualizes: visualizes.map(v => v.yAxis),
+  });
 
   const [timeseriesIngestDelay, setTimeseriesIngestDelay] = useState(
     getMaxIngestDelayTimestamp()
@@ -268,7 +285,6 @@ export function LogsTabContent({datePageFilterProps, tableExpando}: LogsTabProps
   const columnEditorButtonRef = useRef<HTMLButtonElement>(null);
   // always use the smallest interval possible (the most bars)
   const [interval] = useChartInterval();
-  const visualizes = useQueryParamsVisualizes();
 
   const [sidebarOpen, setSidebarOpen] = useState(mode === Mode.AGGREGATE);
 
@@ -540,6 +556,8 @@ export function LogsTabContent({datePageFilterProps, tableExpando}: LogsTabProps
     </Fragment>
   );
 }
+
+export const LogsTabContent = registerLLMContext('logs-explorer', LogsTabContentInner);
 
 const ViewportConstrainedBody = styled(ExploreBodyContent)`
   flex-direction: row;

--- a/static/app/views/explore/releases/list/index.tsx
+++ b/static/app/views/explore/releases/list/index.tsx
@@ -55,6 +55,8 @@ import {ReleaseListInner} from 'sentry/views/explore/releases/list/releaseListIn
 import {isMobileRelease} from 'sentry/views/explore/releases/utils';
 import {TopBar} from 'sentry/views/navigation/topBar';
 import {buildDetailsApiOptions} from 'sentry/views/preprod/utils/buildDetailsApiOptions';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
+import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
 import {ReleasesDisplayOption, ReleasesDisplayOptions} from './releasesDisplayOptions';
 import {ReleasesSortOptions} from './releasesSortOptions';
@@ -119,7 +121,7 @@ const releasesFeedbackOptions = {
   },
 };
 
-export default function ReleasesList() {
+function ReleasesListInnerPage() {
   const api = useApi({persistInFlight: true});
   const organization = useOrganization();
   const {projects} = useProjects();
@@ -305,6 +307,18 @@ export default function ReleasesList() {
     shouldShowSnapshotsTab,
     location.query.tab,
   ]);
+
+  useLLMContext({
+    contextHint:
+      'Sentry releases list page. Shows deployed releases with crash-free rates, adoption, and session/user health. ' +
+      'Users can search, sort, filter by status (active/archived), and toggle sessions vs users display. ' +
+      'You can search live telemetry filtered by release to query related errors, spans, or logs (e.g. "errors in release 1.2.3 in the last 7 days").',
+    searchQuery: activeQuery,
+    activeSort,
+    activeDisplay,
+    activeStatus,
+    selectedTab,
+  });
 
   const handleSearch = useCallback(
     (query: string) => {
@@ -690,3 +704,5 @@ const StyledSearchQueryBuilder = styled(SearchQueryBuilder)`
     grid-column: 1 / -1;
   }
 `;
+
+export default registerLLMContext('releases-list', ReleasesListInnerPage);

--- a/static/app/views/seerExplorer/contexts/llmContextTypes.ts
+++ b/static/app/views/seerExplorer/contexts/llmContextTypes.ts
@@ -22,6 +22,8 @@ export type LLMContextNodeType =
   | 'dashboard'
   | 'issue-detail'
   | 'issue-list'
+  | 'logs-explorer'
+  | 'releases-list'
   | 'trace'
   | 'traces-explorer'
   | 'widget'

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -60,7 +60,10 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/issues/:groupId/events/:eventId/',
 ]);
 /** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>();
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>([
+  '/explore/logs/',
+  '/explore/releases/',
+]);
 
 function supportsStructuredContext(
   referrer: string,


### PR DESCRIPTION
+ Register the logs explorer and releases list pages with the Seer Explorer structured context system so that Seer can read page state (search query, sort, filters, mode).
   - Add 'logs-explorer' and 'releases-list' node types
   - Add /explore/logs/ and /explore/releases/ to experimental routes
   - Wire up useLLMContext in LogsTabContent and ReleasesList

