### PR TITLE
feat(seer): Enable context engine for all Seer plan orgs in explorer

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -46,7 +46,9 @@ from sentry.users.services.user import RpcUser
 logger = logging.getLogger(__name__)
 
 
-def _has_context_engine(organization: Organization, user: User | RpcUser | AnonymousUser) -> bool:
+def _has_context_engine(
+    organization: Organization, user: User | RpcUser | AnonymousUser | None
+) -> bool:
     return (
         features.has("organizations:seer-explorer-context-engine", organization, actor=user)
         or features.has("organizations:seat-based-seer-enabled", organization, actor=user)

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -46,6 +46,14 @@ from sentry.users.services.user import RpcUser
 logger = logging.getLogger(__name__)
 
 
+def _has_context_engine(organization: Organization, user: User | RpcUser | AnonymousUser) -> bool:
+    return (
+        features.has("organizations:seer-explorer-context-engine", organization, actor=user)
+        or features.has("organizations:seat-based-seer-enabled", organization, actor=user)
+        or features.has("organizations:seer-added", organization, actor=user)
+    )
+
+
 class SeerAgentClient:
     """
     A simple client for the Seer Agent, our general debugging agent.
@@ -332,17 +340,7 @@ class SeerAgentClient:
         if ui_tools:
             chat_body["ui_tools"] = ui_tools
 
-        has_context_engine = (
-            features.has(
-                "organizations:seer-explorer-context-engine", self.organization, actor=self.user
-            )
-            or features.has(
-                "organizations:seat-based-seer-enabled", self.organization, actor=self.user
-            )
-            or features.has("organizations:seer-added", self.organization, actor=self.user)
-        )
-
-        if has_context_engine:
+        if _has_context_engine(self.organization, self.user):
             if random.random() < options.get("seer.explorer.context-engine-rollout"):
                 chat_body["is_context_engine_enabled"] = True
 
@@ -465,17 +463,7 @@ class SeerAgentClient:
 
         # No random rollout here — Seer ANDs this with the persisted value from start_run,
         # so the start_run coin flip is the single source of truth.
-        has_context_engine = (
-            features.has(
-                "organizations:seer-explorer-context-engine", self.organization, actor=self.user
-            )
-            or features.has(
-                "organizations:seat-based-seer-enabled", self.organization, actor=self.user
-            )
-            or features.has("organizations:seer-added", self.organization, actor=self.user)
-        )
-
-        if has_context_engine:
+        if _has_context_engine(self.organization, self.user):
             chat_body["is_context_engine_enabled"] = True
 
         response = make_agent_chat_request(chat_body, viewer_context=self.viewer_context)

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -332,9 +332,17 @@ class SeerAgentClient:
         if ui_tools:
             chat_body["ui_tools"] = ui_tools
 
-        if features.has(
-            "organizations:seer-explorer-context-engine", self.organization, actor=self.user
-        ):
+        has_context_engine = (
+            features.has(
+                "organizations:seer-explorer-context-engine", self.organization, actor=self.user
+            )
+            or features.has(
+                "organizations:seat-based-seer-enabled", self.organization, actor=self.user
+            )
+            or features.has("organizations:seer-added", self.organization, actor=self.user)
+        )
+
+        if has_context_engine:
             if random.random() < options.get("seer.explorer.context-engine-rollout"):
                 chat_body["is_context_engine_enabled"] = True
 

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -465,11 +465,17 @@ class SeerAgentClient:
 
         # No random rollout here — Seer ANDs this with the persisted value from start_run,
         # so the start_run coin flip is the single source of truth.
-        if features.has(
-            "organizations:seer-explorer-context-engine",
-            self.organization,
-            actor=self.user,
-        ):
+        has_context_engine = (
+            features.has(
+                "organizations:seer-explorer-context-engine", self.organization, actor=self.user
+            )
+            or features.has(
+                "organizations:seat-based-seer-enabled", self.organization, actor=self.user
+            )
+            or features.has("organizations:seer-added", self.organization, actor=self.user)
+        )
+
+        if has_context_engine:
             chat_body["is_context_engine_enabled"] = True
 
         response = make_agent_chat_request(chat_body, viewer_context=self.viewer_context)


### PR DESCRIPTION
+ Extend the context engine eligibility check in start_run to also accept orgs on the seat-based or usage-based Seer plans, matching the same OR logic already used in the scheduled cron path (get_allowed_org_ids_context_engine_indexing). Previously only the seer-explorer-context-engine FlagPole flag was checked.
