### PR TITLE
ref(explore): Deprecate getQueryFromLocation

### DIFF
--- a/static/app/views/explore/exploreStateQueryParamsProvider.tsx
+++ b/static/app/views/explore/exploreStateQueryParamsProvider.tsx
@@ -7,7 +7,6 @@ import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateFie
 import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
 import {defaultCursor} from 'sentry/views/explore/queryParams/cursor';
 import {defaultMode} from 'sentry/views/explore/queryParams/mode';
-import {defaultQuery} from 'sentry/views/explore/queryParams/query';
 import {
   ReadableQueryParams,
   type ReadableQueryParamsOptions,
@@ -32,7 +31,7 @@ export function ExploreStateQueryParamsProvider({
   frozenParams,
 }: ExploreStateQueryParamsProviderProps) {
   const [mode, _setMode] = useState(defaultMode());
-  const [query, setQuery] = useResettableState(defaultQuery);
+  const [query, setQuery] = useResettableState(() => '');
 
   const [cursor, _setCursor] = useState(defaultCursor());
   const [fields, _setFields] = useState(defaultFields());

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -57,7 +57,7 @@ export function getReadableQueryParamsFromLocation(
   location: Location
 ): ReadableQueryParams {
   const mode = getModeFromLocation(location, LOGS_MODE_KEY);
-  const query = decodeScalar(location.query?.[LOGS_QUERY_KEY]) ?? '';
+  const query = decodeScalar(location.query[LOGS_QUERY_KEY]) ?? '';
 
   const cursor = getCursorFromLocation(location, LOGS_CURSOR_KEY);
   const fields = getFieldsFromLocation(location, LOGS_FIELDS_KEY) ?? defaultLogFields();

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -31,7 +31,6 @@ import {
   isGroupBy,
 } from 'sentry/views/explore/queryParams/groupBy';
 import {getModeFromLocation} from 'sentry/views/explore/queryParams/mode';
-import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {
   getIdFromLocation,
@@ -58,7 +57,7 @@ export function getReadableQueryParamsFromLocation(
   location: Location
 ): ReadableQueryParams {
   const mode = getModeFromLocation(location, LOGS_MODE_KEY);
-  const query = getQueryFromLocation(location, LOGS_QUERY_KEY) ?? '';
+  const query = decodeScalar(location.query?.[LOGS_QUERY_KEY]) ?? '';
 
   const cursor = getCursorFromLocation(location, LOGS_CURSOR_KEY);
   const fields = getFieldsFromLocation(location, LOGS_FIELDS_KEY) ?? defaultLogFields();

--- a/static/app/views/explore/queryParams/query.ts
+++ b/static/app/views/explore/queryParams/query.ts
@@ -1,3 +1,0 @@
-export function defaultQuery(): string {
-  return '';
-}

--- a/static/app/views/explore/queryParams/query.ts
+++ b/static/app/views/explore/queryParams/query.ts
@@ -1,11 +1,3 @@
-import type {Location} from 'history';
-
-import {decodeScalar} from 'sentry/utils/queryString';
-
 export function defaultQuery(): string {
   return '';
-}
-
-export function getQueryFromLocation(location: Location, key: string) {
-  return decodeScalar(location.query?.[key]);
 }

--- a/static/app/views/explore/replays/list/replayQueryParamsProvider.tsx
+++ b/static/app/views/explore/replays/list/replayQueryParamsProvider.tsx
@@ -20,7 +20,7 @@ import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writabl
 const REPLAY_QUERY_KEY = 'query';
 
 function getReadableQueryParamsFromLocation(location: Location): ReadableQueryParams {
-  const query = decodeScalar(location.query?.[REPLAY_QUERY_KEY]) ?? '';
+  const query = decodeScalar(location.query[REPLAY_QUERY_KEY]) ?? '';
   const id = getIdFromLocation(location, ID_KEY);
   const title = getTitleFromLocation(location, TITLE_KEY);
 

--- a/static/app/views/explore/replays/list/replayQueryParamsProvider.tsx
+++ b/static/app/views/explore/replays/list/replayQueryParamsProvider.tsx
@@ -2,12 +2,12 @@ import type {ReactNode} from 'react';
 import {useCallback, useMemo} from 'react';
 import type {Location} from 'history';
 
+import {decodeScalar} from 'sentry/utils/queryString';
 import {updateNullableLocation} from 'sentry/utils/url/updateNullableLocation';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
-import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {
   getIdFromLocation,
@@ -20,7 +20,7 @@ import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writabl
 const REPLAY_QUERY_KEY = 'query';
 
 function getReadableQueryParamsFromLocation(location: Location): ReadableQueryParams {
-  const query = getQueryFromLocation(location, REPLAY_QUERY_KEY) ?? '';
+  const query = decodeScalar(location.query?.[REPLAY_QUERY_KEY]) ?? '';
   const id = getIdFromLocation(location, ID_KEY);
   const title = getTitleFromLocation(location, TITLE_KEY);
 

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -64,7 +64,7 @@ export function getReadableQueryParamsFromLocation(
 ): ReadableQueryParams {
   const extrapolate = getExtrapolateFromLocation(location, SPANS_EXTRAPOLATE_KEY);
   const mode = getModeFromLocation(location, SPANS_MODE_KEY);
-  const query = decodeScalar(location.query?.[SPANS_QUERY_KEY]) ?? '';
+  const query = decodeScalar(location.query[SPANS_QUERY_KEY]) ?? '';
 
   const cursor = getCursorFromLocation(location, SPANS_CURSOR_KEY);
   const fields = getFieldsFromLocation(location, SPANS_FIELD_KEY) ?? defaultFields();

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -3,6 +3,7 @@ import type {Location} from 'history';
 import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {updateNullableLocation} from 'sentry/utils/url/updateNullableLocation';
 import {DEFAULT_VISUALIZATION} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
@@ -18,7 +19,6 @@ import {
   isGroupBy,
 } from 'sentry/views/explore/queryParams/groupBy';
 import {getModeFromLocation} from 'sentry/views/explore/queryParams/mode';
-import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {
   getIdFromLocation,
@@ -64,7 +64,7 @@ export function getReadableQueryParamsFromLocation(
 ): ReadableQueryParams {
   const extrapolate = getExtrapolateFromLocation(location, SPANS_EXTRAPOLATE_KEY);
   const mode = getModeFromLocation(location, SPANS_MODE_KEY);
-  const query = getQueryFromLocation(location, SPANS_QUERY_KEY) ?? '';
+  const query = decodeScalar(location.query?.[SPANS_QUERY_KEY]) ?? '';
 
   const cursor = getCursorFromLocation(location, SPANS_CURSOR_KEY);
   const fields = getFieldsFromLocation(location, SPANS_FIELD_KEY) ?? defaultFields();


### PR DESCRIPTION
## Summary
- Marks `getQueryFromLocation` as deprecated in favor of nuqs for managing URL query params

## Test plan
- [x] Lint passes