### PR TITLE
fix(insights): Validate project access for starred segments

### DIFF
--- a/src/sentry/insights/endpoints/starred_segments.py
+++ b/src/sentry/insights/endpoints/starred_segments.py
@@ -15,7 +15,7 @@ from sentry.utils.db import atomic_transaction
 
 class StarSegmentSerializer(serializers.Serializer):
     segment_name = serializers.CharField(required=True)
-    project_id = serializers.IntegerField(required=True)
+    project_id = serializers.IntegerField(required=True, min_value=1)
 
 
 class MemberPermission(OrganizationPermission):

--- a/src/sentry/insights/endpoints/starred_segments.py
+++ b/src/sentry/insights/endpoints/starred_segments.py
@@ -52,10 +52,16 @@ class InsightsStarredSegmentsEndpoint(OrganizationEndpoint):
 
         segment_name = serializer.validated_data["segment_name"]
         project_id = serializer.validated_data["project_id"]
+        projects = self.get_projects(
+            request=request,
+            organization=organization,
+            project_ids={project_id},
+        )
+        project = projects[0]
         with atomic_transaction(using=router.db_for_write(InsightsStarredSegment)):
             _, created = InsightsStarredSegment.objects.get_or_create(
                 organization=organization,
-                project_id=project_id,
+                project_id=project.id,
                 user_id=request.user.id,
                 segment_name=segment_name,
             )
@@ -81,11 +87,17 @@ class InsightsStarredSegmentsEndpoint(OrganizationEndpoint):
 
         segment_name = serializer.validated_data["segment_name"]
         project_id = serializer.validated_data["project_id"]
+        projects = self.get_projects(
+            request=request,
+            organization=organization,
+            project_ids={project_id},
+        )
+        project = projects[0]
 
         InsightsStarredSegment.objects.filter(
             organization=organization,
             user_id=request.user.id,
-            project_id=project_id,
+            project_id=project.id,
             segment_name=segment_name,
         ).delete()
 

--- a/tests/sentry/insights/endpoints/test_insights_starred_segment.py
+++ b/tests/sentry/insights/endpoints/test_insights_starred_segment.py
@@ -85,6 +85,20 @@ class InsightsStarredSegmentTest(APITestCase, SnubaTestCase):
                 project_id=other_project.id,
             ).exists()
 
+    def test_post_rejects_non_positive_project_id(self) -> None:
+        with self.feature(self.feature_name):
+            response = self.client.post(
+                self.url,
+                data={"segment_name": "my_segment", "project_id": 0},
+            )
+            assert response.status_code == 400
+
+            response = self.client.post(
+                self.url,
+                data={"segment_name": "my_segment", "project_id": -1},
+            )
+            assert response.status_code == 400
+
     def test_delete_rejects_project_from_other_organization(self) -> None:
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)

--- a/tests/sentry/insights/endpoints/test_insights_starred_segment.py
+++ b/tests/sentry/insights/endpoints/test_insights_starred_segment.py
@@ -69,3 +69,39 @@ class InsightsStarredSegmentTest(APITestCase, SnubaTestCase):
                 self.url, data={"segment_name": segment_name, "project_id": self.project_ids[0]}
             )
             assert response.status_code == 403
+
+    def test_post_rejects_project_from_other_organization(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+
+        with self.feature(self.feature_name):
+            response = self.client.post(
+                self.url,
+                data={"segment_name": "my_segment", "project_id": other_project.id},
+            )
+
+            assert response.status_code == 403
+            assert not InsightsStarredSegment.objects.filter(
+                project_id=other_project.id,
+            ).exists()
+
+    def test_delete_rejects_project_from_other_organization(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        InsightsStarredSegment.objects.create(
+            segment_name="my_segment",
+            project_id=other_project.id,
+            organization=other_org,
+            user_id=self.user.id,
+        )
+
+        with self.feature(self.feature_name):
+            response = self.client.delete(
+                self.url,
+                data={"segment_name": "my_segment", "project_id": other_project.id},
+            )
+
+            assert response.status_code == 403
+            assert InsightsStarredSegment.objects.filter(
+                project_id=other_project.id,
+            ).exists()


### PR DESCRIPTION
The starred segments endpoint accepted a caller-supplied `project_id` and wrote it to `InsightsStarredSegment` scoped only by the URL organization. A member of org A could POST a `project_id` belonging to org B and create a cross-org reference; DELETE silently no-op'd against IDs the caller didn't actually own.

Route the input through `self.get_projects(..., project_ids={project_id})` so cross-org, nonexistent, or inaccessible project IDs raise `PermissionDenied` (403) before any DB write or delete. Same check applied to both POST and DELETE.

Fixes DAIN-1353