### PR TITLE
feat(cells) Add option based control for cell rollout

### DIFF
--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -40,13 +40,15 @@ from sentry.services.organization import (
     OrganizationProvisioningOptions,
     PostProvisionOptions,
 )
-from sentry.services.organization.provisioning import organization_provisioning_service
+from sentry.services.organization.provisioning import (
+    organization_provisioning_service,
+    resolve_provisioning_cell,
+)
 from sentry.silo.base import SiloMode
 from sentry.types.cell import (
     CellResolutionError,
     RegionCategory,
     get_locality_by_name,
-    get_new_org_cell_for_locality,
 )
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
@@ -99,7 +101,7 @@ class OrganizationPostSerializer(BaseOrganizationSerializer):
         locality_name = attrs.get("dataStorageLocation")
 
         if locality_name:
-            attrs["cell_name"] = get_new_org_cell_for_locality(locality_name).name
+            attrs["cell_name"] = resolve_provisioning_cell(locality_name)
         else:
             # TODO(cells) Remove this when cell silo compatibility is removed.
             attrs["cell_name"] = settings.SENTRY_LOCAL_CELL or settings.SENTRY_MONOLITH_REGION

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4195,11 +4195,18 @@ register(
 
 # Whether or not provisioning analytics and audits are made in the provision_organization RPC call
 register(
-    "provision_organization_in_cell.record_analytics",
-    type=Bool,
-    default=False,
+    "provision_organization.override.mapping",
+    type=Dict,
+    default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "provision_organization.override.rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # SCM
 

--- a/src/sentry/services/organization/provisioning.py
+++ b/src/sentry/services/organization/provisioning.py
@@ -5,6 +5,7 @@ from django.dispatch import receiver
 from pydantic import ValidationError
 from sentry_sdk import capture_exception
 
+from sentry import options
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.outbox.signals import process_control_outbox
@@ -15,10 +16,11 @@ from sentry.models.organizationslugreservation import (
     OrganizationSlugReservation,
     OrganizationSlugReservationType,
 )
+from sentry.options.rollout import in_random_rollout
 from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.services.organization.model import OrganizationProvisioningOptions
 from sentry.silo.base import SiloMode
-from sentry.types.cell import get_local_cell
+from sentry.types.cell import get_local_cell, get_new_org_cell_for_locality
 
 
 class OrganizationProvisioningException(Exception):
@@ -292,3 +294,14 @@ def update_organization_slug_reservation(
         cell_name=cell_name,
         org_slug_reservation_id=object_identifier,
     )
+
+
+def resolve_provisioning_cell(locality_name: str) -> str:
+    """
+    Resolve the cell that a new organization should be created in.
+    """
+    if in_random_rollout("provision_organization.override.rate"):
+        override_map = options.get("provision_organization.override.mapping")
+        if locality_name in override_map:
+            locality_name = override_map[locality_name]
+    return get_new_org_cell_for_locality(locality_name).name

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -317,6 +317,23 @@ class OrganizationsCreateControlTest(OrganizationIndexTest, HybridCloudTestMixin
             owners = [owner.id for owner in org.get_owners()]
             assert [self.user.id] == owners
 
+    @override_options(
+        {
+            "provision_organization.override.rate": 1.0,
+            "provision_organization.override.mapping": {"us": "de"},
+        }
+    )
+    def test_locality_to_cell_overrides(self) -> None:
+        # When these options are active we can redirect one storage location to another.
+        response = self.get_success_response(
+            name="implicit org", slug="implicit-org", dataStorageLocation="us"
+        )
+
+        organization_id = response.data["id"]
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            mapping = OrganizationMapping.objects.get(organization_id=organization_id)
+        assert mapping.cell_name == "de"
+
     def test_with_default_team_true(self) -> None:
         data = {"name": "hello world", "slug": "foobar", "defaultTeam": True}
         response = self.get_success_response(**data)
@@ -683,7 +700,6 @@ class OrganizationsCreateInCellTest(OrganizationIndexTest, HybridCloudTestMixin)
         assert org.name == data["name"]
         assert OrganizationOption.objects.get_value(org, "sentry:aggregated_data_consent") is True
 
-    @override_options({"provision_organization_in_cell.record_analytics": True})
     @mock.patch("sentry.analytics.record")
     def test_success_analytics_in_rpc_call(self, mock_record: mock.MagicMock) -> None:
         self.login_as(user=self.user)


### PR DESCRIPTION
We'll be adding a new us cell sometime soon. Once all the infra is ready, we'll want a way to incrementally shift new signups to that cell.

The new options added here give us a rollout rate, and the ability to remap a `dataStorageLocation` to another region/cell.

I've also removed an old option that was used for shifting provision logic around that I don't need anymore.

Refs INFRENG-305