### PR TITLE
feat(dashboards): Use widget-aware chart type for Slack unfurl

### DIFF
--- a/src/sentry/charts/types.py
+++ b/src/sentry/charts/types.py
@@ -25,6 +25,7 @@ class ChartType(Enum):
     SLACK_METRIC_DETECTOR_EVENTS = "slack:metricDetector.events"
     SLACK_METRIC_DETECTOR_SESSIONS = "slack:metricDetector.sessions"
     SLACK_TIMESERIES = "slack:timeseries"
+    SLACK_DASHBOARDS_WIDGET = "slack:dashboardsWidget"
 
 
 class ChartSize(TypedDict):

--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -157,11 +157,6 @@ def _unfurl_dashboards(
         if not per_query_params:
             continue
 
-        # ``[ts, widget_query_index]`` tuples. A single widget query can yield
-        # multiple ``TimeSeries`` (multi-aggregate, ``yAxis=[...]``, grouped
-        # queries with ``topEvents``) so we tag each one with the index of
-        # the query that produced it; chartcuterie uses that to pair each
-        # series with its widget query and render the FE-equivalent legend.
         combined_time_series: list[list[Any]] = []
         request_failed = False
         for query_index, params in enumerate(per_query_params):

--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -13,6 +13,7 @@ from django.http.request import QueryDict
 
 from sentry import analytics, features
 from sentry.api import client
+from sentry.api.endpoints.timeseries import TimeSeries
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.dashboard import DashboardWidgetSerializer
 from sentry.charts import backend as charts
@@ -157,7 +158,7 @@ def _unfurl_dashboards(
         if not per_query_params:
             continue
 
-        combined_time_series: list[list[Any]] = []
+        combined_time_series: list[tuple[TimeSeries, int]] = []
         request_failed = False
         for query_index, params in enumerate(per_query_params):
             try:
@@ -173,7 +174,7 @@ def _unfurl_dashboards(
                 break
 
             for ts in resp.data.get("timeSeries", []):
-                combined_time_series.append([ts, query_index])
+                combined_time_series.append((ts, query_index))
 
         if request_failed:
             continue

--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -62,11 +62,13 @@ DASHBOARDS_CHART_SIZE: ChartSize = {"width": 1200, "height": 400}
 
 # Display types where a timeseries chart makes sense. Other display types
 # (table, big number, text, etc.) are not supported for unfurl yet.
-_TIMESERIES_DISPLAY_TYPES = {
-    DashboardWidgetDisplayTypes.LINE_CHART: "line",
-    DashboardWidgetDisplayTypes.AREA_CHART: "area",
-    DashboardWidgetDisplayTypes.BAR_CHART: "bar",
-}
+_TIMESERIES_DISPLAY_TYPES = frozenset(
+    {
+        DashboardWidgetDisplayTypes.LINE_CHART,
+        DashboardWidgetDisplayTypes.AREA_CHART,
+        DashboardWidgetDisplayTypes.BAR_CHART,
+    }
+)
 
 
 _UnfurlEndpoint = Literal["events-timeseries", "issues-timeseries"]
@@ -150,8 +152,7 @@ def _unfurl_dashboards(
         if config is None:
             continue
 
-        display_type = _TIMESERIES_DISPLAY_TYPES.get(widget.display_type)
-        if display_type is None:
+        if widget.display_type not in _TIMESERIES_DISPLAY_TYPES:
             continue
 
         per_query_params = build_widget_timeseries_params(widget, args["query"])

--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -13,7 +13,8 @@ from django.http.request import QueryDict
 
 from sentry import analytics, features
 from sentry.api import client
-from sentry.api.endpoints.timeseries import TimeSeries
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.dashboard import DashboardWidgetSerializer
 from sentry.charts import backend as charts
 from sentry.charts.types import ChartSize, ChartType
 from sentry.integrations.messaging.metrics import (
@@ -156,9 +157,14 @@ def _unfurl_dashboards(
         if not per_query_params:
             continue
 
-        combined_time_series: list[TimeSeries] = []
+        # ``[ts, widget_query_index]`` tuples. A single widget query can yield
+        # multiple ``TimeSeries`` (multi-aggregate, ``yAxis=[...]``, grouped
+        # queries with ``topEvents``) so we tag each one with the index of
+        # the query that produced it; chartcuterie uses that to pair each
+        # series with its widget query and render the FE-equivalent legend.
+        combined_time_series: list[list[Any]] = []
         request_failed = False
-        for params in per_query_params:
+        for query_index, params in enumerate(per_query_params):
             try:
                 resp = client.get(
                     auth=ApiKey(organization_id=org.id, scope_list=["org:read"]),
@@ -171,19 +177,20 @@ def _unfurl_dashboards(
                 request_failed = True
                 break
 
-            combined_time_series.extend(resp.data.get("timeSeries", []))
+            for ts in resp.data.get("timeSeries", []):
+                combined_time_series.append([ts, query_index])
 
         if request_failed:
             continue
 
         chart_data: dict[str, Any] = {
             "timeSeries": combined_time_series,
-            "type": display_type,
+            "widget": serialize(widget, user, DashboardWidgetSerializer()),
         }
 
         try:
             url = charts.generate_chart(
-                ChartType.SLACK_TIMESERIES, chart_data, size=DASHBOARDS_CHART_SIZE
+                ChartType.SLACK_DASHBOARDS_WIDGET, chart_data, size=DASHBOARDS_CHART_SIZE
             )
         except RuntimeError:
             _logger.warning("Failed to generate chart for dashboards unfurl")

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2579,10 +2579,15 @@ class UnfurlTest(TestCase):
             == SlackDiscoverMessageBuilder(title=widget.title, chart_url="chart-url").build()
         )
         assert mock_generate_chart.call_count == 1
-        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_TIMESERIES
+        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_DASHBOARDS_WIDGET
         chart_data = mock_generate_chart.call_args[0][1]
-        assert chart_data["type"] == "line"
-        assert "timeSeries" in chart_data
+        assert chart_data["widget"]["title"] == "My Spans Widget"
+        assert chart_data["widget"]["widgetType"] == "spans"
+        assert chart_data["widget"]["displayType"] == "line"
+        assert chart_data["widget"]["queries"][0]["aggregates"] == ["avg(span.duration)"]
+        # Each timeSeries is tagged with the index of its widget query.
+        assert all(pair[1] == 0 for pair in chart_data["timeSeries"])
+        assert chart_data["timeSeries"][0][0]["yAxis"] == "avg(span.duration)"
 
         api_params = mock_client_get.call_args[1]["params"]
         assert "/events-timeseries/" in mock_client_get.call_args[1]["path"]
@@ -2774,8 +2779,135 @@ class UnfurlTest(TestCase):
         assert len(unfurls) == 1
         assert mock_client_get.call_count == 2
         chart_data = mock_generate_chart.call_args[0][1]
-        y_axes = [series["yAxis"] for series in chart_data["timeSeries"]]
-        assert y_axes == ["avg(span.duration)", "p75(span.duration)"]
+        # ``timeSeries`` is a list of ``[ts, widget_query_index]`` tuples.
+        pairs = chart_data["timeSeries"]
+        assert [pair[0]["yAxis"] for pair in pairs] == [
+            "avg(span.duration)",
+            "p75(span.duration)",
+        ]
+        assert [pair[1] for pair in pairs] == [0, 1]
+
+    @patch("sentry.integrations.slack.unfurl.dashboards.client.get")
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_dashboards_multi_query_same_aggregate(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        # The user's reported widget: two queries with identical aggregates,
+        # differing only by conditions. The widget query index lets
+        # chartcuterie tell them apart in the legend.
+        mock_client_get.side_effect = [
+            MagicMock(data=self._build_mock_timeseries_response(y_axis="count(span.duration)")),
+            MagicMock(data=self._build_mock_timeseries_response(y_axis="count(span.duration)")),
+        ]
+
+        dashboard = self.create_dashboard(organization=self.organization)
+        widget = self.create_dashboard_widget(
+            dashboard=dashboard,
+            title="Multi query",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.SPANS,
+            order=0,
+        )
+        self.create_dashboard_widget_query(
+            widget=widget,
+            order=0,
+            name="",
+            fields=["count(span.duration)"],
+            aggregates=["count(span.duration)"],
+            columns=[],
+            conditions="span.op:db",
+        )
+        self.create_dashboard_widget_query(
+            widget=widget,
+            order=1,
+            name="",
+            fields=["count(span.duration)"],
+            aggregates=["count(span.duration)"],
+            columns=[],
+            conditions="span.op:http.client",
+        )
+
+        url = (
+            f"https://sentry.io/organizations/{self.organization.slug}"
+            f"/dashboard/{dashboard.id}/widget/0/?statsPeriod=7d"
+        )
+        link_type, args = match_link(url)
+        assert link_type is not None and args is not None
+        links = [UnfurlableUrl(url=url, args=args)]
+
+        with self.feature(["organizations:dashboards-widget-unfurl"]):
+            link_handlers[link_type].fn(self.integration, links, self.user)
+
+        chart_data = mock_generate_chart.call_args[0][1]
+        pairs = chart_data["timeSeries"]
+        assert [pair[1] for pair in pairs] == [0, 1]
+        assert [pair[0]["yAxis"] for pair in pairs] == [
+            "count(span.duration)",
+            "count(span.duration)",
+        ]
+        widget_payload = chart_data["widget"]
+        assert [q["conditions"] for q in widget_payload["queries"]] == [
+            "span.op:db",
+            "span.op:http.client",
+        ]
+
+    @patch("sentry.integrations.slack.unfurl.dashboards.client.get")
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_dashboards_single_query_multi_series_share_query_index(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        # A single grouped query returns multiple TimeSeries (one per group).
+        # All series must be tagged with the same query index (0).
+        def grouped_response(group_value: str):
+            return {
+                "timeSeries": [
+                    {
+                        "yAxis": "count(span.duration)",
+                        "groupBy": [{"key": "transaction", "value": group_value}],
+                        "meta": {
+                            "valueType": "duration",
+                            "valueUnit": "millisecond",
+                            "interval": INTERVAL_COUNT * 1000,
+                        },
+                        "values": [],
+                    }
+                ],
+            }
+
+        # One HTTP call returns two grouped series.
+        mock_client_get.return_value = MagicMock(
+            data={
+                "timeSeries": [
+                    grouped_response("/api/db")["timeSeries"][0],
+                    grouped_response("/api/http")["timeSeries"][0],
+                ]
+            }
+        )
+
+        dashboard, _ = self._create_spans_widget(
+            aggregates=["count(span.duration)"],
+            columns=["transaction"],
+        )
+
+        url = (
+            f"https://sentry.io/organizations/{self.organization.slug}"
+            f"/dashboard/{dashboard.id}/widget/0/?statsPeriod=7d"
+        )
+        link_type, args = match_link(url)
+        assert link_type is not None and args is not None
+        links = [UnfurlableUrl(url=url, args=args)]
+
+        with self.feature(["organizations:dashboards-widget-unfurl"]):
+            link_handlers[link_type].fn(self.integration, links, self.user)
+
+        chart_data = mock_generate_chart.call_args[0][1]
+        pairs = chart_data["timeSeries"]
+        # Both series come from the same widget query.
+        assert [pair[1] for pair in pairs] == [0, 0]
+        assert [pair[0]["groupBy"][0]["value"] for pair in pairs] == [
+            "/api/db",
+            "/api/http",
+        ]
 
     @patch("sentry.integrations.slack.unfurl.dashboards.client.get")
     @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
@@ -2800,7 +2932,7 @@ class UnfurlTest(TestCase):
 
         assert len(unfurls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
-        assert chart_data["type"] == "bar"
+        assert chart_data["widget"]["displayType"] == "bar"
 
     def test_match_link_dashboards(self) -> None:
         # Primary domain

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2585,7 +2585,6 @@ class UnfurlTest(TestCase):
         assert chart_data["widget"]["widgetType"] == "spans"
         assert chart_data["widget"]["displayType"] == "line"
         assert chart_data["widget"]["queries"][0]["aggregates"] == ["avg(span.duration)"]
-        # Each timeSeries is tagged with the index of its widget query.
         assert all(pair[1] == 0 for pair in chart_data["timeSeries"])
         assert chart_data["timeSeries"][0][0]["yAxis"] == "avg(span.duration)"
 
@@ -2779,7 +2778,6 @@ class UnfurlTest(TestCase):
         assert len(unfurls) == 1
         assert mock_client_get.call_count == 2
         chart_data = mock_generate_chart.call_args[0][1]
-        # ``timeSeries`` is a list of ``[ts, widget_query_index]`` tuples.
         pairs = chart_data["timeSeries"]
         assert [pair[0]["yAxis"] for pair in pairs] == [
             "avg(span.duration)",
@@ -2792,9 +2790,6 @@ class UnfurlTest(TestCase):
     def test_unfurl_dashboards_multi_query_same_aggregate(
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:
-        # The user's reported widget: two queries with identical aggregates,
-        # differing only by conditions. The widget query index lets
-        # chartcuterie tell them apart in the legend.
         mock_client_get.side_effect = [
             MagicMock(data=self._build_mock_timeseries_response(y_axis="count(span.duration)")),
             MagicMock(data=self._build_mock_timeseries_response(y_axis="count(span.duration)")),
@@ -2856,8 +2851,6 @@ class UnfurlTest(TestCase):
     def test_unfurl_dashboards_single_query_multi_series_share_query_index(
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:
-        # A single grouped query returns multiple TimeSeries (one per group).
-        # All series must be tagged with the same query index (0).
         def grouped_response(group_value: str):
             return {
                 "timeSeries": [
@@ -2874,7 +2867,6 @@ class UnfurlTest(TestCase):
                 ],
             }
 
-        # One HTTP call returns two grouped series.
         mock_client_get.return_value = MagicMock(
             data={
                 "timeSeries": [
@@ -2902,7 +2894,6 @@ class UnfurlTest(TestCase):
 
         chart_data = mock_generate_chart.call_args[0][1]
         pairs = chart_data["timeSeries"]
-        # Both series come from the same widget query.
         assert [pair[1] for pair in pairs] == [0, 0]
         assert [pair[0]["groupBy"][0]["value"] for pair in pairs] == [
             "/api/db",


### PR DESCRIPTION
## Summary

- Wires `_unfurl_dashboards` to the new `SLACK_DASHBOARDS_WIDGET` chartcuterie chart type added in #115312.