### PR TITLE
chore(agents): Clarify frontend typecheck command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ pnpm run dev-ui
 
 #### Typechecking
 
-To typecheck frontend code, run the typecheck script.
+To typecheck frontend code, run `pnpm typecheck` script.
 It checks the whole project and does not accept file paths.
 DO NOT use `tsc` directly.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ pnpm run dev-ui
 
 To typecheck frontend code, run the typecheck script.
 It checks the whole project and does not accept file paths.
+DO NOT use `tsc` directly.
 
 ```bash
 pnpm run typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,8 @@ pnpm run dev-ui
 
 #### Typechecking
 
-Typechecking only works on the entire project. Individual files cannot be checked.
+To typecheck frontend code, run the typecheck script.
+It checks the whole project and does not accept file paths.
 
 ```bash
 pnpm run typecheck


### PR DESCRIPTION
codex was falling back to using tsc manually to typecheck individual files? Try to make it more clear that this is still the command to use.