### PR TITLE
fix(preprod): Clarify rerun analysis description in admin page

### DIFF
--- a/static/gsAdmin/views/launchpadAdminPage.tsx
+++ b/static/gsAdmin/views/launchpadAdminPage.tsx
@@ -383,8 +383,8 @@ export function LaunchpadAdminPage() {
               <Flex direction="column" gap="md">
                 <Heading as="h3">Batch Rerun Analyses</Heading>
                 <Text as="p" variant="muted">
-                  Rerun analysis for one or more preprod artifacts using comma-separated
-                  IDs.
+                  Rerun all enabled analyses (size, snapshots, etc.) for one or more
+                  preprod artifacts using comma-separated IDs.
                 </Text>
                 <label htmlFor="rerunArtifactId">
                   <Text bold>Preprod Artifact ID (comma-separated):</Text>


### PR DESCRIPTION
Updates the "Batch Rerun Analyses" description in the Launchpad admin page
to clarify that it reruns all enabled analyses (size, snapshots, etc.),
not just a single analysis type. The previous copy was ambiguous about
whether snapshot builds would also be reprocessed.