### PR TITLE
feat(autofix): Support coding agents from plan step

### DIFF
--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -159,7 +159,7 @@ function SolutionNextStep({autofix, group, runId, section, referrer}: NextStepPr
     autofix,
     runId,
     group,
-    step: 'root_cause',
+    step: 'solution',
     referrer,
   });
 

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -155,6 +155,14 @@ function SolutionNextStep({autofix, group, runId, section, referrer}: NextStepPr
   const organization = useOrganization();
   const {isPolling, startStep} = autofix;
 
+  const {codingAgentIntegrations, handleCodingAgentHandoff} = useCodingAgents({
+    autofix,
+    runId,
+    group,
+    step: 'root_cause',
+    referrer,
+  });
+
   const handleYesClick = useCallback(() => {
     startStep('code_changes', {runId});
     trackAnalytics('autofix.solution.code', {
@@ -196,6 +204,8 @@ function SolutionNextStep({autofix, group, runId, section, referrer}: NextStepPr
       rethinkPrompt={t('How can this plan be improved?')}
       labelNevermind={t('Nevermind, write a code fix')}
       labelRethink={t('Rethink plan')}
+      codingAgentIntegrations={codingAgentIntegrations}
+      onCodingAgentHandoff={handleCodingAgentHandoff}
     />
   );
 }


### PR DESCRIPTION
Previously coding agents could only be triggered from the root cause step. This change allows users to trigger it from the solution step.