### PR TITLE
ref(process-segments): Remove semantic partitioning option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3379,11 +3379,6 @@ register(
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "spans.process-segments.semantic-partitioning",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 # TTL in seconds for span deduplication tracking. When > 0, the consumer
 # will use Redis SETNX to detect duplicate spans and emit metrics.
 # Set to 0 to disable.

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -153,8 +153,6 @@ def _process_message(
     if not options.get("spans.process-segments.consumer.enable"):
         return []
 
-    use_semantic_partitioning = options.get("spans.process-segments.semantic-partitioning")
-
     assert isinstance(message.value, BrokerValue)
 
     try:
@@ -165,30 +163,20 @@ def _process_message(
             segment["spans"], skip_produce=skip_produce, skip_enrichment=skip_enrichment
         )
         processed = _check_span_duplicates(processed)
-        return [
-            _serialize_payload(span, message.timestamp, use_semantic_partitioning)
-            for span in processed
-        ]
+        return [_serialize_payload(span, message.timestamp) for span in processed]
     except Exception:
         logger.exception("segments.invalid-message")
         raise InvalidMessage(message.value.partition, message.value.offset)
 
 
-def _serialize_payload(
-    span: CompatibleSpan, timestamp: datetime | None, use_semantic_partitioning: bool
-) -> Value[KafkaPayload]:
+def _serialize_payload(span: CompatibleSpan, timestamp: datetime | None) -> Value[KafkaPayload]:
     item = convert_span_to_item(span)
-
-    if use_semantic_partitioning:
-        key = f"{span['project_id']}:{span['trace_id']}:{span['span_id']}".encode()
-    else:
-        key = None
 
     return Value(
         KafkaPayload(
-            key=key,
-            value=item.SerializeToString(),
-            headers=[
+            None,
+            item.SerializeToString(),
+            [
                 ("item_type", str(item.item_type).encode("ascii")),
                 ("project_id", str(span["project_id"]).encode("ascii")),
             ],

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -30,7 +30,6 @@ def build_mock_message(data, topic=None):
 @override_options(
     {
         "spans.process-segments.consumer.enable": True,
-        "spans.process-segments.semantic-partitioning": False,
         "spans.process-segments.dedupe-ttl": 0,
         "spans.process-segments.dedupe-filter-enable": False,
     }


### PR DESCRIPTION
Remove the semantic partitioning option from the segments consumer. Semantic partitioning worked correctly but caused too many produce requests on the broker, which won't scale for all regions.

The consumer now always produces spans without a Kafka key.

ref STREAM-977