### PR TITLE
fix(seer): Add sent_at timestamp to autofix PR analytics events

### DIFF
--- a/src/sentry/analytics/events/ai_autofix_pr_events.py
+++ b/src/sentry/analytics/events/ai_autofix_pr_events.py
@@ -1,6 +1,3 @@
-import time
-from dataclasses import field
-
 from sentry import analytics
 
 
@@ -12,7 +9,7 @@ class AiAutofixPrEvent(analytics.Event):
     run_id: int
     integration: str
     github_app: str
-    sent_at: int = field(default_factory=lambda: int(time.time() * 1000))
+    sent_at: int
     referrer: str | None = None
 
 

--- a/src/sentry/analytics/events/ai_autofix_pr_events.py
+++ b/src/sentry/analytics/events/ai_autofix_pr_events.py
@@ -1,3 +1,6 @@
+import time
+from dataclasses import field
+
 from sentry import analytics
 
 
@@ -9,6 +12,7 @@ class AiAutofixPrEvent(analytics.Event):
     run_id: int
     integration: str
     github_app: str
+    sent_at: int = field(default_factory=lambda: int(time.time() * 1000))
     referrer: str | None = None
 
 

--- a/src/sentry/seer/autofix/webhooks.py
+++ b/src/sentry/seer/autofix/webhooks.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Literal
 
 import sentry_sdk
@@ -23,6 +24,12 @@ ACTION_TO_EVENTS: dict[AnalyticAction, type[AiAutofixPrEvent]] = {
     "merged": AiAutofixPrMergedEvent,
     "closed": AiAutofixPrClosedEvent,
     "opened": AiAutofixPrOpenedEvent,
+}
+
+ACTION_TO_TIMESTAMP_FIELD: dict[AnalyticAction, str] = {
+    "opened": "created_at",
+    "merged": "merged_at",
+    "closed": "closed_at",
 }
 
 
@@ -58,6 +65,8 @@ def record_pr_action_analytic(
     if pull_request["merged"]:
         analytic_action = "merged"
 
+    sent_at = _get_pr_timestamp_ms(pull_request, analytic_action)
+
     autofix_state = get_autofix_state_from_pr_id("integrations:github", pull_request["id"])
     if autofix_state:
         analytics.record(
@@ -68,6 +77,7 @@ def record_pr_action_analytic(
                 group_id=autofix_state.request.issue["id"],
                 run_id=autofix_state.run_id,
                 github_app=github_app,
+                sent_at=sent_at,
             )
         )
 
@@ -89,9 +99,18 @@ def record_pr_action_analytic(
                 group_id=group.id,
                 run_id=agent_state.run_id,
                 github_app=github_app,
+                sent_at=sent_at,
                 referrer=agent_state.metadata.get("referrer") if agent_state.metadata else None,
             )
         )
 
         metrics.incr(f"ai.autofix.pr.{analytic_action}", tags={"mode": "explorer"})
         return
+
+
+def _get_pr_timestamp_ms(pull_request: dict[str, Any], action: AnalyticAction) -> int:
+    ts_field = ACTION_TO_TIMESTAMP_FIELD[action]
+    ts_value = pull_request.get(ts_field)
+    if ts_value:
+        return int(datetime.fromisoformat(ts_value).timestamp() * 1000)
+    return int(datetime.fromisoformat(pull_request["updated_at"]).timestamp() * 1000)

--- a/tests/sentry/autofix/test_webhooks.py
+++ b/tests/sentry/autofix/test_webhooks.py
@@ -65,9 +65,8 @@ class AutofixPrWebhookTest(APITestCase):
                 group_id=3,
                 run_id=1,
                 github_app="seer",
-                sent_at=0,
+                sent_at=1736937000000,
             ),
-            exclude_fields=["sent_at"],
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345", SENTRY_GITHUB_APP_USER_ID="67890")
@@ -115,9 +114,8 @@ class AutofixPrWebhookTest(APITestCase):
                 group_id=3,
                 run_id=1,
                 github_app="sentry",
-                sent_at=0,
+                sent_at=1736937000000,
             ),
-            exclude_fields=["sent_at"],
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
@@ -165,9 +163,8 @@ class AutofixPrWebhookTest(APITestCase):
                 group_id=3,
                 run_id=1,
                 github_app="seer",
-                sent_at=0,
+                sent_at=1736942400000,
             ),
-            exclude_fields=["sent_at"],
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
@@ -214,9 +211,8 @@ class AutofixPrWebhookTest(APITestCase):
                 group_id=3,
                 run_id=1,
                 github_app="seer",
-                sent_at=0,
+                sent_at=1736949600000,
             ),
-            exclude_fields=["sent_at"],
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")

--- a/tests/sentry/autofix/test_webhooks.py
+++ b/tests/sentry/autofix/test_webhooks.py
@@ -46,7 +46,12 @@ class AutofixPrWebhookTest(APITestCase):
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "opened",
-            {"id": 1, "merged": False},
+            {
+                "id": 1,
+                "merged": False,
+                "created_at": "2025-01-15T10:30:00Z",
+                "updated_at": "2025-01-15T10:30:00Z",
+            },
             {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
         )
 
@@ -60,7 +65,9 @@ class AutofixPrWebhookTest(APITestCase):
                 group_id=3,
                 run_id=1,
                 github_app="seer",
+                sent_at=0,
             ),
+            exclude_fields=["sent_at"],
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345", SENTRY_GITHUB_APP_USER_ID="67890")
@@ -89,7 +96,12 @@ class AutofixPrWebhookTest(APITestCase):
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "opened",
-            {"id": 1, "merged": False},
+            {
+                "id": 1,
+                "merged": False,
+                "created_at": "2025-01-15T10:30:00Z",
+                "updated_at": "2025-01-15T10:30:00Z",
+            },
             {"id": settings.SENTRY_GITHUB_APP_USER_ID},
         )
 
@@ -103,7 +115,9 @@ class AutofixPrWebhookTest(APITestCase):
                 group_id=3,
                 run_id=1,
                 github_app="sentry",
+                sent_at=0,
             ),
+            exclude_fields=["sent_at"],
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
@@ -132,7 +146,12 @@ class AutofixPrWebhookTest(APITestCase):
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "closed",
-            {"id": 1, "merged": False},
+            {
+                "id": 1,
+                "merged": False,
+                "closed_at": "2025-01-15T12:00:00Z",
+                "updated_at": "2025-01-15T12:00:00Z",
+            },
             {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
         )
 
@@ -146,7 +165,9 @@ class AutofixPrWebhookTest(APITestCase):
                 group_id=3,
                 run_id=1,
                 github_app="seer",
+                sent_at=0,
             ),
+            exclude_fields=["sent_at"],
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
@@ -175,7 +196,12 @@ class AutofixPrWebhookTest(APITestCase):
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "closed",
-            {"id": 1, "merged": True},
+            {
+                "id": 1,
+                "merged": True,
+                "merged_at": "2025-01-15T14:00:00Z",
+                "updated_at": "2025-01-15T14:00:00Z",
+            },
             {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
         )
         mock_metrics_incr.assert_called_with("ai.autofix.pr.merged")
@@ -188,7 +214,9 @@ class AutofixPrWebhookTest(APITestCase):
                 group_id=3,
                 run_id=1,
                 github_app="seer",
+                sent_at=0,
             ),
+            exclude_fields=["sent_at"],
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
@@ -204,7 +232,12 @@ class AutofixPrWebhookTest(APITestCase):
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "closed",
-            {"id": 1, "merged": True},
+            {
+                "id": 1,
+                "merged": True,
+                "merged_at": "2025-01-15T14:00:00Z",
+                "updated_at": "2025-01-15T14:00:00Z",
+            },
             {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
         )
 
@@ -228,7 +261,12 @@ class AutofixPrWebhookTest(APITestCase):
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "closed",
-            {"id": 1, "merged": True},
+            {
+                "id": 1,
+                "merged": True,
+                "merged_at": "2025-01-15T14:00:00Z",
+                "updated_at": "2025-01-15T14:00:00Z",
+            },
             {"id": "5655"},
         )
 
@@ -249,7 +287,12 @@ class AutofixPrWebhookTest(APITestCase):
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "closed",
-            {"id": 1, "merged": True},
+            {
+                "id": 1,
+                "merged": True,
+                "merged_at": "2025-01-15T14:00:00Z",
+                "updated_at": "2025-01-15T14:00:00Z",
+            },
             {"id": "321"},
         )
 


### PR DESCRIPTION
## Summary
- Autofix PR webhook analytics events (`ai.autofix.pr.opened`, `ai.autofix.pr.merged`, `ai.autofix.pr.closed`) were missing a `sent_at` field in their serialized JSON payload
- The downstream ETL (`seer_autofix_analytics_staging`) relies on `$.sent_at` to populate `pr_opened_ts`, `pr_merged_ts`, and `pr_closed_ts` in `seer_autofix_group_metrics`
- Adds `sent_at` (epoch millis) with a default factory to `AiAutofixPrEvent`, matching the format the ETL expects

## Companion PR
- ETL fallback for historical data: https://github.com/getsentry/etl/pull/2538

## Test plan
- [x] Existing webhook tests pass (7/7)
- [x] Mypy clean
- [x] Ruff clean