### PR TITLE
chore(issue-detection): Increase trace samples for AI Issue Detection 

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -325,16 +325,24 @@ def detect_llm_issues_for_org(org_id: int, plan_tier: str = "business") -> None:
         except json.JSONDecodeError:
             pass
 
+    traces_per_invocation_mapping = options.get(
+        "issue-detection.llm-detection.traces-per-invocation"
+    )
+    traces_per_invocation = traces_per_invocation_mapping.get(
+        plan_tier, DEFAULT_TRACES_PER_INVOCATION
+    )
+    sample_multiplier = 1 if traces_per_invocation == DEFAULT_TRACES_PER_INVOCATION else 2
+
     evidence_traces = get_project_top_transaction_traces_for_llm_detection(
-        project_id, limit=TRANSACTION_BATCH_SIZE, start_time_delta_minutes=START_TIME_DELTA_MINUTES
+        project_id,
+        limit=TRANSACTION_BATCH_SIZE,
+        sample_multiplier=sample_multiplier,
+        start_time_delta_minutes=START_TIME_DELTA_MINUTES,
     )
     if not evidence_traces:
         return
 
-    traces_per_invocation = options.get("issue-detection.llm-detection.traces-per-invocation")
-    traces_to_send = evidence_traces[
-        : traces_per_invocation.get(plan_tier, DEFAULT_TRACES_PER_INVOCATION)
-    ]
+    traces_to_send = evidence_traces[:traces_per_invocation]
 
     sentry_sdk.metrics.count(
         "llm_issue_detection.seer_request",

--- a/src/sentry/tasks/llm_issue_detection/trace_data.py
+++ b/src/sentry/tasks/llm_issue_detection/trace_data.py
@@ -153,8 +153,8 @@ def _build_project_playlist(
 def get_project_top_transaction_traces_for_llm_detection(
     project_id: int,
     limit: int,
-    sample_multiplier: int,
     start_time_delta_minutes: int,
+    sample_multiplier: int = 1,
 ) -> list[TraceMetadataWithSpanCount]:
     """
     Get top transactions by total time spent, return one semi-randomly chosen trace per transaction.

--- a/src/sentry/tasks/llm_issue_detection/trace_data.py
+++ b/src/sentry/tasks/llm_issue_detection/trace_data.py
@@ -153,6 +153,7 @@ def _build_project_playlist(
 def get_project_top_transaction_traces_for_llm_detection(
     project_id: int,
     limit: int,
+    sample_multiplier: int,
     start_time_delta_minutes: int,
 ) -> list[TraceMetadataWithSpanCount]:
     """
@@ -199,7 +200,7 @@ def get_project_top_transaction_traces_for_llm_detection(
 
     transaction_rows = transactions_result.get("data", [])
     random.shuffle(transaction_rows)
-    transaction_rows = transaction_rows[:TRACE_SAMPLE_SIZE]
+    transaction_rows = transaction_rows[: TRACE_SAMPLE_SIZE * sample_multiplier]
 
     trace_ids: list[str] = []
     seen_names: set[str] = set()

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -59,6 +59,7 @@ class LLMIssueDetectionTest(TestCase):
         mock_get_transactions.assert_called_once_with(
             self.project.id,
             limit=TRANSACTION_BATCH_SIZE,
+            sample_multiplier=1,
             start_time_delta_minutes=START_TIME_DELTA_MINUTES,
         )
         mock_seer_request.assert_not_called()


### PR DESCRIPTION
we previously lowered the number of traces we query for to `5`, since we were only picking 1 trace. Now that we sometimes send over multiple traces, we should query for more traces initially so after filtering, we still have enough traces to send to Seer. 