### PR TITLE
chore(dynamic-sampling): add status for snuba timeouts

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
@@ -14,6 +14,7 @@ from sentry.dynamic_sampling.per_org.tasks.gate import (
     metrics_sample_rate,
 )
 from sentry.utils import metrics
+from sentry.utils.snuba_rpc import SnubaRPCError
 
 F = TypeVar("F", bound=Callable[..., object])
 
@@ -38,6 +39,7 @@ class TelemetryStatus(StrEnum):
     ORG_NOT_FOUND = "org_not_found"
     ROLLOUT_DISABLED = "rollout_disabled"
     ROLLOUT_EXCLUDED = "rollout_excluded"
+    SNUBA_TIMEOUT = "snuba_timeout"
 
 
 class DynamicSamplingException(Exception):
@@ -112,6 +114,10 @@ def track_dynamic_sampling(func: F) -> F:
                     result = func(*args, **kwargs)
             except DynamicSamplingException as exc:
                 result = exc.status
+            except SnubaRPCError as exc:
+                sentry_sdk.capture_exception(exc)
+                emit_status(status_metric, TelemetryStatus.SNUBA_TIMEOUT)
+                raise
             except Exception as exc:
                 sentry_sdk.capture_exception(exc)
                 emit_status(status_metric, TelemetryStatus.FAILED)

--- a/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
@@ -14,7 +14,7 @@ from sentry.dynamic_sampling.per_org.tasks.gate import (
     metrics_sample_rate,
 )
 from sentry.utils import metrics
-from sentry.utils.snuba_rpc import SnubaRPCError
+from sentry.utils.snuba_rpc import SnubaRPCError, SnubaRPCTimeout
 
 F = TypeVar("F", bound=Callable[..., object])
 
@@ -40,6 +40,7 @@ class TelemetryStatus(StrEnum):
     ROLLOUT_DISABLED = "rollout_disabled"
     ROLLOUT_EXCLUDED = "rollout_excluded"
     SNUBA_TIMEOUT = "snuba_timeout"
+    SNUBA_ERROR = "snuba_error"
 
 
 class DynamicSamplingException(Exception):
@@ -114,9 +115,13 @@ def track_dynamic_sampling(func: F) -> F:
                     result = func(*args, **kwargs)
             except DynamicSamplingException as exc:
                 result = exc.status
-            except SnubaRPCError as exc:
+            except SnubaRPCTimeout as exc:
                 sentry_sdk.capture_exception(exc)
                 emit_status(status_metric, TelemetryStatus.SNUBA_TIMEOUT)
+                raise
+            except SnubaRPCError as exc:
+                sentry_sdk.capture_exception(exc)
+                emit_status(status_metric, TelemetryStatus.SNUBA_ERROR)
                 raise
             except Exception as exc:
                 sentry_sdk.capture_exception(exc)

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_telemetry.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_telemetry.py
@@ -11,6 +11,7 @@ from sentry.dynamic_sampling.per_org.tasks.telemetry import (
     track_dynamic_sampling,
 )
 from sentry.testutils.helpers.options import override_options
+from sentry.utils.snuba_rpc import SnubaRPCError, SnubaRPCTimeout
 
 _GATE_OPTIONS = {
     "dynamic-sampling.per_org.killswitch": False,
@@ -31,19 +32,71 @@ def _capture_timer_tags() -> tuple[object, dict[str, str]]:
 
 @override_options(_GATE_OPTIONS)
 def test_records_duration_and_reraises_with_failed_status_on_exception() -> None:
+    error = ValueError("nope")
+
     @track_dynamic_sampling
     def boom() -> None:
-        raise ValueError("nope")
+        raise error
 
     timer, timer_tags = _capture_timer_tags()
 
     with (
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer),
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
         pytest.raises(ValueError),
     ):
         boom()
 
     assert timer_tags["status"] == TelemetryStatus.FAILED.value
+    emit.assert_called_once_with("dynamic_sampling.boom.status", TelemetryStatus.FAILED)
+    sdk.capture_exception.assert_called_once_with(error)
+
+
+@override_options(_GATE_OPTIONS)
+def test_reraises_snuba_timeout_and_emits_timeout_status() -> None:
+    error = SnubaRPCTimeout("timed out")
+
+    @track_dynamic_sampling
+    def boom() -> None:
+        raise error
+
+    timer, timer_tags = _capture_timer_tags()
+
+    with (
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer),
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
+        pytest.raises(SnubaRPCTimeout),
+    ):
+        boom()
+
+    assert timer_tags["status"] == TelemetryStatus.FAILED.value
+    emit.assert_called_once_with("dynamic_sampling.boom.status", TelemetryStatus.SNUBA_TIMEOUT)
+    sdk.capture_exception.assert_called_once_with(error)
+
+
+@override_options(_GATE_OPTIONS)
+def test_reraises_snuba_error_and_emits_snuba_error_status() -> None:
+    error = SnubaRPCError("snuba failed")
+
+    @track_dynamic_sampling
+    def boom() -> None:
+        raise error
+
+    timer, timer_tags = _capture_timer_tags()
+
+    with (
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer),
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
+        pytest.raises(SnubaRPCError),
+    ):
+        boom()
+
+    assert timer_tags["status"] == TelemetryStatus.FAILED.value
+    emit.assert_called_once_with("dynamic_sampling.boom.status", TelemetryStatus.SNUBA_ERROR)
+    sdk.capture_exception.assert_called_once_with(error)
 
 
 @override_options(_GATE_OPTIONS)


### PR DESCRIPTION
- Snuba timeouts are not generic failures - they should thus not be marked as such in our observability