### PR TITLE
chore(repositories): Dual write to the new `ProjectRepository` table when we create related rows in other tables

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django.db import router, transaction
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status
@@ -21,6 +22,7 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
 from sentry.models.repository import Repository
 
 
@@ -120,12 +122,19 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
         return default_branch
 
     def create(self, validated_data):
-        return RepositoryProjectPathConfig.objects.create(
-            organization_integration_id=self.org_integration.id,
-            organization_id=self.context["organization"].id,
-            integration_id=self.context["organization_integration"].integration_id,
-            **validated_data,
-        )
+        with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
+            project_repo, _ = ProjectRepository.objects.get_or_create(
+                project_id=validated_data["project_id"],
+                repository_id=validated_data["repository_id"],
+                defaults={"source": ProjectRepositorySource.MANUAL},
+            )
+            return RepositoryProjectPathConfig.objects.create(
+                organization_integration_id=self.org_integration.id,
+                organization_id=self.context["organization"].id,
+                integration_id=self.context["organization_integration"].integration_id,
+                project_repository=project_repo,
+                **validated_data,
+            )
 
     def update(self, instance, validated_data):
         if "id" in validated_data:

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -140,9 +140,18 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
         if "id" in validated_data:
             validated_data.pop("id")
         if self.instance:
-            for key, value in validated_data.items():
-                setattr(self.instance, key, value)
-            self.instance.save()
+            with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
+                project_id = validated_data.get("project_id", self.instance.project_id)
+                repository_id = validated_data.get("repository_id", self.instance.repository_id)
+                project_repo, _ = ProjectRepository.objects.get_or_create(
+                    project_id=project_id,
+                    repository_id=repository_id,
+                    defaults={"source": ProjectRepositorySource.MANUAL},
+                )
+                self.instance.project_repository = project_repo
+                for key, value in validated_data.items():
+                    setattr(self.instance, key, value)
+                self.instance.save()
         return self.instance
 
 

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -28,6 +28,7 @@ from sentry.integrations.source_code_management.repository import RepositoryInte
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
 from sentry.models.repository import Repository
 
 logger = logging.getLogger(__name__)
@@ -259,6 +260,12 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
         has_errors = False
         last_saved_config = None
 
+        project_repo, _ = ProjectRepository.objects.get_or_create(
+            project=project,
+            repository=repo,
+            defaults={"source": ProjectRepositorySource.MANUAL},
+        )
+
         defaults = {
             "repository": repo,
             "organization_integration_id": org_integration.id,
@@ -266,6 +273,7 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
             "integration_id": repo.integration_id,
             "default_branch": default_branch,
             "automatically_generated": False,
+            "project_repository": project_repo,
         }
 
         for mapping in mappings:

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import Any, NamedTuple
 
+from django.db import router, transaction
+
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.source_code_management.repo_trees import (
     RepoAndBranch,
@@ -13,6 +15,7 @@ from sentry.integrations.source_code_management.repo_trees import (
 )
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
 from sentry.models.repository import Repository
 from sentry.utils import metrics
 from sentry.utils.event_frames import EventFrame, try_munge_frame_path
@@ -367,20 +370,26 @@ def create_code_mapping(
             "external_id": code_mapping.repo.external_id,
         },
     )
-    new_code_mapping, _ = RepositoryProjectPathConfig.objects.update_or_create(
-        project=project,
-        stack_root=code_mapping.stacktrace_root,
-        source_root=code_mapping.source_path,
-        defaults={
-            "repository": repository,
-            "organization_id": organization.id,
-            "integration_id": installation.model.id,
-            "organization_integration_id": installation.org_integration.id,
-            "default_branch": code_mapping.repo.branch,
-            # This function is called from the UI, thus, we know that the code mapping is user generated
-            "automatically_generated": False,
-        },
-    )
+    with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
+        project_repo, _ = ProjectRepository.objects.get_or_create(
+            project=project,
+            repository=repository,
+            defaults={"source": ProjectRepositorySource.MANUAL},
+        )
+        new_code_mapping, _ = RepositoryProjectPathConfig.objects.update_or_create(
+            project=project,
+            stack_root=code_mapping.stacktrace_root,
+            source_root=code_mapping.source_path,
+            defaults={
+                "repository": repository,
+                "organization_id": organization.id,
+                "integration_id": installation.model.id,
+                "organization_integration_id": installation.org_integration.id,
+                "default_branch": code_mapping.repo.branch,
+                "automatically_generated": False,
+                "project_repository": project_repo,
+            },
+        )
 
     return new_code_mapping
 

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from enum import StrEnum
 from typing import Any
 
+from django.db import router, transaction
 from google.api_core.exceptions import DeadlineExceeded
 from sentry_sdk import set_tag, set_user
 
@@ -19,6 +20,7 @@ from sentry.issues.auto_source_code_config.code_mapping import CodeMapping, Code
 from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
 from sentry.models.repository import Repository
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -237,18 +239,25 @@ def create_code_mapping(
 ) -> None:
     created = False
     if not tags["dry_run"] and repository is not None:
-        _, created = RepositoryProjectPathConfig.objects.get_or_create(
-            project=project,
-            stack_root=code_mapping.stacktrace_root,
-            source_root=code_mapping.source_path,
-            defaults={
-                "repository": repository,
-                "organization_integration_id": org_integration.id,
-                "integration_id": org_integration.integration_id,
-                "organization_id": org_integration.organization_id,
-                "default_branch": code_mapping.repo.branch,
-                "automatically_generated": True,
-            },
-        )
+        with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
+            project_repo, _ = ProjectRepository.objects.get_or_create(
+                project=project,
+                repository=repository,
+                defaults={"source": ProjectRepositorySource.AUTO_EVENT},
+            )
+            _, created = RepositoryProjectPathConfig.objects.get_or_create(
+                project=project,
+                stack_root=code_mapping.stacktrace_root,
+                source_root=code_mapping.source_path,
+                defaults={
+                    "repository": repository,
+                    "organization_integration_id": org_integration.id,
+                    "integration_id": org_integration.integration_id,
+                    "organization_id": org_integration.organization_id,
+                    "default_branch": code_mapping.repo.branch,
+                    "automatically_generated": True,
+                    "project_repository": project_repo,
+                },
+            )
     if created or tags["dry_run"]:
         metrics.incr(key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0)

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -29,6 +29,7 @@ from sentry.models.group import Group
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
 from sentry.models.repository import Repository
 from sentry.net.http import connection_from_url
 from sentry.projectoptions.defaults import SEER_PROJECT_PREFERENCE_OPTION_KEYS
@@ -518,7 +519,14 @@ def _write_preferences_to_sentry_db(
                     )
 
         if project_repos_to_create:
-            # Create project repos.
+            for spr in project_repos_to_create:
+                project_repo, _ = ProjectRepository.objects.get_or_create(
+                    project=spr.project,
+                    repository_id=spr.repository_id,
+                    defaults={"source": ProjectRepositorySource.SEER_PREFERENCE},
+                )
+                spr.project_repository = project_repo
+
             created_project_repos = SeerProjectRepository.objects.bulk_create(
                 project_repos_to_create
             )

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from sentry.integrations.api.endpoints.organization_code_mappings import BRANCH_NAME_ERROR_MESSAGE
+from sentry.models.projectrepository import ProjectRepository
 from sentry.models.repository import Repository
 from sentry.testutils.cases import APITestCase
 
@@ -254,6 +255,9 @@ class OrganizationCodeMappingsTest(APITestCase):
             "sourceRoot": "/source/root",
             "defaultBranch": "master",
         }
+        assert ProjectRepository.objects.filter(
+            project=self.project1, repository=self.repo1
+        ).exists()
 
     def test_basic_post_from_member_permissions(self) -> None:
         self.login_as(user=self.user2)

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.models.projectrepository import ProjectRepository
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
@@ -66,6 +67,10 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         assert config.repository == self.repo1
         assert config.organization_id == self.organization.id
         assert config.automatically_generated is False
+        assert config.project_repository is not None
+        assert ProjectRepository.objects.filter(
+            project=self.project1, repository=self.repo1
+        ).exists()
 
     def test_create_multiple_mappings(self) -> None:
         response = self.make_post(

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -13,6 +13,7 @@ from sentry.issues.auto_source_code_config.constants import (
 from sentry.issues.auto_source_code_config.integration_utils import InstallationNotFoundError
 from sentry.issues.auto_source_code_config.task import DeriveCodeMappingsErrorReason, process_event
 from sentry.issues.auto_source_code_config.utils.platform import PlatformConfig
+from sentry.models.projectrepository import ProjectRepository
 from sentry.models.repository import Repository
 from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import ApiError
@@ -183,6 +184,12 @@ class BaseDeriveCodeMappings(TestCase):
                         )
                         assert code_mapping is not None
                         assert code_mapping.repository.name == expected_cm["repo_name"]
+                        assert code_mapping.project_repository is not None
+                        assert code_mapping.project_repository.project_id == self.project.id
+                        assert (
+                            code_mapping.project_repository.repository_id
+                            == code_mapping.repository_id
+                        )
                 else:
                     assert current_code_mappings.count() == starting_code_mappings_count
 
@@ -202,6 +209,10 @@ class BaseDeriveCodeMappings(TestCase):
                     )
                 else:
                     assert current_enhancements == starting_enhancements
+
+            if not dry_run and expected_new_code_mappings:
+                project_repos = ProjectRepository.objects.filter(project=self.project)
+                assert project_repos.count() > 0
 
             if (current_repositories.count() > starting_repositories_count) or dry_run:
                 mock_incr.assert_any_call(

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -10,6 +10,7 @@ from sentry.constants import (
     ObjectStatus,
 )
 from sentry.models.options.project_option import ProjectOption
+from sentry.models.projectrepository import ProjectRepository
 from sentry.seer.autofix.constants import (
     AutofixAutomationTuningSettings,
     AutofixStatus,
@@ -703,6 +704,8 @@ class TestWritePreferencesToSentryDb(TestCase):
         assert seer_repo.repository_id == self.repo.id
         assert seer_repo.branch_name == "develop"
         assert seer_repo.instructions == "Use conventional commits"
+        assert seer_repo.project_repository is not None
+        assert ProjectRepository.objects.filter(project=self.project, repository=self.repo).exists()
 
         overrides = SeerProjectRepositoryBranchOverride.objects.filter(
             seer_project_repository=seer_repo


### PR DESCRIPTION
When creating `RepositoryProjectPathConfig` and `RepositoryProjectPathConfig` rows, we now dual write to `ProjectRepository` and store the id in the fk column.

<!-- Describe your PR here. -->