### PR TITLE
fix(pageFilters): clear shift-click anchor on empty selection

### DIFF
--- a/static/app/components/pageFilters/useStagedCompactSelect.spec.tsx
+++ b/static/app/components/pageFilters/useStagedCompactSelect.spec.tsx
@@ -1059,6 +1059,79 @@ describe('useStagedCompactSelect', () => {
       expect(onChange).toHaveBeenLastCalledWith(['one', 'three']);
     });
 
+    it('clears anchor after selection becomes empty so next shift+click is a single toggle', async () => {
+      const onChange = jest.fn();
+
+      function TestComponent() {
+        const [value, setValue] = useState<string[]>([]);
+        const toggleOptionRef = useRef<((val: string) => void) | undefined>(undefined);
+        const options = useTestOptions(toggleOptionRef);
+        const handleChange = (newValue: string[]) => {
+          onChange(newValue);
+          setValue(newValue);
+        };
+        const stagedSelect = useStagedCompactSelect({
+          value,
+          options,
+          onChange: handleChange,
+          multiple: true,
+        });
+        toggleOptionRef.current = stagedSelect.toggleOption;
+
+        return (
+          <CompactSelect
+            grid
+            multiple
+            search
+            {...stagedSelect.compactSelectProps}
+            menuFooter={
+              xor(stagedSelect.value, value).length > 0 ? (
+                <Flex>
+                  <MenuComponents.ApplyButton
+                    onClick={() => {
+                      stagedSelect.dispatch({type: 'remove staged'});
+                      handleChange(stagedSelect.value);
+                    }}
+                  />
+                </Flex>
+              ) : null
+            }
+          />
+        );
+      }
+
+      render(<TestComponent />);
+
+      // Open the menu
+      await userEvent.click(screen.getByRole('button', {expanded: false}));
+
+      // Shift-click Option One — first shift-click acts as a single toggle, sets anchor to one
+      await userEvent.keyboard('{Shift>}');
+      await userEvent.click(screen.getByRole('row', {name: 'Option One'}));
+      await userEvent.keyboard('{/Shift}');
+
+      // Shift-click Option Three — range-selects [one, two, three], anchor now three
+      await userEvent.keyboard('{Shift>}');
+      await userEvent.click(screen.getByRole('row', {name: 'Option Three'}));
+      await userEvent.keyboard('{/Shift}');
+
+      // Shift-click Option One — deselects range [one, two, three], staged selection is now empty
+      await userEvent.keyboard('{Shift>}');
+      await userEvent.click(screen.getByRole('row', {name: 'Option One'}));
+      await userEvent.keyboard('{/Shift}');
+
+      // Shift-click Option Two — since selection is empty, this must act as a single toggle.
+      // Without the fix the stale anchor would range-select [one, two].
+      await userEvent.keyboard('{Shift>}');
+      await userEvent.click(screen.getByRole('row', {name: 'Option Two'}));
+      await userEvent.keyboard('{/Shift}');
+
+      // Apply the changes
+      await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+
+      expect(onChange).toHaveBeenLastCalledWith(['two']);
+    });
+
     it('shift+click range in filtered list only selects visible options', async () => {
       const onChange = jest.fn();
 

--- a/static/app/components/pageFilters/useStagedCompactSelect.tsx
+++ b/static/app/components/pageFilters/useStagedCompactSelect.tsx
@@ -66,13 +66,23 @@ function stagingReducer<Value extends SelectKey>(
     case 'toggle': {
       const newSet = new Set(action.currentStaged);
       newSet.has(action.val) ? newSet.delete(action.val) : newSet.add(action.val);
-      return {...state, stagedValue: Array.from(newSet), lastSelected: action.val};
+      const stagedValue = Array.from(newSet);
+      return {
+        ...state,
+        stagedValue,
+        lastSelected: stagedValue.length === 0 ? null : action.val,
+      };
     }
     case 'toggle range': {
       if (state.lastSelected === null) {
         const newSet = new Set(action.currentStaged);
         newSet.has(action.val) ? newSet.delete(action.val) : newSet.add(action.val);
-        return {...state, stagedValue: Array.from(newSet), lastSelected: action.val};
+        const stagedValue = Array.from(newSet);
+        return {
+          ...state,
+          stagedValue,
+          lastSelected: stagedValue.length === 0 ? null : action.val,
+        };
       }
 
       // Only include options visible in the current filtered state so that
@@ -92,7 +102,12 @@ function stagingReducer<Value extends SelectKey>(
         // Anchor or clicked item not visible — fall back to single toggle
         const newSet = new Set(action.currentStaged);
         newSet.has(action.val) ? newSet.delete(action.val) : newSet.add(action.val);
-        return {...state, stagedValue: Array.from(newSet), lastSelected: action.val};
+        const stagedValue = Array.from(newSet);
+        return {
+          ...state,
+          stagedValue,
+          lastSelected: stagedValue.length === 0 ? null : action.val,
+        };
       }
 
       const targetState = !action.currentStaged.includes(action.val);
@@ -112,7 +127,11 @@ function stagingReducer<Value extends SelectKey>(
         return aIdx - bIdx;
       });
 
-      return {...state, stagedValue: sortedValue, lastSelected: action.val};
+      return {
+        ...state,
+        stagedValue: sortedValue,
+        lastSelected: sortedValue.length === 0 ? null : action.val,
+      };
     }
     case 'remove staged':
       return {...state, stagedValue: null};


### PR DESCRIPTION
The shift-click range selection in `useStagedCompactSelect` kept its anchor (`lastSelected`) pointing at the last clicked option even after the staged selection became empty. The next shift-click would then range-extend from that ghost anchor.

### Repro (environment selector on the traces explorer)

With environments `[A, B, C, D, E]`:

1. Shift-click `A` — selects `[A]`, anchor = `A`
2. Shift-click `E` — range-selects `[A, B, C, D, E]`, anchor = `E`
3. Shift-click `E, D, C, B, A` one by one — incrementally deselects the range; selection ends at `[]`, but anchor lingers at `A`
4. Shift-click `C` — expected `[C]`, actual `[A, B, C]`

### Fix

In the `'toggle'` and `'toggle range'` reducer cases, clear `lastSelected` to `null` whenever the resulting `stagedValue` is empty. The next shift-click then falls through the existing `lastSelected === null` branch, which already treats it as a regular single click (the same path used when the menu first opens).

A stricter check (treat the anchor as invalid whenever it's not in the current selection) was attempted but broke the existing `'deselects range when shift-clicking already selected item'` test, which relies on a ctrl-clicked-off anchor still being usable for a range-deselect.

Added a unit test that walks through the exact repro above.