### PR TITLE
fix(preprod): Quote CSS mask-image URLs to handle special characters

### DIFF
--- a/static/app/views/preprod/snapshots/main/diffOverlay.tsx
+++ b/static/app/views/preprod/snapshots/main/diffOverlay.tsx
@@ -12,11 +12,11 @@ export const DiffOverlay = styled('span')<{
   height: 100%;
   pointer-events: none;
   background-color: ${p => p.$overlayColor};
-  mask-image: url(${p => p.$maskUrl});
+  mask-image: url('${p => p.$maskUrl}');
   mask-size: ${p => p.$maskSize};
   mask-position: top left;
   mask-mode: luminance;
-  -webkit-mask-image: url(${p => p.$maskUrl});
+  -webkit-mask-image: url('${p => p.$maskUrl}');
   -webkit-mask-size: ${p => p.$maskSize};
   -webkit-mask-position: top left;
 `;


### PR DESCRIPTION
Snapshot image names containing spaces or other special characters
(e.g. `+` decoded to space) caused the unquoted CSS `url()` value in
the diff overlay to be silently dropped by the browser. This rendered
the overlay as a solid rectangle covering the entire image instead of
highlighting only the changed regions.

The `mask-image` property was completely absent from the element's
computed styles, confirmed via DevTools — while `mask-mode`,
`mask-size`, and `mask-position` were all present. The root cause is
that CSS `url()` without quotes cannot contain unescaped whitespace.

Quoting the URL (`url('...')`) allows the CSS parser to handle any
characters in the path.