### PR TITLE
docs(spans): Update span buffer docs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3274,7 +3274,8 @@ register(
 )
 # TTL (in seconds) for the per-segment lock acquired at flush time to
 # prevent two flushers from producing the same segment concurrently.
-# The lock is never explicitly released and only expires via this TTL.
+# The lock is explicitly released by the flusher after the segment payloads
+# are flushed/produced and metadata are cleaned up.
 # Pick a value larger than the expected flush+produce latency but smaller than
 # `spans.buffer.root-timeout` so a re-entered segment isn't blocked from its
 # next flush cycle. If set to 0, no locks will be acquired.

--- a/src/sentry/spans/README.md
+++ b/src/sentry/spans/README.md
@@ -78,10 +78,11 @@ event types are limited in terms of frequency.
 
 - This limit is enforced in two places: while accumulating the segment in the
   buffer and when about to flush it to the segment consumer.
-  - As we add spans to subsegments in Redis we prune sets that become too large.
-    This is done by dropping spans until they stay in the max size. This, obviously
-    breaks the structure of the trace as the missing spans may be anywhere in
-    the tree.
+  - While accumulating in Redis, every subsegment is written to a salted payload
+    key and the Lua script tracks the segment's cumulative ingested bytes in
+    `span-buf:ibc:<segment_key>`. If merging a subsegment would push the segment
+    over the limit, the script detaches that subsegment into a new segment instead
+    of merging it into the parent, avoiding dropping data.
 
   - As we extract the subsegments and reassemble them, if the segment size exceeds
     the `max-segment-bytes` limit, we chunk it into multiple Kafka messages, each within
@@ -219,12 +220,14 @@ erDiagram
 **Payload keys**
 
 ```
-span-buf:s:{PROJECT_ID:TRACE_ID:SPAN_ID}:SPAN_ID
+span-buf:s:{PROJECT_ID:TRACE_ID:SALT}:SALT
 ```
 
-Each subsegment gets its own payload key (`{project_id:trace_id:span_id}:span_id`).
-This distributes payloads across Redis cluster nodes instead of concentrating
-all spans of a trace on a single node.
+Each subsegment gets its own payload key (`{project_id:trace_id:salt}:salt`).
+The salt identifies the subsegment and is determined by hashing all span IDs in
+the subsegment. This distributes payloads across Redis cluster nodes instead of
+concentrating all spans of a trace on a single node, and allows the Lua script to
+be able to detach a subsegment into its own segment when needed.
 
 **Member-keys index**
 
@@ -259,6 +262,9 @@ the span IDs of a `Subsegment` and:
    - **Parent span**: If the parent span ID redirects to a different root
      (i.e. it is not the segment root itself), its member-keys are also merged
      into the new root.
+4. Detaches the subsegment into its own salted segment instead of merging when
+   the target segment size would exceed `spans.buffer.max-segment-bytes`, or if
+   the target segment is currently being flushed.
 
 **Redirect set**
 
@@ -315,12 +321,26 @@ by at most one consumer, no two consumers can flush from the same queue.
 Flushing happens in two steps:
 
 1. `flush_segments`: reads segment keys from the queue via `ZRANGEBYSCORE`
-   (segments past their flush deadline), looks up the member-keys index to
-   discover payload keys, loads span payloads from each via `SSCAN`, and
-   produces them to the `buffered-segments` Kafka topic.
+   (segments past their flush deadline), acquires a per-segment Redis lock
+   (`span-buf:fl:<segment_key>`) with `SET NX EX`, looks up the member-keys index
+   to discover payload keys, loads span payloads from each via `SSCAN`, and produces
+   them to the `buffered-segments` Kafka topic.
 2. `done_flush_segments`: cleans up Redis keys (`DELETE` metadata,
    `UNLINK` payload keys, `DELETE` member-keys index, `HDEL` redirect
-   entries, `ZREM` the queue entry).
+   entries, `DELETE` the flush lock, `ZREM` the queue entry).
+
+The per-segment lock prevents duplicate production:
+
+- A segment key can appear in more than one shard queue when spans from
+  the same segment arrive from different Kafka partitions.
+- Each queue is still owned by at most one flusher, but different flushers will
+  have the same segment key in their own queues.
+- Only one flusher can acquire the lock and flush the segment, the other flushers will
+  skip that segment for the flush cycle.
+- After the segment is flushed, `done_flush_segments` deletes the segment metadata and
+  payload keys. It also deletes the lock so later flushers can acquire it and remove
+  stale queue entries instead of repeatedly finding the same locked segment at the front
+  of their queue.
 
 # GCP Log Analyzer Tool
 

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -1,6 +1,6 @@
 """
-Span buffer is a consumer that takes individual spans from snuba-spans (soon
-ingest-spans, anyway, from Relay) and assembles them to segments of this form:
+Span buffer is a consumer that takes individual spans from Relay, in the `ingest-spans` topic,
+and assembles them to segments of this form:
 
     {"spans": <span1>,<span2>,<span3>}
 
@@ -25,10 +25,10 @@ We simplify this set of conditions for the span buffer:
 * Relay writes is_segment based on some other attributes for us, so that we don't have to look at N span-local attributes. This simplifies condition 2.
 * The span buffer is sharded by project. Therefore, condition 4 is handled by the code for condition 3, although with some delay.
 
-Segments are flushed out to `buffered-spans` topic under two conditions:
+Segments are flushed out to `buffered-segments` topic under two conditions:
 
-* If the segment has a root span, it is flushed out after `span_buffer_root_timeout` seconds of inactivity.
-* Otherwise, it is flushed out after `span_buffer_timeout` seconds of inactivity.
+* If the segment has a root span, it is flushed out after `spans.buffer.root-timeout` seconds of inactivity.
+* Otherwise, it is flushed out after `spans.buffer.timeout` seconds of inactivity.
 
 Now how does that look like in Redis? For each incoming span, we:
 
@@ -46,11 +46,15 @@ Now how does that look like in Redis? For each incoming span, we:
       current segment root.
    d. If the segment exceeds max_segment_bytes, detaches the subsegment
       into its own segment keyed by the salt.
+   e. If the target segment is currently locked by a flusher, detaches the
+      subsegment into its own segment so new spans are not written into data
+      that is being produced and cleaned up.
 3. To a "global queue", we write the segment key, sorted by timeout.
 
-Eventually, flushing cronjob looks at that global queue, and removes all timed
-out keys from it. Then fetches the payload keys for each segment via the
-member-keys index, loads their data, and cleans up.
+Eventually, flusher subprocesses read timed-out segment keys from the queue,
+acquire a per-segment flush lock when configured, fetch the payload keys for
+each segment via the member-keys index, load their data, and produce the
+segment.
 
 This happens in two steps: Get the to-be-flushed segments in `flush_segments`,
 then the consumer produces them, then they are deleted from Redis
@@ -68,18 +72,18 @@ Segments can grow unboundedly as spans arrive. To prevent oversized segments fro
 consuming excessive memory during flush, the buffer enforces a maximum byte limit
 per segment (controlled by `spans.buffer.max-segment-bytes`).
 
-Each subsegment is assigned a unique salt (UUID). The Lua script tracks cumulative
+Each subsegment is assigned a unique salt. The Lua script tracks cumulative
 ingested bytes per segment via `span-buf:ibc` keys. If adding a subsegment would
-push the segment over the byte limit, the script detaches it into a new segment
-keyed by the salt instead of merging it into the parent. The detached segment is
-independently tracked and flushed.
+push the segment over the byte limit, or if the target segment is being flushed,
+the script detaches the subsegment into a new segment keyed by the salt instead of
+merging it into the parent. The detached segment is independently tracked and flushed.
 
 During flush, segments that exceed `max-segment-bytes` are chunked into multiple
 Kafka messages to stay within downstream size limits.
 
 Glossary for types of keys:
 
-    * span-buf:s:{project_id:trace_id:span_id}:span_id -- payload keys containing span payloads, distributed across cluster nodes.
+    * span-buf:s:{project_id:trace_id:salt}:salt -- payload keys containing span payloads, distributed across cluster nodes.
     * span-buf:mk:{project_id:trace_id}:root_span_id -- member-keys index, tracks which payload keys belong to a segment.
     * span-buf:q:* -- the priority queue, used to determine which segments are ready to be flushed.
     * span-buf:ssr:{project_id:trace_id} -- redirect mappings so that each incoming span ID can be mapped to the right segment.
@@ -88,6 +92,7 @@ Glossary for types of keys:
     * span-buf:ibc:<segment_key> -- ingested byte count, total bytes originally ingested for a segment.
     * span-buf:fl:<segment_key> -- a per-segment lock (with TTL) to prevent the same segment from being flushed multiple times concurrently.
     <segment_key> -- an internal identifier, see `spans.segment_key` module.
+    <salt> -- a unique identifier for a subsegment, determined by hashing all span IDs in the subsegment.
 """
 
 from __future__ import annotations
@@ -951,6 +956,12 @@ class SpansBuffer:
                         for payload_key in flushed_segment.payload_keys:
                             p.unlink(payload_key)
 
+                    # A segment can be queued in more than one shard when spans from the
+                    # same segment land in different Kafka partitions. Releasing the lock
+                    # here lets a contending flusher later acquire it and remove those stale
+                    # queue entries instead of blocking on ZRANGEBYSCORE until lock TTL expires.
+                    # Since the segment metadata and payload keys have already been deleted
+                    # above, a stale queue entry cannot produce the segment again.
                     p.delete(self._get_flush_lock_key(segment_key))
 
                 for queue_key, keys in queue_removals.items():


### PR DESCRIPTION
There has been a lot of changes with span buffer since the last docs pass, so this refreshes the docs to match the current Lua and flusher behaviour.

The docs now cover salted payload keys, `max-segment-bytes` detaching, and the behaviour of the per-segment flush locks when the same segment appear in multiple queues.