### PR TITLE
feat(dashboards): Render widget thresholds in Slack unfurl chartcuterie chart

### DIFF
--- a/static/app/chartcuterie/dashboardsWidget.tsx
+++ b/static/app/chartcuterie/dashboardsWidget.tsx
@@ -1,10 +1,13 @@
 import type {Theme} from '@emotion/react';
 
+import {defined} from 'sentry/utils';
 import {type Widget} from 'sentry/views/dashboards/types';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 import {formatTimeSeriesLabelForWidgetQuery} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabelForWidgetQuery';
 import {createPlottableFromTimeSeriesAndWidget} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries';
+import type {Plottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/plottable';
+import {Thresholds} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds';
 
 import {buildTimeseriesChartOption, CHART_SIZE} from './timeseries';
 import type {RenderDescriptor} from './types';
@@ -29,9 +32,26 @@ export const makeDashboardsWidgetCharts = (
       const queryIndexByTimeSeries = new Map<TimeSeries, number>(data.timeSeries);
       const flatTimeSeries = data.timeSeries.map(([ts]) => ts);
 
+      // Mirrors visualizationWidget.tsx — render the threshold mark areas /
+      // lines when the widget has at least one threshold value set.
+      const extraPlottables: Plottable[] = [];
+      const {thresholds} = data.widget;
+      if (
+        thresholds &&
+        (defined(thresholds.max_values.max1) || defined(thresholds.max_values.max2))
+      ) {
+        extraPlottables.push(
+          new Thresholds({
+            thresholds,
+            dataType: flatTimeSeries[0]?.meta?.valueType,
+          })
+        );
+      }
+
       return buildTimeseriesChartOption({
         theme,
         timeSeries: flatTimeSeries,
+        extraPlottables,
         createPlottable: (ts, {color}) => {
           const widgetQueryIndex = queryIndexByTimeSeries.get(ts) ?? 0;
           const widgetQuery =

--- a/static/app/chartcuterie/timeseries.tsx
+++ b/static/app/chartcuterie/timeseries.tsx
@@ -51,6 +51,14 @@ export type CreatePlottableForTimeseriesChart<T extends TimeSeries = TimeSeries>
 ) => Plottable | null;
 
 /**
+ * Top edge (in px) of the plot area in chartcuterie's timeseries charts —
+ * matches ``defaults.grid.top``. Threshold plottables anchor "infinite"
+ * mark lines / mark areas to this offset so they land at the top of the
+ * data grid instead of overlapping the legend.
+ */
+const GRID_TOP_OFFSET = 60;
+
+/**
  * Builds the ECharts option for a chartcuterie timeseries chart. Shared
  * between ``SLACK_TIMESERIES`` and ``SLACK_DASHBOARDS_WIDGET``; the only
  * difference between the two is the plottable factory ``createPlottable``,
@@ -60,10 +68,12 @@ export function buildTimeseriesChartOption<T extends TimeSeries>({
   theme,
   timeSeries,
   createPlottable,
+  extraPlottables = [],
 }: {
   createPlottable: CreatePlottableForTimeseriesChart<T>;
   theme: Theme;
   timeSeries: T[];
+  extraPlottables?: Plottable[];
 }) {
   const xAxis = XAxis({
     theme,
@@ -146,13 +156,23 @@ export function buildTimeseriesChartOption<T extends TimeSeries>({
     return plottable?.toSeries(plottingOptions) ?? [];
   });
 
+  const extraSeries = extraPlottables.flatMap(plottable =>
+    plottable.toSeries({
+      color: '',
+      unit: null,
+      yAxisPosition: 'left',
+      theme,
+      maxOffset: GRID_TOP_OFFSET,
+    })
+  );
+
   return {
     ...defaults,
     yAxis,
     xAxis,
     useUTC: true,
     color,
-    series,
+    series: [...series, ...extraSeries],
   };
 }
 

--- a/static/app/chartcuterie/timeseries.tsx
+++ b/static/app/chartcuterie/timeseries.tsx
@@ -51,9 +51,9 @@ export type CreatePlottableForTimeseriesChart<T extends TimeSeries = TimeSeries>
 ) => Plottable | null;
 
 /**
- * Top edge (in px) of the plot area in chartcuterie's timeseries charts —
- * matches ``defaults.grid.top``. Threshold plottables anchor "infinite"
- * mark lines / mark areas to this offset so they land at the top of the
+ * Top edge (in px) of the plot area in chartcuterie's timeseries charts.
+ * Used by both the grid config and the threshold plottable's ``maxOffset``,
+ * so "infinite" threshold mark lines / mark areas anchor at the top of the
  * data grid instead of overlapping the legend.
  */
 const GRID_TOP_OFFSET = 60;
@@ -83,7 +83,7 @@ export function buildTimeseriesChartOption<T extends TimeSeries>({
   });
 
   const defaults = {
-    grid: Grid({left: 10, right: 10, bottom: 10, top: 60}),
+    grid: Grid({left: 10, right: 10, bottom: 10, top: GRID_TOP_OFFSET}),
     backgroundColor: theme.tokens.background.primary,
     legend: Legend({
       theme,

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -28,9 +28,7 @@ import {
   getAggregateAlias,
   isEquation,
   isMeasurement,
-  RATE_UNIT_MULTIPLIERS,
   RateUnit,
-  SIZE_UNIT_MULTIPLIERS,
   stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
 import {DisplayModes, type SavedQueryDatasets} from 'sentry/utils/discover/types';
@@ -118,21 +116,6 @@ export function getThresholdUnitSelectOptions(
   }
 
   return [];
-}
-
-export function normalizeUnit(value: number, unit: string, dataType: string): number {
-  const multiplier =
-    dataType === 'rate'
-      ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        RATE_UNIT_MULTIPLIERS[unit]
-      : dataType === 'duration'
-        ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          DURATION_UNITS[unit]
-        : dataType === 'size'
-          ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-            SIZE_UNIT_MULTIPLIERS[unit]
-          : 1;
-  return value * multiplier;
 }
 
 export function getWidgetInterval(

--- a/static/app/views/dashboards/utils/normalizeUnit.tsx
+++ b/static/app/views/dashboards/utils/normalizeUnit.tsx
@@ -1,0 +1,20 @@
+import {
+  DURATION_UNIT_MULTIPLIERS,
+  RATE_UNIT_MULTIPLIERS,
+  SIZE_UNIT_MULTIPLIERS,
+} from 'sentry/utils/discover/fields';
+
+export function normalizeUnit(value: number, unit: string, dataType: string): number {
+  const multiplier =
+    dataType === 'rate'
+      ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+        RATE_UNIT_MULTIPLIERS[unit]
+      : dataType === 'duration'
+        ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+          DURATION_UNIT_MULTIPLIERS[unit]
+        : dataType === 'size'
+          ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+            SIZE_UNIT_MULTIPLIERS[unit]
+          : 1;
+  return value * multiplier;
+}

--- a/static/app/views/dashboards/widgets/bigNumberWidget/thresholdsIndicator.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/thresholdsIndicator.tsx
@@ -2,7 +2,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import type {Polarity} from 'sentry/components/percentChange';
-import {normalizeUnit} from 'sentry/views/dashboards/utils';
+import {normalizeUnit} from 'sentry/views/dashboards/utils/normalizeUnit';
 import type {ThresholdsConfig} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds';
 import {ThresholdsHoverWrapper} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsHoverWrapper';
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
@@ -8,7 +8,7 @@ import {MarkArea} from 'sentry/components/charts/components/markArea';
 import {MarkLine} from 'sentry/components/charts/components/markLine';
 import {t} from 'sentry/locale';
 import type {Theme} from 'sentry/utils/theme';
-import {normalizeUnit} from 'sentry/views/dashboards/utils';
+import {normalizeUnit} from 'sentry/views/dashboards/utils/normalizeUnit';
 import {
   NEGATIVE_POLARITY_COLOR_ORDER,
   POSITIVE_POLARITY_COLOR_ORDER,


### PR DESCRIPTION
1. Adds threshold support for dashboards slack unfurling
2. Move `normalizeUnit` into it's own file, this is to keep the chartcuterie bundle small and eliminate browser imports