### PR TITLE
feat(preprod): Add compact_metadata param to snapshot details endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -101,6 +101,14 @@ SNAPSHOT_POST_REQUEST_ERROR_MESSAGES: dict[str, str] = {
     **VCS_ERROR_MESSAGES,
 }
 
+_COMPACT_FIELDS = {"display_name", "image_file_name", "group", "description"}
+_COMPACT_IMAGE_LIST_KEYS = ("images", "added", "removed", "unchanged", "skipped")
+_COMPACT_PAIR_LIST_KEYS = ("changed", "renamed", "errored")
+
+
+def _strip_to_compact(img: dict[str, Any]) -> dict[str, Any]:
+    return {k: img[k] for k in _COMPACT_FIELDS if k in img}
+
 
 def validate_preprod_snapshot_post_schema(
     request_body: bytes,
@@ -190,6 +198,8 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             "organizations:preprod-snapshots", organization, actor=request.user
         ):
             return Response({"detail": "Feature not enabled"}, status=403)
+
+        compact = request.GET.get("compact_metadata", "0") in ("1", "true")
 
         try:
             artifact = PreprodArtifact.objects.select_related("commit_comparison", "project").get(
@@ -435,36 +445,44 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 approvers=[],
             )
 
-        return Response(
-            SnapshotDetailsApiResponse(
-                head_artifact_id=str(artifact.id),
-                base_artifact_id=base_artifact_id,
-                project_id=str(artifact.project_id),
-                comparison_type=comparison_type,
-                state=artifact.state,
-                vcs_info=vcs_info,
-                app_id=artifact.app_id,
-                images=image_list,
-                image_count=snapshot_metrics.image_count,
-                changed=categorized.changed,
-                changed_count=len(categorized.changed),
-                added=categorized.added,
-                added_count=len(categorized.added),
-                removed=categorized.removed,
-                removed_count=len(categorized.removed),
-                renamed=categorized.renamed,
-                renamed_count=len(categorized.renamed),
-                unchanged=categorized.unchanged,
-                unchanged_count=len(categorized.unchanged),
-                errored=categorized.errored,
-                errored_count=len(categorized.errored),
-                skipped=categorized.skipped,
-                skipped_count=len(categorized.skipped),
-                comparison_run_info=run_info,
-                approval_info=approval_info,
-                diff_threshold=manifest.diff_threshold,
-            ).dict()
-        )
+        response_data = SnapshotDetailsApiResponse(
+            head_artifact_id=str(artifact.id),
+            base_artifact_id=base_artifact_id,
+            project_id=str(artifact.project_id),
+            comparison_type=comparison_type,
+            state=artifact.state,
+            vcs_info=vcs_info,
+            app_id=artifact.app_id,
+            images=image_list,
+            image_count=snapshot_metrics.image_count,
+            changed=categorized.changed,
+            changed_count=len(categorized.changed),
+            added=categorized.added,
+            added_count=len(categorized.added),
+            removed=categorized.removed,
+            removed_count=len(categorized.removed),
+            renamed=categorized.renamed,
+            renamed_count=len(categorized.renamed),
+            unchanged=categorized.unchanged,
+            unchanged_count=len(categorized.unchanged),
+            errored=categorized.errored,
+            errored_count=len(categorized.errored),
+            skipped=categorized.skipped,
+            skipped_count=len(categorized.skipped),
+            comparison_run_info=run_info,
+            approval_info=approval_info,
+            diff_threshold=manifest.diff_threshold,
+        ).dict()
+
+        if compact:
+            for key in _COMPACT_IMAGE_LIST_KEYS:
+                response_data[key] = [_strip_to_compact(img) for img in response_data[key]]
+            for key in _COMPACT_PAIR_LIST_KEYS:
+                for pair in response_data[key]:
+                    pair["base_image"] = _strip_to_compact(pair["base_image"])
+                    pair["head_image"] = _strip_to_compact(pair["head_image"])
+
+        return Response(response_data)
 
 
 @cell_silo_endpoint


### PR DESCRIPTION
When `?compact_metadata=1` is passed, image metadata in the response is
stripped to only `display_name`, `image_file_name`, `group`, and `description`.
Reduces payload size for callers that only need basic identification info
(e.g. list views). Default behavior is unchanged.