### PR TITLE
fix(onboarding): Center the SCM detection loading indicator

### DIFF
--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -526,7 +526,9 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
               </Flex>
               <Stack gap="lg" width="100%">
                 {isDetecting ? (
-                  <LoadingIndicator mini />
+                  <Flex justify="center">
+                    <LoadingIndicator mini />
+                  </Flex>
                 ) : (
                   <Grid
                     columns={{


### PR DESCRIPTION
Wrap the spinner shown during SCM platform detection in a centered Flex so it sits in the middle of the card instead of left-aligned.