### PR TITLE
ref(seer): Descriptive tool call phrases in context hints 

### DIFF
--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -135,7 +135,7 @@ function DashboardInner({
   // Push dashboard metadata into the LLM context tree for Seer Explorer.
   useLLMContext({
     contextHint:
-      'Sentry dashboard. dateRange, environments, and projects are global filters applied to every widget. Each widget has its own query config. Use telemetry_live_search or telemetry_index_list_nodes to fetch data. Based on the user question, data might be needed from multiple widgets.',
+      'Sentry dashboard. dateRange, environments, and projects are global filters applied to every widget. Each widget has its own query config. You can search live telemetry or list telemetry index nodes to fetch data. Based on the user question, data might be needed from multiple widgets.',
     title: dashboard.title,
     widgetCount: dashboard.widgets.length,
     queryHints: getQueryHintLegend(dashboard.widgets),

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -200,10 +200,8 @@ function SpanTabContentSectionInner({
   useLLMContext({
     contextHint:
       'Sentry traces explorer page. Users search spans/traces by attributes and view samples, aggregates, or breakdowns. ' +
-      'Tools: telemetry_live_search(dataset, question, project_slugs) to query spans/traces/errors/logs/metrics; ' +
-      'get_trace_waterfall(trace_id, span_id?) for full trace waterfall or specific span; ' +
-      'telemetry_index_list_nodes(keyword) to discover span/function types; ' +
-      'telemetry_index_dependencies(title) for upstream/downstream call graph.',
+      'You can search live telemetry for spans/traces/errors/logs/metrics, get a trace waterfall by trace ID, ' +
+      'list telemetry index nodes by keyword to discover span/function types, and query node dependencies for upstream/downstream call graphs.',
     searchQuery: query,
     activeTab: tab,
     visualizes: visualizes.map(v => v.yAxis),

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -569,15 +569,14 @@ function getIssueDetailContextHint(
   view: 'specific-event' | 'events-list' | 'issue-overview'
 ): string {
   const tools =
-    'Tools: get_issue_details(issue_id) for issue aggregate stats and stack trace; ' +
-    'get_event_details(event_id?, issue_id?) for a specific error event; ' +
-    'telemetry_live_search(dataset, question, project_slugs) for querying spans/errors/logs/metrics.';
+    'You can get issue details for aggregate stats and stack trace, get event details for a specific error event, ' +
+    'and search live telemetry for related spans/errors/logs/metrics.';
   const shortIdNote = 'shortId is the human-readable issue identifier (e.g. PROJ-123). ';
 
   if (view === 'specific-event') {
     return (
       'Sentry issue detail page. The user is viewing a specific event — ' +
-      'call get_event_details(event_id) with the eventId below to see what they see. ' +
+      'You can get event details with the eventId below to see what they see. ' +
       shortIdNote +
       tools
     );
@@ -586,7 +585,7 @@ function getIssueDetailContextHint(
   if (view === 'events-list') {
     return (
       'Sentry issue events list. The user is browsing all events for this issue. ' +
-      'Use telemetry_live_search to query events matching this issue. ' +
+      'You can search live telemetry to query events matching this issue. ' +
       shortIdNote +
       tools
     );

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -153,13 +153,9 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
   useLLMContext({
     contextHint:
       'Sentry trace detail page. services lists the projects (services) involved in this trace. ' +
-      'Tools: get_trace_waterfall(trace_id, span_id?) for full waterfall or specific span; ' +
-      'get_event_details(event_id?, issue_id?) for error event details; ' +
-      'get_issue_details(issue_id) for issue aggregate stats; ' +
-      'get_log_attributes(trace_id, log_message_substring) for log entries in this trace; ' +
-      'get_metric_attributes(trace_id, metric_name) for metric samples in this trace; ' +
-      'get_profile_flamegraph(profile_id, trace_id?) for CPU/memory flamegraph; ' +
-      'telemetry_live_search(dataset, question, project_slugs) for related spans/errors/logs/metrics.',
+      'You can get the trace waterfall or focus on a specific span, get event details or issue aggregate stats, ' +
+      'get log attributes or metric attributes by trace ID, view a profile flamegraph, ' +
+      'and search live telemetry for related spans/errors/logs/metrics.',
     traceId: traceSlug,
     activeTab: currentTab,
     durationMs: tree.root.children[0]?.space?.[1],


### PR DESCRIPTION
+ Use natural-language phrasing instead of literal function signatures in contextHint strings so they are decoupled from backend tool names. This is to make it robust to tool name changes and code mode in the future. 
