### PR TITLE
chore(dynamic-sampling): cleanup transaction based health check rule

### DIFF
--- a/src/sentry/dynamic_sampling/__init__.py
+++ b/src/sentry/dynamic_sampling/__init__.py
@@ -1,7 +1,6 @@
 from .rules.base import generate_rules
 from .rules.biases.boost_environments_bias import ENVIRONMENT_GLOBS, BoostEnvironmentsBias
 from .rules.biases.boost_latest_releases_bias import BoostLatestReleasesBias
-from .rules.biases.ignore_health_checks_bias import IgnoreHealthChecksTransactionBias
 from .rules.helpers.latest_releases import (
     ExtendedBoostedRelease,
     ProjectBoostedReleases,
@@ -29,7 +28,6 @@ __all__ = [
     "ExtendedBoostedRelease",
     "ProjectBoostedReleases",
     "Platform",
-    "IgnoreHealthChecksTransactionBias",
     "BoostEnvironmentsBias",
     "BoostLatestReleasesBias",
     "LATEST_RELEASE_TTAS",

--- a/src/sentry/dynamic_sampling/rules/biases/ignore_health_checks_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/ignore_health_checks_bias.py
@@ -2,36 +2,11 @@ from sentry.constants import HEALTH_CHECK_GLOBS
 from sentry.dynamic_sampling.rules.biases.base import Bias
 from sentry.dynamic_sampling.rules.utils import (
     IGNORE_HEALTH_CHECKS_FACTOR_TRACES,
-    IGNORE_HEALTH_CHECKS_FACTOR_TRANSACTIONS,
     RESERVED_IDS,
     PolymorphicRule,
     RuleType,
 )
 from sentry.models.project import Project
-
-
-class IgnoreHealthChecksTransactionBias(Bias):
-    def generate_rules(self, project: Project, base_sample_rate: float) -> list[PolymorphicRule]:
-        return [
-            {
-                "samplingValue": {
-                    "type": "sampleRate",
-                    "value": base_sample_rate / IGNORE_HEALTH_CHECKS_FACTOR_TRANSACTIONS,
-                },
-                "type": "transaction",
-                "condition": {
-                    "op": "or",
-                    "inner": [
-                        {
-                            "op": "glob",
-                            "name": "event.transaction",
-                            "value": HEALTH_CHECK_GLOBS,
-                        }
-                    ],
-                },
-                "id": RESERVED_IDS[RuleType.IGNORE_HEALTH_CHECKS_RULE],
-            }
-        ]
 
 
 class IgnoreHealthChecksTraceBias(Bias):

--- a/src/sentry/dynamic_sampling/rules/combine.py
+++ b/src/sentry/dynamic_sampling/rules/combine.py
@@ -12,7 +12,6 @@ from sentry.dynamic_sampling.rules.biases.boost_low_volume_transactions_bias imp
 from sentry.dynamic_sampling.rules.biases.boost_replay_id_bias import BoostReplayIdBias
 from sentry.dynamic_sampling.rules.biases.ignore_health_checks_bias import (
     IgnoreHealthChecksTraceBias,
-    IgnoreHealthChecksTransactionBias,
 )
 from sentry.dynamic_sampling.rules.biases.minimum_sample_rate_bias import MinimumSampleRateBias
 from sentry.dynamic_sampling.rules.biases.recalibration_bias import RecalibrationBias
@@ -21,19 +20,10 @@ from sentry.models.organization import Organization
 
 
 def get_relay_biases(organization: Organization) -> dict[RuleType, Bias]:
-    is_health_checks_trace_based = features.has(
-        "organizations:ds-health-checks-trace-based", organization, actor=None
-    )
     default_combinator = OrderedBiasesCombinator()
-    default_combinator.add_if(
+    default_combinator.add(
         RuleType.IGNORE_HEALTH_CHECKS_RULE,
         IgnoreHealthChecksTraceBias(),
-        lambda: is_health_checks_trace_based,
-    )
-    default_combinator.add_if(
-        RuleType.IGNORE_HEALTH_CHECKS_RULE,
-        IgnoreHealthChecksTransactionBias(),
-        lambda: not is_health_checks_trace_based,
     )
 
     default_combinator.add(RuleType.BOOST_REPLAY_ID_RULE, BoostReplayIdBias())

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -106,8 +106,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:migrate-transaction-alerts-to-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable migration of AM1 metrics alerts to transactions
     manager.add("organizations:migrate-am1-metrics-alerts-to-transactions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable trace-based health checks rule in dynamic sampling
-    manager.add("organizations:ds-health-checks-trace-based", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=False)
     # Enable custom dynamic sampling rates
     manager.add("organizations:dynamic-sampling-custom", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable dynamic sampling minimum sample rate

--- a/tests/sentry/dynamic_sampling/rules/biases/test_ignore_health_checks_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_ignore_health_checks_bias.py
@@ -5,33 +5,8 @@ import pytest
 from sentry.constants import HEALTH_CHECK_GLOBS
 from sentry.dynamic_sampling.rules.biases.ignore_health_checks_bias import (
     IgnoreHealthChecksTraceBias,
-    IgnoreHealthChecksTransactionBias,
 )
 from sentry.testutils.pytest.fixtures import django_db_all
-
-
-@django_db_all
-def test_generate_bias_rules_v2(default_project) -> None:
-    rules = IgnoreHealthChecksTransactionBias().generate_rules(
-        project=default_project, base_sample_rate=1.0
-    )
-    assert rules == [
-        {
-            "condition": {
-                "inner": [
-                    {
-                        "name": "event.transaction",
-                        "op": "glob",
-                        "value": HEALTH_CHECK_GLOBS,
-                    }
-                ],
-                "op": "or",
-            },
-            "id": 1002,
-            "samplingValue": {"type": "sampleRate", "value": 0.2},
-            "type": "transaction",
-        }
-    ]
 
 
 @django_db_all

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -904,25 +904,14 @@ def test_generate_rules_trace_health_checks_feature_enabled(
             {"id": RuleType.BOOST_REPLAY_ID_RULE.value, "active": False},
         ],
     )
-
     rules = generate_rules(default_old_project)
     assert len(rules) == 2
     assert rules[0]["id"] == 1002
-    assert rules[0]["type"] == "transaction"
+    assert rules[0]["type"] == "trace"
     assert rules[0]["condition"]["op"] == "or"
     assert rules[0]["condition"]["inner"][0]["op"] == "glob"
-    assert rules[0]["condition"]["inner"][0]["name"] == "event.transaction"
+    assert rules[0]["condition"]["inner"][0]["name"] == "trace.transaction"
     assert rules[0]["condition"]["inner"][0]["value"] == HEALTH_CHECK_GLOBS
-
-    with Feature({"organizations:ds-health-checks-trace-based": True}):
-        rules = generate_rules(default_old_project)
-        assert len(rules) == 2
-        assert rules[0]["id"] == 1002
-        assert rules[0]["type"] == "trace"
-        assert rules[0]["condition"]["op"] == "or"
-        assert rules[0]["condition"]["inner"][0]["op"] == "glob"
-        assert rules[0]["condition"]["inner"][0]["name"] == "trace.transaction"
-        assert rules[0]["condition"]["inner"][0]["value"] == HEALTH_CHECK_GLOBS
 
     _validate_rules(default_old_project)
 

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -164,14 +164,14 @@ def test_generate_rules_return_uniform_rules_and_env_rule(
     # no need to create real project in DB
     assert generate_rules(default_old_project) == [
         {
-            "samplingValue": {"type": "sampleRate", "value": 0.02},
-            "type": "transaction",
+            "samplingValue": {"type": "sampleRate", "value": 0.03333333333333333},
+            "type": "trace",
             "condition": {
                 "op": "or",
                 "inner": [
                     {
                         "op": "glob",
-                        "name": "event.transaction",
+                        "name": "trace.transaction",
                         "value": HEALTH_CHECK_GLOBS,
                     }
                 ],
@@ -839,7 +839,7 @@ def test_generate_rules_minimum_sample_rate_correct_order(
 
         # Health checks rule should be first (lowest sample rate)
         assert rules[0]["id"] == 1002
-        assert rules[0]["samplingValue"]["value"] == 0.4 / 5  # IGNORE_HEALTH_CHECKS_FACTOR = 5
+        assert rules[0]["samplingValue"]["value"] == 0.4 / 3  # IGNORE_HEALTH_CHECKS_FACTOR = 5
 
         # Replay ID rule should be second
         assert rules[1]["id"] == 1005

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -330,14 +330,14 @@ def test_project_config_with_all_biases_enabled(
         "version": 2,
         "rules": [
             {
-                "samplingValue": {"type": "sampleRate", "value": 0.02},
-                "type": "transaction",
+                "samplingValue": {"type": "sampleRate", "value": 0.1 / 3},
+                "type": "trace",
                 "condition": {
                     "op": "or",
                     "inner": [
                         {
                             "op": "glob",
-                            "name": "event.transaction",
+                            "name": "trace.transaction",
                             "value": HEALTH_CHECK_GLOBS,
                         }
                     ],

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -459,7 +459,6 @@ def test_project_config_with_trace_health_checks_enabled(
     with Feature(
         {
             "organizations:dynamic-sampling": True,
-            "organizations:ds-health-checks-trace-based": True,
         }
     ):
         with patch(


### PR DESCRIPTION
- We've dialed in the new trace based health check bias to end up roughly with the same volume as the previous transaction based ruleset
- Clean up the rule & all associated artifacts