### PR TITLE
ref(ui): Remove dead ClippedBox height callback

### DIFF
--- a/static/app/components/clippedBox.spec.tsx
+++ b/static/app/components/clippedBox.spec.tsx
@@ -79,28 +79,6 @@ describe('clipped box', () => {
       clearMockGetBoundingClientRect();
     });
 
-    it('calls onSetRenderHeight once', () => {
-      if (!enableResizeObserver) {
-        mockGetBoundingClientRect({height: 100});
-      }
-
-      const onSetRenderHeight = jest.fn();
-      const {rerender} = render(
-        <ClippedBox clipHeight={50} onSetRenderedHeight={onSetRenderHeight}>
-          <Child height={100} />
-        </ClippedBox>
-      );
-
-      expect(onSetRenderHeight).toHaveBeenCalledTimes(1);
-      rerender(
-        <ClippedBox clipHeight={50} onSetRenderedHeight={onSetRenderHeight}>
-          <Child height={100} />
-        </ClippedBox>
-      );
-
-      expect(onSetRenderHeight).toHaveBeenCalledTimes(1);
-      expect(onSetRenderHeight).toHaveBeenCalledWith(100);
-    });
     it('clips height when it exceeds clipHeight and shows button', () => {
       if (!enableResizeObserver) {
         mockGetBoundingClientRect({height: 100});

--- a/static/app/components/clippedBox.stories.tsx
+++ b/static/app/components/clippedBox.stories.tsx
@@ -71,15 +71,11 @@ export default Storybook.story('ClippedBox', story => {
       <Fragment>
         <p>
           Some callbacks are available:{' '}
-          <Storybook.JSXProperty name="onSetRenderedHeight" value={Function} />&{' '}
           <Storybook.JSXProperty name="onReveal" value={Function} />.
         </p>
         <Storybook.SideBySide>
           {[50, 100, 150].map(imgHeight => {
             const [isRevealed, setIsRevealed] = useState(false);
-            const [renderedHeight, setRenderedHeight] = useState<number | undefined>(
-              undefined
-            );
             return (
               <div key={imgHeight}>
                 <p>
@@ -88,13 +84,8 @@ export default Storybook.story('ClippedBox', story => {
                   </Storybook.JSXNode>
                 </p>
                 <p>isRevealed = {String(isRevealed)}</p>
-                <p>renderedHeight = {renderedHeight}</p>
                 <Storybook.SizingWindow>
-                  <ClippedBox
-                    clipHeight={100}
-                    onReveal={() => setIsRevealed(true)}
-                    onSetRenderedHeight={setRenderedHeight}
-                  >
+                  <ClippedBox clipHeight={100} onReveal={() => setIsRevealed(true)}>
                     <img
                       src={onboardingFrameworkSelectionJavascript}
                       height={imgHeight}

--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffectEvent, useLayoutEffect, useRef, useState} from 'react';
+import {useCallback, useLayoutEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 // eslint-disable-next-line no-restricted-imports
 import color from 'color';
@@ -94,18 +94,12 @@ interface ClippedBoxProps {
    * Triggered when user clicks on the show more button
    */
   onReveal?: () => void;
-  /**
-   * Its trigged when the component is mounted and its height available
-   */
-  onSetRenderedHeight?: (renderedHeight: number) => void;
-  renderedHeight?: number;
   title?: string;
 }
 
 export function ClippedBox(props: ClippedBoxProps) {
   const revealTransitionPendingRef = useRef(false);
   const hasMeasuredRef = useRef(false);
-  const mountedRef = useRef(false);
 
   const observerRef = useRef<ResizeObserver | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -118,10 +112,6 @@ export function ClippedBox(props: ClippedBoxProps) {
 
   const clipHeight = props.clipHeight || 200;
   const clipFlex = props.clipFlex || 28;
-
-  const handleRenderedHeight = useEffectEvent((height: number) => {
-    props.onSetRenderedHeight?.(height);
-  });
 
   const handleReveal = (event: React.MouseEvent<HTMLElement>) => {
     const wrapper = wrapperRef.current;
@@ -255,11 +245,6 @@ export function ClippedBox(props: ClippedBoxProps) {
       }
 
       hasMeasuredRef.current = true;
-
-      if (!mountedRef.current) {
-        handleRenderedHeight(height);
-        mountedRef.current = true;
-      }
 
       const _clipped = isClipped({
         clipFlex,


### PR DESCRIPTION
ClippedBox kept an `onSetRenderedHeight` escape hatch for a frame registers layout that stopped using it in 2023. Remove the dead prop, its test coverage, and the story bits so the component no longer needs `useEffectEvent` here.

fixes JAVASCRIPT-39J2