### PR TITLE
fix(pageFilters): cmd-shift-click toggles single option

### DIFF
--- a/static/app/components/pageFilters/useStagedCompactSelect.spec.tsx
+++ b/static/app/components/pageFilters/useStagedCompactSelect.spec.tsx
@@ -927,6 +927,70 @@ describe('useStagedCompactSelect', () => {
       expect(onChange).toHaveBeenLastCalledWith(['one', 'three']);
     });
 
+    it('Cmd/Ctrl takes precedence over Shift when both are held', async () => {
+      const onChange = jest.fn();
+
+      function TestComponent() {
+        const [value, setValue] = useState<string[]>([]);
+        const toggleOptionRef = useRef<((val: string) => void) | undefined>(undefined);
+        const options = useTestOptions(toggleOptionRef);
+        const handleChange = (newValue: string[]) => {
+          onChange(newValue);
+          setValue(newValue);
+        };
+        const stagedSelect = useStagedCompactSelect({
+          value,
+          options,
+          onChange: handleChange,
+          multiple: true,
+        });
+        toggleOptionRef.current = stagedSelect.toggleOption;
+
+        return (
+          <CompactSelect
+            grid
+            multiple
+            search
+            {...stagedSelect.compactSelectProps}
+            menuFooter={
+              xor(stagedSelect.value, value).length > 0 ? (
+                <Flex>
+                  <MenuComponents.ApplyButton
+                    onClick={() => {
+                      stagedSelect.dispatch({type: 'remove staged'});
+                      handleChange(stagedSelect.value);
+                    }}
+                  />
+                </Flex>
+              ) : null
+            }
+          />
+        );
+      }
+
+      render(<TestComponent />);
+
+      // Open the menu
+      await userEvent.click(screen.getByRole('button', {expanded: false}));
+
+      // Ctrl-click row for Option One to set the anchor
+      await userEvent.keyboard('{Control>}');
+      await userEvent.click(screen.getByRole('row', {name: 'Option One'}));
+      await userEvent.keyboard('{/Control}');
+
+      // Ctrl+Shift-click row for Option Three. Ctrl should win and toggle a
+      // single option rather than range-selecting Option Two as well.
+      await userEvent.keyboard('{Control>}{Shift>}');
+      await userEvent.click(screen.getByRole('row', {name: 'Option Three'}));
+      await userEvent.keyboard('{/Shift}{/Control}');
+
+      // Apply the changes
+      await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+
+      // Should only select options one and three (not two)
+      expect(onChange).toHaveBeenLastCalledWith(['one', 'three']);
+    });
+
     it('resets anchor on menu open so shift+click never ranges across sessions', async () => {
       const onChange = jest.fn();
 

--- a/static/app/components/pageFilters/useStagedCompactSelect.spec.tsx
+++ b/static/app/components/pageFilters/useStagedCompactSelect.spec.tsx
@@ -55,6 +55,44 @@ function useTestOptions(
   ];
 }
 
+function StagedSelectTestComponent({onChange}: {onChange: (value: string[]) => void}) {
+  const [value, setValue] = useState<string[]>([]);
+  const toggleOptionRef = useRef<((val: string) => void) | undefined>(undefined);
+  const options = useTestOptions(toggleOptionRef);
+  const handleChange = (newValue: string[]) => {
+    onChange(newValue);
+    setValue(newValue);
+  };
+  const stagedSelect = useStagedCompactSelect({
+    value,
+    options,
+    onChange: handleChange,
+    multiple: true,
+  });
+  toggleOptionRef.current = stagedSelect.toggleOption;
+
+  return (
+    <CompactSelect
+      grid
+      multiple
+      search
+      {...stagedSelect.compactSelectProps}
+      menuFooter={
+        xor(stagedSelect.value, value).length > 0 ? (
+          <Flex>
+            <MenuComponents.ApplyButton
+              onClick={() => {
+                stagedSelect.dispatch({type: 'remove staged'});
+                handleChange(stagedSelect.value);
+              }}
+            />
+          </Flex>
+        ) : null
+      }
+    />
+  );
+}
+
 describe('useStagedCompactSelect', () => {
   it('renders', async () => {
     function TestComponent() {
@@ -929,65 +967,21 @@ describe('useStagedCompactSelect', () => {
 
     it('Cmd/Ctrl takes precedence over Shift when both are held', async () => {
       const onChange = jest.fn();
+      render(<StagedSelectTestComponent onChange={onChange} />);
 
-      function TestComponent() {
-        const [value, setValue] = useState<string[]>([]);
-        const toggleOptionRef = useRef<((val: string) => void) | undefined>(undefined);
-        const options = useTestOptions(toggleOptionRef);
-        const handleChange = (newValue: string[]) => {
-          onChange(newValue);
-          setValue(newValue);
-        };
-        const stagedSelect = useStagedCompactSelect({
-          value,
-          options,
-          onChange: handleChange,
-          multiple: true,
-        });
-        toggleOptionRef.current = stagedSelect.toggleOption;
-
-        return (
-          <CompactSelect
-            grid
-            multiple
-            search
-            {...stagedSelect.compactSelectProps}
-            menuFooter={
-              xor(stagedSelect.value, value).length > 0 ? (
-                <Flex>
-                  <MenuComponents.ApplyButton
-                    onClick={() => {
-                      stagedSelect.dispatch({type: 'remove staged'});
-                      handleChange(stagedSelect.value);
-                    }}
-                  />
-                </Flex>
-              ) : null
-            }
-          />
-        );
-      }
-
-      render(<TestComponent />);
-
-      // Open the menu
       await userEvent.click(screen.getByRole('button', {expanded: false}));
 
-      // Ctrl-click row for Option One to set the anchor
       await userEvent.keyboard('{Control>}');
       await userEvent.click(screen.getByRole('row', {name: 'Option One'}));
       await userEvent.keyboard('{/Control}');
 
-      // Ctrl+Shift-click row for Option Three. Ctrl should win and toggle a
-      // single option rather than range-selecting Option Two as well.
+      // Ctrl should win when both are held — single toggle, not range select.
       await userEvent.keyboard('{Control>}{Shift>}');
       await userEvent.click(screen.getByRole('row', {name: 'Option Three'}));
       await userEvent.keyboard('{/Shift}{/Control}');
 
-      // Apply the changes
       await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
 
-      // Should only select options one and three (not two)
       expect(onChange).toHaveBeenLastCalledWith(['one', 'three']);
     });
 

--- a/static/app/components/pageFilters/useStagedCompactSelect.tsx
+++ b/static/app/components/pageFilters/useStagedCompactSelect.tsx
@@ -407,11 +407,12 @@ export function useStagedCompactSelect<Value extends SelectKey>({
 
   useEffect(() => {
     const onKeyChange = (e: KeyboardEvent) => {
-      keyRef.current = e.shiftKey
-        ? 'shift'
-        : (isAppleDevice() ? e.altKey : e.ctrlKey) || (isMac() ? e.metaKey : e.ctrlKey)
-          ? 'modifier'
-          : null;
+      // Cmd/Ctrl takes precedence over Shift when both are held so that
+      // Cmd+Shift+Click toggles a single option instead of selecting the
+      // entire range from the last anchor.
+      const isModifier =
+        (isAppleDevice() ? e.altKey : e.ctrlKey) || (isMac() ? e.metaKey : e.ctrlKey);
+      keyRef.current = isModifier ? 'modifier' : e.shiftKey ? 'shift' : null;
       setModifierActive(!!keyRef.current);
     };
     // Reset modifier state when the window loses focus so that held keys

--- a/static/app/components/pageFilters/useStagedCompactSelect.tsx
+++ b/static/app/components/pageFilters/useStagedCompactSelect.tsx
@@ -407,9 +407,6 @@ export function useStagedCompactSelect<Value extends SelectKey>({
 
   useEffect(() => {
     const onKeyChange = (e: KeyboardEvent) => {
-      // Cmd/Ctrl takes precedence over Shift when both are held so that
-      // Cmd+Shift+Click toggles a single option instead of selecting the
-      // entire range from the last anchor.
       const isModifier =
         (isAppleDevice() ? e.altKey : e.ctrlKey) || (isMac() ? e.metaKey : e.ctrlKey);
       keyRef.current = isModifier ? 'modifier' : e.shiftKey ? 'shift' : null;


### PR DESCRIPTION
Cmd+Shift+Click in the project/environment page filter (and any other consumer of `useStagedCompactSelect`) currently selects every option between the last-clicked anchor and the click target, instead of toggling a single option.

The modifier-key detection in `useStagedCompactSelect` checked `e.shiftKey` first, so any time Shift was held the click was routed through `shiftToggleRange` even when Cmd/Ctrl was held too. That meant there was no way to do a single-toggle Cmd-click without first releasing Shift, and unintended options got pulled in.

Give Cmd/Ctrl precedence over Shift when both are held so Cmd+Shift+Click behaves like Cmd+Click (toggle one option). Shift-only range selection is unchanged. Added a regression test in the existing shift-click range selection suite.