### PR TITLE
feat(data-forwarding): Enable retries for data forwarders via task dispatch

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -881,6 +881,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.hybridcloud.tasks.deliver_webhooks",
     "sentry.incidents.tasks",
     "sentry.ingest.transaction_clusterer.tasks",
+    "sentry.integrations.data_forwarding.tasks",
     "sentry.integrations.github.tasks.codecov_account_link",
     "sentry.integrations.github.tasks.codecov_account_unlink",
     "sentry.integrations.github.tasks.link_all_repos",

--- a/src/sentry/integrations/data_forwarding/amazon_sqs/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/amazon_sqs/forwarder.py
@@ -27,7 +27,12 @@ class AmazonSQSForwarder(BaseDataForwarder):
     def get_event_payload(
         self, event: Event | GroupEvent, config: dict[str, Any]
     ) -> dict[str, Any]:
-        return serialize(event)
+        # We do this since serialize(event) returns datetime objects, and taskbroker doesn't support
+        # those as arguments. This dump -> load step gets around it, and leaves the payload being
+        # forwarded in the same format it has always been.
+        return orjson.loads(
+            orjson.dumps(serialize(event), option=orjson.OPT_UTC_Z | orjson.OPT_NON_STR_KEYS)
+        )
 
     def is_unrecoverable_client_error(self, error: ClientError) -> bool:
         error_str = str(error)

--- a/src/sentry/integrations/data_forwarding/amazon_sqs/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/amazon_sqs/forwarder.py
@@ -138,3 +138,66 @@ class AmazonSQSForwarder(BaseDataForwarder):
             raise
 
         return True
+
+    def get_task_payload(self, event: Event | GroupEvent, config: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "event_id": event.event_id,
+            "project_slug": event.project.slug,
+            "date": event.datetime.strftime("%Y-%m-%d"),
+        }
+
+    @staticmethod
+    def forward_event_from_task(
+        *,
+        config: dict[str, Any],
+        event_payload: dict[str, Any],
+        task_payload: dict[str, Any],
+    ) -> None:
+        queue_url = config["queue_url"]
+        region = config["region"]
+        access_key = config["access_key"]
+        secret_key = config["secret_key"]
+        message_group_id = config.get("message_group_id")
+        s3_bucket = config.get("s3_bucket")
+
+        boto3_args = {
+            "aws_access_key_id": access_key,
+            "aws_secret_access_key": secret_key,
+            "region_name": region,
+        }
+
+        if s3_bucket:
+            date = task_payload["date"]
+            project_slug = task_payload["project_slug"]
+            event_id = task_payload["event_id"]
+            key = f"{project_slug}/{date}/{event_id}"
+
+            s3_client = boto3.client(
+                service_name="s3", config=Config(signature_version="s3v4"), **boto3_args
+            )
+            s3_client.put_object(
+                Bucket=s3_bucket,
+                Body=orjson.dumps(
+                    event_payload, option=orjson.OPT_UTC_Z | orjson.OPT_NON_STR_KEYS
+                ).decode(),
+                Key=key,
+            )
+
+            url = f"https://{s3_bucket}.s3.{region}.amazonaws.com/{key}"
+            event_payload = {"s3Url": url, "eventID": event_id}
+
+        message = orjson.dumps(
+            event_payload, option=orjson.OPT_UTC_Z | orjson.OPT_NON_STR_KEYS
+        ).decode()
+
+        if len(message) > AWS_SQS_MAX_MESSAGE_SIZE:
+            return
+
+        client = boto3.client(service_name="sqs", **boto3_args)
+        send_message_args = {"QueueUrl": queue_url, "MessageBody": message}
+
+        if message_group_id:
+            send_message_args["MessageGroupId"] = message_group_id
+            send_message_args["MessageDeduplicationId"] = uuid4().hex
+
+        client.send_message(**send_message_args)

--- a/src/sentry/integrations/data_forwarding/base.py
+++ b/src/sentry/integrations/data_forwarding/base.py
@@ -1,13 +1,16 @@
 import logging
+import random
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
-from sentry import ratelimits
+from sentry import options, ratelimits
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.services.eventstore.models import Event, GroupEvent
 
 logger = logging.getLogger(__name__)
+
+from sentry.integrations.data_forwarding.tasks import forward_event
 
 
 class BaseDataForwarder(ABC):
@@ -57,6 +60,26 @@ class BaseDataForwarder(ABC):
     ) -> dict[str, Any]:
         raise NotImplementedError
 
+    @abstractmethod
+    def get_task_payload(self, event: Event | GroupEvent, config: dict[str, Any]) -> dict[str, Any]:
+        """
+        Allows providers to create task-safe payloads from the event to avoid refetching in the task.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def forward_event_from_task(
+        *,
+        config: dict[str, Any],
+        event_payload: dict[str, Any],
+        task_payload: dict[str, Any],
+    ) -> None:
+        """
+        Similar to forward_event, but raises any exception to allow for retries in a task.
+        The task_payload is derived from get_task_payload, to avoid needing to refetch the event.
+        """
+        raise NotImplementedError
+
     def post_process(
         self, event: Event | GroupEvent, data_forwarder_project: DataForwarderProject
     ) -> None:
@@ -65,5 +88,13 @@ class BaseDataForwarder(ABC):
         if self.is_ratelimited(event):
             return
 
-        payload = self.get_event_payload(event=event, config=config)
-        self.forward_event(event=event, payload=payload, config=config)
+        event_payload = self.get_event_payload(event=event, config=config)
+        task_payload = self.get_task_payload(event=event, config=config)
+        if random.random() < options.get("data-forwarding.task-rollout-rate"):
+            forward_event.delay(
+                data_forwarder_project_id=data_forwarder_project.id,
+                event_payload=event_payload,
+                task_payload=task_payload,
+            )
+        else:
+            self.forward_event(event=event, payload=event_payload, config=config)

--- a/src/sentry/integrations/data_forwarding/base.py
+++ b/src/sentry/integrations/data_forwarding/base.py
@@ -7,6 +7,7 @@ from sentry import options, ratelimits
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.services.eventstore.models import Event, GroupEvent
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,9 @@ class BaseDataForwarder(ABC):
                 data_forwarder_project_id=data_forwarder_project.id,
                 event_payload=event_payload,
                 task_payload=task_payload,
+            )
+            metrics.incr(
+                "data_forwarding.post_process.task_scheduled", tags={"provider": self.provider}
             )
         else:
             self.forward_event(event=event, payload=event_payload, config=config)

--- a/src/sentry/integrations/data_forwarding/base.py
+++ b/src/sentry/integrations/data_forwarding/base.py
@@ -88,10 +88,10 @@ class BaseDataForwarder(ABC):
             return
 
         event_payload = self.get_event_payload(event=event, config=config)
-        task_payload = self.get_task_payload(event=event, config=config)
         if random.random() < options.get("data-forwarding.task-rollout-rate"):
             from sentry.integrations.data_forwarding.tasks import forward_event
 
+            task_payload = self.get_task_payload(event=event, config=config)
             forward_event.delay(
                 data_forwarder_project_id=data_forwarder_project.id,
                 event_payload=event_payload,

--- a/src/sentry/integrations/data_forwarding/base.py
+++ b/src/sentry/integrations/data_forwarding/base.py
@@ -10,8 +10,6 @@ from sentry.services.eventstore.models import Event, GroupEvent
 
 logger = logging.getLogger(__name__)
 
-from sentry.integrations.data_forwarding.tasks import forward_event
-
 
 class BaseDataForwarder(ABC):
     """
@@ -68,6 +66,7 @@ class BaseDataForwarder(ABC):
         raise NotImplementedError
 
     @staticmethod
+    @abstractmethod
     def forward_event_from_task(
         *,
         config: dict[str, Any],
@@ -91,6 +90,8 @@ class BaseDataForwarder(ABC):
         event_payload = self.get_event_payload(event=event, config=config)
         task_payload = self.get_task_payload(event=event, config=config)
         if random.random() < options.get("data-forwarding.task-rollout-rate"):
+            from sentry.integrations.data_forwarding.tasks import forward_event
+
             forward_event.delay(
                 data_forwarder_project_id=data_forwarder_project.id,
                 event_payload=event_payload,

--- a/src/sentry/integrations/data_forwarding/base.py
+++ b/src/sentry/integrations/data_forwarding/base.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from sentry import options, ratelimits
-from sentry.integrations.data_forwarding.tasks import forward_event
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -84,6 +83,8 @@ class BaseDataForwarder(ABC):
     def post_process(
         self, event: Event | GroupEvent, data_forwarder_project: DataForwarderProject
     ) -> None:
+        from sentry.integrations.data_forwarding.tasks import forward_event
+
         config = data_forwarder_project.get_config()
         self.initialize_variables(event, config)
         if self.is_ratelimited(event):

--- a/src/sentry/integrations/data_forwarding/base.py
+++ b/src/sentry/integrations/data_forwarding/base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from sentry import options, ratelimits
+from sentry.integrations.data_forwarding.tasks import forward_event
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -90,8 +91,6 @@ class BaseDataForwarder(ABC):
 
         event_payload = self.get_event_payload(event=event, config=config)
         if random.random() < options.get("data-forwarding.task-rollout-rate"):
-            from sentry.integrations.data_forwarding.tasks import forward_event
-
             task_payload = self.get_task_payload(event=event, config=config)
             forward_event.delay(
                 data_forwarder_project_id=data_forwarder_project.id,

--- a/src/sentry/integrations/data_forwarding/segment/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/segment/forwarder.py
@@ -108,3 +108,43 @@ class SegmentForwarder(BaseDataForwarder):
             )
             return False
         return True
+
+    def get_task_payload(self, event: Event | GroupEvent, config: dict[str, Any]) -> dict[str, Any]:
+        # we avoid instantiating interfaces here as they're only going to be
+        # used if there's a User present
+        user_interface = event.interfaces.get("user")
+        if not user_interface:
+            return {"event_type": event.get_event_type(), "has_user": False}
+
+        # if the user id is not present, we can't forward the event
+        return {
+            "event_type": event.get_event_type(),
+            "has_user": True if user_interface.id else False,
+        }
+
+    @staticmethod
+    def forward_event_from_task(
+        *,
+        config: dict[str, Any],
+        event_payload: dict[str, Any],
+        task_payload: dict[str, Any],
+    ) -> None:
+        # we currently only support errors
+        if task_payload.get("event_type") != "error":
+            return
+
+        if not task_payload.get("has_user", False):
+            return
+
+        write_key = config["write_key"]
+        if not write_key:
+            return
+
+        with http.build_session() as session:
+            response = session.post(
+                SegmentForwarder.endpoint,
+                json=event_payload,
+                auth=(write_key, ""),
+                timeout=10,
+            )
+            response.raise_for_status()

--- a/src/sentry/integrations/data_forwarding/segment/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/segment/forwarder.py
@@ -98,7 +98,7 @@ class SegmentForwarder(BaseDataForwarder):
                     self.endpoint,
                     json=payload,
                     auth=(write_key, ""),
-                    timeout=10,
+                    timeout=(3.5, 10),
                 )
                 response.raise_for_status()
         except Exception:
@@ -145,6 +145,6 @@ class SegmentForwarder(BaseDataForwarder):
                 SegmentForwarder.endpoint,
                 json=event_payload,
                 auth=(write_key, ""),
-                timeout=10,
+                timeout=(3.5, 10),
             )
             response.raise_for_status()

--- a/src/sentry/integrations/data_forwarding/splunk/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/splunk/forwarder.py
@@ -149,3 +149,30 @@ class SplunkForwarder(BaseDataForwarder):
                 return False
             raise
         return True
+
+    def get_task_payload(self, event: Event | GroupEvent, config: dict[str, Any]) -> dict[str, Any]:
+        return {"host": self.host}
+
+    @staticmethod
+    def forward_event_from_task(
+        *,
+        config: dict[str, Any],
+        event_payload: dict[str, Any],
+        task_payload: dict[str, Any],
+    ) -> None:
+        token = config.get("token")
+        index = config.get("index")
+        instance = config.get("instance_url")
+
+        if not token or not index or not instance:
+            return
+
+        if not instance.endswith("/services/collector"):
+            instance = instance.rstrip("/") + "/services/collector"
+
+        host = task_payload.get("host")
+        if host:
+            event_payload["host"] = host
+
+        client = SplunkApiClient(instance, token)
+        client.request(event_payload)

--- a/src/sentry/integrations/data_forwarding/tasks.py
+++ b/src/sentry/integrations/data_forwarding/tasks.py
@@ -1,0 +1,68 @@
+import logging
+from typing import Any
+
+from botocore.exceptions import ClientError, ParamValidationError
+from requests import HTTPError, Timeout
+from requests.exceptions import ChunkedEncodingError, ConnectionError, RequestException
+from taskbroker_client.retry import Retry
+
+from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task, retry
+from sentry.taskworker.namespaces import integrations_tasks
+
+logger = logging.getLogger(__name__)
+
+retry_decorator = retry(
+    on=(RequestException,),
+    on_silent=(
+        ChunkedEncodingError,
+        Timeout,
+        ApiHostError,
+        ApiTimeoutError,
+        ConnectionError,
+        HTTPError,
+    ),
+    ignore=(
+        ClientError,
+        ParamValidationError,
+        ValueError,
+    ),
+    raise_on_no_retries=False,
+)
+
+
+@instrumented_task(
+    name="sentry.integrations.data_forwarding.tasks.forward_event",
+    namespace=integrations_tasks,
+    retry=Retry(times=3, delay=60 * 5),
+    silo_mode=SiloMode.CELL,
+)
+@retry_decorator
+def forward_event(
+    data_forwarder_project_id: int,
+    event_payload: dict[str, Any],
+    task_payload: dict[str, Any],
+) -> None:
+    from sentry.integrations.data_forwarding import FORWARDER_REGISTRY
+    from sentry.integrations.data_forwarding.base import BaseDataForwarder
+    from sentry.integrations.models.data_forwarder_project import DataForwarderProject
+
+    try:
+        data_forwarder_project = DataForwarderProject.objects.select_related("data_forwarder").get(
+            id=data_forwarder_project_id
+        )
+    except DataForwarderProject.DoesNotExist:
+        return
+
+    provider = data_forwarder_project.data_forwarder.provider
+    forwarder: type[BaseDataForwarder] = FORWARDER_REGISTRY[provider]
+    forwarder.forward_event_from_task(
+        config=data_forwarder_project.get_config(),
+        event_payload=event_payload,
+        task_payload=task_payload,
+    )
+    logger.info(
+        "data_forwarding.event_forwarded",
+        extra={"provider": provider, "project_id": data_forwarder_project.project_id},
+    )

--- a/src/sentry/integrations/data_forwarding/tasks.py
+++ b/src/sentry/integrations/data_forwarding/tasks.py
@@ -49,10 +49,9 @@ def forward_event(
     task_payload: dict[str, Any],
 ) -> None:
     from sentry.integrations.data_forwarding import FORWARDER_REGISTRY
-    from sentry.integrations.data_forwarding.base import BaseDataForwarder
     from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 
-    logging_ctx = {"data_forwarder_project_id": data_forwarder_project_id}
+    logging_ctx: dict[str, Any] = {"data_forwarder_project_id": data_forwarder_project_id}
     try:
         data_forwarder_project = DataForwarderProject.objects.select_related("data_forwarder").get(
             id=data_forwarder_project_id
@@ -65,7 +64,7 @@ def forward_event(
     logging_ctx["provider"] = provider
     logging_ctx["project_id"] = data_forwarder_project.project_id
 
-    forwarder: type[BaseDataForwarder] = FORWARDER_REGISTRY.get(provider)
+    forwarder = FORWARDER_REGISTRY.get(provider)
     if not forwarder:
         logger.warning("data_forwarding.missing_provider", extra=logging_ctx)
         return

--- a/src/sentry/integrations/data_forwarding/tasks.py
+++ b/src/sentry/integrations/data_forwarding/tasks.py
@@ -18,7 +18,6 @@ _DATA_FORWARDING_RETRY_ON = (RequestException,)
 _DATA_FORWARDING_RETRY_IGNORE = (
     ClientError,
     ParamValidationError,
-    ValueError,
 )
 _DATA_FORWARDING_SILENCED = (
     ChunkedEncodingError,
@@ -53,21 +52,27 @@ def forward_event(
     from sentry.integrations.data_forwarding.base import BaseDataForwarder
     from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 
+    logging_ctx = {"data_forwarder_project_id": data_forwarder_project_id}
     try:
         data_forwarder_project = DataForwarderProject.objects.select_related("data_forwarder").get(
             id=data_forwarder_project_id
         )
     except DataForwarderProject.DoesNotExist:
+        logger.warning("data_forwarding.data_forwarder_project_not_found", extra=logging_ctx)
         return
 
     provider = data_forwarder_project.data_forwarder.provider
-    forwarder: type[BaseDataForwarder] = FORWARDER_REGISTRY[provider]
+    logging_ctx["provider"] = provider
+    logging_ctx["project_id"] = data_forwarder_project.project_id
+
+    forwarder: type[BaseDataForwarder] = FORWARDER_REGISTRY.get(provider)
+    if not forwarder:
+        logger.warning("data_forwarding.missing_provider", extra=logging_ctx)
+        return
+
     forwarder.forward_event_from_task(
         config=data_forwarder_project.get_config(),
         event_payload=event_payload,
         task_payload=task_payload,
     )
-    logger.info(
-        "data_forwarding.event_forwarded",
-        extra={"provider": provider, "project_id": data_forwarder_project.project_id},
-    )
+    logger.info("data_forwarding.event_forwarded_via_task", extra=logging_ctx)

--- a/src/sentry/integrations/data_forwarding/tasks.py
+++ b/src/sentry/integrations/data_forwarding/tasks.py
@@ -6,6 +6,8 @@ from requests import HTTPError, Timeout
 from requests.exceptions import ChunkedEncodingError, ConnectionError, RequestException
 from taskbroker_client.retry import Retry
 
+from sentry.integrations.data_forwarding import FORWARDER_REGISTRY
+from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -48,9 +50,6 @@ def forward_event(
     event_payload: dict[str, Any],
     task_payload: dict[str, Any],
 ) -> None:
-    from sentry.integrations.data_forwarding import FORWARDER_REGISTRY
-    from sentry.integrations.models.data_forwarder_project import DataForwarderProject
-
     logging_ctx: dict[str, Any] = {"data_forwarder_project_id": data_forwarder_project_id}
     try:
         data_forwarder_project = DataForwarderProject.objects.select_related("data_forwarder").get(

--- a/src/sentry/integrations/data_forwarding/tasks.py
+++ b/src/sentry/integrations/data_forwarding/tasks.py
@@ -8,10 +8,17 @@ from taskbroker_client.retry import Retry
 
 from sentry.integrations.data_forwarding import FORWARDER_REGISTRY
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
-from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError
+from sentry.shared_integrations.exceptions import (
+    ApiForbiddenError,
+    ApiHostError,
+    ApiInvalidRequestError,
+    ApiTimeoutError,
+    ApiUnauthorized,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +27,9 @@ _DATA_FORWARDING_RETRY_ON = (RequestException,)
 _DATA_FORWARDING_RETRY_IGNORE = (
     ClientError,
     ParamValidationError,
+    ApiUnauthorized,
+    ApiInvalidRequestError,
+    ApiForbiddenError,
 )
 _DATA_FORWARDING_SILENCED = (
     ChunkedEncodingError,
@@ -73,4 +83,5 @@ def forward_event(
         event_payload=event_payload,
         task_payload=task_payload,
     )
+    metrics.incr("data_forwarding.event_forwarded_via_task", tags={"provider": provider})
     logger.info("data_forwarding.event_forwarded_via_task", extra=logging_ctx)

--- a/src/sentry/integrations/data_forwarding/tasks.py
+++ b/src/sentry/integrations/data_forwarding/tasks.py
@@ -8,37 +8,42 @@ from taskbroker_client.retry import Retry
 
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
 
 logger = logging.getLogger(__name__)
 
-retry_decorator = retry(
-    on=(RequestException,),
-    on_silent=(
-        ChunkedEncodingError,
-        Timeout,
-        ApiHostError,
-        ApiTimeoutError,
-        ConnectionError,
-        HTTPError,
-    ),
-    ignore=(
-        ClientError,
-        ParamValidationError,
-        ValueError,
-    ),
-    raise_on_no_retries=False,
+
+_DATA_FORWARDING_RETRY_ON = (RequestException,)
+_DATA_FORWARDING_RETRY_IGNORE = (
+    ClientError,
+    ParamValidationError,
+    ValueError,
+)
+_DATA_FORWARDING_SILENCED = (
+    ChunkedEncodingError,
+    Timeout,
+    ApiHostError,
+    ApiTimeoutError,
+    ConnectionError,
+    HTTPError,
+    *_DATA_FORWARDING_RETRY_IGNORE,
 )
 
 
 @instrumented_task(
     name="sentry.integrations.data_forwarding.tasks.forward_event",
     namespace=integrations_tasks,
-    retry=Retry(times=3, delay=60 * 5),
+    retry=Retry(
+        times=3,
+        delay=60 * 5,
+        on=_DATA_FORWARDING_RETRY_ON,
+        ignore=_DATA_FORWARDING_RETRY_IGNORE,
+    ),
+    processing_deadline_duration=12,
     silo_mode=SiloMode.CELL,
+    silenced_exceptions=_DATA_FORWARDING_SILENCED,
 )
-@retry_decorator
 def forward_event(
     data_forwarder_project_id: int,
     event_payload: dict[str, Any],

--- a/src/sentry/integrations/data_forwarding/tasks.py
+++ b/src/sentry/integrations/data_forwarding/tasks.py
@@ -83,5 +83,5 @@ def forward_event(
         event_payload=event_payload,
         task_payload=task_payload,
     )
-    metrics.incr("data_forwarding.event_forwarded_via_task", tags={"provider": provider})
-    logger.info("data_forwarding.event_forwarded_via_task", extra=logging_ctx)
+    metrics.incr("data_forwarding.forwarding_task_succeeded", tags={"provider": provider})
+    logger.info("data_forwarding.forwarding_task_succeeded", extra=logging_ctx)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -113,6 +113,12 @@ register(
     default=300,  # 5 minutes
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "data-forwarding.task-rollout-rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Redis
 register(

--- a/tests/sentry/integrations/data_forwarding/amazon_sqs/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/amazon_sqs/test_forwarder.py
@@ -4,11 +4,14 @@ import orjson
 from botocore.exceptions import ClientError
 
 from sentry.api.serializers import serialize
-from sentry.integrations.data_forwarding.amazon_sqs.forwarder import AmazonSQSForwarder
+from sentry.integrations.data_forwarding.amazon_sqs.forwarder import (
+    AmazonSQSForwarder,
+)
 from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 
 
 class AmazonSQSDataForwarderTest(TestCase):
@@ -141,3 +144,40 @@ class AmazonSQSDataForwarderTest(TestCase):
         expected_url = f"https://my_bucket.s3.us-east-1.amazonaws.com/{expected_key}"
         assert message_body["s3Url"] == expected_url
         assert "s3-" not in message_body["s3Url"]
+
+    def test_get_task_payload(self) -> None:
+        event = self.store_event(
+            data={"message": "test", "type": "error"},
+            project_id=self.project.id,
+        )
+
+        config = self.data_forwarder_project.get_config()
+        result = self.forwarder.get_task_payload(event, config)
+
+        assert result["event_id"] == event.event_id
+        assert result["project_slug"] == event.project.slug
+        assert result["date"] == event.datetime.strftime("%Y-%m-%d")
+
+    @patch("boto3.client")
+    @override_options({"data-forwarding.task-rollout-rate": 1.0})
+    def test_forward_event_from_task(self, mock_client) -> None:
+        self.data_forwarder.config["message_group_id"] = "my_group"
+        self.data_forwarder.config["s3_bucket"] = "my_bucket"
+        self.data_forwarder.save()
+
+        event = self.store_event(data={"message": "test"}, project_id=self.project.id)
+        with self.tasks():
+            self.forwarder.post_process(event, self.data_forwarder_project)
+
+        mock_client.return_value.put_object.assert_called_once()
+        put_args = mock_client.return_value.put_object.call_args[1]
+        assert put_args["Bucket"] == "my_bucket"
+        event_date = event.datetime.strftime("%Y-%m-%d")
+        assert put_args["Key"] == f"{self.project.slug}/{event_date}/{event.event_id}"
+
+        send_args = mock_client.return_value.send_message.call_args[1]
+        message_body = orjson.loads(send_args["MessageBody"])
+        assert message_body["eventID"] == event.event_id
+        assert send_args["MessageGroupId"] == "my_group"
+        assert "MessageDeduplicationId" in send_args
+        assert "s3Url" in message_body

--- a/tests/sentry/integrations/data_forwarding/segment/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/segment/test_forwarder.py
@@ -1,5 +1,7 @@
 import orjson
+import pytest
 import responses
+from requests.exceptions import HTTPError
 
 from sentry import VERSION
 from sentry.integrations.data_forwarding.segment.forwarder import SegmentForwarder
@@ -7,6 +9,7 @@ from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 
 
 class SegmentDataForwarderTest(TestCase):
@@ -76,3 +79,67 @@ class SegmentDataForwarderTest(TestCase):
         )
 
         self.forwarder.post_process(event, self.data_forwarder_project)
+
+    def test_get_task_payload(self) -> None:
+        config = self.data_forwarder_project.get_config()
+        event = self.store_event(
+            data={
+                "exception": {"type": "ValueError", "value": "foo bar"},
+                "user": {"id": "1"},
+                "type": "error",
+            },
+            project_id=self.project.id,
+        )
+        assert self.forwarder.get_task_payload(event, config) == {
+            "event_type": "error",
+            "has_user": True,
+        }
+
+        event = self.store_event(
+            data={
+                "user": {"email": "foo@example.com"},
+                "type": "feedback",
+            },
+            project_id=self.project.id,
+        )
+        assert self.forwarder.get_task_payload(event, config) == {
+            "event_type": "feedback",
+            "has_user": False,
+        }
+
+    @responses.activate
+    @override_options({"data-forwarding.task-rollout-rate": 1.0})
+    def test_forward_event_from_task(self) -> None:
+        responses.add(responses.POST, "https://api.segment.io/v1/track")
+
+        event = self.store_event(
+            data={
+                "exception": {"type": "ValueError", "value": "foo bar"},
+                "user": {"id": "1", "email": "foo@example.com"},
+                "type": "error",
+                "level": "warning",
+            },
+            project_id=self.project.id,
+        )
+
+        with self.tasks():
+            self.forwarder.post_process(event, self.data_forwarder_project)
+
+        assert len(responses.calls) == 1
+        request = responses.calls[0].request
+        payload = orjson.loads(request.body)
+        assert payload["userId"] == "1"
+        assert payload["event"] == "Error Captured"
+
+    @responses.activate
+    def test_forward_event_from_task_raises_on_http_error(self) -> None:
+        responses.add(responses.POST, "https://api.segment.io/v1/track", status=500)
+
+        config = self.data_forwarder_project.get_config()
+
+        with pytest.raises(HTTPError):
+            SegmentForwarder.forward_event_from_task(
+                config=config,
+                event_payload={"test": True},
+                task_payload={"event_type": "error", "has_user": True},
+            )

--- a/tests/sentry/integrations/data_forwarding/splunk/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/splunk/test_forwarder.py
@@ -6,6 +6,7 @@ from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 
 
 class SplunkDataForwarderTest(TestCase):
@@ -129,3 +130,44 @@ class SplunkDataForwarderTest(TestCase):
         assert result["event"]["user_ip_trunc"] == "127.0.0.0"
         assert result["index"] == "main"
         assert result["source"] == "sentry"
+
+    def test_get_task_payload(self) -> None:
+        config = self.data_forwarder_project.get_config()
+        event = self.store_event(
+            data={"server_name": "web01.example.com"},
+            project_id=self.project.id,
+        )
+        self.forwarder.initialize_variables(event, config)
+        assert self.forwarder.get_task_payload(event, config) == {"host": "web01.example.com"}
+
+        event = self.store_event(
+            data={"user": {"ip_address": "127.0.0.1"}},
+            project_id=self.project.id,
+        )
+        self.forwarder.initialize_variables(event, config)
+        assert self.forwarder.get_task_payload(event, config) == {"host": "127.0.0.1"}
+
+        event = self.store_event(
+            data={"message": "no host info"},
+            project_id=self.project.id,
+        )
+        self.forwarder.initialize_variables(event, config)
+        assert self.forwarder.get_task_payload(event, config) == {"host": None}
+
+    @responses.activate
+    @override_options({"data-forwarding.task-rollout-rate": 1.0})
+    def test_forward_event_from_task(self) -> None:
+        responses.add(responses.POST, "https://splunk.example.com:8088/services/collector")
+
+        event = self.store_event(
+            data={"server_name": "web01.example.com"},
+            project_id=self.project.id,
+        )
+        with self.tasks():
+            self.forwarder.post_process(event, self.data_forwarder_project)
+
+        assert len(responses.calls) == 1
+        request = responses.calls[0].request
+        payload = orjson.loads(request.body)
+        assert payload["host"] == "web01.example.com"
+        assert request.headers["Authorization"] == "Splunk 12345678-1234-1234-1234-1234567890AB"

--- a/tests/sentry/integrations/data_forwarding/test_base.py
+++ b/tests/sentry/integrations/data_forwarding/test_base.py
@@ -10,18 +10,18 @@ from sentry.testutils.helpers.options import override_options
 
 class BaseDataForwarderTest(TestCase):
     def setUp(self) -> None:
-        self.forwarder = self.create_data_forwarder(
+        self.data_forwarder = self.create_data_forwarder(
             organization=self.organization,
             provider=DataForwarderProviderSlug.SEGMENT,
             config={"write_key": "secret-api-key"},
             is_enabled=True,
         )
-        self.forwarder_project = self.create_data_forwarder_project(
-            data_forwarder=self.forwarder,
+        self.data_forwarder_project = self.create_data_forwarder_project(
+            data_forwarder=self.data_forwarder,
             project=self.project,
             is_enabled=True,
         )
-        self.forwarder_cls = SegmentForwarder()
+        self.forwarder = SegmentForwarder()
         self.event = self.store_event(
             data={
                 "exception": {"type": "ValueError", "value": "foo bar"},
@@ -34,14 +34,13 @@ class BaseDataForwarderTest(TestCase):
     @responses.activate
     @override_options({"data-forwarding.task-rollout-rate": 1.0})
     @patch("sentry.integrations.data_forwarding.tasks.forward_event")
-    @patch("sentry.integrations.data_forwarding.base.random.random", return_value=0.5)
-    def test_post_process_rollout_dispatches_to_task(self, mock_random, mock_forward_event) -> None:
+    def test_post_process_rollout_dispatches_to_task(self, mock_forward_event) -> None:
         responses.add(responses.POST, "https://api.segment.io/v1/track")
-        self.forwarder_cls.post_process(self.event, self.forwarder_project)
+        self.forwarder.post_process(self.event, self.data_forwarder_project)
         mock_forward_event.delay.assert_called_once()
 
     @responses.activate
     def test_post_process_rollout_forwards_directly(self) -> None:
         responses.add(responses.POST, "https://api.segment.io/v1/track")
-        self.forwarder_cls.post_process(self.event, self.forwarder_project)
+        self.forwarder.post_process(self.event, self.data_forwarder_project)
         assert len(responses.calls) == 1

--- a/tests/sentry/integrations/data_forwarding/test_base.py
+++ b/tests/sentry/integrations/data_forwarding/test_base.py
@@ -1,12 +1,14 @@
+from unittest.mock import patch
+
 import responses
 
 from sentry.integrations.data_forwarding.segment.forwarder import SegmentForwarder
-from sentry.integrations.data_forwarding.tasks import forward_event
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 
 
-class ForwardEventTaskTest(TestCase):
+class BaseDataForwarderTest(TestCase):
     def setUp(self) -> None:
         self.forwarder = self.create_data_forwarder(
             organization=self.organization,
@@ -23,27 +25,23 @@ class ForwardEventTaskTest(TestCase):
         self.event = self.store_event(
             data={
                 "exception": {"type": "ValueError", "value": "foo bar"},
-                "user": {"id": "1", "email": "foo@example.com"},
+                "user": {"id": "1"},
                 "type": "error",
-                "metadata": {"type": "ValueError", "value": "foo bar"},
-                "level": "warning",
             },
             project_id=self.project.id,
         )
 
     @responses.activate
-    def test_forwards_event(self) -> None:
+    @override_options({"data-forwarding.task-rollout-rate": 1.0})
+    @patch("sentry.integrations.data_forwarding.tasks.forward_event")
+    @patch("sentry.integrations.data_forwarding.base.random.random", return_value=0.5)
+    def test_post_process_rollout_dispatches_to_task(self, mock_random, mock_forward_event) -> None:
         responses.add(responses.POST, "https://api.segment.io/v1/track")
-        config = self.forwarder_project.get_config()
-        event_payload = self.forwarder_cls.get_event_payload(event=self.event, config=config)
-        task_payload = self.forwarder_cls.get_task_payload(event=self.event, config=config)
-        forward_event(
-            data_forwarder_project_id=self.forwarder_project.id,
-            event_payload=event_payload,
-            task_payload=task_payload,
-        )
-        assert len(responses.calls) == 1
+        self.forwarder_cls.post_process(self.event, self.forwarder_project)
+        mock_forward_event.delay.assert_called_once()
 
-    def test_missing_data_forwarder_project(self) -> None:
-        result = forward_event(data_forwarder_project_id=-1, event_payload={}, task_payload={})
-        assert result is None
+    @responses.activate
+    def test_post_process_rollout_forwards_directly(self) -> None:
+        responses.add(responses.POST, "https://api.segment.io/v1/track")
+        self.forwarder_cls.post_process(self.event, self.forwarder_project)
+        assert len(responses.calls) == 1

--- a/tests/sentry/integrations/data_forwarding/test_tasks.py
+++ b/tests/sentry/integrations/data_forwarding/test_tasks.py
@@ -1,0 +1,89 @@
+from unittest.mock import patch
+
+import pytest
+import responses
+from requests.exceptions import ConnectionError
+from taskbroker_client.retry import RetryTaskError
+
+from sentry.integrations.data_forwarding.segment.forwarder import SegmentForwarder
+from sentry.integrations.data_forwarding.tasks import forward_event
+from sentry.integrations.models.data_forwarder import DataForwarder
+from sentry.integrations.models.data_forwarder_project import DataForwarderProject
+from sentry.integrations.types import DataForwarderProviderSlug
+from sentry.testutils.cases import TestCase
+
+
+class ForwardEventTaskTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.segment_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            provider=DataForwarderProviderSlug.SEGMENT,
+            config={"write_key": "secret-api-key"},
+            is_enabled=True,
+        )
+        self.segment_forwarder_project = DataForwarderProject.objects.create(
+            data_forwarder=self.segment_forwarder,
+            project=self.project,
+            is_enabled=True,
+        )
+        self.forwarder = SegmentForwarder()
+
+    @responses.activate
+    def test_forwards_event(self) -> None:
+        responses.add(responses.POST, "https://api.segment.io/v1/track")
+
+        event = self.store_event(
+            data={
+                "exception": {"type": "ValueError", "value": "foo bar"},
+                "user": {"id": "1", "email": "foo@example.com"},
+                "type": "error",
+                "metadata": {"type": "ValueError", "value": "foo bar"},
+                "level": "warning",
+            },
+            project_id=self.project.id,
+        )
+
+        config = self.segment_forwarder_project.get_config()
+        event_payload = self.forwarder.get_event_payload(event=event, config=config)
+        task_payload = self.forwarder.get_task_payload(event=event, config=config)
+
+        forward_event(
+            data_forwarder_project_id=self.segment_forwarder_project.id,
+            event_payload=event_payload,
+            task_payload=task_payload,
+        )
+
+        assert len(responses.calls) == 1
+
+    def test_missing_data_forwarder_project(self) -> None:
+        forward_event(
+            data_forwarder_project_id=999999,
+            event_payload={},
+            task_payload={},
+        )
+
+    @patch(
+        "sentry.integrations.data_forwarding.segment.forwarder.SegmentForwarder.forward_event_from_task",
+        side_effect=ConnectionError("connection refused"),
+    )
+    def test_retryable_error_triggers_retry(self, mock_forward) -> None:
+        event = self.store_event(
+            data={
+                "exception": {"type": "ValueError", "value": "foo bar"},
+                "user": {"id": "1"},
+                "type": "error",
+            },
+            project_id=self.project.id,
+        )
+
+        config = self.segment_forwarder_project.get_config()
+        event_payload = self.forwarder.get_event_payload(event=event, config=config)
+        task_payload = self.forwarder.get_task_payload(event=event, config=config)
+
+        with pytest.raises(RetryTaskError):
+            forward_event(
+                data_forwarder_project_id=self.segment_forwarder_project.id,
+                event_payload=event_payload,
+                task_payload=task_payload,
+            )

--- a/tests/sentry/integrations/data_forwarding/test_tasks.py
+++ b/tests/sentry/integrations/data_forwarding/test_tasks.py
@@ -4,22 +4,23 @@ from sentry.integrations.data_forwarding.segment.forwarder import SegmentForward
 from sentry.integrations.data_forwarding.tasks import forward_event
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 
 
 class ForwardEventTaskTest(TestCase):
     def setUp(self) -> None:
-        self.forwarder = self.create_data_forwarder(
+        self.data_forwarder = self.create_data_forwarder(
             organization=self.organization,
             provider=DataForwarderProviderSlug.SEGMENT,
             config={"write_key": "secret-api-key"},
             is_enabled=True,
         )
-        self.forwarder_project = self.create_data_forwarder_project(
-            data_forwarder=self.forwarder,
+        self.data_forwarder_project = self.create_data_forwarder_project(
+            data_forwarder=self.data_forwarder,
             project=self.project,
             is_enabled=True,
         )
-        self.forwarder_cls = SegmentForwarder()
+        self.forwarder = SegmentForwarder()
         self.event = self.store_event(
             data={
                 "exception": {"type": "ValueError", "value": "foo bar"},
@@ -34,14 +35,22 @@ class ForwardEventTaskTest(TestCase):
     @responses.activate
     def test_forwards_event(self) -> None:
         responses.add(responses.POST, "https://api.segment.io/v1/track")
-        config = self.forwarder_project.get_config()
-        event_payload = self.forwarder_cls.get_event_payload(event=self.event, config=config)
-        task_payload = self.forwarder_cls.get_task_payload(event=self.event, config=config)
+        config = self.data_forwarder_project.get_config()
+        event_payload = self.forwarder.get_event_payload(event=self.event, config=config)
+        task_payload = self.forwarder.get_task_payload(event=self.event, config=config)
         forward_event(
-            data_forwarder_project_id=self.forwarder_project.id,
+            data_forwarder_project_id=self.data_forwarder_project.id,
             event_payload=event_payload,
             task_payload=task_payload,
         )
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    @override_options({"data-forwarding.task-rollout-rate": 1.0})
+    def test_post_process_dispatches_to_task(self) -> None:
+        responses.add(responses.POST, "https://api.segment.io/v1/track")
+        with self.tasks():
+            self.forwarder.post_process(self.event, self.data_forwarder_project)
         assert len(responses.calls) == 1
 
     def test_missing_data_forwarder_project(self) -> None:

--- a/tests/sentry/integrations/data_forwarding/test_tasks.py
+++ b/tests/sentry/integrations/data_forwarding/test_tasks.py
@@ -57,11 +57,12 @@ class ForwardEventTaskTest(TestCase):
         assert len(responses.calls) == 1
 
     def test_missing_data_forwarder_project(self) -> None:
-        forward_event(
+        result = forward_event(
             data_forwarder_project_id=999999,
             event_payload={},
             task_payload={},
         )
+        assert result is None
 
     @patch(
         "sentry.integrations.data_forwarding.segment.forwarder.SegmentForwarder.forward_event_from_task",
@@ -87,3 +88,58 @@ class ForwardEventTaskTest(TestCase):
                 event_payload=event_payload,
                 task_payload=task_payload,
             )
+
+
+class PostProcessRolloutTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.data_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            provider=DataForwarderProviderSlug.SEGMENT,
+            config={"write_key": "secret-api-key"},
+            is_enabled=True,
+        )
+        self.data_forwarder_project = DataForwarderProject.objects.create(
+            data_forwarder=self.data_forwarder,
+            project=self.project,
+            is_enabled=True,
+        )
+        self.forwarder = SegmentForwarder()
+
+    @responses.activate
+    @patch("sentry.integrations.data_forwarding.base.random.random", return_value=0.0)
+    def test_rollout_dispatches_to_task(self, mock_random) -> None:
+        responses.add(responses.POST, "https://api.segment.io/v1/track")
+
+        event = self.store_event(
+            data={
+                "exception": {"type": "ValueError", "value": "foo bar"},
+                "user": {"id": "1"},
+                "type": "error",
+            },
+            project_id=self.project.id,
+        )
+
+        with (
+            self.options({"data-forwarding.task-rollout-rate": 1.0}),
+            patch("sentry.integrations.data_forwarding.tasks.forward_event") as mock_task,
+        ):
+            self.forwarder.post_process(event, self.data_forwarder_project)
+            mock_task.delay.assert_called_once()
+
+    @responses.activate
+    def test_rollout_zero_calls_forward_event_directly(self) -> None:
+        responses.add(responses.POST, "https://api.segment.io/v1/track")
+
+        event = self.store_event(
+            data={
+                "exception": {"type": "ValueError", "value": "foo bar"},
+                "user": {"id": "1"},
+                "type": "error",
+            },
+            project_id=self.project.id,
+        )
+
+        self.forwarder.post_process(event, self.data_forwarder_project)
+
+        assert len(responses.calls) == 1


### PR DESCRIPTION
Adds retry support for data forwarders, needed a bit of legwork to make it safer.
- The existing path is not touched ** (except for the serialization of SQS events, see comment)
- A rollout option will let us control the task output
- A set of new methods `get_task_payload` and `forward_event_from_task` have been implemented on the forwarders.

Refs ISWF-2406