### PR TITLE
fix(tracemetrics): Use stricter value for selector options

### DIFF
--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -19,7 +19,7 @@ import {
 export interface TraceMetric {
   name: string;
   type: string;
-  unit?: string;
+  unit?: string | null;
 }
 
 function isTraceMetric(value: unknown): value is TraceMetric {
@@ -27,11 +27,14 @@ function isTraceMetric(value: unknown): value is TraceMetric {
     return false;
   }
 
+  const unit = 'unit' in value ? value.unit : undefined;
+
   return (
     'name' in value &&
     typeof value.name === 'string' &&
     'type' in value &&
-    typeof value.type === 'string'
+    typeof value.type === 'string' &&
+    (unit === undefined || unit === null || typeof unit === 'string')
   );
 }
 

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.spec.tsx
@@ -422,7 +422,7 @@ describe('MetricSelector', () => {
       );
     });
 
-    it('only highlights the selected metric when same-name metrics have none and null units', async () => {
+    it('preserves null units when selecting between same-name metrics', async () => {
       MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/events/`,
@@ -469,10 +469,11 @@ describe('MetricSelector', () => {
         ],
       });
 
+      const onChange = jest.fn();
       render(
         <MetricSelector
-          traceMetric={{name: 'lighthouse.cls', type: 'distribution', unit: null} as any}
-          onChange={jest.fn()}
+          traceMetric={{name: 'lighthouse.cls', type: 'distribution', unit: 'none'}}
+          onChange={onChange}
         />,
         {organization}
       );
@@ -485,6 +486,14 @@ describe('MetricSelector', () => {
       expect(
         options.filter(option => option.getAttribute('aria-selected') === 'true')
       ).toHaveLength(1);
+
+      await userEvent.click(options[1]!);
+
+      expect(onChange).toHaveBeenCalledWith({
+        name: 'lighthouse.cls',
+        type: 'distribution',
+        unit: null,
+      });
     });
 
     it('shows unselected metrics as aria-selected="false"', async () => {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.spec.tsx
@@ -12,6 +12,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricSelector';
+import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
 
 const SORTED_METRIC_NAMES = [
   'bar',
@@ -419,6 +420,71 @@ describe('MetricSelector', () => {
         'aria-selected',
         'true'
       );
+    });
+
+    it('only highlights the selected metric when same-name metrics have none and null units', async () => {
+      MockApiClient.clearMockResponses();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events/`,
+        method: 'GET',
+        body: {
+          data: [
+            {
+              [TraceMetricKnownFieldKey.METRIC_NAME]: 'lighthouse.cls',
+              [TraceMetricKnownFieldKey.METRIC_TYPE]: 'distribution',
+              [TraceMetricKnownFieldKey.METRIC_UNIT]: 'none',
+              [`count(${TraceMetricKnownFieldKey.METRIC_NAME})`]: 1,
+              [`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]: 1736507580000000000,
+            },
+            {
+              [TraceMetricKnownFieldKey.METRIC_NAME]: 'lighthouse.cls',
+              [TraceMetricKnownFieldKey.METRIC_TYPE]: 'distribution',
+              [TraceMetricKnownFieldKey.METRIC_UNIT]: null,
+              [`count(${TraceMetricKnownFieldKey.METRIC_NAME})`]: 1,
+              [`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]: 1736507580000000000,
+            },
+          ],
+          meta: {
+            fields: {},
+            units: {},
+            dataScanned: 'full',
+          },
+        },
+        match: [
+          MockApiClient.matchQuery({
+            dataset: 'tracemetrics',
+            referrer: 'api.explore.metric-options',
+          }),
+        ],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/trace-items/attributes/`,
+        method: 'GET',
+        body: [
+          {
+            attributeType: 'string',
+            key: 'release',
+            name: 'release',
+          },
+        ],
+      });
+
+      render(
+        <MetricSelector
+          traceMetric={{name: 'lighthouse.cls', type: 'distribution', unit: null} as any}
+          onChange={jest.fn()}
+        />,
+        {organization}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'lighthouse.cls'}));
+
+      const options = await screen.findAllByRole('option', {name: 'lighthouse.cls'});
+
+      expect(options).toHaveLength(2);
+      expect(
+        options.filter(option => option.getAttribute('aria-selected') === 'true')
+      ).toHaveLength(1);
     });
 
     it('shows unselected metrics as aria-selected="false"', async () => {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -45,6 +45,7 @@ import {
 const METRIC_SELECTOR_OPTION_HEIGHT = 42;
 const METRIC_SELECTOR_DROPDOWN_MAX_HEIGHT = 400;
 const METRIC_SELECTOR_DROPDOWN_MIN_HEIGHT = 0;
+const NULL_METRIC_UNIT_SELECT_VALUE = '__null__';
 
 function maybePortal(element: React.ReactElement, portal?: boolean) {
   return portal ? createPortal(element, document.body) : element;
@@ -79,6 +80,25 @@ function MetricOptionTrailingItems({
   );
 }
 
+function getMetricSelectorUnit(metricUnit?: string | null) {
+  return metricUnit && metricUnit !== '-' ? metricUnit : NONE_UNIT;
+}
+
+function getMetricSelectorValueUnit(metricUnit?: string | null) {
+  if (metricUnit === null) {
+    return NULL_METRIC_UNIT_SELECT_VALUE;
+  }
+  return getMetricSelectorUnit(metricUnit);
+}
+
+function makeMetricSelectorValue(traceMetric: TraceMetric) {
+  return makeMetricSelectValue({
+    name: traceMetric.name,
+    type: traceMetric.type,
+    unit: getMetricSelectorValueUnit(traceMetric.unit),
+  });
+}
+
 export function MetricSelector({
   traceMetric,
   onChange,
@@ -111,9 +131,7 @@ export function MetricSelector({
     environments,
   });
 
-  const traceMetricSelectValue = makeMetricSelectValue(
-    hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
-  );
+  const traceMetricSelectValue = makeMetricSelectorValue(traceMetric);
 
   // Build an option object from the currently selected trace metric so it
   // can be shown in the list even if the API response hasn't loaded yet or
@@ -123,12 +141,12 @@ export function MetricSelector({
       label: traceMetric.name,
       value: traceMetricSelectValue,
       metricType: traceMetric.type as TraceMetricTypeValue,
-      metricUnit: hasMetricUnitsUI ? (traceMetric.unit ?? '-') : undefined,
+      metricUnit: traceMetric.unit,
       metricName: traceMetric.name,
       trailingItems: () => (
         <MetricOptionTrailingItems
           metricType={traceMetric.type as TraceMetricTypeValue}
-          metricUnit={traceMetric.unit ?? '-'}
+          metricUnit={getMetricSelectorUnit(traceMetric.unit)}
           hasMetricUnitsUI={hasMetricUnitsUI}
         />
       ),
@@ -146,53 +164,83 @@ export function MetricSelector({
   // find when the dropdown is reopened. Filter it out of the API results to
   // avoid duplication.
   const metricOptions = useMemo((): MetricSelectorOption[] => {
-    const selectedMetricValue = traceMetric.name ? traceMetricSelectValue : null;
-
     const apiOptions =
-      metricOptionsData?.data?.map(option => ({
-        label: option[TraceMetricKnownFieldKey.METRIC_NAME],
-        value: makeMetricSelectValue({
-          name: option[TraceMetricKnownFieldKey.METRIC_NAME],
-          type: option[TraceMetricKnownFieldKey.METRIC_TYPE] as TraceMetricTypeValue,
-          unit: hasMetricUnitsUI
-            ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
-            : undefined,
-        }),
-        metricType: option[TraceMetricKnownFieldKey.METRIC_TYPE],
-        metricName: option[TraceMetricKnownFieldKey.METRIC_NAME],
-        metricUnit: hasMetricUnitsUI
-          ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
-          : undefined,
-        count: option[`count(${TraceMetricKnownFieldKey.METRIC_NAME})`] as number,
-        lastSeen:
-          option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`] === undefined
-            ? undefined
-            : Number(option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]) /
-              1_000_000,
-        trailingItems: () => (
-          <MetricOptionTrailingItems
-            hasMetricUnitsUI={hasMetricUnitsUI}
-            metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]}
-            metricUnit={option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT}
-          />
-        ),
-      })) ?? [];
+      metricOptionsData?.data?.map(option => {
+        const metricName = option[TraceMetricKnownFieldKey.METRIC_NAME];
+        const metricType = option[
+          TraceMetricKnownFieldKey.METRIC_TYPE
+        ] as TraceMetricTypeValue;
+        const metricUnit = option[TraceMetricKnownFieldKey.METRIC_UNIT] as
+          | string
+          | null
+          | undefined;
+        const metricSelectValueUnit = getMetricSelectorValueUnit(
+          option[TraceMetricKnownFieldKey.METRIC_UNIT]
+        );
+
+        return {
+          label: metricName,
+          value: makeMetricSelectorValue({
+            name: metricName,
+            type: metricType,
+            unit: metricSelectValueUnit,
+          }),
+          metricType,
+          metricName,
+          metricUnit: metricUnit as string | undefined,
+          count: option[`count(${TraceMetricKnownFieldKey.METRIC_NAME})`] as number,
+          lastSeen:
+            option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`] === undefined
+              ? undefined
+              : Number(option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]) /
+                1_000_000,
+          trailingItems: () => (
+            <MetricOptionTrailingItems
+              hasMetricUnitsUI={hasMetricUnitsUI}
+              metricType={metricType}
+              metricUnit={getMetricSelectorUnit(metricUnit)}
+            />
+          ),
+        };
+      }) ?? [];
+    let hasMatchedSelectedMetric = false;
+    const hasExactSelectedMetric = apiOptions.some(
+      option => option.value === traceMetricSelectValue
+    );
+    const selectedApiOptions =
+      traceMetric.unit === undefined && !hasExactSelectedMetric
+        ? apiOptions.map(option => {
+            if (
+              hasMatchedSelectedMetric ||
+              option.metricName !== traceMetric.name ||
+              option.metricType !== traceMetric.type
+            ) {
+              return option;
+            }
+
+            hasMatchedSelectedMetric = true;
+            return {...option, value: traceMetricSelectValue};
+          })
+        : apiOptions;
 
     // Prefer the API version of the selected metric (it has count/lastSeen),
     // falling back to the bare optionFromTraceMetric when the API hasn't
     // returned it (e.g. filtered by search or still loading).
-    const selectedOption = selectedMetricValue
-      ? (apiOptions.find(o => o.value === selectedMetricValue) ?? optionFromTraceMetric)
+    const selectedOption = traceMetric.name
+      ? (selectedApiOptions.find(o => o.value === traceMetricSelectValue) ??
+        optionFromTraceMetric)
       : null;
 
     return [
       ...(selectedOption ? [selectedOption] : []),
-      ...apiOptions.filter(o => o.value !== selectedMetricValue),
+      ...selectedApiOptions.filter(o => o.value !== selectedOption?.value),
     ];
   }, [
     metricOptionsData,
     optionFromTraceMetric,
     traceMetric.name,
+    traceMetric.type,
+    traceMetric.unit,
     traceMetricSelectValue,
     hasMetricUnitsUI,
   ]);
@@ -204,7 +252,7 @@ export function MetricSelector({
       onChange({
         name: metricOptions[0].metricName,
         type: metricOptions[0].metricType,
-        unit: hasMetricUnitsUI ? (metricOptions[0].metricUnit ?? NONE_UNIT) : undefined,
+        unit: metricOptions[0].metricUnit,
       });
     }
   }, [metricOptions, onChange, traceMetric.name, hasMetricUnitsUI]);
@@ -286,7 +334,7 @@ export function MetricSelector({
         onChange({
           name: selectedOption.metricName,
           type: selectedOption.metricType,
-          unit: hasMetricUnitsUI ? selectedOption.metricUnit : undefined,
+          unit: selectedOption.metricUnit,
         });
         // Close via toggle() instead of close() because the combobox
         // overrides close with commitValue which re-fires onSelectionChange

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -184,7 +184,7 @@ export function MetricSelector({
           }),
           metricType,
           metricName,
-          metricUnit: metricUnit ?? undefined,
+          metricUnit,
           count: typeof count === 'number' ? count : undefined,
           lastSeen:
             option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`] === undefined

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -34,6 +34,7 @@ import {MetricDetailPanel} from 'sentry/views/explore/metrics/metricToolbar/metr
 import {MetricListBoxOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricListBoxOption';
 import type {MetricSelectorOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
 import {
+  isTraceMetricTypeValue,
   TraceMetricKnownFieldKey,
   type TraceMetricTypeValue,
 } from 'sentry/views/explore/metrics/types';
@@ -80,25 +81,6 @@ function MetricOptionTrailingItems({
   );
 }
 
-function getMetricSelectorUnit(metricUnit?: string | null) {
-  return metricUnit && metricUnit !== '-' ? metricUnit : NONE_UNIT;
-}
-
-function getMetricSelectorValueUnit(metricUnit?: string | null) {
-  if (metricUnit === null) {
-    return NULL_METRIC_UNIT_SELECT_VALUE;
-  }
-  return getMetricSelectorUnit(metricUnit);
-}
-
-function makeMetricSelectorValue(traceMetric: TraceMetric) {
-  return makeMetricSelectValue({
-    name: traceMetric.name,
-    type: traceMetric.type,
-    unit: getMetricSelectorValueUnit(traceMetric.unit),
-  });
-}
-
 export function MetricSelector({
   traceMetric,
   onChange,
@@ -131,34 +113,48 @@ export function MetricSelector({
     environments,
   });
 
-  const traceMetricSelectValue = makeMetricSelectorValue(traceMetric);
+  const traceMetricDisplayUnit =
+    traceMetric.unit && traceMetric.unit !== '-' ? traceMetric.unit : NONE_UNIT;
+  const traceMetricSelectValue = makeMetricSelectValue({
+    name: traceMetric.name,
+    type: traceMetric.type,
+    unit:
+      traceMetric.unit === null ? NULL_METRIC_UNIT_SELECT_VALUE : traceMetricDisplayUnit,
+  });
+  const traceMetricType = isTraceMetricTypeValue(traceMetric.type)
+    ? traceMetric.type
+    : null;
 
   // Build an option object from the currently selected trace metric so it
   // can be shown in the list even if the API response hasn't loaded yet or
   // doesn't include it (e.g. it was filtered out by search).
-  const optionFromTraceMetric: MetricSelectorOption = useMemo(
-    () => ({
+  const optionFromTraceMetric: MetricSelectorOption | null = useMemo(() => {
+    if (!traceMetricType) {
+      return null;
+    }
+
+    return {
       label: traceMetric.name,
       value: traceMetricSelectValue,
-      metricType: traceMetric.type as TraceMetricTypeValue,
+      metricType: traceMetricType,
       metricUnit: traceMetric.unit,
       metricName: traceMetric.name,
       trailingItems: () => (
         <MetricOptionTrailingItems
-          metricType={traceMetric.type as TraceMetricTypeValue}
-          metricUnit={getMetricSelectorUnit(traceMetric.unit)}
+          metricType={traceMetricType}
+          metricUnit={traceMetricDisplayUnit}
           hasMetricUnitsUI={hasMetricUnitsUI}
         />
       ),
-    }),
-    [
-      traceMetricSelectValue,
-      traceMetric.name,
-      traceMetric.type,
-      traceMetric.unit,
-      hasMetricUnitsUI,
-    ]
-  );
+    };
+  }, [
+    traceMetricSelectValue,
+    traceMetric.name,
+    traceMetricType,
+    traceMetric.unit,
+    traceMetricDisplayUnit,
+    hasMetricUnitsUI,
+  ]);
 
   // Always show the selected metric at the top of the list so it's easy to
   // find when the dropdown is reopened. Filter it out of the API results to
@@ -167,28 +163,29 @@ export function MetricSelector({
     const apiOptions =
       metricOptionsData?.data?.map(option => {
         const metricName = option[TraceMetricKnownFieldKey.METRIC_NAME];
-        const metricType = option[
-          TraceMetricKnownFieldKey.METRIC_TYPE
-        ] as TraceMetricTypeValue;
-        const metricUnit = option[TraceMetricKnownFieldKey.METRIC_UNIT] as
-          | string
-          | null
-          | undefined;
-        const metricSelectValueUnit = getMetricSelectorValueUnit(
-          option[TraceMetricKnownFieldKey.METRIC_UNIT]
-        );
+        const metricType = option[TraceMetricKnownFieldKey.METRIC_TYPE];
+        const rawMetricUnit: unknown = option[TraceMetricKnownFieldKey.METRIC_UNIT];
+        const metricUnit =
+          typeof rawMetricUnit === 'string' || rawMetricUnit === null
+            ? rawMetricUnit
+            : undefined;
+        const metricDisplayUnit =
+          metricUnit && metricUnit !== '-' ? metricUnit : NONE_UNIT;
+        const metricSelectValueUnit =
+          metricUnit === null ? NULL_METRIC_UNIT_SELECT_VALUE : metricDisplayUnit;
+        const count = option[`count(${TraceMetricKnownFieldKey.METRIC_NAME})`];
 
         return {
           label: metricName,
-          value: makeMetricSelectorValue({
+          value: makeMetricSelectValue({
             name: metricName,
             type: metricType,
             unit: metricSelectValueUnit,
           }),
           metricType,
           metricName,
-          metricUnit: metricUnit as string | undefined,
-          count: option[`count(${TraceMetricKnownFieldKey.METRIC_NAME})`] as number,
+          metricUnit: metricUnit ?? undefined,
+          count: typeof count === 'number' ? count : undefined,
           lastSeen:
             option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`] === undefined
               ? undefined
@@ -198,7 +195,7 @@ export function MetricSelector({
             <MetricOptionTrailingItems
               hasMetricUnitsUI={hasMetricUnitsUI}
               metricType={metricType}
-              metricUnit={getMetricSelectorUnit(metricUnit)}
+              metricUnit={metricDisplayUnit}
             />
           ),
         };

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -163,6 +163,7 @@ export function MetricSelector({
     const apiOptions =
       metricOptionsData?.data?.map(option => {
         const metricName = option[TraceMetricKnownFieldKey.METRIC_NAME];
+
         const metricType = option[TraceMetricKnownFieldKey.METRIC_TYPE];
         const rawMetricUnit: unknown = option[TraceMetricKnownFieldKey.METRIC_UNIT];
         const metricUnit =
@@ -173,24 +174,32 @@ export function MetricSelector({
           metricUnit && metricUnit !== '-' ? metricUnit : NONE_UNIT;
         const metricSelectValueUnit =
           metricUnit === null ? NULL_METRIC_UNIT_SELECT_VALUE : metricDisplayUnit;
-        const count = option[`count(${TraceMetricKnownFieldKey.METRIC_NAME})`];
+        const value = makeMetricSelectValue({
+          name: metricName,
+          type: metricType,
+          unit: metricSelectValueUnit,
+        });
+        const countField = option[`count(${TraceMetricKnownFieldKey.METRIC_NAME})`];
+        const count =
+          typeof countField === 'number'
+            ? countField
+            : typeof countField === 'string'
+              ? Number(countField)
+              : undefined;
+        const lastSeen =
+          option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`] === undefined
+            ? undefined
+            : Number(option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]) /
+              1_000_000;
 
         return {
           label: metricName,
-          value: makeMetricSelectValue({
-            name: metricName,
-            type: metricType,
-            unit: metricSelectValueUnit,
-          }),
+          value,
           metricType,
           metricName,
           metricUnit,
-          count: typeof count === 'number' ? count : undefined,
-          lastSeen:
-            option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`] === undefined
-              ? undefined
-              : Number(option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]) /
-                1_000_000,
+          count,
+          lastSeen,
           trailingItems: () => (
             <MetricOptionTrailingItems
               hasMetricUnitsUI={hasMetricUnitsUI}

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/types.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/types.tsx
@@ -7,5 +7,5 @@ export interface MetricSelectorOption extends SelectOption<string> {
   metricType: TraceMetricTypeValue;
   count?: number;
   lastSeen?: number;
-  metricUnit?: string;
+  metricUnit?: string | null;
 }

--- a/static/app/views/explore/metrics/types.tsx
+++ b/static/app/views/explore/metrics/types.tsx
@@ -65,6 +65,19 @@ export type TraceMetricFieldKey = TraceMetricCustomFieldKey | TraceMetricKnownFi
 
 export type TraceMetricTypeValue = 'counter' | 'gauge' | 'distribution';
 
+export function isTraceMetricTypeValue(
+  metricType: string
+): metricType is TraceMetricTypeValue {
+  switch (metricType) {
+    case 'counter':
+    case 'distribution':
+    case 'gauge':
+      return true;
+    default:
+      return false;
+  }
+}
+
 type TraceMetricsKnownFieldResponseMap = Record<
   TraceMetricKnownFieldKey,
   string | number

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -100,7 +100,7 @@ export function createTraceMetricFilter(traceMetric: TraceMetric): string | unde
 
 export function hasDisplayMetricUnit(
   hasMetricUnitsUI: boolean,
-  metricUnit?: string
+  metricUnit?: string | null
 ): metricUnit is string {
   return (
     hasMetricUnitsUI && !!metricUnit && metricUnit !== '-' && metricUnit !== NONE_UNIT
@@ -302,7 +302,7 @@ const PERCENTAGE_UNIT_VALUES = new Set<string>(['ratio', 'percent']);
  * responses, so the frontend must do this mapping based on the selected
  * metric's unit.
  */
-export function mapMetricUnitToFieldType(metricUnit: string | undefined): {
+export function mapMetricUnitToFieldType(metricUnit: string | null | undefined): {
   fieldType: ColumnType;
   unit: string | undefined;
 } {


### PR DESCRIPTION
Currently we don't use a strict enough value in the metric selector for the various options. This leads to an issue where a metric may have the same name but different type or unit, being considered as the same metric, and causing a small UX issue.

This PR resolves this issue by moving to a more strict value for the options.