### PR TITLE
feat(onboarding): Update Hono onboarding with `@sentry/hono`

### DIFF
--- a/static/app/gettingStartedDocs/node-hono/feedback.tsx
+++ b/static/app/gettingStartedDocs/node-hono/feedback.tsx
@@ -24,18 +24,16 @@ export const feedback: OnboardingConfig = {
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              code: `import * as Sentry from "@sentry/node";
-
-const eventId = Sentry.captureMessage("User Feedback");
-// OR: const eventId = Sentry.lastEventId();
+              code: `// Use the import for your runtime:
+// "@sentry/hono/cloudflare", "@sentry/hono/node", or "@sentry/hono/bun"
+import * as Sentry from "@sentry/hono/<your-runtime>";
 
 const userFeedback = {
-  event_id: eventId,
   name: "John Doe",
   email: "john@doe.com",
-  comments: "I really like your App, thanks!",
+  message: "I really like your App, thanks!",
 };
-Sentry.captureUserFeedback(userFeedback);
+Sentry.captureFeedback(userFeedback);
 `,
             },
           ],

--- a/static/app/gettingStartedDocs/node-hono/index.tsx
+++ b/static/app/gettingStartedDocs/node-hono/index.tsx
@@ -9,8 +9,9 @@ import {mcp} from './mcp';
 import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
+import {platformOptions, type PlatformOptions} from './utils';
 
-export const docs: Docs = {
+export const docs: Docs<PlatformOptions> = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
@@ -19,5 +20,6 @@ export const docs: Docs = {
   profilingOnboarding: profiling,
   agentMonitoringOnboarding: agentMonitoring(),
   mcpOnboarding: mcp,
+  platformOptions,
   metricsOnboarding: metrics,
 };

--- a/static/app/gettingStartedDocs/node-hono/logs.tsx
+++ b/static/app/gettingStartedDocs/node-hono/logs.tsx
@@ -2,5 +2,6 @@ import {getNodeLogsOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
 export const logs = getNodeLogsOnboarding({
   docsPlatform: 'hono',
-  packageName: '@sentry/node',
+  packageName: '@sentry/hono',
+  importPath: '@sentry/hono/<your-runtime>',
 });

--- a/static/app/gettingStartedDocs/node-hono/mcp.tsx
+++ b/static/app/gettingStartedDocs/node-hono/mcp.tsx
@@ -1,3 +1,6 @@
 import {getNodeMcpOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
-export const mcp = getNodeMcpOnboarding();
+export const mcp = getNodeMcpOnboarding({
+  packageName: '@sentry/hono',
+  importPath: '@sentry/hono/<your-runtime>',
+});

--- a/static/app/gettingStartedDocs/node-hono/metrics.tsx
+++ b/static/app/gettingStartedDocs/node-hono/metrics.tsx
@@ -2,5 +2,6 @@ import {getNodeMetricsOnboarding} from 'sentry/gettingStartedDocs/node/metrics';
 
 export const metrics = getNodeMetricsOnboarding({
   docsPlatform: 'hono',
-  packageName: '@sentry/node',
+  packageName: '@sentry/hono',
+  importPath: '@sentry/hono/<your-runtime>',
 });

--- a/static/app/gettingStartedDocs/node-hono/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-hono/onboarding.spec.tsx
@@ -6,201 +6,402 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
+import {Runtime} from './utils';
 import {docs} from '.';
 
 describe('hono onboarding docs', () => {
-  it('renders onboarding docs correctly', () => {
-    renderWithOnboardingLayout(docs);
+  describe('Cloudflare Workers runtime (default)', () => {
+    it('renders onboarding docs correctly', () => {
+      renderWithOnboardingLayout(docs);
 
-    // Renders main headings
-    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: /Upload Source Maps/i})
-    ).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Includes import statement
-    const allMatches = screen.getAllByText(
-      textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/)
-    );
-    allMatches.forEach(match => {
-      expect(match).toBeInTheDocument();
-    });
-  });
-
-  it('includes error handler', () => {
-    renderWithOnboardingLayout(docs);
-
-    expect(screen.getByText(textWithMarkupMatcher(/\.onError/))).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry\.captureException\(err\)/))
-    ).toBeInTheDocument();
-  });
-
-  it('displays sample rates by default', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [
-        ProductSolution.ERROR_MONITORING,
-        ProductSolution.PERFORMANCE_MONITORING,
-        ProductSolution.PROFILING,
-      ],
+      expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', {name: /Upload Source Maps/i})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
-    ).toBeInTheDocument();
-  });
+    it('shows @sentry/cloudflare as peer dependency', () => {
+      renderWithOnboardingLayout(docs);
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+      expect(
+        screen.getByText(textWithMarkupMatcher(/@sentry\/cloudflare/))
+      ).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
+    it('shows wrangler.jsonc with nodejs_compat flag', () => {
+      renderWithOnboardingLayout(docs);
 
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
+      expect(
+        screen.getByText(textWithMarkupMatcher(/nodejs_compat/))
+      ).toBeInTheDocument();
     });
 
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
+    it('shows sentry middleware import from @sentry/hono/cloudflare', () => {
+      renderWithOnboardingLayout(docs);
 
-  it('displays logs integration next step when logs are selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(screen.getByText('Logging Integrations')).toBeInTheDocument();
-  });
-
-  it('does not display logs integration next step when logs are not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(screen.queryByText('Logging Integrations')).not.toBeInTheDocument();
-  });
-
-  it('displays logging code in verify section when logs are selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/Sentry\.logger\.info\('User triggered test error'/)
-      )
-    ).toBeInTheDocument();
-  });
-
-  it('does not display logging code in verify section when logs are not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(
-        textWithMarkupMatcher(/Sentry\.logger\.info\('User triggered test error'/)
-      )
-    ).not.toBeInTheDocument();
-  });
-
-  it('enables performance setting the tracesSampleRate to 1', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [
-        ProductSolution.ERROR_MONITORING,
-        ProductSolution.PERFORMANCE_MONITORING,
-      ],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
-    ).toBeInTheDocument();
-  });
-
-  it('enables profiling by setting profiling samplerates', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-    });
-
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(
-          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+      expect(
+        screen.getByText(
+          textWithMarkupMatcher(/import { sentry } from "@sentry\/hono\/cloudflare"/)
         )
-      )
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
-    ).toBeInTheDocument();
-  });
-
-  it('continuous profiling', () => {
-    const organization = OrganizationFixture({
-      features: ['continuous-profiling'],
+      ).toBeInTheDocument();
     });
 
-    renderWithOnboardingLayout(
-      docs,
-      {},
-      {
-        organization,
-      }
-    );
+    it('passes options directly to middleware', () => {
+      renderWithOnboardingLayout(docs);
 
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(
-          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+      expect(
+        screen.getByText(textWithMarkupMatcher(/sentry\(app, \{/))
+      ).toBeInTheDocument();
+    });
+
+    it('displays tracesSampleRate when performance is selected', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [
+          ProductSolution.ERROR_MONITORING,
+          ProductSolution.PERFORMANCE_MONITORING,
+        ],
+      });
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
+      ).toBeInTheDocument();
+    });
+
+    it('enables logs by setting enableLogs to true', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+      });
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
+      ).toBeInTheDocument();
+    });
+
+    it('does not enable logs when not selected', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING],
+      });
+
+      expect(
+        screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows profiling info alert when profiling is selected', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      });
+
+      expect(
+        screen.getByText(
+          textWithMarkupMatcher(/Profiling is only available on the Node.js runtime/)
         )
-      )
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
-    ).toBeInTheDocument();
-
-    // Profiles sample rate should not be set for continuous profiling
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
-    ).not.toBeInTheDocument();
-  });
-
-  it('displays metrics code in verify section when metrics are selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],
+      ).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/Sentry\.metrics\.count\('test_counter', 1\)/)
-      )
-    ).toBeInTheDocument();
+    it('does not show profiling alert when profiling is not selected', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING],
+      });
+
+      expect(
+        screen.queryByText(
+          textWithMarkupMatcher(/Profiling is only available on the Node.js runtime/)
+        )
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it('does not display metrics code in verify section when metrics are not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
+  describe('Node.js runtime', () => {
+    let nodeDocs: typeof docs;
+    beforeAll(() => {
+      nodeDocs = {
+        ...docs,
+        platformOptions: {
+          ...docs.platformOptions,
+          runtime: {
+            ...docs.platformOptions!.runtime,
+            defaultValue: Runtime.NODE,
+          },
+        },
+      };
     });
 
-    expect(
-      screen.queryByText(
-        textWithMarkupMatcher(/Sentry\.metrics\.count\('test_counter', 1\)/)
-      )
-    ).not.toBeInTheDocument();
+    it('renders onboarding docs correctly', () => {
+      renderWithOnboardingLayout(nodeDocs);
+
+      expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', {name: /Upload Source Maps/i})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+    });
+
+    it('shows @sentry/hono/node import in instrument file', () => {
+      renderWithOnboardingLayout(nodeDocs);
+
+      expect(
+        screen.getByText(
+          textWithMarkupMatcher(/import \* as Sentry from "@sentry\/hono\/node"/)
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('shows sentry middleware import from @sentry/hono/node', () => {
+      renderWithOnboardingLayout(nodeDocs);
+
+      expect(
+        screen.getByText(
+          textWithMarkupMatcher(/import { sentry } from "@sentry\/hono\/node"/)
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('includes sentry middleware', () => {
+      renderWithOnboardingLayout(nodeDocs);
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/app\.use\(sentry\(app\)\)/))
+      ).toBeInTheDocument();
+    });
+
+    it('shows node --import command', () => {
+      renderWithOnboardingLayout(nodeDocs);
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/node --import .\/instrument.mjs app.js/))
+      ).toBeInTheDocument();
+    });
+
+    it('displays tracesSampleRate when performance is selected', () => {
+      renderWithOnboardingLayout(nodeDocs, {
+        selectedProducts: [
+          ProductSolution.ERROR_MONITORING,
+          ProductSolution.PERFORMANCE_MONITORING,
+        ],
+      });
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
+      ).toBeInTheDocument();
+    });
+
+    it('enables profiling by setting profiling samplerates', () => {
+      renderWithOnboardingLayout(nodeDocs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      });
+
+      expect(
+        screen.getByText(
+          textWithMarkupMatcher(
+            /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
+          )
+        )
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+      ).toBeInTheDocument();
+    });
+
+    it('continuous profiling', () => {
+      const organization = OrganizationFixture({
+        features: ['continuous-profiling'],
+      });
+
+      renderWithOnboardingLayout(
+        nodeDocs,
+        {},
+        {
+          organization,
+        }
+      );
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+      ).not.toBeInTheDocument();
+    });
+
+    it('enables logs by setting enableLogs to true', () => {
+      renderWithOnboardingLayout(nodeDocs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+      });
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
+      ).toBeInTheDocument();
+    });
+
+    it('does not enable logs when not selected', () => {
+      renderWithOnboardingLayout(nodeDocs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING],
+      });
+
+      expect(
+        screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show profiling alert when profiling is selected', () => {
+      renderWithOnboardingLayout(nodeDocs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      });
+
+      expect(
+        screen.queryByText(
+          textWithMarkupMatcher(/Profiling is only available on the Node.js runtime/)
+        )
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Bun runtime', () => {
+    let bunDocs: typeof docs;
+    beforeAll(() => {
+      bunDocs = {
+        ...docs,
+        platformOptions: {
+          ...docs.platformOptions,
+          runtime: {
+            ...docs.platformOptions!.runtime,
+            defaultValue: Runtime.BUN,
+          },
+        },
+      };
+    });
+
+    it('renders onboarding docs correctly', () => {
+      renderWithOnboardingLayout(bunDocs);
+
+      expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', {name: /Upload Source Maps/i})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+    });
+
+    it('shows @sentry/bun as peer dependency', () => {
+      renderWithOnboardingLayout(bunDocs);
+
+      expect(screen.getByText(textWithMarkupMatcher(/@sentry\/bun/))).toBeInTheDocument();
+    });
+
+    it('shows sentry middleware import from @sentry/hono/bun', () => {
+      renderWithOnboardingLayout(bunDocs);
+
+      expect(
+        screen.getByText(
+          textWithMarkupMatcher(/import { sentry } from "@sentry\/hono\/bun"/)
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('passes options directly to middleware', () => {
+      renderWithOnboardingLayout(bunDocs);
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/sentry\(app, \{/))
+      ).toBeInTheDocument();
+    });
+
+    it('displays tracesSampleRate when performance is selected', () => {
+      renderWithOnboardingLayout(bunDocs, {
+        selectedProducts: [
+          ProductSolution.ERROR_MONITORING,
+          ProductSolution.PERFORMANCE_MONITORING,
+        ],
+      });
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
+      ).toBeInTheDocument();
+    });
+
+    it('enables logs by setting enableLogs to true', () => {
+      renderWithOnboardingLayout(bunDocs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+      });
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
+      ).toBeInTheDocument();
+    });
+
+    it('shows profiling info alert when profiling is selected', () => {
+      renderWithOnboardingLayout(bunDocs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      });
+
+      expect(
+        screen.getByText(
+          textWithMarkupMatcher(/Profiling is only available on the Node.js runtime/)
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('shared behavior', () => {
+    it('displays logs integration next step when logs are selected', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+      });
+
+      expect(screen.getByText('Logging Integrations')).toBeInTheDocument();
+    });
+
+    it('does not display logs integration next step when logs are not selected', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING],
+      });
+
+      expect(screen.queryByText('Logging Integrations')).not.toBeInTheDocument();
+    });
+
+    it('displays logging code in verify section when logs are selected', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+      });
+
+      expect(
+        screen.getByText(
+          textWithMarkupMatcher(/Sentry\.logger\.info\('User triggered test error'/)
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('displays metrics code in verify section when metrics are selected', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],
+      });
+
+      expect(
+        screen.getByText(
+          textWithMarkupMatcher(/Sentry\.metrics\.count\('test_counter', 1\)/)
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('does not display metrics code in verify section when metrics are not selected', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [ProductSolution.ERROR_MONITORING],
+      });
+
+      expect(
+        screen.queryByText(
+          textWithMarkupMatcher(/Sentry\.metrics\.count\('test_counter', 1\)/)
+        )
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/app/gettingStartedDocs/node-hono/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-hono/onboarding.spec.tsx
@@ -25,17 +25,15 @@ describe('hono onboarding docs', () => {
     it('shows @sentry/cloudflare as peer dependency', () => {
       renderWithOnboardingLayout(docs);
 
-      expect(
-        screen.getByText(textWithMarkupMatcher(/@sentry\/cloudflare/))
-      ).toBeInTheDocument();
+      const matches = screen.getAllByText(textWithMarkupMatcher(/@sentry\/cloudflare/));
+      expect(matches.length).toBeGreaterThanOrEqual(1);
     });
 
     it('shows wrangler.jsonc with nodejs_compat flag', () => {
       renderWithOnboardingLayout(docs);
 
-      expect(
-        screen.getByText(textWithMarkupMatcher(/nodejs_compat/))
-      ).toBeInTheDocument();
+      const matches = screen.getAllByText(textWithMarkupMatcher(/nodejs_compat/));
+      expect(matches.length).toBeGreaterThanOrEqual(1);
     });
 
     it('shows sentry middleware import from @sentry/hono/cloudflare', () => {
@@ -294,7 +292,8 @@ describe('hono onboarding docs', () => {
     it('shows @sentry/bun as peer dependency', () => {
       renderWithOnboardingLayout(bunDocs);
 
-      expect(screen.getByText(textWithMarkupMatcher(/@sentry\/bun/))).toBeInTheDocument();
+      const matches = screen.getAllByText(textWithMarkupMatcher(/@sentry\/bun/));
+      expect(matches.length).toBeGreaterThanOrEqual(1);
     });
 
     it('shows sentry middleware import from @sentry/hono/bun', () => {

--- a/static/app/gettingStartedDocs/node-hono/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-hono/onboarding.tsx
@@ -1,4 +1,7 @@
-import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {
+  ContentBlock,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {getInstallCodeBlock} from 'sentry/gettingStartedDocs/node/utils';
@@ -6,8 +9,31 @@ import {t, tct} from 'sentry/locale';
 
 import {Runtime, type Params, type PlatformOptions} from './utils';
 
+const RUNTIME_CONFIG: Record<
+  Runtime,
+  {importPath: string; label: string; peerDep: `@sentry/${string}`}
+> = {
+  [Runtime.NODE]: {
+    importPath: '@sentry/hono/node',
+    peerDep: '@sentry/node',
+    label: 'the Node.js runtime',
+  },
+  [Runtime.CLOUDFLARE]: {
+    importPath: '@sentry/hono/cloudflare',
+    peerDep: '@sentry/cloudflare',
+    label: 'Cloudflare Workers',
+  },
+  [Runtime.BUN]: {
+    importPath: '@sentry/hono/bun',
+    peerDep: '@sentry/bun',
+    label: 'the Bun runtime',
+  },
+};
+
 function getNodeInstrumentSnippet(params: Params): string {
-  const imports = [`import * as Sentry from "@sentry/hono/node";`];
+  const imports = [
+    `import * as Sentry from "${RUNTIME_CONFIG[Runtime.NODE].importPath}";`,
+  ];
   if (params.isProfilingSelected) {
     imports.push('import { nodeProfilingIntegration } from "@sentry/profiling-node";');
   }
@@ -53,7 +79,7 @@ Sentry.init({
 function getNodeAppSnippet(): string {
   return `import { Hono } from "hono";
 import { serve } from "@hono/node-server";
-import { sentry } from "@sentry/hono/node";
+import { sentry } from "${RUNTIME_CONFIG[Runtime.NODE].importPath}";
 
 const app = new Hono();
 
@@ -64,40 +90,13 @@ app.use(sentry(app));
 serve(app);`;
 }
 
-function getBunAppSnippet(params: Params): string {
+/**
+ * Generates the app snippet for runtimes that pass Sentry options
+ * directly to the middleware (Cloudflare Workers and Bun).
+ */
+function getInlineInitAppSnippet(runtime: Runtime, params: Params): string {
   return `import { Hono } from "hono";
-import { sentry } from "@sentry/hono/bun";
-
-const app = new Hono();
-
-app.use(
-  sentry(app, {
-    dsn: "${params.dsn.public}",${
-      params.isPerformanceSelected
-        ? `
-    tracesSampleRate: 1.0,`
-        : ''
-    }${
-      params.isLogsSelected
-        ? `
-    enableLogs: true,`
-        : ''
-    }
-    sendDefaultPii: true,
-  }),
-);
-
-// Your routes here
-app.get("/", (c) => {
-  return c.text("Hello Hono!");
-});
-
-export default app;`;
-}
-
-function getCloudflareAppSnippet(params: Params): string {
-  return `import { Hono } from "hono";
-import { sentry } from "@sentry/hono/cloudflare";
+import { sentry } from "${RUNTIME_CONFIG[runtime].importPath}";
 
 const app = new Hono();
 
@@ -132,44 +131,104 @@ function getWranglerSnippet(): string {
 }`;
 }
 
-const getVerifySnippet = (params: Params) => `app.get("/debug-sentry", () => {${
-  params.isLogsSelected
-    ? `
+function getVerifySnippet(params: Params): string {
+  const needsSentryImport = params.isLogsSelected || params.isMetricsSelected;
+  const importLine = needsSentryImport
+    ? `import * as Sentry from "${RUNTIME_CONFIG[params.platformOptions.runtime].importPath}";\n\n`
+    : '';
+
+  return `${importLine}app.get("/debug-sentry", () => {${
+    params.isLogsSelected
+      ? `
   // Send a log before throwing the error
   Sentry.logger.info('User triggered test error', {
     action: 'test_error_endpoint',
   });`
-    : ''
-}${
-  params.isMetricsSelected
-    ? `
+      : ''
+  }${
+    params.isMetricsSelected
+      ? `
   // Send a test metric before throwing the error
   Sentry.metrics.count('test_counter', 1);`
-    : ''
-}
+      : ''
+  }
   throw new Error("My first Sentry error!");
 });`;
+}
+
+function getInstallStep(runtime: Runtime, params: Params) {
+  const config = RUNTIME_CONFIG[runtime];
+  const suppressProfiling = runtime !== Runtime.NODE;
+
+  return {
+    type: StepType.INSTALL as const,
+    content: [
+      {
+        type: 'text' as const,
+        text: tct(
+          'Install the [sentryHono] package and the [peerDep] peer dependency for [label]:',
+          {
+            sentryHono: <code>@sentry/hono</code>,
+            peerDep: <code>{config.peerDep}</code>,
+            label: config.label,
+          }
+        ),
+      },
+      getInstallCodeBlock(
+        suppressProfiling ? {...params, isProfilingSelected: false} : params,
+        {
+          packageName: '@sentry/hono',
+          additionalPackages: [config.peerDep],
+        }
+      ),
+    ],
+  };
+}
+
+function getProfilingAlert(params: Params): ContentBlock {
+  return {
+    type: 'conditional',
+    condition: params.isProfilingSelected,
+    content: [
+      {
+        type: 'alert',
+        alertType: 'info',
+        showIcon: true,
+        text: t(
+          'Profiling is only available on the Node.js runtime. Select the Node.js runtime above to see profiling setup instructions.'
+        ),
+      },
+    ],
+  };
+}
+
+function getSourceMapsStep(params: Params) {
+  return getUploadSourceMapsStep({
+    guideLink: 'https://docs.sentry.io/platforms/javascript/guides/hono/sourcemaps/',
+    ...params,
+  });
+}
+
+function getVerifyStep(params: Params) {
+  return {
+    type: StepType.VERIFY as const,
+    content: [
+      {
+        type: 'text' as const,
+        text: t('Add a route that triggers an error to verify Sentry is working:'),
+      },
+      {
+        type: 'code' as const,
+        language: 'javascript',
+        code: getVerifySnippet(params),
+      },
+    ],
+  };
+}
 
 const runtimeOnboarding: Record<Runtime, OnboardingConfig<PlatformOptions>> = {
   [Runtime.NODE]: {
-    install: (params: Params) => [
-      {
-        type: StepType.INSTALL,
-        content: [
-          {
-            type: 'text',
-            text: tct(
-              'Install the [code:@sentry/hono] package and the [code:@sentry/node] peer dependency for the Node.js runtime:',
-              {code: <code />}
-            ),
-          },
-          getInstallCodeBlock(params, {
-            packageName: '@sentry/hono',
-            additionalPackages: ['@sentry/node'],
-          }),
-        ],
-      },
-    ],
+    install: (params: Params) => [getInstallStep(Runtime.NODE, params)],
     configure: (params: Params) => [
       {
         type: StepType.CONFIGURE,
@@ -226,68 +285,17 @@ const runtimeOnboarding: Record<Runtime, OnboardingConfig<PlatformOptions>> = {
           },
         ],
       },
-      getUploadSourceMapsStep({
-        guideLink: 'https://docs.sentry.io/platforms/javascript/guides/hono/sourcemaps/',
-        ...params,
-      }),
+      getSourceMapsStep(params),
     ],
-    verify: (params: Params) => [
-      {
-        type: StepType.VERIFY,
-        content: [
-          {
-            type: 'text',
-            text: t('Add a route that triggers an error to verify Sentry is working:'),
-          },
-          {
-            type: 'code',
-            language: 'javascript',
-            code: getVerifySnippet(params),
-          },
-        ],
-      },
-    ],
+    verify: (params: Params) => [getVerifyStep(params)],
   },
   [Runtime.CLOUDFLARE]: {
-    install: (params: Params) => [
-      {
-        type: StepType.INSTALL,
-        content: [
-          {
-            type: 'text',
-            text: tct(
-              'Install the [code:@sentry/hono] package and the [code:@sentry/cloudflare] peer dependency for Cloudflare Workers:',
-              {code: <code />}
-            ),
-          },
-          getInstallCodeBlock(
-            {...params, isProfilingSelected: false},
-            {
-              packageName: '@sentry/hono',
-              additionalPackages: ['@sentry/cloudflare'],
-            }
-          ),
-        ],
-      },
-    ],
+    install: (params: Params) => [getInstallStep(Runtime.CLOUDFLARE, params)],
     configure: (params: Params) => [
       {
         type: StepType.CONFIGURE,
         content: [
-          {
-            type: 'conditional',
-            condition: params.isProfilingSelected,
-            content: [
-              {
-                type: 'alert',
-                alertType: 'info',
-                showIcon: true,
-                text: t(
-                  'Profiling is only available on the Node.js runtime. Select the Node.js runtime above to see profiling setup instructions.'
-                ),
-              },
-            ],
-          },
+          getProfilingAlert(params),
           {
             type: 'text',
             text: tct(
@@ -322,7 +330,7 @@ const runtimeOnboarding: Record<Runtime, OnboardingConfig<PlatformOptions>> = {
                 language: 'typescript',
                 filename: 'index.ts',
                 value: 'typescript',
-                code: getCloudflareAppSnippet(params),
+                code: getInlineInitAppSnippet(Runtime.CLOUDFLARE, params),
               },
             ],
           },
@@ -335,68 +343,17 @@ const runtimeOnboarding: Record<Runtime, OnboardingConfig<PlatformOptions>> = {
           },
         ],
       },
-      getUploadSourceMapsStep({
-        guideLink: 'https://docs.sentry.io/platforms/javascript/guides/hono/sourcemaps/',
-        ...params,
-      }),
+      getSourceMapsStep(params),
     ],
-    verify: (params: Params) => [
-      {
-        type: StepType.VERIFY,
-        content: [
-          {
-            type: 'text',
-            text: t('Add a route that triggers an error to verify Sentry is working:'),
-          },
-          {
-            type: 'code',
-            language: 'javascript',
-            code: getVerifySnippet(params),
-          },
-        ],
-      },
-    ],
+    verify: (params: Params) => [getVerifyStep(params)],
   },
   [Runtime.BUN]: {
-    install: (params: Params) => [
-      {
-        type: StepType.INSTALL,
-        content: [
-          {
-            type: 'text',
-            text: tct(
-              'Install the [code:@sentry/hono] package and the [code:@sentry/bun] peer dependency for the Bun runtime:',
-              {code: <code />}
-            ),
-          },
-          getInstallCodeBlock(
-            {...params, isProfilingSelected: false},
-            {
-              packageName: '@sentry/hono',
-              additionalPackages: ['@sentry/bun'],
-            }
-          ),
-        ],
-      },
-    ],
+    install: (params: Params) => [getInstallStep(Runtime.BUN, params)],
     configure: (params: Params) => [
       {
         type: StepType.CONFIGURE,
         content: [
-          {
-            type: 'conditional',
-            condition: params.isProfilingSelected,
-            content: [
-              {
-                type: 'alert',
-                alertType: 'info',
-                showIcon: true,
-                text: t(
-                  'Profiling is only available on the Node.js runtime. Select the Node.js runtime above to see profiling setup instructions.'
-                ),
-              },
-            ],
-          },
+          getProfilingAlert(params),
           {
             type: 'text',
             text: tct(
@@ -412,33 +369,15 @@ const runtimeOnboarding: Record<Runtime, OnboardingConfig<PlatformOptions>> = {
                 language: 'typescript',
                 filename: 'index.ts',
                 value: 'typescript',
-                code: getBunAppSnippet(params),
+                code: getInlineInitAppSnippet(Runtime.BUN, params),
               },
             ],
           },
         ],
       },
-      getUploadSourceMapsStep({
-        guideLink: 'https://docs.sentry.io/platforms/javascript/guides/hono/sourcemaps/',
-        ...params,
-      }),
+      getSourceMapsStep(params),
     ],
-    verify: (params: Params) => [
-      {
-        type: StepType.VERIFY,
-        content: [
-          {
-            type: 'text',
-            text: t('Add a route that triggers an error to verify Sentry is working:'),
-          },
-          {
-            type: 'code',
-            language: 'javascript',
-            code: getVerifySnippet(params),
-          },
-        ],
-      },
-    ],
+    verify: (params: Params) => [getVerifyStep(params)],
   },
 };
 

--- a/static/app/gettingStartedDocs/node-hono/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-hono/onboarding.tsx
@@ -1,20 +1,138 @@
-import {ExternalLink} from '@sentry/scraps/link';
-
-import type {
-  DocsParams,
-  OnboardingConfig,
-} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
-import {
-  getImportInstrumentSnippet,
-  getInstallCodeBlock,
-  getSdkInitSnippet,
-  getSentryImportSnippet,
-} from 'sentry/gettingStartedDocs/node/utils';
+import {getInstallCodeBlock} from 'sentry/gettingStartedDocs/node/utils';
 import {t, tct} from 'sentry/locale';
 
-const getVerifySnippet = (params: DocsParams) => `app.get("/debug-sentry", () => {${
+import {Runtime, type Params, type PlatformOptions} from './utils';
+
+function getNodeInstrumentSnippet(params: Params): string {
+  const imports = [`import * as Sentry from "@sentry/hono/node";`];
+  if (params.isProfilingSelected) {
+    imports.push('import { nodeProfilingIntegration } from "@sentry/profiling-node";');
+  }
+
+  return `${imports.join('\n')}
+
+Sentry.init({
+  dsn: "${params.dsn.public}",${
+    params.isProfilingSelected
+      ? `
+  integrations: [
+    nodeProfilingIntegration(),
+  ],`
+      : ''
+  }${
+    params.isPerformanceSelected
+      ? `
+  tracesSampleRate: 1.0,`
+      : ''
+  }${
+    params.isProfilingSelected &&
+    params.profilingOptions?.defaultProfilingMode !== 'continuous'
+      ? `
+  profilesSampleRate: 1.0,`
+      : ''
+  }${
+    params.isProfilingSelected &&
+    params.profilingOptions?.defaultProfilingMode === 'continuous'
+      ? `
+  profileSessionSampleRate: 1.0,
+  profileLifecycle: 'trace',`
+      : ''
+  }${
+    params.isLogsSelected
+      ? `
+  enableLogs: true,`
+      : ''
+  }
+  sendDefaultPii: true,
+});`;
+}
+
+function getNodeAppSnippet(): string {
+  return `import { Hono } from "hono";
+import { serve } from "@hono/node-server";
+import { sentry } from "@sentry/hono/node";
+
+const app = new Hono();
+
+app.use(sentry(app));
+
+// Your routes here
+
+serve(app);`;
+}
+
+function getBunAppSnippet(params: Params): string {
+  return `import { Hono } from "hono";
+import { sentry } from "@sentry/hono/bun";
+
+const app = new Hono();
+
+app.use(
+  sentry(app, {
+    dsn: "${params.dsn.public}",${
+      params.isPerformanceSelected
+        ? `
+    tracesSampleRate: 1.0,`
+        : ''
+    }${
+      params.isLogsSelected
+        ? `
+    enableLogs: true,`
+        : ''
+    }
+    sendDefaultPii: true,
+  }),
+);
+
+// Your routes here
+app.get("/", (c) => {
+  return c.text("Hello Hono!");
+});
+
+export default app;`;
+}
+
+function getCloudflareAppSnippet(params: Params): string {
+  return `import { Hono } from "hono";
+import { sentry } from "@sentry/hono/cloudflare";
+
+const app = new Hono();
+
+app.use(
+  sentry(app, {
+    dsn: "${params.dsn.public}",${
+      params.isPerformanceSelected
+        ? `
+    tracesSampleRate: 1.0,`
+        : ''
+    }${
+      params.isLogsSelected
+        ? `
+    enableLogs: true,`
+        : ''
+    }
+    sendDefaultPii: true,
+  }),
+);
+
+// Your routes here
+app.get("/", (c) => {
+  return c.text("Hello Hono!");
+});
+
+export default app;`;
+}
+
+function getWranglerSnippet(): string {
+  return `{
+  "compatibility_flags": ["nodejs_compat"]
+}`;
+}
+
+const getVerifySnippet = (params: Params) => `app.get("/debug-sentry", () => {${
   params.isLogsSelected
     ? `
   // Send a log before throwing the error
@@ -32,160 +150,311 @@ const getVerifySnippet = (params: DocsParams) => `app.get("/debug-sentry", () =>
   throw new Error("My first Sentry error!");
 });`;
 
-const getSdkSetupSnippet = () => `
-${getImportInstrumentSnippet()}
-
-// All other imports below
-${getSentryImportSnippet('@sentry/node')}
-const { Hono } = require("hono");
-const { HTTPException } = require("hono/http-exception");
-
-
-const app = new Hono()
-  // Add an onError hook to report unhandled exceptions to Sentry.
-  .onError((err, c) => {
-    // Report _all_ unhandled errors.
-    Sentry.captureException(err);
-    if (err instanceof HTTPException) {
-      return err.getResponse();
-    }
-    // Or just report errors which are not instances of HTTPException
-    // Sentry.captureException(err);
-    return c.json({ error: "Internal server error" }, 500);
-  })
-  // Optional: Bind global context via Hono middleware
-  // Note: This requires session middleware to be configured
-  .use((c, next) => {
-    // Only set user context if session exists and has user data
-    if (c.session?.user?.email) {
-      Sentry.setUser({
-        email: c.session.user.email,
-      });
-    }
-
-    // Only set project tag if session has project data
-    if (c.session?.projectId !== undefined && c.session?.projectId !== null) {
-      Sentry.setTag("project_id", c.session.projectId);
-    }
-
-    return next();
-  })
-  // Your routes...
-  .get("/", () => {
-    // ...
-  });
-`;
-
-export const onboarding: OnboardingConfig = {
-  install: params => [
-    {
-      type: StepType.INSTALL,
-      content: [
-        {
-          type: 'alert',
-          alertType: 'info',
-          showIcon: false,
-          text: tct(
-            "This guide assumes you're using the Node.js runtime for Hono. For setup instructions on Cloudflare Workers, see our [honoCloudFlareLink:Hono on Cloudflare guide].",
+const runtimeOnboarding: Record<Runtime, OnboardingConfig<PlatformOptions>> = {
+  [Runtime.NODE]: {
+    install: (params: Params) => [
+      {
+        type: StepType.INSTALL,
+        content: [
+          {
+            type: 'text',
+            text: tct(
+              'Install the [code:@sentry/hono] package and the [code:@sentry/node] peer dependency for the Node.js runtime:',
+              {code: <code />}
+            ),
+          },
+          getInstallCodeBlock(params, {
+            packageName: '@sentry/hono',
+            additionalPackages: ['@sentry/node'],
+          }),
+        ],
+      },
+    ],
+    configure: (params: Params) => [
+      {
+        type: StepType.CONFIGURE,
+        content: [
+          {
+            type: 'text',
+            text: tct(
+              'Node.js requires Sentry to initialize before your application loads. Create a file called [code:instrument.mjs]:',
+              {code: <code />}
+            ),
+          },
+          {
+            type: 'code',
+            tabs: [
+              {
+                label: 'JavaScript',
+                language: 'javascript',
+                filename: 'instrument.mjs',
+                value: 'javascript',
+                code: getNodeInstrumentSnippet(params),
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: tct(
+              'Start your app with the [code:--import] flag to load the instrument file:',
+              {code: <code />}
+            ),
+          },
+          {
+            type: 'code',
+            language: 'bash',
+            code: 'node --import ./instrument.mjs app.js',
+          },
+          {
+            type: 'text',
+            text: tct(
+              'Add the [code:sentry()] middleware as early as possible in your Hono app:',
+              {code: <code />}
+            ),
+          },
+          {
+            type: 'code',
+            tabs: [
+              {
+                label: 'JavaScript',
+                language: 'javascript',
+                filename: 'app.js',
+                value: 'javascript',
+                code: getNodeAppSnippet(),
+              },
+            ],
+          },
+        ],
+      },
+      getUploadSourceMapsStep({
+        guideLink: 'https://docs.sentry.io/platforms/javascript/guides/hono/sourcemaps/',
+        ...params,
+      }),
+    ],
+    verify: (params: Params) => [
+      {
+        type: StepType.VERIFY,
+        content: [
+          {
+            type: 'text',
+            text: t('Add a route that triggers an error to verify Sentry is working:'),
+          },
+          {
+            type: 'code',
+            language: 'javascript',
+            code: getVerifySnippet(params),
+          },
+        ],
+      },
+    ],
+  },
+  [Runtime.CLOUDFLARE]: {
+    install: (params: Params) => [
+      {
+        type: StepType.INSTALL,
+        content: [
+          {
+            type: 'text',
+            text: tct(
+              'Install the [code:@sentry/hono] package and the [code:@sentry/cloudflare] peer dependency for Cloudflare Workers:',
+              {code: <code />}
+            ),
+          },
+          getInstallCodeBlock(
+            {...params, isProfilingSelected: false},
             {
-              honoCloudFlareLink: (
-                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/cloudflare/frameworks/hono/" />
-              ),
+              packageName: '@sentry/hono',
+              additionalPackages: ['@sentry/cloudflare'],
             }
           ),
-        },
-        {
-          type: 'text',
-          text: t('Add the Sentry Node SDK as a dependency:'),
-        },
-        getInstallCodeBlock(params),
-      ],
-    },
-  ],
-  configure: params => [
-    {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: t(
-            "Initialize Sentry as early as possible in your application's lifecycle."
-          ),
-        },
-        {
-          type: 'text',
-          text: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
-            {code: <code />}
-          ),
-        },
-        {
-          type: 'code',
-          tabs: [
+        ],
+      },
+    ],
+    configure: (params: Params) => [
+      {
+        type: StepType.CONFIGURE,
+        content: [
+          {
+            type: 'conditional',
+            condition: params.isProfilingSelected,
+            content: [
+              {
+                type: 'alert',
+                alertType: 'info',
+                showIcon: true,
+                text: t(
+                  'Profiling is only available on the Node.js runtime. Select the Node.js runtime above to see profiling setup instructions.'
+                ),
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: tct(
+              'Enable the [code:nodejs_compat] compatibility flag in your [code:wrangler.jsonc]. The SDK needs [code:AsyncLocalStorage], which requires this flag:',
+              {code: <code />}
+            ),
+          },
+          {
+            type: 'code',
+            tabs: [
+              {
+                label: 'jsonc',
+                language: 'json',
+                filename: 'wrangler.jsonc',
+                value: 'jsonc',
+                code: getWranglerSnippet(),
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: tct(
+              'Add the [code:sentry()] middleware as early as possible in your Hono app. On Cloudflare, you pass your Sentry options directly to the middleware:',
+              {code: <code />}
+            ),
+          },
+          {
+            type: 'code',
+            tabs: [
+              {
+                label: 'TypeScript',
+                language: 'typescript',
+                filename: 'index.ts',
+                value: 'typescript',
+                code: getCloudflareAppSnippet(params),
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: tct(
+              'To access environment variables from Worker Bindings (e.g. to store the DSN as a secret), pass a callback instead: [code:sentry(app, (env) => (\\{ dsn: env.SENTRY_DSN \\}))].',
+              {code: <code />}
+            ),
+          },
+        ],
+      },
+      getUploadSourceMapsStep({
+        guideLink: 'https://docs.sentry.io/platforms/javascript/guides/hono/sourcemaps/',
+        ...params,
+      }),
+    ],
+    verify: (params: Params) => [
+      {
+        type: StepType.VERIFY,
+        content: [
+          {
+            type: 'text',
+            text: t('Add a route that triggers an error to verify Sentry is working:'),
+          },
+          {
+            type: 'code',
+            language: 'javascript',
+            code: getVerifySnippet(params),
+          },
+        ],
+      },
+    ],
+  },
+  [Runtime.BUN]: {
+    install: (params: Params) => [
+      {
+        type: StepType.INSTALL,
+        content: [
+          {
+            type: 'text',
+            text: tct(
+              'Install the [code:@sentry/hono] package and the [code:@sentry/bun] peer dependency for the Bun runtime:',
+              {code: <code />}
+            ),
+          },
+          getInstallCodeBlock(
+            {...params, isProfilingSelected: false},
             {
-              label: 'JavaScript',
-              language: 'javascript',
-              filename: 'instrument.(js|mjs)',
-              value: 'javascript',
-              code: getSdkInitSnippet(params, 'node'),
-            },
-          ],
-        },
-        {
-          type: 'text',
-          text: tct(
-            "Make sure to import [code:instrument.js/mjs] at the top of your file. Set up the error handler. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)]. If you're running your application in ESM mode, or looking for alternative ways to set up Sentry, read about [docs:installation methods in our docs].",
-            {
-              code: <code />,
-              docs: (
-                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/hono/install/" />
-              ),
+              packageName: '@sentry/hono',
+              additionalPackages: ['@sentry/bun'],
             }
           ),
-        },
-        {
-          type: 'code',
-          tabs: [
-            {
-              label: 'JavaScript',
-              language: 'javascript',
-              filename: 'index.(js|mjs)',
-              value: 'javascript',
-              code: getSdkSetupSnippet(),
-            },
-          ],
-        },
-      ],
-    },
-    getUploadSourceMapsStep({
-      guideLink: 'https://docs.sentry.io/platforms/javascript/guides/hono/sourcemaps/',
-      ...params,
-    }),
-  ],
-  verify: (params: DocsParams) => [
-    {
-      type: StepType.VERIFY,
-      content: [
-        {
-          type: 'text',
-          text: t(
-            'Add the following code snippet to your main application file, adding a route that triggers an error that Sentry will capture.'
-          ),
-        },
-        {
-          type: 'code',
-          tabs: [
-            {
-              label: 'JavaScript',
-              language: 'javascript',
-              code: getVerifySnippet(params),
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  nextSteps: (params: DocsParams) => {
+        ],
+      },
+    ],
+    configure: (params: Params) => [
+      {
+        type: StepType.CONFIGURE,
+        content: [
+          {
+            type: 'conditional',
+            condition: params.isProfilingSelected,
+            content: [
+              {
+                type: 'alert',
+                alertType: 'info',
+                showIcon: true,
+                text: t(
+                  'Profiling is only available on the Node.js runtime. Select the Node.js runtime above to see profiling setup instructions.'
+                ),
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: tct(
+              'Add the [code:sentry()] middleware as early as possible in your Hono app. On Bun, you pass your Sentry options directly to the middleware:',
+              {code: <code />}
+            ),
+          },
+          {
+            type: 'code',
+            tabs: [
+              {
+                label: 'TypeScript',
+                language: 'typescript',
+                filename: 'index.ts',
+                value: 'typescript',
+                code: getBunAppSnippet(params),
+              },
+            ],
+          },
+        ],
+      },
+      getUploadSourceMapsStep({
+        guideLink: 'https://docs.sentry.io/platforms/javascript/guides/hono/sourcemaps/',
+        ...params,
+      }),
+    ],
+    verify: (params: Params) => [
+      {
+        type: StepType.VERIFY,
+        content: [
+          {
+            type: 'text',
+            text: t('Add a route that triggers an error to verify Sentry is working:'),
+          },
+          {
+            type: 'code',
+            language: 'javascript',
+            code: getVerifySnippet(params),
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const onboarding: OnboardingConfig<PlatformOptions> = {
+  introduction: () =>
+    tct(
+      'The [code:@sentry/hono] SDK supports Hono 4+ across multiple runtimes. Select your runtime below to see the setup instructions.',
+      {code: <code />}
+    ),
+  install: (params: Params) =>
+    runtimeOnboarding[params.platformOptions.runtime].install(params),
+  configure: (params: Params) =>
+    runtimeOnboarding[params.platformOptions.runtime].configure(params),
+  verify: (params: Params) =>
+    runtimeOnboarding[params.platformOptions.runtime].verify(params),
+  nextSteps: (params: Params) => {
     const steps = [];
 
     if (params.isLogsSelected) {

--- a/static/app/gettingStartedDocs/node-hono/profiling.tsx
+++ b/static/app/gettingStartedDocs/node-hono/profiling.tsx
@@ -1,3 +1,5 @@
 import {getNodeProfilingOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
-export const profiling = getNodeProfilingOnboarding();
+export const profiling = getNodeProfilingOnboarding({
+  packageName: '@sentry/hono',
+});

--- a/static/app/gettingStartedDocs/node-hono/utils.tsx
+++ b/static/app/gettingStartedDocs/node-hono/utils.tsx
@@ -1,0 +1,35 @@
+import type {
+  BasePlatformOptions,
+  DocsParams,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t} from 'sentry/locale';
+
+export enum Runtime {
+  NODE = 'node',
+  CLOUDFLARE = 'cloudflare',
+  BUN = 'bun',
+}
+
+export const platformOptions = {
+  runtime: {
+    label: t('Runtime'),
+    items: [
+      {
+        label: t('Cloudflare Workers'),
+        value: Runtime.CLOUDFLARE,
+      },
+      {
+        label: t('Node.js'),
+        value: Runtime.NODE,
+      },
+      {
+        label: t('Bun'),
+        value: Runtime.BUN,
+      },
+    ],
+    defaultValue: Runtime.CLOUDFLARE,
+  },
+} satisfies BasePlatformOptions;
+
+export type PlatformOptions = typeof platformOptions;
+export type Params = DocsParams<PlatformOptions>;

--- a/static/app/gettingStartedDocs/node/metrics.tsx
+++ b/static/app/gettingStartedDocs/node/metrics.tsx
@@ -14,58 +14,62 @@ export const getNodeMetricsOnboarding = <
 >({
   docsPlatform,
   packageName,
+  importPath,
 }: {
   docsPlatform: string;
   packageName: `@sentry/${string}`;
-}): OnboardingConfig<PlatformOptions> => ({
-  install: (params: DocsParams) => [
-    {
-      type: StepType.INSTALL,
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'Add the Sentry SDK as a dependency. The minimum version of [packageName] that supports metrics is [code:10.25.0].',
-            {
-              code: <code />,
-              packageName: <code>{packageName}</code>,
-            }
-          ),
-        },
-        getInstallCodeBlock(params, {packageName}),
-        {
-          type: 'text',
-          text: tct(
-            'If you are on an older version of the SDK, follow our [link:migration guide] to upgrade.',
-            {
-              link: (
-                <ExternalLink
-                  href={`https://docs.sentry.io/platforms/javascript/guides/${docsPlatform}/migration/`}
-                />
-              ),
-            }
-          ),
-        },
-      ],
-    },
-  ],
-  configure: () => [],
-  verify: (params: DocsParams) => [
-    {
-      type: StepType.VERIFY,
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'Metrics are automatically enabled after Sentry is initialized. You can emit metrics using the [code:Sentry.metrics] API.',
-            {code: <code />}
-          ),
-        },
-        {
-          type: 'code',
-          language: 'javascript',
-          code: `
-import * as Sentry from "${packageName}";
+  importPath?: string;
+}): OnboardingConfig<PlatformOptions> => {
+  const importFrom = importPath ?? packageName;
+  return {
+    install: (params: DocsParams) => [
+      {
+        type: StepType.INSTALL,
+        content: [
+          {
+            type: 'text',
+            text: tct(
+              'Add the Sentry SDK as a dependency. The minimum version of [packageName] that supports metrics is [code:10.25.0].',
+              {
+                code: <code />,
+                packageName: <code>{packageName}</code>,
+              }
+            ),
+          },
+          getInstallCodeBlock(params, {packageName}),
+          {
+            type: 'text',
+            text: tct(
+              'If you are on an older version of the SDK, follow our [link:migration guide] to upgrade.',
+              {
+                link: (
+                  <ExternalLink
+                    href={`https://docs.sentry.io/platforms/javascript/guides/${docsPlatform}/migration/`}
+                  />
+                ),
+              }
+            ),
+          },
+        ],
+      },
+    ],
+    configure: () => [],
+    verify: (params: DocsParams) => [
+      {
+        type: StepType.VERIFY,
+        content: [
+          {
+            type: 'text',
+            text: tct(
+              'Metrics are automatically enabled after Sentry is initialized. You can emit metrics using the [code:Sentry.metrics] API.',
+              {code: <code />}
+            ),
+          },
+          {
+            type: 'code',
+            language: 'javascript',
+            code: `
+import * as Sentry from "${importFrom}";
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -75,21 +79,22 @@ Sentry.metrics.count('button_click', 1);
 Sentry.metrics.gauge('page_load_time', 150);
 Sentry.metrics.distribution('response_time', 200);
 `,
-        },
-        {
-          type: 'text',
-          text: tct(
-            'For more detailed information, see the [link:metrics documentation].',
-            {
-              link: (
-                <ExternalLink
-                  href={`https://docs.sentry.io/platforms/javascript/guides/${docsPlatform}/metrics/`}
-                />
-              ),
-            }
-          ),
-        },
-      ],
-    },
-  ],
-});
+          },
+          {
+            type: 'text',
+            text: tct(
+              'For more detailed information, see the [link:metrics documentation].',
+              {
+                link: (
+                  <ExternalLink
+                    href={`https://docs.sentry.io/platforms/javascript/guides/${docsPlatform}/metrics/`}
+                  />
+                ),
+              }
+            ),
+          },
+        ],
+      },
+    ],
+  };
+};

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -314,43 +314,47 @@ Sentry.profiler.stopProfiler();
 
 export const getNodeMcpOnboarding = ({
   packageName = '@sentry/node',
+  importPath,
 }: {
+  importPath?: string;
   packageName?: `@sentry/${string}`;
-} = {}): OnboardingConfig => ({
-  install: params => [
-    {
-      type: StepType.INSTALL,
-      content: [
+} = {}): OnboardingConfig => {
+  const importFrom = (importPath ?? packageName) as `@sentry/${string}`;
+  return {
+    install: params => [
+      {
+        type: StepType.INSTALL,
+        content: [
+          {
+            type: 'text',
+            text: tct(
+              'To enable MCP monitoring, you need to install the Sentry SDK with a minimum version of [code:9.44.0].',
+              {
+                code: <code />,
+              }
+            ),
+          },
+          getInstallCodeBlock(params, {
+            packageName,
+          }),
+        ],
+      },
+    ],
+    configure: params => {
+      const mcpSdkStep: ContentBlock[] = [
         {
           type: 'text',
-          text: tct(
-            'To enable MCP monitoring, you need to install the Sentry SDK with a minimum version of [code:9.44.0].',
-            {
-              code: <code />,
-            }
-          ),
+          text: tct('Initialize the Sentry SDK by calling [code:Sentry.init()]:', {
+            code: <code />,
+          }),
         },
-        getInstallCodeBlock(params, {
-          packageName,
-        }),
-      ],
-    },
-  ],
-  configure: params => {
-    const mcpSdkStep: ContentBlock[] = [
-      {
-        type: 'text',
-        text: tct('Initialize the Sentry SDK by calling [code:Sentry.init()]:', {
-          code: <code />,
-        }),
-      },
-      {
-        type: 'code',
-        tabs: [
-          {
-            label: 'JavaScript',
-            language: 'javascript',
-            code: `${getImport(packageName).join('\n')}
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: `${getImport(importFrom).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -358,93 +362,94 @@ Sentry.init({
   tracesSampleRate: 1.0,
   sendDefaultPii: true,
 });`,
-          },
-        ],
-      },
-      {
-        type: 'text',
-        text: tct(
-          'Wrap your MCP server in a [code:Sentry.wrapMcpServerWithSentry()] call. This will automatically capture spans for all MCP server interactions.',
-          {
-            code: <code />,
-          }
-        ),
-      },
-      {
-        type: 'code',
-        tabs: [
-          {
-            label: 'JavaScript',
-            language: 'javascript',
-            code: `
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'Wrap your MCP server in a [code:Sentry.wrapMcpServerWithSentry()] call. This will automatically capture spans for all MCP server interactions.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: `
 const { McpServer } = require("@modelcontextprotocol/sdk");
 
 const server = Sentry.wrapMcpServerWithSentry(new McpServer({
     name: "my-mcp-server",
     version: "1.0.0",
 }));`,
-          },
-        ],
-      },
-    ];
+            },
+          ],
+        },
+      ];
 
-    const manualStep: ContentBlock[] = [
-      {
-        type: 'text',
-        text: t('Initialize the Sentry SDK in the entry point of your application:'),
-      },
-      {
-        type: 'code',
-        tabs: [
-          {
-            label: 'JavaScript',
-            language: 'javascript',
-            code: `${getImport(packageName).join('\n')}
+      const manualStep: ContentBlock[] = [
+        {
+          type: 'text',
+          text: t('Initialize the Sentry SDK in the entry point of your application:'),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: `${getImport(importFrom).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn.public}",
   tracesSampleRate: 1.0,
 });`,
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'Then follow the [link:manual instrumentation guide] to instrument your MCP server.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/node/tracing/instrumentation/custom-instrumentation/mcp-module/#manual-instrumentation" />
+              ),
+            }
+          ),
+        },
+      ];
+
+      const selected = (params.platformOptions as any)?.integration ?? 'mcp_sdk';
+      const content = selected === 'manual' ? manualStep : mcpSdkStep;
+
+      return [
+        {
+          type: StepType.CONFIGURE,
+          content,
+        },
+      ];
+    },
+    verify: () => [
+      {
+        type: StepType.VERIFY,
+        content: [
+          {
+            type: 'text',
+            text: t(
+              'Verify that MCP monitoring is working correctly by triggering some MCP server interactions in your application.'
+            ),
           },
         ],
       },
-      {
-        type: 'text',
-        text: tct(
-          'Then follow the [link:manual instrumentation guide] to instrument your MCP server.',
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/node/tracing/instrumentation/custom-instrumentation/mcp-module/#manual-instrumentation" />
-            ),
-          }
-        ),
-      },
-    ];
-
-    const selected = (params.platformOptions as any)?.integration ?? 'mcp_sdk';
-    const content = selected === 'manual' ? manualStep : mcpSdkStep;
-
-    return [
-      {
-        type: StepType.CONFIGURE,
-        content,
-      },
-    ];
-  },
-  verify: () => [
-    {
-      type: StepType.VERIFY,
-      content: [
-        {
-          type: 'text',
-          text: t(
-            'Verify that MCP monitoring is working correctly by triggering some MCP server interactions in your application.'
-          ),
-        },
-      ],
-    },
-  ],
-});
+    ],
+  };
+};
 
 function getNodeLogsConfigureSnippet(
   params: DocsParams,
@@ -473,87 +478,97 @@ export const getNodeLogsOnboarding = <
 >({
   docsPlatform,
   packageName,
+  importPath,
   generateConfigureSnippet = getNodeLogsConfigureSnippet,
 }: {
   docsPlatform: string;
   packageName: `@sentry/${string}`;
   generateConfigureSnippet?: typeof getNodeLogsConfigureSnippet;
-}): OnboardingConfig<PlatformOptions> => ({
-  install: (params: DocsParams) => [
-    {
-      type: StepType.INSTALL,
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'Add the Sentry SDK as a dependency. The minimum version of [packageName] that supports logs is [code:9.41.0].',
-            {
-              code: <code />,
-              packageName: <code>{packageName}</code>,
-            }
-          ),
-        },
-        getInstallCodeBlock(params, {packageName}),
-        {
-          type: 'text',
-          text: tct(
-            'If you are on an older version of the SDK, follow our [link:migration guide] to upgrade.',
-            {
-              link: (
-                <ExternalLink
-                  href={`https://docs.sentry.io/platforms/javascript/guides/${docsPlatform}/migration/`}
-                />
-              ),
-            }
-          ),
-        },
-      ],
-    },
-  ],
-  configure: (params: DocsParams) => [
-    {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'Enable Sentry logs by adding [code:enableLogs: true] to your [code:Sentry.init()] configuration.',
-            {code: <code />}
-          ),
-        },
-        generateConfigureSnippet(params, packageName),
-        {
-          type: 'text',
-          text: tct('For more detailed information, see the [link:logs documentation].', {
-            link: (
-              <ExternalLink
-                href={`https://docs.sentry.io/platforms/javascript/guides/${docsPlatform}/logs/`}
-              />
+  importPath?: string;
+}): OnboardingConfig<PlatformOptions> => {
+  const importFrom = importPath ?? packageName;
+  return {
+    install: (params: DocsParams) => [
+      {
+        type: StepType.INSTALL,
+        content: [
+          {
+            type: 'text',
+            text: tct(
+              'Add the Sentry SDK as a dependency. The minimum version of [packageName] that supports logs is [code:9.41.0].',
+              {
+                code: <code />,
+                packageName: <code>{packageName}</code>,
+              }
             ),
-          }),
-        },
-      ],
-    },
-  ],
-  verify: () => [
-    {
-      type: StepType.VERIFY,
-      content: [
-        {
-          type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
-        },
-        {
-          type: 'code',
-          language: 'javascript',
-          code: `import * as Sentry from "${packageName}";
+          },
+          getInstallCodeBlock(params, {packageName}),
+          {
+            type: 'text',
+            text: tct(
+              'If you are on an older version of the SDK, follow our [link:migration guide] to upgrade.',
+              {
+                link: (
+                  <ExternalLink
+                    href={`https://docs.sentry.io/platforms/javascript/guides/${docsPlatform}/migration/`}
+                  />
+                ),
+              }
+            ),
+          },
+        ],
+      },
+    ],
+    configure: (params: DocsParams) => [
+      {
+        type: StepType.CONFIGURE,
+        content: [
+          {
+            type: 'text',
+            text: tct(
+              'Enable Sentry logs by adding [code:enableLogs: true] to your [code:Sentry.init()] configuration.',
+              {code: <code />}
+            ),
+          },
+          generateConfigureSnippet(params, importFrom as `@sentry/${string}`),
+          {
+            type: 'text',
+            text: tct(
+              'For more detailed information, see the [link:logs documentation].',
+              {
+                link: (
+                  <ExternalLink
+                    href={`https://docs.sentry.io/platforms/javascript/guides/${docsPlatform}/logs/`}
+                  />
+                ),
+              }
+            ),
+          },
+        ],
+      },
+    ],
+    verify: () => [
+      {
+        type: StepType.VERIFY,
+        content: [
+          {
+            type: 'text',
+            text: t(
+              'Send a test log from your app to verify logs are arriving in Sentry.'
+            ),
+          },
+          {
+            type: 'code',
+            language: 'javascript',
+            code: `import * as Sentry from "${importFrom}";
 
 Sentry.logger.info('User triggered test log', { action: 'test_log' })`,
-        },
-      ],
-    },
-  ],
-});
+          },
+        ],
+      },
+    ],
+  };
+};
 
 /**
  *  Returns the init() with the necessary imports. It is possible to omit the imports.


### PR DESCRIPTION


Updates the Hono onboarding guide to use the new dedicated @sentry/hono SDK which supports multiple runtimes (Cloudflare Workers, Node.js, and Bun).





- Replaces the generic Node.js-only onboarding with runtime-specific installation and configuration steps
- Adds a runtime selector (`platformOptions`) so users can switch between Cloudflare Workers, Node.js, and Bun instructions
- Adds an informational alert when profiling is selected on non-Node.js runtimes (profiling is only supported on Node.js)
- Adds an `importPath` option to shared onboarding utilities (logs, metrics, mcp) so Hono can use a different path for import statements (`@sentry/hono/node`) than for install commands (`@sentry/hono`)

closes https://github.com/getsentry/sentry-javascript/issues/20817


---

<img width="853" height="383" alt="image" src="https://github.com/user-attachments/assets/89241de6-c736-41f7-acba-74e54dd18b75" />



