### PR TITLE
Add metric alert context to Seer issue details RPC

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -991,6 +991,40 @@ _SEER_EXPLORER_ACTIVITY_TYPES = [
 ]
 
 
+def _extract_metric_alert_context(serialized_event: dict[str, Any]) -> dict[str, Any] | None:
+    occurrence = serialized_event.get("occurrence")
+    if not isinstance(occurrence, dict):
+        return None
+
+    return {
+        "event_id": serialized_event.get("eventID") or serialized_event.get("id"),
+        "subtitle": occurrence.get("subtitle"),
+        "evidence_data": occurrence.get("evidenceData") or {},
+        "evidence_display": occurrence.get("evidenceDisplay") or [],
+        "detection_time": occurrence.get("detectionTime"),
+        "level": occurrence.get("level"),
+    }
+
+
+def _get_metric_alert_context(
+    group: Group,
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> dict[str, Any] | None:
+    if group.issue_category != GroupCategory.METRIC:
+        return None
+
+    event = group.get_latest_event(start=start, end=end)
+    if event is None:
+        return None
+
+    if isinstance(event, Event):
+        event = event.for_group(group)
+
+    serialized_event = serialize(event, user=None, serializer=EventSerializer())
+    return _extract_metric_alert_context(serialized_event)
+
+
 def get_issue_and_event_response(
     event: Event | GroupEvent,
     group: Group | None,
@@ -1013,6 +1047,11 @@ def get_issue_and_event_response(
         serialized_group = dict(serialize(group, user=None, serializer=GroupSerializer()))
         # Add issueTypeDescription as it provides better context for LLMs. Note the initial type should be BaseGroupSerializerResponse.
         serialized_group["issueTypeDescription"] = group.issue_type.description
+        metric_alert_context = (
+            _extract_metric_alert_context(serialized_event)
+            if group.issue_category == GroupCategory.METRIC
+            else None
+        )
 
         logger.info(
             "get_issue_and_event_details_v2: Querying for tags overview",
@@ -1087,6 +1126,7 @@ def get_issue_and_event_response(
             "timeseries_interval": timeseries_interval,
             "tags_overview": tags_overview,
             "user_activity": serialized_activities,
+            "metric_alert_context": metric_alert_context,
         }
 
     return result
@@ -1111,7 +1151,8 @@ def get_issue_details(
         project_slug: The slug of the project (optional, used to improve numeric ID lookups).
 
     Returns:
-        Dict with issue metadata, event_timeseries, tags_overview, and user_activity, or None if not found.
+        Dict with issue metadata, event_timeseries, tags_overview, user_activity, and
+        optional metric_alert_context, or None if not found.
     """
     start_dt, end_dt = get_date_range_from_params({"start": start, "end": end}, optional=True)
 
@@ -1168,6 +1209,15 @@ def get_issue_details(
         timeseries, timeseries_stats_period, timeseries_interval = None, None, None
 
     try:
+        metric_alert_context = _get_metric_alert_context(group, start_dt, end_dt)
+    except Exception:
+        logger.exception(
+            "get_issue_details: Failed to get metric alert context",
+            extra={"organization_id": organization_id, "issue_id": issue_id},
+        )
+        metric_alert_context = None
+
+    try:
         activities = Activity.objects.filter(
             group=group,
             type__in=_SEER_EXPLORER_ACTIVITY_TYPES,
@@ -1189,6 +1239,7 @@ def get_issue_details(
         "timeseries_interval": timeseries_interval,
         "tags_overview": tags_overview,
         "user_activity": serialized_activities,
+        "metric_alert_context": metric_alert_context,
         "project_id": group.project_id,
         "project_slug": group.project.slug,
     }

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -1014,6 +1014,8 @@ def _get_metric_alert_context(
     if group.issue_category != GroupCategory.METRIC:
         return None
 
+    # Metric issue group metadata only has the short summary string. The
+    # aggregate/query/window/condition evidence lives on the latest occurrence event.
     event = group.get_latest_event(start=start, end=end)
     if event is None:
         return None

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -10,6 +10,7 @@ from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
 from sentry.api import client
 from sentry.constants import ObjectStatus
+from sentry.incidents.grouptype import MetricIssue
 from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.models.activity import Activity
 from sentry.models.group import Group
@@ -19,6 +20,7 @@ from sentry.replays.testutils import mock_replay
 from sentry.search.utils import parse_iso_timestamp
 from sentry.seer.agent.tools import (
     EVENT_TIMESERIES_RESOLUTIONS,
+    _extract_metric_alert_context,
     _get_issue_event_timeseries,
     _get_recommended_event,
     execute_table_query,
@@ -1026,6 +1028,40 @@ def _validate_event_timeseries(timeseries: dict, expected_total: int | None = No
         )
 
 
+def test_extract_metric_alert_context_from_serialized_occurrence_event() -> None:
+    context = _extract_metric_alert_context(
+        {
+            "eventID": "75d35076ec874b95a0131d9e6959e788",
+            "occurrence": {
+                "subtitle": "Critical: count(span.duration) in the last hour below 1",
+                "evidenceData": {
+                    "alertId": 257662,
+                    "detectorId": 2809110,
+                    "value": 0,
+                    "conditions": [{"type": "lt", "comparison": 1}],
+                },
+                "evidenceDisplay": [],
+                "detectionTime": 1778515192.58846,
+                "level": "error",
+            },
+        }
+    )
+
+    assert context == {
+        "event_id": "75d35076ec874b95a0131d9e6959e788",
+        "subtitle": "Critical: count(span.duration) in the last hour below 1",
+        "evidence_data": {
+            "alertId": 257662,
+            "detectorId": 2809110,
+            "value": 0,
+            "conditions": [{"type": "lt", "comparison": 1}],
+        },
+        "evidence_display": [],
+        "detection_time": 1778515192.58846,
+        "level": "error",
+    }
+
+
 class TestGetIssueAndEventDetailsV2(
     APITransactionTestCase, SnubaTestCase, SearchIssueTestMixin, SpanTestCase
 ):
@@ -1472,6 +1508,7 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, SearchIssueTest
         assert isinstance(result["timeseries_interval"], str | None)
         assert isinstance(result["tags_overview"], dict | None)
         assert isinstance(result["user_activity"], list | None)
+        assert isinstance(result["metric_alert_context"], dict | None)
         assert isinstance(result["project_id"], int)
         assert isinstance(result["project_slug"], str)
 
@@ -1632,6 +1669,49 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, SearchIssueTest
         assert result["tags_overview"] is None
         # Other fields still present
         assert result["issue"] is not None
+
+    # --- metric alert context ---
+
+    @patch("sentry.seer.agent.tools._get_metric_alert_context")
+    @patch("sentry.seer.agent.tools._get_issue_event_timeseries")
+    @patch("sentry.seer.agent.tools.get_all_tags_overview")
+    def test_metric_alert_context_forwarded(self, mock_tags, mock_ts, mock_metric_context):
+        mock_ts.return_value = ({"count()": {"data": []}}, "6h", "15m")
+        mock_tags.return_value = {"tags_overview": []}
+        expected_context = {
+            "event_id": "abc123",
+            "subtitle": "Critical: count(span.duration) in the last hour below 1",
+            "evidence_data": {
+                "alertId": 257662,
+                "detectorId": 2809110,
+                "value": 0,
+                "conditions": [{"type": "lt", "comparison": 1}],
+                "dataSources": [
+                    {
+                        "queryObj": {
+                            "snubaQuery": {
+                                "aggregate": "count(span.duration)",
+                                "query": "transaction:/v0/issues/similar-issues",
+                                "timeWindow": 3600,
+                            }
+                        }
+                    }
+                ],
+            },
+        }
+        mock_metric_context.return_value = expected_context
+
+        group = self.create_group(project=self.project, type=MetricIssue.type_id)
+
+        result = get_issue_details(
+            organization_id=self.organization.id,
+            issue_id=str(group.id),
+        )
+
+        assert result is not None
+        assert result["issue"]["issueType"] == MetricIssue.slug
+        assert result["metric_alert_context"] == expected_context
+        mock_metric_context.assert_called_once()
 
     # --- user activity ---
 


### PR DESCRIPTION
## Summary
- Add optional `metric_alert_context` to Seer's Sentry RPC issue-details payload for metric issues.
- Extract the context from serialized occurrence data so downstream agents can see alert aggregate, query, conditions, observed value, and detector/alert IDs.
- Cover the new extraction and forwarding behavior in Seer agent tool tests.

## Companion PR
- Seer consumer/formatter PR: https://github.com/getsentry/seer/pull/6360

## Tests
- `.venv/bin/pytest -n0 -svv --reuse-db tests/sentry/seer/agent/test_tools.py -k "TestGetIssueDetails or TestGetIssueAndEventDetailsV2 or extract_metric_alert_context"`
- `.venv/bin/prek run -q --files src/sentry/seer/agent/tools.py tests/sentry/seer/agent/test_tools.py`
- `git diff --check`
