### PR TITLE
feat(preprod): Add Snapshot Settings link to snapshot details menu

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -22,10 +22,12 @@ import {
   IconOpen,
   IconReceipt,
   IconRefresh,
+  IconSettings,
   IconThumb,
   IconTimer,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {AvatarUser} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {downloadFromHref} from 'sentry/utils/downloadFromHref';
@@ -56,6 +58,7 @@ export function SnapshotHeaderActions({
   const organization = useOrganization();
   const breakpoints = useBreakpoints();
   const isSentryEmployee = useIsSentryEmployee();
+  const project = ProjectsStore.getById(data.project_id);
   const [isApproving, setIsApproving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -298,6 +301,24 @@ export function SnapshotHeaderActions({
               onAction: handleRerunStatusChecks,
               textValue: t('Rerun Status Checks'),
             },
+            ...(project
+              ? [
+                  {
+                    key: 'snapshot-settings',
+                    label: (
+                      <Flex align="center" gap="sm">
+                        <IconSettings size="sm" />
+                        {t('Snapshot Settings')}
+                      </Flex>
+                    ),
+                    onAction: () =>
+                      navigate(
+                        `/settings/${organizationSlug}/projects/${project.slug}/snapshots/`
+                      ),
+                    textValue: t('Snapshot Settings'),
+                  },
+                ]
+              : []),
             {
               key: 'delete',
               label: (


### PR DESCRIPTION
Add a "Snapshot Settings" item to the ellipsis overflow menu on the snapshot details page, linking to the project's snapshot settings page. The build details header already has a settings link — this adds the equivalent for snapshots.

**Menu Item**

Resolves the project from `ProjectsStore.getById(data.project_id)` (same pattern as `snapshotHeaderContent.tsx`) and adds a "Snapshot Settings" entry that navigates to `/settings/{org}/projects/{project}/snapshots/`. Hidden when the project can't be resolved.

Refs EME-1127

<img width="556" height="706" alt="CleanShot 2026-05-13 at 11 25 09@2x" src="https://github.com/user-attachments/assets/f7f4f231-f2ae-44cd-8fa4-31d7220b30f3" />
