### PR TITLE
feat(seer): Add CLI, Linear agent, and MCP autofix referrers

### DIFF
--- a/src/sentry/seer/autofix/constants.py
+++ b/src/sentry/seer/autofix/constants.py
@@ -55,6 +55,10 @@ class AutofixReferrer(enum.StrEnum):
     SLACK = "slack"
     ON_COMPLETION_HOOK = "autofix.on_completion_hook"
     NIGHT_SHIFT = "night_shift"
+    CLI = "api.cli"
+    LINEAR_AGENT = "api.linear_agent"
+    MCP = "api.mcp"
+    WEB = "api.web"
     UNKNOWN = "unknown"
 
 


### PR DESCRIPTION
Register `CLI`, `LINEAR_AGENT`, `MCP`, `WEB` values on `AutofixReferrer` so those
surfaces can be identified when they trigger an issue fix via the `referrer`
field added to `GroupAutofixEndpoint`.

Split so we can bikeshed names more efficiently. 

Agent transcript: https://claudescope.sentry.dev/share/i4W6VXngS4YP7BH1ZmYupMKzKNfaSxHEzpqUOgoAl8Y