### PR TITLE
perf(ourlogs): removed `observed_timestamp` from `AlwaysPresentLogFields`

### DIFF
--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -46,8 +46,6 @@ export const AlwaysPresentLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.SEVERITY,
   OurLogKnownFieldKey.TIMESTAMP,
   OurLogKnownFieldKey.TIMESTAMP_PRECISE,
-  OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE,
-  OurLogKnownFieldKey.TEMPLATE,
 ] as const;
 
 const AlwaysHiddenLogFields: OurLogFieldKey[] = [

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -46,6 +46,7 @@ export const AlwaysPresentLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.SEVERITY,
   OurLogKnownFieldKey.TIMESTAMP,
   OurLogKnownFieldKey.TIMESTAMP_PRECISE,
+  OurLogKnownFieldKey.TEMPLATE,
 ] as const;
 
 const AlwaysHiddenLogFields: OurLogFieldKey[] = [

--- a/static/app/views/explore/logs/logsTimeTooltip.spec.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.spec.tsx
@@ -73,7 +73,7 @@ describe('TimestampTooltipBody', () => {
     );
 
     expect(screen.getByText('Occurred')).toBeInTheDocument();
-    expect(screen.getByText('Received')).toBeInTheDocument();
+    expect(screen.queryAllByRole('time')).toHaveLength(3);
   });
 
   it('does not render received time when observed timestamp is not provided', () => {
@@ -92,7 +92,7 @@ describe('TimestampTooltipBody', () => {
     );
 
     expect(screen.getByText('Occurred')).toBeInTheDocument();
-    expect(screen.queryByText('Received')).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('time')).toHaveLength(2);
   });
 
   it('renders in 24h format when user preference is set', () => {

--- a/static/app/views/explore/logs/logsTimeTooltip.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.tsx
@@ -7,6 +7,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {AutoSelectText} from 'sentry/components/autoSelectText';
 import {DateTime} from 'sentry/components/dateTime';
 import {Duration} from 'sentry/components/duration/duration';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {useTimezone} from 'sentry/components/timezoneProvider';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -97,12 +98,14 @@ function TimestampTooltipBody({
         <HorizontalRule />
         <dt>{t('Received')}</dt>
         <dd>
-          {observedTime && (
+          {observedTime ? (
             <TimestampValues>
               <AutoSelectText>
                 <DateTime date={observedTime} seconds timeZone />
               </AutoSelectText>
             </TimestampValues>
+          ) : (
+            <LoadingIndicator size={16} style={{margin: 0}} />
           )}
         </dd>
       </Fragment>

--- a/static/app/views/explore/logs/logsTimeTooltip.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.tsx
@@ -39,10 +39,9 @@ function TimestampTooltipBody({
   const timestampToUse = preciseTimestampMs ? new Date(preciseTimestampMs) : timestamp;
 
   const observedTimeNanos = attributes[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE];
-  const observedTimeMs = observedTimeNanos
-    ? Math.floor(Number(observedTimeNanos) / 1_000_000)
+  const observedTime = observedTimeNanos
+    ? new Date(Math.floor(Number(observedTimeNanos) / 1_000_000))
     : null;
-  const observedTime = observedTimeMs ? new Date(observedTimeMs) : null;
 
   const isUTCLocalTimezone = currentTimezone === 'UTC';
 
@@ -94,19 +93,19 @@ function TimestampTooltipBody({
         </Fragment>
       )}
 
-      {observedTime && (
-        <Fragment>
-          <HorizontalRule />
-          <dt>{t('Received')}</dt>
-          <dd>
+      <Fragment>
+        <HorizontalRule />
+        <dt>{t('Received')}</dt>
+        <dd>
+          {observedTime && (
             <TimestampValues>
               <AutoSelectText>
                 <DateTime date={observedTime} seconds timeZone />
               </AutoSelectText>
             </TimestampValues>
-          </dd>
-        </Fragment>
-      )}
+          )}
+        </dd>
+      </Fragment>
     </DescriptionList>
   );
 }

--- a/static/app/views/explore/logs/logsTimeTooltip.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.tsx
@@ -39,10 +39,9 @@ function TimestampTooltipBody({
   const timestampToUse = preciseTimestampMs ? new Date(preciseTimestampMs) : timestamp;
 
   const observedTimeNanos = attributes[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE];
-  const observedTimeMs =
-    observedTimeNanos && typeof observedTimeNanos === 'string'
-      ? Math.floor(Number(observedTimeNanos) / 1_000_000)
-      : null;
+  const observedTimeMs = observedTimeNanos
+    ? Math.floor(Number(observedTimeNanos) / 1_000_000)
+    : null;
   const observedTime = observedTimeMs ? new Date(observedTimeMs) : null;
 
   const isUTCLocalTimezone = currentTimezone === 'UTC';

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -438,7 +438,6 @@ describe('LogsInfiniteTable', () => {
             'severity',
             'timestamp',
             'timestamp_precise',
-            'observed_timestamp',
             'message',
             'replay_id',
           ]),

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -321,6 +321,10 @@ export const LogRowContent = memo(function LogRowContent({
   });
   const [caseInsensitivity] = useCaseInsensitivity();
 
+  const observedTimestampAttr = traceItemsResult.data?.attributes?.find(
+    a => a.name === OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE
+  );
+
   const rendererExtra: RendererExtra = {
     highlightTerms,
     caseSensitiveHighlighting: !caseInsensitivity,
@@ -328,7 +332,12 @@ export const LogRowContent = memo(function LogRowContent({
     useFullSeverityText: false,
     location,
     organization,
-    attributes: dataRow as OurLogsResponseItem,
+    attributes: {
+      ...dataRow,
+      ...(observedTimestampAttr
+        ? {[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE]: observedTimestampAttr.value}
+        : {}),
+    } as OurLogsResponseItem,
     attributeTypes: meta?.fields ?? {},
     theme,
     projectSlug,

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -321,8 +321,8 @@ export const LogRowContent = memo(function LogRowContent({
   });
   const [caseInsensitivity] = useCaseInsensitivity();
 
-  const observedTimestampAttr = traceItemsResult.data?.attributes?.find(
-    a => a.name === OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE
+  const observedTimestamp = traceItemsResult.data?.attributes?.find(
+    a => a.name === 'sentry.observed_timestamp_nanos'
   );
 
   const rendererExtra: RendererExtra = {
@@ -334,9 +334,9 @@ export const LogRowContent = memo(function LogRowContent({
     organization,
     attributes: {
       ...dataRow,
-      ...(observedTimestampAttr
-        ? {[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE]: observedTimestampAttr.value}
-        : {}),
+      ...(observedTimestamp && {
+        [OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE]: String(observedTimestamp.value),
+      }),
     } as OurLogsResponseItem,
     attributeTypes: meta?.fields ?? {},
     theme,

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -78,7 +78,7 @@ type OurLogsKnownFieldResponseMap = Record<
   [OurLogKnownFieldKey.PROJECT_ID]: string;
   [OurLogKnownFieldKey.TIMESTAMP]: string;
   [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: string | number;
-  [OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE]: string | number;
+  [OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE]?: string | number;
 };
 
 type OurLogsCustomFieldResponseMap = Record<OurLogCustomFieldKey, string | number>;

--- a/static/app/views/explore/logs/useLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.spec.tsx
@@ -344,7 +344,7 @@ describe('useInfiniteLogsQuery', () => {
   describe('high fidelity', () => {
     function makeLinkHeader(cursor: string, hasNext = true) {
       const url =
-        'https://sentry.io/api/0/organizations/org-slug/events/?caseInsensitive=&dataset=ourlogs&field=id&field=project.id&field=trace&field=severity_number&field=severity&field=timestamp&field=timestamp_precise&field=message&orderby=-timestamp&per_page=1000&query=&referrer=api.explore.logs-table&sampling=HIGHEST_ACCURACY_FLEX_TIME&sort=-timestamp&statsPeriod=1h&highFidelity=true';
+        'https://sentry.io/api/0/organizations/org-slug/events/?caseInsensitive=&dataset=ourlogs&field=id&field=project.id&field=trace&field=severity_number&field=severity&field=timestamp&field=timestamp_precise&field=message.template&field=message&orderby=-timestamp&per_page=1000&query=&referrer=api.explore.logs-table&sampling=HIGHEST_ACCURACY_FLEX_TIME&sort=-timestamp&statsPeriod=1h&highFidelity=true';
       return [
         [
           `<${url}&cursor=:0:1>`,

--- a/static/app/views/explore/logs/useLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.spec.tsx
@@ -344,7 +344,7 @@ describe('useInfiniteLogsQuery', () => {
   describe('high fidelity', () => {
     function makeLinkHeader(cursor: string, hasNext = true) {
       const url =
-        'https://sentry.io/api/0/organizations/org-slug/events/?caseInsensitive=&dataset=ourlogs&field=id&field=project.id&field=trace&field=severity_number&field=severity&field=timestamp&field=timestamp_precise&field=observed_timestamp&field=message.template&field=message&orderby=-timestamp&per_page=1000&query=&referrer=api.explore.logs-table&sampling=HIGHEST_ACCURACY_FLEX_TIME&sort=-timestamp&statsPeriod=1h&highFidelity=true';
+        'https://sentry.io/api/0/organizations/org-slug/events/?caseInsensitive=&dataset=ourlogs&field=id&field=project.id&field=trace&field=severity_number&field=severity&field=timestamp&field=timestamp_precise&field=message&orderby=-timestamp&per_page=1000&query=&referrer=api.explore.logs-table&sampling=HIGHEST_ACCURACY_FLEX_TIME&sort=-timestamp&statsPeriod=1h&highFidelity=true';
       return [
         [
           `<${url}&cursor=:0:1>`,


### PR DESCRIPTION
This field was there solely to populate the "Received" section of the timestamp hover tooltip (showing ingestion delay). `useTraceItemDetails` -> `useFetchTraceItemDetailsOnHover` already retrieves it on hover. So there may be a bit of a delay for it to pop up on first hover if the user moves their mouse quickly. 

The result is a reduction in the  response size: on `sentry.io/explore/logs`'s initial 1000 logs query, I see it shrink from ~60-65 kB to ~50-55 kB. I don't think this significantly moves the needle for any one end-user but it should help reduce Snuba load a bit, I think.

Two potential followups:

* ~Claude had also ideated removing `message.template`, since that's almost never used. But it is actually sometimes used when `message === '[Filtered]'` (PII scrubbing). Maybe we could change its default behavior to only include it for that PII scrubbing case?~
  * Talked with Kevan: this wouldn't improve server-side performance because we have to query `message.template` in Clickhouse to know whether it's `null`. And PII scrubbing is on by default, so most users wouldn't benefit. 
* We also retrieve both `timestamp` and `timestamp_precise`. Maybe we could infer only fetch `timestamp_precise`, and then infer `timestamp` in the client?
  * We need `timestamp_precise` to get the log order correctly, it's not going anywhere
  * We have to include `timestamp` in the event query so that the query is fast, because otherwise the partition isn't resolved quickly.
  * ...so in essence, the backend will always grab both.
  * Kevan and Pierre have discussed changing this in the future (changing the `timestamp` column to datetime64 to make it precise on its own).

Fixes LOGS-806