### PR TITLE
fix(agent-ui): derive staleness from a direct check w/scheduled rerender

### DIFF
--- a/static/app/utils/useTimeout.spec.tsx
+++ b/static/app/utils/useTimeout.spec.tsx
@@ -92,6 +92,20 @@ describe('useTimeout', () => {
     expect(result.current.end).toBe(firstRender.end);
   });
 
+  it('should use overrideTimeMs from start() when provided', () => {
+    const {result} = renderHook(useTimeout, {
+      initialProps: {timeMs, onTimeout},
+    });
+
+    result.current.start(2000);
+
+    jest.advanceTimersByTime(timeMs + 10);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(2000);
+    expect(onTimeout).toHaveBeenCalled();
+  });
+
   it('should not exec the callback after unmount', () => {
     const {result, unmount} = renderHook(useTimeout, {
       initialProps: {timeMs, onTimeout},

--- a/static/app/utils/useTimeout.tsx
+++ b/static/app/utils/useTimeout.tsx
@@ -21,10 +21,15 @@ export function useTimeout({timeMs, onTimeout}: Options) {
     timeoutRef.current = timeout;
   }, []);
 
-  const start = useCallback(() => {
-    saveTimeout(null);
-    saveTimeout(window.setTimeout(() => onTimeoutRef.current(), timeMs));
-  }, [saveTimeout, timeMs]);
+  const start = useCallback(
+    (overrideTimeMs?: number) => {
+      saveTimeout(null);
+      saveTimeout(
+        window.setTimeout(() => onTimeoutRef.current(), overrideTimeMs ?? timeMs)
+      );
+    },
+    [saveTimeout, timeMs]
+  );
 
   const cancel = useCallback(() => {
     saveTimeout(null);
@@ -40,7 +45,10 @@ export function useTimeout({timeMs, onTimeout}: Options) {
 
   return {
     /**
-     * Start the timer
+     * Start the timer.
+     *
+     * Pass an optional `overrideTimeMs` to fire after a different duration
+     * than the one provided at construction.
      *
      * If there was a previous timer, then it will be cancelled.
      */

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
@@ -23,20 +23,19 @@ const isResponseComplete = (sessionData: SeerExplorerResponse['session'] | undef
     state => state.pr_creation_status !== 'creating'
   );
 
-/** Checks if a timestamp is older than STALE_TIME_MS. */
-const isTimestampStale = (updatedAt: string | undefined) => {
+/** Get the age of an ISO timestamp relative to now, in milliseconds. */
+const getTimestampAge = (updatedAt: string | undefined): number | null => {
   const date = getDateFromTimestampAssumeUtc(updatedAt);
-  if (!date) {
-    return false;
+  if (!date || isNaN(date.getTime())) {
+    return null;
   }
-  return Date.now() - date.getTime() >= STALE_TIME_MS;
+  return Date.now() - date.getTime();
 };
 
 const getPollingState = (
   runId: number | null,
   sessionData: SeerExplorerResponse['session'] | undefined,
   isError: boolean,
-  isStale: boolean,
   override: boolean | undefined
 ): 'polling' | 'not-polling' | 'timed-out' => {
   if (override !== undefined) {
@@ -51,7 +50,7 @@ const getPollingState = (
   if (isResponseComplete(sessionData)) {
     return 'not-polling';
   }
-  if (isStale) {
+  if ((getTimestampAge(sessionData?.updated_at) ?? 0) >= STALE_TIME_MS) {
     return 'timed-out';
   }
   return 'polling';
@@ -100,7 +99,6 @@ export const useSeerExplorerPolling = ({
           runId,
           query.state.data?.json?.session,
           query.state.status === 'error',
-          isTimestampStale(query.state.data?.json?.session?.updated_at),
           shouldPollOverride
         ) === 'polling'
       ) {
@@ -110,40 +108,36 @@ export const useSeerExplorerPolling = ({
     },
   });
 
-  // Forces a re-render at the moment `updated_at` would cross STALE_TIME_MS,
-  // so the returned `isPolling` / `isTimedOut` track the callback's check.
-  const [, forceRender] = useState(0);
+  // Schedule a timeout to force a re-render at the moment `updated_at` crosses STALE_TIME_MS,
+  // so the returned pollingState is consistent with `refetchInterval`.
+  const [, forceRender] = useState(false);
 
   const {start: startStaleTimeout, cancel: cancelStaleTimeout} = useTimeout({
     timeMs: STALE_TIME_MS,
-    onTimeout: () => forceRender(t => t + 1),
+    onTimeout: () => forceRender(v => !v),
   });
 
   useEffect(() => {
-    const updatedAt = apiData?.session?.updated_at;
-    if (!updatedAt || runId === null) {
+    const updatedAtAge = getTimestampAge(apiData?.session?.updated_at);
+    if (updatedAtAge === null || runId === null) {
+      // Empty state or no fetches yet
       cancelStaleTimeout();
       return;
     }
-    const date = getDateFromTimestampAssumeUtc(updatedAt);
-    if (!date) {
+    if (updatedAtAge >= STALE_TIME_MS) {
+      // Already stale
       cancelStaleTimeout();
       return;
     }
-    const remaining = STALE_TIME_MS - (Date.now() - date.getTime());
-    if (remaining <= 0) {
-      // Already stale — the render below will compute isTimedOut.
-      cancelStaleTimeout();
-      return;
-    }
-    startStaleTimeout(remaining);
+    const remaining = STALE_TIME_MS - updatedAtAge;
+    startStaleTimeout(remaining + 1);
   }, [runId, apiData?.session?.updated_at, startStaleTimeout, cancelStaleTimeout]);
 
+  // Polling state for UI components
   const pollingState = getPollingState(
     runId,
     apiData?.session,
     isError,
-    isTimestampStale(apiData?.session?.updated_at),
     shouldPollOverride
   );
 

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
@@ -79,6 +79,10 @@ export const useSeerExplorerPolling = ({
   const organization = useOrganization({allowNull: true});
   const orgSlug = organization?.slug;
 
+  // Track isStale as a state so it can trigger UI rerenders,
+  // and we can timeout from wall clock time when updated_at stops changing.
+  const [isStale, setIsStale] = useState(false);
+
   const {
     data: apiData,
     isError,
@@ -93,7 +97,7 @@ export const useSeerExplorerPolling = ({
           runId,
           query.state.data?.json?.session,
           query.state.status === 'error',
-          isTimestampStale(query.state.data?.json?.session?.updated_at),
+          isStale,
           shouldPollOverride
         ) === 'polling'
       ) {
@@ -103,10 +107,7 @@ export const useSeerExplorerPolling = ({
     },
   });
 
-  // Track a separate isStale state for return value.
-  // This allows us to trigger rerenders, and timeout after updated_at stops changing.
-  const [isStale, setIsStale] = useState(false);
-
+  // Wall clock timer for when updated_at stops changing
   const {start: startStaleTimeout, cancel: cancelStaleTimeout} = useTimeout({
     timeMs: STALE_TIME_MS,
     onTimeout: () => {
@@ -119,6 +120,7 @@ export const useSeerExplorerPolling = ({
     if (isTimestampStale(apiData?.session?.updated_at)) {
       // Already stale
       setIsStale(true);
+      cancelStaleTimeout();
     } else if (runId !== null && apiData?.session?.updated_at) {
       // Start a timeout to set isStale after STALE_TIME_MS
       setIsStale(false);

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
@@ -79,10 +79,6 @@ export const useSeerExplorerPolling = ({
   const organization = useOrganization({allowNull: true});
   const orgSlug = organization?.slug;
 
-  // Track isStale as a state so it can trigger UI rerenders,
-  // and we can timeout from wall clock time when updated_at stops changing.
-  const [isStale, setIsStale] = useState(false);
-
   const {
     data: apiData,
     isError,
@@ -97,7 +93,7 @@ export const useSeerExplorerPolling = ({
           runId,
           query.state.data?.json?.session,
           query.state.status === 'error',
-          isStale,
+          isTimestampStale(query.state.data?.json?.session?.updated_at),
           shouldPollOverride
         ) === 'polling'
       ) {
@@ -107,7 +103,10 @@ export const useSeerExplorerPolling = ({
     },
   });
 
-  // Wall clock timer for when updated_at stops changing (e.g. backend task killed)
+  // Track a separate isStale state for return value.
+  // This allows us to trigger rerenders, and timeout after updated_at stops changing.
+  const [isStale, setIsStale] = useState(false);
+
   const {start: startStaleTimeout, cancel: cancelStaleTimeout} = useTimeout({
     timeMs: STALE_TIME_MS,
     onTimeout: () => {
@@ -120,7 +119,6 @@ export const useSeerExplorerPolling = ({
     if (isTimestampStale(apiData?.session?.updated_at)) {
       // Already stale
       setIsStale(true);
-      cancelStaleTimeout();
     } else if (runId !== null && apiData?.session?.updated_at) {
       // Start a timeout to set isStale after STALE_TIME_MS
       setIsStale(false);

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
@@ -107,7 +107,7 @@ export const useSeerExplorerPolling = ({
     },
   });
 
-  // Wall clock timer for when updated_at stops changing
+  // Wall clock timer for when updated_at stops changing (e.g. backend task killed)
   const {start: startStaleTimeout, cancel: cancelStaleTimeout} = useTimeout({
     timeMs: STALE_TIME_MS,
     onTimeout: () => {

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
@@ -92,6 +92,7 @@ export const useSeerExplorerPolling = ({
   } = useApiQuery<SeerExplorerResponse>(makeSeerExplorerQueryKey(orgSlug || '', runId), {
     staleTime: 0,
     retry: false,
+    refetchOnWindowFocus: true,
     enabled: !!runId && isSeerExplorerEnabled(organization),
     refetchInterval: query => {
       if (

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
@@ -62,13 +62,6 @@ const getPollingState = (
  * `useSeerExplorer` (with mutation state) and `SeerExplorerContextProvider`
  * (without) so the session state is observable globally.
  *
- * Staleness is computed directly from `updated_at` at both the `refetchInterval`
- * callback and the render-side `getPollingState` call, so they can't disagree.
- * A single timer is scheduled to fire at the exact moment the timestamp would
- * cross STALE_TIME_MS — its only job is to force a re-render so the returned
- * `isPolling` / `isTimedOut` reflect the transition (React Query's structural
- * sharing can otherwise suppress re-renders when `updated_at` is unchanged).
- *
  * @param runId - The run ID to poll.
  * @param shouldPollOverride - Useful for passing a state variable to always poll / not poll
  *  when some condition is true, e.g. a mutation is pending. Disables timeout detection.

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
@@ -23,7 +23,7 @@ const isResponseComplete = (sessionData: SeerExplorerResponse['session'] | undef
     state => state.pr_creation_status !== 'creating'
   );
 
-/** Checks if a timestamp is older than SESSION_STALE_TIME_MS. */
+/** Checks if a timestamp is older than STALE_TIME_MS. */
 const isTimestampStale = (updatedAt: string | undefined) => {
   const date = getDateFromTimestampAssumeUtc(updatedAt);
   if (!date) {
@@ -62,6 +62,13 @@ const getPollingState = (
  * (deduped across observers by key) and derives `isPolling`. Called by both
  * `useSeerExplorer` (with mutation state) and `SeerExplorerContextProvider`
  * (without) so the session state is observable globally.
+ *
+ * Staleness is computed directly from `updated_at` at both the `refetchInterval`
+ * callback and the render-side `getPollingState` call, so they can't disagree.
+ * A single timer is scheduled to fire at the exact moment the timestamp would
+ * cross STALE_TIME_MS — its only job is to force a re-render so the returned
+ * `isPolling` / `isTimedOut` reflect the transition (React Query's structural
+ * sharing can otherwise suppress re-renders when `updated_at` is unchanged).
  *
  * @param runId - The run ID to poll.
  * @param shouldPollOverride - Useful for passing a state variable to always poll / not poll
@@ -103,38 +110,40 @@ export const useSeerExplorerPolling = ({
     },
   });
 
-  // Track a separate isStale state for return value.
-  // This allows us to trigger rerenders, and timeout after updated_at stops changing.
-  const [isStale, setIsStale] = useState(false);
+  // Forces a re-render at the moment `updated_at` would cross STALE_TIME_MS,
+  // so the returned `isPolling` / `isTimedOut` track the callback's check.
+  const [, forceRender] = useState(0);
 
   const {start: startStaleTimeout, cancel: cancelStaleTimeout} = useTimeout({
     timeMs: STALE_TIME_MS,
-    onTimeout: () => {
-      setIsStale(true);
-    },
+    onTimeout: () => forceRender(t => t + 1),
   });
 
-  // Update isStale on any timestamp or runId change
   useEffect(() => {
-    if (isTimestampStale(apiData?.session?.updated_at)) {
-      // Already stale
-      setIsStale(true);
-    } else if (runId !== null && apiData?.session?.updated_at) {
-      // Start a timeout to set isStale after STALE_TIME_MS
-      setIsStale(false);
-      startStaleTimeout(); // overwrites any existing timeout
-    } else {
-      // Empty state or no data
-      setIsStale(false);
+    const updatedAt = apiData?.session?.updated_at;
+    if (!updatedAt || runId === null) {
       cancelStaleTimeout();
+      return;
     }
+    const date = getDateFromTimestampAssumeUtc(updatedAt);
+    if (!date) {
+      cancelStaleTimeout();
+      return;
+    }
+    const remaining = STALE_TIME_MS - (Date.now() - date.getTime());
+    if (remaining <= 0) {
+      // Already stale — the render below will compute isTimedOut.
+      cancelStaleTimeout();
+      return;
+    }
+    startStaleTimeout(remaining);
   }, [runId, apiData?.session?.updated_at, startStaleTimeout, cancelStaleTimeout]);
 
   const pollingState = getPollingState(
     runId,
     apiData?.session,
     isError,
-    isStale,
+    isTimestampStale(apiData?.session?.updated_at),
     shouldPollOverride
   );
 


### PR DESCRIPTION
`useSeerExplorerPolling` derives `isPolling` / `isTimedOut` for callers and separately drives the `useApiQuery` `refetchInterval`. Previously these two paths used different staleness signals and could disagree — the rendered `isPolling` stayed `true` after polling had already halted.

Old setup:
- `refetchInterval` called `isTimestampStale(updated_at)` directly — a wall-clock check.
- Returned `isPolling` / `isTimedOut` derived from an `isStale` React state set by a `useTimeout` fired 90s after React first *observed* `updated_at`.

When the observed timestamp was already partially old (e.g., server stops bumping `updated_at`), the callback's wall-clock check tripped before the React-time `useTimeout` fired, leaving a window where the network had stopped polling but the UI still rendered as if it were.

This change drops the `isStale` state entirely. Both the callback and the render-side `getPollingState` now evaluate `isTimestampStale(updated_at)` against `Date.now()` at their respective call sites, so they can't diverge.

The one wrinkle: when `updated_at` doesn't change across polls, React Query's `structuralSharing` keeps the `data` reference identical and suppresses re-renders, so a pure render-time check would never re-evaluate. To force the render-side transition at the right moment, schedule a single timer calibrated to fire when the timestamp would cross `STALE_TIME_MS`. Its only job is to bump a render-counter — no state coupling.

Extended `useTimeout` to let `start()` take an optional `overrideTimeMs`, so we can pass the dynamically computed remaining time. Other callers are unaffected.

---

Also opts the polling query into `refetchOnWindowFocus: true` so the session refetches immediately when the user returns to the tab, instead of waiting for the next poll tick. Project-wide default is `false` so this only affects this query.