### PR TITLE
ref(preprod): Increase process_artifact deadline from 12 to 15 minutes

### DIFF
--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 @launchpad_tasks.register(
     name="process_artifact",
     retry=Retry(times=3),
-    processing_deadline_duration=60 * 12,
+    processing_deadline_duration=60 * 15,
 )
 def process_artifact(artifact_id: str, project_id: str, organization_id: str) -> None:
     pass


### PR DESCRIPTION
Increases the `processing_deadline_duration` for the `process_artifact` Launchpad task from 12 minutes (720s) to 15 minutes (900s).

Some artifacts are hitting the 12-minute deadline and getting retried unnecessarily. Bumping to 15 minutes gives them enough headroom to complete without triggering the deadline.