### PR TITLE
ref: Migrate simple useQueryParamState call sites to nuqs

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useEffect, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
+import {useQueryState} from 'nuqs';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Flex} from '@sentry/scraps/layout';
@@ -14,7 +15,6 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {EventView} from 'sentry/utils/discover/eventView';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDismissAlert} from 'sentry/utils/useDismissAlert';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -42,9 +42,7 @@ type PaginationState = {
 };
 
 export function AttributeDistribution() {
-  const [searchQuery, setSearchQuery] = useQueryParamState({
-    fieldName: 'attributeBreakdownsSearch',
-  });
+  const [searchQuery, setSearchQuery] = useQueryState('attributeBreakdownsSearch');
 
   // Little unconventional, but the /trace-items/stats/ endpoint but recommends fetching
   // more data than we need to display the current page. We maintain a cursor to fetch the next page,

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
@@ -2,6 +2,7 @@ import {Fragment, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
+import {useQueryState} from 'nuqs';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -12,7 +13,6 @@ import {Panel} from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import {getUserTimezone} from 'sentry/utils/dates';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useAttributeBreakdownComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
 import {useAttributeBreakdownsTooltipAction} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
@@ -47,9 +47,7 @@ export function CohortComparison({
     dataset,
     extrapolate,
   });
-  const [searchQuery, setSearchQuery] = useQueryParamState({
-    fieldName: 'attributeBreakdownsSearch',
-  });
+  const [searchQuery, setSearchQuery] = useQueryState('attributeBreakdownsSearch');
   const theme = useTheme();
 
   // Debouncing the search query here to ensure smooth typing, by delaying the re-mounts a little as the user types.

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -1,7 +1,7 @@
 import {useCallback} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import styled from '@emotion/styled';
-import {parseAsBoolean, useQueryState} from 'nuqs';
+import {parseAsBoolean, parseAsStringLiteral, useQueryState} from 'nuqs';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -16,7 +16,6 @@ import {t} from 'sentry/locale';
 import {parseApiError} from 'sentry/utils/parseApiError';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
-import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 import {BuildDetailsMetricCards} from 'sentry/views/preprod/buildDetails/main/buildDetailsMetricCards';
 import {AppSizeInsights} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsights';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
@@ -73,31 +72,27 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   // If the main data fetch fails, this component will not be rendered
   // so we don't handle 'isBuildDetailsError'.
 
-  const [selectedContentParam, setSelectedContentParam] = useQueryParamState<
-    'treemap' | 'categories'
-  >({
-    fieldName: 'view',
-  });
+  const [selectedContentParam, setSelectedContentParam] = useQueryState(
+    'view',
+    parseAsStringLiteral(['treemap', 'categories'] as const)
+  );
   const selectedContent =
     selectedContentParam === 'treemap' || selectedContentParam === 'categories'
       ? selectedContentParam
       : 'treemap';
 
   const handleContentChange = (value: 'treemap' | 'categories') => {
-    setSelectedContentParam(value === 'treemap' ? undefined : value);
+    setSelectedContentParam(value === 'treemap' ? null : value);
   };
-  const [searchQuery, setSearchQuery] = useQueryParamState({
-    fieldName: 'search',
-  });
+  const [searchQuery, setSearchQuery] = useQueryState('search');
 
   const [highlightInsights, setHighlightInsights] = useQueryState(
     'highlightInsights',
     parseAsBoolean.withDefault(true)
   );
 
-  const [selectedCategoriesParam, setSelectedCategoriesParam] = useQueryParamState({
-    fieldName: 'categories',
-  });
+  const [selectedCategoriesParam, setSelectedCategoriesParam] =
+    useQueryState('categories');
 
   const selectedCategories = selectedCategoriesParam
     ? new Set(
@@ -117,7 +112,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     } else {
       next.add(category);
     }
-    setSelectedCategoriesParam(next.size > 0 ? Array.from(next).join(',') : undefined);
+    setSelectedCategoriesParam(next.size > 0 ? Array.from(next).join(',') : null);
   };
 
   const sizeInfo = buildDetailsData?.size_info;
@@ -336,7 +331,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
                 ? handleAlertClick
                 : undefined
             }
-            onSearchChange={value => setSearchQuery(value || undefined)}
+            onSearchChange={value => setSearchQuery(value || null)}
             highlightInsights={highlightInsights}
             onHighlightInsightsChange={setHighlightInsights}
             insightsAvailable={insightsAvailable}
@@ -359,7 +354,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
             ? handleAlertClick
             : undefined
         }
-        onSearchChange={value => setSearchQuery(value || undefined)}
+        onSearchChange={value => setSearchQuery(value || null)}
         highlightInsights={highlightInsights}
         onHighlightInsightsChange={setHighlightInsights}
         insightsAvailable={insightsAvailable}
@@ -399,12 +394,12 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
               <InputGroup.Input
                 placeholder="Search files"
                 value={searchQuery || ''}
-                onChange={e => setSearchQuery(e.target.value || undefined)}
+                onChange={e => setSearchQuery(e.target.value || null)}
               />
               {searchQuery && (
                 <InputGroup.TrailingItems>
                   <Button
-                    onClick={() => setSearchQuery(undefined)}
+                    onClick={() => setSearchQuery(null)}
                     aria-label="Clear search"
                     variant="transparent"
                     size="zero"

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -72,17 +72,13 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   // If the main data fetch fails, this component will not be rendered
   // so we don't handle 'isBuildDetailsError'.
 
-  const [selectedContentParam, setSelectedContentParam] = useQueryState(
+  const [selectedContent, setSelectedContent] = useQueryState(
     'view',
-    parseAsStringLiteral(['treemap', 'categories'] as const)
+    parseAsStringLiteral(['treemap', 'categories'] as const).withDefault('treemap')
   );
-  const selectedContent =
-    selectedContentParam === 'treemap' || selectedContentParam === 'categories'
-      ? selectedContentParam
-      : 'treemap';
 
   const handleContentChange = (value: 'treemap' | 'categories') => {
-    setSelectedContentParam(value === 'treemap' ? null : value);
+    setSelectedContent(value === 'treemap' ? null : value);
   };
   const [searchQuery, setSearchQuery] = useQueryState('search');
 

--- a/static/app/views/pullRequest/details/pullRequestDetails.tsx
+++ b/static/app/views/pullRequest/details/pullRequestDetails.tsx
@@ -1,3 +1,5 @@
+import {parseAsStringLiteral, useQueryState} from 'nuqs';
+
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {TabList} from '@sentry/scraps/tabs';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -7,7 +9,6 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {PullRequestDetailsHeaderContent} from 'sentry/views/pullRequest/details/header/pullRequestDetailsHeaderContent';
@@ -22,9 +23,10 @@ import type {
 export default function PullRequestDetails() {
   const organization = useOrganization();
   const params = useParams() as {prId: string; repoName: string; repoOrg: string};
-  const [selectedTab, setSelectedTab] = useQueryParamState<'files' | 'size_analysis'>({
-    fieldName: 'tab',
-  });
+  const [selectedTab, setSelectedTab] = useQueryState(
+    'tab',
+    parseAsStringLiteral(['files', 'size_analysis'] as const)
+  );
 
   const pullRequestQuery = useApiQuery<PullRequestDetailsResponse>(
     [

--- a/static/app/views/pullRequest/details/pullRequestDetails.tsx
+++ b/static/app/views/pullRequest/details/pullRequestDetails.tsx
@@ -25,7 +25,7 @@ export default function PullRequestDetails() {
   const params = useParams() as {prId: string; repoName: string; repoOrg: string};
   const [selectedTab, setSelectedTab] = useQueryState(
     'tab',
-    parseAsStringLiteral(['files', 'size_analysis'] as const)
+    parseAsStringLiteral(['files', 'size_analysis'] as const).withDefault('files')
   );
 
   const pullRequestQuery = useApiQuery<PullRequestDetailsResponse>(
@@ -113,7 +113,7 @@ export default function PullRequestDetails() {
     >
       <Layout.Header>
         <PullRequestDetailsHeaderContent pullRequest={prSuccessData} />
-        <Layout.HeaderTabs value={selectedTab || 'files'} onChange={setSelectedTab}>
+        <Layout.HeaderTabs value={selectedTab} onChange={setSelectedTab}>
           <TabList>
             <TabList.Item key="files">{t('Files')}</TabList.Item>
             {hasSizeAnalysis ? (


### PR DESCRIPTION
## Summary
- Replace `useQueryParamState` with nuqs `useQueryState` and `parseAsStringLiteral` in 4 files (5 call sites)
- Migrated: `pullRequestDetails` (tab selector), `cohortComparisonContent` (search), `attributeDistributionContent` (search), `buildDetailsMainContent` (view selector, search, categories)
- Updated clearing calls from `undefined` to `null` per nuqs conventions

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [ ] Verify tab switching on pull request details page
- [x] Verify search and view toggle on build details page
- [x] Verify attribute breakdown search on explore page