### PR TITLE
feat(ai-conversations): Emit Sentry event on empty conversation detail page

### DIFF
--- a/static/app/views/explore/conversations/components/conversationView.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.tsx
@@ -1,4 +1,5 @@
-import {memo, useState} from 'react';
+import {memo, useEffect, useState} from 'react';
+import * as Sentry from '@sentry/react';
 
 import {Container, Flex} from '@sentry/scraps/layout';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
@@ -84,6 +85,14 @@ function ConversationView({
 }) {
   const organization = useOrganization();
   const [activeTab, setActiveTab] = useState<ConversationTab>('messages');
+
+  useEffect(() => {
+    if (!isLoading && !error && nodes.length === 0) {
+      Sentry.captureMessage('User landed on empty conversation detail page', {
+        level: 'warning',
+      });
+    }
+  }, [isLoading, error, nodes.length]);
 
   const handleTabChange = (newTab: ConversationTab) => {
     if (activeTab !== newTab) {

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -261,7 +261,7 @@ export function useConversation(
   return {
     nodes,
     nodeTraceMap,
-    isLoading: isLoading || isFetchingNextPage,
+    isLoading: isLoading || isFetchingNextPage || hasNextPage,
     error: isError,
   };
 }


### PR DESCRIPTION
Captures a warning-level `Sentry.captureMessage` when users land on a conversation detail page with no AI spans (`nodes.length === 0`). This helps us track how often users encounter empty conversations.


Closes TET-2347