### PR TITLE
fix(onboarding): Add missing logs/metrics snippets to JS onboarding variants

### DIFF
--- a/static/app/gettingStartedDocs/javascript-solidstart/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-solidstart/onboarding.tsx
@@ -26,6 +26,12 @@ Sentry.init({
         tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],`
       : ''
   }${
+    params.isLogsSelected
+      ? `
+        // Enable logs to be sent to Sentry
+        enableLogs: true,`
+      : ''
+  }${
     params.isProfilingSelected
       ? `
         // Set profileSessionSampleRate to 1.0 to profile during every session.
@@ -331,6 +337,17 @@ export const onboarding: OnboardingConfig = {
           'Add logging integrations to automatically capture logs from your application.'
         ),
         link: 'https://docs.sentry.io/platforms/javascript/guides/solidstart/logs/#integrations',
+      });
+    }
+
+    if (params.isMetricsSelected) {
+      steps.push({
+        id: 'metrics',
+        name: t('Application Metrics'),
+        description: t(
+          'Learn how to track custom metrics to monitor your application performance and business KPIs.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/solidstart/metrics/',
       });
     }
 

--- a/static/app/gettingStartedDocs/javascript-solidstart/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-solidstart/utils.tsx
@@ -54,6 +54,12 @@ const getDynamicParts = (params: DocsParams): string[] => {
       replaysOnErrorSampleRate: 1.0 // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`);
   }
 
+  if (params.isLogsSelected) {
+    dynamicParts.push(`
+      // Enable logs to be sent to Sentry
+      enableLogs: true`);
+  }
+
   if (params.isProfilingSelected) {
     dynamicParts.push(`
         // Set profileSessionSampleRate to 1.0 to profile during every session.

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
@@ -498,6 +498,14 @@ const route = createRoute({
               code: `<button
   type="button"
   onClick={() => {${
+    params.isLogsSelected
+      ? `
+    // Send a log before throwing the error
+    Sentry.logger.info('User triggered test error', {
+      action: 'test_error_button_click',
+    });`
+      : ''
+  }${
     params.isMetricsSelected
       ? `
     // Send a test metric before throwing the error
@@ -633,4 +641,31 @@ export const Route = createFileRoute("/api/sentry-example")({
       ],
     },
   ],
+  nextSteps: params => {
+    const steps = [];
+
+    if (params.isLogsSelected) {
+      steps.push({
+        id: 'logs',
+        name: t('Logging Integrations'),
+        description: t(
+          'Add logging integrations to automatically capture logs from your application.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/logs/#integrations',
+      });
+    }
+
+    if (params.isMetricsSelected) {
+      steps.push({
+        id: 'metrics',
+        name: t('Application Metrics'),
+        description: t(
+          'Learn how to track custom metrics to monitor your application performance and business KPIs.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/metrics/',
+      });
+    }
+
+    return steps;
+  },
 };

--- a/static/app/gettingStartedDocs/javascript-vue/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/onboarding.tsx
@@ -11,13 +11,21 @@ import {
 } from './utils';
 
 const getVerifySnippet = (params: Params) => {
+  const logsCode = params.isLogsSelected
+    ? `  // Send a log before calling undefined function
+  Sentry.logger.info('User triggered test error', {
+    action: 'test_error_button_click',
+  });
+`
+    : '';
+
   const metricsCode = params.isMetricsSelected
     ? `  // Send a test metric before calling undefined function
   Sentry.metrics.count('test_counter', 1);
 `
     : '';
 
-  return `${metricsCode}myUndefinedFunction();`;
+  return `${logsCode}${metricsCode}myUndefinedFunction();`;
 };
 
 export const onboarding: OnboardingConfig<PlatformOptions> = {

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -92,6 +92,12 @@ const getDynamicParts = (params: Params): string[] => {
       replaysOnErrorSampleRate: 1.0 // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`);
   }
 
+  if (params.isLogsSelected) {
+    dynamicParts.push(`
+      // Enable logs to be sent to Sentry
+      enableLogs: true`);
+  }
+
   if (params.isProfilingSelected) {
     dynamicParts.push(`
         // Set profileSessionSampleRate to 1.0 to profile during every session.
@@ -146,13 +152,21 @@ export const installSnippetBlock: ContentBlock = {
 };
 
 const getVerifyJSSnippet = (params: Params) => {
+  const logsCode = params.isLogsSelected
+    ? `  // Send a log before calling undefined function
+  Sentry.logger.info('User triggered test error', {
+    action: 'test_error_button_click',
+  });
+`
+    : '';
+
   const metricsCode = params.isMetricsSelected
     ? `  // Send a test metric before calling undefined function
   Sentry.metrics.count('test_counter', 1);
 `
     : '';
 
-  return `${metricsCode}myUndefinedFunction();`;
+  return `${logsCode}${metricsCode}myUndefinedFunction();`;
 };
 
 const getVerifySnippetBlock = (params: Params): ContentBlock[] => [
@@ -325,6 +339,17 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
       },
     ];
 
+    if (params.isLogsSelected) {
+      steps.push({
+        id: 'logs',
+        name: t('Logs'),
+        description: t(
+          'Learn how to send structured logs to Sentry and correlate them with your errors.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/logs/',
+      });
+    }
+
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
@@ -444,6 +469,17 @@ export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
   verify: (params: Params) => getVerifyConfig(params),
   nextSteps: (params: Params) => {
     const steps = [];
+
+    if (params.isLogsSelected) {
+      steps.push({
+        id: 'logs',
+        name: t('Logs'),
+        description: t(
+          'Learn how to send structured logs to Sentry and correlate them with your errors.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/logs/',
+      });
+    }
 
     if (params.isMetricsSelected) {
       steps.push({


### PR DESCRIPTION
Several JavaScript onboarding variants did not update code snippets when
toggling the Logs or Metrics product selections, even though these products
are declared as available.

**Base JavaScript (`javascript/utils.tsx`)**

Init config was missing `enableLogs: true`, verify snippet was missing a
`Sentry.logger.info()` example, and nextSteps was missing a Logs
documentation link — for both loader-script and npm/yarn modes.

**Vue (`javascript-vue/onboarding.tsx`)**

Verify snippet was missing the logs code block (only had metrics).

**SolidStart (`javascript-solidstart/`)**

Client-side `getDynamicParts` and server-side init snippet were both
missing `enableLogs: true`. NextSteps was missing a metrics entry.

**TanStack Start (`javascript-tanstackstart-react/onboarding.tsx`)**

Verify snippet was missing the logs code block. Had no `nextSteps`
function at all (no logs or metrics entries).