### PR TITLE
ref(seer-explorer): Increase stale timeout to 120s

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
@@ -12,7 +12,7 @@ import {
 } from 'sentry/views/seerExplorer/utils';
 
 const POLL_INTERVAL = 500; // Poll every 500ms
-const STALE_TIME_MS = 90_000;
+const STALE_TIME_MS = 120_000;
 
 /** Checks if session is in a terminal state where the agent is done processing. */
 const isResponseComplete = (sessionData: SeerExplorerResponse['session'] | undefined) =>


### PR DESCRIPTION
For timeout ui. Bumping in case 90 is too aggressive for slower tool calls / complex thinking. Will monitor the effect on amplitude metric

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Increases the `STALE_TIME_MS` constant in `useSeerExplorerPolling` from 90 seconds to 120 seconds.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0ANGU44SMT/p1778603121991469?thread_ts=1778603121.991469&cid=C0ANGU44SMT)

<div><a href="https://cursor.com/agents/bc-868b1989-eee5-5ba0-9d4c-a5f40e9a2f56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-868b1989-eee5-5ba0-9d4c-a5f40e9a2f56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

