### PR TITLE
ref(profiling): Remove base64 rollout option for profile task payload

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3108,14 +3108,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Enable sending raw bytes payload to taskbroker instead of base64 encoded
-register(
-    "profiling.process.raw_bytes_payload.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Enable sending a post update signal after we update groups using a queryset update
 register(
     "groups.enable-post-update-signal",

--- a/src/sentry/profiles/consumers/process/factory.py
+++ b/src/sentry/profiles/consumers/process/factory.py
@@ -1,4 +1,3 @@
-from base64 import b64encode
 from collections.abc import Iterable, Mapping
 
 from arroyo.backends.kafka.consumer import KafkaPayload
@@ -20,11 +19,7 @@ def process_message(message: Message[KafkaPayload]) -> None:
     sampled = is_sampled(message.payload.headers)
 
     if sampled or options.get("profiling.profile_metrics.unsampled_profiles.enabled"):
-        if options.get("profiling.process.raw_bytes_payload.enabled"):
-            process_profile_task.delay(payload=message.payload.value, sampled=sampled)
-        else:
-            encoded = b64encode(message.payload.value).decode("utf-8")
-            process_profile_task.delay(payload=encoded, sampled=sampled)
+        process_profile_task.delay(payload=message.payload.value, sampled=sampled)
 
 
 class ProcessProfileStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import io
 import logging
-import zlib
-from base64 import b64decode, b64encode
+from base64 import b64decode
 from collections.abc import Generator
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -120,15 +119,6 @@ eap_producer = SingletonProducer(
 )
 
 logger = logging.getLogger(__name__)
-
-
-def encode_payload(message: dict[str, Any]) -> str:
-    return b64encode(
-        zlib.compress(
-            msgpack.packb(message),
-            level=1,
-        )
-    ).decode("utf-8")
 
 
 @instrumented_task(

--- a/tests/sentry/profiles/consumers/test_process.py
+++ b/tests/sentry/profiles/consumers/test_process.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from base64 import b64encode
 from collections.abc import MutableSequence
 from datetime import datetime
 from typing import Any
@@ -57,7 +56,7 @@ def test_basic_profile_to_task(
     processing_strategy.terminate()
 
     process_profile_task.assert_called_with(
-        payload=b64encode(payload).decode("utf-8"),
+        payload=payload,
         sampled=True,
     )
 

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import zipfile
-from base64 import b64encode
 from io import BytesIO
 from os.path import join
 from typing import Any
@@ -1056,7 +1055,7 @@ def test_track_latest_sdk_with_payload(
         "payload": json.dumps(profile),
     }
 
-    payload = b64encode(msgpack.packb(kafka_payload)).decode("utf-8")
+    payload = msgpack.packb(kafka_payload)
 
     process_profile_task(payload=payload)
 


### PR DESCRIPTION
## Summary

- Remove the `profiling.process.raw_bytes_payload.enabled` option - always send raw bytes from the consumer
- The task still accepts both bytes and base64 string formats for backward compatibility with in-flight tasks
- Remove unused `encode_payload` function and its `zlib` import

Follow-up to #115069

Refs STREAM-974