### PR TITLE
feat(snapshots): Add success logs for PR comments and status checks

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -280,6 +280,14 @@ def post_snapshot_pr_comment_task(
                 save_pr_comment_result(cc, "snapshots", success=False, error=api_error)
             else:
                 save_pr_comment_result(cc, "snapshots", success=True, comment_id=comment_id)
+                logger.info(
+                    "preprod.snapshot_pr_comments.post.success",
+                    extra={
+                        "commit_comparison_id": commit_comparison_id,
+                        "organization_id": organization_id,
+                        "comment_id": comment_id,
+                    },
+                )
     except CommitComparison.DoesNotExist:
         logger.info(
             "preprod.snapshot_pr_comments.post.cc_deleted",

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -202,6 +202,7 @@ def create_preprod_snapshot_pr_comment_task(
         provider=commit_comparison.provider,
         pr_number=commit_comparison.pr_number,
         commit_comparison_id=cc_id,
+        artifact_id=artifact.id,
         comment_body=comment_body,
         existing_comment_id=existing_comment_id,
     )
@@ -221,6 +222,7 @@ def post_snapshot_pr_comment_task(
     provider: str,
     pr_number: int,
     commit_comparison_id: int,
+    artifact_id: int | None = None,
     comment_body: str,
     existing_comment_id: str | None,
     **kwargs: Any,
@@ -285,6 +287,7 @@ def post_snapshot_pr_comment_task(
                     extra={
                         "commit_comparison_id": commit_comparison_id,
                         "organization_id": organization_id,
+                        "artifact_id": artifact_id,
                         "comment_id": comment_id,
                     },
                 )

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -427,3 +427,11 @@ def post_snapshot_status_check_task(
     update_posted_status_check(
         preprod_artifact, check_type="snapshots", success=True, check_id=check_id
     )
+    logger.info(
+        "preprod.snapshot_status_checks.post.success",
+        extra={
+            "artifact_id": preprod_artifact.id,
+            "organization_id": preprod_artifact.project.organization_id,
+            "check_id": check_id,
+        },
+    )

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
@@ -103,6 +103,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
             provider="github",
             pr_number=42,
             commit_comparison_id=artifact.commit_comparison.id,
+            artifact_id=artifact.id,
             comment_body="## Sentry Snapshot Testing\n...",
             existing_comment_id=None,
         )


### PR DESCRIPTION
The snapshot PR comment and status check posting paths only logged failures,
making it difficult to confirm successful posts in production. This adds
`logger.info` calls on the success paths for both flows to improve
observability.