### PR TITLE
fix(onboarding): Mobile style tweaks for SCM onboarding

### DIFF
--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -80,7 +80,7 @@ export function ScmFeatureCard({
               </Text>
             </Container>
 
-            <Container area="volume">
+            <Flex area="volume" align="center">
               {isVolumeLoading ? (
                 <Placeholder height="22px" width="100px" />
               ) : (
@@ -90,9 +90,9 @@ export function ScmFeatureCard({
                   </Tag>
                 </Tooltip>
               )}
-            </Container>
+            </Flex>
 
-            <Container area="switch">
+            <Flex area="switch" align="center">
               <Tooltip title={disabledReason} disabled={!disabledReason} delay={500}>
                 <Switch
                   checked={isSelected}
@@ -103,7 +103,7 @@ export function ScmFeatureCard({
                   size="sm"
                 />
               </Tooltip>
-            </Container>
+            </Flex>
 
             <Container area="description" column="2 / 4">
               <Text variant="secondary">{description}</Text>

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -105,7 +105,7 @@ export function ScmFeatureCard({
               </Tooltip>
             </Flex>
 
-            <Container area="description" column="2 / 4">
+            <Container area="description" column="2 / -1">
               <Text variant="secondary">{description}</Text>
             </Container>
           </Grid>

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -48,20 +48,20 @@ export function ScmFeatureCard({
     >
       <ScmSelectableContainer
         isSelected={isSelected}
-        padding={{xs: 'md', md: 'lg'}}
+        padding="lg"
         height="100%"
         borderCompensation={3}
       >
         <Flex align="start">
           <Grid
-            columns="min-content 1fr"
+            columns="min-content 1fr min-content min-content"
             rows="min-content min-content"
-            gap={{xs: 'xs md', md: 'xs lg'}}
+            gap="xs lg"
             align="center"
             width="100%"
             areas={`
-                    "icon label"
-                    ". description"
+                    "icon label volume switch"
+                    ". description . ."
                   `}
           >
             <Container area="icon">
@@ -79,31 +79,36 @@ export function ScmFeatureCard({
                 {label}
               </Text>
             </Container>
-            <Container area="description">
+
+            <Container area="volume">
+              {isVolumeLoading ? (
+                <Placeholder height="22px" width="100px" />
+              ) : (
+                <Tooltip title={volumeTooltip} delay={100}>
+                  <Tag variant="muted" icon={<IconInfo size="sm" />}>
+                    {volume}
+                  </Tag>
+                </Tooltip>
+              )}
+            </Container>
+
+            <Container area="switch">
+              <Tooltip title={disabledReason} disabled={!disabledReason} delay={500}>
+                <Switch
+                  checked={isSelected}
+                  disabled={disabled}
+                  role="presentation"
+                  tabIndex={-1}
+                  readOnly
+                  size="sm"
+                />
+              </Tooltip>
+            </Container>
+
+            <Container area="description" column="2 / 4">
               <Text variant="secondary">{description}</Text>
             </Container>
           </Grid>
-          <Flex align="start" gap="sm">
-            {isVolumeLoading ? (
-              <Placeholder height="22px" width="100px" />
-            ) : (
-              <Tooltip title={volumeTooltip} delay={100}>
-                <Tag variant="muted" icon={<IconInfo size="sm" />}>
-                  {volume}
-                </Tag>
-              </Tooltip>
-            )}
-            <Tooltip title={disabledReason} disabled={!disabledReason} delay={500}>
-              <Switch
-                checked={isSelected}
-                disabled={disabled}
-                role="presentation"
-                tabIndex={-1}
-                readOnly
-                size="sm"
-              />
-            </Tooltip>
-          </Flex>
         </Flex>
       </ScmSelectableContainer>
     </ScmCardButton>

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -54,14 +54,14 @@ export function ScmFeatureCard({
       >
         <Flex align="start">
           <Grid
-            columns="min-content 1fr min-content min-content"
+            columns="min-content 1fr min-content"
             rows="min-content min-content"
             gap="xs lg"
             align="center"
             width="100%"
             areas={`
-                    "icon label volume switch"
-                    ". description . ."
+                    "icon label toggle"
+                    ". description ."
                   `}
           >
             <Container area="icon">
@@ -80,7 +80,7 @@ export function ScmFeatureCard({
               </Text>
             </Container>
 
-            <Flex area="volume" align="center">
+            <Flex area="toggle" align="start" gap="sm">
               {isVolumeLoading ? (
                 <Placeholder height="22px" width="100px" />
               ) : (
@@ -90,9 +90,7 @@ export function ScmFeatureCard({
                   </Tag>
                 </Tooltip>
               )}
-            </Flex>
 
-            <Flex area="switch" align="center">
               <Tooltip title={disabledReason} disabled={!disabledReason} delay={500}>
                 <Switch
                   checked={isSelected}

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -70,7 +70,7 @@ export function ScmFeatureInfoCards({
               <Grid
                 columns="min-content 1fr"
                 rows="min-content min-content"
-                gap={{xs: 'xs md', sm: 'xs lg'}}
+                gap="xs lg"
                 align="center"
                 areas={`
                     "icon label"

--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -196,7 +196,9 @@ export function ScmConnect({onComplete, genBackButton}: StepProps) {
                 variant="transparent"
                 style={{minWidth: 0}}
               >
-                <Text ellipsis>{t('Continue without a repo')}</Text>
+                <Text ellipsis variant="inherit">
+                  {t('Continue without a repo')}
+                </Text>
               </Button>
             )}
 

--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -184,7 +184,7 @@ export function ScmConnect({onComplete, genBackButton}: StepProps) {
           paddingTop="3xl"
         >
           <Flex align="center">{genBackButton?.()}</Flex>
-          <Flex align="center" gap="md">
+          <Flex align="center" gap="md" minWidth={0}>
             {!selectedRepository && (
               <Button
                 analyticsEventKey="onboarding.scm_connect_skip_clicked"
@@ -194,8 +194,9 @@ export function ScmConnect({onComplete, genBackButton}: StepProps) {
                 }}
                 onClick={() => onComplete()}
                 variant="transparent"
+                style={{minWidth: 0}}
               >
-                {t('Continue without a repo')}
+                <Text ellipsis>{t('Continue without a repo')}</Text>
               </Button>
             )}
 


### PR DESCRIPTION
## Summary

Tightens up several SCM onboarding screens on narrow viewports:

- Restructure the SCM feature card into a 3-column grid (icon, label, toggle) with the volume tag and switch sharing the toggle cell and the description spanning the columns beneath the label and toggle. The previous layout split the row into a 2-column grid plus a sibling flex, which overflowed and wrapped awkwardly.
- Allow the "Continue without a repo" skip button label to truncate with an ellipsis instead of pushing the action row off the screen.
- Drop the responsive gap override on the info cards grid for consistency.

| before | after |
| :----: | :----: |
| <img width="383" height="675" alt="Screenshot 2026-05-12 at 5 09 21 PM" src="https://github.com/user-attachments/assets/73f799a7-3e3d-42ac-b4be-01f1686e2541" /> | <img width="383" height="674" alt="Screenshot 2026-05-12 at 5 22 33 PM" src="https://github.com/user-attachments/assets/7ef4a486-60c5-4fae-b592-3a34ccefb839" /> |
| <img width="384" height="674" alt="Screenshot 2026-05-12 at 5 11 11 PM" src="https://github.com/user-attachments/assets/94413a5a-b67e-4190-b1b7-98fb604b8164" /> | <img width="383" height="673" alt="Screenshot 2026-05-12 at 4 58 36 PM" src="https://github.com/user-attachments/assets/628895d2-96ef-4396-b635-eae7e2878361" /> |

