### PR TITLE
ref(explore): Deprecate getIdFromLocation

### DIFF
--- a/static/app/views/explore/queryParams/savedQuery.ts
+++ b/static/app/views/explore/queryParams/savedQuery.ts
@@ -5,6 +5,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 export const ID_KEY = 'id';
 export const TITLE_KEY = 'title';
 
+/** @deprecated Use nuqs to manage query params instead. */
 export function getIdFromLocation(location: Location, key: string): string | undefined {
   return decodeScalar(location.query?.[key]);
 }


### PR DESCRIPTION
## Summary
- Marks `getIdFromLocation` as deprecated in favor of nuqs for managing URL query params

## Test plan
- [x] Lint passes