### PR TITLE
chore(onboarding): Exclude flutter profiling from SCM info cards

### DIFF
--- a/scripts/genPlatformProductInfo.ts
+++ b/scripts/genPlatformProductInfo.ts
@@ -77,6 +77,19 @@ const FEATURES: Record<string, string> = {
   METRICS: 'metrics',
 };
 
+// Overrides for (platform, product) combinations that the sentry-docs
+// frontmatter declares as supported, but which the SDK owners have asked us
+// not to surface in new-project onboarding (typically because the feature is
+// still alpha or has narrower real-world scope than the frontmatter implies).
+//
+// Keep this list small and document the rationale per-entry so future
+// regenerations don't quietly drop or restore overrides.
+const PRODUCT_EXCLUSIONS: Record<string, Set<string>> = {
+  // Flutter profiling is still alpha and iOS/macOS-only as of 2026-05.
+  // Confirmed by Chris Aigner (Flutter SDK) in #team-value-discovery.
+  flutter: new Set(['PROFILING']),
+};
+
 // Sentry platform-ids whose docs canonical doesn't fall out of the link path.
 // Most platforms map cleanly via /platforms/<lang>/(guides|integrations)/<guide>/.
 const CANONICAL_OVERRIDES: Record<string, {lang: string; guide?: string}> = {
@@ -341,6 +354,7 @@ function deriveProducts(
 
     if (!supported) continue;
     if (product === 'METRICS' && !withMetricsOnboarding.has(platform.id)) continue;
+    if (PRODUCT_EXCLUSIONS[platform.id]?.has(product)) continue;
 
     products.push(product);
   }

--- a/static/app/data/platformProductInfo.generated.ts
+++ b/static/app/data/platformProductInfo.generated.ts
@@ -42,7 +42,6 @@ export const PLATFORM_PRODUCT_INFO: Partial<
     ProductSolution.LOGS,
     ProductSolution.SESSION_REPLAY,
     ProductSolution.PERFORMANCE_MONITORING,
-    ProductSolution.PROFILING,
     ProductSolution.METRICS,
   ],
   'javascript-nextjs': [


### PR DESCRIPTION
Drop `PROFILING` from `flutter` in `platformProductInfo.generated.ts`. Flutter profiling is still alpha and iOS/macOS-only per the SDK team, but `sentry-docs` frontmatter doesn't declare it `notSupported`, so the previous regen surfaced it as available for new-project onboarding.

Confirmed by Chris Aigner (Flutter SDK) in [#team-value-discovery](https://sentry.slack.com/archives/CA2V2LBDL/p1778178531405179) after the docs-frontmatter audit on [#115092](https://github.com/getsentry/sentry/pull/115092).

### Mechanism

Adds a `PRODUCT_EXCLUSIONS` override map to `scripts/genPlatformProductInfo.ts` for (platform, product) combinations where the docs declare support but SDK owners have asked us not to surface the feature. Each entry is documented with rationale so future regens don't quietly drop or restore overrides.

### Regen

`pnpm gen:platform-info` against a sibling `sentry-docs` checkout.

## Test plan
- [ ] `scmPlatformFeatures.spec.tsx` passes (25/25 locally)
- [ ] Generated diff is one line: `ProductSolution.PROFILING` removed from `flutter`