### PR TITLE
fix(cells): Replicate Organization.date_added to mapping row

### DIFF
--- a/src/sentry/hybridcloud/services/organization_mapping/impl.py
+++ b/src/sentry/hybridcloud/services/organization_mapping/impl.py
@@ -126,6 +126,7 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
             status=update.status,
             slug=update.slug,
             cell_name=update.cell_name,
+            date_created=update.date_created,
             require_2fa=update.requires_2fa,
             early_adopter=update.early_adopter,
             allow_joinleave=update.allow_joinleave,

--- a/src/sentry/hybridcloud/services/organization_mapping/model.py
+++ b/src/sentry/hybridcloud/services/organization_mapping/model.py
@@ -33,6 +33,7 @@ class RpcOrganizationMappingUpdate(RpcModel):
     status: int = 0
     slug: str = ""
     cell_name: str = ""
+    date_created: datetime = Field(default_factory=timezone.now)
 
     # When not set, no change to customer id performed,
     # when set with a CustomerId, the customer_id set to either None or string

--- a/src/sentry/hybridcloud/services/organization_mapping/serial.py
+++ b/src/sentry/hybridcloud/services/organization_mapping/serial.py
@@ -19,6 +19,7 @@ def update_organization_mapping_from_instance(
         status=organization.status,
         slug=organization.slug,
         cell_name=cell.name,
+        date_created=organization.date_added,
         requires_2fa=bool(organization.flags.require_2fa),
         early_adopter=bool(organization.flags.early_adopter),
         codecov_access=bool(organization.flags.codecov_access),


### PR DESCRIPTION
OrganizationMapping.date_created previously held a fresh timezone.now() captured at mapping insert time rather than the source Organization.date_added. The RpcOrganizationMappingUpdate payload didn't have value, so update_or_create never supplied it and the column's default=timezone.now fired on every new row.

Now we carry the value through the replication path: RpcOrganizationMappingUpdate has date_created which is populated from organization.date_added in update_organization_mapping_from_instance.

We need this field to be consistent as the real org creation date is used by the UI in filtering audit logs. Since the org listing API is moving to control, this functionality will not behave correctly unless we have the real org creation date in control.

Rolling deployment should be safe in both directions:
- old producers that omit the field fall back to the default factory
- old consumers that receive the field ignore it (pydantic ignores by default)

A backfill that rewrites the values in old columns will be added as a follow up
