### PR TITLE
ref(saved-queries): align list endpoint access checks with detail

### DIFF
--- a/src/sentry/discover/endpoints/bases.py
+++ b/src/sentry/discover/endpoints/bases.py
@@ -1,5 +1,7 @@
+from django.db.models import Exists, OuterRef, Q, QuerySet
+
 from sentry.api.bases.organization import OrganizationPermission
-from sentry.discover.models import DiscoverSavedQuery
+from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 from sentry.models.organization import Organization
 
 
@@ -37,3 +39,36 @@ class DiscoverSavedQueryPermission(OrganizationPermission):
 
             return False
         return True
+
+
+def filter_to_accessible_discover_queries(
+    request, queryset: QuerySet[DiscoverSavedQuery]
+) -> QuerySet[DiscoverSavedQuery]:
+    """
+    Filter a ``DiscoverSavedQuery`` queryset to only those rows the request actor can access.
+
+    This mirrors ``DiscoverSavedQueryPermission.has_object_permission`` so that listing endpoints
+    return the same set the detail endpoint would allow on a per-row basis.
+    """
+    access = request.access
+
+    # Open Membership and Managers/Owners can see every saved query in the org.
+    if access.has_global_access or access.has_scope("org:write"):
+        return queryset
+
+    accessible_project_ids = access.accessible_project_ids
+
+    # Hide queries that reference at least one project the actor can't access.
+    has_inaccessible_project = DiscoverSavedQueryProject.objects.filter(
+        discover_saved_query_id=OuterRef("id"),
+    ).exclude(project_id__in=accessible_project_ids)
+    queryset = queryset.exclude(Exists(has_inaccessible_project))
+
+    # For queries that target no projects ("All Projects" / "My Projects"), only show
+    # those the actor created — Open Membership and org:write are already short-circuited above.
+    has_any_project = DiscoverSavedQueryProject.objects.filter(
+        discover_saved_query_id=OuterRef("id"),
+    )
+    queryset = queryset.filter(Exists(has_any_project) | Q(created_by_id=request.user.id))
+
+    return queryset

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -26,7 +26,10 @@ from sentry.apidocs.parameters import (
     VisibilityParams,
 )
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
+from sentry.discover.endpoints.bases import (
+    DiscoverSavedQueryPermission,
+    filter_to_accessible_discover_queries,
+)
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
 from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.models.organization import Organization
@@ -78,6 +81,10 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
             .prefetch_related("projects")
             .extra(select={"lower_name": "lower(name)"})
         ).exclude(is_homepage=True)
+        # Hide saved queries whose project scope the caller cannot access. The detail endpoint
+        # enforces this via `check_object_permissions`; without this filter the list endpoint
+        # would leak the body of queries belonging to projects the caller has no access to.
+        queryset = filter_to_accessible_discover_queries(request, queryset)
         query = request.query_params.get("query")
         if query:
             tokens = tokenize_query(query)

--- a/src/sentry/explore/endpoints/bases.py
+++ b/src/sentry/explore/endpoints/bases.py
@@ -1,5 +1,7 @@
+from django.db.models import Exists, OuterRef, Q, QuerySet
+
 from sentry.api.bases.organization import OrganizationPermission
-from sentry.explore.models import ExploreSavedQuery
+from sentry.explore.models import ExploreSavedQuery, ExploreSavedQueryProject
 from sentry.models.organization import Organization
 
 
@@ -37,3 +39,36 @@ class ExploreSavedQueryPermission(OrganizationPermission):
 
             return False
         return True
+
+
+def filter_to_accessible_explore_queries(
+    request, queryset: QuerySet[ExploreSavedQuery]
+) -> QuerySet[ExploreSavedQuery]:
+    """
+    Filter an ``ExploreSavedQuery`` queryset to only those rows the request actor can access.
+
+    This mirrors ``ExploreSavedQueryPermission.has_object_permission`` so that listing endpoints
+    return the same set the detail endpoint would allow on a per-row basis.
+    """
+    access = request.access
+
+    # Open Membership and Managers/Owners can see every saved query in the org.
+    if access.has_global_access or access.has_scope("org:write"):
+        return queryset
+
+    accessible_project_ids = access.accessible_project_ids
+
+    # Hide queries that reference at least one project the actor can't access.
+    has_inaccessible_project = ExploreSavedQueryProject.objects.filter(
+        explore_saved_query_id=OuterRef("id"),
+    ).exclude(project_id__in=accessible_project_ids)
+    queryset = queryset.exclude(Exists(has_inaccessible_project))
+
+    # For queries that target no projects ("All Projects" / "My Projects"), only show
+    # those the actor created — Open Membership and org:write are already short-circuited above.
+    has_any_project = ExploreSavedQueryProject.objects.filter(
+        explore_saved_query_id=OuterRef("id"),
+    )
+    queryset = queryset.filter(Exists(has_any_project) | Q(created_by_id=request.user.id))
+
+    return queryset

--- a/src/sentry/explore/endpoints/bases.py
+++ b/src/sentry/explore/endpoints/bases.py
@@ -19,6 +19,11 @@ class ExploreSavedQueryPermission(OrganizationPermission):
             return super().has_object_permission(request, view, obj)
 
         if isinstance(obj, ExploreSavedQuery):
+            # Prebuilt queries are product-level content with no user data; any org member
+            # should be able to see and open them regardless of project access.
+            if obj.prebuilt_id is not None:
+                return True
+
             # 1. Saved Query contains certain projects
             if obj.projects.exists():
                 return request.access.has_projects_access(obj.projects.all())
@@ -65,10 +70,13 @@ def filter_to_accessible_explore_queries(
     queryset = queryset.exclude(Exists(has_inaccessible_project))
 
     # For queries that target no projects ("All Projects" / "My Projects"), only show
-    # those the actor created — Open Membership and org:write are already short-circuited above.
+    # those the actor created. Prebuilt queries are product-level content and stay visible
+    # to any org member. Open Membership and org:write are already short-circuited above.
     has_any_project = ExploreSavedQueryProject.objects.filter(
         explore_saved_query_id=OuterRef("id"),
     )
-    queryset = queryset.filter(Exists(has_any_project) | Q(created_by_id=request.user.id))
+    queryset = queryset.filter(
+        Exists(has_any_project) | Q(created_by_id=request.user.id) | Q(prebuilt_id__isnull=False)
+    )
 
     return queryset

--- a/src/sentry/explore/endpoints/bases.py
+++ b/src/sentry/explore/endpoints/bases.py
@@ -63,20 +63,24 @@ def filter_to_accessible_explore_queries(
 
     accessible_project_ids = access.accessible_project_ids
 
-    # Hide queries that reference at least one project the actor can't access.
+    # Prebuilt queries are product-level content and bypass project access in
+    # `has_object_permission`; the queryset filter must do the same.
+    is_prebuilt = Q(prebuilt_id__isnull=False)
+
+    # Hide non-prebuilt queries that reference at least one project the actor can't access.
     has_inaccessible_project = ExploreSavedQueryProject.objects.filter(
         explore_saved_query_id=OuterRef("id"),
     ).exclude(project_id__in=accessible_project_ids)
-    queryset = queryset.exclude(Exists(has_inaccessible_project))
+    queryset = queryset.exclude(Q(Exists(has_inaccessible_project)) & ~is_prebuilt)
 
-    # For queries that target no projects ("All Projects" / "My Projects"), only show
-    # those the actor created. Prebuilt queries are product-level content and stay visible
-    # to any org member. Open Membership and org:write are already short-circuited above.
+    # For non-prebuilt queries that target no projects ("All Projects" / "My Projects"),
+    # only show those the actor created. Open Membership and org:write are already
+    # short-circuited above.
     has_any_project = ExploreSavedQueryProject.objects.filter(
         explore_saved_query_id=OuterRef("id"),
     )
     queryset = queryset.filter(
-        Exists(has_any_project) | Q(created_by_id=request.user.id) | Q(prebuilt_id__isnull=False)
+        Exists(has_any_project) | Q(created_by_id=request.user.id) | is_prebuilt
     )
 
     return queryset

--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -28,7 +28,10 @@ from sentry.apidocs.parameters import (
     VisibilityParams,
 )
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.explore.endpoints.bases import ExploreSavedQueryPermission
+from sentry.explore.endpoints.bases import (
+    ExploreSavedQueryPermission,
+    filter_to_accessible_explore_queries,
+)
 from sentry.explore.endpoints.serializers import ExploreSavedQuerySerializer
 from sentry.explore.models import (
     ExploreSavedQuery,
@@ -377,6 +380,10 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
             .prefetch_related("projects")
             .extra(select={"lower_name": "lower(name)"})
         )
+        # Hide saved queries whose project scope the caller cannot access. The detail endpoint
+        # enforces this via `check_object_permissions`; without this filter the list endpoint
+        # would leak the body of queries belonging to projects the caller has no access to.
+        queryset = filter_to_accessible_explore_queries(request, queryset)
 
         if not features.has(
             "organizations:expose-migrated-discover-queries", organization, actor=request.user

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -414,16 +414,16 @@ class ExploreSavedQueriesTest(APITestCase):
         restricted_team = self.create_team(organization=self.org, members=[])
         restricted_project = self.create_project(organization=self.org, teams=[restricted_team])
 
-        # Use a `prebuilt_id` that matches an entry in `PREBUILT_SAVED_QUERIES` so
-        # `sync_prebuilt_queries` keeps the row in place (same version, not deleted).
-        canonical = PREBUILT_SAVED_QUERIES[0]
+        # `prebuilt_id` / `prebuilt_version` must match the first entry of
+        # `PREBUILT_SAVED_QUERIES` so `sync_prebuilt_queries` doesn't update or delete
+        # the row from under us when the list endpoint runs.
         prebuilt = ExploreSavedQuery.objects.create(
             organization=self.org,
             created_by_id=None,
             name="Edge-case prebuilt",
             query={"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]},
-            prebuilt_id=canonical["prebuilt_id"],
-            prebuilt_version=canonical["prebuilt_version"],
+            prebuilt_id=1,
+            prebuilt_version=1,
         )
         prebuilt.set_projects([restricted_project.id])
 

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -403,6 +403,40 @@ class ExploreSavedQueriesTest(APITestCase):
         prebuilt_names = {q["name"] for q in PREBUILT_SAVED_QUERIES}
         assert prebuilt_names.issubset(names)
 
+    def test_get_prebuilt_visible_even_with_inaccessible_project(self) -> None:
+        # Prebuilts normally have no projects, but the queryset filter must mirror
+        # `has_object_permission`, which exempts prebuilts before any project check.
+        # Pin that contract: even a prebuilt that has somehow been linked to an
+        # inaccessible project must remain visible to a closed-membership member.
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+
+        restricted_team = self.create_team(organization=self.org, members=[])
+        restricted_project = self.create_project(organization=self.org, teams=[restricted_team])
+
+        # Use a `prebuilt_id` that matches an entry in `PREBUILT_SAVED_QUERIES` so
+        # `sync_prebuilt_queries` keeps the row in place (same version, not deleted).
+        canonical = PREBUILT_SAVED_QUERIES[0]
+        prebuilt = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=None,
+            name="Edge-case prebuilt",
+            query={"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]},
+            prebuilt_id=canonical["prebuilt_id"],
+            prebuilt_version=canonical["prebuilt_version"],
+        )
+        prebuilt.set_projects([restricted_project.id])
+
+        outsider = self.create_user()
+        self.create_member(user=outsider, organization=self.org, role="member", teams=[])
+        self.login_as(outsider)
+
+        with self.feature(self.features):
+            response = self.client.get(self.url)
+        assert response.status_code == 200, response.content
+        names = {item["name"] for item in response.data}
+        assert "Edge-case prebuilt" in names
+
     def test_get_shows_unprojected_query_to_creator_only(self) -> None:
         self.org.flags.allow_joinleave = False
         self.org.save()

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.explore.endpoints.explore_saved_queries import (
+    PREBUILT_SAVED_QUERIES,
     sync_prebuilt_queries,
     sync_prebuilt_queries_starred,
 )
@@ -398,6 +399,9 @@ class ExploreSavedQueriesTest(APITestCase):
         assert "Accessible query" in names
         assert "Test query" not in names
         assert "Owner all-projects query" not in names
+        # Prebuilt queries are product-level content and must remain visible to any org member.
+        prebuilt_names = {q["name"] for q in PREBUILT_SAVED_QUERIES}
+        assert prebuilt_names.issubset(names)
 
     def test_get_shows_unprojected_query_to_creator_only(self) -> None:
         self.org.flags.allow_joinleave = False

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -359,6 +359,80 @@ class ExploreSavedQueriesTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
 
+    def test_get_hides_queries_when_no_project_access(self) -> None:
+        # Disable Open Membership so project-level access actually applies.
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+
+        # The "Test query" created in setUp is scoped to self.projects, which the outsider
+        # will not have access to. Add one query scoped to a project the outsider DOES
+        # have access to via a team — only this one should appear.
+        accessible_team = self.create_team(organization=self.org)
+        accessible_project = self.create_project(organization=self.org, teams=[accessible_team])
+        accessible_query = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Accessible query",
+            query={"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]},
+        )
+        accessible_query.set_projects([accessible_project.id])
+
+        # And a "no projects" query authored by the owner — outsider must not see it.
+        ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Owner all-projects query",
+            query={"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]},
+        )
+
+        outsider = self.create_user()
+        self.create_member(
+            user=outsider, organization=self.org, role="member", teams=[accessible_team]
+        )
+        self.login_as(outsider)
+
+        with self.feature(self.features):
+            response = self.client.get(self.url)
+        assert response.status_code == 200, response.content
+        names = {item["name"] for item in response.data}
+        assert "Accessible query" in names
+        assert "Test query" not in names
+        assert "Owner all-projects query" not in names
+
+    def test_get_shows_unprojected_query_to_creator_only(self) -> None:
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+
+        # Owner-authored "no projects" query that members shouldn't see.
+        ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Owner all-projects query",
+            query={"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]},
+        )
+
+        outsider = self.create_user()
+        team = self.create_team(organization=self.org)
+        self.create_member(user=outsider, organization=self.org, role="member", teams=[team])
+
+        # Outsider's own "no projects" query — they should still see it as the creator.
+        own_query = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=outsider.id,
+            name="Outsider all-projects query",
+            query={"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]},
+        )
+
+        self.login_as(outsider)
+        with self.feature(self.features):
+            response = self.client.get(self.url)
+        assert response.status_code == 200, response.content
+        names = {item["name"] for item in response.data}
+        assert "Outsider all-projects query" in names
+        assert "Owner all-projects query" not in names
+        assert "Test query" not in names
+        assert str(own_query.id) in {item["id"] for item in response.data}
+
     def test_sync_prebuilt_starred_alphabetical_for_new_user(self) -> None:
         sync_prebuilt_queries(self.org)
         sync_prebuilt_queries_starred(self.org, self.user.id)

--- a/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
@@ -78,6 +78,34 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 403, response.content
 
+    def test_get_prebuilt_visible_without_project_access(self) -> None:
+        # Prebuilt queries are product-level content; any org member must be able to open them
+        # even when Open Membership is disabled and they have no project access.
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+
+        prebuilt = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=None,
+            name="Prebuilt query",
+            query={"query": [{"fields": ["span.op"], "mode": "samples"}]},
+            prebuilt_id=1,
+            prebuilt_version=1,
+        )
+
+        outsider = self.create_user()
+        self.create_member(user=outsider, organization=self.org, role="member", teams=[])
+        self.login_as(outsider)
+
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-explore-saved-query-detail", args=[self.org.slug, prebuilt.id]
+            )
+            response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == str(prebuilt.id)
+
     def test_get_starred(self) -> None:
         ExploreSavedQueryStarred.objects.create(
             organization=self.org,

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -282,6 +282,88 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
         assert len(response.data) == 1
         assert not any([query["name"] == "Homepage Test Query" for query in response.data])
 
+    def test_get_hides_queries_when_no_project_access(self) -> None:
+        # Disable Open Membership so project-level access actually applies.
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+
+        # Original Test query (created in setUp) is scoped to self.projects.
+        # Create a second project that the no-team user will have access to via a team.
+        accessible_team = self.create_team(organization=self.org)
+        accessible_project = self.create_project(organization=self.org, teams=[accessible_team])
+        accessible_query = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Accessible query",
+            query={"fields": ["test"], "conditions": [], "limit": 10},
+            version=1,
+        )
+        accessible_query.set_projects([accessible_project.id])
+
+        # And one with no projects at all (covers "All Projects" / "My Projects").
+        DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="All-projects query",
+            query={"fields": ["test"], "conditions": [], "limit": 10},
+            version=1,
+        )
+
+        # A regular member with access only to `accessible_team` should NOT see queries
+        # scoped to projects they cannot access, nor the "no projects" query authored by
+        # someone else (since they aren't org:write or the creator).
+        outsider = self.create_user()
+        self.create_member(
+            user=outsider, organization=self.org, role="member", teams=[accessible_team]
+        )
+        self.login_as(outsider)
+
+        with self.feature(self.feature_name):
+            response = self.client.get(self.url)
+        assert response.status_code == 200, response.content
+        names = sorted(item["name"] for item in response.data)
+        assert names == ["Accessible query"]
+
+        # The `all=1` branch must apply the same filter.
+        with self.feature(self.feature_name):
+            response = self.client.get(self.url, data={"all": "1"})
+        assert response.status_code == 200, response.content
+        names = sorted(item["name"] for item in response.data)
+        assert names == ["Accessible query"]
+
+    def test_get_shows_unprojected_query_to_creator_only(self) -> None:
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+
+        # Owner-authored "no projects" query that members shouldn't see.
+        DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Owner-authored all-projects query",
+            query={"fields": ["test"], "conditions": [], "limit": 10},
+            version=1,
+        )
+
+        outsider = self.create_user()
+        team = self.create_team(organization=self.org)
+        self.create_member(user=outsider, organization=self.org, role="member", teams=[team])
+        # Member-authored "no projects" query — same user should still see it.
+        own_query = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=outsider.id,
+            name="Outsider's all-projects query",
+            query={"fields": ["test"], "conditions": [], "limit": 10},
+            version=1,
+        )
+
+        self.login_as(outsider)
+        with self.feature(self.feature_name):
+            response = self.client.get(self.url)
+        assert response.status_code == 200, response.content
+        names = sorted(item["name"] for item in response.data)
+        assert names == ["Outsider's all-projects query"]
+        assert response.data[0]["id"] == str(own_query.id)
+
     def test_post(self) -> None:
         with self.feature(self.feature_name):
             response = self.client.post(


### PR DESCRIPTION
Apply the same project-access logic the Discover and Explore *detail* saved-query endpoints already enforce to their corresponding *list* endpoints, so both report the same view of the org for any given actor.

The detail endpoints have been calling `check_object_permissions` since #72159 / #78830 — the list handlers were not updated alongside, and when the Explore endpoints landed (#86578, #86888) they inherited the same shape. This PR closes the gap on both Discover and Explore in one place.

Implementation: a small `filter_to_accessible_*_queries(request, queryset)` helper in each app's `endpoints/bases.py` that mirrors the existing `has_object_permission` logic at the queryset level (short-circuits for Open Membership / `org:write`, then `Exists()` subqueries on the through-tables for the project-scoped and unprojected cases). The list endpoints call it once after building the base queryset; the `all=1` branch on Discover is covered by the same filter.

Behaviour is unchanged for any actor who could already see every saved query in the org.

Fixes EXP-942