### PR TITLE
chore(snuba): add exception type for snuba timeouts

### DIFF
--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -83,6 +83,10 @@ class SnubaRPCError(SnubaError):
     pass
 
 
+class SnubaRPCTimeout(SnubaRPCError):
+    pass
+
+
 class SnubaRPCRateLimitExceeded(SnubaRPCError):
     pass
 
@@ -397,6 +401,7 @@ def _make_rpc_request(
                 except urllib3.exceptions.HTTPError as err:
                     if isinstance(err, urllib3.exceptions.ReadTimeoutError):
                         metrics.incr("snuba_rpc.read_timeout_error", tags={"referrer": referrer})
+                        raise SnubaRPCTimeout(err)
                     raise SnubaRPCError(err)
                 span.set_tag("timeout", "False")
                 if http_resp.status != 200 and http_resp.status != 202:


### PR DESCRIPTION
- Add a separate exception type for timeouts, so that we can bubble these up in other parts of the backend
- The exception continues to be of type SnubaRPCError, so any code handling retries etc. should continue to work without change