### PR TITLE
feat(codeowners): Support excluding subdirectories via no-owner rules

### DIFF
--- a/src/sentry/issues/ownership/grammar.py
+++ b/src/sentry/issues/ownership/grammar.py
@@ -628,6 +628,12 @@ def create_schema_from_issue_owners(
             {"raw": f"Parse error: {rule_name} (line {e.line()}, column {e.column()})"}
         )
 
+    for rule in rules:
+        if not rule.owners and rule.matcher.type != CODEOWNERS:
+            raise ValidationError(
+                {"raw": f"Missing owner in rule: {rule.matcher.type}:{rule.matcher.pattern}"}
+            )
+
     schema = dump_schema(rules)
 
     owners = {o for rule in rules for o in rule.owners}

--- a/src/sentry/issues/ownership/grammar.py
+++ b/src/sentry/issues/ownership/grammar.py
@@ -68,7 +68,7 @@ matcher_type = "{URL}" / "{PATH}" / "{MODULE}" / "{CODEOWNERS}" / event_tag
 
 event_tag   = ~r"tags.[^:]+"
 
-owners       = _ owner+
+owners       = _ owner*
 owner        = _ team_prefix identifier
 team_prefix  = "#"?
 
@@ -96,6 +96,8 @@ class Rule(namedtuple("Rule", "matcher owners")):
     """
 
     def __str__(self) -> str:
+        if not self.owners:
+            return str(self.matcher)
         owners = [o.dump() for o in self.owners]
         owners_str = " ".join(
             f"#{owner['identifier']}" if owner["type"] == "team" else owner["identifier"]
@@ -347,7 +349,13 @@ def convert_schema_to_rules_text(schema: OwnershipSchema) -> str:
         return ""
 
     for rule in rules:
-        text += f"{rule.matcher.type}:{rule.matcher.pattern} {' '.join([f'{owner_prefix(owner.type)}{owner.identifier}' for owner in rule.owners])}\n"
+        owners_str = " ".join(
+            f"{owner_prefix(owner.type)}{owner.identifier}" for owner in rule.owners
+        )
+        if owners_str:
+            text += f"{rule.matcher.type}:{rule.matcher.pattern} {owners_str}\n"
+        else:
+            text += f"{rule.matcher.type}:{rule.matcher.pattern}\n"
 
     return text
 
@@ -439,21 +447,25 @@ def convert_codeowners_syntax(
                 # we skip associations
                 continue
 
-        if sentry_assignees:
-            # Replace source_root with stack_root for anchored paths
-            # /foo/dir -> anchored
-            # foo/dir -> anchored
-            # foo/dir/ -> anchored
-            # foo/ -> not anchored
-            if re.search(r"[\/].{1}", path):
-                path_with_stack_root = path.replace(
-                    code_mapping.source_root, code_mapping.stack_root, 1
-                )
-                # flatten multiple '/' if not protocol
-                formatted_path = re.sub(r"(?<!:)\/{2,}", "/", path_with_stack_root)
-                result += f"codeowners:{formatted_path} {' '.join(sentry_assignees)}\n"
-            else:
-                result += f"codeowners:{path} {' '.join(sentry_assignees)}\n"
+        # Replace source_root with stack_root for anchored paths
+        # /foo/dir -> anchored
+        # foo/dir -> anchored
+        # foo/dir/ -> anchored
+        # foo/ -> not anchored
+        if re.search(r"[\/].{1}", path):
+            path_with_stack_root = path.replace(
+                code_mapping.source_root, code_mapping.stack_root, 1
+            )
+            # flatten multiple '/' if not protocol
+            formatted_path = re.sub(r"(?<!:)\/{2,}", "/", path_with_stack_root)
+        else:
+            formatted_path = path
+
+        if not code_owners:
+            # Exclusion rule: path with no owners means "no ownership" for this path
+            result += f"codeowners:{formatted_path}\n"
+        elif sentry_assignees:
+            result += f"codeowners:{formatted_path} {' '.join(sentry_assignees)}\n"
 
     return result
 
@@ -578,6 +590,8 @@ def remove_deleted_owners_from_schema(
     valid_rules = rules
 
     for rule in rules:
+        if not rule["owners"]:
+            continue
         valid_owners = rule["owners"]
         for rule_owner in rule["owners"]:
             if rule_owner["identifier"] not in owners_id.keys():

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -16,6 +16,7 @@ from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, cell_silo_model, sane_repr
 from sentry.db.models.fields import FlexibleForeignKey
 from sentry.issues.ownership.grammar import (
+    CODEOWNERS,
     Matcher,
     OwnershipSchema,
     Rule,
@@ -135,6 +136,12 @@ class ProjectOwnership(Model):
 
         rules = cls._matching_ownership_rules(ownership, data)
 
+        # CODEOWNERS exclusion: if the last matching codeowners rule has no owners,
+        # it means "no ownership" — remove all codeowners rules from the match set
+        codeowners_matches = [r for r in rules if r.matcher.type == CODEOWNERS]
+        if codeowners_matches and not codeowners_matches[-1].owners:
+            rules = [r for r in rules if r.matcher.type != CODEOWNERS]
+
         if not rules:
             return [], None
 
@@ -217,6 +224,9 @@ class ProjectOwnership(Model):
 
         with metrics.timer("projectownership.get_issue_owners_codeowners_rules"):
             codeowners_rules = list(reversed(cls._matching_ownership_rules(codeowners, data)))
+            # CODEOWNERS exclusion: last matching rule (first after reversal) has no owners
+            if codeowners_rules and not codeowners_rules[0].owners:
+                return rules_with_owners
             hydrated_codeowners_rules = cls._hydrate_rules(
                 project_id, codeowners_rules, OwnerRuleType.CODEOWNERS.value
             )

--- a/tests/sentry/issues/endpoints/test_project_codeowners_index.py
+++ b/tests/sentry/issues/endpoints/test_project_codeowners_index.py
@@ -194,7 +194,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         "sentry.integrations.source_code_management.repository.RepositoryIntegration.get_codeowner_file",
         return_value={"html_url": "https://github.com/test/CODEOWNERS"},
     )
-    def test_invalid_codeowners_text(self, get_codeowner_mock_file: MagicMock) -> None:
+    def test_codeowners_exclusion_rule(self, get_codeowner_mock_file: MagicMock) -> None:
         self.data["raw"] = "docs/*"
         with self.feature({"organizations:integrations-codeowners": True}):
             response = self.client.post(self.url, self.data)
@@ -202,7 +202,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert response.data["raw"] == "docs/*"
         assert response.data["codeMappingId"] == str(self.code_mapping.id)
         assert response.data["provider"] == "github"
-        assert response.data["ownershipSyntax"] == ""
+        assert response.data["ownershipSyntax"] == "codeowners:docs/*\n"
 
         errors = response.data["errors"]
         assert errors["missing_external_teams"] == []

--- a/tests/sentry/issues/ownership/test_grammar.py
+++ b/tests/sentry/issues/ownership/test_grammar.py
@@ -1299,3 +1299,132 @@ class GetInvalidOwnerDetailsTest(TestCase):
         project = self.create_project()
         messages = get_invalid_owner_details([], project.id)
         assert messages == []
+
+
+def test_parse_rules_with_exclusion_rule() -> None:
+    rules = parse_rules("codeowners:/apps/\ncodeowners:/apps/github\n")
+    assert rules == [
+        Rule(Matcher("codeowners", "/apps/"), []),
+        Rule(Matcher("codeowners", "/apps/github"), []),
+    ]
+
+
+def test_parse_rules_exclusion_rule_mixed() -> None:
+    rules = parse_rules("codeowners:/apps/ shash@sentry.io\ncodeowners:/apps/github\n")
+    assert rules == [
+        Rule(Matcher("codeowners", "/apps/"), [Owner("user", "shash@sentry.io")]),
+        Rule(Matcher("codeowners", "/apps/github"), []),
+    ]
+
+
+def test_dump_load_schema_exclusion_rule() -> None:
+    rule_with_owner = Rule(Matcher("codeowners", "/apps/"), [Owner("user", "shash@sentry.io")])
+    rule_exclusion = Rule(Matcher("codeowners", "/apps/github"), [])
+
+    schema = dump_schema([rule_with_owner, rule_exclusion])
+    assert schema == {
+        "$version": 1,
+        "rules": [
+            {
+                "matcher": {"type": "codeowners", "pattern": "/apps/"},
+                "owners": [{"type": "user", "identifier": "shash@sentry.io"}],
+            },
+            {
+                "matcher": {"type": "codeowners", "pattern": "/apps/github"},
+                "owners": [],
+            },
+        ],
+    }
+    assert load_schema(schema) == [rule_with_owner, rule_exclusion]
+
+
+def test_str_exclusion_rule() -> None:
+    assert str(Rule(Matcher("codeowners", "/apps/github"), [])) == "codeowners:/apps/github"
+
+
+def test_convert_schema_to_rules_text_exclusion_rule() -> None:
+    assert (
+        convert_schema_to_rules_text(
+            {
+                "$version": 1,
+                "rules": [
+                    {
+                        "matcher": {"type": "codeowners", "pattern": "/apps/"},
+                        "owners": [{"type": "user", "identifier": "shash@sentry.io"}],
+                    },
+                    {
+                        "matcher": {"type": "codeowners", "pattern": "/apps/github"},
+                        "owners": [],
+                    },
+                ],
+            }
+        )
+        == "codeowners:/apps/ shash@sentry.io\ncodeowners:/apps/github\n"
+    )
+
+
+def test_convert_codeowners_syntax_exclusion_rule() -> None:
+    code_mapping = type("", (), {})()
+    code_mapping.stack_root = ""
+    code_mapping.source_root = ""
+
+    codeowners = "/apps/ @octocat\n/apps/github\n"
+    result = convert_codeowners_syntax(
+        codeowners,
+        {"@octocat": "octocat@sentry.io"},
+        code_mapping,
+    )
+    assert "codeowners:/apps/ octocat@sentry.io\n" in result
+    assert "codeowners:/apps/github\n" in result
+
+
+def test_convert_codeowners_syntax_exclusion_with_comment() -> None:
+    code_mapping = type("", (), {})()
+    code_mapping.stack_root = ""
+    code_mapping.source_root = ""
+
+    codeowners = "/apps/ @octocat\n/apps/github # Skip\n"
+    result = convert_codeowners_syntax(
+        codeowners,
+        {"@octocat": "octocat@sentry.io"},
+        code_mapping,
+    )
+    assert "codeowners:/apps/ octocat@sentry.io\n" in result
+    assert "codeowners:/apps/github\n" in result
+
+
+def test_convert_codeowners_syntax_unmapped_owner_not_exclusion() -> None:
+    code_mapping = type("", (), {})()
+    code_mapping.stack_root = ""
+    code_mapping.source_root = ""
+
+    codeowners = "/apps/ @unknown-user\n"
+    result = convert_codeowners_syntax(
+        codeowners,
+        {},
+        code_mapping,
+    )
+    assert "codeowners:/apps/" not in result
+
+
+def test_convert_codeowners_syntax_exclusion_with_stack_root() -> None:
+    code_mapping = type("", (), {})()
+    code_mapping.stack_root = "webpack://static/"
+    code_mapping.source_root = ""
+
+    codeowners = "/apps/ @octocat\n/apps/github\n"
+    result = convert_codeowners_syntax(
+        codeowners,
+        {"@octocat": "octocat@sentry.io"},
+        code_mapping,
+    )
+    assert "codeowners:webpack://static/apps/ octocat@sentry.io\n" in result
+    assert "codeowners:webpack://static/apps/github\n" in result
+
+
+def test_parse_code_owners_exclusion_rule() -> None:
+    codeowners = "/apps/ @getsentry/frontend\n/apps/github\n"
+    teams, usernames, emails = parse_code_owners(codeowners)
+    assert teams == ["@getsentry/frontend"]
+    assert usernames == []
+    assert emails == []

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -202,6 +202,147 @@ class ProjectOwnershipTestCase(TestCase):
             ),
         )
 
+    def test_get_owners_codeowners_exclusion_rule(self) -> None:
+        self.code_mapping = self.create_code_mapping(project=self.project)
+
+        rule_a = Rule(Matcher("codeowners", "/apps/"), [Owner("team", self.team.slug)])
+        rule_exclusion = Rule(Matcher("codeowners", "/apps/github"), [])
+
+        self.create_codeowners(
+            self.project,
+            self.code_mapping,
+            raw="/apps/ @tiger-team\n/apps/github\n",
+            schema=dump_schema([rule_a, rule_exclusion]),
+        )
+
+        # File in /apps/github — last matching codeowners rule is exclusion → no owners
+        assert ProjectOwnership.get_owners(
+            self.project.id,
+            {"stacktrace": {"frames": [{"filename": "apps/github/foo.py"}]}},
+        ) == ([], None)
+
+        # File in /apps/bar — only matches rule_a → owned
+        self.assert_ownership_equals(
+            ProjectOwnership.get_owners(
+                self.project.id,
+                {"stacktrace": {"frames": [{"filename": "apps/bar/foo.py"}]}},
+            ),
+            ([Actor(id=self.team.id, actor_type=ActorType.TEAM)], [rule_a]),
+        )
+
+    def test_get_owners_codeowners_exclusion_overridden_by_later_rule(self) -> None:
+        self.code_mapping = self.create_code_mapping(project=self.project)
+
+        rule_a = Rule(Matcher("codeowners", "/apps/"), [Owner("team", self.team.slug)])
+        rule_exclusion = Rule(Matcher("codeowners", "/apps/github"), [])
+        rule_c = Rule(
+            Matcher("codeowners", "/apps/github/special"), [Owner("team", self.team.slug)]
+        )
+
+        self.create_codeowners(
+            self.project,
+            self.code_mapping,
+            raw="/apps/ @tiger-team\n/apps/github\n/apps/github/special @tiger-team\n",
+            schema=dump_schema([rule_a, rule_exclusion, rule_c]),
+        )
+
+        # File in /apps/github/special — last matching codeowners rule has owners,
+        # so exclusion logic doesn't activate. All matching rules are returned.
+        self.assert_ownership_equals(
+            ProjectOwnership.get_owners(
+                self.project.id,
+                {"stacktrace": {"frames": [{"filename": "apps/github/special/foo.py"}]}},
+            ),
+            (
+                [Actor(id=self.team.id, actor_type=ActorType.TEAM)],
+                [rule_a, rule_exclusion, rule_c],
+            ),
+        )
+
+    def test_get_owners_codeowners_exclusion_issueowners_still_apply(self) -> None:
+        self.code_mapping = self.create_code_mapping(project=self.project)
+
+        codeowner_rule = Rule(Matcher("codeowners", "/apps/"), [Owner("team", self.team.slug)])
+        codeowner_exclusion = Rule(Matcher("codeowners", "/apps/github"), [])
+
+        self.create_codeowners(
+            self.project,
+            self.code_mapping,
+            raw="/apps/ @tiger-team\n/apps/github\n",
+            schema=dump_schema([codeowner_rule, codeowner_exclusion]),
+        )
+
+        issueowner_rule = Rule(Matcher("path", "*.py"), [Owner("user", self.user.email)])
+        ProjectOwnership.objects.create(
+            project_id=self.project.id,
+            schema=dump_schema([issueowner_rule]),
+        )
+
+        # File in /apps/github — codeowners excluded, but issueowner rule still matches
+        self.assert_ownership_equals(
+            ProjectOwnership.get_owners(
+                self.project.id,
+                {"stacktrace": {"frames": [{"filename": "apps/github/foo.py"}]}},
+            ),
+            ([Actor(id=self.user.id, actor_type=ActorType.USER)], [issueowner_rule]),
+        )
+
+    def test_get_issue_owners_codeowners_exclusion_rule(self) -> None:
+        self.code_mapping = self.create_code_mapping(project=self.project)
+
+        rule_a = Rule(Matcher("codeowners", "/apps/"), [Owner("team", self.team.slug)])
+        rule_exclusion = Rule(Matcher("codeowners", "/apps/github"), [])
+
+        ProjectOwnership.objects.create(project_id=self.project.id)
+
+        self.create_codeowners(
+            self.project,
+            self.code_mapping,
+            raw="/apps/ @tiger-team\n/apps/github\n",
+            schema=dump_schema([rule_a, rule_exclusion]),
+        )
+
+        # File in /apps/github — exclusion prevents codeowners ownership
+        assert (
+            ProjectOwnership.get_issue_owners(
+                self.project.id,
+                {"stacktrace": {"frames": [{"filename": "apps/github/foo.py"}]}},
+            )
+            == []
+        )
+
+        # File in /apps/bar — only matches rule_a → owned
+        assert ProjectOwnership.get_issue_owners(
+            self.project.id,
+            {"stacktrace": {"frames": [{"filename": "apps/bar/foo.py"}]}},
+        ) == [(rule_a, [self.team], OwnerRuleType.CODEOWNERS.value)]
+
+    def test_get_issue_owners_codeowners_exclusion_issueowners_still_apply(self) -> None:
+        self.code_mapping = self.create_code_mapping(project=self.project)
+
+        codeowner_rule = Rule(Matcher("codeowners", "/apps/"), [Owner("team", self.team.slug)])
+        codeowner_exclusion = Rule(Matcher("codeowners", "/apps/github"), [])
+
+        issueowner_rule = Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)])
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id,
+            schema=dump_schema([issueowner_rule]),
+        )
+
+        self.create_codeowners(
+            self.project,
+            self.code_mapping,
+            raw="/apps/ @tiger-team\n/apps/github\n",
+            schema=dump_schema([codeowner_rule, codeowner_exclusion]),
+        )
+
+        # File in /apps/github — codeowners excluded, but issueowner rule matches
+        assert ProjectOwnership.get_issue_owners(
+            self.project.id,
+            {"stacktrace": {"frames": [{"filename": "apps/github/foo.py"}]}},
+        ) == [(issueowner_rule, [self.team], OwnerRuleType.OWNERSHIP_RULE.value)]
+
     def test_get_issue_owners_no_codeowners_or_issueowners(self) -> None:
         assert ProjectOwnership.get_issue_owners(self.project.id, {}) == []
 

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -231,18 +231,18 @@ class ProjectOwnershipTestCase(TestCase):
         )
 
     def test_get_owners_codeowners_exclusion_overridden_by_later_rule(self) -> None:
-        self.code_mapping = self.create_code_mapping(project=self.project)
+        code_mapping = self.create_code_mapping(project=self.project2)
 
         rule_a = Rule(Matcher("codeowners", "/apps/"), [Owner("team", self.team.slug)])
         rule_exclusion = Rule(Matcher("codeowners", "/apps/github"), [])
         rule_c = Rule(
-            Matcher("codeowners", "/apps/github/special"), [Owner("team", self.team.slug)]
+            Matcher("codeowners", "/apps/github/special"), [Owner("team", self.team2.slug)]
         )
 
         self.create_codeowners(
-            self.project,
-            self.code_mapping,
-            raw="/apps/ @tiger-team\n/apps/github\n/apps/github/special @tiger-team\n",
+            self.project2,
+            code_mapping,
+            raw="/apps/ @tiger-team\n/apps/github\n/apps/github/special @dolphin-team\n",
             schema=dump_schema([rule_a, rule_exclusion, rule_c]),
         )
 
@@ -250,11 +250,14 @@ class ProjectOwnershipTestCase(TestCase):
         # so exclusion logic doesn't activate. All matching rules are returned.
         self.assert_ownership_equals(
             ProjectOwnership.get_owners(
-                self.project.id,
+                self.project2.id,
                 {"stacktrace": {"frames": [{"filename": "apps/github/special/foo.py"}]}},
             ),
             (
-                [Actor(id=self.team.id, actor_type=ActorType.TEAM)],
+                [
+                    Actor(id=self.team.id, actor_type=ActorType.TEAM),
+                    Actor(id=self.team2.id, actor_type=ActorType.TEAM),
+                ],
                 [rule_a, rule_exclusion, rule_c],
             ),
         )


### PR DESCRIPTION
Resolves https://linear.app/getsentry/issue/ID-243/codeowners-doesnt-support-excluding-subdirectories.

Follow-up to https://github.com/getsentry/sentry/pull/115391.

The [CODEOWNERS spec](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file) (see below) allows for excluding ownership of subdirectories/specified paths by writing a rule with zero owners. With CODEOWNERS synced into Sentry, we are currently ignoring these no-owner rules. This PR implements that exclusion in ownership calculation.
```
# In this example, @octocat owns any file in the `/apps`
# directory in the root of your repository except for the `/apps/github`
# subdirectory, as its owners are left empty. Without an owner, changes
# to `apps/github` can be made with the approval of any user who has
# write access to the repository.
/apps/ @octocat
/apps/github
```

We will continue to skip lines where owners exist but aren't mapped into Sentry. Our "last match wins" semantics remain.