### PR TITLE
ref: inline getExtrapolateFromLocation and remove helper

### DIFF
--- a/static/app/views/explore/queryParams/extrapolate.ts
+++ b/static/app/views/explore/queryParams/extrapolate.ts
@@ -1,7 +1,0 @@
-import type {Location} from 'history';
-
-import {decodeScalar} from 'sentry/utils/queryString';
-
-export function getExtrapolateFromLocation(location: Location, key: string) {
-  return decodeScalar(location.query?.[key], '1') === '1';
-}

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -3,6 +3,7 @@ import type {Location} from 'history';
 import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {updateNullableLocation} from 'sentry/utils/url/updateNullableLocation';
 import {DEFAULT_VISUALIZATION} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
@@ -10,7 +11,6 @@ import {getAggregateFieldsFromLocation} from 'sentry/views/explore/queryParams/a
 import {getAggregateSortBysFromLocation} from 'sentry/views/explore/queryParams/aggregateSortBy';
 import {getCrossEventsFromLocation} from 'sentry/views/explore/queryParams/crossEvent';
 import {getCursorFromLocation} from 'sentry/views/explore/queryParams/cursor';
-import {getExtrapolateFromLocation} from 'sentry/views/explore/queryParams/extrapolate';
 import {getFieldsFromLocation} from 'sentry/views/explore/queryParams/field';
 import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {
@@ -62,7 +62,7 @@ export function isDefaultFields(location: Location): boolean {
 export function getReadableQueryParamsFromLocation(
   location: Location
 ): ReadableQueryParams {
-  const extrapolate = getExtrapolateFromLocation(location, SPANS_EXTRAPOLATE_KEY);
+  const extrapolate = decodeScalar(location.query?.[SPANS_EXTRAPOLATE_KEY], '1') === '1';
   const mode = getModeFromLocation(location, SPANS_MODE_KEY);
   const query = getQueryFromLocation(location, SPANS_QUERY_KEY) ?? '';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The function `getExtrapolateFromLocation` had exactly one callsite and wrapped a single expression. This PR inlines it directly at that callsite and deletes the now-empty `extrapolate.ts` file.

**Changes:**
- `static/app/views/explore/spans/spansQueryParams.tsx`: replace `getExtrapolateFromLocation(location, SPANS_EXTRAPOLATE_KEY)` with `decodeScalar(location.query?.[SPANS_EXTRAPOLATE_KEY], '1') === '1'`; swap the `extrapolate` import for a `decodeScalar` import
- `static/app/views/explore/queryParams/extrapolate.ts`: deleted
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c01ef007-9636-4391-838e-3a064a3f73dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c01ef007-9636-4391-838e-3a064a3f73dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

