### PR TITLE
feat(snapshots): Add frontend logic for downloading images zip

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -16,6 +16,7 @@ import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {
   IconCheckmark,
   IconDelete,
+  IconDownload,
   IconEllipsis,
   IconInfo,
   IconOpen,
@@ -27,6 +28,7 @@ import {
 import {t} from 'sentry/locale';
 import type {AvatarUser} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {downloadFromHref} from 'sentry/utils/downloadFromHref';
 import {useBreakpoints} from 'sentry/utils/useBreakpoints';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -159,6 +161,34 @@ export function SnapshotHeaderActions({
     });
   }, [apiUrl, navigate]);
 
+  const handleDownloadImages = useCallback(async () => {
+    const downloadUrl = `/api/0/organizations/${organizationSlug}/preprodartifacts/snapshots/${data.head_artifact_id}/download/`;
+
+    try {
+      const response = await fetch(downloadUrl, {credentials: 'include'});
+
+      if (!response.ok) {
+        if (response.status === 403) {
+          const detail = await response.json().catch(() => ({}));
+          handleStaffPermissionError(detail?.detail);
+        } else if (response.status === 404) {
+          addErrorMessage(t('Snapshot images not found.'));
+        } else {
+          addErrorMessage(t('Download failed (status: %s)', response.status));
+        }
+        return;
+      }
+
+      const blob = await response.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      downloadFromHref(`snapshot_images_${data.head_artifact_id}.zip`, blobUrl);
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 100);
+      addSuccessMessage(t('Snapshot images download started'));
+    } catch (error) {
+      addErrorMessage(t('Download failed: %s', String(error)));
+    }
+  }, [organizationSlug, data.head_artifact_id]);
+
   return (
     <Flex align="center" gap="md">
       {data.approval_info &&
@@ -215,6 +245,18 @@ export function SnapshotHeaderActions({
         {({open: openDeleteModal}) => {
           const menuItems: MenuItemProps[] = [];
 
+          menuItems.push({
+            key: 'build-debug-info',
+            label: (
+              <Flex align="center" gap="sm">
+                <IconReceipt size="sm" />
+                {t('Build Metadata')}
+              </Flex>
+            ),
+            onAction: () => openBuildDebugInfoModal(data),
+            textValue: t('Build Metadata'),
+          });
+
           if (data.base_artifact_id) {
             const baseBuildPath = getSnapshotPath({
               organizationSlug,
@@ -235,6 +277,17 @@ export function SnapshotHeaderActions({
 
           menuItems.push(
             {
+              key: 'download-images',
+              label: (
+                <Flex align="center" gap="sm">
+                  <IconDownload size="sm" />
+                  {t('Download Images')}
+                </Flex>
+              ),
+              onAction: handleDownloadImages,
+              textValue: t('Download Images'),
+            },
+            {
               key: 'rerun-status-checks',
               label: (
                 <Flex align="center" gap="sm">
@@ -244,17 +297,6 @@ export function SnapshotHeaderActions({
               ),
               onAction: handleRerunStatusChecks,
               textValue: t('Rerun Status Checks'),
-            },
-            {
-              key: 'build-debug-info',
-              label: (
-                <Flex align="center" gap="sm">
-                  <IconReceipt size="sm" />
-                  {t('Build Metadata')}
-                </Flex>
-              ),
-              onAction: () => openBuildDebugInfoModal(data),
-              textValue: t('Build Metadata'),
             },
             {
               key: 'delete',


### PR DESCRIPTION
Screenshots:
<img width="688" height="800" alt="image" src="https://github.com/user-attachments/assets/9a234440-405a-428f-b5fe-a8969e94e359" />

<img width="1274" height="1842" alt="image" src="https://github.com/user-attachments/assets/60e7b20d-45a9-465c-81fd-504ca8f4b931" />

## Summary

Frontend companion to #115337. Adds a "Download Images" action to the snapshot header dropdown menu that fetches the zip from the new download endpoint and triggers a browser download.

Also cleans up the `SnapshotImage` type and test fixtures:
- Removes `content_hash` from the frontend `SnapshotImage` interface — it's an internal storage detail not needed by the UI
- Stops filtering `content_hash` from the metadata copy-to-clipboard JSON (since the field is gone)
- Filters out `null` values from the metadata JSON to reduce noise
- Reorders dropdown menu items: Build Metadata → View Base Build → Download Images → Rerun Status Checks → Delete

## Test plan
- [ ] Open a snapshot detail page and verify the dropdown menu shows the new "Download Images" option
- [ ] Click "Download Images" and confirm the zip downloads with the correct filename
- [ ] Verify the metadata copy button no longer includes `content_hash` or null fields
- [ ] Confirm existing snapshot stories still render correctly without `content_hash`