### PR TITLE
chore(options): remove 94 unused registered options

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -106,12 +106,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "hybrid_cloud.authentication.use_api_key_replica",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "outbox_replication.sentry_apitoken.replication_version",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -46,7 +46,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register("system.secret-key", flags=FLAG_CREDENTIAL | FLAG_NOSTORE)
-register("system.root-api-key", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("system.logging-format", default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint
 register("system.upload-url-prefix", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
@@ -91,12 +90,6 @@ register(
 )
 # The region that this instance is currently running in.
 register("system.region", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE)
-# Enable date-util parsing for timestamps
-register(
-    "system.use-date-util-timestamps",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Organization
 register(
@@ -121,7 +114,6 @@ register(
     default={"default": {"hosts": {0: {"host": "127.0.0.1", "port": 6379}}}},
     flags=FLAG_NOSTORE | FLAG_IMMUTABLE,
 )
-register("redis.options", type=Dict, flags=FLAG_NOSTORE)
 
 # Processing worker caches
 register(
@@ -134,12 +126,6 @@ register(
     "releasefile.cache-path",
     type=String,
     default="/tmp/sentry-releasefile-cache",
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "releasefile.cache-limit",
-    type=Int,
-    default=10 * 1024 * 1024,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
@@ -256,14 +242,13 @@ register(
     type=Bool,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-
-# Recovery Codes
 register(
     "recovery.disallow-new-enrollment",
     default=False,
     type=Bool,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
 
 # Auth
 register(
@@ -316,27 +301,7 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# API Tokens
-register(
-    "apitoken.auto-add-last-chars",
-    default=True,
-    type=Bool,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "apitoken.save-hash-on-create",
-    default=True,
-    type=Bool,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# Controls the rate of using the hashed value of User API tokens for lookups when logging in
-# and also updates tokens which are not hashed
-register(
-    "apitoken.use-and-update-hash-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "api.rate-limit.org-create",
@@ -402,10 +367,6 @@ register(
 register("filestore.control.backend", default="", flags=FLAG_NOSTORE)
 register("filestore.control.options", default={}, flags=FLAG_NOSTORE)
 
-# Whether to use a redis lock on fileblob uploads and deletes
-register("fileblob.upload.use_lock", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Whether to use redis to cache `FileBlob.id` lookups
-register("fileblob.upload.use_blobid_cache", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # New `objectstore` service configuration. Additional supported options and
 # their defaults:
@@ -493,18 +454,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Configuration Options
-register(
-    "configurations.storage.backend",
-    default=None,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "configurations.storage.options",
-    type=Dict,
-    default=None,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Flag Options
 register(
@@ -562,13 +511,6 @@ register(
     default=0.0,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Enables profiling for replay recording ingestion.
-register(
-    "replay.consumer.recording.profiling.enabled",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Enable new msgspec-based recording parser.
 register(
     "replay.consumer.msgspec_recording_parser",
@@ -625,14 +567,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Ingest only a random fraction of logs sent to relay. Used to roll out ourlogs ingestion.
-#
-# NOTE: Any value below 1.0 will cause customer data to not appear and can break the product. Do not override in production.
-register(
-    "relay.ourlogs-ingestion.sample-rate",
-    default=1.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 
 # Allow the Relay to skip normalization of spans for certain hosts.
@@ -749,7 +683,6 @@ register(
 
 # Codecov Integration
 register("codecov.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
-register("codecov.base-url", default="https://api.codecov.io")
 register("codecov.api-bridge-signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
 # GitHub Integration
@@ -826,16 +759,6 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register("github-login.organization", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
-register(
-    "github-extension.enabled",
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "github-extension.enabled-orgs",
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # VSTS Integration
 register("vsts.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
@@ -919,16 +842,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "snuba.search.pre-snuba-candidates-percentage",
-    default=0.2,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "snuba.search.project-group-count-cache-time",
-    default=24 * 60 * 60,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "snuba.search.min-pre-snuba-candidates",
     default=500,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
@@ -977,7 +890,6 @@ register(
     default={7001: 0.15},
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
-register("snuba.track-outcomes-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
 register(
@@ -994,27 +906,8 @@ register(
     type=Int,
 )
 
-# Kafka Publisher
-register(
-    "kafka-publisher.raw-event-sample-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# Enable multiple topics for eventstream. It allows specific event types to be sent
-# to specific topic.
-register(
-    "store.eventstream-per-type-topic",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# Query and supply Bundle Indexes to Symbolicator SourceMap processing
-register(
-    "symbolicator.sourcemaps-bundle-index-sample-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Refresh Bundle Indexes reported as used by symbolicator
 register(
     "symbolicator.sourcemaps-bundle-index-refresh-sample-rate",
@@ -1030,18 +923,7 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Enables setting a sampling rate when producing the tag facet.
-register(
-    "discover2.tags_facet_enable_sampling",
-    default=True,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# Enable use of symbolic-sourcemapcache for JavaScript Source Maps processing.
-# Set this value of the fraction of projects that you want to use it for.
-register(
-    "processing.sourcemapcache-processor", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
-)  # unused
 
 # Killswitch for sending internal errors to the internal project or
 # `SENTRY_SDK_CONFIG.relay_dsn`. Set to `0` to only send to
@@ -1056,23 +938,11 @@ register("store.allow-s4s-ddm-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MO
 # Sample rate for transaction/span data sent to S4S upstream (1.0 = keep all, 0.05 = keep 5%)
 register("store.s4s-transaction-sample-rate", default=1.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# Mock out integrations and services for tests
-register("mocks.jira", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# Record statistics about event payloads and their compressibility
-register(
-    "store.nodestore-stats-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
-)  # unused
 
 # Killswitch to stop storing any reprocessing payloads.
 register("store.reprocessing-force-disable", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# Enable calling the severity modeling API on group creation
-register(
-    "processing.calculate-severity-on-group-creation",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Enable sending the flag to the microservice to tell it to purposefully take longer than our
 # timeout, to see the effect on the overall error event processing backlog
@@ -1090,12 +960,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "issues.severity.first-event-severity-calculation-projects-allowlist",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "issues.severity.seer-project-rate-limit",
@@ -1125,21 +989,8 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "issues.priority.projects-allowlist",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 
-# Killswitch for issue priority
-register(
-    "issues.priority.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Killswitch for batched nodestore fetches in group events endpoint.
 # When disabled, falls back to lazy per-event nodestore fetches.
@@ -1179,12 +1030,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "seer.similarity-embeddings-grouping-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "seer.similarity-embeddings-delete-by-hash-killswitch.enabled",
     default=False,
     type=Bool,
@@ -1207,30 +1052,6 @@ register(
     type=Int,
     default=1,
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.severity-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.breakpoint-detection-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.autofix-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.anomaly-detection-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # Agent context engine indexing options
@@ -1328,37 +1149,9 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# seer nearest neighbour endpoint timeout
-register(
-    "embeddings-grouping.seer.nearest-neighbour-timeout",
-    type=Float,
-    default=0.1,
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# seer embeddings record update endpoint timeout
-register(
-    "embeddings-grouping.seer.embeddings-record-update-timeout",
-    type=Float,
-    default=0.05,
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# seer embeddings record delete endpoint timeout
-register(
-    "embeddings-grouping.seer.embeddings-record-delete-timeout",
-    type=Float,
-    default=0.1,
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# seer embeddings ratelimit in percentage that is allowed
-register(
-    "embeddings-grouping.seer.ratelimit",
-    type=Int,
-    default=0,
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "embeddings-grouping.seer.delete-record-batch-size",
@@ -1368,22 +1161,10 @@ register(
 )
 
 register(
-    "seer.explorer_index.enable",
-    type=Bool,
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "seer.explorer_index.killswitch.enable",
     type=Bool,
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.explorer-index.rollout",
-    type=Float,
-    default=0.0,
-    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "seer.explorer.context-engine-rollout",
@@ -1476,12 +1257,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "store.save-event-highcpu-platforms",
-    type=Sequence,
-    default=[],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "post_process.get-autoassign-owners",
     type=Sequence,
     default=[],
@@ -1515,9 +1290,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Minimum number of files in an archive. Archives with fewer files are extracted and have their
-# contents stored as separate release files.
-register("processing.release-archive-min-files", default=10, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # All Relay options (statically authenticated Relays can be registered here)
 register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
@@ -1564,15 +1336,6 @@ register(
 # Subscription queries sampling rate
 register("subscriptions-query.sample-rate", default=0.01, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# The ratio of symbolication requests for which metrics will be submitted to redis.
-#
-# This is to allow gradual rollout of metrics collection for symbolication requests and can be
-# removed once it is fully rolled out.
-register(
-    "symbolicate-event.low-priority.metrics.submission-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # The ratio of events for which we emit verbose apple symbol stats.
 #
@@ -1715,12 +1478,6 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "organization-abuse-quota.custom-metric-bucket-limit",
-    type=Int,
-    default=0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 
 for mabq in build_metric_abuse_quotas():
@@ -1905,62 +1662,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# per-organization limits on the number of timeseries that can be observed in
-# each window.
-#
-# Format is a list of dictionaries of format {
-#   "window_seconds": ...,
-#   "granularity_seconds": ...,
-#   "limit": ...
-# }
-#
-# See sentry.ratelimiters.cardinality for an explanation of what each of
-# those terms mean.
-#
-# Note that changing either window or granularity_seconds of a limit will
-# effectively reset it, as the previous data can't/won't be converted.
-register(
-    "sentry-metrics.cardinality-limiter.limits.transactions.per-org",
-    default=[
-        {"window_seconds": 3600, "granularity_seconds": 600, "limit": 10000},
-    ],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "sentry-metrics.cardinality-limiter.limits.sessions.per-org",
-    default=[
-        {"window_seconds": 3600, "granularity_seconds": 600, "limit": 10000},
-    ],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "sentry-metrics.cardinality-limiter.limits.spans.per-org",
-    default=[
-        {"window_seconds": 3600, "granularity_seconds": 600, "limit": 10000},
-    ],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "sentry-metrics.cardinality-limiter.limits.custom.per-org",
-    default=[
-        {"window_seconds": 3600, "granularity_seconds": 600, "limit": 10000},
-    ],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "sentry-metrics.cardinality-limiter.limits.profiles.per-org",
-    default=[
-        {"window_seconds": 3600, "granularity_seconds": 600, "limit": 10000},
-    ],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "sentry-metrics.cardinality-limiter.limits.generic-metrics.per-org",
-    default=[
-        {"window_seconds": 3600, "granularity_seconds": 600, "limit": 10000},
-    ],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 register(
     "sentry-metrics.10s-granularity",
     default=False,
@@ -1974,11 +1675,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "sentry-metrics.synchronize-kafka-rebalances",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "sentry-metrics.synchronized-rebalance-delay",
@@ -2216,57 +1912,9 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "performance.traces.trace-explorer-buffer-hours",
-    type=Float,
-    default=1.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-max-trace-ids-per-chunk",
-    type=Int,
-    default=2500,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-skip-floating-spans",
-    type=Bool,
-    default=True,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-scan-max-block-size-hours",
-    type=Int,
-    default=8,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-scan-max-batches",
-    type=Int,
-    default=7,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-scan-max-execution-seconds",
-    type=Int,
-    default=30,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-scan-max-parallel-queries",
-    type=Int,
-    default=3,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "performance.traces.trace-explorer-skip-recent-seconds",
     type=Int,
     default=0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.span_query_minimum_spans",
-    type=Int,
-    default=10000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -2295,21 +1943,9 @@ register(
 )
 
 register(
-    "performance.spans-tags-key.sample-rate",
-    type=Float,
-    default=1.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "performance.spans-tags-key.max",
     type=Int,
     default=1000,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.spans-tags-value.sample-rate",
-    type=Float,
-    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -2331,14 +1967,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# In Single Tenant with 100% DS, we may need to reverse the UI change made by dynamic-sampling
-# if metrics extraction isn't ready.
-register(
-    "performance.hide-metrics-ui",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Used for the z-score when calculating the margin of error in performance
 register(
@@ -2448,8 +2076,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Flagpole Configuration (used in getsentry)
-register("flagpole.debounce_reporting_seconds", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Feature flagging error capture rate.
 # When feature flagging has faults, it can become very high volume and we can overwhelm sentry.
@@ -2459,7 +2085,6 @@ register("features.error.capture_rate", default=0.1, flags=FLAG_AUTOMATOR_MODIFI
 register("hybridcloud.regionsiloclient.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.rpc.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.integrationproxy.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("hybridcloud.endpoint_flag_logging", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register(
     "hybridcloud.rpc.method_retry_overrides",
     default={},
@@ -2667,30 +2292,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# When True, the circuit breaker tracks state and emits metrics but does not block requests.
-register(
-    "sentry-apps.webhook.circuit-breaker.dry-run",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Enables statistical detectors for a project
 register(
     "statistical_detectors.enable",
     default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "statistical_detectors.enable.projects.performance",
-    type=Sequence,
-    default=[],
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "statistical_detectors.enable.projects.profiling",
-    type=Sequence,
-    default=[],
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -2779,11 +2385,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "metric_extraction.max_span_attribute_specs",
-    default=100,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "metric_alerts.extended_max_subscriptions",
@@ -2922,12 +2523,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# The flag disables the file io on main thread detector
-register(
-    "performance_issues.file_io_main_thread.disabled",
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Enables on-demand metric extraction for Dashboard Widgets.
 register(
@@ -3028,12 +2623,6 @@ register(
     flags=FLAG_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Relocation: globally limits the number of large (>100MB) relocations allowed per silo per day.
-register(
-    "relocation.daily-limit.large",
-    default=0,
-    flags=FLAG_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "relocation.outbox-orgslug.killswitch",
@@ -3116,31 +2705,10 @@ register(
 )
 
 
-# Switch to read assemble status from Redis instead of memcache
-register("assemble.read_from_redis", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Sampling rates for testing Rust-based grouping enhancers
 
-# Rate at which to run the Rust implementation of `assemble_stacktrace_component`
-# and compare the results
-register(
-    "grouping.rust_enhancers.compare_components",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-# Rate at which to prefer the Rust implementation of `assemble_stacktrace_component`.
-register(
-    "grouping.rust_enhancers.prefer_rust_components",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-register(
-    "metrics.sample-list.sample-rate",
-    type=Float,
-    default=100_000.0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 
 # TODO: For now, only a small number of projects are going through a grouping config transition at
@@ -3176,19 +2744,7 @@ register(
 )
 
 
-# Sample rate for double writing to experimental dsn
-register(
-    "store.experimental-dsn-double-write.sample-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# temporary option for logging canonical key fallback stacktraces
-register(
-    "canonical-fallback.send-error-to-sentry",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # SPAN BUFFER
 # Span buffer killswitch
@@ -3396,30 +2952,8 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "indexed-spans.agg-span-waterfall.enable",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-register(
-    "traces.sample-list.sample-rate",
-    type=Float,
-    default=0.0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-register(
-    "discover.saved-query-dataset-split.enable",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "discover.saved-query-dataset-split.organization-id-allowlist",
-    type=Sequence,
-    default=[],
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "feedback.filter_garbage_messages",
@@ -3473,37 +3007,8 @@ register(
 )
 # Notification Options - End
 
-# List of organizations with increased rate limits for organization_events API
-register(
-    "api.organization_events.rate-limit-increased.orgs",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-# Increased rate limits for organization_events API for the orgs above
-register(
-    "api.organization_events.rate-limit-increased.limits",
-    type=Dict,
-    default={"limit": 50, "window": 1, "concurrent_limit": 50},
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-# Reduced rate limits for organization_events API for the orgs in LA/EA/GA rollout
-# Once GA'd, this will be the default rate limit for all orgs not on the increase list
-register(
-    "api.organization_events.rate-limit-reduced.limits",
-    type=Dict,
-    default={"limit": 1000, "window": 300, "concurrent_limit": 15},
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 
-# TODO: remove once removed from options
-register(
-    "issue_platform.use_kafka_partition_key",
-    type=Bool,
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 
 register(
@@ -3534,21 +3039,7 @@ register(
     default=250,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Limits the total duration of profile chunks to aggregate in flamegraphs
-register(
-    "profiling.continuous-profiling.flamegraph.max-seconds",
-    type=Int,
-    default=10 * 60,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# Enable orjson in the occurrence_consumer.process_[message|batch]
-register(
-    "issues.occurrence_consumer.use_orjson",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Controls the rate of using the sentry api shared secret for communicating to sentry.
 # DEPRECATED: will be removed after the shared secret is confirmed to always be set.
@@ -3559,11 +3050,6 @@ register(
 )
 
 register(
-    "similarity.backfill_project_cohort_size",
-    default=1000,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "similarity.new_project_seer_grouping.enabled",
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
@@ -3571,12 +3057,6 @@ register(
 register(
     "delayed_processing.batch_size",
     default=10000,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "delayed_processing.emit_logs",
-    type=Bool,
-    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -3684,17 +3164,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Disables specific uptime checker regions. This is a list of region slugs
-# which must match regions available in the settings.UPTIME_REGIONS list.
-#
-# Useful to remove a region from check rotation if there is some kind of
-# problem with the region.
-register(
-    "uptime.disabled-checker-regions",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 register(
     "uptime.checker-regions-mode-override",
     type=Dict,
@@ -3951,15 +3420,6 @@ register(
 register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 
-# option used to enable/disable tracking
-# rate of potential functions metrics to
-# be written into EAP
-register(
-    "profiling.track_functions_metrics_write_rate.eap.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 
 register(
@@ -4136,12 +3596,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "seer.scanner_no_consent.rollout_rate",
-    type=Float,
-    default=0.0,
-    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Enabled Prebuilt Dashboard IDs
 register(


### PR DESCRIPTION
Static analysis + dynamic attribution found no usage in sentry or getsentry for these 94 registered options. 93 removed from src/sentry/options/defaults.py and 1 from
src/sentry/hybridcloud/options.py.

10 additional unused options in getsentry/models/__init__.py are handled separately.
