### PR TITLE
ref(preprod): Remove redundant content_hash and fix extra field leakage in snapshot responses

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -301,7 +301,8 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 **{
                     k: v
                     for k, v in metadata.dict().items()
-                    if k not in first_class and k not in ("diff_threshold", "content_hash")
+                    if k not in first_class
+                    and k not in ("diff_threshold", "content_hash", "description", "tags")
                 },
                 key=metadata.content_hash,
                 display_name=metadata.display_name,

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -294,15 +294,9 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             )
         )
 
-        first_class = SnapshotImageResponse.__fields__
         global_threshold = manifest.diff_threshold
         image_list = [
             SnapshotImageResponse(
-                **{
-                    k: v
-                    for k, v in metadata.dict().items()
-                    if k not in first_class and k not in ("diff_threshold", "content_hash")
-                },
                 key=metadata.content_hash,
                 display_name=metadata.display_name,
                 image_file_name=key,
@@ -312,6 +306,8 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 diff_threshold=metadata.diff_threshold
                 if metadata.diff_threshold is not None
                 else global_threshold,
+                description=metadata.description,
+                tags=metadata.tags,
             )
             for key, metadata in sorted(manifest.images.items())
         ]

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -301,8 +301,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 **{
                     k: v
                     for k, v in metadata.dict().items()
-                    if k not in first_class
-                    and k not in ("diff_threshold", "content_hash", "description", "tags")
+                    if k not in first_class and k not in ("diff_threshold", "content_hash")
                 },
                 key=metadata.content_hash,
                 display_name=metadata.display_name,

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -301,7 +301,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 **{
                     k: v
                     for k, v in metadata.dict().items()
-                    if k not in first_class and k != "diff_threshold"
+                    if k not in first_class and k not in ("diff_threshold", "content_hash")
                 },
                 key=metadata.content_hash,
                 display_name=metadata.display_name,

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -37,21 +37,17 @@ def _base_image_from_comparison(name: str, img: ComparisonImageResult) -> Snapsh
 def _build_base_images(
     base_images: dict[str, ImageMetadata],
 ) -> dict[str, SnapshotImageResponse]:
-    first_class = SnapshotImageResponse.__fields__
     result: dict[str, SnapshotImageResponse] = {}
     for key, meta in base_images.items():
         result[key] = SnapshotImageResponse(
-            **{
-                k: v
-                for k, v in meta.dict().items()
-                if k not in first_class and k not in ("diff_threshold", "content_hash")
-            },
             key=meta.content_hash,
             display_name=meta.display_name,
             image_file_name=key,
             group=meta.group,
             width=meta.width,
             height=meta.height,
+            description=meta.description,
+            tags=meta.tags,
         )
     return result
 

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -41,7 +41,12 @@ def _build_base_images(
     result: dict[str, SnapshotImageResponse] = {}
     for key, meta in base_images.items():
         result[key] = SnapshotImageResponse(
-            **{k: v for k, v in meta.dict().items() if k not in first_class},
+            **{
+                k: v
+                for k, v in meta.dict().items()
+                if k not in first_class
+                and k not in ("diff_threshold", "content_hash", "description", "tags")
+            },
             key=meta.content_hash,
             display_name=meta.display_name,
             image_file_name=key,

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -44,8 +44,7 @@ def _build_base_images(
             **{
                 k: v
                 for k, v in meta.dict().items()
-                if k not in first_class
-                and k not in ("diff_threshold", "content_hash", "description", "tags")
+                if k not in first_class and k not in ("diff_threshold", "content_hash")
             },
             key=meta.content_hash,
             display_name=meta.display_name,

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
@@ -70,7 +70,6 @@ const displayHeights = {
 
 function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
   return {
-    content_hash: 'synthetic-content-hash',
     display_name: 'Button / light',
     height: 180,
     image_file_name: 'button.light.png',
@@ -82,13 +81,11 @@ function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
 
 const pair: SnapshotDiffPair = {
   base_image: image({
-    content_hash: 'base-content-hash',
     key: 'base-button-light',
   }),
   diff: 0.042,
   diff_image_key: 'diff-button-light',
   head_image: image({
-    content_hash: 'head-content-hash',
     key: 'head-button-light',
   }),
 };

--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -116,7 +116,6 @@ const copyUrl = 'https://example.com/snapshots/button-light';
 
 function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
   return {
-    content_hash: 'synthetic-content-hash',
     display_name: 'Button / light',
     height: 180,
     image_file_name: 'button.light.png',
@@ -127,13 +126,11 @@ function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
 }
 
 const baseImage = image({
-  content_hash: 'base-content-hash',
   display_name: 'Button / light',
   key: 'base-button-light',
 });
 
 const headImage = image({
-  content_hash: 'head-content-hash',
   key: 'head-button-light',
 });
 
@@ -146,7 +143,6 @@ const changedPair: SnapshotDiffPair = {
 
 const renamedPair: SnapshotDiffPair = {
   base_image: image({
-    content_hash: 'base-renamed-content-hash',
     display_name: 'Button / light old',
     image_file_name: 'button.light.old.png',
     key: 'base-button-light-old',
@@ -154,7 +150,6 @@ const renamedPair: SnapshotDiffPair = {
   diff: null,
   diff_image_key: null,
   head_image: image({
-    content_hash: 'head-renamed-content-hash',
     display_name: 'Button / light',
     image_file_name: 'button.light.png',
     key: 'head-button-light',

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -320,7 +320,7 @@ function MetadataInfoButton({
   const {copy} = useCopyToClipboard();
   const json = JSON.stringify(
     copyData,
-    (k, v) => (METADATA_BLOCKLIST.has(k) ? undefined : v),
+    (k, v) => (METADATA_BLOCKLIST.has(k) || v === null ? undefined : v),
     2
   );
 

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -308,7 +308,7 @@ function MetadataTooltip({json}: {json: string}) {
   );
 }
 
-const METADATA_BLOCKLIST = new Set(['content_hash', 'key', 'diff_image_key']);
+const METADATA_BLOCKLIST = new Set(['key', 'diff_image_key']);
 
 function MetadataInfoButton({
   copyData,

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -61,7 +61,6 @@ function renderSnapshotMainContent(
 
 function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
   return {
-    content_hash: 'synthetic-content-hash',
     display_name: 'Button / light',
     height: 180,
     image_file_name: 'button.light.png',
@@ -72,14 +71,12 @@ function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
 }
 
 const baseImage = image({
-  content_hash: 'base-content-hash',
   display_name: 'Button / light base',
   image_file_name: 'button.light.base.png',
   key: 'base-button-light',
 });
 
 const headImage = image({
-  content_hash: 'head-content-hash',
   group: 'components',
   key: 'head-button-light',
 });
@@ -93,7 +90,6 @@ const changedPair: SnapshotDiffPair = {
 
 const renamedPair: SnapshotDiffPair = {
   base_image: image({
-    content_hash: 'base-renamed-content-hash',
     display_name: 'Button / light old',
     image_file_name: 'button.light.old.png',
     key: 'base-button-light-old',
@@ -101,7 +97,6 @@ const renamedPair: SnapshotDiffPair = {
   diff: null,
   diff_image_key: null,
   head_image: image({
-    content_hash: 'head-renamed-content-hash',
     group: 'components',
     image_file_name: 'button.light.png',
     key: 'head-button-light',

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -198,7 +198,6 @@ describe('SnapshotMainContent', () => {
         image_file_name: 'button.light.old.png',
         width: 320,
       },
-      diff: null,
       head_image: {
         display_name: 'Button / light',
         group: 'components',

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -8,7 +8,6 @@ export interface SnapshotImage {
   height: number;
   key: string;
   width: number;
-  content_hash: string;
 }
 
 export interface SnapshotDiffPair {


### PR DESCRIPTION
Remove the `content_hash` field from snapshot image responses — it was always identical to the `key` field (set via `key=metadata.content_hash`) and never rendered in the frontend UI (explicitly blocklisted from the metadata copy feature).

Also fix `_build_base_images` in the comparison categorizer to filter out `diff_threshold`, `content_hash`, `description`, and `tags`. These were leaking through as extra fields via Pydantic's `extra="allow"`, unlike the endpoint code which already filtered them for head images.

**Why frontend + backend in one PR is safe here:** We're removing a field (`content_hash`) that the frontend never reads at runtime — it was declared in the TypeScript type but immediately blocklisted from the only place metadata is surfaced (the "copy metadata as JSON" button). The `key` field already carries the same value and is what's used for image URL construction. Regardless of deploy order:
- Backend first → frontend still works, it just ignores the now-absent field
- Frontend first → the TS type is looser (field removed), no runtime error from the field still being present in the response