### PR TITLE
feat(dashboards): Avoid issue assignee row fetches

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -57,7 +57,7 @@ type AssignableTeam = {
   team: Team;
 };
 
-type AssigneeGroup = Pick<Group, 'assignedTo' | 'id' | 'owners'> & {
+export type AssigneeGroup = Pick<Group, 'assignedTo' | 'id' | 'owners'> & {
   project: Pick<Group['project'], 'id' | 'slug'>;
 };
 

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -57,12 +57,16 @@ type AssignableTeam = {
   team: Team;
 };
 
+type AssigneeGroup = Pick<Group, 'assignedTo' | 'id' | 'owners'> & {
+  project: Pick<Group['project'], 'id' | 'slug'>;
+};
+
 interface AssigneeSelectorDropdownProps {
   /**
    * The group (issue) that the assignee selector is for
    * TODO: generalize this for alerts
    */
-  group: Group;
+  group: AssigneeGroup;
   /**
    * If true, there will be a loading indicator in the menu header.
    */

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -7,6 +7,7 @@ import {AssigneeBadge} from 'sentry/components/assigneeBadge';
 import {
   AssigneeSelectorDropdown,
   type AssignableEntity,
+  type AssigneeGroup,
   type SuggestedAssignee,
 } from 'sentry/components/assigneeSelectorDropdown';
 import {t} from 'sentry/locale';
@@ -23,10 +24,6 @@ import {
 
 type HandleAssignOptions = {
   assignedBy?: AssignedBy;
-};
-
-type AssigneeGroup = Pick<Group, 'assignedTo' | 'id' | 'owners'> & {
-  project: Pick<Group['project'], 'id' | 'slug'>;
 };
 
 interface AssigneeSelectorProps {

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -25,9 +25,13 @@ type HandleAssignOptions = {
   assignedBy?: AssignedBy;
 };
 
+type AssigneeGroup = Pick<Group, 'assignedTo' | 'id' | 'owners'> & {
+  project: Pick<Group['project'], 'id' | 'slug'>;
+};
+
 interface AssigneeSelectorProps {
   assigneeLoading: boolean;
-  group: Group;
+  group: AssigneeGroup;
   handleAssigneeChange: (
     assignedActor: AssignableEntity | null,
     options?: HandleAssignOptions
@@ -51,7 +55,7 @@ export function useHandleAssigneeChange({
   onSuccess,
   onError,
 }: {
-  group: Group;
+  group: AssigneeGroup;
   organization: Organization;
   onAssign?: OnAssignCallback;
   onError?: (error: Error) => void;

--- a/static/app/utils/dashboards/issueAssignee.tsx
+++ b/static/app/utils/dashboards/issueAssignee.tsx
@@ -1,5 +1,4 @@
-import {useCallback} from 'react';
-import {useQueryClient} from '@tanstack/react-query';
+import {useCallback, useMemo, useState} from 'react';
 
 import {
   AssigneeSelector,
@@ -7,43 +6,58 @@ import {
 } from 'sentry/components/group/assigneeSelector';
 import type {Group} from 'sentry/types/group';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {groupApiOptions, useGroup} from 'sentry/views/issueDetails/useGroup';
-import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 interface IssueAssigneeProps {
   groupId: string;
+  projectId: string;
+  projectSlug: string;
+  assignedTo?: Group['assignedTo'];
+  owners?: Group['owners'];
 }
 
-export function IssueAssignee({groupId}: IssueAssigneeProps) {
+export function IssueAssignee({
+  groupId,
+  projectId,
+  projectSlug,
+  assignedTo,
+  owners,
+}: IssueAssigneeProps) {
   const organization = useOrganization();
-  const environments = useEnvironmentsFromUrl();
-  const queryClient = useQueryClient();
-  const {data: group} = useGroup({groupId});
+  const [assignedToOverride, setAssignedToOverride] = useState<{
+    assignedTo: Group['assignedTo'];
+    groupId: IssueAssigneeProps['groupId'];
+  } | null>(null);
 
-  // Update useGroup() query cache
+  const currentAssignedTo =
+    assignedToOverride?.groupId === groupId
+      ? assignedToOverride.assignedTo
+      : (assignedTo ?? null);
+
+  const group = useMemo(
+    () => ({
+      id: groupId,
+      assignedTo: currentAssignedTo,
+      owners,
+      project: {
+        id: projectId,
+        slug: projectSlug,
+      },
+    }),
+    [currentAssignedTo, groupId, owners, projectId, projectSlug]
+  );
+
   const onSuccess = useCallback(
-    (assignedTo: Group['assignedTo']) => {
-      queryClient.setQueryData(
-        groupApiOptions({
-          organizationSlug: organization.slug,
-          groupId,
-          environments,
-        }).queryKey,
-        prev => (prev ? {...prev, json: {...prev.json, assignedTo}} : prev)
-      );
+    (nextAssignedTo: Group['assignedTo']) => {
+      setAssignedToOverride({groupId, assignedTo: nextAssignedTo});
     },
-    [queryClient, organization.slug, groupId, environments]
+    [groupId]
   );
 
   const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({
-    group: group!,
+    group,
     organization,
     onSuccess,
   });
-
-  if (!group) {
-    return null;
-  }
 
   return (
     <AssigneeSelector

--- a/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
@@ -55,6 +55,7 @@ describe('getIssueFieldRenderer', () => {
       filteredEvents: 3000,
       events: 6000,
       period: '7d',
+      projectId: project.id,
       links: [{url: 'sentry.io', displayName: 'ANNO-123'}],
     };
 
@@ -86,18 +87,16 @@ describe('getIssueFieldRenderer', () => {
         },
       });
 
-      const group = GroupFixture({
-        project,
-        assignedTo: {
-          email: 'test@sentry.io',
-          type: 'user',
-          id: '1',
-          name: 'Test User',
-        },
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/issues/${group.id}/`,
-        body: group,
+      const assignedTo = {
+        email: 'test@sentry.io',
+        type: 'user',
+        id: '1',
+        name: 'Test User',
+      } as const;
+      const issueDetailMock = MockApiClient.addMockResponse({
+        method: 'GET',
+        url: `/organizations/${organization.slug}/issues/${data.id}/`,
+        body: GroupFixture({id: data.id, project, assignedTo}),
       });
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/users/`,
@@ -110,13 +109,20 @@ describe('getIssueFieldRenderer', () => {
       const renderer = getIssueFieldRenderer('assignee', {});
 
       render(
-        renderer(data, {
-          location,
-          organization,
-          theme,
-        }) as React.ReactElement
+        renderer(
+          {
+            ...data,
+            assignedTo,
+          },
+          {
+            location,
+            organization,
+            theme,
+          }
+        ) as React.ReactElement
       );
       expect(await screen.findByText('TU')).toBeInTheDocument();
+      expect(issueDetailMock).not.toHaveBeenCalled();
     });
 
     it('updates assignee when changed', async () => {
@@ -133,20 +139,17 @@ describe('getIssueFieldRenderer', () => {
         }),
       ];
 
-      const group = GroupFixture({
-        id: data.id,
-        project,
-        assignedTo: {
-          email: 'test@sentry.io',
-          type: 'user',
-          id: '1',
-          name: 'Test User',
-        },
-      });
+      const assignedTo = {
+        email: 'test@sentry.io',
+        type: 'user',
+        id: '1',
+        name: 'Test User',
+      } as const;
 
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/issues/${group.id}/`,
-        body: group,
+      const issueDetailMock = MockApiClient.addMockResponse({
+        method: 'GET',
+        url: `/organizations/${organization.slug}/issues/${data.id}/`,
+        body: GroupFixture({id: data.id, project, assignedTo}),
       });
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/users/`,
@@ -159,9 +162,9 @@ describe('getIssueFieldRenderer', () => {
 
       const assignMock = MockApiClient.addMockResponse({
         method: 'PUT',
-        url: `/organizations/${organization.slug}/issues/${group.id}/`,
+        url: `/organizations/${organization.slug}/issues/${data.id}/`,
         body: {
-          ...group,
+          ...GroupFixture({id: data.id, project, assignedTo}),
           assignedTo: {
             email: 'next@sentry.io',
             type: 'user',
@@ -174,11 +177,17 @@ describe('getIssueFieldRenderer', () => {
       const renderer = getIssueFieldRenderer('assignee', {});
 
       render(
-        renderer(data, {
-          location,
-          organization,
-          theme,
-        }) as React.ReactElement
+        renderer(
+          {
+            ...data,
+            assignedTo,
+          },
+          {
+            location,
+            organization,
+            theme,
+          }
+        ) as React.ReactElement
       );
 
       await userEvent.click(
@@ -188,7 +197,7 @@ describe('getIssueFieldRenderer', () => {
 
       await waitFor(() =>
         expect(assignMock).toHaveBeenCalledWith(
-          `/organizations/${organization.slug}/issues/${group.id}/`,
+          `/organizations/${organization.slug}/issues/${data.id}/`,
           expect.objectContaining({
             data: {assignedTo: 'user:2', assignedBy: 'assignee_selector'},
           })
@@ -196,6 +205,7 @@ describe('getIssueFieldRenderer', () => {
       );
 
       expect(await screen.findByText('NU')).toBeInTheDocument();
+      expect(issueDetailMock).not.toHaveBeenCalled();
     });
 
     it('can render counts', async () => {

--- a/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
@@ -7,13 +7,10 @@ import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingL
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Group} from 'sentry/types/group';
-import {getIssueFieldRenderer} from 'sentry/utils/dashboards/issueFieldRenderers';
-
-type IssueRowMetadata = {
-  assignedTo: Group['assignedTo'];
-  links: Group['annotations'];
-  owners: Group['owners'];
-};
+import {
+  getIssueFieldRenderer,
+  type IssueRowMetadata,
+} from 'sentry/utils/dashboards/issueFieldRenderers';
 
 describe('getIssueFieldRenderer', () => {
   let location: any,

--- a/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
@@ -6,7 +6,14 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {Group} from 'sentry/types/group';
 import {getIssueFieldRenderer} from 'sentry/utils/dashboards/issueFieldRenderers';
+
+type IssueRowMetadata = {
+  assignedTo: Group['assignedTo'];
+  links: Group['annotations'];
+  owners: Group['owners'];
+};
 
 describe('getIssueFieldRenderer', () => {
   let location: any,
@@ -75,6 +82,14 @@ describe('getIssueFieldRenderer', () => {
     });
   });
 
+  function makeIssueMeta(issueId: string, metadata: IssueRowMetadata) {
+    return {
+      issueRowMetadata: {
+        [issueId]: metadata,
+      },
+    };
+  }
+
   describe('Issue fields', () => {
     it('can render assignee', async () => {
       const assignedUser = UserFixture({
@@ -92,7 +107,7 @@ describe('getIssueFieldRenderer', () => {
         type: 'user',
         id: '1',
         name: 'Test User',
-      } as const;
+      } satisfies Group['assignedTo'];
       const issueDetailMock = MockApiClient.addMockResponse({
         method: 'GET',
         url: `/organizations/${organization.slug}/issues/${data.id}/`,
@@ -106,20 +121,17 @@ describe('getIssueFieldRenderer', () => {
         url: `/organizations/${organization.slug}/members/`,
         body: [{user: assignedUser}],
       });
-      const renderer = getIssueFieldRenderer('assignee', {});
+      const renderer = getIssueFieldRenderer(
+        'assignee',
+        makeIssueMeta(data.id, {assignedTo, links: [], owners: []})
+      );
 
       render(
-        renderer(
-          {
-            ...data,
-            assignedTo,
-          },
-          {
-            location,
-            organization,
-            theme,
-          }
-        ) as React.ReactElement
+        renderer(data, {
+          location,
+          organization,
+          theme,
+        }) as React.ReactElement
       );
       expect(await screen.findByText('TU')).toBeInTheDocument();
       expect(issueDetailMock).not.toHaveBeenCalled();
@@ -144,7 +156,7 @@ describe('getIssueFieldRenderer', () => {
         type: 'user',
         id: '1',
         name: 'Test User',
-      } as const;
+      } satisfies Group['assignedTo'];
 
       const issueDetailMock = MockApiClient.addMockResponse({
         method: 'GET',
@@ -174,20 +186,17 @@ describe('getIssueFieldRenderer', () => {
         },
       });
 
-      const renderer = getIssueFieldRenderer('assignee', {});
+      const renderer = getIssueFieldRenderer(
+        'assignee',
+        makeIssueMeta(data.id, {assignedTo, links: [], owners: []})
+      );
 
       render(
-        renderer(
-          {
-            ...data,
-            assignedTo,
-          },
-          {
-            location,
-            organization,
-            theme,
-          }
-        ) as React.ReactElement
+        renderer(data, {
+          location,
+          organization,
+          theme,
+        }) as React.ReactElement
       );
 
       await userEvent.click(
@@ -228,7 +237,14 @@ describe('getIssueFieldRenderer', () => {
   });
 
   it('can render links', () => {
-    const renderer = getIssueFieldRenderer('links', {});
+    const renderer = getIssueFieldRenderer(
+      'links',
+      makeIssueMeta(data.id, {
+        assignedTo: null,
+        links: [{url: 'sentry.io', displayName: 'ANNO-123'}],
+        owners: [],
+      })
+    );
 
     render(
       renderer(data, {
@@ -241,25 +257,24 @@ describe('getIssueFieldRenderer', () => {
   });
 
   it('can render multiple links', () => {
-    const renderer = getIssueFieldRenderer('links', {});
+    const renderer = getIssueFieldRenderer(
+      'links',
+      makeIssueMeta(data.id, {
+        assignedTo: null,
+        links: [
+          {url: 'sentry.io', displayName: 'ANNO-123'},
+          {url: 'sentry.io', displayName: 'ANNO-456'},
+        ],
+        owners: [],
+      })
+    );
 
     render(
-      renderer(
-        {
-          data,
-          ...{
-            links: [
-              {url: 'sentry.io', displayName: 'ANNO-123'},
-              {url: 'sentry.io', displayName: 'ANNO-456'},
-            ],
-          },
-        },
-        {
-          location,
-          organization,
-          theme,
-        }
-      ) as React.ReactElement
+      renderer(data, {
+        location,
+        organization,
+        theme,
+      }) as React.ReactElement
     );
     expect(screen.getByText('ANNO-123')).toBeInTheDocument();
     expect(screen.getByText('ANNO-456')).toBeInTheDocument();

--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -93,7 +93,15 @@ const SPECIAL_FIELDS: SpecialFields = {
   },
   assignee: {
     sortField: null,
-    renderFunc: data => <IssueAssignee groupId={data.id} />,
+    renderFunc: data => (
+      <IssueAssignee
+        groupId={data.id}
+        projectId={data.projectId}
+        projectSlug={data.project}
+        assignedTo={data.assignedTo}
+        owners={data.owners}
+      />
+    ),
   },
   lifetimeEvents: {
     sortField: null,

--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -33,7 +33,7 @@ type RenderFunctionBaggage = {
   eventView?: EventView;
 };
 
-type IssueRowMetadata = {
+export type IssueRowMetadata = {
   assignedTo: Group['assignedTo'];
   links: Group['annotations'];
   owners: Group['owners'];

--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -10,6 +10,7 @@ import {Count} from 'sentry/components/count';
 import {getRelativeSummary} from 'sentry/components/timeRangeSelector/utils';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {IssueAssignee} from 'sentry/utils/dashboards/issueAssignee';
 import type {EventData, MetaType} from 'sentry/utils/discover/eventView';
@@ -32,9 +33,16 @@ type RenderFunctionBaggage = {
   eventView?: EventView;
 };
 
+type IssueRowMetadata = {
+  assignedTo: Group['assignedTo'];
+  links: Group['annotations'];
+  owners: Group['owners'];
+};
+
 type SpecialFieldRenderFunc = (
   data: EventData,
-  baggage: RenderFunctionBaggage
+  baggage: RenderFunctionBaggage,
+  meta: MetaType
 ) => React.ReactNode;
 
 type SpecialField = {
@@ -55,6 +63,13 @@ type SpecialFields = {
   userCount: SpecialField;
   users: SpecialField;
 };
+
+function getIssueRowMetadata(
+  meta: MetaType,
+  issueId: string
+): IssueRowMetadata | undefined {
+  return meta.issueRowMetadata?.[issueId];
+}
 
 /**
  * "Special fields" either do not map 1:1 to an single column in the event database,
@@ -93,15 +108,19 @@ const SPECIAL_FIELDS: SpecialFields = {
   },
   assignee: {
     sortField: null,
-    renderFunc: data => (
-      <IssueAssignee
-        groupId={data.id}
-        projectId={data.projectId}
-        projectSlug={data.project}
-        assignedTo={data.assignedTo}
-        owners={data.owners}
-      />
-    ),
+    renderFunc: (data, _baggage, meta) => {
+      const issueMetadata = getIssueRowMetadata(meta, data.id);
+
+      return (
+        <IssueAssignee
+          groupId={data.id}
+          projectId={data.projectId}
+          projectSlug={data.project}
+          assignedTo={issueMetadata?.assignedTo}
+          owners={issueMetadata?.owners}
+        />
+      );
+    },
   },
   lifetimeEvents: {
     sortField: null,
@@ -145,17 +164,25 @@ const SPECIAL_FIELDS: SpecialFields = {
   },
   links: {
     sortField: null,
-    renderFunc: ({links}) => (
-      <LinksContainer>
-        {links.map((link: any, index: any) => (
-          <ExternalLink key={index} href={link.url}>
-            {link.displayName}
-          </ExternalLink>
-        ))}
-      </LinksContainer>
-    ),
+    renderFunc: (data, _baggage, meta) => {
+      const links = getIssueRowMetadata(meta, data.id)?.links ?? [];
+
+      return (
+        <LinksContainer>
+          {links.map((link, index) => (
+            <ExternalLink key={index} href={link.url}>
+              {link.displayName}
+            </ExternalLink>
+          ))}
+        </LinksContainer>
+      );
+    },
   },
 };
+
+function isSpecialField(field: string): field is keyof SpecialFields {
+  return Object.hasOwn(SPECIAL_FIELDS, field);
+}
 
 const issuesCountRenderer = (
   data: EventData,
@@ -244,8 +271,8 @@ const getDiscoverUrl = (
 };
 
 export function getSortField(field: string): string | null {
-  if (Object.hasOwn(SPECIAL_FIELDS, field)) {
-    return SPECIAL_FIELDS[field as keyof typeof SPECIAL_FIELDS].sortField;
+  if (isSpecialField(field)) {
+    return SPECIAL_FIELDS[field].sortField;
   }
   switch (field) {
     case FieldKey.LAST_SEEN:
@@ -319,9 +346,9 @@ export function getIssueFieldRenderer(
   field: string,
   meta: MetaType
 ): FieldFormatterRenderFunctionPartial {
-  if (Object.hasOwn(SPECIAL_FIELDS, field)) {
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    return SPECIAL_FIELDS[field].renderFunc;
+  if (isSpecialField(field)) {
+    const specialField = SPECIAL_FIELDS[field];
+    return (data, baggage) => specialField.renderFunc(data, baggage, meta);
   }
 
   return getFieldRenderer(field, meta, false);

--- a/static/app/views/dashboards/datasetConfig/issues.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.spec.tsx
@@ -21,6 +21,12 @@ describe('transformIssuesResponseToTable', () => {
               id: '3',
             }),
             status: GroupStatus.UNRESOLVED,
+            assignedTo: {
+              email: 'test@sentry.io',
+              type: 'user',
+              id: '2',
+              name: 'Test User',
+            },
             owners: [
               {
                 type: 'ownershipRule',
@@ -50,12 +56,25 @@ describe('transformIssuesResponseToTable', () => {
         data: [
           expect.objectContaining({
             discoverSearchQuery: ' assigned_or_suggested:#visibility timesSeen:>100',
+            assignedTo: {
+              email: 'test@sentry.io',
+              type: 'user',
+              id: '2',
+              name: 'Test User',
+            },
             events: '6',
             firstSeen: '2022-01-01T13:04:02Z',
             id: '1',
             'issue.id': '1',
             lifetimeUsers: 5,
             links: [],
+            owners: [
+              {
+                type: 'ownershipRule',
+                owner: 'user:2',
+                date_added: '2022-01-01T13:04:02Z',
+              },
+            ],
             period: '',
             projectId: '3',
             status: 'unresolved',

--- a/static/app/views/dashboards/datasetConfig/issues.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.spec.tsx
@@ -3,6 +3,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
+import type {Group} from 'sentry/types/group';
 import {GroupStatus} from 'sentry/types/group';
 import {
   transformIssuesResponseToSeries,
@@ -11,70 +12,58 @@ import {
 
 describe('transformIssuesResponseToTable', () => {
   it('transforms issues response', () => {
-    expect(
-      transformIssuesResponseToTable(
-        [
-          GroupFixture({
-            id: '1',
-            title: 'Error: Failed',
-            project: ProjectFixture({
-              id: '3',
-            }),
-            status: GroupStatus.UNRESOLVED,
-            assignedTo: {
-              email: 'test@sentry.io',
-              type: 'user',
-              id: '2',
-              name: 'Test User',
-            },
-            owners: [
-              {
-                type: 'ownershipRule',
-                owner: 'user:2',
-                date_added: '2022-01-01T13:04:02Z',
-              },
-            ],
-            lifetime: {count: '10', firstSeen: '', lastSeen: '', stats: {}, userCount: 5},
-            count: '6',
-            userCount: 3,
-            firstSeen: '2022-01-01T13:04:02Z',
+    const assignedTo = {
+      email: 'test@sentry.io',
+      type: 'user',
+      id: '2',
+      name: 'Test User',
+    } satisfies Group['assignedTo'];
+    const owners = [
+      {
+        type: 'ownershipRule',
+        owner: 'user:2',
+        date_added: '2022-01-01T13:04:02Z',
+      },
+    ] satisfies Group['owners'];
+    const table = transformIssuesResponseToTable(
+      [
+        GroupFixture({
+          id: '1',
+          title: 'Error: Failed',
+          project: ProjectFixture({
+            id: '3',
           }),
-        ],
-        {
-          name: '',
-          fields: ['issue', 'assignee', 'title', 'culprit', 'status'],
-          columns: ['issue', 'assignee', 'title', 'culprit', 'status'],
-          aggregates: [],
-          conditions: 'assigned_or_suggested:#visibility timesSeen:>100',
-          orderby: '',
-        },
-        OrganizationFixture(),
-        GlobalSelectionFixture()
-      )
-    ).toEqual(
+          status: GroupStatus.UNRESOLVED,
+          assignedTo,
+          owners,
+          lifetime: {count: '10', firstSeen: '', lastSeen: '', stats: {}, userCount: 5},
+          count: '6',
+          userCount: 3,
+          firstSeen: '2022-01-01T13:04:02Z',
+        }),
+      ],
+      {
+        name: '',
+        fields: ['issue', 'assignee', 'title', 'culprit', 'status'],
+        columns: ['issue', 'assignee', 'title', 'culprit', 'status'],
+        aggregates: [],
+        conditions: 'assigned_or_suggested:#visibility timesSeen:>100',
+        orderby: '',
+      },
+      OrganizationFixture(),
+      GlobalSelectionFixture()
+    );
+
+    expect(table).toEqual(
       expect.objectContaining({
         data: [
           expect.objectContaining({
             discoverSearchQuery: ' assigned_or_suggested:#visibility timesSeen:>100',
-            assignedTo: {
-              email: 'test@sentry.io',
-              type: 'user',
-              id: '2',
-              name: 'Test User',
-            },
             events: '6',
             firstSeen: '2022-01-01T13:04:02Z',
             id: '1',
             'issue.id': '1',
             lifetimeUsers: 5,
-            links: [],
-            owners: [
-              {
-                type: 'ownershipRule',
-                owner: 'user:2',
-                date_added: '2022-01-01T13:04:02Z',
-              },
-            ],
             period: '',
             projectId: '3',
             status: 'unresolved',
@@ -84,7 +73,7 @@ describe('transformIssuesResponseToTable', () => {
             start: '2019-10-09T11:18:59',
           }),
         ],
-        meta: {
+        meta: expect.objectContaining({
           fields: expect.objectContaining({
             assignee: 'string',
             events: 'string',
@@ -104,9 +93,17 @@ describe('transformIssuesResponseToTable', () => {
             title: 'string',
             users: 'string',
           }),
-        },
+        }),
       })
     );
+    expect(table.data[0]).not.toHaveProperty('assignedTo');
+    expect(table.data[0]).not.toHaveProperty('owners');
+    expect(table.data[0]).not.toHaveProperty('links');
+    expect(table.meta?.issueRowMetadata?.['1']).toEqual({
+      assignedTo,
+      links: [],
+      owners,
+    });
   });
   it('transforms issues timeseries response to series', () => {
     expect(

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -139,6 +139,8 @@ export function transformIssuesResponseToTable(
       userCount,
       project,
       annotations,
+      assignedTo,
+      owners,
       ...resultProps
     }) => {
       const transformedResultProps: Omit<TableDataRow, 'id'> = {};
@@ -159,6 +161,8 @@ export function transformIssuesResponseToTable(
         issue: shortId,
         title,
         project: project.slug,
+        assignedTo,
+        owners,
         links: (annotations ?? []) as any,
       };
 

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -71,6 +71,12 @@ export type IssuesSeriesResponse = {
   };
 };
 
+type IssueRowMetadata = {
+  assignedTo: Group['assignedTo'];
+  links: Group['annotations'];
+  owners: Group['owners'];
+};
+
 export const IssuesConfig: DatasetConfig<IssuesSeriesResponse, Group[]> = {
   defaultField: DEFAULT_FIELD,
   defaultSeriesField: DEFAULT_SERIES_FIELD,
@@ -121,23 +127,13 @@ function getTableSortOptions(_organization: Organization, _widgetQuery: WidgetQu
   }));
 }
 
-function addIssueRowMetadata(
-  row: TableDataRow,
-  metadata: {
-    assignedTo: Group['assignedTo'];
-    links: Group['annotations'];
-    owners: Group['owners'];
-  }
-) {
-  return Object.assign(row, metadata);
-}
-
 export function transformIssuesResponseToTable(
   data: Group[],
   widgetQuery: WidgetQuery,
   _organization: Organization,
   pageFilters: PageFilters
 ): TableData {
+  const issueRowMetadata: Record<string, IssueRowMetadata> = {};
   const transformedTableResults: TableDataRow[] = [];
   data.forEach(
     ({
@@ -163,23 +159,22 @@ export function transformIssuesResponseToTable(
           transformedResultProps[key] = resultProps[key];
         });
 
-      const transformedTableResult = addIssueRowMetadata(
-        {
-          ...transformedResultProps,
-          events: count,
-          users: userCount,
-          id,
-          'issue.id': id,
-          issue: shortId,
-          title,
-          project: project.slug,
-        },
-        {
-          assignedTo,
-          owners,
-          links: annotations ?? [],
-        }
-      );
+      issueRowMetadata[id] = {
+        assignedTo,
+        owners,
+        links: annotations ?? [],
+      };
+
+      const transformedTableResult: TableDataRow = {
+        ...transformedResultProps,
+        events: count,
+        users: userCount,
+        id,
+        'issue.id': id,
+        issue: shortId,
+        title,
+        project: project.slug,
+      };
 
       // Get lifetime stats
       if (lifetime) {
@@ -214,7 +209,7 @@ export function transformIssuesResponseToTable(
 
   return {
     data: transformedTableResults,
-    meta: {fields: ISSUE_TABLE_FIELDS},
+    meta: {fields: ISSUE_TABLE_FIELDS, issueRowMetadata},
   };
 }
 

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -4,7 +4,10 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import {getIssueFieldRenderer} from 'sentry/utils/dashboards/issueFieldRenderers';
+import {
+  getIssueFieldRenderer,
+  type IssueRowMetadata,
+} from 'sentry/utils/dashboards/issueFieldRenderers';
 import {getUtcDateString} from 'sentry/utils/dates';
 import type {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
@@ -69,12 +72,6 @@ export type IssuesSeriesResponse = {
     end: number;
     start: number;
   };
-};
-
-type IssueRowMetadata = {
-  assignedTo: Group['assignedTo'];
-  links: Group['annotations'];
-  owners: Group['owners'];
 };
 
 export const IssuesConfig: DatasetConfig<IssuesSeriesResponse, Group[]> = {

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -121,6 +121,17 @@ function getTableSortOptions(_organization: Organization, _widgetQuery: WidgetQu
   }));
 }
 
+function addIssueRowMetadata(
+  row: TableDataRow,
+  metadata: {
+    assignedTo: Group['assignedTo'];
+    links: Group['annotations'];
+    owners: Group['owners'];
+  }
+) {
+  return Object.assign(row, metadata);
+}
+
 export function transformIssuesResponseToTable(
   data: Group[],
   widgetQuery: WidgetQuery,
@@ -152,19 +163,23 @@ export function transformIssuesResponseToTable(
           transformedResultProps[key] = resultProps[key];
         });
 
-      const transformedTableResult: TableDataRow = {
-        ...transformedResultProps,
-        events: count,
-        users: userCount,
-        id,
-        'issue.id': id,
-        issue: shortId,
-        title,
-        project: project.slug,
-        assignedTo,
-        owners,
-        links: (annotations ?? []) as any,
-      };
+      const transformedTableResult = addIssueRowMetadata(
+        {
+          ...transformedResultProps,
+          events: count,
+          users: userCount,
+          id,
+          'issue.id': id,
+          issue: shortId,
+          title,
+          project: project.slug,
+        },
+        {
+          assignedTo,
+          owners,
+          links: annotations ?? [],
+        }
+      );
 
       // Get lifetime stats
       if (lifetime) {

--- a/static/app/views/dashboards/widgets/tableWidget/utils.ts
+++ b/static/app/views/dashboards/widgets/tableWidget/utils.ts
@@ -14,6 +14,7 @@ export function convertTableDataToTabularData(tableData?: TableData): TabularDat
   return {
     data: tableData?.data ?? [],
     meta: {
+      ...tableData?.meta,
       units: tableData?.meta?.units as Record<string, TabularValueUnit>,
       fields: tableData?.meta?.fields,
     },


### PR DESCRIPTION
Issue dashboard tables were fetching the full issue once per assignee cell just to render and update assignment state.

Use the row payload for the dashboard assignee cell instead, and keep the post-assignment display update local to that dashboard wrapper. The shared assignment mutation still updates the normal useGroup cache for issue detail consumers.