### PR TITLE
ref(explore): Deprecate getTitleFromLocation

### DIFF
--- a/static/app/views/explore/queryParams/savedQuery.ts
+++ b/static/app/views/explore/queryParams/savedQuery.ts
@@ -9,6 +9,7 @@ export function getIdFromLocation(location: Location, key: string): string | und
   return decodeScalar(location.query?.[key]);
 }
 
+/** @deprecated Use nuqs to manage query params instead. */
 export function getTitleFromLocation(
   location: Location,
   key: string


### PR DESCRIPTION
## Summary
- Marks `getTitleFromLocation` as deprecated in favor of nuqs for managing URL query params

## Test plan
- [x] Lint passes