### PR TITLE
chore(ACI): Update API docs landing page description

### DIFF
--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -157,7 +157,7 @@ OPENAPI_TAGS = [
     {
         "name": "Monitors",
         "x-sidebar-name": "Monitors & Alerts",
-        "description": "⚠️ These endpoints are currently in **beta** and may be subject to change. They are supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.",
+        "description": "Endpoints for Monitors and Alerts",
         "x-display-description": True,
         "externalDocs": {
             "description": "Found an error? Let us know.",

--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -158,7 +158,7 @@ OPENAPI_TAGS = [
         "name": "Monitors",
         "x-sidebar-name": "Monitors & Alerts",
         "description": "Endpoints for Monitors and Alerts",
-        "x-display-description": True,
+        "x-display-description": False,
         "externalDocs": {
             "description": "Found an error? Let us know.",
             "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/monitors/&template=api_error_template.md",


### PR DESCRIPTION
Missed this part earlier when I removed the beta stuff from the individual endpoints. 