### PR TITLE
fix(snapshots): Show 'Waiting for base' instead of 'Base' when base artifact not found

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -346,7 +346,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
 
         if comparison_manifest is not None:
             comparison_type = "diff"
-        elif commit_comparison and commit_comparison.base_sha:
+        elif commit_comparison and commit_comparison.base_sha and pending_or_failed_state is None:
             comparison_type = "waiting_for_base"
         else:
             comparison_type = "solo"

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -344,7 +344,12 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             if pending_or_failed_state is not None:
                 comparison_state = PreprodSnapshotComparison.State(pending_or_failed_state).name
 
-        comparison_type = "diff" if comparison_manifest is not None else "solo"
+        if comparison_manifest is not None:
+            comparison_type = "diff"
+        elif commit_comparison and commit_comparison.base_sha:
+            comparison_type = "waiting_for_base"
+        else:
+            comparison_type = "solo"
 
         run_info: SnapshotComparisonRunInfo | None = None
         if comparison_state is not None:

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -299,7 +299,11 @@ def to_snapshot_comparison_info(head_artifact: PreprodArtifact) -> SnapshotCompa
         reverse=True,
     )
     comparison = comparisons[0] if comparisons else None
-    if comparison:
+    if not comparison:
+        cc = head_artifact.commit_comparison
+        if cc and cc.base_sha:
+            comparison_state = "waiting_for_base"
+    elif comparison:
         comparison_state = PreprodSnapshotComparison.State(comparison.state).name.lower()
         if comparison.state == PreprodSnapshotComparison.State.SUCCESS:
             images_added = comparison.images_added

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -91,7 +91,9 @@ class PostedStatusChecks(BaseModel):
 
 class SnapshotComparisonInfo(BaseModel):
     image_count: int
-    comparison_state: Literal["pending", "processing", "success", "failed"] | None = None
+    comparison_state: (
+        Literal["pending", "processing", "success", "failed", "waiting_for_base"] | None
+    ) = None
     comparison_error_message: str | None = None
     images_added: int = 0
     images_removed: int = 0

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -65,6 +65,17 @@ function ChangeCounts({
   if (!comparisonState) {
     return <Tag variant="info">{t('Base')}</Tag>;
   }
+  if (comparisonState === 'waiting_for_base') {
+    return (
+      <Tooltip
+        title={t(
+          "Base snapshots haven't been uploaded yet. This will resolve automatically within ~10 minutes or fail."
+        )}
+      >
+        <Tag variant="muted">{t('Waiting for base')}</Tag>
+      </Tooltip>
+    );
+  }
   if (comparisonState === 'pending') {
     return (
       <Tooltip title={t('Waiting to start comparison')}>

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -54,7 +54,7 @@ export interface NavButtonRefs {
 interface SnapshotMainContentProps {
   canNavigateNext: boolean;
   canNavigatePrev: boolean;
-  comparisonType: 'diff' | 'solo' | undefined;
+  comparisonType: 'diff' | 'solo' | 'waiting_for_base' | undefined;
   diffImageBaseUrl: string;
   diffMode: DiffMode;
   hasDiffComparison: boolean;
@@ -192,6 +192,16 @@ export function SnapshotMainContent({
     );
   } else if (comparisonType === 'solo') {
     soloDiffToggle = <Tag variant="promotion">{t('Base')}</Tag>;
+  } else if (comparisonType === 'waiting_for_base') {
+    soloDiffToggle = (
+      <Tooltip
+        title={t(
+          "Base snapshots haven't been uploaded yet. This will resolve automatically within ~10 minutes or fail."
+        )}
+      >
+        <Tag variant="muted">{t('Waiting for base')}</Tag>
+      </Tooltip>
+    );
   }
 
   if (viewMode === 'list') {

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -266,7 +266,7 @@ export default function SnapshotsPage() {
     viewOverride === 'solo' ? 'solo' : (data?.comparison_type ?? 'solo');
   const comparisonRunInfo = data?.comparison_run_info;
 
-  const isSoloView = comparisonType === 'solo';
+  const isSoloView = comparisonType === 'solo' || comparisonType === 'waiting_for_base';
   const handleToggleView = useCallback(() => {
     const {view: _view, ...restQuery} = location.query;
     if (isSoloView) {

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -194,7 +194,12 @@ export function isStatusCheckFailure(
   return result?.success === false;
 }
 
-export type SnapshotComparisonState = 'pending' | 'processing' | 'success' | 'failed';
+export type SnapshotComparisonState =
+  | 'pending'
+  | 'processing'
+  | 'success'
+  | 'failed'
+  | 'waiting_for_base';
 export type SnapshotApprovalStatus = 'approved' | 'requires_approval';
 
 interface SnapshotComparisonInfo {

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -40,7 +40,7 @@ interface SnapshotApprovalInfo {
 }
 
 export interface SnapshotDetailsApiResponse {
-  comparison_type: 'solo' | 'diff';
+  comparison_type: 'solo' | 'diff' | 'waiting_for_base';
   head_artifact_id: string;
   image_count: number;
   images: SnapshotImage[];


### PR DESCRIPTION
When a snapshot is uploaded with a `base_sha` but no matching base artifact exists yet, both the snapshot list and detail pages incorrectly show a "Base" badge — implying the build is a base build with no comparison intended. In reality, the upload explicitly requested a comparison but the base hasn't been uploaded yet.

This changes both the list and detail APIs to return a `waiting_for_base` state when `base_sha` is present but no base artifact or comparison exists. The frontend now shows a "Waiting for base" tag with a tooltip explaining the build will resolve within ~10 minutes or fail.

**Backend:**
- Detail API (`comparison_type`): returns `"waiting_for_base"` instead of `"solo"` when `base_sha` exists but no comparison manifest found
- List API (`comparison_state`): returns `"waiting_for_base"` instead of `null` when `base_sha` exists but no `PreprodSnapshotComparison` record found
- `SnapshotComparisonInfo` Pydantic model: added `"waiting_for_base"` to the `comparison_state` Literal type to prevent `ValidationError` at runtime

**Frontend:**
- List view: renders `<Tag variant="muted">Waiting for base</Tag>` with tooltip
- Detail view: renders the same tag instead of the pink "Base" badge
- `isSoloView` treats `waiting_for_base` the same as `solo` for rendering purposes