### PR TITLE
fix(insights): span id link overflow

### DIFF
--- a/static/app/views/insights/common/components/tableCells/spanIdCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/spanIdCell.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import {Link} from '@sentry/scraps/link';
@@ -49,16 +50,23 @@ export function SpanIdCell({
   );
 
   return (
-    <Link
-      onClick={() =>
-        trackAnalytics('performance_views.sample_spans.span_clicked', {
-          organization,
-          source: moduleName,
-        })
-      }
-      to={url}
-    >
-      {spanId.slice(0, SPAN_ID_DISPLAY_LENGTH)}
-    </Link>
+    <OverflowContainer>
+      <Link
+        onClick={() =>
+          trackAnalytics('performance_views.sample_spans.span_clicked', {
+            organization,
+            source: moduleName,
+          })
+        }
+        to={url}
+      >
+        {spanId.slice(0, SPAN_ID_DISPLAY_LENGTH)}
+      </Link>
+    </OverflowContainer>
   );
 }
+
+const OverflowContainer = styled('span')`
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/static/app/views/insights/common/components/tableCells/spanIdCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/spanIdCell.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
@@ -50,7 +50,7 @@ export function SpanIdCell({
   );
 
   return (
-    <OverflowContainer>
+    <Text ellipsis>
       <Link
         onClick={() =>
           trackAnalytics('performance_views.sample_spans.span_clicked', {
@@ -62,11 +62,6 @@ export function SpanIdCell({
       >
         {spanId.slice(0, SPAN_ID_DISPLAY_LENGTH)}
       </Link>
-    </OverflowContainer>
+    </Text>
   );
 }
-
-const OverflowContainer = styled('span')`
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;


### PR DESCRIPTION
Fixes a bug where the Link does not properly handle overflow ellipses. I've added in a wrapper that puts in the ellipsis when the column is to small.

| Before | After |
|--------|--------|
| <img width="870" height="333" alt="image" src="https://github.com/user-attachments/assets/98cf8766-f8c4-47c3-81c8-abc515018629" /> | <img width="932" height="342" alt="image" src="https://github.com/user-attachments/assets/580ad562-d338-4a89-9422-700c90889a90" /> | 