### PR TITLE
feat(agent-ui): Track analytics event when explorer session times out

### DIFF
--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -146,6 +146,9 @@ export type SeerAnalyticsEventsParameters = {
     surface: 'global_panel';
   };
   'seer.explorer.session_link_copied': Record<string, unknown>;
+  'seer.explorer.timed_out': {
+    run_id: number | null;
+  };
 };
 
 type SeerAnalyticsEventKey = keyof SeerAnalyticsEventsParameters;
@@ -178,4 +181,5 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'seer.explorer.session_copied_to_clipboard':
     'Seer Explorer: Session Copied to Clipboard',
   'seer.explorer.session_link_copied': 'Seer Explorer: Session Link Copied',
+  'seer.explorer.timed_out': 'Seer Explorer: Timed Out',
 };

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -319,6 +319,15 @@ export function ExplorerDrawerContent({
   // Deep link effect
   useSeerExplorerDeepLink({callback: switchToRun});
 
+  // Track when a session times out
+  const prevIsTimedOutRef = useRef(false);
+  useEffect(() => {
+    if (isTimedOut && !prevIsTimedOutRef.current) {
+      trackAnalytics('seer.explorer.timed_out', {organization, run_id: runId});
+    }
+    prevIsTimedOutRef.current = isTimedOut;
+  }, [isTimedOut, organization, runId]);
+
   // Interrupt button and placeholder state
   const interruptState =
     isPolling && hasSentInterrupt


### PR DESCRIPTION
## Summary

- Adds a new `seer.explorer.timed_out` analytic event that fires when `isTimedOut` transitions from `false` to `true` in the explorer drawer
- Registers the event key, display name, and params in `seerAnalyticsEvents.tsx`
- Uses a ref to track the previous value and a `useEffect` to detect the transition

## Test plan

- [ ] Open Seer explorer drawer and trigger a timeout scenario
- [ ] Verify `seer.explorer.timed_out` event is emitted with correct `run_id`
- [ ] Verify the event only fires on the false→true transition, not on re-renders