### PR TITLE
fix(release-health): Add stable processing jitter

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1515,6 +1515,13 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "release-health.monitor-release-adoption-jitter-seconds",
+    type=Int,
+    default=45 * 60,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Minimum number of files in an archive. Archives with fewer files are extracted and have their
 # contents stored as separate release files.
 register("processing.release-archive-min-files", default=10, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -22,9 +22,11 @@ from sentry.release_health.release_monitor.base import Totals
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import release_health_tasks
 from sentry.utils import metrics
+from sentry.utils.hashlib import md5_text
 
 CHUNK_SIZE = 1000
 MAX_SECONDS = 60
+PROCESS_PROJECTS_WITH_SESSIONS_JITTER_SECONDS = 45 * 60
 
 # Sampling rate for updating ReleaseProjectEnvironment.last_seen
 LAST_SEEN_UPDATE_SAMPLE_RATE = 0.01  # 1%
@@ -44,7 +46,16 @@ def monitor_release_adoption(**kwargs) -> None:
         "sentry.tasks.monitor_release_adoption.process_projects_with_sessions", sample_rate=1.0
     ):
         for org_id, project_ids in release_monitor.fetch_projects_with_recent_sessions().items():
-            process_projects_with_sessions.delay(org_id, project_ids)
+            process_projects_with_sessions.apply_async(
+                args=[org_id, project_ids],
+                countdown=get_process_projects_with_sessions_countdown(org_id),
+            )
+
+
+def get_process_projects_with_sessions_countdown(org_id: int) -> int:
+    return (
+        int(md5_text(str(org_id)).hexdigest(), 16) % PROCESS_PROJECTS_WITH_SESSIONS_JITTER_SECONDS
+    )
 
 
 @instrumented_task(

--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -26,7 +26,9 @@ from sentry.utils.hashlib import md5_text
 
 CHUNK_SIZE = 1000
 MAX_SECONDS = 60
-PROCESS_PROJECTS_WITH_SESSIONS_JITTER_SECONDS = 45 * 60
+PROCESS_PROJECTS_WITH_SESSIONS_JITTER_SECONDS_OPTION = (
+    "release-health.monitor-release-adoption-jitter-seconds"
+)
 
 # Sampling rate for updating ReleaseProjectEnvironment.last_seen
 LAST_SEEN_UPDATE_SAMPLE_RATE = 0.01  # 1%
@@ -53,9 +55,11 @@ def monitor_release_adoption(**kwargs) -> None:
 
 
 def get_process_projects_with_sessions_countdown(org_id: int) -> int:
-    return (
-        int(md5_text(str(org_id)).hexdigest(), 16) % PROCESS_PROJECTS_WITH_SESSIONS_JITTER_SECONDS
-    )
+    jitter_seconds = max(0, options.get(PROCESS_PROJECTS_WITH_SESSIONS_JITTER_SECONDS_OPTION))
+    if jitter_seconds == 0:
+        return 0
+
+    return int(md5_text(str(org_id)).hexdigest(), 16) % jitter_seconds
 
 
 @instrumented_task(

--- a/tests/sentry/release_health/test_tasks.py
+++ b/tests/sentry/release_health/test_tasks.py
@@ -504,6 +504,13 @@ class BaseTestReleaseMonitor(TestCase, BaseMetricsTestCase):
             for org_id, project_ids in org_projects.items()
         ]
 
+    def test_process_projects_with_sessions_countdown_uses_jitter_option(self) -> None:
+        with self.options({"release-health.monitor-release-adoption-jitter-seconds": 1}):
+            assert get_process_projects_with_sessions_countdown(1) == 0
+
+        with self.options({"release-health.monitor-release-adoption-jitter-seconds": 0}):
+            assert get_process_projects_with_sessions_countdown(self.organization.id) == 0
+
     def test_missing_rpe_is_created(self) -> None:
         self.bulk_store_sessions(
             [

--- a/tests/sentry/release_health/test_tasks.py
+++ b/tests/sentry/release_health/test_tasks.py
@@ -16,6 +16,7 @@ from sentry.release_health.release_monitor.base import BaseReleaseMonitorBackend
 from sentry.release_health.release_monitor.metrics import MetricReleaseMonitorBackend
 from sentry.release_health.tasks import (
     adopt_releases,
+    get_process_projects_with_sessions_countdown,
     has_been_adopted,
     monitor_release_adoption,
     process_projects_with_sessions,
@@ -475,6 +476,33 @@ class BaseTestReleaseMonitor(TestCase, BaseMetricsTestCase):
             adopted__gte=now,
             unadopted=None,
         ).exists()
+
+    def test_monitor_release_adoption_jitters_project_processing(self) -> None:
+        org2 = self.create_organization()
+        project_ids = [self.project1.id, self.project2.id]
+        org_projects = {
+            self.organization.id: project_ids,
+            org2.id: [self.create_project(organization=org2).id],
+        }
+
+        with (
+            mock.patch(
+                "sentry.release_health.tasks.release_monitor.fetch_projects_with_recent_sessions",
+                return_value=org_projects,
+            ),
+            mock.patch(
+                "sentry.release_health.tasks.process_projects_with_sessions.apply_async"
+            ) as mock_apply_async,
+        ):
+            monitor_release_adoption()
+
+        assert mock_apply_async.call_args_list == [
+            mock.call(
+                args=[org_id, project_ids],
+                countdown=get_process_projects_with_sessions_countdown(org_id),
+            )
+            for org_id, project_ids in org_projects.items()
+        ]
 
     def test_missing_rpe_is_created(self) -> None:
         self.bulk_store_sessions(


### PR DESCRIPTION
Stagger release health project processing with a deterministic per-org countdown during the hourly adoption monitor run.

Each org now lands in the same slot within a configurable jitter window, which spreads the follow-up processing work without changing the adoption logic itself. The window is controlled by `release-health.monitor-release-adoption-jitter-seconds`, defaults to 45 minutes, and can be set to `0` to disable the delay. The release health task tests cover the scheduled countdown behavior and the option override.

**Jitter Precedent**

This follows the same shape as [Seer Night Shift's per-org fanout](https://github.com/getsentry/sentry/blob/8a91eee5cbec71a5ab246e9689b81bb411d6794a/src/sentry/tasks/seer/night_shift/cron.py#L149-L150): hash the org id into a spread window, then pass that stable delay as the task countdown.

**Result Stability**

The delayed task still calls `fetch_project_release_health_totals` with the same org/project inputs and a six-hour lookback relative to execution time. The monitor runs hourly, and the jitter is stable per org, so the first delayed run just shifts that org to its assigned offset; after that, the org continues to run once per monitor cycle. Staggering only changes when that org is evaluated, not how projects are grouped or how adoption thresholds are computed.

Fix for #inc-2162 where every hour the Snuba API gets overloaded by these requests