### PR TITLE
chore(alerts): Remove metric alerts dual processing log flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -397,8 +397,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:update-action-status", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable logging to debug workflow engine process workflows
     manager.add("organizations:workflow-engine-process-workflows-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable logs to debug various metric issue things
-    manager.add("organizations:workflow-engine-metric-alert-dual-processing-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine
     manager.add("organizations:workflow-engine-metric-alert-group-by-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable ingestion through trusted relays only

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -175,18 +175,6 @@ def fetch_metric_issue_open_periods(
                     **time_period,
                 },
             )
-        if features.has(
-            "organizations:workflow-engine-metric-alert-dual-processing-logs",
-            organization,
-        ):
-            logger.info(
-                "fetching metric issue open periods",
-                extra={
-                    "organization_id": organization.id,
-                    "open_period_id": open_period_identifier,
-                    "response_data": resp.data,
-                },
-            )
         return resp.data
     except Exception as exc:
         logger.error(
@@ -359,17 +347,6 @@ def build_metric_alert_chart(
             chart_data.update(chart_data_detector)
         else:
             chart_data.update(chart_data_alert_rule)
-        if features.has(
-            "organizations:workflow-engine-metric-alert-dual-processing-logs",
-            organization,
-        ):
-            logger.info(
-                "passed chart data",
-                extra={
-                    "chart_data": chart_data,
-                    "style": style,
-                },
-            )
         return charts.generate_chart(style, chart_data, size=size)
     except RuntimeError as exc:
         logger.error(

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -205,20 +205,6 @@ class SubscriptionProcessor:
             )
             results = process_data_packet(metric_data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
 
-        if features.has(
-            "organizations:workflow-engine-metric-alert-dual-processing-logs",
-            self.subscription.project.organization,
-        ):
-            logger.info(
-                "incidents.workflow_engine.results",
-                extra={
-                    "results": results,
-                    "num_results": len(results),
-                    "value": aggregation_value,
-                    "detector_id": detector.id,
-                    "subscription_update": subscription_update,
-                },
-            )
         return results
 
     def process_update(self, subscription_update: QuerySubscriptionUpdate) -> bool:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -14,7 +14,7 @@ from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient, DelayedWorkflowItem
 from sentry.workflow_engine.caches.action_filters import get_action_filters_by_workflows
 from sentry.workflow_engine.caches.workflow import get_workflows_by_detectors
-from sentry.workflow_engine.models import DataConditionGroup, Detector, DetectorWorkflow, Workflow
+from sentry.workflow_engine.models import DataConditionGroup, Detector, Workflow
 from sentry.workflow_engine.models.data_condition import DataCondition
 from sentry.workflow_engine.processors.contexts.workflow_event_context import (
     WorkflowEventContext,
@@ -156,12 +156,6 @@ def evaluate_workflow_triggers(
     # Retrieve these as a batch to avoid a query/cache-lookup per DCG.
     data_conditions_by_dcg_id = _get_data_conditions_for_group_by_dcg(dcg_ids)
 
-    project = event_data.event.project  # expected to be already cached
-    dual_processing_logs_enabled = features.has(
-        "organizations:workflow-engine-metric-alert-dual-processing-logs",
-        project.organization,
-    )
-
     tainted_untriggered, untainted_untriggered = 0, 0
     for workflow in workflows:
         when_data_conditions = None
@@ -196,22 +190,6 @@ def evaluate_workflow_triggers(
         else:
             if evaluation.triggered:
                 triggered_workflows[workflow] = evaluation
-                if dual_processing_logs_enabled:
-                    try:
-                        detector = WorkflowEventContext.get().detector
-                        detector_id = detector.id if detector else None
-                        logger.info(
-                            "workflow_engine.process_workflows.workflow_triggered",
-                            extra={
-                                "workflow_id": workflow.id,
-                                "detector_id": detector_id,
-                                "organization_id": project.organization.id,
-                                "project_id": project.id,
-                                "group_type": event_data.group.type,
-                            },
-                        )
-                    except DetectorWorkflow.DoesNotExist:
-                        continue
             else:
                 if evaluation.is_tainted():
                     tainted_untriggered += 1

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -18,10 +18,6 @@ from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient, De
 from sentry.workflow_engine.models import Action, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
-from sentry.workflow_engine.processors.contexts.workflow_event_context import (
-    WorkflowEventContext,
-    WorkflowEventContextData,
-)
 from sentry.workflow_engine.processors.data_condition_group import (
     ProcessedDataConditionGroup,
     TriggerResult,
@@ -484,28 +480,6 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             {self.workflow}, self.event_data, self.event_start_time
         )
         assert set(triggered_workflows.keys()) == {self.workflow}
-
-    @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @patch("sentry.workflow_engine.processors.workflow.logger")
-    def test_logs_triggered_workflows(self, mock_logger: MagicMock) -> None:
-        ctx_token = WorkflowEventContext.set(
-            WorkflowEventContextData(
-                detector=self.detector,
-            )
-        )
-        evaluate_workflow_triggers({self.workflow}, self.event_data, self.event_start_time)
-        mock_logger.info.assert_called_once_with(
-            "workflow_engine.process_workflows.workflow_triggered",
-            extra={
-                "workflow_id": self.workflow.id,
-                "detector_id": self.detector.id,
-                "organization_id": self.workflow.organization.id,
-                "project_id": self.event_data.group.project.id,
-                "group_type": self.event_data.group.type,
-            },
-        )
-
-        WorkflowEventContext.reset(ctx_token)
 
     def test_workflow_trigger__no_conditions(self) -> None:
         assert self.workflow.when_condition_group


### PR DESCRIPTION
Remove an unused flag we used for dual processing rollout. 