### PR TITLE
ref(preprod): Standardize logging key to preprod_artifact_id

### DIFF
--- a/src/sentry/preprod/api/endpoints/builds.py
+++ b/src/sentry/preprod/api/endpoints/builds.py
@@ -36,7 +36,8 @@ class BuildsEndpoint(OrganizationEndpoint):
                     results.append(transform_preprod_artifact_to_build_details(artifact).dict())
                 except Exception:
                     logger.exception(
-                        "preprod.builds.transform_failed", extra={"artifact_id": artifact.id}
+                        "preprod.builds.transform_failed",
+                        extra={"preprod_artifact_id": artifact.id},
                     )
             return results
 

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -229,7 +229,7 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                     "project_id": project.id,
                     "checksum": checksum,
                     "chunks": chunks,
-                    "artifact_id": artifact.id,
+                    "preprod_artifact_id": artifact.id,
                     "build_configuration": data.get("build_configuration"),
                 }
             )

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -229,7 +229,7 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                     "project_id": project.id,
                     "checksum": checksum,
                     "chunks": chunks,
-                    "preprod_artifact_id": artifact.id,
+                    "artifact_id": artifact.id,
                     "build_configuration": data.get("build_configuration"),
                 }
             )

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_admin_info.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_admin_info.py
@@ -301,7 +301,7 @@ class PreprodArtifactAdminInfoEndpoint(Endpoint):
         logger.info(
             "preprod_artifact.admin_get_info",
             extra={
-                "artifact_id": head_artifact_id,
+                "preprod_artifact_id": head_artifact_id,
                 "user_id": request.user.id,
                 "organization_id": preprod_artifact.project.organization_id,
                 "project_id": preprod_artifact.project.id,

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
@@ -80,7 +80,7 @@ class PreprodArtifactRerunAnalysisEndpoint(PreprodArtifactEndpoint):
         logger.info(
             "preprod_artifact.rerun_analysis",
             extra={
-                "artifact_id": head_artifact_id,
+                "preprod_artifact_id": head_artifact_id,
                 "user_id": request.user.id,
                 "organization_id": organization.id,
                 "project_id": head_artifact.project.id,
@@ -159,7 +159,7 @@ class PreprodArtifactAdminRerunAnalysisEndpoint(Endpoint):
         logger.info(
             "preprod_artifact.admin_rerun_analysis",
             extra={
-                "artifact_id": preprod_artifact_id,
+                "preprod_artifact_id": preprod_artifact_id,
                 "user_id": request.user.id,
                 "organization_id": preprod_artifact.project.organization_id,
                 "project_id": preprod_artifact.project.id,
@@ -245,7 +245,7 @@ class PreprodArtifactAdminBatchRerunAnalysisEndpoint(Endpoint):
                 artifact.refresh_from_db()
 
             result: dict[str, object] = {
-                "artifact_id": str(artifact_id),
+                "preprod_artifact_id": str(artifact_id),
                 "success": dispatched,
                 "new_state": artifact.state,
                 "cleanup_stats": asdict(cleanup_stats),
@@ -258,7 +258,7 @@ class PreprodArtifactAdminBatchRerunAnalysisEndpoint(Endpoint):
                 logger.info(
                     "preprod_artifact.admin_batch_rerun_analysis",
                     extra={
-                        "artifact_id": artifact_id,
+                        "preprod_artifact_id": artifact_id,
                         "user_id": request.user.id,
                         "organization_id": organization.id,
                         "project_id": artifact.project.id,
@@ -338,7 +338,7 @@ def success_response(
 ) -> Response:
     response_data = {
         "success": True,
-        "artifact_id": artifact_id,
+        "preprod_artifact_id": artifact_id,
         "message": f"Analysis rerun initiated for artifact {artifact_id}",
         "new_state": state,
     }

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
@@ -245,7 +245,7 @@ class PreprodArtifactAdminBatchRerunAnalysisEndpoint(Endpoint):
                 artifact.refresh_from_db()
 
             result: dict[str, object] = {
-                "preprod_artifact_id": str(artifact_id),
+                "artifact_id": str(artifact_id),
                 "success": dispatched,
                 "new_state": artifact.state,
                 "cleanup_stats": asdict(cleanup_stats),
@@ -338,7 +338,7 @@ def success_response(
 ) -> Response:
     response_data = {
         "success": True,
-        "preprod_artifact_id": artifact_id,
+        "artifact_id": artifact_id,
         "message": f"Analysis rerun initiated for artifact {artifact_id}",
         "new_state": state,
     }

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_status_checks.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_status_checks.py
@@ -142,7 +142,7 @@ class PreprodArtifactRerunStatusChecksEndpoint(PreprodArtifactEndpoint):
         return Response(
             {
                 "success": True,
-                "preprod_artifact_id": str(head_artifact.id),
+                "artifact_id": str(head_artifact.id),
                 "message": f"Status check rerun initiated for artifact {head_artifact.id}",
                 "check_types": supported_types,
             },

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_status_checks.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_status_checks.py
@@ -110,7 +110,7 @@ class PreprodArtifactRerunStatusChecksEndpoint(PreprodArtifactEndpoint):
                 logger.exception(
                     "preprod_artifact.rerun_status_checks.task_error",
                     extra={
-                        "artifact_id": head_artifact.id,
+                        "preprod_artifact_id": head_artifact.id,
                         "user_id": request.user.id,
                         "organization_id": head_artifact.project.organization_id,
                         "project_id": head_artifact.project.id,
@@ -131,7 +131,7 @@ class PreprodArtifactRerunStatusChecksEndpoint(PreprodArtifactEndpoint):
         logger.info(
             "preprod_artifact.rerun_status_checks",
             extra={
-                "artifact_id": head_artifact.id,
+                "preprod_artifact_id": head_artifact.id,
                 "user_id": request.user.id,
                 "organization_id": head_artifact.project.organization_id,
                 "project_id": head_artifact.project.id,
@@ -142,7 +142,7 @@ class PreprodArtifactRerunStatusChecksEndpoint(PreprodArtifactEndpoint):
         return Response(
             {
                 "success": True,
-                "artifact_id": str(head_artifact.id),
+                "preprod_artifact_id": str(head_artifact.id),
                 "message": f"Status check rerun initiated for artifact {head_artifact.id}",
                 "check_types": supported_types,
             },

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -154,7 +154,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         except Exception:
             logger.exception(
                 "preprod_snapshot.delete_failed",
-                extra={"artifact_id": artifact.id},
+                extra={"preprod_artifact_id": artifact.id},
             )
             return Response(
                 {"detail": "Internal error deleting snapshot."},
@@ -175,7 +175,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         logger.info(
             "preprod_snapshot.deleted",
             extra={
-                "artifact_id": artifact.id,
+                "preprod_artifact_id": artifact.id,
                 "user_id": request.user.id if request.user else None,
                 "files_deleted": result.files_deleted,
                 "size_metrics_deleted": result.size_metrics_deleted,

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_assemble_generic.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_assemble_generic.py
@@ -160,7 +160,7 @@ class ProjectPreprodArtifactAssembleGenericEndpoint(ProjectEndpoint):
                         "project_id": project.id,
                         "checksum": checksum,
                         "chunks": chunks,
-                        "preprod_artifact_id": head_artifact_id,
+                        "artifact_id": head_artifact_id,
                     }
                 )
             elif assemble_type == AssembleType.INSTALLABLE_APP.value:
@@ -174,7 +174,7 @@ class ProjectPreprodArtifactAssembleGenericEndpoint(ProjectEndpoint):
                         "project_id": project.id,
                         "checksum": checksum,
                         "chunks": chunks,
-                        "preprod_artifact_id": head_artifact_id,
+                        "artifact_id": head_artifact_id,
                     }
                 )
             else:

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_assemble_generic.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_assemble_generic.py
@@ -160,7 +160,7 @@ class ProjectPreprodArtifactAssembleGenericEndpoint(ProjectEndpoint):
                         "project_id": project.id,
                         "checksum": checksum,
                         "chunks": chunks,
-                        "artifact_id": head_artifact_id,
+                        "preprod_artifact_id": head_artifact_id,
                     }
                 )
             elif assemble_type == AssembleType.INSTALLABLE_APP.value:
@@ -174,7 +174,7 @@ class ProjectPreprodArtifactAssembleGenericEndpoint(ProjectEndpoint):
                         "project_id": project.id,
                         "checksum": checksum,
                         "chunks": chunks,
-                        "artifact_id": head_artifact_id,
+                        "preprod_artifact_id": head_artifact_id,
                     }
                 )
             else:

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_delete.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_delete.py
@@ -48,7 +48,7 @@ class ProjectPreprodArtifactDeleteEndpoint(PreprodArtifactEndpoint):
         except Exception:
             logger.exception(
                 "preprod_artifact.delete_failed",
-                extra={"artifact_id": int(head_artifact_id), "user_id": request.user.id},
+                extra={"preprod_artifact_id": int(head_artifact_id), "user_id": request.user.id},
             )
             return Response(
                 {
@@ -61,7 +61,7 @@ class ProjectPreprodArtifactDeleteEndpoint(PreprodArtifactEndpoint):
         logger.info(
             "preprod_artifact.deleted",
             extra={
-                "artifact_id": int(head_artifact_id),
+                "preprod_artifact_id": int(head_artifact_id),
                 "user_id": request.user.id,
                 "files_deleted": result.files_deleted,
                 "size_metrics_deleted": result.size_metrics_deleted,
@@ -73,7 +73,7 @@ class ProjectPreprodArtifactDeleteEndpoint(PreprodArtifactEndpoint):
             {
                 "success": True,
                 "message": f"Artifact {head_artifact_id} deleted successfully.",
-                "artifact_id": str(head_artifact_id),
+                "preprod_artifact_id": str(head_artifact_id),
                 "files_deleted_count": result.files_deleted,
                 "size_metrics_deleted": result.size_metrics_deleted,
                 "installable_artifacts_deleted": result.installable_artifacts_deleted,

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_delete.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_delete.py
@@ -73,7 +73,7 @@ class ProjectPreprodArtifactDeleteEndpoint(PreprodArtifactEndpoint):
             {
                 "success": True,
                 "message": f"Artifact {head_artifact_id} deleted successfully.",
-                "preprod_artifact_id": str(head_artifact_id),
+                "artifact_id": str(head_artifact_id),
                 "files_deleted_count": result.files_deleted,
                 "size_metrics_deleted": result.size_metrics_deleted,
                 "installable_artifacts_deleted": result.installable_artifacts_deleted,

--- a/src/sentry/preprod/api/endpoints/public/organization_preprod_size_analysis.py
+++ b/src/sentry/preprod/api/endpoints/public/organization_preprod_size_analysis.py
@@ -147,7 +147,7 @@ class OrganizationPreprodPublicSizeAnalysisEndpoint(OrganizationEndpoint):
             sentry_sdk.capture_message(
                 "preprod.public_api.size_analysis.invalid_state",
                 level="warning",
-                extra={"artifact_id": head_artifact.id, "state": main_metric.state},
+                extra={"preprod_artifact_id": head_artifact.id, "state": main_metric.state},
             )
             return Response(
                 {"detail": "There was an error retrieving size analysis results"}, status=500
@@ -199,7 +199,7 @@ class OrganizationPreprodPublicSizeAnalysisEndpoint(OrganizationEndpoint):
             sentry_sdk.capture_message(
                 "preprod.public_api.size_analysis.no_file_id",
                 level="warning",
-                extra={"artifact_id": head_artifact.id, "size_metric_id": main_metric.id},
+                extra={"preprod_artifact_id": head_artifact.id, "size_metric_id": main_metric.id},
             )
             return Response(
                 {"detail": "There was an error retrieving size analysis results"}, status=500
@@ -211,7 +211,10 @@ class OrganizationPreprodPublicSizeAnalysisEndpoint(OrganizationEndpoint):
             sentry_sdk.capture_message(
                 "preprod.public_api.size_analysis.file_not_found",
                 level="warning",
-                extra={"artifact_id": head_artifact.id, "analysis_file_id": analysis_file_id},
+                extra={
+                    "preprod_artifact_id": head_artifact.id,
+                    "analysis_file_id": analysis_file_id,
+                },
             )
             return Response({"detail": "Analysis file not found"}, status=404)
 
@@ -223,7 +226,10 @@ class OrganizationPreprodPublicSizeAnalysisEndpoint(OrganizationEndpoint):
         except Exception:
             logger.exception(
                 "preprod.public_api.size_analysis.parse_error",
-                extra={"artifact_id": head_artifact.id, "analysis_file_id": analysis_file_id},
+                extra={
+                    "preprod_artifact_id": head_artifact.id,
+                    "analysis_file_id": analysis_file_id,
+                },
             )
             return Response(
                 {"detail": "There was an error retrieving size analysis results"}, status=500

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -444,7 +444,7 @@ def _parse_success_check(raw_size: dict[str, Any], artifact_id: int) -> StatusCh
         logger.warning(
             "preprod.build_details.invalid_check_id",
             extra={
-                "artifact_id": artifact_id,
+                "preprod_artifact_id": artifact_id,
                 "check_id_type": type(check_id).__name__,
             },
         )
@@ -463,7 +463,7 @@ def _parse_failure_check(raw_size: dict[str, Any], artifact_id: int) -> StatusCh
             logger.warning(
                 "preprod.build_details.invalid_error_type",
                 extra={
-                    "artifact_id": artifact_id,
+                    "preprod_artifact_id": artifact_id,
                     "error_type": error_type_str,
                 },
             )

--- a/src/sentry/preprod/api/models/public/installable_builds.py
+++ b/src/sentry/preprod/api/models/public/installable_builds.py
@@ -147,7 +147,7 @@ def build_build_distribution_summary(
             logger.warning(
                 "preprod.build_distribution.summary.both_file_and_error",
                 extra={
-                    "artifact_id": artifact.id,
+                    "preprod_artifact_id": artifact.id,
                     "error_code": error_code_value,
                 },
             )

--- a/src/sentry/preprod/build_distribution_webhooks.py
+++ b/src/sentry/preprod/build_distribution_webhooks.py
@@ -40,7 +40,7 @@ def build_webhook_payload(
     except PreprodArtifact.DoesNotExist:
         logger.warning(
             "preprod.build_distribution.webhook.artifact_not_found",
-            extra={"artifact_id": artifact.id},
+            extra={"preprod_artifact_id": artifact.id},
         )
         return None
 
@@ -49,7 +49,7 @@ def build_webhook_payload(
     except BuildDistributionSummaryBuildError:
         logger.exception(
             "preprod.build_distribution.webhook.build_error",
-            extra={"artifact_id": artifact.id},
+            extra={"preprod_artifact_id": artifact.id},
         )
         return None
 
@@ -69,7 +69,7 @@ def send_build_distribution_webhook(
         if payload is None:
             logger.info(
                 "preprod.build_distribution.webhook.no_payload",
-                extra={"artifact_id": artifact.id},
+                extra={"preprod_artifact_id": artifact.id},
             )
             return
 
@@ -83,7 +83,7 @@ def send_build_distribution_webhook(
         logger.exception(
             "preprod.build_distribution.webhook.failed",
             extra={
-                "artifact_id": artifact.id,
+                "preprod_artifact_id": artifact.id,
                 "organization_id": organization_id,
             },
         )

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -56,7 +56,7 @@ def _artifact_to_tags(artifact: PreprodArtifact) -> dict[str, str]:
     if artifact.artifact_type is not None:
         tags["artifact_type"] = PreprodArtifactModel.ArtifactType(artifact.artifact_type).to_str()
 
-    tags["artifact_id"] = str(artifact.id)
+    tags["preprod_artifact_id"] = str(artifact.id)
 
     return tags
 

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -56,7 +56,7 @@ def _artifact_to_tags(artifact: PreprodArtifact) -> dict[str, str]:
     if artifact.artifact_type is not None:
         tags["artifact_type"] = PreprodArtifactModel.ArtifactType(artifact.artifact_type).to_str()
 
-    tags["preprod_artifact_id"] = str(artifact.id)
+    tags["artifact_id"] = str(artifact.id)
 
     return tags
 

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -58,7 +58,7 @@ def compare_preprod_artifact_size_analysis(
 ) -> None:
     logger.info(
         "preprod.size_analysis.compare.start",
-        extra={"artifact_id": artifact_id},
+        extra={"preprod_artifact_id": artifact_id},
     )
 
     try:
@@ -71,7 +71,7 @@ def compare_preprod_artifact_size_analysis(
         logger.exception(
             "preprod.size_analysis.compare.artifact_not_found",
             extra={
-                "artifact_id": artifact_id,
+                "preprod_artifact_id": artifact_id,
             },
         )
         return
@@ -281,7 +281,7 @@ def compare_preprod_artifact_size_analysis(
         else:
             logger.info(
                 "preprod.size_analysis.compare.artifact_no_commit_comparison",
-                extra={"artifact_id": artifact_id},
+                extra={"preprod_artifact_id": artifact_id},
             )
     finally:
         send_size_analysis_webhook(artifact=artifact, organization_id=org_id)
@@ -612,7 +612,7 @@ def _maybe_emit_issues_from_diff_size_results(
     if not head_metrics:
         logger.info(
             "preprod.size_analysis.diff_results.no_head_metrics",
-            extra={"artifact_id": artifact.id},
+            extra={"preprod_artifact_id": artifact.id},
         )
         return
 
@@ -672,7 +672,7 @@ def _maybe_emit_issues_from_diff_size_results(
         if base_artifact is None:
             logger.info(
                 "preprod.size_analysis.diff_results.no_base",
-                extra={"detector_id": detector.id, "artifact_id": artifact.id},
+                extra={"detector_id": detector.id, "preprod_artifact_id": artifact.id},
             )
             continue
 
@@ -707,7 +707,7 @@ def _maybe_emit_issues_from_diff_size_results(
             "preprod.size_analysis.diff_results.evaluating",
             extra={
                 "detector_id": detector.id,
-                "artifact_id": artifact.id,
+                "preprod_artifact_id": artifact.id,
                 "base_artifact_id": base_artifact.id,
             },
         )

--- a/src/sentry/preprod/size_analysis/webhooks.py
+++ b/src/sentry/preprod/size_analysis/webhooks.py
@@ -41,7 +41,7 @@ def build_webhook_payload(
     except PreprodArtifact.DoesNotExist:
         logger.warning(
             "preprod.size_analysis.webhook.artifact_not_found",
-            extra={"artifact_id": artifact.id},
+            extra={"preprod_artifact_id": artifact.id},
         )
         return None
 
@@ -55,7 +55,7 @@ def build_webhook_payload(
     except SizeAnalysisSummaryBuildError:
         logger.exception(
             "preprod.size_analysis.webhook.build_error",
-            extra={"artifact_id": artifact.id},
+            extra={"preprod_artifact_id": artifact.id},
         )
         return None
 
@@ -75,7 +75,7 @@ def send_size_analysis_webhook(
         if payload is None:
             logger.info(
                 "preprod.size_analysis.webhook.no_payload",
-                extra={"artifact_id": artifact.id},
+                extra={"preprod_artifact_id": artifact.id},
             )
             return
 
@@ -89,7 +89,7 @@ def send_size_analysis_webhook(
         logger.exception(
             "preprod.size_analysis.webhook.failed",
             extra={
-                "artifact_id": artifact.id,
+                "preprod_artifact_id": artifact.id,
                 "organization_id": organization_id,
             },
         )

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -671,7 +671,7 @@ def _assemble_preprod_artifact_size_analysis(
         kwargs={
             "project_id": project.id,
             "org_id": org_id,
-            "preprod_artifact_id": artifact_id,
+            "artifact_id": artifact_id,
             "triggered_at": timezone.now().isoformat(),
         }
     )

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -671,7 +671,7 @@ def _assemble_preprod_artifact_size_analysis(
         kwargs={
             "project_id": project.id,
             "org_id": org_id,
-            "artifact_id": artifact_id,
+            "preprod_artifact_id": artifact_id,
             "triggered_at": timezone.now().isoformat(),
         }
     )
@@ -719,7 +719,7 @@ def _assemble_preprod_artifact_installable_app(
         logger.exception(
             "PreprodArtifact not found during installable app assembly",
             extra={
-                "artifact_id": artifact_id,
+                "preprod_artifact_id": artifact_id,
                 "project_id": project.id,
                 "organization_id": org_id,
             },
@@ -888,7 +888,7 @@ def detect_expired_preprod_artifacts() -> None:
                 "PreprodArtifact expired",
                 level="error",
                 extras={
-                    "artifact_id": artifact_id,
+                    "preprod_artifact_id": artifact_id,
                 },
             )
             try:
@@ -898,7 +898,7 @@ def detect_expired_preprod_artifacts() -> None:
             except Exception:
                 logger.exception(
                     "preprod.tasks.detect_expired_preprod_artifacts.failed_to_trigger_status_check",
-                    extra={"artifact_id": artifact_id},
+                    extra={"preprod_artifact_id": artifact_id},
                 )
 
     # Find expired PreprodArtifactSizeMetrics (those in PROCESSING state for more than 30 minutes)

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -58,14 +58,14 @@ def create_preprod_snapshot_pr_comment_task(
     except PreprodArtifact.DoesNotExist:
         logger.exception(
             "preprod.snapshot_pr_comments.create.artifact_not_found",
-            extra={"artifact_id": preprod_artifact_id, "caller": caller},
+            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
         )
         return
 
     if not artifact.commit_comparison:
         logger.info(
             "preprod.snapshot_pr_comments.create.no_commit_comparison",
-            extra={"artifact_id": artifact.id},
+            extra={"preprod_artifact_id": artifact.id},
         )
         return
 
@@ -78,7 +78,7 @@ def create_preprod_snapshot_pr_comment_task(
         logger.info(
             "preprod.snapshot_pr_comments.create.no_pr_info",
             extra={
-                "artifact_id": artifact.id,
+                "preprod_artifact_id": artifact.id,
                 "pr_number": commit_comparison.pr_number,
                 "head_repo_name": commit_comparison.head_repo_name,
             },
@@ -88,7 +88,7 @@ def create_preprod_snapshot_pr_comment_task(
     if not artifact.project.get_option(ENABLED_OPTION_KEY):
         logger.info(
             "preprod.snapshot_pr_comments.create.project_disabled",
-            extra={"artifact_id": artifact.id, "project_id": artifact.project.id},
+            extra={"preprod_artifact_id": artifact.id, "project_id": artifact.project.id},
         )
         return
 
@@ -96,7 +96,7 @@ def create_preprod_snapshot_pr_comment_task(
     if not features.has(FEATURE_FLAG, organization):
         logger.info(
             "preprod.snapshot_pr_comments.create.feature_disabled",
-            extra={"artifact_id": artifact.id, "organization_id": organization.id},
+            extra={"preprod_artifact_id": artifact.id, "organization_id": organization.id},
         )
         return
 
@@ -106,7 +106,7 @@ def create_preprod_snapshot_pr_comment_task(
     if not client:
         logger.info(
             "preprod.snapshot_pr_comments.create.no_client",
-            extra={"artifact_id": artifact.id},
+            extra={"preprod_artifact_id": artifact.id},
         )
         return
 
@@ -219,7 +219,7 @@ def create_preprod_snapshot_pr_comment_task(
             if not has_changes and not has_failures and not existing_comment_id:
                 logger.info(
                     "preprod.snapshot_pr_comments.create.skipped_no_diff",
-                    extra={"artifact_id": artifact.id},
+                    extra={"preprod_artifact_id": artifact.id},
                 )
                 return
 
@@ -324,7 +324,7 @@ def post_snapshot_pr_comment_task(
                     extra={
                         "commit_comparison_id": commit_comparison_id,
                         "organization_id": organization_id,
-                        "artifact_id": artifact_id,
+                        "preprod_artifact_id": artifact_id,
                         "comment_id": comment_id,
                     },
                 )

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -43,14 +43,14 @@ def create_preprod_pr_comment_task(
     except PreprodArtifact.DoesNotExist:
         logger.exception(
             "preprod.pr_comments.create.artifact_not_found",
-            extra={"artifact_id": preprod_artifact_id, "caller": caller},
+            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
         )
         return
 
     if not artifact.commit_comparison:
         logger.info(
             "preprod.pr_comments.create.no_commit_comparison",
-            extra={"artifact_id": artifact.id},
+            extra={"preprod_artifact_id": artifact.id},
         )
         return
 
@@ -63,7 +63,7 @@ def create_preprod_pr_comment_task(
         logger.info(
             "preprod.pr_comments.create.no_pr_info",
             extra={
-                "artifact_id": artifact.id,
+                "preprod_artifact_id": artifact.id,
                 "pr_number": commit_comparison.pr_number,
                 "head_repo_name": commit_comparison.head_repo_name,
             },
@@ -75,7 +75,7 @@ def create_preprod_pr_comment_task(
     ):
         logger.info(
             "preprod.pr_comments.create.project_disabled",
-            extra={"artifact_id": artifact.id, "project_id": artifact.project.id},
+            extra={"preprod_artifact_id": artifact.id, "project_id": artifact.project.id},
         )
         return
 
@@ -83,7 +83,7 @@ def create_preprod_pr_comment_task(
     if not features.has("organizations:preprod-build-distribution-pr-comments", organization):
         logger.info(
             "preprod.pr_comments.create.feature_disabled",
-            extra={"artifact_id": artifact.id, "organization_id": organization.id},
+            extra={"preprod_artifact_id": artifact.id, "organization_id": organization.id},
         )
         return
 
@@ -93,7 +93,7 @@ def create_preprod_pr_comment_task(
     if not client:
         logger.info(
             "preprod.pr_comments.create.no_client",
-            extra={"artifact_id": artifact.id},
+            extra={"preprod_artifact_id": artifact.id},
         )
         return
 
@@ -130,7 +130,7 @@ def create_preprod_pr_comment_task(
             logger.info(
                 "preprod.pr_comments.create.no_installable_artifacts",
                 extra={
-                    "artifact_id": artifact.id,
+                    "preprod_artifact_id": artifact.id,
                     "project_id": artifact.project.id,
                     "sibling_count": len(siblings),
                 },
@@ -151,7 +151,7 @@ def create_preprod_pr_comment_task(
                 comment_id = existing_comment_id
                 logger.info(
                     "preprod.pr_comments.create.updated",
-                    extra={"artifact_id": artifact.id, "comment_id": comment_id},
+                    extra={"preprod_artifact_id": artifact.id, "comment_id": comment_id},
                 )
             else:
                 resp = client.create_comment(
@@ -162,11 +162,11 @@ def create_preprod_pr_comment_task(
                 comment_id = str(resp["id"])
                 logger.info(
                     "preprod.pr_comments.create.created",
-                    extra={"artifact_id": artifact.id, "comment_id": comment_id},
+                    extra={"preprod_artifact_id": artifact.id, "comment_id": comment_id},
                 )
         except Exception as e:
             extra: dict[str, Any] = {
-                "artifact_id": artifact.id,
+                "preprod_artifact_id": artifact.id,
                 "organization_id": organization.id,
                 "error_type": type(e).__name__,
             }

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -125,26 +125,26 @@ def create_preprod_status_check_task(
     except PreprodArtifact.DoesNotExist:
         logger.exception(
             "preprod.status_checks.create.artifact_not_found",
-            extra={"artifact_id": preprod_artifact_id, "caller": caller},
+            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
         )
         return
 
     if not preprod_artifact or not isinstance(preprod_artifact, PreprodArtifact):
         logger.error(
             "preprod.status_checks.create.artifact_not_found",
-            extra={"artifact_id": preprod_artifact_id, "caller": caller},
+            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
         )
         return
 
     logger.info(
         "preprod.status_checks.create.start",
-        extra={"artifact_id": preprod_artifact.id, "caller": caller},
+        extra={"preprod_artifact_id": preprod_artifact.id, "caller": caller},
     )
 
     if not preprod_artifact.commit_comparison:
         logger.info(
             "preprod.status_checks.create.no_commit_comparison",
-            extra={"artifact_id": preprod_artifact.id},
+            extra={"preprod_artifact_id": preprod_artifact.id},
         )
         return
 
@@ -154,7 +154,7 @@ def create_preprod_status_check_task(
         logger.error(
             "preprod.status_checks.create.missing_git_info",
             extra={
-                "artifact_id": preprod_artifact.id,
+                "preprod_artifact_id": preprod_artifact.id,
                 "commit_comparison_id": commit_comparison.id,
             },
         )
@@ -165,7 +165,7 @@ def create_preprod_status_check_task(
         logger.info(
             "preprod.status_checks.create.disabled",
             extra={
-                "artifact_id": preprod_artifact.id,
+                "preprod_artifact_id": preprod_artifact.id,
                 "project_id": preprod_artifact.project.id,
             },
         )
@@ -226,7 +226,7 @@ def create_preprod_status_check_task(
     if not all_artifacts:
         logger.info(
             "preprod.status_checks.create.all_skipped",
-            extra={"artifact_id": preprod_artifact.id},
+            extra={"preprod_artifact_id": preprod_artifact.id},
         )
         title, subtitle, summary = format_all_skipped_messages(preprod_artifact.project)
         status = StatusCheckStatus.NEUTRAL
@@ -297,7 +297,7 @@ def create_preprod_status_check_task(
         )
     except Exception as e:
         extra: dict[str, Any] = {
-            "artifact_id": preprod_artifact.id,
+            "preprod_artifact_id": preprod_artifact.id,
             "organization_id": preprod_artifact.project.organization_id,
             "organization_slug": preprod_artifact.project.organization.slug,
             "error_type": type(e).__name__,
@@ -315,7 +315,7 @@ def create_preprod_status_check_task(
         logger.error(
             "preprod.status_checks.create.failed",
             extra={
-                "artifact_id": preprod_artifact.id,
+                "preprod_artifact_id": preprod_artifact.id,
                 "organization_id": preprod_artifact.project.organization_id,
                 "organization_slug": preprod_artifact.project.organization.slug,
                 "error_type": "null_check_id",
@@ -339,7 +339,7 @@ def create_preprod_status_check_task(
     logger.info(
         "preprod.status_checks.create.success",
         extra={
-            "artifact_id": preprod_artifact.id,
+            "preprod_artifact_id": preprod_artifact.id,
             "status": status.value,
             "check_id": check_id,
             "organization_id": preprod_artifact.project.organization_id,
@@ -636,7 +636,7 @@ def _compute_overall_status(
                             logger.info(
                                 "preprod.status_checks.rule_triggered",
                                 extra={
-                                    "artifact_id": artifact.id,
+                                    "preprod_artifact_id": artifact.id,
                                     "rule_id": rule.id,
                                     "metric": rule.metric,
                                     "measurement": rule.measurement,

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -73,26 +73,26 @@ def create_preprod_snapshot_status_check_task(
     except PreprodArtifact.DoesNotExist:
         logger.exception(
             "preprod.snapshot_status_checks.create.artifact_not_found",
-            extra={"artifact_id": preprod_artifact_id, "caller": caller},
+            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
         )
         return
 
     if not preprod_artifact or not isinstance(preprod_artifact, PreprodArtifact):
         logger.error(
             "preprod.snapshot_status_checks.create.artifact_not_found",
-            extra={"artifact_id": preprod_artifact_id, "caller": caller},
+            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
         )
         return
 
     logger.info(
         "preprod.snapshot_status_checks.create.start",
-        extra={"artifact_id": preprod_artifact.id, "caller": caller},
+        extra={"preprod_artifact_id": preprod_artifact.id, "caller": caller},
     )
 
     if not preprod_artifact.commit_comparison:
         logger.info(
             "preprod.snapshot_status_checks.create.no_commit_comparison",
-            extra={"artifact_id": preprod_artifact.id},
+            extra={"preprod_artifact_id": preprod_artifact.id},
         )
         return
 
@@ -101,7 +101,7 @@ def create_preprod_snapshot_status_check_task(
         logger.error(
             "preprod.snapshot_status_checks.create.missing_git_info",
             extra={
-                "artifact_id": preprod_artifact.id,
+                "preprod_artifact_id": preprod_artifact.id,
                 "commit_comparison_id": commit_comparison.id,
             },
         )
@@ -112,7 +112,7 @@ def create_preprod_snapshot_status_check_task(
         logger.info(
             "preprod.snapshot_status_checks.create.disabled",
             extra={
-                "artifact_id": preprod_artifact.id,
+                "preprod_artifact_id": preprod_artifact.id,
                 "project_id": preprod_artifact.project.id,
             },
         )
@@ -137,7 +137,7 @@ def create_preprod_snapshot_status_check_task(
     if not all_artifacts:
         logger.info(
             "preprod.snapshot_status_checks.create.no_snapshot_metrics",
-            extra={"artifact_id": preprod_artifact.id},
+            extra={"preprod_artifact_id": preprod_artifact.id},
         )
         return
 
@@ -243,7 +243,7 @@ def create_preprod_snapshot_status_check_task(
                 logger.info(
                     "preprod.snapshot_status_checks.create.missing_base_grace_period",
                     extra={
-                        "artifact_id": preprod_artifact.id,
+                        "preprod_artifact_id": preprod_artifact.id,
                         "countdown": MISSING_BASE_GRACE_PERIOD_SECONDS,
                     },
                 )
@@ -394,7 +394,7 @@ def post_snapshot_status_check_task(
     except PreprodArtifact.DoesNotExist:
         logger.info(
             "preprod.snapshot_status_checks.post.artifact_not_found",
-            extra={"artifact_id": preprod_artifact_id},
+            extra={"preprod_artifact_id": preprod_artifact_id},
         )
         return
 
@@ -402,7 +402,7 @@ def post_snapshot_status_check_task(
     if not commit_comparison:
         logger.info(
             "preprod.snapshot_status_checks.post.no_commit_comparison",
-            extra={"artifact_id": preprod_artifact_id},
+            extra={"preprod_artifact_id": preprod_artifact_id},
         )
         return
 
@@ -445,7 +445,7 @@ def post_snapshot_status_check_task(
         )
     except Exception as e:
         extra: dict[str, Any] = {
-            "artifact_id": preprod_artifact.id,
+            "preprod_artifact_id": preprod_artifact.id,
             "organization_id": preprod_artifact.project.organization_id,
             "error_type": type(e).__name__,
         }
@@ -460,7 +460,7 @@ def post_snapshot_status_check_task(
     if check_id is None:
         logger.error(
             "preprod.snapshot_status_checks.post.null_check_id",
-            extra={"artifact_id": preprod_artifact.id},
+            extra={"preprod_artifact_id": preprod_artifact.id},
         )
         update_posted_status_check(preprod_artifact, check_type="snapshots", success=False)
         return
@@ -471,7 +471,7 @@ def post_snapshot_status_check_task(
     logger.info(
         "preprod.snapshot_status_checks.post.success",
         extra={
-            "artifact_id": preprod_artifact.id,
+            "preprod_artifact_id": preprod_artifact.id,
             "organization_id": preprod_artifact.project.organization_id,
             "check_id": check_id,
         },

--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -113,7 +113,7 @@ def handle_preprod_check_run_event(
     except PreprodArtifact.DoesNotExist:
         logger.warning(
             Log.ARTIFACT_NOT_FOUND,
-            extra={**extra, "artifact_id": artifact_id},
+            extra={**extra, "preprod_artifact_id": artifact_id},
         )
         metrics.incr(Log.ARTIFACT_NOT_FOUND)
         return
@@ -195,7 +195,7 @@ def handle_preprod_check_run_event(
         Log.APPROVALS_CREATED,
         extra={
             **extra,
-            "artifact_id": artifact_id,
+            "preprod_artifact_id": artifact_id,
             "sibling_count": len(sibling_artifacts),
             "approvals_created": approvals_created,
         },

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -671,8 +671,8 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert event_data["tags"]["head.app_id"] == "com.example.app"
         assert event_data["tags"]["base.app_id"] == "com.example.app"
         assert event_data["tags"]["head.artifact_type"] == "apk"
-        assert event_data["tags"]["head.artifact_id"] == str(head_artifact.id)
-        assert event_data["tags"]["base.artifact_id"] == str(base_artifact.id)
+        assert event_data["tags"]["head.preprod_artifact_id"] == str(head_artifact.id)
+        assert event_data["tags"]["base.preprod_artifact_id"] == str(base_artifact.id)
         assert event_data["tags"]["git.sha"] == "a" * 40
         assert event_data["tags"]["git.branch"] == "feature/test-branch"
         assert event_data["tags"]["git.repo"] == "owner/repo"
@@ -738,7 +738,7 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert event_data["platform"] == "apple"
         assert event_data["tags"]["regression_kind"] == "download"
         assert event_data["tags"]["head.app_name"] == "MyApp"
-        assert event_data["tags"]["head.artifact_id"] == str(head_artifact.id)
+        assert event_data["tags"]["head.preprod_artifact_id"] == str(head_artifact.id)
         assert event_data["tags"]["git.sha"] == "c" * 40
         assert event_data["tags"]["git.branch"] == "feature/download-test"
         assert event_data["tags"]["git.repo"] == "owner/repo"
@@ -776,8 +776,8 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         event_data = result[None].event_data
         assert event_data is not None
 
-        assert event_data["tags"]["head.artifact_id"] == str(head_artifact.id)
-        assert event_data["tags"]["base.artifact_id"] == str(base_artifact.id)
+        assert event_data["tags"]["head.preprod_artifact_id"] == str(head_artifact.id)
+        assert event_data["tags"]["base.preprod_artifact_id"] == str(base_artifact.id)
         assert "git.sha" not in event_data["tags"]
         assert "git.branch" not in event_data["tags"]
         assert "git.repo" not in event_data["tags"]

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -415,4 +415,4 @@ class ArtifactToTagsTest(TestCase):
 
         tags = _artifact_to_tags(artifact)
 
-        assert tags == {"app_id": "com.example.app", "artifact_id": str(artifact.id)}
+        assert tags == {"app_id": "com.example.app", "preprod_artifact_id": str(artifact.id)}

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -1158,7 +1158,9 @@ class DetectExpiredPreprodArtifactsTest(TestCase):
 
             # Verify the message text and parameters
             call_args_list = mock_capture_message.call_args_list
-            captured_artifact_ids = [call[1]["extras"]["artifact_id"] for call in call_args_list]
+            captured_artifact_ids = [
+                call[1]["extras"]["preprod_artifact_id"] for call in call_args_list
+            ]
 
             assert expired_artifact_1.id in captured_artifact_ids
             assert expired_artifact_2.id in captured_artifact_ids
@@ -1167,7 +1169,7 @@ class DetectExpiredPreprodArtifactsTest(TestCase):
             for call in call_args_list:
                 assert call[0][0] == "PreprodArtifact expired"
                 assert call[1]["level"] == "error"
-                assert "artifact_id" in call[1]["extras"]
+                assert "preprod_artifact_id" in call[1]["extras"]
 
     def test_detect_expired_preprod_artifacts_mixed_states(self) -> None:
         """Test that only artifacts in the right states are considered for expiration"""


### PR DESCRIPTION
Logging and SDK tags inconsistently used both `artifact_id` and `preprod_artifact_id` across preprod code, making it difficult to search and filter logs in Sentry (you'd have to query for both key names to find all logs for a given artifact).

This standardizes all logging extra fields, SDK tags, and test assertions to use `preprod_artifact_id`, which is more specific and avoids ambiguity with other artifact concepts in Sentry (release artifacts, debug artifacts, etc.).

API parameter definitions (`name="artifact_id"`) are left unchanged since they are URL/query parameters, not observability keys.

Companion PR in launchpad: https://github.com/getsentry/launchpad/pull/620