### PR TITLE
fix(slack): Skip explore unfurls for unsupported chart types

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -409,7 +409,7 @@ def _unfurl_explore(
             params.setlist("yAxis", y_axes)
 
         display_type = _resolve_display_type(chart_type, y_axes)
-        if display_type is None:
+        if display_type not in SUPPORTED_DISPLAY_TYPES:
             continue
 
         group_bys = params.getlist("groupBy")
@@ -491,17 +491,17 @@ SUPPORTED_DISPLAY_TYPES = frozenset({"bar", "line", "area"})
 _BAR_AGGREGATES = {"count", "count_unique", "sum"}
 
 
-def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str | None:
-    """Return the display type string for the chart, or ``None`` when the
-    resolved type isn't supported by the unfurl renderer.
+def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str:
+    """Return the display type string for the chart.
 
     Uses the explicit chartType from the URL when present, otherwise mirrors
     the frontend's ``determineDefaultChartType`` logic which maps
     count/count_unique/sum aggregates to bar and everything else to line.
+    Unknown chartType values pass through as ``"unknown"`` so the caller can
+    decide how to handle them (see ``SUPPORTED_DISPLAY_TYPES``).
     """
     if chart_type is not None:
-        resolved = CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type)
-        return resolved if resolved in SUPPORTED_DISPLAY_TYPES else None
+        return CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type, "unknown")
 
     for y_axis in y_axes:
         func_name = y_axis.split("(")[0] if "(" in y_axis else ""

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -410,9 +410,6 @@ def _unfurl_explore(
 
         display_type = _resolve_display_type(chart_type, y_axes)
         if display_type is None:
-            # The chart's visualization (e.g. a heatmap) isn't one the Slack
-            # timeseries renderer can show; skip before hitting the
-            # events-timeseries API rather than rendering a misleading chart.
             continue
 
         group_bys = params.getlist("groupBy")

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -408,6 +408,13 @@ def _unfurl_explore(
             y_axes = [dataset_config["default_y_axis"]]
             params.setlist("yAxis", y_axes)
 
+        display_type = _resolve_display_type(chart_type, y_axes)
+        if display_type is None:
+            # The chart's visualization (e.g. a heatmap) isn't one the Slack
+            # timeseries renderer can show; skip before hitting the
+            # events-timeseries API rather than rendering a misleading chart.
+            continue
+
         group_bys = params.getlist("groupBy")
 
         style = ChartType.SLACK_TIMESERIES
@@ -438,13 +445,6 @@ def _unfurl_explore(
             )
         except Exception:
             _logger.warning("Failed to load events-timeseries for explore unfurl")
-            continue
-
-        display_type = _resolve_display_type(chart_type, y_axes)
-        if display_type is None:
-            # The chart's visualization (e.g. a heatmap) isn't one the Slack
-            # timeseries renderer can show; skip rather than render a
-            # misleading line chart.
             continue
 
         chart_data: dict[str, Any] = {

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -491,17 +491,18 @@ SUPPORTED_DISPLAY_TYPES = frozenset({"bar", "line", "area"})
 _BAR_AGGREGATES = {"count", "count_unique", "sum"}
 
 
-def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str:
-    """Return the display type string for the chart.
+def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str | None:
+    """Return the display type string for the chart, or ``None`` when the
+    URL's chartType isn't recognized.
 
     Uses the explicit chartType from the URL when present, otherwise mirrors
     the frontend's ``determineDefaultChartType`` logic which maps
     count/count_unique/sum aggregates to bar and everything else to line.
-    Unknown chartType values pass through as ``"unknown"`` so the caller can
-    decide how to handle them (see ``SUPPORTED_DISPLAY_TYPES``).
+    The caller decides whether the resolved type is renderable (see
+    ``SUPPORTED_DISPLAY_TYPES``).
     """
     if chart_type is not None:
-        return CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type, "unknown")
+        return CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type)
 
     for y_axis in y_axes:
         func_name = y_axis.split("(")[0] if "(" in y_axis else ""

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -492,18 +492,18 @@ SUPPORTED_DISPLAY_TYPES = frozenset({"bar", "line", "area"})
 _BAR_AGGREGATES = {"count", "count_unique", "sum"}
 
 
-def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str:
-    """Return the display type string for the chart.
+def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str | None:
+    """Return the display type string for the chart, or ``None`` when the
+    URL's chartType isn't recognized.
 
     Uses the explicit chartType from the URL when present, otherwise mirrors
     the frontend's ``determineDefaultChartType`` logic which maps
     count/count_unique/sum aggregates to bar and everything else to line.
-    Unmapped chartType values fall back to ``"line"``, matching the Explore
-    UI. The caller decides whether the resolved type is renderable (see
+    The caller decides whether the resolved type is renderable (see
     ``SUPPORTED_DISPLAY_TYPES``).
     """
     if chart_type is not None:
-        return CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type, "line")
+        return CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type)
 
     for y_axis in y_axes:
         func_name = y_axis.split("(")[0] if "(" in y_axis else ""

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -440,9 +440,16 @@ def _unfurl_explore(
             _logger.warning("Failed to load events-timeseries for explore unfurl")
             continue
 
+        display_type = _resolve_display_type(chart_type, y_axes)
+        if display_type is None:
+            # The chart's visualization (e.g. a heatmap) isn't one the Slack
+            # timeseries renderer can show; skip rather than render a
+            # misleading line chart.
+            continue
+
         chart_data: dict[str, Any] = {
             "timeSeries": resp.data.get("timeSeries", []),
-            "type": _resolve_display_type(chart_type, y_axes),
+            "type": display_type,
         }
 
         try:
@@ -477,21 +484,27 @@ CHART_TYPE_TO_DISPLAY_TYPE = {
     2: "area",
 }
 
+# Display types the Slack timeseries renderer can produce. Any chartType that
+# resolves outside this set (e.g. a future heatmap) should not unfurl, since
+# rendering it as a line chart would be misleading.
+SUPPORTED_DISPLAY_TYPES = frozenset({"bar", "line", "area"})
+
 # Aggregates that default to bar charts in Explore's determineDefaultChartType.
 # All other aggregates default to line.
 _BAR_AGGREGATES = {"count", "count_unique", "sum"}
 
 
-def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str:
-    """Return the display type string for the chart.
+def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str | None:
+    """Return the display type string for the chart, or ``None`` when the
+    resolved type isn't supported by the unfurl renderer.
 
-    Uses the explicit chartType from the URL when present, otherwise
-    mirrors the frontend's ``determineDefaultChartType`` logic which
-    maps count/count_unique/sum aggregates to bar and everything else
-    to line.
+    Uses the explicit chartType from the URL when present, otherwise mirrors
+    the frontend's ``determineDefaultChartType`` logic which maps
+    count/count_unique/sum aggregates to bar and everything else to line.
     """
     if chart_type is not None:
-        return CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type, "line")
+        resolved = CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type)
+        return resolved if resolved in SUPPORTED_DISPLAY_TYPES else None
 
     for y_axis in y_axes:
         func_name = y_axis.split("(")[0] if "(" in y_axis else ""

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -479,10 +479,11 @@ CHART_TYPE_TO_DISPLAY_TYPE = {
     0: "bar",
     1: "line",
     2: "area",
+    3: "histogram",
 }
 
 # Display types the Slack timeseries renderer can produce. Any chartType that
-# resolves outside this set (e.g. a future heatmap) should not unfurl, since
+# resolves outside this set (e.g. histogram) should not unfurl, since
 # rendering it as a line chart would be misleading.
 SUPPORTED_DISPLAY_TYPES = frozenset({"bar", "line", "area"})
 
@@ -491,18 +492,18 @@ SUPPORTED_DISPLAY_TYPES = frozenset({"bar", "line", "area"})
 _BAR_AGGREGATES = {"count", "count_unique", "sum"}
 
 
-def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str | None:
-    """Return the display type string for the chart, or ``None`` when the
-    URL's chartType isn't recognized.
+def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str:
+    """Return the display type string for the chart.
 
     Uses the explicit chartType from the URL when present, otherwise mirrors
     the frontend's ``determineDefaultChartType`` logic which maps
     count/count_unique/sum aggregates to bar and everything else to line.
-    The caller decides whether the resolved type is renderable (see
+    Unmapped chartType values fall back to ``"line"``, matching the Explore
+    UI. The caller decides whether the resolved type is renderable (see
     ``SUPPORTED_DISPLAY_TYPES``).
     """
     if chart_type is not None:
-        return CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type)
+        return CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type, "line")
 
     for y_axis in y_axes:
         func_name = y_axis.split("(")[0] if "(" in y_axis else ""

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1921,6 +1921,9 @@ class UnfurlTest(TestCase):
             unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert unfurls == {}
+        # Skip happens before the events-timeseries call, so neither the API
+        # nor chartcuterie should be hit for unsupported visualizations.
+        assert mock_client_get.call_count == 0
         assert mock_generate_chart.call_count == 0
 
     @patch(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1901,6 +1901,32 @@ class UnfurlTest(TestCase):
         "sentry.integrations.slack.unfurl.explore.client.get",
     )
     @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_skips_unsupported_chart_type(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+        # chartType=99 isn't in CHART_TYPE_TO_DISPLAY_TYPE, simulating a new
+        # visualization (e.g. heatmap) the unfurl renderer can't draw.
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%2C%22chartType%22%3A99%7D&project={self.project.id}&statsPeriod=24h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert unfurls == {}
+        assert mock_generate_chart.call_count == 0
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
     def test_unfurl_explore_without_chart_type_count_defaults_to_bar(
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1905,9 +1905,9 @@ class UnfurlTest(TestCase):
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:
         mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
-        # chartType=99 isn't in CHART_TYPE_TO_DISPLAY_TYPE, simulating a new
-        # visualization (e.g. heatmap) the unfurl renderer can't draw.
-        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%2C%22chartType%22%3A99%7D&project={self.project.id}&statsPeriod=24h"
+        # chartType=3 (histogram) is mapped but isn't in SUPPORTED_DISPLAY_TYPES,
+        # so the unfurl should be skipped rather than rendered as a line chart.
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%2C%22chartType%22%3A3%7D&project={self.project.id}&statsPeriod=24h"
         link_type, args = match_link(url)
 
         if not args or not link_type:


### PR DESCRIPTION
Generated with claude, 

Don't unfurl in the following cases
1. unsupported chart types like heatmaps
2. Non-existent chart type