### PR TITLE
ref: replace withOrganization with useOrganization in function components

### DIFF
--- a/static/app/components/modals/createNewIntegrationModal.tsx
+++ b/static/app/components/modals/createNewIntegrationModal.tsx
@@ -16,7 +16,7 @@ import {
 } from 'sentry/utils/analytics/integrations/platformAnalyticsEvents';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import ExampleIntegrationButton from 'sentry/views/settings/organizationIntegrations/exampleIntegrationButton';
+import {ExampleIntegrationButton} from 'sentry/views/settings/organizationIntegrations/exampleIntegrationButton';
 
 const analyticsView = 'new_integration_modal';
 

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -504,7 +504,6 @@ function AddToDashboardModal({
                   >
                     <WidgetCardWrapper>
                       <WidgetCard
-                        organization={organization}
                         isEditingDashboard={false}
                         showContextMenu={false}
                         widgetLimitReached={false}

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -101,7 +101,6 @@ export function WidgetPreview({
       forceDescriptionTooltip={shouldForceDescriptionTooltip ? true : undefined}
       isWidgetInvalid={isWidgetInvalid}
       shouldResize={state.displayType !== DisplayType.TABLE}
-      organization={organization}
       selection={pageFilters.selection}
       widget={
         widget.widgetType === WidgetType.SPANS && isTimeSeries

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -662,13 +662,6 @@ describe('Dashboards > WidgetCard', () => {
     renderWithProviders(
       <WidgetCard
         api={api}
-        organization={{
-          ...organization,
-          features: [
-            ...organization.features,
-            'transaction-widget-deprecation-explore-view',
-          ],
-        }}
         widget={transactionQueryWidget}
         selection={selection}
         isEditingDashboard={false}
@@ -680,7 +673,6 @@ describe('Dashboards > WidgetCard', () => {
         isPreview
         widgetLegendState={widgetLegendState}
       />,
-      // passed feature flag in context because the hook for the warning does not have org passed in
       ['transaction-widget-deprecation-explore-view']
     );
 

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -20,7 +20,7 @@ import {t, tct} from 'sentry/locale';
 import {getOverride} from 'sentry/overrideRegistry';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
-import type {Confidence, Organization} from 'sentry/types/organization';
+import type {Confidence} from 'sentry/types/organization';
 import {CAN_MARK} from 'sentry/utils/analytics';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, DataUnit, Sort} from 'sentry/utils/discover/fields';
@@ -36,7 +36,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {withApi} from 'sentry/utils/withApi';
-import {withOrganization} from 'sentry/utils/withOrganization';
 import {withPageFilters} from 'sentry/utils/withPageFilters';
 import {DASHBOARD_CHART_GROUP} from 'sentry/views/dashboards/dashboard';
 import type {DashboardFilters, Widget as TWidget} from 'sentry/views/dashboards/types';
@@ -90,7 +89,6 @@ export const SESSION_DURATION_ALERT = (
 type Props = {
   api: Client;
   isEditingDashboard: boolean;
-  organization: Organization;
   selection: PageFilters;
   widget: TWidget;
   widgetLegendState: WidgetLegendSelectionState;
@@ -143,6 +141,7 @@ type Data = {
 };
 
 function WidgetCard(props: Props) {
+  const organization = useOrganization();
   const [data, setData] = useState<Data>();
   const [isLoadingTextVisible, setIsLoadingTextVisible] = useState(false);
   const navigate = useNavigate();
@@ -191,7 +190,6 @@ function WidgetCard(props: Props) {
 
   const {
     api,
-    organization,
     selection,
     widget,
     isMobile,
@@ -490,10 +488,7 @@ function WidgetCard(props: Props) {
   );
 }
 
-export default registerLLMContext(
-  'widget',
-  withApi(withOrganization(withPageFilters(WidgetCard)))
-);
+export default registerLLMContext('widget', withApi(withPageFilters(WidgetCard)));
 
 function useOnDemandWarning(props: {widget: TWidget}): string | null {
   const organization = useOrganization();

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -50,7 +50,7 @@ import {
 } from 'sentry/views/explore/releases/utils';
 
 import {ReleaseComparisonChartRow} from './releaseComparisonChartRow';
-import ReleaseEventsChart from './releaseEventsChart';
+import {ReleaseEventsChart} from './releaseEventsChart';
 import ReleaseSessionsChart from './releaseSessionsChart';
 
 export type ReleaseComparisonRow = {

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -9,7 +9,6 @@ import {HeaderTitleLegend, HeaderValue} from 'sentry/components/charts/styles';
 import {getInterval} from 'sentry/components/charts/utils';
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import type {ReleaseProject, ReleaseWithHealth} from 'sentry/types/release';
 import {ReleaseComparisonChartType} from 'sentry/types/release';
 import {tooltipFormatter} from 'sentry/utils/discover/charts';
@@ -19,7 +18,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   generateReleaseMarkLines,
   releaseComparisonChartTitles,
@@ -30,7 +29,6 @@ import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 type Props = {
   chartType: ReleaseComparisonChartType;
   diff: React.ReactNode;
-  organization: Organization;
   project: ReleaseProject;
   release: ReleaseWithHealth;
   value: React.ReactNode;
@@ -40,18 +38,18 @@ type Props = {
   utc?: boolean;
 };
 
-function ReleaseEventsChart({
+export function ReleaseEventsChart({
   release,
   project,
   chartType,
   value,
   diff,
-  organization,
   period,
   start,
   end,
   utc,
 }: Props) {
+  const organization = useOrganization();
   const location = useLocation();
   const api = useApi();
   const theme = useTheme();
@@ -232,5 +230,3 @@ function ReleaseEventsChart({
     </EventsRequest>
   );
 }
-
-export default withOrganization(ReleaseEventsChart);

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -19,7 +19,6 @@ import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnh
 import {usePerformanceDisplayType} from 'sentry/utils/performance/contexts/performanceDisplayContext';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {withOrganization} from 'sentry/utils/withOrganization';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -53,7 +52,6 @@ interface Props extends ChartRowProps {
   defaultChartSetting: PerformanceWidgetSetting;
   eventView: EventView;
   index: number;
-  organization: Organization;
   rowChartSettings: PerformanceWidgetSetting[];
   setRowChartSettings: (settings: PerformanceWidgetSetting[]) => void;
   withStaticFilters: boolean;
@@ -75,15 +73,9 @@ function trackChartSettingChange(
   });
 }
 
-function WidgetContainerInner(props: Props) {
-  const {
-    organization,
-    index,
-    chartHeight,
-    rowChartSettings,
-    setRowChartSettings,
-    ...rest
-  } = props;
+export function WidgetContainer(props: Props) {
+  const organization = useOrganization();
+  const {index, chartHeight, rowChartSettings, setRowChartSettings, ...rest} = props;
   const theme = useTheme();
   const performanceType = usePerformanceDisplayType();
   let _chartSetting = getChartSetting(
@@ -95,7 +87,7 @@ function WidgetContainerInner(props: Props) {
   );
   const mepSetting = useMEPSettingContext();
   const allowedCharts = filterAllowedChartsMetrics(
-    props.organization,
+    organization,
     props.allowedCharts,
     mepSetting
   );
@@ -151,13 +143,10 @@ function WidgetContainerInner(props: Props) {
         : null,
   };
 
-  const passedProps = pick(props, [
-    'eventView',
-    'location',
-    'organization',
-    'chartHeight',
-    'withStaticFilters',
-  ]);
+  const passedProps = {
+    ...pick(props, ['eventView', 'location', 'chartHeight', 'withStaticFilters']),
+    organization,
+  };
 
   switch (widgetProps.dataType) {
     case GenericPerformanceWidgetDataType.TRENDS:
@@ -313,5 +302,3 @@ const makeEventViewForWidget = (
 
   return widgetEventView;
 };
-
-export const WidgetContainer = withOrganization(WidgetContainerInner);

--- a/static/app/views/settings/organizationAuthTokens/index.spec.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.spec.tsx
@@ -13,22 +13,12 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import * as indicators from 'sentry/actionCreators/indicator';
 import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import type {OrgAuthToken} from 'sentry/types/user';
-import {OrganizationAuthTokensIndex} from 'sentry/views/settings/organizationAuthTokens';
+import OrganizationAuthTokensIndex from 'sentry/views/settings/organizationAuthTokens';
 
 describe('OrganizationAuthTokensIndex', () => {
   const ENDPOINT = '/organizations/org-slug/org-auth-tokens/';
   const PROJECTS_ENDPOINT = '/organizations/org-slug/projects/';
-  const {organization, project, router} = initializeOrg();
-
-  const defaultProps = {
-    organization,
-    router,
-    location: router.location,
-    params: {orgId: organization.slug},
-    routes: router.routes,
-    route: {},
-    routeParams: router.params,
-  };
+  const {organization, project} = initializeOrg();
 
   let projectsMock: jest.Mock;
 
@@ -72,7 +62,7 @@ describe('OrganizationAuthTokensIndex', () => {
       body: tokens,
     });
 
-    render(<OrganizationAuthTokensIndex {...defaultProps} />);
+    render(<OrganizationAuthTokensIndex />, {organization});
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -126,7 +116,7 @@ describe('OrganizationAuthTokensIndex', () => {
       body: tokens,
     });
 
-    render(<OrganizationAuthTokensIndex {...defaultProps} />);
+    render(<OrganizationAuthTokensIndex />, {organization});
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -143,7 +133,7 @@ describe('OrganizationAuthTokensIndex', () => {
       statusCode: 400,
     });
 
-    render(<OrganizationAuthTokensIndex {...defaultProps} />);
+    render(<OrganizationAuthTokensIndex />, {organization});
 
     expect(await screen.findByTestId('loading-error')).toHaveTextContent(
       'Failed to load organization tokens.'
@@ -163,7 +153,7 @@ describe('OrganizationAuthTokensIndex', () => {
       body: tokens,
     });
 
-    render(<OrganizationAuthTokensIndex {...defaultProps} />);
+    render(<OrganizationAuthTokensIndex />, {organization});
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -211,7 +201,7 @@ describe('OrganizationAuthTokensIndex', () => {
         method: 'DELETE',
       });
 
-      render(<OrganizationAuthTokensIndex {...defaultProps} />);
+      render(<OrganizationAuthTokensIndex />, {organization});
       renderGlobalModal();
 
       expect(await screen.findByText('My Token 1')).toBeInTheDocument();
@@ -260,7 +250,7 @@ describe('OrganizationAuthTokensIndex', () => {
         statusCode: 400,
       });
 
-      render(<OrganizationAuthTokensIndex {...defaultProps} />);
+      render(<OrganizationAuthTokensIndex />, {organization});
       renderGlobalModal();
 
       expect(await screen.findByText('My Token 1')).toBeInTheDocument();
@@ -295,18 +285,13 @@ describe('OrganizationAuthTokensIndex', () => {
         },
       ];
 
-      const props = {
-        ...defaultProps,
-        organization: org,
-      };
-
       MockApiClient.addMockResponse({
         url: ENDPOINT,
         method: 'GET',
         body: tokens,
       });
 
-      render(<OrganizationAuthTokensIndex {...props} />, {organization: org});
+      render(<OrganizationAuthTokensIndex />, {organization: org});
 
       expect(await screen.findByText('My Token 1')).toBeInTheDocument();
 

--- a/static/app/views/settings/organizationAuthTokens/index.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.tsx
@@ -22,7 +22,7 @@ import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import {setApiQueryData, useApiQuery} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {OrganizationAuthTokensAuthTokenRow} from 'sentry/views/settings/organizationAuthTokens/authTokenRow';
@@ -97,11 +97,8 @@ function TokenList({
   );
 }
 
-export function OrganizationAuthTokensIndex({
-  organization,
-}: {
-  organization: Organization;
-}) {
+function OrganizationAuthTokensIndex() {
+  const organization = useOrganization();
   const api = useApi();
   const hasPageFrame = useHasPageFrameFeature();
   const queryClient = useQueryClient();
@@ -249,8 +246,6 @@ export function tokenPreview(tokenLastCharacters: string, tokenPrefix = '') {
   return `${tokenPrefix}************${tokenLastCharacters}`;
 }
 
-export default withOrganization(OrganizationAuthTokensIndex);
-
 const ResponsivePanelTable = styled(PanelTable)`
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     grid-template-columns: 1fr 1fr;
@@ -261,3 +256,5 @@ const ResponsivePanelTable = styled(PanelTable)`
     }
   }
 `;
+
+export default OrganizationAuthTokensIndex;

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -28,7 +28,7 @@ import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFea
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {SentryApplicationRow} from 'sentry/views/settings/organizationDeveloperSettings/sentryApplicationRow';
 import {CreateIntegrationButton} from 'sentry/views/settings/organizationIntegrations/createIntegrationButton';
-import ExampleIntegrationButton from 'sentry/views/settings/organizationIntegrations/exampleIntegrationButton';
+import {ExampleIntegrationButton} from 'sentry/views/settings/organizationIntegrations/exampleIntegrationButton';
 
 type Tab = 'public' | 'internal';
 

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -6,7 +6,7 @@ import {
   EVENT_CHOICES,
   PERMISSIONS_MAP,
 } from 'sentry/views/settings/organizationDeveloperSettings/constants';
-import SubscriptionBox from 'sentry/views/settings/organizationDeveloperSettings/subscriptionBox';
+import {SubscriptionBox} from 'sentry/views/settings/organizationDeveloperSettings/subscriptionBox';
 
 type Resource = (typeof EVENT_CHOICES)[number];
 

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
@@ -3,26 +3,28 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import SubscriptionBox from 'sentry/views/settings/organizationDeveloperSettings/subscriptionBox';
+import {SubscriptionBox} from 'sentry/views/settings/organizationDeveloperSettings/subscriptionBox';
 
 describe('SubscriptionBox', () => {
   const onChange = jest.fn();
-  let org = OrganizationFixture();
 
   beforeEach(() => {
     onChange.mockReset();
   });
-  function renderComponent(props: Partial<ComponentProps<typeof SubscriptionBox>> = {}) {
+  function renderComponent(
+    props: Partial<ComponentProps<typeof SubscriptionBox>> = {},
+    {organization = OrganizationFixture()} = {}
+  ) {
     return render(
       <SubscriptionBox
         resource="issue"
         checked={false}
         disabledFromPermissions={false}
         onChange={onChange}
-        organization={org}
         isNew={false}
         {...props}
-      />
+      />,
+      {organization}
     );
   }
 
@@ -63,8 +65,10 @@ describe('SubscriptionBox', () => {
     });
 
     it('checkbox visible with integrations-event-hooks flag', () => {
-      org = OrganizationFixture({features: ['integrations-event-hooks']});
-      renderComponent({resource: 'error', organization: org});
+      renderComponent(
+        {resource: 'error'},
+        {organization: OrganizationFixture({features: ['integrations-event-hooks']})}
+      );
 
       expect(screen.getByRole('checkbox')).toBeEnabled();
     });
@@ -91,8 +95,10 @@ describe('SubscriptionBox', () => {
     });
 
     it('renders preprod_artifact checkbox enabled with preprod-artifact-webhooks flag', () => {
-      const orgWithFlag = OrganizationFixture({features: ['preprod-artifact-webhooks']});
-      renderComponent({resource: 'preprod_artifact', organization: orgWithFlag});
+      renderComponent(
+        {resource: 'preprod_artifact'},
+        {organization: OrganizationFixture({features: ['preprod-artifact-webhooks']})}
+      );
 
       expect(screen.getByRole('checkbox')).toBeEnabled();
     });

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -6,8 +6,7 @@ import {Stack} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import type {EVENT_CHOICES} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {PERMISSIONS_MAP} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 
@@ -18,21 +17,19 @@ type Props = {
   disabledFromPermissions: boolean;
   isNew: boolean;
   onChange: (resource: Resource, checked: boolean) => void;
-  organization: Organization;
   resource: Resource;
   webhookDisabled?: boolean;
 };
 
-function SubscriptionBox({
+export function SubscriptionBox({
   checked,
   disabledFromPermissions,
   isNew,
   onChange,
-  organization,
   resource,
   webhookDisabled = false,
 }: Props) {
-  const {features} = organization;
+  const {features} = useOrganization();
 
   if (
     resource === 'preprod_artifact' &&
@@ -89,8 +86,6 @@ function SubscriptionBox({
     </Tooltip>
   );
 }
-
-export default withOrganization(SubscriptionBox);
 
 const SubscriptionGridItem = styled('div')<{disabled: boolean}>`
   display: flex;

--- a/static/app/views/settings/organizationIntegrations/exampleIntegrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/exampleIntegrationButton.tsx
@@ -2,28 +2,26 @@ import {LinkButton, type LinkButtonProps} from '@sentry/scraps/button';
 
 import {IconGithub} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import type {IntegrationView} from 'sentry/utils/analytics/integrations';
 import {
   platformEventLinkMap,
   PlatformEvents,
 } from 'sentry/utils/analytics/integrations/platformAnalyticsEvents';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface ExampleIntegrationButtonProps extends Omit<LinkButtonProps, 'to' | 'href'> {
   analyticsView: IntegrationView['view'];
-  organization: Organization;
 }
 
 /**
  * Button to direct users to the Example App repository
  */
-function ExampleIntegrationButton({
-  organization,
+export function ExampleIntegrationButton({
   analyticsView,
   ...buttonProps
 }: ExampleIntegrationButtonProps) {
+  const organization = useOrganization();
   return (
     <LinkButton
       size="sm"
@@ -42,4 +40,3 @@ function ExampleIntegrationButton({
     </LinkButton>
   );
 }
-export default withOrganization(ExampleIntegrationButton);

--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
@@ -26,7 +26,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
-import {withOrganization} from 'sentry/utils/withOrganization';
 import {
   INSTALLED,
   NOT_INSTALLED,
@@ -370,4 +369,4 @@ const AddButton = styled(Button)`
   margin-bottom: ${p => p.theme.space.md};
 `;
 
-export default withOrganization(PluginDetailedView);
+export default PluginDetailedView;

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -48,12 +48,8 @@ describe('inviteBanner', () => {
     const org = OrganizationFixture();
 
     render(
-      <InviteBanner
-        onSendInvite={() => {}}
-        organization={org}
-        allowedRoles={[]}
-        onModalClose={() => {}}
-      />
+      <InviteBanner onSendInvite={() => {}} allowedRoles={[]} onModalClose={() => {}} />,
+      {organization: org}
     );
 
     expect(
@@ -75,12 +71,8 @@ describe('inviteBanner', () => {
     });
 
     const {container} = render(
-      <InviteBanner
-        onSendInvite={() => {}}
-        organization={org}
-        allowedRoles={[]}
-        onModalClose={() => {}}
-      />
+      <InviteBanner onSendInvite={() => {}} allowedRoles={[]} onModalClose={() => {}} />,
+      {organization: org}
     );
 
     await waitFor(() => expect(mock).toHaveBeenCalledTimes(1));
@@ -97,12 +89,8 @@ describe('inviteBanner', () => {
     });
 
     const {container} = render(
-      <InviteBanner
-        onSendInvite={() => {}}
-        organization={org}
-        allowedRoles={[]}
-        onModalClose={() => {}}
-      />
+      <InviteBanner onSendInvite={() => {}} allowedRoles={[]} onModalClose={() => {}} />,
+      {organization: org}
     );
 
     await waitFor(() => expect(mock).toHaveBeenCalledTimes(1));
@@ -119,12 +107,8 @@ describe('inviteBanner', () => {
     });
 
     const {container} = render(
-      <InviteBanner
-        onSendInvite={() => {}}
-        organization={org}
-        allowedRoles={[]}
-        onModalClose={() => {}}
-      />
+      <InviteBanner onSendInvite={() => {}} allowedRoles={[]} onModalClose={() => {}} />,
+      {organization: org}
     );
 
     await waitFor(() => expect(mock).toHaveBeenCalledTimes(1));
@@ -135,12 +119,8 @@ describe('inviteBanner', () => {
     const org = OrganizationFixture({access: []});
 
     const {container} = render(
-      <InviteBanner
-        onSendInvite={() => {}}
-        organization={org}
-        allowedRoles={[]}
-        onModalClose={() => {}}
-      />
+      <InviteBanner onSendInvite={() => {}} allowedRoles={[]} onModalClose={() => {}} />,
+      {organization: org}
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -162,12 +142,8 @@ describe('inviteBanner', () => {
     });
 
     render(
-      <InviteBanner
-        onSendInvite={() => {}}
-        organization={org}
-        allowedRoles={[]}
-        onModalClose={() => {}}
-      />
+      <InviteBanner onSendInvite={() => {}} allowedRoles={[]} onModalClose={() => {}} />,
+      {organization: org}
     );
 
     expect(
@@ -193,12 +169,8 @@ describe('inviteBanner', () => {
     });
 
     const {container} = render(
-      <InviteBanner
-        onSendInvite={() => {}}
-        organization={org}
-        allowedRoles={[]}
-        onModalClose={() => {}}
-      />
+      <InviteBanner onSendInvite={() => {}} allowedRoles={[]} onModalClose={() => {}} />,
+      {organization: org}
     );
 
     await waitFor(() => expect(mockPrompt).toHaveBeenCalled());
@@ -242,12 +214,8 @@ describe('inviteBanner', () => {
     const org = OrganizationFixture();
 
     render(
-      <InviteBanner
-        onSendInvite={() => {}}
-        organization={org}
-        allowedRoles={[]}
-        onModalClose={() => {}}
-      />
+      <InviteBanner onSendInvite={() => {}} allowedRoles={[]} onModalClose={() => {}} />,
+      {organization: org}
     );
 
     expect(

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -18,12 +18,12 @@ import {FloatingFeedbackButton} from 'sentry/components/feedbackButton/floatingF
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconCommit, IconEllipsis, IconGithub, IconMail} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import type {MissingMember, Organization, OrgRole} from 'sentry/types/organization';
+import type {MissingMember, OrgRole} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 const MAX_MEMBERS_TO_SHOW = 5;
 
@@ -31,15 +31,10 @@ type Props = {
   allowedRoles: OrgRole[];
   onModalClose: () => void;
   onSendInvite: () => void;
-  organization: Organization;
 };
 
-export function InviteBanner({
-  organization,
-  allowedRoles,
-  onSendInvite,
-  onModalClose,
-}: Props) {
+export function InviteBanner({allowedRoles, onSendInvite, onModalClose}: Props) {
+  const organization = useOrganization();
   const isEligibleForBanner = organization.access.includes('org:write');
   const [sendingInvite, setSendingInvite] = useState(false);
   const [showBanner, setShowBanner] = useState(false);
@@ -217,8 +212,6 @@ export function InviteBanner({
     </Fragment>
   );
 }
-
-export default withOrganization(InviteBanner);
 
 type MemberCardsProps = {
   handleSendInvite: (email: string) => void;

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -37,7 +37,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import InviteBanner from 'sentry/views/settings/organizationMembers/inviteBanner';
+import {InviteBanner} from 'sentry/views/settings/organizationMembers/inviteBanner';
 
 import {MembersFilter} from './components/membersFilter';
 import {InviteRequestRow} from './inviteRequestRow';

--- a/static/gsApp/components/features/dateRangeQueryLimitFooter.tsx
+++ b/static/gsApp/components/features/dateRangeQueryLimitFooter.tsx
@@ -4,9 +4,8 @@ import {Button, LinkButton, type ButtonProps} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {openUpsellModal} from 'getsentry/actionCreators/modal';
 import UpgradeOrTrialButton from 'getsentry/components/upgradeOrTrialButton';
@@ -17,17 +16,12 @@ const BUTTON_SIZE: ButtonProps['size'] = 'sm';
 
 interface Props {
   description: string;
-  organization: Organization;
   source: string;
   subscription: Subscription;
 }
 
-function DateRangeQueryLimitFooter({
-  description,
-  organization,
-  source,
-  subscription,
-}: Props) {
+function DateRangeQueryLimitFooter({description, source, subscription}: Props) {
+  const organization = useOrganization();
   const checkoutUrl = normalizeUrl(
     `/checkout/${organization.slug}/?referrer=checkout-${source}`
   );
@@ -71,9 +65,7 @@ function DateRangeQueryLimitFooter({
   );
 }
 
-export default withOrganization(
-  withSubscription(DateRangeQueryLimitFooter, {noLoader: true})
-);
+export default withSubscription(DateRangeQueryLimitFooter, {noLoader: true});
 
 const DescriptionContainer = styled('div')`
   font-size: 12px;

--- a/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.spec.tsx
+++ b/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.spec.tsx
@@ -33,12 +33,9 @@ describe('InsightsUpsellPage', () => {
   it('renders if plan includes feature', async () => {
     subscription.planDetails.features = ['insights-query-date-range-limit'];
 
-    render(
-      <InsightsDateRangeQueryLimitFooter
-        organization={organization}
-        subscription={subscription}
-      />
-    );
+    render(<InsightsDateRangeQueryLimitFooter subscription={subscription} />, {
+      organization,
+    });
 
     expect(
       await screen.findByText(
@@ -48,12 +45,9 @@ describe('InsightsUpsellPage', () => {
   });
 
   it('does not render if feature is not included', () => {
-    render(
-      <InsightsDateRangeQueryLimitFooter
-        organization={organization}
-        subscription={subscription}
-      />
-    );
+    render(<InsightsDateRangeQueryLimitFooter subscription={subscription} />, {
+      organization,
+    });
 
     expect(
       screen.queryByText(

--- a/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.tsx
+++ b/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.tsx
@@ -1,6 +1,6 @@
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 import DateRangeQueryLimitFooter from 'getsentry/components/features/dateRangeQueryLimitFooter';
 import {withSubscription} from 'getsentry/components/withSubscription';
@@ -8,7 +8,6 @@ import {useBillingConfig} from 'getsentry/hooks/useBillingConfig';
 import type {Subscription} from 'getsentry/types';
 
 interface Props {
-  organization: Organization;
   subscription: Subscription;
 }
 
@@ -18,7 +17,8 @@ const DESCRIPTION = t(
 
 const QUERY_LIMIT_REFERRER = 'insights-query-limit-footer';
 
-export function InsightsDateRangeQueryLimitFooter({organization, subscription}: Props) {
+export function InsightsDateRangeQueryLimitFooter({subscription}: Props) {
+  const organization = useOrganization();
   const shouldShowQueryLimitFooter = useHasRequiredFeatures(organization, subscription);
 
   if (!shouldShowQueryLimitFooter) {
@@ -53,6 +53,4 @@ const useHasRequiredFeatures = (
   return enabledFeatures.includes('insights-query-date-range-limit');
 };
 
-export default withOrganization(
-  withSubscription(InsightsDateRangeQueryLimitFooter, {noLoader: true})
-);
+export default withSubscription(InsightsDateRangeQueryLimitFooter, {noLoader: true});

--- a/static/gsApp/components/features/pageUpsellOverlay.spec.tsx
+++ b/static/gsApp/components/features/pageUpsellOverlay.spec.tsx
@@ -41,7 +41,8 @@ describe('PageUpsellOverlay', () => {
         description=""
         requiredPlan=""
         source=""
-      />
+      />,
+      {organization: org}
     );
     expect(screen.queryByText('Learn More')).not.toBeInTheDocument();
     expect(screen.getByText('My Text')).toBeInTheDocument();
@@ -64,7 +65,8 @@ describe('PageUpsellOverlay', () => {
         description=""
         requiredPlan=""
         source=""
-      />
+      />,
+      {organization: org}
     );
     expect(screen.getByText('Learn More')).toBeInTheDocument();
     expect(screen.getByText('Upgrade Plan')).toBeInTheDocument();
@@ -86,7 +88,8 @@ describe('PageUpsellOverlay', () => {
         description=""
         requiredPlan=""
         source=""
-      />
+      />,
+      {organization: org}
     );
     expect(screen.getByText('Learn More')).toBeInTheDocument();
     expect(screen.queryByText('Upgrade Plan')).not.toBeInTheDocument();

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -44,7 +44,7 @@ import {ProductTrialAlert} from 'getsentry/components/productTrial/productTrialA
 import {getProductForPath} from 'getsentry/components/productTrial/productTrialPaths';
 import {makeLinkToOwnersAndBillingMembers} from 'getsentry/components/profiling/alerts';
 import {withSubscription} from 'getsentry/components/withSubscription';
-import ZendeskLink from 'getsentry/components/zendeskLink';
+import {ZendeskLink} from 'getsentry/components/zendeskLink';
 import {BILLED_DATA_CATEGORY_INFO} from 'getsentry/constants';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import {

--- a/static/gsApp/components/helpSearchFooter.tsx
+++ b/static/gsApp/components/helpSearchFooter.tsx
@@ -3,22 +3,19 @@ import styled from '@emotion/styled';
 import {LinkButton} from '@sentry/scraps/button';
 
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 
-import ZendeskLink from 'getsentry/components/zendeskLink';
+import {ZendeskLink} from 'getsentry/components/zendeskLink';
 
 type Props = {
   closeModal: () => void;
-  organization: Organization;
 };
 
-export function HelpSearchFooter({organization, closeModal}: Props) {
+export function HelpSearchFooter({closeModal}: Props) {
   return (
     <Container>
       {t('Need personalized help? Contact our support team!')}
       <ZendeskLink
         source="help_modal"
-        organization={organization}
         Component={({href, onClick}) => (
           <LinkButton
             href={href ?? ''}

--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -7,7 +7,7 @@ import {Hovercard} from 'sentry/components/hovercard';
 import {IconLightning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {openUpsellModal} from 'getsentry/actionCreators/modal';
 import PlanFeature from 'getsentry/components/features/planFeature';
@@ -26,7 +26,6 @@ interface PowerFeatureHovercardProps {
    * is up to the parent component to decide whether this should be rendered.
    */
   features: Organization['features'];
-  organization: Organization;
 
   subscription: Subscription;
   children?: React.ReactNode;
@@ -58,12 +57,12 @@ function PowerFeatureHovercard({
   id,
   containerClassName,
   containerDisplayMode,
-  organization,
   subscription,
   partial,
   features,
   children,
 }: PowerFeatureHovercardProps) {
+  const organization = useOrganization();
   const recordAnalytics = () => {
     trackGetsentryAnalytics('power_icon.clicked', {
       organization,
@@ -146,6 +145,4 @@ const StyledHovercard = styled(Hovercard)`
   }
 `;
 
-export default withOrganization(
-  withSubscription(PowerFeatureHovercard, {noLoader: true})
-);
+export default withSubscription(PowerFeatureHovercard, {noLoader: true});

--- a/static/gsApp/components/upsellProvider.tsx
+++ b/static/gsApp/components/upsellProvider.tsx
@@ -6,11 +6,10 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {Client} from 'sentry/api';
 import {Confirm} from 'sentry/components/confirm';
 import {t, tct} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {withApi} from 'sentry/utils/withApi';
-import {withOrganization} from 'sentry/utils/withOrganization';
 
 import {openUpsellModal} from 'getsentry/actionCreators/modal';
 import {sendTrialRequest, sendUpgradeRequest} from 'getsentry/actionCreators/upsell';
@@ -39,7 +38,6 @@ type ChildRenderProps = {
 type Props = {
   api: Client;
   children: (opts: ChildRenderProps) => React.ReactNode;
-  organization: Organization;
   source: string;
   subscription: Subscription;
   extraAnalyticsParams?: Record<string, any>;
@@ -79,7 +77,6 @@ function LoadingButton(props: {
 function UpsellProvider({
   api,
   onTrialStarted,
-  organization,
   subscription,
   source,
   extraAnalyticsParams,
@@ -88,6 +85,7 @@ function UpsellProvider({
   children,
 }: Props) {
   const navigate = useNavigate();
+  const organization = useOrganization({allowNull: true});
   // if the org or subscription isn't loaded yet, don't render anything
   if (!organization || !subscription) {
     return null;
@@ -235,6 +233,4 @@ function UpsellProvider({
   );
 }
 
-export default withApi(
-  withOrganization(withSubscription(UpsellProvider, {noLoader: true}))
-);
+export default withApi(withSubscription(UpsellProvider, {noLoader: true}));

--- a/static/gsApp/components/zendeskLink.tsx
+++ b/static/gsApp/components/zendeskLink.tsx
@@ -2,14 +2,12 @@ import React, {useEffect} from 'react';
 
 import {ExternalLink} from '@sentry/scraps/link';
 
-import type {Organization} from 'sentry/types/organization';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {activateZendesk, zendeskIsLoaded} from 'sentry/utils/zendesk';
 
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 type Props = {
-  organization: Organization;
   Component?: typeof ExternalLink;
   address?: string;
   children?: React.ReactNode;
@@ -18,8 +16,7 @@ type Props = {
   subject?: string;
 };
 
-function ZendeskLink({
-  organization,
+export function ZendeskLink({
   source,
   Component,
   subject,
@@ -27,6 +24,7 @@ function ZendeskLink({
   children,
   ...props
 }: Props) {
+  const organization = useOrganization();
   useEffect(() => {
     if (organization) {
       trackGetsentryAnalytics('zendesk_link.viewed', {organization, source});
@@ -55,5 +53,3 @@ function ZendeskLink({
     </LinkComponent>
   );
 }
-
-export default withOrganization(ZendeskLink);

--- a/static/gsApp/registerOverrides.tsx
+++ b/static/gsApp/registerOverrides.tsx
@@ -163,7 +163,9 @@ const GETSENTRY_OVERRIDES: Partial<Overrides> = {
   /**
    * Augment the global help search modal with a contat support button
    */
-  'help-modal:footer': props => <HelpSearchFooter key="help-search-footer" {...props} />,
+  'help-modal:footer': ({closeModal}) => (
+    <HelpSearchFooter key="help-search-footer" closeModal={closeModal} />
+  ),
 
   /**
    * Registers usage & billing org settings as globally-available CMDK actions.

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -22,16 +22,15 @@ import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {DataCategory} from 'sentry/types/core';
-import type {Organization} from 'sentry/types/organization';
 import {showIntercom} from 'sentry/utils/intercom';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {withApi} from 'sentry/utils/withApi';
-import {withOrganization} from 'sentry/utils/withOrganization';
 import {activateZendesk, hasZendesk} from 'sentry/utils/zendesk';
 
 import {withSubscription} from 'getsentry/components/withSubscription';
-import ZendeskLink from 'getsentry/components/zendeskLink';
+import {ZendeskLink} from 'getsentry/components/zendeskLink';
 import {
   ANNUAL,
   MONTHLY,
@@ -82,7 +81,6 @@ type Props = {
   isLoading: boolean;
   location: Location;
   navigate: ReactRouter3Navigate;
-  organization: Organization;
   queryClient: QueryClient;
   subscription: Subscription;
   promotionData?: PromotionData;
@@ -101,16 +99,9 @@ export type State = {
 };
 
 function AMCheckout(props: Props) {
-  const {
-    api,
-    checkoutTier,
-    isLoading,
-    location,
-    navigate,
-    organization,
-    subscription,
-    promotionData,
-  } = props;
+  const organization = useOrganization();
+  const {api, checkoutTier, isLoading, location, navigate, subscription, promotionData} =
+    props;
 
   const hasFetchedBillingConfig = useRef(false);
   const [loading, setLoading] = useState(true);
@@ -969,4 +960,4 @@ const CheckoutStepsContainer = styled('div')`
   }
 `;
 
-export default withPromotions(withApi(withOrganization(withSubscription(AMCheckout))));
+export default withPromotions(withApi(withSubscription(AMCheckout)));

--- a/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
@@ -60,10 +60,10 @@ describe('SetSpendLimit', () => {
       <AMCheckout
         {...RouteComponentPropsFixture({})}
         api={api}
-        organization={organization}
         checkoutTier={PlanTier.AM3}
         navigate={jest.fn()}
-      />
+      />,
+      {organization}
     );
 
     expect(await screen.findByText('Set your pay-as-you-go limit')).toBeInTheDocument();
@@ -98,10 +98,10 @@ describe('SetSpendLimit', () => {
       <AMCheckout
         {...RouteComponentPropsFixture()}
         api={api}
-        organization={preAm3Organization}
         checkoutTier={PlanTier.AM2}
         navigate={jest.fn()}
-      />
+      />,
+      {organization: preAm3Organization}
     );
 
     expect(await screen.findByText('Set your on-demand limit')).toBeInTheDocument();

--- a/static/gsApp/views/spendAllocations/components/allocationForm.tsx
+++ b/static/gsApp/views/spendAllocations/components/allocationForm.tsx
@@ -16,10 +16,9 @@ import {PanelTable} from 'sentry/components/panels/panelTable';
 import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
-import type {Organization} from 'sentry/types/organization';
 import type {RequestMethod} from 'sentry/utils/api/apiQueryKey';
 import {useApi} from 'sentry/utils/useApi';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {AllocationTargetTypes, BILLED_DATA_CATEGORY_INFO} from 'getsentry/constants';
 import type {Subscription} from 'getsentry/types';
@@ -37,7 +36,6 @@ import type {SpendAllocation} from './types';
 
 type AllocationFormProps = {
   fetchSpendAllocations: () => Promise<void>;
-  organization: Organization;
   rootAllocation: SpendAllocation | undefined;
   selectedMetric: DataCategory;
   spendAllocations: SpendAllocation[];
@@ -45,18 +43,18 @@ type AllocationFormProps = {
   initializedData?: SpendAllocation;
 } & ModalRenderProps;
 
-function AllocationForm({
+export function AllocationForm({
   Footer,
   Header,
   closeModal,
   fetchSpendAllocations,
   initializedData,
-  organization,
   selectedMetric: initialMetric,
   rootAllocation,
   spendAllocations,
   subscription,
 }: AllocationFormProps) {
+  const organization = useOrganization();
   const [allocationVolume, setAllocationVolume] = useState(0);
   const [errorFields, setErrorFields] = useState<string[]>([]);
   const [showPrice, setShowPrice] = useState(false);
@@ -504,8 +502,6 @@ function AllocationForm({
     </div>
   );
 }
-
-export default withOrganization(AllocationForm);
 
 const FancyInput = styled('input')`
   line-height: 1.4;

--- a/static/gsApp/views/spendAllocations/index.spec.tsx
+++ b/static/gsApp/views/spendAllocations/index.spec.tsx
@@ -58,9 +58,7 @@ describe('SpendAllocations feature enable flow', () => {
       'project:read',
       'project:admin',
     ];
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     await waitFor(() =>
       screen.findByRole('button', {
         name: 'Get started',
@@ -91,18 +89,14 @@ describe('SpendAllocations feature enable flow', () => {
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     expect(await screen.findByTestId('partnership-note')).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Get Started'})).not.toBeInTheDocument();
   });
 
   it('does not render enable button for non billing role for org that has not enabled spend allocations', async () => {
     organization.access = ['project:read', 'project:admin'];
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     // Waiting a tick for requests to finish
     await act(tick);
     expect(screen.queryByRole('button', {name: 'Get Started'})).not.toBeInTheDocument();
@@ -117,9 +111,7 @@ describe('SpendAllocations feature enable flow', () => {
       'project:read',
       'project:admin',
     ];
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     const enableSpendAllocations = await screen.findByRole('button', {
       name: 'Get started',
     });
@@ -188,9 +180,7 @@ describe('enabled Spend Allocations page', () => {
 
   it('Does not render with insufficient access', async () => {
     organization.access = ['org:read'];
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     // Waiting a tick for requests to finish
     await act(tick);
     expect(screen.queryByTestId('spend-allocation-form')).not.toBeInTheDocument();
@@ -198,25 +188,19 @@ describe('enabled Spend Allocations page', () => {
   });
 
   it('renders allocations table', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     await waitFor(() => screen.findByTestId('allocations-table'));
   });
 
   it('renders billing metric select dropdown', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     expect(
       await screen.findByRole('button', {name: 'Category Errors'})
     ).toBeInTheDocument();
   });
 
   it('properly filters allocations by select dropdown', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
 
     const dropdown = await screen.findByRole('button', {name: 'Category Errors'});
     await selectEvent.select(dropdown, 'Transactions');
@@ -249,7 +233,7 @@ describe('enabled Spend Allocations page', () => {
       plan: 'am3_f',
       planTier: 'am3',
     });
-    render(<SpendAllocationsRoot organization={organization} subscription={am3Sub} />);
+    render(<SpendAllocationsRoot subscription={am3Sub} />, {organization});
 
     const dropdown = await screen.findByRole('button', {name: 'Category Errors'});
     await selectEvent.openMenu(dropdown);
@@ -261,9 +245,7 @@ describe('enabled Spend Allocations page', () => {
   // NOTE: Period navigation has been removed for now
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('refetches allocations on view period change', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     await screen.findAllByTestId('allocation-row');
     const tableRows = screen.getAllByTestId('allocation-row');
     expect(tableRows).toHaveLength(2); // default metric is error with 2 project mocks
@@ -292,9 +274,7 @@ describe('enabled Spend Allocations page', () => {
   });
 
   it('deletes allocations on disable', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     await waitFor(() => screen.findByTestId('allocations-table'));
     expect(
       screen.queryByRole('button', {
@@ -369,17 +349,13 @@ describe('enabled Spend Allocations page without root', () => {
   });
 
   it('renders missing root card', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     expect(mockGet).toHaveBeenCalledTimes(1);
     await screen.findByTestId('missing-root');
   });
 
   it('creates root allocation for billing metric', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
 
     await screen.findByRole('button', {
       name: 'Create Organization-Level Allocation',
@@ -460,9 +436,7 @@ describe('POST Create spend allocation', () => {
   });
 
   it('opens and closes form', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     expect(
       await screen.findByRole('button', {name: 'New Allocation'})
     ).toBeInTheDocument();
@@ -486,9 +460,7 @@ describe('POST Create spend allocation', () => {
   });
 
   it('prevents submit on incomplete form', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     expect(
       await screen.findByRole('button', {name: 'New Allocation'})
     ).toBeInTheDocument();
@@ -546,9 +518,7 @@ describe('Disable Submit button in Spend Allocation', () => {
   });
 
   it('prevents submit with no root allocations', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     expect(
       await screen.findByRole('button', {name: 'New Allocation'})
     ).toBeInTheDocument();
@@ -604,9 +574,7 @@ describe('DELETE spend allocation', () => {
     });
   });
   it('renders delete button for project allocations', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     await screen.findAllByTestId('allocation-row');
     const tableRows = screen.getAllByTestId('allocation-row');
     expect(tableRows).toHaveLength(2);
@@ -614,9 +582,7 @@ describe('DELETE spend allocation', () => {
     expect(within(tableRows[1]!).getByTestId('delete')).toBeInTheDocument();
   });
   it('fires delete request on click', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     expect(mockGet.mock.calls).toHaveLength(1);
     await screen.findAllByTestId('allocation-row');
     const tableRows = screen.getAllByTestId('allocation-row');
@@ -679,9 +645,7 @@ describe('PUT edit spend allocation', () => {
   });
 
   it('opens, initializes form on edit, and submits PUT', async () => {
-    render(
-      <SpendAllocationsRoot organization={organization} subscription={subscription} />
-    );
+    render(<SpendAllocationsRoot subscription={subscription} />, {organization});
     await screen.findAllByTestId('allocation-row');
     const tableRows = screen.getAllByTestId('allocation-row');
     expect(tableRows).toHaveLength(2);

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -19,9 +19,8 @@ import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {IconAdd, IconBroadcast} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
-import type {Organization} from 'sentry/types/organization';
 import {useApi} from 'sentry/utils/useApi';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
@@ -41,7 +40,7 @@ import {SubscriptionPageContainer} from 'getsentry/views/subscriptionPage/compon
 import {PartnershipNote} from 'getsentry/views/subscriptionPage/partnershipNote';
 import {hasPermissions} from 'getsentry/views/subscriptionPage/utils';
 
-import AllocationForm from './components/allocationForm';
+import {AllocationForm} from './components/allocationForm';
 import type {SpendAllocation} from './components/types';
 import {EnableSpendAllocations} from './enableSpendAllocations';
 import {ProjectAllocationsTable} from './projectAllocationsTable';
@@ -49,11 +48,11 @@ import {RootAllocationCard} from './rootAllocationCard';
 import {BigNumUnits} from './utils';
 
 type Props = {
-  organization: Organization;
   subscription: Subscription;
 };
 
-export function SpendAllocationsRoot({organization, subscription}: Props) {
+export function SpendAllocationsRoot({subscription}: Props) {
+  const organization = useOrganization();
   const {openModal} = useModal();
 
   const theme = useTheme();
@@ -293,7 +292,6 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
           {...modalProps}
           fetchSpendAllocations={fetchSpendAllocations}
           initializedData={formData}
-          organization={organization}
           selectedMetric={selectedMetric}
           rootAllocation={rootAllocationForMetric}
           spendAllocations={currentAllocations}
@@ -528,7 +526,7 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
   );
 }
 
-export default withOrganization(withSubscription(SpendAllocationsRoot));
+export default withSubscription(SpendAllocationsRoot);
 
 const DropdownDataCategory = styled(CompactSelect)`
   grid-column: auto / span 1;

--- a/static/gsApp/views/spikeProtection/index.tsx
+++ b/static/gsApp/views/spikeProtection/index.tsx
@@ -5,8 +5,7 @@ import {ExternalLink, Link} from '@sentry/scraps/link';
 import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 
@@ -20,9 +19,10 @@ import {SPIKE_PROTECTION_DOCS_LINK} from 'getsentry/views/spikeProtection/consta
 import SpikeProtectionProjects from 'getsentry/views/spikeProtection/spikeProtectionProjects';
 import {SubscriptionPageContainer} from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
 
-type Props = {organization: Organization; subscription: Subscription};
+type Props = {subscription: Subscription};
 
-function SpikeProtectionRoot({organization, subscription}: Props) {
+function SpikeProtectionRoot({subscription}: Props) {
+  const organization = useOrganization();
   useEffect(() => {
     trackSpendVisibilityAnaltyics(SpendVisibilityEvents.SP_SETTINGS_VIEWED, {
       organization,
@@ -70,4 +70,4 @@ function SpikeProtectionRoot({organization, subscription}: Props) {
   );
 }
 
-export default withOrganization(withSubscription(SpikeProtectionRoot));
+export default withSubscription(SpikeProtectionRoot);

--- a/static/gsApp/views/subscriptionPage/planMigrationActive/index.tsx
+++ b/static/gsApp/views/subscriptionPage/planMigrationActive/index.tsx
@@ -12,7 +12,7 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import {showIntercom} from 'sentry/utils/intercom';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import ZendeskLink from 'getsentry/components/zendeskLink';
+import {ZendeskLink} from 'getsentry/components/zendeskLink';
 import {ANNUAL} from 'getsentry/constants';
 import {CohortId, type PlanMigration, type Subscription} from 'getsentry/types';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';

--- a/static/gsApp/views/subscriptionPage/trial/trialEnded.tsx
+++ b/static/gsApp/views/subscriptionPage/trial/trialEnded.tsx
@@ -8,7 +8,7 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import {showIntercom} from 'sentry/utils/intercom';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import ZendeskLink from 'getsentry/components/zendeskLink';
+import {ZendeskLink} from 'getsentry/components/zendeskLink';
 import type {Subscription} from 'getsentry/types';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 


### PR DESCRIPTION
Swap the 17 trivial (already-FC) consumers of `withOrganization` to call `useOrganization` directly. The HoC itself stays — the class-component consumers will need conversion first.

Where `withOrganization` was the only HoC wrapping the export, the file moves to a named export (and its importers update to match) because the `no-default-exports` eslint rule disallows plain-identifier default exports. Two of those (`organizationAuthTokens/index.tsx` and `organizationIntegrations/pluginDetailedView.tsx`) are lazy-imported in `router/routes.tsx`, so the lazy import unwraps the named export into a `{default: ...}` shape.

Follow-up to #115334 (drop withSentryAppComponents HoC), continuing the legacy HoC cleanup.