### PR TITLE
feat(admin): Add admin audit log tab to user details view

### DIFF
--- a/static/gsAdmin/components/users/userAuditLog.spec.tsx
+++ b/static/gsAdmin/components/users/userAuditLog.spec.tsx
@@ -1,0 +1,115 @@
+import {UserFixture} from 'sentry-fixture/user';
+
+import {AdminAuditLogFixture} from 'getsentry-test/fixtures/adminAuditLog';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {UserAuditLog} from 'admin/components/users/userAuditLog';
+
+describe('UserAuditLog', () => {
+  const user = UserFixture();
+
+  function mockAuditLogsEndpoint(rows: Array<ReturnType<typeof AdminAuditLogFixture>>) {
+    MockApiClient.addMockResponse({
+      url: '/audit-logs/',
+      body: {rows, filters: {}},
+    });
+  }
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders column headers', async () => {
+    mockAuditLogsEndpoint([]);
+
+    render(<UserAuditLog userId={user.id} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Time')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Action')).toBeInTheDocument();
+    expect(screen.getByText('Staff')).toBeInTheDocument();
+    expect(screen.getByText('Ticket')).toBeInTheDocument();
+    expect(screen.getByText('Notes')).toBeInTheDocument();
+  });
+
+  it('renders a suspension log entry', async () => {
+    const entry = AdminAuditLogFixture({
+      eventType: 'User: Suspend',
+      eventCode: 117,
+      actor: {email: 'admin@sentry.io', name: 'Admin User'},
+      ticketId: 'https://sentry.zendesk.com/tickets/456',
+      data: {notes: 'Suspicious activity detected'},
+    });
+
+    mockAuditLogsEndpoint([entry]);
+
+    render(<UserAuditLog userId={user.id} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('User: Suspend')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Admin User')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Admin User'})).toHaveAttribute(
+      'href',
+      'mailto:admin@sentry.io'
+    );
+    expect(screen.getByRole('link', {name: 'Ticket'})).toHaveAttribute(
+      'href',
+      'https://sentry.zendesk.com/tickets/456'
+    );
+    expect(screen.getByText('Suspicious activity detected')).toBeInTheDocument();
+  });
+
+  it('renders em dash when actor is null', async () => {
+    const entry = AdminAuditLogFixture({actor: null});
+
+    mockAuditLogsEndpoint([entry]);
+
+    render(<UserAuditLog userId={user.id} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders em dash when ticketId is null', async () => {
+    const entry = AdminAuditLogFixture({ticketId: null});
+
+    mockAuditLogsEndpoint([entry]);
+
+    render(<UserAuditLog userId={user.id} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('link', {name: 'Ticket'})).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders em dash when notes are absent', async () => {
+    const entry = AdminAuditLogFixture({data: {}});
+
+    mockAuditLogsEndpoint([entry]);
+
+    render(<UserAuditLog userId={user.id} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders multiple entries', async () => {
+    const entries = [
+      AdminAuditLogFixture({id: '1', eventType: 'User: Suspend', eventCode: 117}),
+      AdminAuditLogFixture({id: '2', eventType: 'User: Unsuspend', eventCode: 118}),
+    ];
+
+    mockAuditLogsEndpoint(entries);
+
+    render(<UserAuditLog userId={user.id} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('User: Suspend')).toBeInTheDocument();
+    });
+    expect(screen.getByText('User: Unsuspend')).toBeInTheDocument();
+  });
+});

--- a/static/gsAdmin/components/users/userAuditLog.tsx
+++ b/static/gsAdmin/components/users/userAuditLog.tsx
@@ -1,0 +1,50 @@
+import {DateTime} from 'sentry/components/dateTime';
+
+import ResultGrid from 'admin/components/resultGrid';
+
+type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
+  userId: string;
+};
+
+export function UserAuditLog({userId, ...props}: Props) {
+  return (
+    <ResultGrid
+      path=""
+      endpoint="/audit-logs/"
+      method="GET"
+      defaultParams={{target_id: userId, event_prefix: 'User', per_page: 100}}
+      useQueryString={false}
+      hasPagination={false}
+      rowsFromData={(data: any) => data.rows}
+      columns={[
+        <th key="timestamp" style={{width: 180}}>
+          Time
+        </th>,
+        <th key="event">Action</th>,
+        <th key="actor" style={{width: 200}}>
+          Staff
+        </th>,
+        <th key="ticket" style={{width: 200}}>
+          Ticket
+        </th>,
+        <th key="notes">Notes</th>,
+      ]}
+      columnsForRow={(row: any) => [
+        <td key="timestamp">
+          <DateTime date={row.timestamp} />
+        </td>,
+        <td key="event">{row.eventType}</td>,
+        <td key="actor">
+          {row.actor?.email ? (
+            <a href={`mailto:${row.actor.email}`}>{row.actor.name ?? row.actor.email}</a>
+          ) : (
+            '—'
+          )}
+        </td>,
+        <td key="ticket">{row.ticketId ? <a href={row.ticketId}>Ticket</a> : '—'}</td>,
+        <td key="notes">{row.data?.notes ?? '—'}</td>,
+      ]}
+      {...props}
+    />
+  );
+}

--- a/static/gsAdmin/views/userDetails.spec.tsx
+++ b/static/gsAdmin/views/userDetails.spec.tsx
@@ -42,6 +42,11 @@ describe('User Details', () => {
       url: `/users/${mockUser.id}/user-identities/`,
       body: [],
     });
+
+    MockApiClient.addMockResponse({
+      url: '/audit-logs/',
+      body: {rows: [], filters: {}},
+    });
   });
 
   afterEach(() => {
@@ -63,6 +68,7 @@ describe('User Details', () => {
       expect(await screen.findByText('Active')).toBeInTheDocument();
       expect(screen.getByText('Customer')).toBeInTheDocument();
       expect(screen.getByText('User Emails')).toBeInTheDocument();
+      expect(screen.getByText('Admin Audit Log')).toBeInTheDocument();
     });
 
     it('renders correct dropdown options for active account', async () => {

--- a/static/gsAdmin/views/userDetails.tsx
+++ b/static/gsAdmin/views/userDetails.tsx
@@ -23,6 +23,7 @@ import {useParams} from 'sentry/utils/useParams';
 import {DetailsPage} from 'admin/components/detailsPage';
 import {MergeAccountsModal} from 'admin/components/mergeAccounts';
 import {SelectableContainer} from 'admin/components/selectableContainer';
+import {UserAuditLog} from 'admin/components/users/userAuditLog';
 import {UserCustomers} from 'admin/components/users/userCustomers';
 import {UserEmailLog} from 'admin/components/users/userEmailLog';
 import {UserEmails} from 'admin/components/users/userEmails';
@@ -329,6 +330,10 @@ export function UserDetails() {
         {
           noPanel: true,
           content: userEmails,
+        },
+        {
+          name: 'Admin Audit Log',
+          content: <UserAuditLog userId={user.id} />,
         },
       ]}
     />


### PR DESCRIPTION
## Summary
- Adds an "Admin Audit Log" section to the gsAdmin user details page, mirroring how [PR #113943](https://github.com/getsentry/sentry/pull/113943) added the same for customer/org details
- Creates a `UserAuditLog` component that queries `/audit-logs/` filtered by `target_id` (user ID) and `event_prefix=User` to show user-scoped admin actions: suspend, unsuspend, merge, reactivate, identity deletion, 2FA deletion
- Surfaces the suspension audit logs added in [getsentry#20159](https://github.com/getsentry/getsentry/pull/20159) directly in the admin user view

## Changes
- **New**: `static/gsAdmin/components/users/userAuditLog.tsx` — `UserAuditLog` component using `ResultGrid`
- **New**: `static/gsAdmin/components/users/userAuditLog.spec.tsx` — 6 tests
- **Modified**: `static/gsAdmin/views/userDetails.tsx` — added import and section
- **Modified**: `static/gsAdmin/views/userDetails.spec.tsx` — added mock and assertion

## Dependencies
- Companion backend PR: [getsentry#20313](https://github.com/getsentry/getsentry/pull/20313) adds the `event_prefix` filter to the `/audit-logs/` endpoint. Without it, the tab still works but may show non-user audit entries if org and user IDs collide.

## Test plan
- [x] `userAuditLog.spec.tsx` — 6 tests pass (column headers, suspension entry rendering, null actor/ticket/notes fallbacks, multiple entries)
- [x] `userDetails.spec.tsx` — 7 tests pass (includes new assertion for "Admin Audit Log" section)
- [x] `customerAuditLog.spec.tsx` — 7 tests pass (no regression)