### PR TITLE
fix(events): invert PS/AMD logos in dark mode

### DIFF
--- a/static/app/components/events/contexts/contextIcon.tsx
+++ b/static/app/components/events/contexts/contextIcon.tsx
@@ -117,18 +117,13 @@ const LOGO_MAPPING = {
 /** @internal used in stories **/
 export const NAMES = Object.keys(LOGO_MAPPING);
 
-// The icons in this list will be inverted when the theme is set to dark mode
-const INVERT_IN_DARKMODE = [
-  'darwin',
-  'ios',
-  'macos',
-  'tvos',
-  'mac-os-x',
-  'mac',
-  'apple',
-  'watchos',
-  'vercel',
-];
+// The logos in this list will be inverted when the theme is set to dark mode
+const INVERT_IN_DARKMODE = new Set<string>([
+  logoApple,
+  logoVercel,
+  logoPlaystation,
+  logoAmd,
+]);
 
 const darkCss = css`
   filter: invert(100%);
@@ -170,8 +165,8 @@ export function ContextIcon({name, size: providedSize = 'xl'}: ContextIconProps)
 
   // Apply darkmode CSS to icon when in darkmode
   const isDarkmode = useLegacyStore(ConfigStore).theme === 'dark';
-  const extraCass = isDarkmode && INVERT_IN_DARKMODE.includes(name) ? darkCss : null;
   const imageName = getLogoImage(name);
+  const extraCass = isDarkmode && INVERT_IN_DARKMODE.has(imageName) ? darkCss : null;
 
   return <img height={size} width={size} css={extraCass} src={imageName} />;
 }


### PR DESCRIPTION
The PlayStation logo SVG uses `fill:#1f1f1f` and the AMD logo SVG has no explicit fill (so it defaults to black). Both were invisible against the dark mode background in the event context section.

This adds `logoPlaystation` and `logoAmd` to the dark-mode inversion list. The inversion check is also switched from comparing the raw `name` to comparing the resolved logo image, which removes the redundant Apple-alias enumeration (`darwin`, `ios`, `macos`, `tvos`, `mac-os-x`, `mac`, `apple`, `watchos`) and correctly inverts `amd-*` prefixed CPU names handled by `getLogoImage`.

Fixes ISWF-663