### PR TITLE
feat(explore): hide arrays behind feature flag to avoid any production failures

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -506,6 +506,12 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
                 extrapolation_mode = self.get_extrapolation_mode(request)
 
+                disable_array_attributes = not features.has(
+                    "organizations:trace-item-details-array-fields",
+                    organization,
+                    actor=request.user,
+                )
+
                 if scoped_dataset == Spans:
                     return SearchResolverConfig(
                         auto_fields=True,
@@ -513,6 +519,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         fields_acl=FieldsACL(functions={"time_spent_percentage"}),
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
+                        disable_array_attributes=disable_array_attributes,
                     )
                 elif scoped_dataset == OurLogs:
                     # ourlogs doesn't have use aggregate conditions
@@ -520,6 +527,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         use_aggregate_conditions=False,
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
+                        disable_array_attributes=disable_array_attributes,
                     )
                 elif scoped_dataset == TraceMetrics:
                     # tracemetrics uses aggregate conditions
@@ -531,6 +539,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         auto_fields=True,
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
+                        disable_array_attributes=disable_array_attributes,
                     )
                 elif scoped_dataset == ProfileFunctions:
                     # profile_functions uses aggregate conditions
@@ -539,6 +548,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         auto_fields=True,
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
+                        disable_array_attributes=disable_array_attributes,
                     )
                 elif scoped_dataset == uptime_results.UptimeResults:
                     return SearchResolverConfig(
@@ -546,6 +556,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         auto_fields=True,
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
+                        disable_array_attributes=disable_array_attributes,
                     )
                 elif scoped_dataset == ProcessingErrors:
                     return SearchResolverConfig(
@@ -553,18 +564,21 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         auto_fields=True,
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
+                        disable_array_attributes=disable_array_attributes,
                     )
                 elif scoped_dataset == PreprodSize:
                     return PreprodSizeSearchResolverConfig(
                         use_aggregate_conditions=use_aggregate_conditions,
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
+                        disable_array_attributes=disable_array_attributes,
                     )
                 else:
                     return SearchResolverConfig(
                         use_aggregate_conditions=use_aggregate_conditions,
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
+                        disable_array_attributes=disable_array_attributes,
                     )
 
             if snuba_params.sampling_mode == "HIGHEST_ACCURACY_FLEX_TIME":

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -232,6 +232,11 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                     raise NotImplementedError
 
                 extrapolation_mode = self.get_extrapolation_mode(request)
+                disable_array_attributes = not features.has(
+                    "organizations:trace-item-details-array-fields",
+                    organization,
+                    actor=request.user,
+                )
 
                 if scoped_dataset == TraceMetrics:
                     # tracemetrics uses aggregate conditions
@@ -246,6 +251,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                         )
                         == "1",
                         extrapolation_mode=extrapolation_mode,
+                        disable_array_attributes=disable_array_attributes,
                     )
 
                 if scoped_dataset == PreprodSize:
@@ -257,6 +263,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                         )
                         == "1",
                         extrapolation_mode=extrapolation_mode,
+                        disable_array_attributes=disable_array_attributes,
                     )
 
                 return SearchResolverConfig(
@@ -267,6 +274,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                     )
                     == "1",
                     extrapolation_mode=extrapolation_mode,
+                    disable_array_attributes=disable_array_attributes,
                 )
 
             if top_events > 0:

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.analytics.events.agent_monitoring_events import AgentMonitoringQuery
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -215,13 +215,20 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 status=200,
             )
 
-    def get_rpc_config(self, dataset: Any, request: Request) -> SearchResolverConfig:
+    def get_rpc_config(
+        self, dataset: Any, request: Request, organization: Organization
+    ) -> SearchResolverConfig:
         if dataset not in RPC_DATASETS:
             raise NotImplementedError
 
         extrapolation_mode = self.get_extrapolation_mode(request)
         disable_aggregate_extrapolation = (
             request.GET.get("disableAggregateExtrapolation", "0") == "1"
+        )
+        disable_array_attributes = not features.has(
+            "organizations:trace-item-details-array-fields",
+            organization,
+            actor=request.user,
         )
 
         if dataset == TraceMetrics:
@@ -232,6 +239,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 use_aggregate_conditions=True,
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
+                disable_array_attributes=disable_array_attributes,
             )
         elif dataset == PreprodSize:
             return PreprodSizeSearchResolverConfig(
@@ -239,6 +247,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 use_aggregate_conditions=True,
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
+                disable_array_attributes=disable_array_attributes,
             )
         else:
             return SearchResolverConfig(
@@ -246,6 +255,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 use_aggregate_conditions=True,
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
+                disable_array_attributes=disable_array_attributes,
             )
 
     def get_event_stats(
@@ -295,7 +305,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                     limit=top_events,
                     include_other=include_other,
                     referrer=referrer,
-                    config=self.get_rpc_config(dataset, request),
+                    config=self.get_rpc_config(dataset, request, organization),
                     sampling_mode=snuba_params.sampling_mode,
                     equations=self.get_equation_list(organization, request, param_name="groupBy"),
                     additional_queries=additional_queries,
@@ -325,7 +335,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 query_string=query,
                 y_axes=query_columns,
                 referrer=referrer,
-                config=self.get_rpc_config(dataset, request),
+                config=self.get_rpc_config(dataset, request, organization),
                 sampling_mode=snuba_params.sampling_mode,
                 comparison_delta=comparison_delta,
                 additional_queries=additional_queries,

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -968,6 +968,12 @@ class SearchResolver:
             match = fields.is_function(column)
             has_aggregates = has_aggregates or match is not None
             resolved_column, context = self.resolve_column(column, match)
+            if (
+                self.config.disable_array_attributes
+                and isinstance(resolved_column, ResolvedAttribute)
+                and resolved_column.internal_type == constants.ARRAY
+            ):
+                continue
             resolved_columns.append(resolved_column)
             resolved_contexts.append(context)
 
@@ -1018,6 +1024,8 @@ class SearchResolver:
         resolved_contexts = []
         for column in columns:
             col, context = self.resolve_attribute(column)
+            if self.config.disable_array_attributes and col.internal_type == constants.ARRAY:
+                continue
             resolved_columns.append(col)
             resolved_contexts.append(context)
         return resolved_columns, resolved_contexts

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -36,7 +36,7 @@ class SearchResolverConfig:
     stable_timestamp_quantization: bool = True
     # Whether to 0 when timeseries results have missing data
     zerofill_timeseries: bool = True
-    # When True, ResolvedAttributes whose internal_type is ARRAY are silently based on
+    # When True, ResolvedAttributes whose internal_type is ARRAY are silently dropped based on
     # feature flag organizations:trace-item-details-array-fields
     disable_array_attributes: bool = True
 

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -36,6 +36,9 @@ class SearchResolverConfig:
     stable_timestamp_quantization: bool = True
     # Whether to 0 when timeseries results have missing data
     zerofill_timeseries: bool = True
+    # When True, ResolvedAttributes whose internal_type is ARRAY are silently based on
+    # feature flag organizations:trace-item-details-array-fields
+    disable_array_attributes: bool = True
 
     def extra_conditions(
         self,

--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -518,10 +518,15 @@ class OrganizationEventsOccurrencesArrayQueryTest(
     callsite_name = "api.events.endpoints"
 
     def request_with_feature_flag(self, payload: dict) -> Response:
+        # Array attributes are behind `organizations:trace-item-details-array-fields`.
+        features = {
+            "organizations:discover-basic": True,
+            "organizations:trace-item-details-array-fields": True,
+        }
         with self.options(
             {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
         ):
-            response = self.do_request({**payload, "dataset": "occurrences"})
+            response = self.do_request({**payload, "dataset": "occurrences"}, features=features)
         assert response.status_code == 200, response.content
         return response
 
@@ -770,3 +775,30 @@ class OrganizationEventsOccurrencesArrayQueryTest(
                     f"{description}: query={query!r} matched row with {field}={row[field]!r}; "
                     f"value {value!r} present={is_present}, expected present={must_contain}"
                 )
+
+    def test_array_fields_dropped_when_feature_flag_off(self) -> None:
+        _, expected = self._create_occurrence_with_arrays(occurrence_count=1)
+        event_id = expected[0]["event_id"]
+        expected_http_url = expected[0]["http_url"]
+
+        with self.options(
+            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+        ):
+            response = self.do_request(
+                {
+                    "field": ["id", "stack.filename", "http.url", "stack.colno"],
+                    "statsPeriod": "1h",
+                    "project": [self.project.id],
+                    "dataset": "occurrences",
+                },
+            )
+        assert response.status_code == 200, response.content
+
+        data = response.data.get("data", [])
+        assert len(data) == 1
+        assert data[0]["id"] == event_id
+        # Scalar field is still returned.
+        assert data[0].get("http.url") == expected_http_url
+        # Array-typed fields are silently dropped when the flag is off.
+        assert "stack.filename" not in data[0]
+        assert "stack.colno" not in data[0]


### PR DESCRIPTION

Hide arrays in trace items behind a feature flag, until entire UI and query layer is ready