### PR TITLE
feat(cells): Populate org listing fields on control serializer

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -395,7 +395,7 @@ class ControlSiloOrganizationMappingSerializer(Serializer):
         return dict(
             id=str(obj.organization_id),
             slug=obj.slug,
-            name=obj.name,
+            name=obj.name or obj.slug,
             status={"id": status.name.lower(), "name": status.label},
             dateCreated=obj.date_created,
             isEarlyAdopter=obj.early_adopter,

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from urllib.parse import urljoin
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
@@ -70,11 +71,13 @@ from sentry.dynamic_sampling.utils import (
 )
 from sentry.killswitches import killswitch_matches_context
 from sentry.lang.native.utils import convert_crashreport_count
+from sentry.models.authprovider import AuthProvider
 from sentry.models.avatars.organization_avatar import OrganizationAvatar
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationaccessrequest import OrganizationAccessRequest
+from sentry.models.organizationavatarreplica import OrganizationAvatarReplica
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationonboardingtask import OrganizationOnboardingTask
 from sentry.models.project import Project
@@ -83,6 +86,7 @@ from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.replays.models import OrganizationMemberReplayAccess
 from sentry.seer.autofix.utils import get_valid_automated_run_stopping_points
+from sentry.types.cell import get_locality_name_for_cell
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -317,20 +321,94 @@ class ControlSiloOrganizationSerializer(Serializer):
         )
 
 
+class ControlSiloOrganizationMappingSerializerResponse(TypedDict):
+    # Mirror of `OrganizationSummarySerializerResponse`, populated from
+    # `OrganizationMapping` so the listing endpoint can serve responses without
+    # crossing into a cell. Fields are added incrementally as data becomes
+    # available on the control silo.
+    id: str
+    slug: str
+    name: str
+    status: _Status
+    dateCreated: datetime
+    isEarlyAdopter: bool
+    require2FA: bool
+    allowMemberInvite: bool
+    allowMemberProjectCreation: bool
+    allowSuperuserAccess: bool
+    avatar: SerializedAvatarFields
+    links: _Links
+    hasAuthProvider: bool
+
+
 class ControlSiloOrganizationMappingSerializer(Serializer):
-    # TODO(cells): Add the `avatar` to this serializer
-    # once it is available in the control silo
+    _AVATAR_TYPE_BY_ID: ClassVar[dict[int, str]] = dict(OrganizationAvatar.AVATAR_TYPES)
+
+    def get_attrs(
+        self,
+        item_list: Sequence[OrganizationMapping],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> MutableMapping[OrganizationMapping, MutableMapping[str, Any]]:
+        org_ids = [m.organization_id for m in item_list]
+        org_ids_with_auth_provider = set(
+            AuthProvider.objects.filter(organization_id__in=org_ids).values_list(
+                "organization_id", flat=True
+            )
+        )
+        avatars_by_org_id = {
+            a.organization_id: a
+            for a in OrganizationAvatarReplica.objects.filter(organization_id__in=org_ids)
+        }
+        return {
+            m: {
+                "has_auth_provider": m.organization_id in org_ids_with_auth_provider,
+                "avatar": avatars_by_org_id.get(m.organization_id),
+            }
+            for m in item_list
+        }
+
     def serialize(
         self,
         obj: OrganizationMapping,
         attrs: Mapping[str, Any],
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
-    ) -> ControlSiloOrganizationSerializerResponse:
+    ) -> ControlSiloOrganizationMappingSerializerResponse:
+        status = OrganizationStatus(obj.status)
+        avatar_replica: OrganizationAvatarReplica | None = attrs["avatar"]
+        if avatar_replica is not None:
+            avatar_type = self._AVATAR_TYPE_BY_ID[avatar_replica.avatar_type]
+            # The avatar file is served by the cell that owns the org, so the
+            # URL must point at that cell's locality rather than the local
+            # control silo.
+            locality_url = generate_locality_url(get_locality_name_for_cell(obj.cell_name))
+            avatar: SerializedAvatarFields = {
+                "avatarType": avatar_type,
+                "avatarUuid": avatar_replica.avatar_ident if avatar_type == "upload" else None,
+                "avatarUrl": urljoin(
+                    locality_url, f"/{OrganizationAvatar.url_path}/{avatar_replica.avatar_ident}/"
+                ),
+            }
+        else:
+            avatar = {"avatarType": "letter_avatar", "avatarUuid": None, "avatarUrl": None}
         return dict(
             id=str(obj.organization_id),
             slug=obj.slug,
             name=obj.name,
+            status={"id": status.name.lower(), "name": status.label},
+            dateCreated=obj.date_created,
+            isEarlyAdopter=obj.early_adopter,
+            require2FA=obj.require_2fa,
+            allowMemberInvite=not obj.disable_member_invite,
+            allowMemberProjectCreation=not obj.disable_member_project_creation,
+            allowSuperuserAccess=not obj.prevent_superuser_access,
+            avatar=avatar,
+            links={
+                "organizationUrl": generate_organization_url(obj.slug),
+                "regionUrl": generate_locality_url(get_locality_name_for_cell(obj.cell_name)),
+            },
+            hasAuthProvider=attrs["has_auth_provider"],
         )
 
 

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -217,24 +217,7 @@ class OrganizationsControlListTest(OrganizationIndexTest):
         assert len(control_response.data) == 1
         assert len(cell_response.data) == 1
 
-        # TODO(cells): fields the control serializer doesn't return yet. Remove
-        # entries as they're ported — once empty, drop the filter and assert
-        # full equality.
-        missing_fields = {
-            "allowMemberInvite",
-            "allowMemberProjectCreation",
-            "allowSuperuserAccess",
-            "avatar",
-            "dateCreated",
-            "hasAuthProvider",
-            "isEarlyAdopter",
-            "links",
-            "require2FA",
-            "status",
-        }
-        assert control_response.data[0] == {
-            k: v for k, v in cell_response.data[0].items() if k not in missing_fields
-        }
+        assert control_response.data == cell_response.data
 
 
 @control_silo_test(cells=create_test_cells("us", "de"))


### PR DESCRIPTION
Adds the following fields to the control version of the org listing api in order to align to the cell version.

- isEarlyAdopter
- require2FA
- allowMemberInvite
- allowMemberProjectCreation
- allowSuperuserAccess
- status
- links
- hasAuthProvider
- avatar
- dateCreated

Updated the test to assert the control payload exactly matches the cell version

Split `ControlSiloOrganizationMappingSerializer` off from `ControlSiloOrganizationSerializer` so the user-identity-config call site stays minimal and doesn't pull in fields it doesn't need.
