### PR TITLE
chore(alerts): Remove triggered_for_incident from tests

### DIFF
--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -485,7 +485,6 @@ class Fixtures:
         self,
         alert_rule_trigger=None,
         target_identifier=None,
-        triggered_for_incident=None,
         *args,
         **kwargs,
     ):

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -109,9 +109,7 @@ class BuildMetricAlertChartTest(TestCase):
             date_started=timezone.now() - datetime.timedelta(minutes=2),
         )
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
+        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
 
         alert_rule_serialized_response: AlertRuleSerializerResponse = serialize(
             alert_rule, None, AlertRuleSerializer()
@@ -157,9 +155,7 @@ class BuildMetricAlertChartTest(TestCase):
             date_started=timezone.now() - datetime.timedelta(minutes=2),
         )
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
+        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
 
         alert_rule_serialized_response: AlertRuleSerializerResponse = serialize(
             alert_rule, None, AlertRuleSerializer()
@@ -204,9 +200,7 @@ class BuildMetricAlertChartTest(TestCase):
             date_started=timezone.now() - datetime.timedelta(minutes=2),
         )
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
+        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
 
         alert_rule_serialized_response: AlertRuleSerializerResponse = serialize(
             alert_rule, None, AlertRuleSerializer()

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -438,9 +438,7 @@ class UnfurlTest(TestCase):
         )
         incident.update(identifier=123)
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
+        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
 
         links = [
             UnfurlableUrl(
@@ -477,9 +475,7 @@ class UnfurlTest(TestCase):
         )
         incident.update(identifier=123)
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
+        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
         self._wire_workflow_engine_for_incident(alert_rule, incident)
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/issues/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}"
@@ -587,9 +583,7 @@ class UnfurlTest(TestCase):
             date_started=timezone.now() - timedelta(minutes=2),
         )
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
+        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
         self._wire_workflow_engine_for_incident(alert_rule, incident)
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/issues/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}"

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -45,9 +45,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
             date_started=date_started,
         )
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
+        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
         metric_value = 123
         referrer = "metric_alert_custom"
         notification_uuid = str(uuid.uuid4())
@@ -115,9 +113,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
             date_started=date_started,
         )
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
+        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
         metric_value = 123
         referrer = "metric_alert_custom"
         notification_uuid = str(uuid.uuid4())


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/115436 to clean up test usages of `create_alert_rule_trigger_action` that pass `triggered_for_incident` - I forgot to push these changes 🙃 