### PR TITLE
ref(explore): Deprecate getCursorFromLocation

### DIFF
--- a/static/app/views/explore/queryParams/cursor.ts
+++ b/static/app/views/explore/queryParams/cursor.ts
@@ -6,6 +6,7 @@ export function defaultCursor(): string {
   return '';
 }
 
+/** @deprecated Use nuqs to manage query params instead. */
 export function getCursorFromLocation(location: Location, key: string) {
   return decodeScalar(location.query?.[key], defaultCursor());
 }


### PR DESCRIPTION
## Summary
- Marks `getCursorFromLocation` as deprecated in favor of nuqs for managing URL query params

## Test plan
- [x] Lint passes