### PR TITLE
build: Upgrade backend mypy to 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ dev = [
   "honcho>=2.0.0",
   "lxml-stubs>=0.4.0",
   "msgpack-types>=0.2.0",
-  "mypy>=1.20.2",
+  "mypy>=2.1.0",
   "mypy-extensions>=1.0.0",
   "openapi-core>=0.18.2",
   "openapi-pydantic>=0.4.0",
@@ -310,6 +310,7 @@ looponfailroots = ["src", "tests"]
 
 [tool.mypy]
 python_version = "3.13"
+num_workers = 5
 mypy_path = ["fixtures/stubs-for-mypy"]
 plugins = ["pydantic.mypy", "mypy_django_plugin.main", "tools.mypy_helpers.plugin"]
 files = ["."]

--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -255,7 +255,7 @@ def download_segments(segments: list[RecordingSegmentStorageMeta]) -> Iterator[b
     yield b"["
 
     for i, segment in iter_segment_data(segments):
-        yield segment
+        yield segment.tobytes()
         if i < len(segments) - 1:
             yield b","
 
@@ -277,14 +277,14 @@ def iter_segment_data(
 
 def download_segment(segment: RecordingSegmentStorageMeta, span: Any) -> bytes:
     results = _download_segment(segment)
-    return results[1] if results is not None else b"[]"
+    return results[1].tobytes() if results is not None else b"[]"
 
 
 def download_video(segment: RecordingSegmentStorageMeta) -> bytes | None:
     result = _download_segment(segment)
     if result is not None:
         video, _ = result
-        return video
+        return video.tobytes() if video is not None else None
     return None
 
 

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -1105,9 +1105,8 @@ class SearchResolver:
                 if mapped_column is not None:
                     field = mapped_column
 
-            search_type = cast(constants.SearchType, field_type)
             column_definition = ResolvedAttribute(
-                public_alias=alias, internal_name=field, search_type=search_type
+                public_alias=alias, internal_name=field, search_type=field_type
             )
             column_context = None
 

--- a/uv.lock
+++ b/uv.lock
@@ -31,6 +31,16 @@ wheels = [
 ]
 
 [[package]]
+name = "ast-serialize"
+version = "0.3.0"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/ast_serialize-0.3.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ef6d3c08b7b4cd29b48410338e134764a00e76d25841eb02c1084e868c888ecc" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d841424f41b886e98044abc80769c14a956e6e5ccd5fb5b0d9f5ead72be18a4" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1c9e763d70293d65ce1e1ea8c943140c68d0953f0268c7ee0998f2e07f77dd0" },
+]
+
+[[package]]
 name = "attrs"
 version = "24.2.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
@@ -1109,15 +1119,15 @@ wheels = [
 
 [[package]]
 name = "librt"
-version = "0.9.0"
+version = "0.11.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175" },
 ]
 
 [[package]]
@@ -1256,21 +1266,22 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.20.2"
+version = "2.1.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
+    { name = "ast-serialize", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "librt", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
     { name = "mypy-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pathspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef" },
 ]
 
 [[package]]
@@ -2380,7 +2391,7 @@ dev = [
     { name = "honcho", specifier = ">=2.0.0" },
     { name = "lxml-stubs", specifier = ">=0.4.0" },
     { name = "msgpack-types", specifier = ">=0.2.0" },
-    { name = "mypy", specifier = ">=1.20.2" },
+    { name = "mypy", specifier = ">=2.1.0" },
     { name = "mypy-extensions", specifier = ">=1.0.0" },
     { name = "openapi-core", specifier = ">=0.18.2" },
     { name = "openapi-pydantic", specifier = ">=0.4.0" },


### PR DESCRIPTION
Upgrade backend mypy to 2.1.0 and turn on config-driven parallel checking via `num_workers = 5`. 

**Type Compatibility**

Fix stricter 2.1.0 checks for replay segment byte iterators and an EAP resolver cast.

**Local Runtime Benchmark**

Measured locally with `/usr/bin/time -p` from the Sentry repo, using `PYTHONWARNINGS=error::RuntimeWarning`. Cold incremental runs used separate empty `--cache-dir` paths under `/tmp/sentry-mypy-bench` so worker-count rows did not reuse each other's cache.

| Run | Command shape | Result | Real time |
| --- | --- | ---: | ---: |
| old mypy serial | `mypy==1.20.2 -n1` | 1 error | `41.77s` |
| old mypy no incremental | `mypy==1.20.2 -n1 --no-incremental` | 1 error | `40.65s` |
| new mypy serial | `mypy==2.1.0 -n1` | pass | `40.29s` |
| new mypy workers=2 | `mypy==2.1.0 -n2` | pass | `26.57s` |
| new mypy workers=4 | `mypy==2.1.0 -n4` | pass | `19.27s` |
| new mypy config workers=5 | `mypy==2.1.0` using `num_workers = 5` | pass | `18.60s` |
| new mypy workers=8 | `mypy==2.1.0 -n8` | pass | `17.60s` |
| new mypy workers=12 | `mypy==2.1.0 -n12` | pass | `20.76s` |
| new mypy no incremental | `mypy==2.1.0 --no-incremental` using `num_workers = 5` | pass | `18.50s` |
| new mypy warm cache | `mypy==2.1.0` using `num_workers = 5` | pass | `7.68s` |

The version upgrade alone is roughly flat in serial mode locally, but enabling parallel checking cuts cold runtime from about 40s to about 18.6s with the configured 5 workers. `-n8` was the fastest single local run at 17.6s, while `-n12` regressed, so 5 workers keeps most of the speedup without pushing CPU contention as hard.


| Run | Command shape | Result | Real time |
| --- | --- | ---: | ---: |
| old mypy serial | `mypy==1.20.2 -n1` | `41.77s` |
| new mypy no incremental | `mypy==2.1.0 --no-incremental` using `num_workers = 5` | `18.50s` |
| new mypy warm cache | `mypy==2.1.0` using `num_workers = 5` |  `7.68s` |