### PR TITLE
ref(ds): Remove reservoir sampling rule

### DIFF
--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -84,7 +84,7 @@ SamplingValueType = Literal["sampleRate", "factor", "minimumSampleRate"]
 
 class SamplingValue(TypedDict):
     type: SamplingValueType
-    value: NotRequired[float]
+    value: float
 
 
 class TimeRange(TypedDict):

--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -79,7 +79,7 @@ RESERVED_IDS = {
 REVERSE_RESERVED_IDS = {value: key for key, value in RESERVED_IDS.items()}
 
 
-SamplingValueType = Literal["sampleRate", "factor", "reservoir", "minimumSampleRate"]
+SamplingValueType = Literal["sampleRate", "factor", "minimumSampleRate"]
 
 
 # (RaduW) Maybe we can split in two types, one for reservoir and one for sampleRate and factor

--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -85,7 +85,6 @@ SamplingValueType = Literal["sampleRate", "factor", "minimumSampleRate"]
 class SamplingValue(TypedDict):
     type: SamplingValueType
     value: NotRequired[float]
-    limit: NotRequired[int]
 
 
 class TimeRange(TypedDict):

--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -82,9 +82,6 @@ REVERSE_RESERVED_IDS = {value: key for key, value in RESERVED_IDS.items()}
 SamplingValueType = Literal["sampleRate", "factor", "minimumSampleRate"]
 
 
-# (RaduW) Maybe we can split in two types, one for reservoir and one for sampleRate and factor
-# Wanted to do this but couldn't think of three good names for the types (SamplingValue, ReservoirSamplingValue and ?
-# some type name for the old SamplingValue type)
 class SamplingValue(TypedDict):
     type: SamplingValueType
     value: NotRequired[float]

--- a/static/gsAdmin/views/dynamicSamplingPanel.spec.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.spec.tsx
@@ -146,7 +146,7 @@ describe('Dynamic Sampling Panel', () => {
 
     const rule1 = {
       samplingValue: {
-        type: 'reservoir',
+        type: 'minimumSampleRate',
         limit: 100,
       },
       type: 'transaction',
@@ -163,7 +163,7 @@ describe('Dynamic Sampling Panel', () => {
 
     const rule2 = {
       samplingValue: {
-        type: 'reservoir',
+        type: 'minimumSampleRate',
         limit: 300,
       },
       type: 'transaction',

--- a/static/gsAdmin/views/dynamicSamplingPanel.spec.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.spec.tsx
@@ -290,8 +290,9 @@ describe('Dynamic Sampling Panel', () => {
     expect(timeRanges[0]).toHaveTextContent('Start:Jun 19, 2024 9:03 AM');
     expect(timeRanges[0]).toHaveTextContent('End:Jun 21, 2024 9:03 AM');
 
-    // Check that the limit is displayed if available
-    const limits = screen.queryAllByTestId('limit');
-    expect(limits[0]).toHaveTextContent('Limit:100');
+    // Check that minimum sample rate values are displayed.
+    expect(screen.getAllByText('Minimum Sample Rate')).toHaveLength(2);
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getAllByText('100%')).toHaveLength(3);
   });
 });

--- a/static/gsAdmin/views/dynamicSamplingPanel.spec.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.spec.tsx
@@ -147,7 +147,7 @@ describe('Dynamic Sampling Panel', () => {
     const rule1 = {
       samplingValue: {
         type: 'minimumSampleRate',
-        limit: 100,
+        value: 1,
       },
       type: 'transaction',
       id: 3005,
@@ -164,7 +164,7 @@ describe('Dynamic Sampling Panel', () => {
     const rule2 = {
       samplingValue: {
         type: 'minimumSampleRate',
-        limit: 300,
+        value: 0.5,
       },
       type: 'transaction',
       id: 3001,

--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -52,7 +52,6 @@ type RuleV2 = {
   samplingValue: {
     type: 'factor' | 'sampleRate' | 'minimumSampleRate';
     value: number;
-    limit?: number;
   };
   type: 'trace' | 'transaction' | 'project';
   timeRange?: {

--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -50,11 +50,11 @@ type RuleV2 = {
   };
   id: number;
   samplingValue: {
-    type: 'factor' | 'sampleRate';
+    type: 'factor' | 'sampleRate' | 'minimumSampleRate';
     value: number;
     limit?: number;
   };
-  type: 'trace' | 'transaction';
+  type: 'trace' | 'transaction' | 'project';
   timeRange?: {
     end: string;
     start: string;

--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -50,7 +50,7 @@ type RuleV2 = {
   };
   id: number;
   samplingValue: {
-    type: 'factor' | 'sampleRate' | 'reservoir';
+    type: 'factor' | 'sampleRate';
     value: number;
     limit?: number;
   };
@@ -335,9 +335,6 @@ function DynamicSamplingRulesTable({
     ) {
       return `${round(samplingValue.value * 100)}%`;
     }
-    if (samplingValue.type === 'reservoir') {
-      return '100%';
-    }
     return `* ${round(samplingValue.value)}`;
   };
 
@@ -347,9 +344,6 @@ function DynamicSamplingRulesTable({
     }
     if (rule.samplingValue.type === 'sampleRate') {
       return round(rule.samplingValue.value - baseSampleRate);
-    }
-    if (rule.samplingValue.type === 'reservoir') {
-      return 1;
     }
     return round(rule.samplingValue.value - 1);
   };

--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -342,7 +342,10 @@ function DynamicSamplingRulesTable({
     if (getRuleType(rule) === RuleType.BOOST_LOW_VOLUME_PROJECTS) {
       return 0;
     }
-    if (rule.samplingValue.type === 'sampleRate') {
+    if (
+      rule.samplingValue.type === 'sampleRate' ||
+      rule.samplingValue.type === 'minimumSampleRate'
+    ) {
       return round(rule.samplingValue.value - baseSampleRate);
     }
     return round(rule.samplingValue.value - 1);

--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -376,12 +376,6 @@ function DynamicSamplingRulesTable({
           <Fragment key={row.id}>
             <Stack gap="xs">
               {row.type}
-              {defined(row.samplingValue.limit) && (
-                <NameColumnDetail data-test-id="limit">
-                  <strong>Limit:</strong>
-                  <span>{row.samplingValue.limit}</span>
-                </NameColumnDetail>
-              )}
               {defined(row.timeRange) && (
                 <div data-test-id="timerange">
                   <NameColumnDetail>


### PR DESCRIPTION
This is no longer exposed in the product. This is also the first step of removing the reservoir sampling code from Relay.