### PR TITLE
fix(replays): Cap Mobile Replay `<video>` element pool

### DIFF
--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -597,39 +597,4 @@ describe('VideoReplayer - maxVideoElements eviction', () => {
     // @ts-expect-error accessing a private field
     expect(inst._currentIndex).toBe(0);
   });
-
-  it('respects the default cap when option is omitted', () => {
-    const attachments = makeAttachments(3);
-    const root = document.createElement('div');
-    const inst = new VideoReplayer(attachments, {
-      videoApiPrefix: '/foo/',
-      root,
-      start: 0,
-      onFinished: jest.fn(),
-      onLoaded: jest.fn(),
-      onBuffer: jest.fn(),
-      durationMs: 3 * 5000,
-      config: {skipInactive: false, speed: 1},
-    });
-    // @ts-expect-error accessing a private field
-    expect(inst._maxVideoElements).toBe(500);
-  });
-
-  it('floors maxVideoElements at 2*PRELOAD_BUFFER+1', () => {
-    const attachments = makeAttachments(3);
-    const root = document.createElement('div');
-    const inst = new VideoReplayer(attachments, {
-      videoApiPrefix: '/foo/',
-      root,
-      start: 0,
-      onFinished: jest.fn(),
-      onLoaded: jest.fn(),
-      onBuffer: jest.fn(),
-      durationMs: 3 * 5000,
-      config: {skipInactive: false, speed: 1},
-      maxVideoElements: 2,
-    });
-    // @ts-expect-error accessing a private field
-    expect(inst._maxVideoElements).toBe(7);
-  });
 });

--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -13,6 +13,9 @@ jest.spyOn(window.HTMLMediaElement.prototype, 'pause').mockImplementation(() => 
 jest
   .spyOn(window.HTMLMediaElement.prototype, 'play')
   .mockImplementation(() => Promise.resolve());
+// jsdom doesn't implement load(); destroyVideo calls it to release the media
+// resource on eviction.
+jest.spyOn(window.HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
 
 describe('VideoReplayer - no starting gap', () => {
   beforeEach(() => {
@@ -485,5 +488,148 @@ describe('VideoReplayer - with ending gap', () => {
     expect(inst.getCurrentTime()).toBeLessThan(50100);
     // @ts-expect-error accessing a private field
     expect(inst._isPlaying).toBe(false);
+  });
+});
+
+describe('VideoReplayer - maxVideoElements eviction', () => {
+  beforeEach(() => {
+    jest.clearAllTimers();
+  });
+
+  const makeAttachments = (count: number) =>
+    Array.from({length: count}, (_, i) => ({
+      id: i,
+      timestamp: i * 5000,
+      duration: 5000,
+    }));
+
+  it('caps _videos at maxVideoElements when seeking forward', async () => {
+    const attachments = makeAttachments(50);
+    const root = document.createElement('div');
+    const inst = new VideoReplayer(attachments, {
+      videoApiPrefix: '/foo/',
+      root,
+      start: 0,
+      onFinished: jest.fn(),
+      onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
+      durationMs: 50 * 5000,
+      config: {skipInactive: false, speed: 1},
+      maxVideoElements: 8,
+    });
+
+    // Seek through many distant segments so preloadVideos keeps wanting to add
+    // new entries.
+    for (const offset of [0, 25_000, 50_000, 100_000, 150_000, 200_000, 230_000]) {
+      const p = inst.play(offset);
+      jest.advanceTimersByTime(100);
+      await p;
+      // @ts-expect-error accessing a private field
+      expect(inst._videos.size).toBeLessThanOrEqual(8);
+      // Pool size must equal the number of <video> children we left in the DOM.
+      // @ts-expect-error accessing a private field
+      expect(inst.wrapper.querySelectorAll('video')).toHaveLength(inst._videos.size);
+    }
+  });
+
+  it('never evicts the current segment or its preload window', async () => {
+    const attachments = makeAttachments(50);
+    const root = document.createElement('div');
+    const inst = new VideoReplayer(attachments, {
+      videoApiPrefix: '/foo/',
+      root,
+      start: 0,
+      onFinished: jest.fn(),
+      onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
+      durationMs: 50 * 5000,
+      config: {skipInactive: false, speed: 1},
+      maxVideoElements: 8,
+    });
+
+    for (const offset of [0, 30_000, 80_000, 130_000, 180_000]) {
+      const p = inst.play(offset);
+      jest.advanceTimersByTime(100);
+      await p;
+
+      // @ts-expect-error accessing a private field
+      const currentIndex = inst._currentIndex!;
+      // @ts-expect-error accessing a private field
+      const videos = inst._videos as Map<number, HTMLVideoElement>;
+
+      // Current segment is alive.
+      expect(videos.has(currentIndex)).toBe(true);
+      // Forward preload window is alive (loadSegment preloads [index, index+3)).
+      expect(videos.has(currentIndex + 1)).toBe(true);
+      expect(videos.has(currentIndex + 2)).toBe(true);
+    }
+  });
+
+  it('re-creates an evicted segment when seeked back to', async () => {
+    const attachments = makeAttachments(50);
+    const root = document.createElement('div');
+    const inst = new VideoReplayer(attachments, {
+      videoApiPrefix: '/foo/',
+      root,
+      start: 0,
+      onFinished: jest.fn(),
+      onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
+      durationMs: 50 * 5000,
+      config: {skipInactive: false, speed: 1},
+      maxVideoElements: 8,
+    });
+
+    // Step through many distant segments to force segment 0 out of the pool.
+    for (const offset of [50_000, 100_000, 150_000, 200_000, 230_000]) {
+      const p = inst.play(offset);
+      jest.advanceTimersByTime(100);
+      await p;
+    }
+    // @ts-expect-error accessing a private field
+    expect(inst._videos.has(0)).toBe(false);
+
+    const seekBack = inst.play(0);
+    jest.advanceTimersByTime(100);
+    await seekBack;
+    // @ts-expect-error accessing a private field
+    expect(inst._videos.has(0)).toBe(true);
+    // @ts-expect-error accessing a private field
+    expect(inst._currentIndex).toBe(0);
+  });
+
+  it('respects the default cap when option is omitted', () => {
+    const attachments = makeAttachments(3);
+    const root = document.createElement('div');
+    const inst = new VideoReplayer(attachments, {
+      videoApiPrefix: '/foo/',
+      root,
+      start: 0,
+      onFinished: jest.fn(),
+      onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
+      durationMs: 3 * 5000,
+      config: {skipInactive: false, speed: 1},
+    });
+    // @ts-expect-error accessing a private field
+    expect(inst._maxVideoElements).toBe(500);
+  });
+
+  it('floors maxVideoElements at 2*PRELOAD_BUFFER+1', () => {
+    const attachments = makeAttachments(3);
+    const root = document.createElement('div');
+    const inst = new VideoReplayer(attachments, {
+      videoApiPrefix: '/foo/',
+      root,
+      start: 0,
+      onFinished: jest.fn(),
+      onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
+      durationMs: 3 * 5000,
+      config: {skipInactive: false, speed: 1},
+      maxVideoElements: 2,
+    });
+    // @ts-expect-error accessing a private field
+    expect(inst._maxVideoElements).toBe(7);
   });
 });

--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -597,4 +597,40 @@ describe('VideoReplayer - maxVideoElements eviction', () => {
     // @ts-expect-error accessing a private field
     expect(inst._currentIndex).toBe(0);
   });
+
+  it('tears down every live video on destroy() mid-playback', async () => {
+    const attachments = makeAttachments(50);
+    const root = document.createElement('div');
+    const inst = new VideoReplayer(attachments, {
+      videoApiPrefix: '/foo/',
+      root,
+      start: 0,
+      onFinished: jest.fn(),
+      onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
+      durationMs: 50 * 5000,
+      config: {skipInactive: false, speed: 1},
+      maxVideoElements: 8,
+    });
+
+    // Build up a pool by scrubbing through a few positions.
+    for (const offset of [0, 25_000, 50_000, 100_000]) {
+      const p = inst.play(offset);
+      jest.advanceTimersByTime(100);
+      await p;
+    }
+    // @ts-expect-error accessing a private field
+    expect(inst._videos.size).toBeGreaterThan(0);
+
+    inst.destroy();
+
+    // @ts-expect-error accessing a private field
+    expect(inst._videos.size).toBe(0);
+    // @ts-expect-error accessing a private field
+    expect(inst._videoListeners.size).toBe(0);
+    // Wrapper has been removed from the root.
+    expect(root.contains(inst.wrapper)).toBe(false);
+    // No <video> elements remain inside the (now-detached) wrapper either.
+    expect(inst.wrapper.querySelectorAll('video')).toHaveLength(0);
+  });
 });

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -9,8 +9,10 @@ const PRELOAD_BUFFER = 3;
 
 // Cap on simultaneously-attached <video> elements. Long mobile replays can have
 // thousands of segments, and browsers run out of decoder slots / media players
-// well before that. When the cap is hit we evict the least-recently-used video
-// that is outside the active preload window. Tunable via VideoReplayerOptions.
+// well before that — Chrome appears to cap concurrent media elements at around
+// 1,000, after which new <video>s fail to decode. When this cap is hit we evict
+// the least-recently-used video that is outside the active preload window.
+// Tunable via VideoReplayerOptions.
 export const DEFAULT_MAX_VIDEO_ELEMENTS = 500;
 
 interface OffsetOptions {
@@ -246,7 +248,9 @@ export class VideoReplayer {
   }
 
   /**
-   * Bumps a video to the most-recently-used end of `_videos` insertion order.
+   * Bumps a video to the most-recently-used end of `_videos`. JavaScript's
+   * `Map` iterates in insertion order, so deleting and re-setting an entry
+   * is enough to move it to the tail — no separate LRU list needed.
    * No-op if the index is not currently in the pool.
    */
   private touchVideo(index: number): void {
@@ -263,6 +267,9 @@ export class VideoReplayer {
    * resources. Just calling `.remove()` on a <video> doesn't free those — the
    * media element must have its resource detached and `.load()` called to
    * abort the resource-selection algorithm.
+   *
+   * See the HTML spec for `HTMLMediaElement.load()`:
+   * https://html.spec.whatwg.org/multipage/media.html#dom-media-load
    */
   private destroyVideo(index: number): void {
     const el = this._videos.get(index);
@@ -452,7 +459,6 @@ export class VideoReplayer {
       const dictIndex = index + l;
 
       if (this._videos.has(dictIndex)) {
-        // Bump existing entry to most-recently-used.
         this.touchVideo(dictIndex);
         return;
       }

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -19,7 +19,7 @@ interface OffsetOptions {
   segmentOffsetMs?: number;
 }
 
-export interface VideoReplayerOptions {
+interface VideoReplayerOptions {
   config: VideoReplayerConfig;
   durationMs: number;
   onBuffer: (isBuffering: boolean) => void;

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -43,7 +43,7 @@ export interface VideoReplayerConfig {
   speed: number;
 }
 
-type RemoveListener = () => void;
+type TeardownVideo = () => void;
 
 /**
  * A special replayer that is specific to mobile replays. Should replicate rrweb's player interface.
@@ -62,11 +62,13 @@ export class VideoReplayer {
    */
   private _videos: Map<any, HTMLVideoElement>;
   /**
-   * Maps attachment index to a function that removes every event listener
-   * we attached to that video. Keyed by segment index so we can tear down
-   * one video's listeners independently when it's evicted from the pool.
+   * Maps attachment index to a function that fully tears down that video —
+   * removes its event listeners, aborts its media resource, detaches it from
+   * the DOM, and drops its entries from both this map and `_videos`. Used by
+   * both LRU eviction and `destroy()`, so the cleanup path is identical in
+   * either case.
    */
-  private _videoListeners: Map<number, RemoveListener>;
+  private _videoListeners: Map<number, TeardownVideo>;
   /**
    * Upper bound on simultaneously-attached <video> elements. Long mobile
    * replays (>1000 segments) blow past the browser's decoder budget; once
@@ -106,7 +108,7 @@ export class VideoReplayer {
       onBuffer,
     };
     this._videos = new Map<any, HTMLVideoElement>();
-    this._videoListeners = new Map<number, RemoveListener>();
+    this._videoListeners = new Map<number, TeardownVideo>();
     this._maxVideoElements = Math.max(
       // The protected window (current + ±PRELOAD_BUFFER) must always fit, so
       // floor the cap at 2 * PRELOAD_BUFFER + 1.
@@ -156,15 +158,33 @@ export class VideoReplayer {
   }
 
   public destroy() {
-    this._videoListeners.forEach(listener => listener());
-    this._videoListeners.clear();
+    // Snapshot keys: each teardown deletes itself from _videoListeners and
+    // _videos, so iterating the live Map would be order-dependent.
+    for (const index of Array.from(this._videoListeners.keys())) {
+      this._videoListeners.get(index)?.();
+    }
     this._trackList = [];
-    this._videos = new Map<any, HTMLVideoElement>();
     this._timer.stop();
     this.wrapper.remove();
   }
 
-  private addListeners(el: HTMLVideoElement, index: number): RemoveListener {
+  /**
+   * Wire up event listeners and lifecycle for a freshly-created <video> and
+   * return a function that tears the whole thing down: removes listeners,
+   * aborts the media resource, detaches the element from the DOM, and drops
+   * its entries from `_videos` and `_videoListeners`.
+   *
+   * Folding teardown into a single closure keeps the eviction path and the
+   * `destroy()` path identical — both just call this returned function.
+   *
+   * The resource-detach step (drop <source> children, clear src, call
+   * `.load()`) is what actually releases the decoder + aborts pending fetch.
+   * Calling `.remove()` alone doesn't, since the browser keeps the player
+   * alive as long as the media element is bound to a resource.
+   * See HTML spec, `HTMLMediaElement.load()`:
+   * https://html.spec.whatwg.org/multipage/media.html#dom-media-load
+   */
+  private setupVideo(el: HTMLVideoElement, index: number): TeardownVideo {
     const handleEnded = () => this.handleSegmentEnd(index);
 
     const handleLoadedData = (event: any) => {
@@ -221,6 +241,29 @@ export class VideoReplayer {
       el.removeEventListener('play', handlePlay);
       el.removeEventListener('loadedmetadata', handleLoadedMetaData);
       el.removeEventListener('seeking', handleSeeking);
+
+      el.pause();
+
+      // The src lives on a <source> child (see createVideo), not on the
+      // <video> src attribute. Drop the child(ren), clear any src that may
+      // have been set, then call .load() to run the media element load
+      // algorithm with no resource — that's what aborts the in-flight fetch
+      // and releases the decoder slot.
+      while (el.firstChild) {
+        el.removeChild(el.firstChild);
+      }
+      el.removeAttribute('src');
+      // Wrap in try/catch: some test environments (jsdom) don't implement load.
+      try {
+        el.load();
+      } catch {
+        // ignore
+      }
+
+      el.remove();
+
+      this._videos.delete(index);
+      this._videoListeners.delete(index);
     };
   }
 
@@ -239,7 +282,7 @@ export class VideoReplayer {
     el.setAttribute('playbackRate', `${this.config.speed}`);
     el.appendChild(sourceEl);
 
-    this._videoListeners.set(index, this.addListeners(el, index));
+    this._videoListeners.set(index, this.setupVideo(el, index));
 
     // Append the video element to the mobile player wrapper element
     this.wrapper.appendChild(el);
@@ -263,50 +306,6 @@ export class VideoReplayer {
   }
 
   /**
-   * Tear down a single video element and release its decoder + network
-   * resources. Just calling `.remove()` on a <video> doesn't free those — the
-   * media element must have its resource detached and `.load()` called to
-   * abort the resource-selection algorithm.
-   *
-   * See the HTML spec for `HTMLMediaElement.load()`:
-   * https://html.spec.whatwg.org/multipage/media.html#dom-media-load
-   */
-  private destroyVideo(index: number): void {
-    const el = this._videos.get(index);
-    if (el === undefined) {
-      return;
-    }
-
-    el.pause();
-
-    const removeListener = this._videoListeners.get(index);
-    if (removeListener !== undefined) {
-      removeListener();
-      this._videoListeners.delete(index);
-    }
-
-    // Source lives on a <source> child (see createVideo), not on the <video>
-    // src attribute. Remove the child(ren), clear any src that may have been
-    // set, then call .load() to force the element to abort the current
-    // resource-selection algorithm. Without .load(), browsers keep the
-    // network fetch + decoder alive even after DOM removal.
-    while (el.firstChild) {
-      el.removeChild(el.firstChild);
-    }
-    el.removeAttribute('src');
-    // Wrap in try/catch: some test environments (jsdom) don't implement load.
-    try {
-      el.load();
-    } catch {
-      // ignore
-    }
-
-    el.remove();
-
-    this._videos.delete(index);
-  }
-
-  /**
    * Evict the least-recently-used video in `_videos` that is safe to drop —
    * i.e. whose index falls outside the caller-supplied protected window.
    * The protected window is the active preload range; evicting inside it
@@ -316,7 +315,7 @@ export class VideoReplayer {
   private evictLRUVideo(protectedRange: {high: number; low: number}): boolean {
     for (const index of this._videos.keys()) {
       if (index < protectedRange.low || index > protectedRange.high) {
-        this.destroyVideo(index);
+        this._videoListeners.get(index)?.();
         return true;
       }
     }

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -7,11 +7,17 @@ import {findVideoSegmentIndex} from './utils';
 // Also the number of segments we load initially
 const PRELOAD_BUFFER = 3;
 
+// Cap on simultaneously-attached <video> elements. Long mobile replays can have
+// thousands of segments, and browsers run out of decoder slots / media players
+// well before that. When the cap is hit we evict the least-recently-used video
+// that is outside the active preload window. Tunable via VideoReplayerOptions.
+export const DEFAULT_MAX_VIDEO_ELEMENTS = 500;
+
 interface OffsetOptions {
   segmentOffsetMs?: number;
 }
 
-interface VideoReplayerOptions {
+export interface VideoReplayerOptions {
   config: VideoReplayerConfig;
   durationMs: number;
   onBuffer: (isBuffering: boolean) => void;
@@ -21,6 +27,7 @@ interface VideoReplayerOptions {
   start: number;
   videoApiPrefix: string;
   clipWindow?: ClipWindow;
+  maxVideoElements?: number;
 }
 
 export interface VideoReplayerConfig {
@@ -47,12 +54,24 @@ export class VideoReplayer {
   private _timer = new Timer();
   private _trackList: Array<[ts: number, index: number]>;
   private _isPlaying = false;
-  private _listeners: RemoveListener[] = [];
   /**
    * Maps attachment index to the video element.
    * Video elements in this dict are preloaded and ready to be played.
    */
   private _videos: Map<any, HTMLVideoElement>;
+  /**
+   * Maps attachment index to a function that removes every event listener
+   * we attached to that video. Keyed by segment index so we can tear down
+   * one video's listeners independently when it's evicted from the pool.
+   */
+  private _videoListeners: Map<number, RemoveListener>;
+  /**
+   * Upper bound on simultaneously-attached <video> elements. Long mobile
+   * replays (>1000 segments) blow past the browser's decoder budget; once
+   * `_videos` reaches this size, `preloadVideos` evicts the LRU entry
+   * outside the active preload window before adding a new one.
+   */
+  private _maxVideoElements: number;
   private _videoApiPrefix: string;
   private _clipDuration: number | undefined;
   private _durationMs: number;
@@ -72,6 +91,7 @@ export class VideoReplayer {
       clipWindow,
       durationMs,
       config,
+      maxVideoElements,
     }: VideoReplayerOptions
   ) {
     this._attachments = attachments;
@@ -84,6 +104,13 @@ export class VideoReplayer {
       onBuffer,
     };
     this._videos = new Map<any, HTMLVideoElement>();
+    this._videoListeners = new Map<number, RemoveListener>();
+    this._maxVideoElements = Math.max(
+      // The protected window (current + ±PRELOAD_BUFFER) must always fit, so
+      // floor the cap at 2 * PRELOAD_BUFFER + 1.
+      2 * PRELOAD_BUFFER + 1,
+      maxVideoElements ?? DEFAULT_MAX_VIDEO_ELEMENTS
+    );
     this._clipDuration = undefined;
     this._durationMs = durationMs;
     this.config = config;
@@ -127,14 +154,15 @@ export class VideoReplayer {
   }
 
   public destroy() {
-    this._listeners.forEach(listener => listener());
+    this._videoListeners.forEach(listener => listener());
+    this._videoListeners.clear();
     this._trackList = [];
     this._videos = new Map<any, HTMLVideoElement>();
     this._timer.stop();
     this.wrapper.remove();
   }
 
-  private addListeners(el: HTMLVideoElement, index: number): void {
+  private addListeners(el: HTMLVideoElement, index: number): RemoveListener {
     const handleEnded = () => this.handleSegmentEnd(index);
 
     const handleLoadedData = (event: any) => {
@@ -185,13 +213,13 @@ export class VideoReplayer {
     el.addEventListener('loadedmetadata', handleLoadedMetaData);
     el.addEventListener('seeking', handleSeeking);
 
-    this._listeners.push(() => {
+    return () => {
       el.removeEventListener('ended', handleEnded);
       el.removeEventListener('loadeddata', handleLoadedData);
       el.removeEventListener('play', handlePlay);
       el.removeEventListener('loadedmetadata', handleLoadedMetaData);
       el.removeEventListener('seeking', handleSeeking);
-    });
+    };
   }
 
   private createVideo(segmentData: VideoEvent, index: number) {
@@ -209,12 +237,83 @@ export class VideoReplayer {
     el.setAttribute('playbackRate', `${this.config.speed}`);
     el.appendChild(sourceEl);
 
-    this.addListeners(el, index);
+    this._videoListeners.set(index, this.addListeners(el, index));
 
     // Append the video element to the mobile player wrapper element
     this.wrapper.appendChild(el);
 
     return el;
+  }
+
+  /**
+   * Bumps a video to the most-recently-used end of `_videos` insertion order.
+   * No-op if the index is not currently in the pool.
+   */
+  private touchVideo(index: number): void {
+    const el = this._videos.get(index);
+    if (el === undefined) {
+      return;
+    }
+    this._videos.delete(index);
+    this._videos.set(index, el);
+  }
+
+  /**
+   * Tear down a single video element and release its decoder + network
+   * resources. Just calling `.remove()` on a <video> doesn't free those — the
+   * media element must have its resource detached and `.load()` called to
+   * abort the resource-selection algorithm.
+   */
+  private destroyVideo(index: number): void {
+    const el = this._videos.get(index);
+    if (el === undefined) {
+      return;
+    }
+
+    el.pause();
+
+    const removeListener = this._videoListeners.get(index);
+    if (removeListener !== undefined) {
+      removeListener();
+      this._videoListeners.delete(index);
+    }
+
+    // Source lives on a <source> child (see createVideo), not on the <video>
+    // src attribute. Remove the child(ren), clear any src that may have been
+    // set, then call .load() to force the element to abort the current
+    // resource-selection algorithm. Without .load(), browsers keep the
+    // network fetch + decoder alive even after DOM removal.
+    while (el.firstChild) {
+      el.removeChild(el.firstChild);
+    }
+    el.removeAttribute('src');
+    // Wrap in try/catch: some test environments (jsdom) don't implement load.
+    try {
+      el.load();
+    } catch {
+      // ignore
+    }
+
+    el.remove();
+
+    this._videos.delete(index);
+  }
+
+  /**
+   * Evict the least-recently-used video in `_videos` that is safe to drop —
+   * i.e. whose index falls outside the caller-supplied protected window.
+   * The protected window is the active preload range; evicting inside it
+   * would cause the browser to immediately re-fetch the segment we just
+   * showed the user. Returns true if an eviction happened.
+   */
+  private evictLRUVideo(protectedRange: {high: number; low: number}): boolean {
+    for (const index of this._videos.keys()) {
+      if (index < protectedRange.low || index > protectedRange.high) {
+        this.destroyVideo(index);
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -345,13 +444,32 @@ export class VideoReplayer {
     const l = Math.max(0, low);
     const h = Math.min(high, this._attachments.length + 1);
 
+    // Active window is protected from eviction so that scrubbing within ±
+    // PRELOAD_BUFFER never re-fetches what we just loaded.
+    const protectedRange = {low: l, high: h - 1};
+
     return this._attachments.slice(l, h).forEach((attachment, index) => {
       const dictIndex = index + l;
 
-      // Might be some videos we've already loaded before
-      if (!this._videos.get(dictIndex)) {
-        this._videos.set(dictIndex, this.createVideo(attachment, dictIndex));
+      if (this._videos.has(dictIndex)) {
+        // Bump existing entry to most-recently-used.
+        this.touchVideo(dictIndex);
+        return;
       }
+
+      // Enforce the cap before adding a new video. Loop in case we're growing
+      // the window past the cap from a cold start.
+      while (this._videos.size >= this._maxVideoElements) {
+        const evicted = this.evictLRUVideo(protectedRange);
+        if (!evicted) {
+          // Nothing left to evict — the entire pool is protected. This should
+          // not happen given the floor on _maxVideoElements, but bail rather
+          // than spin.
+          break;
+        }
+      }
+
+      this._videos.set(dictIndex, this.createVideo(attachment, dictIndex));
     });
   }
 
@@ -396,6 +514,10 @@ export class VideoReplayer {
     if (index === undefined || index < 0 || index >= this._attachments.length) {
       return undefined;
     }
+
+    // Accessing a video counts as a "use" for LRU purposes — keep recently
+    // shown segments alive longer than ones we preloaded but never displayed.
+    this.touchVideo(index);
 
     return this._videos.get(index);
   }

--- a/static/app/components/replays/videoReplayerWithInteractions.tsx
+++ b/static/app/components/replays/videoReplayerWithInteractions.tsx
@@ -18,6 +18,7 @@ interface VideoReplayerWithInteractionsOptions {
   videoApiPrefix: string;
   videoEvents: VideoEvent[];
   clipWindow?: ClipWindow;
+  maxVideoElements?: number;
 }
 
 /**
@@ -42,6 +43,7 @@ export class VideoReplayerWithInteractions {
     durationMs,
     theme,
     speed,
+    maxVideoElements,
   }: VideoReplayerWithInteractionsOptions) {
     this.config = {
       skipInactive: false,
@@ -58,6 +60,7 @@ export class VideoReplayerWithInteractions {
       clipWindow,
       durationMs,
       config: this.config,
+      maxVideoElements,
     });
 
     this.replayer = new Replayer(eventsWithSnapshots, {

--- a/static/app/components/replays/videoReplayerWithInteractions.tsx
+++ b/static/app/components/replays/videoReplayerWithInteractions.tsx
@@ -2,7 +2,10 @@ import type {Theme} from '@emotion/react';
 import {Replayer} from '@sentry-internal/rrweb';
 
 import type {VideoReplayerConfig} from 'sentry/components/replays/videoReplayer';
-import {VideoReplayer} from 'sentry/components/replays/videoReplayer';
+import {
+  VideoReplayer,
+  DEFAULT_MAX_VIDEO_ELEMENTS,
+} from 'sentry/components/replays/videoReplayer';
 import type {ClipWindow, RecordingFrame, VideoEvent} from 'sentry/utils/replays/types';
 
 interface VideoReplayerWithInteractionsOptions {
@@ -18,7 +21,6 @@ interface VideoReplayerWithInteractionsOptions {
   videoApiPrefix: string;
   videoEvents: VideoEvent[];
   clipWindow?: ClipWindow;
-  maxVideoElements?: number;
 }
 
 /**
@@ -43,7 +45,6 @@ export class VideoReplayerWithInteractions {
     durationMs,
     theme,
     speed,
-    maxVideoElements,
   }: VideoReplayerWithInteractionsOptions) {
     this.config = {
       skipInactive: false,
@@ -60,7 +61,7 @@ export class VideoReplayerWithInteractions {
       clipWindow,
       durationMs,
       config: this.config,
-      maxVideoElements,
+      maxVideoElements: DEFAULT_MAX_VIDEO_ELEMENTS,
     });
 
     this.replayer = new Replayer(eventsWithSnapshots, {


### PR DESCRIPTION
DAIN-831 shows a problem where a user with a very long Mobile Replay sees some weird console warnings and a crash. A bit of research suggests that Chrome has a cap on how many media elements (`<video>` and `<audio>`) can be added to a page before it starts complaining. Interestingly, I didn't see high heap usage for mobile replays (surprising) but the limit exists.

A bit more info:

- Chrome's cap on video elements is apparently 1,000. Above that limit, it starts to refuse to create new `<video>` elements and starts dumping "Blocked attempt to create a WebMediaPlayer" warnings into console, and it seems like _sometimes_ that also leads to a crash. I could reproduce the warnings but not the crash, though! It's hard to reproduce due to some other bugs in Mobile Replays to be tackled separately
- I have metrics on Mobile Replay size, and on a bad day the p99 for segment count is ~750, but cases >1,000 and even >2,000 also exist! Someone would have to watch _the whole one_ for the error to show up, which might be rare
- I chose a pool of 500 mostly arbitrarily, on the assumption that other browsers might also have limits (especially mobile ones). I could tune it up or down, but being <1,000 is the important part
- the logic to "destroy" a video is a bit elaborate. This is what Claude suggested and it looks legitimate to me. I checked the Dev Tools for loose uncollected elements and didn't find any. If you want to double-check this another way, try opening `chrome://media-internals/` and seeing the "Destroyed" video elements that start showing up once the pool is exhausted. It's easier to do that locally with a smaller pool size! "Destroyed" is good here
- as I said above, it's honestly strange that the heap doesn't meaningfully grow as `<video>` elements are added, I think the elements are cheap, and the videos themselves are stored separately somehow, I'm not sure! Regardless, I thought this PR would help with heap sizes too, but turns out it doesn't matter

The Linear ticket has a specific Replay link where you can try this out.

The tl;dr on this fix is that I'm keeping a `Map` of the video elements and I start destroying the "old" ones as the pool fills up. The "old" is a little hand-wavy, it's relying on `Map` insertion order, and evicting anything that hasn't been touched in a while. "Touch" happens too often right now due to a separate bug with the play timer, but one problem at a time. This at least guarantees that we won't hit the 1,000 limit.