### PR TITLE
fix(issues): Resolve custom tag / column name collision in events tab & timeline chart

### DIFF
--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
@@ -6,6 +7,7 @@ from typing import cast
 import sentry_sdk
 from snuba_sdk import Column, Condition
 
+from sentry import options
 from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.group import STATUS_QUERY_CHOICES, Group
@@ -28,7 +30,7 @@ from sentry.snuba.discover import (
 from sentry.snuba.discover import get_facets as get_discover_facets
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.query_sources import QuerySource
-from sentry.utils.snuba import SnubaTSResult, bulk_snuba_queries
+from sentry.utils.snuba import SnubaTSResult, bulk_snuba_queries, get_snuba_column_name
 
 is_filter_translation = {}
 for status_key, status_value in STATUS_QUERY_CHOICES.items():
@@ -121,6 +123,11 @@ def timeseries_query(
 ):
     with sentry_sdk.start_span(op="errors", name="timeseries.filter_transform"):
         equations, columns = categorize_columns(selected_columns)
+
+        column_resolver = None
+        if options.get("issues.search.use-tag-aware-condition-resolver"):
+            column_resolver = functools.partial(get_snuba_column_name, dataset=Dataset.Events)
+
         base_builder = ErrorsTimeseriesQueryBuilder(
             Dataset.Events,
             params={},
@@ -134,6 +141,7 @@ def timeseries_query(
                 has_metrics=has_metrics,
                 parser_config_overrides=PARSER_CONFIG_OVERRIDES,
                 transform_alias_to_input_format=transform_alias_to_input_format,
+                column_resolver=column_resolver,
             ),
         )
         query_list = [base_builder]
@@ -153,7 +161,10 @@ def timeseries_query(
                 query=query,
                 selected_columns=columns,
                 equations=equations,
-                config=QueryBuilderConfig(parser_config_overrides=PARSER_CONFIG_OVERRIDES),
+                config=QueryBuilderConfig(
+                    parser_config_overrides=PARSER_CONFIG_OVERRIDES,
+                    column_resolver=column_resolver,
+                ),
             )
             query_list.append(comparison_builder)
 

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -1,8 +1,10 @@
+import functools
 from collections.abc import Sequence
 from datetime import timedelta
 
 import sentry_sdk
 
+from sentry import options
 from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
@@ -12,7 +14,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.query_sources import QuerySource
-from sentry.utils.snuba import SnubaTSResult, bulk_snuba_queries
+from sentry.utils.snuba import SnubaTSResult, bulk_snuba_queries, get_snuba_column_name
 
 
 def query(
@@ -150,6 +152,13 @@ def timeseries_query(
 
     with sentry_sdk.start_span(op="issueplatform", name="timeseries.filter_transform"):
         equations, columns = categorize_columns(selected_columns)
+
+        column_resolver = None
+        if options.get("issues.search.use-tag-aware-condition-resolver"):
+            column_resolver = functools.partial(
+                get_snuba_column_name, dataset=Dataset.IssuePlatform
+            )
+
         base_builder = IssuePlatformTimeseriesQueryBuilder(
             Dataset.IssuePlatform,
             {},
@@ -162,6 +171,7 @@ def timeseries_query(
                 functions_acl=functions_acl,
                 has_metrics=has_metrics,
                 transform_alias_to_input_format=transform_alias_to_input_format,
+                column_resolver=column_resolver,
             ),
         )
         query_list = [base_builder]
@@ -181,6 +191,7 @@ def timeseries_query(
                 query=query,
                 selected_columns=columns,
                 equations=equations,
+                config=QueryBuilderConfig(column_resolver=column_resolver),
             )
             query_list.append(comparison_builder)
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1272,6 +1272,78 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         assert response.status_code == 200
         assert all([interval[1][0]["count"] == 0 for interval in response.data["data"]])
 
+    def _store_platform_tag_collision_events(self):
+        group = None
+        for i in range(3):
+            event = self.store_event(
+                data={
+                    "event_id": f"{i + 1}" * 32,
+                    "timestamp": (self.day_ago + timedelta(minutes=i + 1)).isoformat(),
+                    "fingerprint": ["platform-collision-group"],
+                    "tags": {"platform": "SJ1"},
+                },
+                project_id=self.project.id,
+            )
+            group = event.group
+        return group
+
+    def test_platform_tag_collision_without_option(self) -> None:
+        group = self._store_platform_tag_collision_events()
+        response = self.do_request(
+            {
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=2),
+                "interval": "1h",
+                "query": f"issue:{group.qualified_short_id} platform:SJ1",
+                "dataset": "errors",
+                "yAxis": "count()",
+            },
+        )
+        assert response.status_code == 200, response.content
+        total = sum(
+            attrs[0]["count"] for _time, attrs in response.data["data"] if attrs[0]["count"] > 0
+        )
+        assert total == 0
+
+    def test_platform_tag_collision_with_option(self) -> None:
+        group = self._store_platform_tag_collision_events()
+        with self.options({"issues.search.use-tag-aware-condition-resolver": True}):
+            response = self.do_request(
+                {
+                    "start": self.day_ago,
+                    "end": self.day_ago + timedelta(hours=2),
+                    "interval": "1h",
+                    "query": f"issue:{group.qualified_short_id} platform:SJ1",
+                    "dataset": "errors",
+                    "yAxis": "count()",
+                },
+            )
+        assert response.status_code == 200, response.content
+        total = sum(
+            attrs[0]["count"] for _time, attrs in response.data["data"] if attrs[0]["count"] > 0
+        )
+        assert total == 3
+
+    def test_explicit_tag_query_works_regardless_of_option(self) -> None:
+        group = self._store_platform_tag_collision_events()
+        for option_value in (False, True):
+            with self.options({"issues.search.use-tag-aware-condition-resolver": option_value}):
+                response = self.do_request(
+                    {
+                        "start": self.day_ago,
+                        "end": self.day_ago + timedelta(hours=2),
+                        "interval": "1h",
+                        "query": f"issue:{group.qualified_short_id} tags[platform]:SJ1",
+                        "dataset": "errors",
+                        "yAxis": "count()",
+                    },
+                )
+            assert response.status_code == 200, response.content
+            total = sum(
+                attrs[0]["count"] for _time, attrs in response.data["data"] if attrs[0]["count"] > 0
+            )
+            assert total == 3
+
 
 class OrganizationEventsStatsTopNEventsSpans(APITestCase, SnubaTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/115096.

Extends the column name collision fix from https://github.com/getsentry/sentry/pull/114245 to the events tab & timeline chart on the issue details page.

When a custom tag name collides with a Snuba column name (e.g. custom tag `platform` vs. SDK `platform` column), `resolve_column` incorrectly resolves bare `platform` in a search query to the SDK column instead of `tags[platform]`. This caused the Events tab and event navigation (latest/oldest/recommended) to return 0 results when filtering by the colliding tag.

[Slack thread for context](https://sentry.slack.com/archives/C04KZQBNQ2U/p1777371987714729)