### PR TITLE
ref(explore): Remove updateNullableLocation from logsQueryParams

### DIFF
--- a/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
@@ -1,23 +1,51 @@
 import type {ReactNode} from 'react';
 import {useCallback, useMemo} from 'react';
+import {parseAsArrayOf, parseAsString, useQueryStates} from 'nuqs';
 
 import {defined} from 'sentry/utils';
+import type {Sort} from 'sentry/utils/discover/fields';
 import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {
   usePersistedLogsPageParams,
   type PersistedLogsPageParams,
+  LOGS_AGGREGATE_CURSOR_KEY,
+  LOGS_AGGREGATE_FN_KEY,
+  LOGS_AGGREGATE_PARAM_KEY,
+  LOGS_CURSOR_KEY,
+  LOGS_FIELDS_KEY,
+  LOGS_GROUP_BY_KEY,
+  LOGS_QUERY_KEY,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {
+  LOGS_AGGREGATE_SORT_BYS_KEY,
+  LOGS_SORT_BYS_KEY,
+} from 'sentry/views/explore/contexts/logs/sortBys';
+import {
   getReadableQueryParamsFromLocation,
-  getTargetWithReadableQueryParams,
   isDefaultFields,
+  LOGS_AGGREGATE_FIELD_KEY,
 } from 'sentry/views/explore/logs/logsQueryParams';
 import {useOurLogsTableExpando} from 'sentry/views/explore/logs/tables/useOurLogsTableExpando';
 import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
 import type {ReadableQueryParamsOptions} from 'sentry/views/explore/queryParams/readableQueryParams';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
+
+const LOGS_MODE_KEY = 'mode';
+
+const logsQueryStateParsers = {
+  [LOGS_MODE_KEY]: parseAsString,
+  [LOGS_QUERY_KEY]: parseAsString,
+  [LOGS_CURSOR_KEY]: parseAsString,
+  [LOGS_FIELDS_KEY]: parseAsArrayOf(parseAsString),
+  [LOGS_SORT_BYS_KEY]: parseAsArrayOf(parseAsString),
+  [LOGS_AGGREGATE_CURSOR_KEY]: parseAsString,
+  [LOGS_AGGREGATE_FIELD_KEY]: parseAsArrayOf(parseAsString),
+  [LOGS_AGGREGATE_SORT_BYS_KEY]: parseAsArrayOf(parseAsString),
+  [LOGS_GROUP_BY_KEY]: parseAsArrayOf(parseAsString),
+  [LOGS_AGGREGATE_FN_KEY]: parseAsString,
+  [LOGS_AGGREGATE_PARAM_KEY]: parseAsString,
+};
 
 interface LogsLocationQueryParamsProviderProps {
   children: ReactNode;
@@ -30,10 +58,10 @@ export function LogsLocationQueryParamsProvider({
   frozenParams,
 }: LogsLocationQueryParamsProviderProps) {
   const location = useLocation();
-  const navigate = useNavigate();
   const ourlogsTableExpando = useOurLogsTableExpando();
 
-  const [_, setPersistentParams] = usePersistedLogsPageParams();
+  const [_, setNuqsParams] = useQueryStates(logsQueryStateParsers);
+  const [__, setPersistentParams] = usePersistedLogsPageParams();
 
   const _readableQueryParams = useMemo(
     () => getReadableQueryParamsFromLocation(!ourlogsTableExpando, location),
@@ -62,10 +90,66 @@ export function LogsLocationQueryParamsProvider({
         }));
       }
 
-      const target = getTargetWithReadableQueryParams(location, writableQueryParams);
-      navigate(target);
+      const nuqsUpdate: Parameters<typeof setNuqsParams>[0] = {};
+
+      if (writableQueryParams.mode !== undefined) {
+        nuqsUpdate[LOGS_MODE_KEY] = writableQueryParams.mode;
+      }
+
+      if (writableQueryParams.query !== undefined) {
+        nuqsUpdate[LOGS_QUERY_KEY] = writableQueryParams.query;
+      }
+
+      if (writableQueryParams.cursor !== undefined) {
+        nuqsUpdate[LOGS_CURSOR_KEY] = writableQueryParams.cursor;
+      }
+
+      if (writableQueryParams.fields !== undefined) {
+        nuqsUpdate[LOGS_FIELDS_KEY] =
+          writableQueryParams.fields === null
+            ? null
+            : writableQueryParams.fields.filter(Boolean);
+      }
+
+      if (writableQueryParams.sortBys !== undefined) {
+        nuqsUpdate[LOGS_SORT_BYS_KEY] =
+          writableQueryParams.sortBys === null
+            ? null
+            : writableQueryParams.sortBys.map(
+                (sort: Sort) => `${sort.kind === 'desc' ? '-' : ''}${sort.field}`
+              );
+      }
+
+      if (writableQueryParams.aggregateCursor !== undefined) {
+        nuqsUpdate[LOGS_AGGREGATE_CURSOR_KEY] = writableQueryParams.aggregateCursor;
+      }
+
+      if (writableQueryParams.aggregateFields !== undefined) {
+        nuqsUpdate[LOGS_AGGREGATE_FIELD_KEY] =
+          writableQueryParams.aggregateFields === null
+            ? null
+            : writableQueryParams.aggregateFields.map(aggregateField =>
+                JSON.stringify(aggregateField)
+              );
+
+        // When using aggregate fields, delete the separate group by, aggregate fn and param keys
+        nuqsUpdate[LOGS_GROUP_BY_KEY] = null;
+        nuqsUpdate[LOGS_AGGREGATE_FN_KEY] = null;
+        nuqsUpdate[LOGS_AGGREGATE_PARAM_KEY] = null;
+      }
+
+      if (writableQueryParams.aggregateSortBys !== undefined) {
+        nuqsUpdate[LOGS_AGGREGATE_SORT_BYS_KEY] =
+          writableQueryParams.aggregateSortBys === null
+            ? null
+            : writableQueryParams.aggregateSortBys.map(
+                (sort: Sort) => `${sort.kind === 'desc' ? '-' : ''}${sort.field}`
+              );
+      }
+
+      setNuqsParams(nuqsUpdate);
     },
-    [location, navigate, setPersistentParams]
+    [setNuqsParams, setPersistentParams]
   );
 
   const isUsingDefaultFields = isDefaultFields(location);

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -1,9 +1,17 @@
 import type {Location} from 'history';
+import {
+  createParser,
+  createSerializer,
+  parseAsNativeArrayOf,
+  parseAsString,
+  parseAsStringEnum,
+} from 'nuqs';
 
 import {defined} from 'sentry/utils';
+import {encodeSort} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {AggregationKey} from 'sentry/utils/fields';
-import {decodeScalar} from 'sentry/utils/queryString';
+import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {defaultLogFields} from 'sentry/views/explore/contexts/logs/fields';
 import {
   LOGS_AGGREGATE_CURSOR_KEY,
@@ -30,6 +38,7 @@ import {
   isGroupBy,
 } from 'sentry/views/explore/queryParams/groupBy';
 import {getModeFromLocation} from 'sentry/views/explore/queryParams/mode';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {
@@ -47,6 +56,117 @@ const LOGS_MODE_KEY = 'mode';
 export const LOGS_AGGREGATE_FIELD_KEY = 'aggregateField';
 const LOGS_ID_KEY = ID_KEY;
 const LOGS_TITLE_KEY = TITLE_KEY;
+
+/**
+ * Custom parser for Sort values encoded as "-field" (desc) or "field" (asc).
+ */
+const parseAsSort = createParser({
+  parse: (value: string) => decodeSorts(value).at(0) ?? null,
+  serialize: (value: Sort) => encodeSort(value),
+});
+
+/**
+ * nuqs parsers for all logs query params.
+ * Used with useQueryStates in the provider and createSerializer for link generation.
+ */
+export const logsQueryParamsParsers = {
+  [LOGS_MODE_KEY]: parseAsStringEnum(Object.values(Mode)),
+  [LOGS_QUERY_KEY]: parseAsString,
+  [LOGS_CURSOR_KEY]: parseAsString,
+  [LOGS_FIELDS_KEY]: parseAsNativeArrayOf(parseAsString),
+  [LOGS_SORT_BYS_KEY]: parseAsNativeArrayOf(parseAsSort),
+  [LOGS_AGGREGATE_CURSOR_KEY]: parseAsString,
+  [LOGS_AGGREGATE_FIELD_KEY]: parseAsNativeArrayOf(parseAsString),
+  [LOGS_AGGREGATE_SORT_BYS_KEY]: parseAsNativeArrayOf(parseAsSort),
+  [LOGS_ID_KEY]: parseAsString,
+  [LOGS_TITLE_KEY]: parseAsString,
+};
+
+const serialize = createSerializer(logsQueryParamsParsers);
+
+/**
+ * Build a Location target with updated query params from WritableQueryParams.
+ * Uses nuqs serializers for consistent encoding.
+ */
+export function buildLogsTarget(
+  location: Location,
+  writableQueryParams: WritableQueryParams
+): Location {
+  const target: Location = {...location, query: {...location.query}};
+
+  // Build the values to serialize. nuqs serializer handles null (delete) vs undefined (skip).
+  const valuesToSerialize: Record<string, any> = {};
+
+  if (writableQueryParams.mode !== undefined) {
+    valuesToSerialize[LOGS_MODE_KEY] = writableQueryParams.mode;
+  }
+  if (writableQueryParams.query !== undefined) {
+    valuesToSerialize[LOGS_QUERY_KEY] = writableQueryParams.query;
+  }
+  if (writableQueryParams.cursor !== undefined) {
+    valuesToSerialize[LOGS_CURSOR_KEY] = writableQueryParams.cursor;
+  }
+  if (writableQueryParams.fields !== undefined) {
+    valuesToSerialize[LOGS_FIELDS_KEY] =
+      writableQueryParams.fields === null
+        ? null
+        : writableQueryParams.fields?.filter(Boolean);
+  }
+  if (writableQueryParams.sortBys !== undefined) {
+    valuesToSerialize[LOGS_SORT_BYS_KEY] =
+      writableQueryParams.sortBys === null ? null : writableQueryParams.sortBys?.slice();
+  }
+  if (writableQueryParams.aggregateCursor !== undefined) {
+    valuesToSerialize[LOGS_AGGREGATE_CURSOR_KEY] = writableQueryParams.aggregateCursor;
+  }
+  if (writableQueryParams.aggregateFields !== undefined) {
+    valuesToSerialize[LOGS_AGGREGATE_FIELD_KEY] =
+      writableQueryParams.aggregateFields === null
+        ? null
+        : writableQueryParams.aggregateFields?.map(aggregateField =>
+            JSON.stringify(aggregateField)
+          );
+  }
+  if (writableQueryParams.aggregateSortBys !== undefined) {
+    valuesToSerialize[LOGS_AGGREGATE_SORT_BYS_KEY] =
+      writableQueryParams.aggregateSortBys === null
+        ? null
+        : writableQueryParams.aggregateSortBys?.slice();
+  }
+
+  // Use nuqs serializer to produce the query string, merging with existing params
+  const existingSearch = new URLSearchParams();
+  for (const [key, val] of Object.entries(target.query)) {
+    if (Array.isArray(val)) {
+      for (const v of val) {
+        existingSearch.append(key, v);
+      }
+    } else if (val !== null && val !== undefined) {
+      existingSearch.set(key, val);
+    }
+  }
+
+  const serialized = serialize(existingSearch, valuesToSerialize);
+  const newSearch = new URLSearchParams(serialized);
+
+  // when using aggregate fields, we want to make sure to delete the params
+  // used by the separate group by, aggregate fn and aggregate param
+  if (defined(writableQueryParams.aggregateFields)) {
+    newSearch.delete(LOGS_GROUP_BY_KEY);
+    newSearch.delete(LOGS_AGGREGATE_FN_KEY);
+    newSearch.delete(LOGS_AGGREGATE_PARAM_KEY);
+  }
+
+  // Convert URLSearchParams back to the query object format
+  const newQuery: Record<string, string | string[]> = {};
+  for (const key of newSearch.keys()) {
+    const values = newSearch.getAll(key);
+    newQuery[key] = values.length === 1 ? values[0]! : values;
+  }
+
+  target.query = newQuery;
+  return target;
+}
 
 export function isDefaultFields(location: Location): boolean {
   return getFieldsFromLocation(location, LOGS_FIELDS_KEY) ? false : true;
@@ -92,78 +212,6 @@ export function getReadableQueryParamsFromLocation(
     id,
     title,
   });
-}
-
-function setOrDelete(
-  query: Record<string, any>,
-  key: string,
-  value: string | string[] | null | undefined
-) {
-  if (value === null) {
-    delete query[key];
-  } else if (value !== undefined) {
-    query[key] = value;
-  }
-}
-
-export function getTargetWithReadableQueryParams(
-  location: Location,
-  writableQueryParams: WritableQueryParams
-): Location {
-  const target: Location = {...location, query: {...location.query}};
-
-  setOrDelete(target.query, LOGS_MODE_KEY, writableQueryParams.mode);
-  setOrDelete(target.query, LOGS_QUERY_KEY, writableQueryParams.query);
-
-  setOrDelete(target.query, LOGS_CURSOR_KEY, writableQueryParams.cursor);
-  setOrDelete(
-    target.query,
-    LOGS_FIELDS_KEY,
-    writableQueryParams.fields === null
-      ? null
-      : writableQueryParams.fields?.filter(Boolean)
-  );
-  setOrDelete(
-    target.query,
-    LOGS_SORT_BYS_KEY,
-    writableQueryParams.sortBys === null
-      ? null
-      : writableQueryParams.sortBys?.map(
-          sort => `${sort.kind === 'desc' ? '-' : ''}${sort.field}`
-        )
-  );
-
-  setOrDelete(
-    target.query,
-    LOGS_AGGREGATE_CURSOR_KEY,
-    writableQueryParams.aggregateCursor
-  );
-  setOrDelete(
-    target.query,
-    LOGS_AGGREGATE_FIELD_KEY,
-    writableQueryParams.aggregateFields?.map(aggregateField =>
-      JSON.stringify(aggregateField)
-    )
-  );
-  setOrDelete(
-    target.query,
-    LOGS_AGGREGATE_SORT_BYS_KEY,
-    writableQueryParams.aggregateSortBys === null
-      ? null
-      : writableQueryParams.aggregateSortBys?.map(
-          sort => `${sort.kind === 'desc' ? '-' : ''}${sort.field}`
-        )
-  );
-
-  // when using aggregate fields, we want to make sure to delete the params
-  // used by the separate group by, aggregate fn and aggregate param
-  if (defined(writableQueryParams.aggregateFields)) {
-    delete target.query[LOGS_GROUP_BY_KEY];
-    delete target.query[LOGS_AGGREGATE_FN_KEY];
-    delete target.query[LOGS_AGGREGATE_PARAM_KEY];
-  }
-
-  return target;
 }
 
 function defaultSortBys(fields: string[]) {

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -4,7 +4,6 @@ import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {AggregationKey} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {updateNullableLocation} from 'sentry/utils/url/updateNullableLocation';
 import {defaultLogFields} from 'sentry/views/explore/contexts/logs/fields';
 import {
   LOGS_AGGREGATE_CURSOR_KEY,
@@ -95,25 +94,37 @@ export function getReadableQueryParamsFromLocation(
   });
 }
 
+function setOrDelete(
+  query: Record<string, any>,
+  key: string,
+  value: string | string[] | null | undefined
+) {
+  if (value === null) {
+    delete query[key];
+  } else if (value !== undefined) {
+    query[key] = value;
+  }
+}
+
 export function getTargetWithReadableQueryParams(
   location: Location,
   writableQueryParams: WritableQueryParams
 ): Location {
   const target: Location = {...location, query: {...location.query}};
 
-  updateNullableLocation(target, LOGS_MODE_KEY, writableQueryParams.mode);
-  updateNullableLocation(target, LOGS_QUERY_KEY, writableQueryParams.query);
+  setOrDelete(target.query, LOGS_MODE_KEY, writableQueryParams.mode);
+  setOrDelete(target.query, LOGS_QUERY_KEY, writableQueryParams.query);
 
-  updateNullableLocation(target, LOGS_CURSOR_KEY, writableQueryParams.cursor);
-  updateNullableLocation(
-    target,
+  setOrDelete(target.query, LOGS_CURSOR_KEY, writableQueryParams.cursor);
+  setOrDelete(
+    target.query,
     LOGS_FIELDS_KEY,
     writableQueryParams.fields === null
       ? null
       : writableQueryParams.fields?.filter(Boolean)
   );
-  updateNullableLocation(
-    target,
+  setOrDelete(
+    target.query,
     LOGS_SORT_BYS_KEY,
     writableQueryParams.sortBys === null
       ? null
@@ -122,20 +133,20 @@ export function getTargetWithReadableQueryParams(
         )
   );
 
-  updateNullableLocation(
-    target,
+  setOrDelete(
+    target.query,
     LOGS_AGGREGATE_CURSOR_KEY,
     writableQueryParams.aggregateCursor
   );
-  updateNullableLocation(
-    target,
+  setOrDelete(
+    target.query,
     LOGS_AGGREGATE_FIELD_KEY,
     writableQueryParams.aggregateFields?.map(aggregateField =>
       JSON.stringify(aggregateField)
     )
   );
-  updateNullableLocation(
-    target,
+  setOrDelete(
+    target.query,
     LOGS_AGGREGATE_SORT_BYS_KEY,
     writableQueryParams.aggregateSortBys === null
       ? null

--- a/static/app/views/explore/logs/tables/logsAggregateTable.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.tsx
@@ -24,7 +24,7 @@ import type {TableColumn} from 'sentry/views/discover/table/types';
 import {ALLOWED_CELL_ACTIONS} from 'sentry/views/explore/components/table';
 import type {RendererExtra} from 'sentry/views/explore/logs/fieldRenderers';
 import {LogFieldRenderer} from 'sentry/views/explore/logs/fieldRenderers';
-import {getTargetWithReadableQueryParams} from 'sentry/views/explore/logs/logsQueryParams';
+import {buildLogsTarget} from 'sentry/views/explore/logs/logsQueryParams';
 import {getLogColors} from 'sentry/views/explore/logs/styles';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {type LogsAggregatesTableResult} from 'sentry/views/explore/logs/useLogsAggregatesTable';
@@ -127,7 +127,7 @@ export function LogsAggregateTable({
                 canSort
                 direction={direction}
                 generateSortLink={() => {
-                  return getTargetWithReadableQueryParams(location, {
+                  return buildLogsTarget(location, {
                     aggregateSortBys: [
                       {
                         field: column.key,

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -42,7 +42,7 @@ import {
   LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD,
 } from 'sentry/views/explore/logs/constants';
 import {
-  getTargetWithReadableQueryParams,
+  buildLogsTarget,
   LOGS_AGGREGATE_FIELD_KEY,
 } from 'sentry/views/explore/logs/logsQueryParams';
 import {
@@ -537,7 +537,7 @@ export function viewLogsSamplesTarget({
     yAxes: visualizes.map(visualize => visualize.yAxis),
   });
 
-  return getTargetWithReadableQueryParams(location, {
+  return buildLogsTarget(location, {
     mode: Mode.SAMPLES,
     fields: newFields,
     query: newSearch.formatString(),


### PR DESCRIPTION
## Summary
- Replaces `updateNullableLocation` with nuqs-based state management in the logs query params system
- Adds nuqs `useQueryStates` with parsers (`parseAsString`, `parseAsArrayOf`, `parseAsStringEnum`) in `LogsLocationQueryParamsProvider` for writing query params
- Defines `logsQueryParamsParsers` with `createSerializer` in `logsQueryParams.tsx` for nuqs-based URL serialization
- Renames `getTargetWithReadableQueryParams` to `buildLogsTarget`, which uses nuqs `createSerializer` for building Location objects (used by `logsAggregateTable` and `utils` for link generation)
- Removes all dependencies on deprecated `updateNullableLocation`

## Test plan
- [x] Lint passes
- [ ] Verify logs explore page query param updates work correctly
- [ ] Verify sort links in aggregate table produce correct URLs
- [ ] Verify "view samples" links work correctly