### PR TITLE
feat(seer): expose replay search RPC

### DIFF
--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -64,6 +64,7 @@ def query_replays_collection_paginated(
     preferred_source: PREFERRED_SOURCE,
     organization: Organization | None = None,
     actor: Any | None = None,
+    referrer: str | None = None,
 ):
     """Query aggregated replay collection."""
     paginators = Paginators(limit, offset)
@@ -80,6 +81,7 @@ def query_replays_collection_paginated(
         period_stop=end,
         request_user_id=actor.id if actor else None,
         preferred_source=preferred_source,
+        referrer=referrer,
     )
 
 

--- a/src/sentry/replays/usecases/query/__init__.py
+++ b/src/sentry/replays/usecases/query/__init__.py
@@ -233,6 +233,7 @@ def query_using_optimized_search(
     period_stop: datetime,
     request_user_id: int | None = None,
     preferred_source: PREFERRED_SOURCE = "scalar",
+    referrer: str | None = None,
 ):
     tenant_id = _make_tenant_id(organization)
 
@@ -255,7 +256,7 @@ def query_using_optimized_search(
         search_filters = handle_viewed_by_me_filters(search_filters, request_user_id)
 
     if preferred_source == "aggregated":
-        query, referrer, source = _query_using_aggregated_strategy(
+        query, strategy_referrer, source = _query_using_aggregated_strategy(
             search_filters,
             sort,
             project_ids,
@@ -263,7 +264,7 @@ def query_using_optimized_search(
             period_stop,
         )
     else:
-        query, referrer, source = _query_using_scalar_strategy(
+        query, strategy_referrer, source = _query_using_scalar_strategy(
             search_filters,
             sort,
             project_ids,
@@ -271,10 +272,12 @@ def query_using_optimized_search(
             period_stop,
         )
 
+    used_referrer = referrer or strategy_referrer
+
     query = query.set_limit(pagination.limit)
     query = query.set_offset(pagination.offset)
 
-    subquery_response = execute_query(query, tenant_id, referrer)
+    subquery_response = execute_query(query, tenant_id, used_referrer)
 
     # The query "has more rows" if the number of rows found matches the limit (which is
     # the requested limit + 1).
@@ -306,7 +309,7 @@ def query_using_optimized_search(
             request_user_id=request_user_id,
         ),
         tenant_id,
-        referrer="replays.query.browse_query",
+        used_referrer,
     )["data"]
 
     return QueryResponse(

--- a/src/sentry/replays/usecases/query/__init__.py
+++ b/src/sentry/replays/usecases/query/__init__.py
@@ -309,7 +309,7 @@ def query_using_optimized_search(
             request_user_id=request_user_id,
         ),
         tenant_id,
-        used_referrer,
+        referrer or "replays.query.browse_query",
     )["data"]
 
     return QueryResponse(

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from django.core.exceptions import BadRequest
 from django.db import models
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, ParseError
 from sentry_protos.snuba.v1.endpoint_get_trace_pb2 import GetTraceRequest
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from snuba_sdk import Column, Condition, Entity, Function, Limit, Op, Query, Request
@@ -41,6 +41,7 @@ from sentry.replays.query import (
     query_replays_collection_paginated,
     replay_url_parser_config,
 )
+from sentry.replays.validators import VALID_FIELD_SET
 from sentry.search.eap.constants import BOOLEAN, DOUBLE, INT, STRING
 from sentry.search.eap.occurrences.query_utils import build_event_id_in_filter
 from sentry.search.eap.resolver import SearchResolver
@@ -451,6 +452,11 @@ def execute_replays_query(
     if not resolved_project_ids:
         return {"data": []}
 
+    requested_fields = fields or DEFAULT_REPLAY_SEARCH_FIELDS
+    invalid_fields = sorted(set(requested_fields) - set(VALID_FIELD_SET))
+    if invalid_fields:
+        return {"error": f"Invalid replay field(s): {', '.join(invalid_fields)}"}
+
     date_params: dict[str, Any] = {}
     if start and end:
         date_params["start"] = start
@@ -467,15 +473,26 @@ def execute_replays_query(
             end=end_dt,
             environment=[],
             sort=sort,
-            fields=fields or DEFAULT_REPLAY_SEARCH_FIELDS,
-            limit=per_page,
+            fields=requested_fields,
+            limit=per_page + 1,
             offset=0,
             search_filters=search_filters,
             preferred_source="scalar",
             organization=organization,
             actor=None,
         )
-    except (InvalidParams, InvalidSearchQuery, SentryBadRequest, BadRequest) as e:
+        processed_response = process_raw_response(response.response, fields=requested_fields)
+    except KeyError as e:
+        logger.exception(
+            "execute_replays_query: unsupported response field",
+            extra={
+                "org_id": organization_id,
+                "query": query,
+                "field": e.args[0] if e.args else None,
+            },
+        )
+        return {"error": f"Invalid replay field: {e.args[0]}" if e.args else "Invalid replay field"}
+    except (InvalidParams, InvalidSearchQuery, SentryBadRequest, BadRequest, ParseError) as e:
         logger.exception(
             "execute_replays_query: bad request",
             extra={"org_id": organization_id, "query": query},
@@ -483,9 +500,7 @@ def execute_replays_query(
         return {"error": str(e)}
 
     return {
-        "data": process_raw_response(
-            response.response, fields=fields or DEFAULT_REPLAY_SEARCH_FIELDS
-        ),
+        "data": processed_response,
         "meta": {"source": response.source, "has_more": response.has_more},
     }
 

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -41,7 +41,7 @@ from sentry.replays.query import (
     query_replays_collection_paginated,
     replay_url_parser_config,
 )
-from sentry.replays.validators import VALID_FIELD_SET
+from sentry.replays.validators import VALID_FIELD_SET as REPLAY_VALID_FIELD_SET
 from sentry.search.eap.constants import BOOLEAN, DOUBLE, INT, STRING
 from sentry.search.eap.occurrences.query_utils import build_event_id_in_filter
 from sentry.search.eap.resolver import SearchResolver

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -41,6 +41,7 @@ from sentry.replays.query import (
     query_replays_collection_paginated,
     replay_url_parser_config,
 )
+from sentry.replays.validators import VALID_FIELD_SET as REPLAY_VALID_FIELD_SET
 from sentry.search.eap.constants import BOOLEAN, DOUBLE, INT, STRING
 from sentry.search.eap.occurrences.query_utils import build_event_id_in_filter
 from sentry.search.eap.resolver import SearchResolver
@@ -452,7 +453,7 @@ def execute_replays_query(
         return {"data": []}
 
     requested_fields = fields or DEFAULT_REPLAY_SEARCH_FIELDS
-    invalid_fields = sorted(set(requested_fields) - set(VALID_FIELD_SET))
+    invalid_fields = sorted(set(requested_fields) - set(REPLAY_VALID_FIELD_SET))
     if invalid_fields:
         return {"error": f"Invalid replay field(s): {', '.join(invalid_fields)}"}
 
@@ -479,6 +480,7 @@ def execute_replays_query(
             preferred_source="scalar",
             organization=organization,
             actor=None,
+            referrer=Referrer.SEER_EXPLORER_TOOLS.value,
         )
         processed_response = process_raw_response(response.response, fields=requested_fields)
     except KeyError as e:

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -17,12 +17,15 @@ from sentry.api.endpoints.organization_events_timeseries import TOP_EVENTS_DATAS
 from sentry.api.endpoints.organization_trace_item_attributes_ranked import (
     query_attribute_distributions,
 )
+from sentry.api.event_search import parse_search_query
+from sentry.api.exceptions import BadRequest as SentryBadRequest
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.activity import ActivitySerializer
 from sentry.api.serializers.models.event import EventSerializer
 from sentry.api.serializers.models.group import GroupSerializer
 from sentry.api.utils import MAX_STATS_PERIOD, default_start_end_dates, get_date_range_from_params
 from sentry.constants import ALL_ACCESS_PROJECT_ID, ObjectStatus
+from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
 from sentry.models.apikey import ApiKey
@@ -32,7 +35,12 @@ from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus, UseCase
 from sentry.models.repository import Repository
 from sentry.replays.post_process import process_raw_response
-from sentry.replays.query import query_replay_id_by_prefix, query_replay_instance
+from sentry.replays.query import (
+    query_replay_id_by_prefix,
+    query_replay_instance,
+    query_replays_collection_paginated,
+    replay_url_parser_config,
+)
 from sentry.search.eap.constants import BOOLEAN, DOUBLE, INT, STRING
 from sentry.search.eap.occurrences.query_utils import build_event_id_in_filter
 from sentry.search.eap.resolver import SearchResolver
@@ -372,6 +380,114 @@ def execute_trace_table_query(
             error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
             return {"error": str(error_detail) if error_detail is not None else str(e.body)}
         raise
+
+
+DEFAULT_REPLAY_SEARCH_FIELDS = [
+    "id",
+    "project_id",
+    "started_at",
+    "finished_at",
+    "duration",
+    "count_errors",
+    "count_dead_clicks",
+    "count_rage_clicks",
+    "count_urls",
+    "urls",
+    "user",
+    "trace_ids",
+    "platform",
+]
+
+
+def execute_replays_query(
+    *,
+    organization_id: int,
+    per_page: int,
+    query: str | None = None,
+    fields: list[str] | None = None,
+    sort: str | None = None,
+    project_ids: list[int] | None = None,
+    project_slugs: list[str] | None = None,
+    stats_period: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+) -> dict[str, Any] | None:
+    """
+    Execute a session replay search using the dedicated Replay collection query.
+
+    Arg notes:
+        project_ids: The IDs of the projects to query. Cannot be provided with project_slugs.
+        project_slugs: The slugs of the projects to query. Cannot be provided with project_ids.
+        If neither project_ids nor project_slugs are provided, all active projects will be queried.
+        Start/end params take precedence over stats_period. Defaults to Sentry's standard max period.
+    """
+    try:
+        organization = Organization.objects.get(id=organization_id)
+    except Organization.DoesNotExist:
+        logger.warning(
+            "execute_replays_query: Organization not found", extra={"org_id": organization_id}
+        )
+        return None
+
+    if not features.has("organizations:session-replay", organization):
+        return {"error": "Session Replay is not enabled for this organization."}
+
+    if project_ids and project_slugs:
+        return {"error": "Pass either project_ids or project_slugs, not both."}
+
+    project_filter: dict[str, Any] = {}
+    if project_ids:
+        project_filter["id__in"] = project_ids
+    elif project_slugs:
+        project_filter["slug__in"] = project_slugs
+
+    resolved_project_ids = list(
+        Project.objects.filter(
+            organization_id=organization.id,
+            status=ObjectStatus.ACTIVE,
+            **project_filter,
+        ).values_list("id", flat=True)
+    )
+    if not resolved_project_ids:
+        return {"data": []}
+
+    date_params: dict[str, Any] = {}
+    if start and end:
+        date_params["start"] = start
+        date_params["end"] = end
+    elif stats_period:
+        date_params["statsPeriod"] = stats_period
+
+    try:
+        start_dt, end_dt = get_date_range_from_params(date_params)
+        search_filters = parse_search_query(query or "", config=replay_url_parser_config)
+        response = query_replays_collection_paginated(
+            project_ids=resolved_project_ids,
+            start=start_dt,
+            end=end_dt,
+            environment=[],
+            sort=sort,
+            fields=fields or DEFAULT_REPLAY_SEARCH_FIELDS,
+            limit=per_page,
+            offset=0,
+            search_filters=search_filters,
+            preferred_source="scalar",
+            organization=organization,
+            actor=None,
+        )
+    except (InvalidParams, InvalidSearchQuery, SentryBadRequest, BadRequest) as e:
+        logger.exception(
+            "execute_replays_query: bad request",
+            extra={"org_id": organization_id, "query": query},
+        )
+        return {"error": str(e)}
+
+    return {
+        "data": process_raw_response(
+            response.response, fields=fields or DEFAULT_REPLAY_SEARCH_FIELDS
+        ),
+        "meta": {"source": response.source, "has_more": response.has_more},
+    }
 
 
 def get_trace_waterfall(

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -41,7 +41,6 @@ from sentry.replays.query import (
     query_replays_collection_paginated,
     replay_url_parser_config,
 )
-from sentry.replays.validators import VALID_FIELD_SET as REPLAY_VALID_FIELD_SET
 from sentry.search.eap.constants import BOOLEAN, DOUBLE, INT, STRING
 from sentry.search.eap.occurrences.query_utils import build_event_id_in_filter
 from sentry.search.eap.resolver import SearchResolver

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -66,6 +66,7 @@ from sentry.seer.agent.index_data import (
 )
 from sentry.seer.agent.on_completion_hook import call_on_completion_hook
 from sentry.seer.agent.tools import (
+    execute_replays_query,
     execute_table_query,
     execute_timeseries_query,
     execute_trace_table_query,
@@ -928,6 +929,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "execute_table_query": execute_table_query,
     "execute_timeseries_query": execute_timeseries_query,
     "execute_trace_table_query": execute_trace_table_query,
+    "execute_replays_query": execute_replays_query,
     "execute_issues_query": execute_issues_query,
     "get_trace_item_attributes": get_trace_item_attributes,
     "get_repository_definition": get_repository_definition,

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -15,12 +15,13 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.repository import Repository
-from sentry.replays.testutils import mock_replay
+from sentry.replays.testutils import mock_replay, mock_replay_click
 from sentry.search.utils import parse_iso_timestamp
 from sentry.seer.agent.tools import (
     EVENT_TIMESERIES_RESOLUTIONS,
     _get_issue_event_timeseries,
     _get_recommended_event,
+    execute_replays_query,
     execute_table_query,
     execute_timeseries_query,
     execute_trace_table_query,
@@ -2953,6 +2954,49 @@ class TestGetReplayMetadata(ReplaysSnubaTestCase):
                 )
                 is None
             )
+
+    def test_execute_replays_query(self) -> None:
+        replay_id = uuid.uuid4().hex
+        replay_timestamp = datetime.now(UTC) - timedelta(minutes=10)
+        self.store_replays(
+            mock_replay(
+                replay_timestamp,
+                self.project.id,
+                replay_id,
+                urls=["https://example.com/checkout"],
+            )
+        )
+        self.store_replays(
+            mock_replay_click(
+                replay_timestamp + timedelta(seconds=5),
+                self.project.id,
+                replay_id,
+                node_id=1,
+                tag="button",
+                is_dead=1,
+                is_rage=1,
+            )
+        )
+
+        with self.feature({"organizations:session-replay": True}):
+            result = execute_replays_query(
+                organization_id=self.organization.id,
+                project_ids=[self.project.id],
+                query="count_rage_clicks:>0",
+                fields=["id", "project_id", "started_at", "count_rage_clicks", "urls"],
+                sort="-started_at",
+                stats_period="7d",
+                per_page=5,
+            )
+
+        assert result is not None
+        assert len(result["data"]) == 1
+        row = result["data"][0]
+        assert row["id"] == replay_id
+        assert row["project_id"] == str(self.project.id)
+        assert row["started_at"] == replay_timestamp.replace(microsecond=0).isoformat()
+        assert row["count_rage_clicks"] == 1
+        assert row["urls"] == ["https://example.com/checkout"]
 
 
 class TestLogsQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -2998,6 +2998,37 @@ class TestGetReplayMetadata(ReplaysSnubaTestCase):
         assert row["count_rage_clicks"] == 1
         assert row["urls"] == ["https://example.com/checkout"]
 
+    def test_execute_replays_query_with_project_slugs(self) -> None:
+        replay_id = uuid.uuid4().hex
+        replay_timestamp = datetime.now(UTC) - timedelta(minutes=10)
+        self.store_replays(
+            mock_replay(
+                replay_timestamp,
+                self.project.id,
+                replay_id,
+                urls=["https://example.com/checkout"],
+            )
+        )
+
+        with self.feature({"organizations:session-replay": True}):
+            result = execute_replays_query(
+                organization_id=self.organization.id,
+                project_slugs=[self.project.slug],
+                query="url:*checkout*",
+                fields=["id", "project_id", "started_at", "urls"],
+                sort="-started_at",
+                stats_period="7d",
+                per_page=5,
+            )
+
+        assert result is not None
+        assert len(result["data"]) == 1
+        row = result["data"][0]
+        assert row["id"] == replay_id
+        assert row["project_id"] == str(self.project.id)
+        assert row["started_at"] == replay_timestamp.replace(microsecond=0).isoformat()
+        assert row["urls"] == ["https://example.com/checkout"]
+
 
 class TestLogsQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
     def setUp(self) -> None:

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -3029,6 +3029,60 @@ class TestGetReplayMetadata(ReplaysSnubaTestCase):
         assert row["started_at"] == replay_timestamp.replace(microsecond=0).isoformat()
         assert row["urls"] == ["https://example.com/checkout"]
 
+    def test_execute_replays_query_rejects_invalid_fields(self) -> None:
+        with self.feature({"organizations:session-replay": True}):
+            result = execute_replays_query(
+                organization_id=self.organization.id,
+                project_ids=[self.project.id],
+                fields=["id", "not_a_replay_field"],
+                stats_period="7d",
+                per_page=5,
+            )
+
+        assert result == {"error": "Invalid replay field(s): not_a_replay_field"}
+
+    def test_execute_replays_query_handles_invalid_sort(self) -> None:
+        replay_id = uuid.uuid4().hex
+        replay_timestamp = datetime.now(UTC) - timedelta(minutes=10)
+        self.store_replays(mock_replay(replay_timestamp, self.project.id, replay_id))
+
+        with self.feature({"organizations:session-replay": True}):
+            result = execute_replays_query(
+                organization_id=self.organization.id,
+                project_ids=[self.project.id],
+                fields=["id", "started_at"],
+                sort="-not_a_sortable_field",
+                stats_period="7d",
+                per_page=5,
+            )
+
+        assert result is not None
+        assert "not_a_sortable_field" in result["error"]
+        assert "sortable field" in result["error"]
+
+    def test_execute_replays_query_pagination_has_more(self) -> None:
+        older_replay_id = uuid.uuid4().hex
+        newer_replay_id = uuid.uuid4().hex
+        older_timestamp = datetime.now(UTC) - timedelta(minutes=10)
+        newer_timestamp = datetime.now(UTC) - timedelta(minutes=5)
+        self.store_replays(mock_replay(older_timestamp, self.project.id, older_replay_id))
+        self.store_replays(mock_replay(newer_timestamp, self.project.id, newer_replay_id))
+
+        with self.feature({"organizations:session-replay": True}):
+            result = execute_replays_query(
+                organization_id=self.organization.id,
+                project_ids=[self.project.id],
+                fields=["id", "started_at"],
+                sort="-started_at",
+                stats_period="7d",
+                per_page=1,
+            )
+
+        assert result is not None
+        assert len(result["data"]) == 1
+        assert result["data"][0]["id"] == newer_replay_id
+        assert result["meta"]["has_more"] is True
+
 
 class TestLogsQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary
- add a Seer RPC wrapper around the dedicated Replay collection search API
- register `execute_replays_query` for Seer callers
- cover the rage-click replay search result shape

## Testing
- `uv run ruff check --fix src/sentry/seer/agent/tools.py src/sentry/seer/endpoints/seer_rpc.py tests/sentry/seer/agent/test_tools.py && uv run ruff format src/sentry/seer/agent/tools.py src/sentry/seer/endpoints/seer_rpc.py tests/sentry/seer/agent/test_tools.py`
- `uv run pytest tests/sentry/seer/agent/test_tools.py::TestGetReplayMetadata -q`
