### PR TITLE
chore(dynamic-sampling): rename dynamic sampling status enum

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/tasks/configuration.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/configuration.py
@@ -9,7 +9,7 @@ from sentry import options, quotas
 from sentry.constants import SAMPLING_MODE_DEFAULT, TARGET_SAMPLE_RATE_DEFAULT, ObjectStatus
 from sentry.dynamic_sampling.per_org.tasks.telemetry import (
     DynamicSamplingException,
-    TelemetryStatus,
+    DynamicSamplingStatus,
 )
 from sentry.dynamic_sampling.rules.utils import ProjectId
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
@@ -90,7 +90,7 @@ class AutomaticDynamicSamplingConfiguration(BaseDynamicSamplingConfiguration):
                 organization_id=organization.id
             )
         except ObjectDoesNotExist as exc:
-            raise DynamicSamplingException(TelemetryStatus.NO_SUBSCRIPTION) from exc
+            raise DynamicSamplingException(DynamicSamplingStatus.NO_SUBSCRIPTION) from exc
 
     @property
     def is_enabled(self) -> bool:

--- a/src/sentry/dynamic_sampling/per_org/tasks/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/scheduler.py
@@ -13,7 +13,7 @@ from sentry.dynamic_sampling.per_org.tasks.gate import is_org_in_rollout
 from sentry.dynamic_sampling.per_org.tasks.queries import get_eap_organization_volume
 from sentry.dynamic_sampling.per_org.tasks.telemetry import (
     SCHEDULER_BUCKET_ORG_STATUS_METRIC,
-    TelemetryStatus,
+    DynamicSamplingStatus,
     emit_status,
     track_dynamic_sampling,
 )
@@ -76,13 +76,13 @@ def schedule_per_org_calculations() -> None:
 
     emit_status(
         SCHEDULER_BUCKET_ORG_STATUS_METRIC,
-        TelemetryStatus.DISPATCHED,
+        DynamicSamplingStatus.DISPATCHED,
         amount=dispatched,
         extra_tags=bucket_tag,
     )
     emit_status(
         SCHEDULER_BUCKET_ORG_STATUS_METRIC,
-        TelemetryStatus.ROLLOUT_EXCLUDED,
+        DynamicSamplingStatus.ROLLOUT_EXCLUDED,
         amount=skipped,
         extra_tags=bucket_tag,
     )
@@ -96,13 +96,13 @@ def schedule_per_org_calculations() -> None:
     silo_mode=SiloMode.CELL,
 )
 @track_dynamic_sampling
-def run_calculations_per_org_task(org_id: OrganizationId) -> TelemetryStatus | None:
+def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStatus | None:
     config = get_configuration(org_id)
     if not config.is_enabled:
-        return TelemetryStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
+        return DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
 
     org_volume = get_eap_organization_volume(config)
     if org_volume is None:
-        return TelemetryStatus.NO_VOLUME
+        return DynamicSamplingStatus.NO_VOLUME
 
     return None

--- a/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
@@ -27,7 +27,7 @@ SCHEDULER_BUCKET_ORG_STATUS_METRIC = (
 )
 
 
-class TelemetryStatus(StrEnum):
+class DynamicSamplingStatus(StrEnum):
     COMPLETED = "completed"
     DISPATCHED = "dispatched"
     FAILED = "failed"
@@ -46,14 +46,14 @@ class TelemetryStatus(StrEnum):
 class DynamicSamplingException(Exception):
     """This exception allows a task to bubble up the status to the caller, for the task decorator to emit a metric with a status that derives from the status recorded in the exception."""
 
-    def __init__(self, status: TelemetryStatus) -> None:
+    def __init__(self, status: DynamicSamplingStatus) -> None:
         super().__init__(status.value)
         self.status = status
 
 
 def emit_status(
     metric: str,
-    status: TelemetryStatus,
+    status: DynamicSamplingStatus,
     *,
     amount: int = 1,
     extra_tags: Mapping[str, str] | None = None,
@@ -75,25 +75,25 @@ def emit_gauge(metric: str, value: float, *, tags: Mapping[str, str] | None = No
     )
 
 
-def _get_status_from_result(result: object) -> TelemetryStatus:
-    if isinstance(result, TelemetryStatus):
+def _get_status_from_result(result: object) -> DynamicSamplingStatus:
+    if isinstance(result, DynamicSamplingStatus):
         return result
-    return TelemetryStatus.COMPLETED
+    return DynamicSamplingStatus.COMPLETED
 
 
 @contextmanager
-def emit_duration(metric: str) -> Generator[Callable[[object], TelemetryStatus]]:
+def emit_duration(metric: str) -> Generator[Callable[[object], DynamicSamplingStatus]]:
     with metrics.timer(metric, sample_rate=metrics_sample_rate()) as duration_tags:
         try:
 
-            def set_status_from_result(result: object) -> TelemetryStatus:
+            def set_status_from_result(result: object) -> DynamicSamplingStatus:
                 status = _get_status_from_result(result)
                 duration_tags["status"] = status.value
                 return status
 
             yield set_status_from_result
         except Exception:
-            duration_tags["status"] = TelemetryStatus.FAILED.value
+            duration_tags["status"] = DynamicSamplingStatus.FAILED.value
             raise
 
 
@@ -104,20 +104,20 @@ def track_dynamic_sampling(func: F) -> F:
     @functools.wraps(func)
     def wrapper(*args: object, **kwargs: object) -> object:
         result: object
-        status: TelemetryStatus
+        status: DynamicSamplingStatus
         with emit_duration(duration_metric) as set_duration_status:
             try:
                 if is_killswitch_engaged():
-                    result = TelemetryStatus.KILLSWITCHED
+                    result = DynamicSamplingStatus.KILLSWITCHED
                 elif not is_rollout_enabled():
-                    result = TelemetryStatus.ROLLOUT_DISABLED
+                    result = DynamicSamplingStatus.ROLLOUT_DISABLED
                 else:
                     result = func(*args, **kwargs)
             except DynamicSamplingException as exc:
                 result = exc.status
             except SnubaRPCTimeout as exc:
                 sentry_sdk.capture_exception(exc)
-                emit_status(status_metric, TelemetryStatus.SNUBA_TIMEOUT)
+                emit_status(status_metric, DynamicSamplingStatus.SNUBA_TIMEOUT)
                 raise
             except SnubaRPCError as exc:
                 sentry_sdk.capture_exception(exc)
@@ -125,7 +125,7 @@ def track_dynamic_sampling(func: F) -> F:
                 raise
             except Exception as exc:
                 sentry_sdk.capture_exception(exc)
-                emit_status(status_metric, TelemetryStatus.FAILED)
+                emit_status(status_metric, DynamicSamplingStatus.FAILED)
                 raise
 
             status = set_duration_status(result)

--- a/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/telemetry.py
@@ -121,7 +121,7 @@ def track_dynamic_sampling(func: F) -> F:
                 raise
             except SnubaRPCError as exc:
                 sentry_sdk.capture_exception(exc)
-                emit_status(status_metric, TelemetryStatus.SNUBA_ERROR)
+                emit_status(status_metric, DynamicSamplingStatus.SNUBA_ERROR)
                 raise
             except Exception as exc:
                 sentry_sdk.capture_exception(exc)

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_configuration.py
@@ -16,7 +16,7 @@ from sentry.dynamic_sampling.per_org.tasks.configuration import (
 )
 from sentry.dynamic_sampling.per_org.tasks.telemetry import (
     DynamicSamplingException,
-    TelemetryStatus,
+    DynamicSamplingStatus,
 )
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
 from sentry.models.organization import Organization
@@ -95,7 +95,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         ):
             get_configuration(org.id)
 
-        assert exc_info.value.status == TelemetryStatus.NO_SUBSCRIPTION
+        assert exc_info.value.status == DynamicSamplingStatus.NO_SUBSCRIPTION
 
     def test_am2_ignores_project_mode_option(self) -> None:
         org = self.create_organization()

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_scheduler.py
@@ -12,7 +12,7 @@ from sentry.dynamic_sampling.per_org.tasks.scheduler import (
     run_calculations_per_org_task,
     schedule_per_org_calculations,
 )
-from sentry.dynamic_sampling.per_org.tasks.telemetry import TelemetryStatus
+from sentry.dynamic_sampling.per_org.tasks.telemetry import DynamicSamplingStatus
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.models.organization import OrganizationStatus
@@ -139,7 +139,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         ):
             result = run_calculations_per_org_task(org.id)
 
-        assert result == TelemetryStatus.NO_VOLUME
+        assert result == DynamicSamplingStatus.NO_VOLUME
         _assert_called_once_with_config(get_volume, org.id)
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
@@ -177,7 +177,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         ):
             result = run_calculations_per_org_task(org.id)
 
-        assert result == TelemetryStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
+        assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
         get_volume.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
@@ -195,7 +195,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         ):
             result = run_calculations_per_org_task(org.id)
 
-        assert result == TelemetryStatus.NO_SUBSCRIPTION
+        assert result == DynamicSamplingStatus.NO_SUBSCRIPTION
         get_volume.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
@@ -205,7 +205,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         ) as get_volume:
             result = run_calculations_per_org_task(99999999)
 
-        assert result == TelemetryStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
+        assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
         get_volume.assert_not_called()
 
 

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_telemetry.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_telemetry.py
@@ -7,7 +7,7 @@ import pytest
 
 from sentry.dynamic_sampling.per_org.tasks.telemetry import (
     DynamicSamplingException,
-    TelemetryStatus,
+    DynamicSamplingStatus,
     track_dynamic_sampling,
 )
 from sentry.testutils.helpers.options import override_options
@@ -48,8 +48,8 @@ def test_records_duration_and_reraises_with_failed_status_on_exception() -> None
     ):
         boom()
 
-    assert timer_tags["status"] == TelemetryStatus.FAILED.value
-    emit.assert_called_once_with("dynamic_sampling.boom.status", TelemetryStatus.FAILED)
+    assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
+    emit.assert_called_once_with("dynamic_sampling.boom.status", DynamicSamplingStatus.FAILED)
     sdk.capture_exception.assert_called_once_with(error)
 
 
@@ -71,8 +71,10 @@ def test_reraises_snuba_timeout_and_emits_timeout_status() -> None:
     ):
         boom()
 
-    assert timer_tags["status"] == TelemetryStatus.FAILED.value
-    emit.assert_called_once_with("dynamic_sampling.boom.status", TelemetryStatus.SNUBA_TIMEOUT)
+    assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
+    emit.assert_called_once_with(
+        "dynamic_sampling.boom.status", DynamicSamplingStatus.SNUBA_TIMEOUT
+    )
     sdk.capture_exception.assert_called_once_with(error)
 
 
@@ -94,8 +96,8 @@ def test_reraises_snuba_error_and_emits_snuba_error_status() -> None:
     ):
         boom()
 
-    assert timer_tags["status"] == TelemetryStatus.FAILED.value
-    emit.assert_called_once_with("dynamic_sampling.boom.status", TelemetryStatus.SNUBA_ERROR)
+    assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
+    emit.assert_called_once_with("dynamic_sampling.boom.status", DynamicSamplingStatus.SNUBA_ERROR)
     sdk.capture_exception.assert_called_once_with(error)
 
 
@@ -116,16 +118,16 @@ def test_passes_result_through_and_emits_completed_on_success() -> None:
         assert add(2, 3) == 5
 
     timer_mock.assert_called_once_with("dynamic_sampling.add.duration", sample_rate=1.0)
-    assert timer_tags["status"] == TelemetryStatus.COMPLETED.value
-    emit.assert_called_once_with("dynamic_sampling.add.status", TelemetryStatus.COMPLETED)
+    assert timer_tags["status"] == DynamicSamplingStatus.COMPLETED.value
+    emit.assert_called_once_with("dynamic_sampling.add.status", DynamicSamplingStatus.COMPLETED)
     sdk.capture_exception.assert_not_called()
 
 
 @override_options(_GATE_OPTIONS)
 def test_emits_returned_terminal_status_without_completed_status() -> None:
     @track_dynamic_sampling
-    def skipped() -> TelemetryStatus:
-        return TelemetryStatus.NOT_IN_ROLLOUT
+    def skipped() -> DynamicSamplingStatus:
+        return DynamicSamplingStatus.NOT_IN_ROLLOUT
 
     timer, timer_tags = _capture_timer_tags()
     with (
@@ -135,11 +137,13 @@ def test_emits_returned_terminal_status_without_completed_status() -> None:
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
     ):
-        assert skipped() == TelemetryStatus.NOT_IN_ROLLOUT
+        assert skipped() == DynamicSamplingStatus.NOT_IN_ROLLOUT
 
     timer_mock.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
-    assert timer_tags["status"] == TelemetryStatus.NOT_IN_ROLLOUT.value
-    emit.assert_called_once_with("dynamic_sampling.skipped.status", TelemetryStatus.NOT_IN_ROLLOUT)
+    assert timer_tags["status"] == DynamicSamplingStatus.NOT_IN_ROLLOUT.value
+    emit.assert_called_once_with(
+        "dynamic_sampling.skipped.status", DynamicSamplingStatus.NOT_IN_ROLLOUT
+    )
     sdk.capture_exception.assert_not_called()
 
 
@@ -147,7 +151,7 @@ def test_emits_returned_terminal_status_without_completed_status() -> None:
 def test_emits_terminal_status_exception_without_failed_status() -> None:
     @track_dynamic_sampling
     def skipped() -> None:
-        raise DynamicSamplingException(TelemetryStatus.NO_SUBSCRIPTION)
+        raise DynamicSamplingException(DynamicSamplingStatus.NO_SUBSCRIPTION)
 
     timer, timer_tags = _capture_timer_tags()
     with (
@@ -157,9 +161,11 @@ def test_emits_terminal_status_exception_without_failed_status() -> None:
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
     ):
-        assert skipped() == TelemetryStatus.NO_SUBSCRIPTION
+        assert skipped() == DynamicSamplingStatus.NO_SUBSCRIPTION
 
     timer_mock.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
-    assert timer_tags["status"] == TelemetryStatus.NO_SUBSCRIPTION.value
-    emit.assert_called_once_with("dynamic_sampling.skipped.status", TelemetryStatus.NO_SUBSCRIPTION)
+    assert timer_tags["status"] == DynamicSamplingStatus.NO_SUBSCRIPTION.value
+    emit.assert_called_once_with(
+        "dynamic_sampling.skipped.status", DynamicSamplingStatus.NO_SUBSCRIPTION
+    )
     sdk.capture_exception.assert_not_called()


### PR DESCRIPTION
This name makes more sense - it's the status of the dynamic sampling job, so let's not make this more complicated than necessary