### PR TITLE
feat(preprod): Add single-image metadata endpoint for snapshots

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -110,6 +110,26 @@ def _strip_to_compact(img: dict[str, Any]) -> dict[str, Any]:
     return {k: img[k] for k in _COMPACT_FIELDS if k in img}
 
 
+def build_snapshot_image_response(
+    image_file_name: str,
+    metadata: ImageMetadata,
+    global_diff_threshold: float | None,
+) -> SnapshotImageResponse:
+    return SnapshotImageResponse(
+        key=metadata.content_hash,
+        display_name=metadata.display_name,
+        image_file_name=image_file_name,
+        group=metadata.group,
+        width=metadata.width,
+        height=metadata.height,
+        diff_threshold=metadata.diff_threshold
+        if metadata.diff_threshold is not None
+        else global_diff_threshold,
+        description=metadata.description,
+        tags=metadata.tags,
+    )
+
+
 def validate_preprod_snapshot_post_schema(
     request_body: bytes,
 ) -> tuple[dict[str, Any], str | None]:
@@ -304,21 +324,8 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             )
         )
 
-        global_threshold = manifest.diff_threshold
         image_list = [
-            SnapshotImageResponse(
-                key=metadata.content_hash,
-                display_name=metadata.display_name,
-                image_file_name=key,
-                group=metadata.group,
-                width=metadata.width,
-                height=metadata.height,
-                diff_threshold=metadata.diff_threshold
-                if metadata.diff_threshold is not None
-                else global_threshold,
-                description=metadata.description,
-                tags=metadata.tags,
-            )
+            build_snapshot_image_response(key, metadata, manifest.diff_threshold)
             for key, metadata in sorted(manifest.images.items())
         ]
 

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot_image_detail.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot_image_detail.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+
+import orjson
+from django.conf import settings
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import (
+    OrganizationEndpoint,
+    OrganizationReleasePermission,
+)
+from sentry.auth.staff import is_active_staff
+from sentry.models.organization import Organization
+from sentry.objectstore import get_preprod_session
+from sentry.preprod.api.endpoints.preprod_artifact_snapshot import (
+    build_snapshot_image_response,
+)
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
+from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+
+logger = logging.getLogger(__name__)
+
+
+def _find_image_in_manifest(
+    manifest: SnapshotManifest, identifier: str
+) -> tuple[str | None, ImageMetadata | None]:
+    if identifier in manifest.images:
+        return identifier, manifest.images[identifier]
+    for fname, meta in manifest.images.items():
+        if meta.content_hash == identifier:
+            return fname, meta
+    return None, None
+
+
+@cell_silo_endpoint
+class OrganizationPreprodSnapshotImageDetailEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    permission_classes = (OrganizationReleasePermission,)
+
+    def get(
+        self,
+        request: Request,
+        organization: Organization,
+        snapshot_id: str,
+        image_identifier: str,
+    ) -> Response:
+        if not settings.IS_DEV and not features.has(
+            "organizations:preprod-snapshots", organization, actor=request.user
+        ):
+            return Response({"detail": "Feature not enabled"}, status=403)
+
+        try:
+            artifact = PreprodArtifact.objects.select_related("project").get(
+                id=snapshot_id, project__organization_id=organization.id
+            )
+        except (PreprodArtifact.DoesNotExist, ValueError):
+            return Response({"detail": "Snapshot not found"}, status=404)
+
+        if not is_active_staff(request) and not request.access.has_project_access(artifact.project):
+            return Response({"detail": "Snapshot not found"}, status=404)
+
+        try:
+            snapshot_metrics = artifact.preprodsnapshotmetrics
+        except PreprodSnapshotMetrics.DoesNotExist:
+            return Response({"detail": "Snapshot metrics not found"}, status=404)
+
+        manifest_key = (snapshot_metrics.extras or {}).get("manifest_key")
+        if not manifest_key:
+            return Response({"detail": "Manifest key not found"}, status=404)
+
+        try:
+            session = get_preprod_session(organization.id, artifact.project_id)
+            manifest_data = orjson.loads(session.get(manifest_key).payload.read())
+            manifest = SnapshotManifest(**manifest_data)
+        except Exception:
+            logger.exception(
+                "Failed to retrieve snapshot manifest",
+                extra={
+                    "preprod_artifact_id": artifact.id,
+                    "manifest_key": manifest_key,
+                },
+            )
+            return Response({"detail": "Internal server error"}, status=500)
+
+        image_file_name, metadata = _find_image_in_manifest(manifest, image_identifier)
+        if metadata is None or image_file_name is None:
+            return Response({"detail": "Image not found in snapshot"}, status=404)
+
+        image_response = build_snapshot_image_response(
+            image_file_name, metadata, manifest.diff_threshold
+        )
+        image_url = f"/api/0/projects/{organization.slug}/{artifact.project.slug}/files/images/{metadata.content_hash}/"
+
+        return Response({**image_response.dict(), "image_url": image_url})

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -33,6 +33,9 @@ from .preprod_artifact_snapshot import (
     ProjectPreprodSnapshotEndpoint,
 )
 from .preprod_artifact_snapshot_download import OrganizationPreprodSnapshotDownloadEndpoint
+from .preprod_artifact_snapshot_image_detail import (
+    OrganizationPreprodSnapshotImageDetailEndpoint,
+)
 from .preprod_snapshot_recompare import PreprodSnapshotRecompareEndpoint
 from .project_installable_preprod_artifact_download import (
     ProjectInstallablePreprodArtifactDownloadEndpoint,
@@ -220,6 +223,11 @@ preprod_organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/snapshots/(?P<snapshot_id>[^/]+)/download/$",
         OrganizationPreprodSnapshotDownloadEndpoint.as_view(),
         name="sentry-api-0-organization-preprod-snapshots-download",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/snapshots/(?P<snapshot_id>[^/]+)/images/(?P<image_identifier>.+)/$",
+        OrganizationPreprodSnapshotImageDetailEndpoint.as_view(),
+        name="sentry-api-0-organization-preprod-snapshots-image-detail",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/(?P<head_artifact_id>[^/]+)/distribution/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -488,6 +488,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/preprodartifacts/size-analysis/compare/$headArtifactId/$baseArtifactId/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/download/'
+  | '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/images/$imageIdentifier/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/recompare/'
   | '/organizations/$organizationIdOrSlug/prevent/owner/$owner/repositories/'
   | '/organizations/$organizationIdOrSlug/prevent/owner/$owner/repositories/sync/'


### PR DESCRIPTION
Add a new endpoint to look up metadata for a single image within a snapshot:

`GET /api/0/organizations/{org}/preprodartifacts/snapshots/{id}/images/{identifier}/`

The `{identifier}` can be either the `image_file_name` (e.g.
`static/app/components/core/alert/alert-dark-danger-no-icon.png`) or the
`content_hash`. The endpoint returns all image metadata plus an `image_url`
field with the direct API path to fetch the binary, so consumers (including
LLMs) don't need to compose the URL themselves.

Also extracts `build_snapshot_image_response` as a shared helper so the
`ImageMetadata` → `SnapshotImageResponse` mapping lives in one place,
used by both the snapshot detail and image detail endpoints.

Follows up on #115494 which added the `compact_metadata` param.