### PR TITLE
fix(grouping): Parameterize error message fingerprint variables

### DIFF
--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -337,7 +337,10 @@ def resolve_fingerprint_values(
         if resolved_value is None:  # variable wasn't recognized
             return entry
 
-        if variable_key == "message" and resolved_value != "<no-message>":
+        if variable_key in ("message", "value", "error.value") and resolved_value not in (
+            "<no-message>",
+            "<no-value>",
+        ):
             return normalize_message_for_grouping(
                 resolved_value, context, reason="fingerprint_variable", trim_message=False
             )

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -246,7 +246,7 @@ def resolve_fingerprint_variable(
         exception_type = get_path(event.data, "exception", "values", -1, "type")
         return exception_type or "<no-type>"
 
-    elif variable_key in ("value", "error.value"):
+    elif variable_key in ("value", "raw_value", "error.value", "error.raw_value"):
         value = get_path(event.data, "exception", "values", -1, "value")
         return value or "<no-value>"
 

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -295,7 +295,11 @@ def test_variable_resolution() -> None:
         ("{{  default }}", "{{ default }}"),
         ("{{ dog }}", "<unrecognized-variable-dog>"),
         ("{{ message }}", "That's ball number <int> that Charlie hasn't brought back!"),
+        ("{{ value }}", "That's ball number <int> that Charlie hasn't brought back!"),
+        ("{{ error.value }}", "That's ball number <int> that Charlie hasn't brought back!"),
         ("{{ raw_message }}", "That's ball number 6 that Charlie hasn't brought back!"),
+        ("{{ raw_value }}", "That's ball number 6 that Charlie hasn't brought back!"),
+        ("{{ error.raw_value }}", "That's ball number 6 that Charlie hasn't brought back!"),
     ]:
         assert resolve_fingerprint_values([fingerprint_entry], event, context) == [
             expected_resolved_value


### PR DESCRIPTION
In our grouping algorithm, when using component-based grouping, we parameterize both log and error messages, but when using fingerprint-based grouping, we only parameterize log messages, an inadvertent difference in behavior. 

This PR fixes that by extending parameterization to also include the two error message fingerprint variables, `{{ value }}` and `{{ error.value }}`. It also introduces two new variables, `{{ raw_value }}` and `{{ error.raw_value }}`, as analogs to the `{{ raw_message }}` variable, so that people can opt out of the parameterization if they choose to. 