### PR TITLE
feat(settings): Convert project environments table to FC

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -178,9 +178,6 @@ export type Environment = {
   displayName: string;
   id: string;
   name: string;
-
-  // XXX: Provided by the backend but unused due to `getUrlRoutingName()`
-  // urlRoutingName: string;
 };
 
 export interface TeamWithProjects extends Team {

--- a/static/app/utils/environment.tsx
+++ b/static/app/utils/environment.tsx
@@ -1,23 +1,6 @@
 import type {Environment} from 'sentry/types/project';
 
-const DEFAULT_EMPTY_ROUTING_NAME = 'none';
 const DEFAULT_EMPTY_ENV_NAME = '(No Environment)';
-
-/**
- * Double encodes the environment name or display name to be used in the URL routing name.
- * This is necessary because the environment name or display name may contain special characters
- * that need to be encoded for the URL.
- */
-export function getUrlRoutingName(env: Partial<Environment>) {
-  if (env.name) {
-    return encodeURIComponent(encodeURIComponent(env.name));
-  }
-
-  if (env.displayName) {
-    return encodeURIComponent(encodeURIComponent(env.displayName));
-  }
-  return DEFAULT_EMPTY_ROUTING_NAME;
-}
 
 export function getDisplayName(env: Partial<Environment>) {
   return env.name || env.displayName || DEFAULT_EMPTY_ENV_NAME;

--- a/static/app/views/settings/project/projectEnvironments.spec.tsx
+++ b/static/app/views/settings/project/projectEnvironments.spec.tsx
@@ -4,7 +4,7 @@ import {
 } from 'sentry-fixture/environments';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import ProjectEnvironments from 'sentry/views/settings/project/projectEnvironments';
 
@@ -27,193 +27,96 @@ function renderComponent(isHidden: boolean) {
   });
 }
 
+function getEnvironmentRow(name: string) {
+  const row = screen.getByText(name).closest('[role="row"]');
+
+  if (!(row instanceof HTMLElement)) {
+    throw new Error(`Unable to find row for environment: ${name}`);
+  }
+
+  return row;
+}
+
+async function clickEnvironmentAction(name: string, action: string) {
+  await screen.findByText(name);
+  await userEvent.click(
+    within(getEnvironmentRow(name)).getByRole('button', {name: action})
+  );
+}
+
 describe('ProjectEnvironments', () => {
-  describe('render active', () => {
-    it('renders empty message', async () => {
-      MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/environments/',
-        body: [],
-      });
-
-      renderComponent(false);
-
-      expect(
-        await screen.findByText("You don't have any environments yet.")
-      ).toBeInTheDocument();
+  it.each([
+    ['active', false, "You don't have any environments yet."],
+    ['hidden', true, "You don't have any hidden environments."],
+  ])('renders the %s empty state', async (_label, isHidden, message) => {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/environments/',
+      body: [],
     });
 
-    it('renders environment list', async () => {
-      MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/environments/',
-        body: EnvironmentsFixture(),
-      });
-      renderComponent(false);
+    renderComponent(isHidden);
 
-      expect(await screen.findByText('production')).toBeInTheDocument();
-      expect(await screen.findAllByRole('button', {name: 'Hide'})).toHaveLength(3);
-    });
+    expect(await screen.findByText(message)).toBeInTheDocument();
   });
 
-  describe('render hidden', () => {
-    it('renders empty message', async () => {
-      MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/environments/',
-        body: [],
-      });
-
-      renderComponent(true);
-
-      expect(
-        await screen.findByText("You don't have any hidden environments.")
-      ).toBeInTheDocument();
+  it('renders active environments', async () => {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/environments/',
+      body: EnvironmentsFixture(),
     });
 
-    it('renders environment list', async () => {
-      MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/environments/',
-        body: HiddenEnvironmentsFixture(),
-      });
-      renderComponent(true);
+    renderComponent(false);
 
-      // Hidden buttons should not have "Set as default"
-      expect(await screen.findByRole('button', {name: 'Show'})).toBeInTheDocument();
-    });
+    expect(await screen.findByText('production')).toBeInTheDocument();
+    expect(screen.getByText('All Environments')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', {name: 'Hide'})).toHaveLength(3);
   });
 
-  describe('toggle', () => {
-    let hideMock: jest.Mock;
-    let showMock: jest.Mock;
-    const baseUrl = '/projects/org-slug/project-slug/environments/';
-    beforeEach(() => {
-      hideMock = MockApiClient.addMockResponse({
-        url: `${baseUrl}production/`,
-        method: 'PUT',
-      });
-      showMock = MockApiClient.addMockResponse({
-        url: `${baseUrl}zzz/`,
-        method: 'PUT',
-      });
-
-      MockApiClient.addMockResponse({
-        url: baseUrl,
-      });
+  it.each([
+    ['%app_env%', '%2525app_env%2525'],
+    ['us%2Feast', 'us%25252Feast'],
+  ])('double-encodes environment path params for %s', async (name, encodedName) => {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/environments/',
+      body: [{id: '1', name, displayName: name}],
+    });
+    const hideMock = MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/environments/${encodedName}/`,
+      method: 'PUT',
     });
 
-    it('hides', async () => {
-      MockApiClient.addMockResponse({
-        url: baseUrl,
-        body: EnvironmentsFixture(),
-      });
+    renderComponent(false);
 
-      renderComponent(false);
+    await clickEnvironmentAction(name, 'Hide');
 
-      // Click first row 'hide' (production)
-      //
-      // XXX(epurkhiser): In the future we should improve the accessability of
-      // lists, because right now there's no way to associate the hide button
-      // with its environment
-      await userEvent.click((await screen.findAllByRole('button', {name: 'Hide'}))[0]!);
+    expect(hideMock).toHaveBeenCalledWith(
+      `/projects/org-slug/project-slug/environments/${encodedName}/`,
+      expect.objectContaining({
+        data: expect.objectContaining({isHidden: true}),
+      })
+    );
+  });
 
-      expect(hideMock).toHaveBeenCalledWith(
-        `${baseUrl}production/`,
-        expect.objectContaining({
-          data: expect.objectContaining({isHidden: true}),
-        })
-      );
+  it('renders hidden environments and unhides them', async () => {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/environments/',
+      body: HiddenEnvironmentsFixture(),
+    });
+    const showMock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/environments/zzz/',
+      method: 'PUT',
     });
 
-    it('optimistically removes hidden environments without showing loading state', async () => {
-      hideMock = MockApiClient.addMockResponse({
-        url: `${baseUrl}production/`,
-        method: 'PUT',
-        asyncDelay: 50,
-      });
-      let environmentRequestCount = 0;
+    renderComponent(true);
 
-      MockApiClient.addMockResponse({
-        url: baseUrl,
-        body: () => {
-          environmentRequestCount += 1;
-          return environmentRequestCount === 1
-            ? EnvironmentsFixture()
-            : EnvironmentsFixture().filter(
-                environment => environment.name !== 'production'
-              );
-        },
-      });
+    await clickEnvironmentAction('zzz', 'Show');
 
-      renderComponent(false);
-
-      expect(await screen.findByText('production')).toBeInTheDocument();
-
-      await userEvent.click((await screen.findAllByRole('button', {name: 'Hide'}))[0]!);
-
-      expect(screen.queryByText('production')).not.toBeInTheDocument();
-      expect(screen.queryAllByTestId('loading-placeholder')).toHaveLength(0);
-
-      await act(async () => {
-        await new Promise(resolve => setTimeout(resolve, 60));
-      });
-
-      expect(screen.queryAllByTestId('loading-placeholder')).toHaveLength(0);
-      expect(hideMock).toHaveBeenCalledWith(
-        `${baseUrl}production/`,
-        expect.objectContaining({
-          data: expect.objectContaining({isHidden: true}),
-        })
-      );
-    });
-
-    it('hides names requiring encoding', async () => {
-      MockApiClient.addMockResponse({
-        url: baseUrl,
-        body: [{id: '1', name: '%app_env%', isHidden: false}],
-      });
-
-      hideMock = MockApiClient.addMockResponse({
-        url: `${baseUrl}%25app_env%25/`,
-        method: 'PUT',
-      });
-
-      renderComponent(false);
-
-      await userEvent.click(await screen.findByRole('button', {name: 'Hide'}));
-
-      expect(hideMock).toHaveBeenCalledWith(
-        `${baseUrl}%25app_env%25/`,
-        expect.objectContaining({
-          data: expect.objectContaining({isHidden: true}),
-        })
-      );
-    });
-
-    it('shows', async () => {
-      MockApiClient.addMockResponse({
-        url: baseUrl,
-        body: HiddenEnvironmentsFixture(),
-      });
-
-      renderComponent(true);
-
-      await userEvent.click(await screen.findByRole('button', {name: 'Show'}));
-
-      expect(showMock).toHaveBeenCalledWith(
-        `${baseUrl}zzz/`,
-        expect.objectContaining({
-          data: expect.objectContaining({isHidden: false}),
-        })
-      );
-    });
-
-    it('does not have "All Environments" rows', async () => {
-      MockApiClient.addMockResponse({
-        url: baseUrl,
-        body: HiddenEnvironmentsFixture(),
-      });
-
-      renderComponent(true);
-      await screen.findByRole('button', {name: 'Show'});
-      expect(screen.queryByText('All Environments')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByText('All Environments')).not.toBeInTheDocument();
+    expect(showMock).toHaveBeenCalledWith(
+      '/projects/org-slug/project-slug/environments/zzz/',
+      expect.objectContaining({
+        data: expect.objectContaining({isHidden: false}),
+      })
+    );
   });
 });

--- a/static/app/views/settings/project/projectEnvironments.spec.tsx
+++ b/static/app/views/settings/project/projectEnvironments.spec.tsx
@@ -4,24 +4,18 @@ import {
 } from 'sentry-fixture/environments';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {recreateRoute} from 'sentry/utils/recreateRoute';
 import ProjectEnvironments from 'sentry/views/settings/project/projectEnvironments';
-
-jest.mock('sentry/utils/recreateRoute');
-jest
-  .mocked(recreateRoute)
-  .mockReturnValue('/org-slug/project-slug/settings/environments/');
 
 function renderComponent(isHidden: boolean) {
   const {organization, project} = initializeOrg();
   const pathname = isHidden
-    ? `/settings/projects/${project.slug}/environments/hidden/`
-    : `/settings/projects/${project.slug}/environments/`;
+    ? `/settings/${organization.slug}/projects/${project.slug}/environments/hidden/`
+    : `/settings/${organization.slug}/projects/${project.slug}/environments/`;
   const route = isHidden
-    ? '/settings/projects/:projectId/environments/hidden/'
-    : '/settings/projects/:projectId/environments/';
+    ? '/settings/:orgId/projects/:projectId/environments/hidden/'
+    : '/settings/:orgId/projects/:projectId/environments/';
 
   return render(<ProjectEnvironments />, {
     organization,
@@ -34,12 +28,8 @@ function renderComponent(isHidden: boolean) {
 }
 
 describe('ProjectEnvironments', () => {
-  afterEach(() => {
-    MockApiClient.clearMockResponses();
-  });
-
   describe('render active', () => {
-    it('renders empty message', () => {
+    it('renders empty message', async () => {
       MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/environments/',
         body: [],
@@ -48,24 +38,24 @@ describe('ProjectEnvironments', () => {
       renderComponent(false);
 
       expect(
-        screen.getByText("You don't have any environments yet.")
+        await screen.findByText("You don't have any environments yet.")
       ).toBeInTheDocument();
     });
 
-    it('renders environment list', () => {
+    it('renders environment list', async () => {
       MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/environments/',
         body: EnvironmentsFixture(),
       });
       renderComponent(false);
 
-      expect(screen.getByText('production')).toBeInTheDocument();
-      expect(screen.getAllByRole('button', {name: 'Hide'})).toHaveLength(3);
+      expect(await screen.findByText('production')).toBeInTheDocument();
+      expect(await screen.findAllByRole('button', {name: 'Hide'})).toHaveLength(3);
     });
   });
 
   describe('render hidden', () => {
-    it('renders empty message', () => {
+    it('renders empty message', async () => {
       MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/environments/',
         body: [],
@@ -74,11 +64,11 @@ describe('ProjectEnvironments', () => {
       renderComponent(true);
 
       expect(
-        screen.getByText("You don't have any hidden environments.")
+        await screen.findByText("You don't have any hidden environments.")
       ).toBeInTheDocument();
     });
 
-    it('renders environment list', () => {
+    it('renders environment list', async () => {
       MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/environments/',
         body: HiddenEnvironmentsFixture(),
@@ -86,7 +76,7 @@ describe('ProjectEnvironments', () => {
       renderComponent(true);
 
       // Hidden buttons should not have "Set as default"
-      expect(screen.getByRole('button', {name: 'Show'})).toBeInTheDocument();
+      expect(await screen.findByRole('button', {name: 'Show'})).toBeInTheDocument();
     });
   });
 
@@ -122,8 +112,50 @@ describe('ProjectEnvironments', () => {
       // XXX(epurkhiser): In the future we should improve the accessability of
       // lists, because right now there's no way to associate the hide button
       // with its environment
-      await userEvent.click(screen.getAllByRole('button', {name: 'Hide'})[0]!);
+      await userEvent.click((await screen.findAllByRole('button', {name: 'Hide'}))[0]!);
 
+      expect(hideMock).toHaveBeenCalledWith(
+        `${baseUrl}production/`,
+        expect.objectContaining({
+          data: expect.objectContaining({isHidden: true}),
+        })
+      );
+    });
+
+    it('optimistically removes hidden environments without showing loading state', async () => {
+      hideMock = MockApiClient.addMockResponse({
+        url: `${baseUrl}production/`,
+        method: 'PUT',
+        asyncDelay: 50,
+      });
+      let environmentRequestCount = 0;
+
+      MockApiClient.addMockResponse({
+        url: baseUrl,
+        body: () => {
+          environmentRequestCount += 1;
+          return environmentRequestCount === 1
+            ? EnvironmentsFixture()
+            : EnvironmentsFixture().filter(
+                environment => environment.name !== 'production'
+              );
+        },
+      });
+
+      renderComponent(false);
+
+      expect(await screen.findByText('production')).toBeInTheDocument();
+
+      await userEvent.click((await screen.findAllByRole('button', {name: 'Hide'}))[0]!);
+
+      expect(screen.queryByText('production')).not.toBeInTheDocument();
+      expect(screen.queryAllByTestId('loading-placeholder')).toHaveLength(0);
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 60));
+      });
+
+      expect(screen.queryAllByTestId('loading-placeholder')).toHaveLength(0);
       expect(hideMock).toHaveBeenCalledWith(
         `${baseUrl}production/`,
         expect.objectContaining({
@@ -139,16 +171,16 @@ describe('ProjectEnvironments', () => {
       });
 
       hideMock = MockApiClient.addMockResponse({
-        url: `${baseUrl}%2525app_env%2525/`,
+        url: `${baseUrl}%25app_env%25/`,
         method: 'PUT',
       });
 
       renderComponent(false);
 
-      await userEvent.click(screen.getByRole('button', {name: 'Hide'}));
+      await userEvent.click(await screen.findByRole('button', {name: 'Hide'}));
 
       expect(hideMock).toHaveBeenCalledWith(
-        `${baseUrl}%2525app_env%2525/`,
+        `${baseUrl}%25app_env%25/`,
         expect.objectContaining({
           data: expect.objectContaining({isHidden: true}),
         })
@@ -163,7 +195,7 @@ describe('ProjectEnvironments', () => {
 
       renderComponent(true);
 
-      await userEvent.click(screen.getByRole('button', {name: 'Show'}));
+      await userEvent.click(await screen.findByRole('button', {name: 'Show'}));
 
       expect(showMock).toHaveBeenCalledWith(
         `${baseUrl}zzz/`,
@@ -173,13 +205,14 @@ describe('ProjectEnvironments', () => {
       );
     });
 
-    it('does not have "All Environments" rows', () => {
+    it('does not have "All Environments" rows', async () => {
       MockApiClient.addMockResponse({
         url: baseUrl,
         body: HiddenEnvironmentsFixture(),
       });
 
       renderComponent(true);
+      await screen.findByRole('button', {name: 'Show'});
       expect(screen.queryByText('All Environments')).not.toBeInTheDocument();
     });
   });

--- a/static/app/views/settings/project/projectEnvironments.spec.tsx
+++ b/static/app/views/settings/project/projectEnvironments.spec.tsx
@@ -78,7 +78,7 @@ describe('ProjectEnvironments', () => {
   ])('double-encodes environment path params for %s', async (name, encodedName) => {
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/environments/',
-      body: [{id: '1', name, displayName: name}],
+      body: [{id: '1', name}],
     });
     const hideMock = MockApiClient.addMockResponse({
       url: `/projects/org-slug/project-slug/environments/${encodedName}/`,

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -12,7 +12,6 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
-import type {Environment} from 'sentry/types/project';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {getDisplayName} from 'sentry/utils/environment';
@@ -29,8 +28,14 @@ interface EnvironmentRowProps {
   children?: React.ReactNode;
 }
 
+interface ProjectEnvironment {
+  id: string;
+  isHidden: boolean;
+  name: string;
+}
+
 interface ToggleEnvironmentVariables {
-  environment: Environment;
+  environment: ProjectEnvironment;
   shouldHide: boolean;
 }
 
@@ -65,14 +70,6 @@ function EnvironmentTableSkeleton({isHidden}: {isHidden: boolean}) {
   );
 }
 
-function getEnvironmentPathParam(environment: Environment) {
-  // Django decodes route params before the endpoint calls
-  // `Environment.get_name_from_path_segment()`, which unquotes the value again.
-  // Pre-encode here so `getApiUrl`'s normal path-param encoding produces the
-  // double-encoded URL needed to preserve literal percent sequences in names.
-  return encodeURIComponent(environment.name || environment.displayName || 'none');
-}
-
 export default function ProjectEnvironments() {
   const location = useLocation();
   const params = useParams<{projectId: string}>();
@@ -81,7 +78,7 @@ export default function ProjectEnvironments() {
   const queryClient = useQueryClient();
 
   const isHidden = location.pathname.endsWith('hidden/');
-  const environmentsQueryOptions = apiOptions.as<Environment[]>()(
+  const environmentsQueryOptions = apiOptions.as<ProjectEnvironment[]>()(
     '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/',
     {
       path: {
@@ -103,7 +100,11 @@ export default function ProjectEnvironments() {
             path: {
               organizationIdOrSlug: organization.slug,
               projectIdOrSlug: params.projectId,
-              environment: getEnvironmentPathParam(environment),
+              // Django decodes route params before the endpoint calls
+              // `Environment.get_name_from_path_segment()`, which unquotes the value again.
+              // Pre-encode here so `getApiUrl`'s normal path-param encoding produces the
+              // double-encoded URL needed to preserve literal percent sequences in names.
+              environment: encodeURIComponent(environment.name),
             },
           }
         ),

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -1,303 +1,227 @@
-import {Component, Fragment} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Container} from '@sentry/scraps/layout';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import type {Client} from 'sentry/api';
 import {Access} from 'sentry/components/acl/access';
-import {EmptyMessage} from 'sentry/components/emptyMessage';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {Panel} from 'sentry/components/panels/panel';
-import {PanelBody} from 'sentry/components/panels/panelBody';
-import {PanelHeader} from 'sentry/components/panels/panelHeader';
-import {PanelItem} from 'sentry/components/panels/panelItem';
+import {Placeholder} from 'sentry/components/placeholder';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
-import {ALL_ENVIRONMENTS_KEY} from 'sentry/constants';
-import {t, tct} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Organization} from 'sentry/types/organization';
-import type {Environment, Project} from 'sentry/types/project';
-import {getDisplayName, getUrlRoutingName} from 'sentry/utils/environment';
-import {recreateRoute} from 'sentry/utils/recreateRoute';
-import {useApi} from 'sentry/utils/useApi';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {t} from 'sentry/locale';
+import type {Environment} from 'sentry/types/project';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {getDisplayName} from 'sentry/utils/environment';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
-type Props = {
-  api: Client;
-  organization: Organization;
-  project: Project;
-} & RouteComponentProps<{projectId: string}>;
-
-type State = {
-  environments: null | Environment[];
-  isLoading: boolean;
-};
-
-class ProjectEnvironments extends Component<Props, State> {
-  state: State = {
-    environments: null,
-    isLoading: true,
-  };
-
-  componentDidMount() {
-    this.fetchData();
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (
-      this.props.location.pathname.endsWith('hidden/') !==
-      prevProps.location.pathname.endsWith('hidden/')
-    ) {
-      this.fetchData();
-    }
-  }
-
-  fetchData() {
-    const isHidden = this.props.location.pathname.endsWith('hidden/');
-
-    if (!this.state.isLoading) {
-      this.setState({isLoading: true});
-    }
-
-    const {organization} = this.props;
-    const {projectId} = this.props.params;
-    this.props.api.request(`/projects/${organization.slug}/${projectId}/environments/`, {
-      query: {
-        visibility: isHidden ? 'hidden' : 'visible',
-      },
-      success: environments => {
-        this.setState({environments, isLoading: false});
-      },
-    });
-  }
-
-  // Toggle visibility of environment
-  toggleEnv = (env: Environment, shouldHide: boolean) => {
-    const {organization} = this.props;
-    const {projectId} = this.props.params;
-
-    this.props.api.request(
-      `/projects/${organization.slug}/${projectId}/environments/${getUrlRoutingName(env)}/`,
-      {
-        method: 'PUT',
-        data: {
-          isHidden: shouldHide,
-        },
-        success: () => {
-          addSuccessMessage(
-            tct('Updated [environment]', {
-              environment: getDisplayName(env),
-            })
-          );
-        },
-        error: () => {
-          addErrorMessage(
-            tct('Unable to update [environment]', {
-              environment: getDisplayName(env),
-            })
-          );
-        },
-        complete: this.fetchData.bind(this),
-      }
-    );
-  };
-
-  renderEmpty() {
-    const isHidden = this.props.location.pathname.endsWith('hidden/');
-    const message = isHidden
-      ? t("You don't have any hidden environments.")
-      : t("You don't have any environments yet.");
-    return <EmptyMessage>{message}</EmptyMessage>;
-  }
-
-  /**
-   * Renders rows for "system" environments:
-   * - "All Environments"
-   * - "No Environment"
-   *
-   */
-  renderAllEnvironmentsSystemRow() {
-    // Not available in "Hidden" tab
-    const isHidden = this.props.location.pathname.endsWith('hidden/');
-    if (isHidden) {
-      return null;
-    }
-
-    const {project} = this.props;
-    return (
-      <EnvironmentRow
-        project={project}
-        name={ALL_ENVIRONMENTS_KEY}
-        environment={{
-          id: ALL_ENVIRONMENTS_KEY,
-          name: ALL_ENVIRONMENTS_KEY,
-          displayName: ALL_ENVIRONMENTS_KEY,
-        }}
-        isSystemRow
-      />
-    );
-  }
-
-  renderEnvironmentList(envs: Environment[]) {
-    const {project} = this.props;
-    const isHidden = this.props.location.pathname.endsWith('hidden/');
-    const buttonText = isHidden ? t('Show') : t('Hide');
-
-    return (
-      <Fragment>
-        {this.renderAllEnvironmentsSystemRow()}
-        {envs.map(env => (
-          <EnvironmentRow
-            project={project}
-            key={env.id}
-            name={env.name}
-            environment={env}
-            isHidden={isHidden}
-            onHide={this.toggleEnv}
-            actionText={buttonText}
-            shouldShowAction
-          />
-        ))}
-      </Fragment>
-    );
-  }
-
-  renderBody() {
-    const {environments, isLoading} = this.state;
-
-    if (isLoading) {
-      return <LoadingIndicator />;
-    }
-
-    return (
-      <PanelBody>
-        {environments?.length
-          ? this.renderEnvironmentList(environments)
-          : this.renderEmpty()}
-      </PanelBody>
-    );
-  }
-
-  render() {
-    const {routes, params, location, project} = this.props;
-    const isHidden = location.pathname.endsWith('hidden/');
-
-    const baseUrl = recreateRoute('', {routes, params, stepBack: -1});
-    return (
-      <div>
-        <SentryDocumentTitle title={t('Environments')} projectSlug={params.projectId} />
-        <SettingsPageHeader
-          title={t('Manage Environments')}
-          tabs={
-            <TabsContainer>
-              <Tabs value={isHidden ? 'hidden' : 'environments'}>
-                <TabList>
-                  <TabList.Item key="environments" to={baseUrl}>
-                    {t('Environments')}
-                  </TabList.Item>
-                  <TabList.Item key="hidden" to={`${baseUrl}hidden/`}>
-                    {t('Hidden')}
-                  </TabList.Item>
-                </TabList>
-              </Tabs>
-            </TabsContainer>
-          }
-        />
-        <ProjectPermissionAlert project={project} />
-
-        <Panel>
-          <PanelHeader>{isHidden ? t('Hidden') : t('Active Environments')}</PanelHeader>
-          {this.renderBody()}
-        </Panel>
-      </div>
-    );
-  }
+interface EnvironmentRowProps {
+  name: React.ReactNode;
+  children?: React.ReactNode;
 }
 
-type RowProps = {
+interface ToggleEnvironmentVariables {
   environment: Environment;
-  name: string;
-  project: Project;
-  actionText?: string;
-  isHidden?: boolean;
-  isSystemRow?: boolean;
-  onHide?: (env: Environment, isHidden: boolean) => void;
-  shouldShowAction?: boolean;
-};
+  shouldHide: boolean;
+}
 
-function EnvironmentRow({
-  project,
-  environment,
-  name,
-  onHide,
-  shouldShowAction = false,
-  isSystemRow = false,
-  isHidden = false,
-  actionText = '',
-}: RowProps) {
+function EnvironmentRow({children, name}: EnvironmentRowProps) {
   return (
-    <EnvironmentItem>
-      <Flex align="center">{isSystemRow ? t('All Environments') : name}</Flex>
-      <Access access={['project:write']} project={project}>
-        {({hasAccess}) => (
-          <Fragment>
-            {shouldShowAction && onHide && (
-              <EnvironmentButton
-                size="xs"
-                disabled={!hasAccess}
-                onClick={() => onHide(environment, !isHidden)}
-              >
-                {actionText}
-              </EnvironmentButton>
-            )}
-          </Fragment>
-        )}
-      </Access>
-    </EnvironmentItem>
+    <SimpleTable.Row>
+      <SimpleTable.RowCell minHeight="40px" padding="md lg">
+        {name}
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell justify="end" minHeight="40px" padding="md lg">
+        {children}
+      </SimpleTable.RowCell>
+    </SimpleTable.Row>
   );
 }
 
-const EnvironmentItem = styled(PanelItem)`
-  align-items: center;
-  justify-content: space-between;
-`;
+function EnvironmentTableSkeleton({isHidden}: {isHidden: boolean}) {
+  return (
+    <Fragment>
+      {!isHidden && <EnvironmentRow name={t('All Environments')} />}
+      {['35%', '28%', '42%', '24%'].map(width => (
+        <SimpleTable.Row key={width}>
+          <SimpleTable.RowCell minHeight="40px" padding="md lg">
+            <Placeholder height="16px" width={width} />
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell justify="end" minHeight="40px" padding="md lg">
+            <Placeholder height="24px" width="44px" />
+          </SimpleTable.RowCell>
+        </SimpleTable.Row>
+      ))}
+    </Fragment>
+  );
+}
 
-const TabsContainer = styled('div')`
-  margin-bottom: ${p => p.theme.space.xl};
-`;
-
-const EnvironmentButton = styled(Button)`
-  margin-left: ${p => p.theme.space.xs};
-`;
-
-export default function ProjectEnvironmentsWrapper() {
-  const api = useApi();
+export default function ProjectEnvironments() {
   const location = useLocation();
   const params = useParams<{projectId: string}>();
-  const routes = useRoutes();
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
+  const queryClient = useQueryClient();
+
+  const isHidden = location.pathname.endsWith('hidden/');
+  const environmentsQueryOptions = apiOptions.as<Environment[]>()(
+    '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/',
+    {
+      path: {
+        organizationIdOrSlug: organization.slug,
+        projectIdOrSlug: params.projectId,
+      },
+      query: {visibility: isHidden ? 'hidden' : 'visible'},
+      staleTime: 0,
+    }
+  );
+  const {data: environments, isPending} = useQuery(environmentsQueryOptions);
+
+  const toggleEnvironment = useMutation({
+    mutationFn: ({environment, shouldHide}: ToggleEnvironmentVariables) =>
+      fetchMutation({
+        url: getApiUrl(
+          '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/$environment/',
+          {
+            path: {
+              organizationIdOrSlug: organization.slug,
+              projectIdOrSlug: params.projectId,
+              environment: environment.name,
+            },
+          }
+        ),
+        method: 'PUT',
+        data: {isHidden: shouldHide},
+      }),
+    onMutate: async ({environment}) => {
+      await queryClient.cancelQueries({queryKey: environmentsQueryOptions.queryKey});
+
+      const previousData = queryClient.getQueryData(environmentsQueryOptions.queryKey);
+
+      queryClient.setQueryData(environmentsQueryOptions.queryKey, previous =>
+        previous
+          ? {
+              ...previous,
+              json: previous.json.filter(env => env.id !== environment.id),
+            }
+          : previous
+      );
+
+      return {previousData};
+    },
+    onSuccess: (_data, {environment, shouldHide}) => {
+      addSuccessMessage(
+        shouldHide
+          ? t('Hidden %s', getDisplayName(environment))
+          : t('Unhidden %s', getDisplayName(environment))
+      );
+    },
+    onError: (_error, {environment, shouldHide}, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(environmentsQueryOptions.queryKey, context.previousData);
+      }
+
+      addErrorMessage(
+        shouldHide
+          ? t('Unable to hide %s', getDisplayName(environment))
+          : t('Unable to unhide %s', getDisplayName(environment))
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({queryKey: environmentsQueryOptions.queryKey});
+    },
+  });
 
   return (
-    <ProjectEnvironments
-      api={api}
-      location={location}
-      params={params}
-      routes={routes}
-      organization={organization}
-      project={project}
-      router={undefined as any}
-      route={undefined as any}
-      routeParams={undefined as any}
-    />
+    <div>
+      <SentryDocumentTitle title={t('Environments')} projectSlug={params.projectId} />
+      <SettingsPageHeader
+        title={t('Manage Environments')}
+        tabs={
+          <Container marginBottom="xl">
+            <Tabs value={isHidden ? 'hidden' : 'environments'}>
+              <TabList>
+                <TabList.Item
+                  key="environments"
+                  to={`/settings/${organization.slug}/projects/${params.projectId}/environments/`}
+                >
+                  {t('Environments')}
+                </TabList.Item>
+                <TabList.Item
+                  key="hidden"
+                  to={`/settings/${organization.slug}/projects/${params.projectId}/environments/hidden/`}
+                >
+                  {t('Hidden')}
+                </TabList.Item>
+              </TabList>
+            </Tabs>
+          </Container>
+        }
+      />
+      <ProjectPermissionAlert project={project} />
+
+      <EnvironmentTable>
+        <SimpleTable.Header>
+          <SimpleTable.HeaderCell>
+            {isHidden ? t('Hidden') : t('Active Environments')}
+          </SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell />
+        </SimpleTable.Header>
+        {isPending ? (
+          <EnvironmentTableSkeleton isHidden={isHidden} />
+        ) : environments?.length ? (
+          <Fragment>
+            {!isHidden && <EnvironmentRow name={t('All Environments')} />}
+            {environments.map(env => (
+              <EnvironmentRow key={env.id} name={env.name}>
+                <Access access={['project:write']} project={project}>
+                  {({hasAccess}) => (
+                    <Button
+                      size="xs"
+                      disabled={!hasAccess}
+                      onClick={() =>
+                        toggleEnvironment.mutate({
+                          environment: env,
+                          shouldHide: !isHidden,
+                        })
+                      }
+                    >
+                      {isHidden ? t('Show') : t('Hide')}
+                    </Button>
+                  )}
+                </Access>
+              </EnvironmentRow>
+            ))}
+          </Fragment>
+        ) : (
+          <SimpleTable.Empty>
+            {isHidden
+              ? t("You don't have any hidden environments.")
+              : t("You don't have any environments yet.")}
+          </SimpleTable.Empty>
+        )}
+      </EnvironmentTable>
+    </div>
   );
 }
+
+const EnvironmentTable = styled(SimpleTable)`
+  grid-template-columns: minmax(0, 1fr) max-content;
+
+  > [role='row']:first-child {
+    min-height: 32px;
+  }
+
+  [role='columnheader'] {
+    padding: 0 ${p => p.theme.space.xl};
+  }
+`;

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -37,10 +37,10 @@ interface ToggleEnvironmentVariables {
 function EnvironmentRow({children, name}: EnvironmentRowProps) {
   return (
     <SimpleTable.Row>
-      <SimpleTable.RowCell minHeight="40px" padding="md lg">
+      <SimpleTable.RowCell minHeight="45px" padding="md xl">
         {name}
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell justify="end" minHeight="40px" padding="md lg">
+      <SimpleTable.RowCell justify="end" minHeight="45px" padding="md xl">
         {children}
       </SimpleTable.RowCell>
     </SimpleTable.Row>
@@ -53,10 +53,10 @@ function EnvironmentTableSkeleton({isHidden}: {isHidden: boolean}) {
       {!isHidden && <EnvironmentRow name={t('All Environments')} />}
       {['35%', '28%', '42%', '24%'].map(width => (
         <SimpleTable.Row key={width}>
-          <SimpleTable.RowCell minHeight="40px" padding="md lg">
+          <SimpleTable.RowCell minHeight="40px" padding="md xl">
             <Placeholder height="16px" width={width} />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell justify="end" minHeight="40px" padding="md lg">
+          <SimpleTable.RowCell justify="end" minHeight="40px" padding="md xl">
             <Placeholder height="24px" width="44px" />
           </SimpleTable.RowCell>
         </SimpleTable.Row>
@@ -224,12 +224,4 @@ export default function ProjectEnvironments() {
 
 const EnvironmentTable = styled(SimpleTable)`
   grid-template-columns: minmax(0, 1fr) max-content;
-
-  > [role='row']:first-child {
-    min-height: 32px;
-  }
-
-  [role='columnheader'] {
-    padding: 0 ${p => p.theme.space.xl};
-  }
 `;

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -65,6 +65,14 @@ function EnvironmentTableSkeleton({isHidden}: {isHidden: boolean}) {
   );
 }
 
+function getEnvironmentPathParam(environment: Environment) {
+  // Django decodes route params before the endpoint calls
+  // `Environment.get_name_from_path_segment()`, which unquotes the value again.
+  // Pre-encode here so `getApiUrl`'s normal path-param encoding produces the
+  // double-encoded URL needed to preserve literal percent sequences in names.
+  return encodeURIComponent(environment.name || environment.displayName || 'none');
+}
+
 export default function ProjectEnvironments() {
   const location = useLocation();
   const params = useParams<{projectId: string}>();
@@ -95,7 +103,7 @@ export default function ProjectEnvironments() {
             path: {
               organizationIdOrSlug: organization.slug,
               projectIdOrSlug: params.projectId,
-              environment: environment.name,
+              environment: getEnvironmentPathParam(environment),
             },
           }
         ),

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -7,6 +7,7 @@ import {TabList, Tabs} from '@sentry/scraps/tabs';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Access} from 'sentry/components/acl/access';
+import {LoadingError} from 'sentry/components/loadingError';
 import {Placeholder} from 'sentry/components/placeholder';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
@@ -88,7 +89,12 @@ export default function ProjectEnvironments() {
       staleTime: 0,
     }
   );
-  const {data: environments, isPending} = useQuery(environmentsQueryOptions);
+  const {
+    data: environments,
+    isPending,
+    isError,
+    refetch,
+  } = useQuery(environmentsQueryOptions);
 
   const toggleEnvironment = useMutation({
     mutationFn: ({environment, shouldHide}: ToggleEnvironmentVariables) =>
@@ -186,6 +192,10 @@ export default function ProjectEnvironments() {
         </SimpleTable.Header>
         {isPending ? (
           <EnvironmentTableSkeleton isHidden={isHidden} />
+        ) : isError ? (
+          <SimpleTable.Empty>
+            <LoadingError onRetry={refetch} />
+          </SimpleTable.Empty>
         ) : environments?.length ? (
           <Fragment>
             {!isHidden && <EnvironmentRow name={t('All Environments')} />}

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -156,7 +155,7 @@ export default function ProjectEnvironments() {
       <SettingsPageHeader
         title={t('Manage Environments')}
         tabs={
-          <Container marginBottom="xl">
+          <TabsContainer>
             <Tabs value={isHidden ? 'hidden' : 'environments'}>
               <TabList>
                 <TabList.Item
@@ -173,7 +172,7 @@ export default function ProjectEnvironments() {
                 </TabList.Item>
               </TabList>
             </Tabs>
-          </Container>
+          </TabsContainer>
         }
       />
       <ProjectPermissionAlert project={project} />
@@ -222,6 +221,10 @@ export default function ProjectEnvironments() {
     </div>
   );
 }
+
+const TabsContainer = styled('div')`
+  margin-bottom: ${p => p.theme.space.xl};
+`;
 
 const EnvironmentTable = styled(SimpleTable)`
   grid-template-columns: minmax(0, 1fr) max-content;


### PR DESCRIPTION
Uses react query and hide/unhide are optimistic, no longer displays loading state after each hide action. Increases the density of the table a little bit.

before

<img width="892" height="526" alt="image" src="https://github.com/user-attachments/assets/bdd8d1f2-448c-45e3-a54c-9cc50c9afbcc" />


after

<img width="885" height="499" alt="image" src="https://github.com/user-attachments/assets/2594771c-f0ec-454b-8413-782b02c871e5" />

