### PR TITLE
feat(onboarding): Add streamGenAiSpans to JS agent monitoring init options

### DIFF
--- a/static/app/gettingStartedDocs/deno/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/deno/agentMonitoring.tsx
@@ -12,7 +12,7 @@ import {ManualInstrumentationNote} from 'sentry/views/insights/pages/agents/llmO
 import {AgentIntegration} from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
 
 const PACKAGE_NAME = '@sentry/deno';
-const MIN_VERSION = '10.45.0';
+const MIN_VERSION = '10.53.0';
 
 const sentryImport = `import * as Sentry from "npm:${PACKAGE_NAME}";`;
 
@@ -86,6 +86,8 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
+  // Stream GenAI spans for conversations
+  streamGenAiSpans: true,
   // Add data like inputs and responses to/from LLMs and tools;
   // see https://docs.sentry.io/platforms/javascript/data-management/data-collected/ for more info
   sendDefaultPii: true,

--- a/static/app/gettingStartedDocs/deno/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/deno/agentMonitoring.tsx
@@ -86,7 +86,6 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  // Stream GenAI spans for conversations
   streamGenAiSpans: true,
   // Add data like inputs and responses to/from LLMs and tools;
   // see https://docs.sentry.io/platforms/javascript/data-management/data-collected/ for more info

--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -80,7 +80,6 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  // Stream GenAI spans for conversations
   streamGenAiSpans: true,
   // Add data like inputs and responses to/from LLMs and tools;
   // see https://docs.sentry.io/platforms/javascript/data-management/data-collected/ for more info

--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -80,6 +80,8 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
+  // Stream GenAI spans for conversations
+  streamGenAiSpans: true,
   // Add data like inputs and responses to/from LLMs and tools;
   // see https://docs.sentry.io/platforms/javascript/data-management/data-collected/ for more info
   sendDefaultPii: true,

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -16,7 +16,7 @@ import {
   AgentIntegration,
 } from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
 
-export const MIN_REQUIRED_VERSION = '10.28.0';
+export const MIN_REQUIRED_VERSION = '10.53.0';
 
 export function getAgentIntegration(params: DocsParams): AgentIntegration {
   return (params.platformOptions?.integration ??
@@ -177,6 +177,8 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
+  // Stream GenAI spans for conversations
+  streamGenAiSpans: true,
   // Add data like inputs and responses to/from LLMs and tools;
   // see https://docs.sentry.io/platforms/javascript/data-management/data-collected/ for more info
   sendDefaultPii: true,
@@ -346,6 +348,8 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
+  // Stream GenAI spans for conversations
+  streamGenAiSpans: true,
   // Add data like inputs and responses to/from LLMs and tools;
   // see https://docs.sentry.io/platforms/javascript/data-management/data-collected/ for more info
   sendDefaultPii: true,

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -177,7 +177,6 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  // Stream GenAI spans for conversations
   streamGenAiSpans: true,
   // Add data like inputs and responses to/from LLMs and tools;
   // see https://docs.sentry.io/platforms/javascript/data-management/data-collected/ for more info
@@ -348,7 +347,6 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  // Stream GenAI spans for conversations
   streamGenAiSpans: true,
   // Add data like inputs and responses to/from LLMs and tools;
   // see https://docs.sentry.io/platforms/javascript/data-management/data-collected/ for more info


### PR DESCRIPTION
Add `streamGenAiSpans: true` to all `Sentry.init()` code snippets in the JS agent monitoring onboarding docs and bump the minimum recommended SDK version to `10.53.0`. This covers both the agent monitoring and conversations onboarding flows since the conversations onboarding reuses the same platform docs.

**Updated init snippets**

All `Sentry.init()` blocks in the Node, Browser JS, and Deno agent monitoring onboarding now include `streamGenAiSpans: true`.

**Minimum version bump**

Node/Browser JS: `10.28.0` → `10.53.0`
Deno: `10.45.0` → `10.53.0`

Refs TET-2344