### PR TITLE
fix(seer-explorer): Clear input when switching sessions or starting new chat

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -64,8 +64,8 @@ export function ExplorerDrawerContent({
     errorStatusCode,
     isTimedOut,
     sendMessage,
-    startNewSession: startNewSessionBase,
-    switchToRun: switchToRunBase,
+    startNewSession,
+    switchToRun,
     respondToUserInput,
     createPR,
     interruptRun,
@@ -75,14 +75,7 @@ export function ExplorerDrawerContent({
     setOverrideCodeModeEnable,
   } = useSeerExplorer();
 
-  const startNewSession = () => {
-    startNewSessionBase();
-    setInputValue('');
-  };
-  const switchToRun = (...args: Parameters<typeof switchToRunBase>) => {
-    switchToRunBase(...args);
-    setInputValue('');
-  };
+  const clearInput = () => setInputValue('');
 
   const readOnly =
     sessionData?.owner_user_id !== undefined &&
@@ -217,7 +210,7 @@ export function ExplorerDrawerContent({
     textAreaRef: textareaRef,
     panelSize: 'max',
     slashCommandHandlers: {
-      onNew: startNewSession,
+      onNew: () => startNewSession({onSuccess: clearInput}),
       onFeedback: openFeedbackForm ? handleFeedback : undefined,
       onLangfuse: langfuseUrl ? handleOpenLangfuse : undefined,
       onConversations: conversationsUrl ? handleOpenConversations : undefined,
@@ -326,7 +319,9 @@ export function ExplorerDrawerContent({
   }, [blocks]);
 
   // Deep link effect
-  useSeerExplorerDeepLink({callback: switchToRun});
+  useSeerExplorerDeepLink({
+    callback: newRunId => switchToRun(newRunId, {onSuccess: clearInput}),
+  });
 
   // Interrupt button and placeholder state
   const interruptState =
@@ -343,10 +338,10 @@ export function ExplorerDrawerContent({
       <ExplorerDrawerHeader
         disableNewChatButton={runId === null}
         onNewChatClick={() => {
-          startNewSession();
+          startNewSession({onSuccess: clearInput});
           focusInput();
         }}
-        onChangeSession={switchToRun}
+        onChangeSession={newRunId => switchToRun(newRunId, {onSuccess: clearInput})}
         onCopySessionClick={copySessionEnabled ? copySessionToClipboard : undefined}
         onCopyLinkClick={runId === null ? undefined : handleCopyLink}
         overrideCtxEngEnable={overrideCtxEngEnable}

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -64,8 +64,8 @@ export function ExplorerDrawerContent({
     errorStatusCode,
     isTimedOut,
     sendMessage,
-    startNewSession,
-    switchToRun,
+    startNewSession: startNewSessionBase,
+    switchToRun: switchToRunBase,
     respondToUserInput,
     createPR,
     interruptRun,
@@ -74,6 +74,16 @@ export function ExplorerDrawerContent({
     setOverrideCtxEngEnable,
     setOverrideCodeModeEnable,
   } = useSeerExplorer();
+
+  const startNewSession = () => {
+    startNewSessionBase();
+    setInputValue('');
+  };
+  const switchToRun = (...args: Parameters<typeof switchToRunBase>) => {
+    const result = switchToRunBase(...args);
+    setInputValue('');
+    return result;
+  };
 
   const readOnly =
     sessionData?.owner_user_id !== undefined &&

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -80,9 +80,8 @@ export function ExplorerDrawerContent({
     setInputValue('');
   };
   const switchToRun = (...args: Parameters<typeof switchToRunBase>) => {
-    const result = switchToRunBase(...args);
+    switchToRunBase(...args);
     setInputValue('');
-    return result;
   };
 
   const readOnly =

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -64,8 +64,8 @@ export function ExplorerDrawerContent({
     errorStatusCode,
     isTimedOut,
     sendMessage,
-    startNewSession,
-    switchToRun,
+    startNewSession: startNewSessionBase,
+    switchToRun: switchToRunBase,
     respondToUserInput,
     createPR,
     interruptRun,
@@ -76,9 +76,9 @@ export function ExplorerDrawerContent({
   } = useSeerExplorer();
 
   const clearInput = () => setInputValue('');
-  const handleStartNewSession = () => startNewSession({onSuccess: clearInput});
-  const handleSwitchToRun = (newRunId: number | null) =>
-    switchToRun(newRunId, {onSuccess: clearInput});
+  const startNewSession = () => startNewSessionBase({onSuccess: clearInput});
+  const switchToRun = (newRunId: number | null) =>
+    switchToRunBase(newRunId, {onSuccess: clearInput});
 
   const readOnly =
     sessionData?.owner_user_id !== undefined &&
@@ -213,7 +213,7 @@ export function ExplorerDrawerContent({
     textAreaRef: textareaRef,
     panelSize: 'max',
     slashCommandHandlers: {
-      onNew: handleStartNewSession,
+      onNew: startNewSession,
       onFeedback: openFeedbackForm ? handleFeedback : undefined,
       onLangfuse: langfuseUrl ? handleOpenLangfuse : undefined,
       onConversations: conversationsUrl ? handleOpenConversations : undefined,
@@ -322,7 +322,7 @@ export function ExplorerDrawerContent({
   }, [blocks]);
 
   // Deep link effect
-  useSeerExplorerDeepLink({callback: handleSwitchToRun});
+  useSeerExplorerDeepLink({callback: switchToRun});
 
   // Interrupt button and placeholder state
   const interruptState =
@@ -339,10 +339,10 @@ export function ExplorerDrawerContent({
       <ExplorerDrawerHeader
         disableNewChatButton={runId === null}
         onNewChatClick={() => {
-          handleStartNewSession();
+          startNewSession();
           focusInput();
         }}
-        onChangeSession={handleSwitchToRun}
+        onChangeSession={switchToRun}
         onCopySessionClick={copySessionEnabled ? copySessionToClipboard : undefined}
         onCopyLinkClick={runId === null ? undefined : handleCopyLink}
         overrideCtxEngEnable={overrideCtxEngEnable}

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -76,6 +76,9 @@ export function ExplorerDrawerContent({
   } = useSeerExplorer();
 
   const clearInput = () => setInputValue('');
+  const handleStartNewSession = () => startNewSession({onSuccess: clearInput});
+  const handleSwitchToRun = (newRunId: number | null) =>
+    switchToRun(newRunId, {onSuccess: clearInput});
 
   const readOnly =
     sessionData?.owner_user_id !== undefined &&
@@ -204,13 +207,13 @@ export function ExplorerDrawerContent({
 
   // Menu component
   const {menu, closeMenu, openPRWidget} = useExplorerMenu({
-    clearInput: () => setInputValue(''),
+    clearInput,
     inputValue,
     focusInput,
     textAreaRef: textareaRef,
     panelSize: 'max',
     slashCommandHandlers: {
-      onNew: () => startNewSession({onSuccess: clearInput}),
+      onNew: handleStartNewSession,
       onFeedback: openFeedbackForm ? handleFeedback : undefined,
       onLangfuse: langfuseUrl ? handleOpenLangfuse : undefined,
       onConversations: conversationsUrl ? handleOpenConversations : undefined,
@@ -319,9 +322,7 @@ export function ExplorerDrawerContent({
   }, [blocks]);
 
   // Deep link effect
-  useSeerExplorerDeepLink({
-    callback: newRunId => switchToRun(newRunId, {onSuccess: clearInput}),
-  });
+  useSeerExplorerDeepLink({callback: handleSwitchToRun});
 
   // Interrupt button and placeholder state
   const interruptState =
@@ -338,10 +339,10 @@ export function ExplorerDrawerContent({
       <ExplorerDrawerHeader
         disableNewChatButton={runId === null}
         onNewChatClick={() => {
-          startNewSession({onSuccess: clearInput});
+          handleStartNewSession();
           focusInput();
         }}
-        onChangeSession={newRunId => switchToRun(newRunId, {onSuccess: clearInput})}
+        onChangeSession={handleSwitchToRun}
         onCopySessionClick={copySessionEnabled ? copySessionToClipboard : undefined}
         onCopyLinkClick={runId === null ? undefined : handleCopyLink}
         overrideCtxEngEnable={overrideCtxEngEnable}

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -388,7 +388,7 @@ export const useSeerExplorer = () => {
 
   /** Switches to a different run and fetches its latest state. */
   const switchToRun = useCallback(
-    (newRunId: number | null) => {
+    (newRunId: number | null, {onSuccess}: {onSuccess?: () => void} = {}) => {
       if (newRunId === runId) {
         return;
       }
@@ -404,12 +404,19 @@ export const useSeerExplorer = () => {
           queryKey: makeSeerExplorerQueryKey(orgSlug, newRunId),
         });
       }
+
+      onSuccess?.();
     },
     [orgSlug, queryClient, runId, setRunId]
   );
 
   /** Resets the hook state. The session isn't actually created until the user sends a message. */
-  const startNewSession = useCallback(() => switchToRun(null), [switchToRun]);
+  const startNewSession = useCallback(
+    ({onSuccess}: {onSuccess?: () => void} = {}) => {
+      switchToRun(null, {onSuccess});
+    },
+    [switchToRun]
+  );
 
   const sendMessage = useCallback(
     (query: string, explicitInsertIndex?: number, explicitRunId?: number | null) => {


### PR DESCRIPTION
## Summary
- Wraps `startNewSession` and `switchToRun` in `explorerDrawerContent.tsx` to clear `inputValue` after each call, preventing stale text from persisting across session changes.

## Test plan
- Open Seer Explorer drawer, type something in the input
- Click "New Chat" → input should be cleared
- Switch to a different session → input should be cleared