### PR TITLE
ref(explore): Deprecate getExtrapolateFromLocation

### DIFF
--- a/static/app/views/explore/queryParams/extrapolate.ts
+++ b/static/app/views/explore/queryParams/extrapolate.ts
@@ -2,6 +2,7 @@ import type {Location} from 'history';
 
 import {decodeScalar} from 'sentry/utils/queryString';
 
+/** @deprecated Use nuqs to manage query params instead. */
 export function getExtrapolateFromLocation(location: Location, key: string) {
   return decodeScalar(location.query?.[key], '1') === '1';
 }


### PR DESCRIPTION
## Summary
- Marks `getExtrapolateFromLocation` as deprecated in favor of nuqs for managing URL query params

## Test plan
- [x] Lint passes