### PR TITLE
chore(repositories): Switch over queries for `RepositoryProjectPathConfig` to use the new `ProjectRepository` table

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_coverage.py
+++ b/src/sentry/api/endpoints/project_stacktrace_coverage.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -52,7 +53,8 @@ class ProjectStacktraceCoverageEndpoint(ProjectEndpoint):
         if not configs:
             return Response({"detail": "No code mappings found for this project"}, status=400)
 
-        result = get_stacktrace_config(configs, ctx)
+        use_fk = features.has("organizations:project-repository-fk-reads", project.organization)
+        result = get_stacktrace_config(configs, ctx, use_project_repository_fk=use_fk)
         error = result["error"]
         serialized_config = None
 

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from sentry import features
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.integrations.api.serializers.models.repository_project_path_config import (
     RepositoryProjectPathConfigSerializer,
@@ -23,6 +24,12 @@ class ProjectCodeOwnersSerializer(Serializer):
 
     def get_attrs(self, item_list, user, **kwargs):
         attrs = {}
+        use_fk = False
+        if item_list:
+            use_fk = features.has(
+                "organizations:project-repository-fk-reads",
+                item_list[0].project.organization,
+            )
         integrations = {
             i.id: i
             for i in integration_service.get_integrations(
@@ -31,6 +38,9 @@ class ProjectCodeOwnersSerializer(Serializer):
         }
         for item in item_list:
             code_mapping = item.repository_project_path_config
+            repository = (
+                code_mapping.project_repository.repository if use_fk else code_mapping.repository
+            )
 
             integration = integrations[item.repository_project_path_config.integration_id]
             install = integration.get_installation(
@@ -42,7 +52,7 @@ class ProjectCodeOwnersSerializer(Serializer):
             ):
                 try:
                     codeowners_response = install.get_codeowner_file(
-                        code_mapping.repository, ref=code_mapping.default_branch
+                        repository, ref=code_mapping.default_branch
                     )
                     if codeowners_response is not None:
                         codeowners_url = codeowners_response["html_url"]

--- a/src/sentry/autopilot/tasks/missing_sdk_integration.py
+++ b/src/sentry/autopilot/tasks/missing_sdk_integration.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
-from sentry import options
+from sentry import features, options
 from sentry.autopilot.tasks.common import AutopilotDetectorName, create_instrumentation_issue
 from sentry.constants import INTEGRATION_ID_TO_PLATFORM_DATA, ObjectStatus
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
@@ -88,16 +88,28 @@ def run_missing_sdk_integration_detector() -> None:
             continue
 
         # Get repo configs for this project
-        repo_names = (
-            RepositoryProjectPathConfig.objects.filter(
-                project=project,
-                repository__status=ObjectStatus.ACTIVE,
-                repository__provider="integrations:github",
+        if features.has("organizations:project-repository-fk-reads", project.organization):
+            repo_names = (
+                RepositoryProjectPathConfig.objects.filter(
+                    project_repository__project=project,
+                    project_repository__repository__status=ObjectStatus.ACTIVE,
+                    project_repository__repository__provider="integrations:github",
+                )
+                .order_by("project_repository__repository__name")
+                .distinct("project_repository__repository__name")
+                .values_list("project_repository__repository__name", flat=True)
             )
-            .order_by("repository__name")
-            .distinct("repository__name")
-            .values_list("repository__name", flat=True)
-        )
+        else:
+            repo_names = (
+                RepositoryProjectPathConfig.objects.filter(
+                    project=project,
+                    repository__status=ObjectStatus.ACTIVE,
+                    repository__provider="integrations:github",
+                )
+                .order_by("repository__name")
+                .distinct("repository__name")
+                .values_list("repository__name", flat=True)
+            )
         for repo_name in repo_names:
             run_missing_sdk_integration_detector_for_project_task.apply_async(
                 args=(

--- a/src/sentry/integrations/api/endpoints/organization_code_mapping_codeowners.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mapping_codeowners.py
@@ -4,6 +4,7 @@ from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -15,7 +16,7 @@ from sentry.integrations.source_code_management.repository import RepositoryInte
 from sentry.shared_integrations.exceptions import ApiError
 
 
-def get_codeowner_contents(config):
+def get_codeowner_contents(config, use_project_repository_fk: bool = False):
     if not config.organization_integration_id:
         raise NotFound(detail="No associated integration")
 
@@ -24,9 +25,15 @@ def get_codeowner_contents(config):
     )
     if not integration:
         return None
-    install = integration.get_installation(organization_id=config.project.organization_id)
+    if use_project_repository_fk:
+        org_id = config.project_repository.project.organization_id
+        repository = config.project_repository.repository
+    else:
+        org_id = config.project.organization_id
+        repository = config.repository
+    install = integration.get_installation(organization_id=org_id)
     if isinstance(install, RepositoryIntegration):
-        return install.get_codeowner_file(config.repository, ref=config.default_branch)
+        return install.get_codeowner_file(repository, ref=config.default_branch)
 
 
 @cell_silo_endpoint
@@ -44,7 +51,12 @@ class OrganizationCodeMappingCodeOwnersEndpoint(OrganizationEndpoint):
         organization = kwargs["organization"]
 
         try:
-            kwargs["config"] = RepositoryProjectPathConfig.objects.get(
+            kwargs["config"] = RepositoryProjectPathConfig.objects.select_related(
+                "project",
+                "repository",
+                "project_repository__project",
+                "project_repository__repository",
+            ).get(
                 id=config_id,
                 organization_id=organization.id,
             )
@@ -55,7 +67,8 @@ class OrganizationCodeMappingCodeOwnersEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, config_id, organization, config) -> Response:
         try:
-            codeowner_contents = get_codeowner_contents(config)
+            use_fk = features.has("organizations:project-repository-fk-reads", organization)
+            codeowner_contents = get_codeowner_contents(config, use_project_repository_fk=use_fk)
         except ApiError as e:
             return self.respond({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -38,7 +39,9 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
             organization_id=kwargs["organization"].id
         )
         try:
-            kwargs["config"] = RepositoryProjectPathConfig.objects.get(
+            kwargs["config"] = RepositoryProjectPathConfig.objects.select_related(
+                "project", "project_repository__project"
+            ).get(
                 id=config_id,
                 organization_integration_id__in=[oi.id for oi in ois],
             )
@@ -66,7 +69,11 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
         :param string default_branch:
         :auth: required
         """
-        if not request.access.has_projects_access([config.project, new_project]):
+        if features.has("organizations:project-repository-fk-reads", organization):
+            project = config.project_repository.project
+        else:
+            project = config.project
+        if not request.access.has_projects_access([project, new_project]):
             return self.respond(status=status.HTTP_403_FORBIDDEN)
 
         try:
@@ -102,7 +109,11 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
         :auth: required
         """
 
-        if not request.access.has_project_access(config.project):
+        if features.has("organizations:project-repository-fk-reads", organization):
+            project = config.project_repository.project
+        else:
+            project = config.project
+        if not request.access.has_project_access(project):
             return self.respond(status=status.HTTP_403_FORBIDDEN)
 
         try:

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -7,6 +7,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -71,11 +72,18 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
         return self.context["organization"]
 
     def validate(self, attrs):
-        query = RepositoryProjectPathConfig.objects.filter(
-            project_id=attrs.get("project_id"),
-            stack_root=attrs.get("stack_root"),
-            source_root=attrs.get("source_root"),
-        )
+        if features.has("organizations:project-repository-fk-reads", self.organization):
+            query = RepositoryProjectPathConfig.objects.filter(
+                project_repository__project_id=attrs.get("project_id"),
+                stack_root=attrs.get("stack_root"),
+                source_root=attrs.get("source_root"),
+            )
+        else:
+            query = RepositoryProjectPathConfig.objects.filter(
+                project_id=attrs.get("project_id"),
+                stack_root=attrs.get("stack_root"),
+                source_root=attrs.get("source_root"),
+            )
         if self.instance:
             query = query.exclude(id=self.instance.id)
         if query.exists():
@@ -203,9 +211,19 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
         projects = self.get_projects(
             request, organization, include_all_accessible=not has_explicit_projects
         )
-        queryset = RepositoryProjectPathConfig.objects.filter(project__in=projects).select_related(
-            "project", "repository"
-        )
+        if features.has("organizations:project-repository-fk-reads", organization):
+            queryset = RepositoryProjectPathConfig.objects.filter(
+                project_repository__project__in=projects
+            ).select_related(
+                "project",
+                "repository",
+                "project_repository__project",
+                "project_repository__repository",
+            )
+        else:
+            queryset = RepositoryProjectPathConfig.objects.filter(
+                project__in=projects
+            ).select_related("project", "repository")
 
         if integration_id:
             # get_organization_integration will raise a 404 if no org_integration is found

--- a/src/sentry/integrations/api/serializers/models/repository_project_path_config.py
+++ b/src/sentry/integrations/api/serializers/models/repository_project_path_config.py
@@ -1,3 +1,6 @@
+from django.db.models import prefetch_related_objects
+
+from sentry import features
 from sentry.api.serializers import Serializer, register
 from sentry.integrations.api.serializers.models.integration import serialize_provider
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
@@ -6,6 +9,21 @@ from sentry.integrations.services.integration import integration_service
 
 @register(RepositoryProjectPathConfig)
 class RepositoryProjectPathConfigSerializer(Serializer):
+    def get_attrs(self, item_list, user, **kwargs):
+        if not item_list:
+            return {}
+
+        organization = item_list[0].project.organization
+        use_fk = features.has("organizations:project-repository-fk-reads", organization)
+        if use_fk:
+            prefetch_related_objects(
+                item_list, "project_repository__project", "project_repository__repository"
+            )
+        else:
+            prefetch_related_objects(item_list, "project", "repository")
+
+        return {item: {"use_project_repository_fk": use_fk} for item in item_list}
+
     def serialize(self, obj, attrs, user, **kwargs):
         integration = None
         if obj.organization_integration_id:
@@ -17,12 +35,19 @@ class RepositoryProjectPathConfigSerializer(Serializer):
         serialized_provider = serialize_provider(provider) if provider else None
         integration_id = str(integration.id) if integration else None
 
+        if attrs.get("use_project_repository_fk"):
+            project = obj.project_repository.project
+            repository = obj.project_repository.repository
+        else:
+            project = obj.project
+            repository = obj.repository
+
         return {
             "id": str(obj.id),
-            "projectId": str(obj.project_id),
-            "projectSlug": obj.project.slug,
-            "repoId": str(obj.repository.id),
-            "repoName": obj.repository.name,
+            "projectId": str(project.id),
+            "projectSlug": project.slug,
+            "repoId": str(repository.id),
+            "repoName": repository.name,
             "integrationId": integration_id,
             "provider": serialized_provider,
             "stackRoot": obj.stack_root,

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from django.utils.datastructures import OrderedSet
 
-from sentry import analytics, options
+from sentry import analytics, features, options
 from sentry.analytics.events.integration_commit_context_all_frames import (
     IntegrationsFailedToFetchCommitContextAllFrames,
     IntegrationsSuccessfullyFetchedCommitContextAllFrames,
@@ -199,6 +199,7 @@ def _generate_integration_to_files_mapping(
     this function is used to separate files into each integration so that
     we can later call get_commit_context_all_frames on each integration.
     """
+    use_fk = features.has("organizations:project-repository-fk-reads", organization)
     integration_to_files_mapping: dict[int, list[SourceLineInfo]] = {}
     num_successfully_mapped_frames = 0
 
@@ -257,7 +258,11 @@ def _generate_integration_to_files_mapping(
                     lineno=frame.lineno,
                     path=src_path,
                     ref=code_mapping.default_branch or "master",
-                    repo=code_mapping.repository,
+                    repo=(
+                        code_mapping.project_repository.repository
+                        if use_fk
+                        else code_mapping.repository
+                    ),
                     code_mapping=code_mapping,
                 )
             )

--- a/src/sentry/integrations/utils/source_context.py
+++ b/src/sentry/integrations/utils/source_context.py
@@ -61,6 +61,7 @@ def _format_context(
 
 def _resolve_integration(
     config: RepositoryProjectPathConfig,
+    use_project_repository_fk: bool = False,
 ) -> tuple[RpcIntegration, RepositoryIntegration] | None:
     """Resolve the integration and installation for a code mapping config."""
     integration = integration_service.get_integration(
@@ -70,7 +71,12 @@ def _resolve_integration(
     if not integration:
         return None
 
-    install = integration.get_installation(organization_id=config.project.organization_id)
+    org_id = (
+        config.project_repository.project.organization_id
+        if use_project_repository_fk
+        else config.project.organization_id
+    )
+    install = integration.get_installation(organization_id=org_id)
     if not isinstance(install, RepositoryIntegration):
         return None
 
@@ -153,6 +159,7 @@ def fetch_source_context_from_scm(
     configs: Sequence[RepositoryProjectPathConfig],
     ctx: StacktraceLinkContext,
     context_lines: int = LINES_OF_CONTEXT,
+    use_project_repository_fk: bool = False,
 ) -> SourceContextResult:
     """
     Fetch source context lines from an SCM integration for a stack trace frame.
@@ -197,7 +204,9 @@ def fetch_source_context_from_scm(
 
         org_integration_id = config.organization_integration_id
         if org_integration_id not in resolved_integrations:
-            resolved_integrations[org_integration_id] = _resolve_integration(config)
+            resolved_integrations[org_integration_id] = _resolve_integration(
+                config, use_project_repository_fk=use_project_repository_fk
+            )
 
         resolved = resolved_integrations[org_integration_id]
         if resolved is None:
@@ -207,8 +216,11 @@ def fetch_source_context_from_scm(
 
         ref = ctx.get("commit_id") or str(config.default_branch or "")
 
+        repository = (
+            config.project_repository.repository if use_project_repository_fk else config.repository
+        )
         file_content, fetch_error = _fetch_file_from_scm(
-            install, integration.id, config.repository, src_path, ref
+            install, integration.id, repository, src_path, ref
         )
 
         if fetch_error:
@@ -230,7 +242,7 @@ def fetch_source_context_from_scm(
 
         try:
             source_url = install.get_stacktrace_link(
-                config.repository, src_path, str(config.default_branch or ""), ctx.get("commit_id")
+                repository, src_path, str(config.default_branch or ""), ctx.get("commit_id")
             )
             result["source_url"] = source_url
         except (ApiError, IntegrationConfigurationError):

--- a/src/sentry/integrations/utils/stacktrace_link.py
+++ b/src/sentry/integrations/utils/stacktrace_link.py
@@ -29,9 +29,19 @@ class RepositoryLinkOutcome(TypedDict):
 
 
 def get_link(
-    config: RepositoryProjectPathConfig, src_path: str, version: str | None = None
+    config: RepositoryProjectPathConfig,
+    src_path: str,
+    version: str | None = None,
+    use_project_repository_fk: bool = False,
 ) -> RepositoryLinkOutcome:
     result: RepositoryLinkOutcome = {}
+
+    if use_project_repository_fk:
+        project = config.project_repository.project
+        repository = config.project_repository.repository
+    else:
+        project = config.project
+        repository = config.repository
 
     integration = integration_service.get_integration(
         organization_integration_id=config.organization_integration_id, status=ObjectStatus.ACTIVE
@@ -40,13 +50,13 @@ def get_link(
         result["error"] = "integration_not_found"
         return result
 
-    install = integration.get_installation(organization_id=config.project.organization_id)
+    install = integration.get_installation(organization_id=project.organization_id)
 
     link = None
     try:
         if isinstance(install, RepositoryIntegration):
             link = install.get_stacktrace_link(
-                config.repository, src_path, str(config.default_branch or ""), version
+                repository, src_path, str(config.default_branch or ""), version
             )
     except ApiError as e:
         if e.code != 403:
@@ -60,7 +70,7 @@ def get_link(
         result["error"] = result.get("error") or "file_not_found"
         assert isinstance(install, RepositoryIntegration)
         result["attemptedUrl"] = install.format_source_url(
-            config.repository, src_path, str(config.default_branch or "")
+            repository, src_path, str(config.default_branch or "")
         )
     result["sourcePath"] = src_path
 
@@ -82,7 +92,9 @@ class StacktraceLinkOutcome(TypedDict):
 
 
 def get_stacktrace_config(
-    configs: Sequence[RepositoryProjectPathConfig], ctx: StacktraceLinkContext
+    configs: Sequence[RepositoryProjectPathConfig],
+    ctx: StacktraceLinkContext,
+    use_project_repository_fk: bool = False,
 ) -> StacktraceLinkOutcome:
     result: StacktraceLinkOutcome = {
         "source_url": None,
@@ -103,13 +115,21 @@ def get_stacktrace_config(
             result["error"] = "stack_root_mismatch"
             continue
 
-        outcome = get_link(config, src_path, ctx["commit_id"])
+        outcome = get_link(
+            config,
+            src_path,
+            ctx["commit_id"],
+            use_project_repository_fk=use_project_repository_fk,
+        )
         result["iteration_count"] += 1
 
+        repository = (
+            config.project_repository.repository if use_project_repository_fk else config.repository
+        )
         result["current_config"] = {
             "config": config,
             "outcome": outcome,
-            "repository": config.repository,
+            "repository": repository,
         }
 
         # Stop processing if a match is found

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -7,6 +7,7 @@ from typing import Any, NamedTuple
 
 from django.db import router, transaction
 
+from sentry import features
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.source_code_management.repo_trees import (
     RepoAndBranch,
@@ -409,13 +410,23 @@ def get_sorted_code_mapping_configs(project: Project) -> list[RepositoryProjectP
     # sure that we are still ordering by `id` because we want to make sure
     # the ordering is deterministic
     # codepath mappings must have an associated integration for stacktrace linking.
-    configs = (
-        RepositoryProjectPathConfig.objects.filter(
-            project=project, organization_integration_id__isnull=False
+    if features.has("organizations:project-repository-fk-reads", project.organization):
+        configs = (
+            RepositoryProjectPathConfig.objects.filter(
+                project_repository__project=project,
+                organization_integration_id__isnull=False,
+            )
+            .select_related("repository", "project_repository", "project_repository__repository")
+            .order_by("id")
         )
-        .select_related("repository")
-        .order_by("id")
-    )
+    else:
+        configs = (
+            RepositoryProjectPathConfig.objects.filter(
+                project=project, organization_integration_id__isnull=False
+            )
+            .select_related("repository", "project_repository", "project_repository__repository")
+            .order_by("id")
+        )
 
     sorted_configs: list[RepositoryProjectPathConfig] = []
 

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -416,7 +416,11 @@ def get_sorted_code_mapping_configs(project: Project) -> list[RepositoryProjectP
                 project_repository__project=project,
                 organization_integration_id__isnull=False,
             )
-            .select_related("repository", "project_repository", "project_repository__repository")
+            .select_related(
+                "project_repository",
+                "project_repository__project",
+                "project_repository__repository",
+            )
             .order_by("id")
         )
     else:
@@ -424,7 +428,7 @@ def get_sorted_code_mapping_configs(project: Project) -> list[RepositoryProjectP
             RepositoryProjectPathConfig.objects.filter(
                 project=project, organization_integration_id__isnull=False
             )
-            .select_related("repository", "project_repository", "project_repository__repository")
+            .select_related("repository")
             .order_by("id")
         )
 

--- a/src/sentry/issues/endpoints/project_stacktrace_link.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_link.py
@@ -8,7 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import Scope
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -150,7 +150,8 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         scope = Scope.get_isolation_scope()
 
         set_top_tags(scope, project, ctx, len(configs) > 0)
-        result = get_stacktrace_config(configs, ctx)
+        use_fk = features.has("organizations:project-repository-fk-reads", project.organization)
+        result = get_stacktrace_config(configs, ctx, use_project_repository_fk=use_fk)
         error = result["error"]
         src_path = result["src_path"]
         # Post-processing before exiting scope context

--- a/src/sentry/issues/endpoints/project_stacktrace_source_context.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_source_context.py
@@ -5,6 +5,7 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -60,7 +61,8 @@ class ProjectStacktraceSourceContextEndpoint(ProjectEndpoint):
                 }
             )
 
-        result = fetch_source_context_from_scm(configs, ctx)
+        use_fk = features.has("organizations:project-repository-fk-reads", project.organization)
+        result = fetch_source_context_from_scm(configs, ctx, use_project_repository_fk=use_fk)
 
         return Response(
             {

--- a/src/sentry/issues/endpoints/serializers.py
+++ b/src/sentry/issues/endpoints/serializers.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.analytics.events.codeowners_max_length_exceeded import CodeOwnersMaxLengthExceeded
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.validators.project_codeowners import build_codeowners_associations
@@ -95,10 +95,13 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer[ProjectCodeOwners]):
         ):
             raise serializers.ValidationError("This code mapping is already in use.")
 
+        project = self.context["project"]
         try:
-            return RepositoryProjectPathConfig.objects.get(
-                id=code_mapping_id, project=self.context["project"]
-            )
+            if features.has("organizations:project-repository-fk-reads", project.organization):
+                return RepositoryProjectPathConfig.objects.get(
+                    id=code_mapping_id, project_repository__project=project
+                )
+            return RepositoryProjectPathConfig.objects.get(id=code_mapping_id, project=project)
         except RepositoryProjectPathConfig.DoesNotExist:
             raise serializers.ValidationError("This code mapping does not exist.")
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -16,6 +16,7 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
 from bitfield import TypedClassBitField
+from sentry import features
 from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
@@ -499,6 +500,7 @@ class Project(Model):
         )
         from sentry.models.environment import Environment, EnvironmentProject
         from sentry.models.projectcodeowners import ProjectCodeOwners
+        from sentry.models.projectrepository import ProjectRepository
         from sentry.models.projectteam import ProjectTeam
         from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
         from sentry.models.releases.release_project import ReleaseProject
@@ -736,10 +738,12 @@ class Project(Model):
 
         # Delete issue ownership objects to prevent them from being stuck on the old org
         ProjectCodeOwners.objects.filter(project_id=self.id).delete()
-        RepositoryProjectPathConfig.objects.filter(project_id=self.id).delete()
-
-        from sentry.models.projectrepository import ProjectRepository
-
+        if features.has("organizations:project-repository-fk-reads", organization):
+            RepositoryProjectPathConfig.objects.filter(
+                project_repository__project_id=self.id
+            ).delete()
+        else:
+            RepositoryProjectPathConfig.objects.filter(project_id=self.id).delete()
         ProjectRepository.objects.filter(project_id=self.id).delete()
 
         for external_issues in chunked(

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -189,6 +189,7 @@ def _get_serialized_event(
 def _pre_resolve_stacktrace_frames(
     serialized_event: dict[str, Any],
     code_mappings: list[RepositoryProjectPathConfig],
+    use_project_repository_fk: bool = False,
 ) -> None:
     """
     Pre-resolve stacktrace frame repo_name and filename using Sentry's code mappings
@@ -203,7 +204,7 @@ def _pre_resolve_stacktrace_frames(
     # Build ordered list of (repo_full_name, code_mapping) preserving global priority
     ordered_mappings: list[tuple[str, RepositoryProjectPathConfig]] = []
     for cm in code_mappings:
-        repo = cm.repository
+        repo = cm.project_repository.repository if use_project_repository_fk else cm.repository
         repo_name_sections = repo.name.split("/")
         if len(repo_name_sections) > 1 and repo.provider:
             ordered_mappings.append((repo.name, cm))
@@ -729,7 +730,12 @@ def trigger_legacy_autofix(
     # Pre-resolve stacktrace frame paths using code mappings so Seer can skip
     # expensive git tree fetches for large repos.
     try:
-        _pre_resolve_stacktrace_frames(serialized_event, code_mappings)
+        use_fk = features.has(
+            "organizations:project-repository-fk-reads", group.project.organization
+        )
+        _pre_resolve_stacktrace_frames(
+            serialized_event, code_mappings, use_project_repository_fk=use_fk
+        )
     except Exception:
         logger.exception("Failed to pre-resolve stacktrace frames")
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -870,9 +870,12 @@ def get_autofix_repos_from_project_code_mappings(
     if code_mappings is None:
         code_mappings = get_sorted_code_mapping_configs(project)
 
+    use_fk = features.has("organizations:project-repository-fk-reads", project.organization)
     repos: dict[tuple, dict] = {}
     for code_mapping in code_mappings:
-        repo: Repository = code_mapping.repository
+        repo: Repository = (
+            code_mapping.project_repository.repository if use_fk else code_mapping.repository
+        )
         repo_name_sections = repo.name.split("/")
 
         if (

--- a/src/sentry/seer/fetch_issues/by_function_name.py
+++ b/src/sentry/seer/fetch_issues/by_function_name.py
@@ -8,8 +8,10 @@ from django.db.models.functions import StrIndex
 from snuba_sdk import BooleanCondition, BooleanOp, Column, Condition, Entity, Function, Op, Query
 from snuba_sdk import Request as SnubaRequest
 
+from sentry import features
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.group import Group, GroupStatus
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.constants import SeerSCMProvider
 from sentry.seer.fetch_issues import utils
@@ -206,15 +208,25 @@ def _get_projects_and_filenames_from_source_file(
     org_id: int, repo_id: int, pr_filename: str, max_num_left_truncated_paths: int = 2
 ) -> tuple[set[Project], set[str]]:
     # Fetch the code mappings in which the source_root is a substring at the start of pr_filename
-    code_mappings = (
-        RepositoryProjectPathConfig.objects.filter(
+    org = Organization.objects.get(id=org_id)
+    use_fk = features.has("organizations:project-repository-fk-reads", org)
+    if use_fk:
+        base_qs = RepositoryProjectPathConfig.objects.filter(
+            organization_id=org_id,
+            project_repository__repository_id=repo_id,
+        ).select_related("project", "project_repository__project")
+    else:
+        base_qs = RepositoryProjectPathConfig.objects.filter(
             organization_id=org_id,
             repository_id=repo_id,
-        )
-        .annotate(substring_match=StrIndex(Value(pr_filename), "source_root"))
-        .filter(substring_match=1)
-    )
-    projects_set = {code_mapping.project for code_mapping in code_mappings}
+        ).select_related("project")
+    code_mappings = base_qs.annotate(
+        substring_match=StrIndex(Value(pr_filename), "source_root")
+    ).filter(substring_match=1)
+    if use_fk:
+        projects_set = {cm.project_repository.project for cm in code_mappings}
+    else:
+        projects_set = {cm.project for cm in code_mappings}
     sentry_filenames = {
         pr_filename.replace(code_mapping.source_root, code_mapping.stack_root, 1)
         for code_mapping in code_mappings

--- a/src/sentry/seer/fetch_issues/utils.py
+++ b/src/sentry/seer/fetch_issues/utils.py
@@ -6,10 +6,12 @@ from typing import Any, TypedDict
 
 import sentry_sdk
 
+from sentry import features
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.event import EventSerializer
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.group import Group
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.seer.constants import SeerSCMProvider
@@ -89,18 +91,31 @@ def get_repo_and_projects(
     repo = filter_repo_by_provider(organization_id, provider, external_id, owner, name).first()
     if repo is None:
         raise Repository.DoesNotExist
-    repo_configs = list(
-        RepositoryProjectPathConfig.objects.filter(
-            organization_id=organization_id,
-            repository_id=repo.id,
+    org = Organization.objects.get(id=organization_id)
+    use_fk = features.has("organizations:project-repository-fk-reads", org)
+    if use_fk:
+        repo_configs = list(
+            RepositoryProjectPathConfig.objects.filter(
+                organization_id=organization_id,
+                project_repository__repository_id=repo.id,
+            ).select_related("project", "project_repository__project")
         )
-    )
+    else:
+        repo_configs = list(
+            RepositoryProjectPathConfig.objects.filter(
+                organization_id=organization_id,
+                repository_id=repo.id,
+            ).select_related("project", "project_repository__project")
+        )
 
     projects = []
     valid_configs = []
     for config in repo_configs:
         try:
-            project = config.project
+            if use_fk:
+                project = config.project_repository.project
+            else:
+                project = config.project
         except Project.DoesNotExist:
             continue
         else:

--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -84,7 +84,9 @@ def code_owners_auto_sync(commit_id: int, **kwargs: Any) -> None:
 
     for code_mapping in code_mappings:
         try:
-            codeowner_contents = get_codeowner_contents(code_mapping)
+            codeowner_contents = get_codeowner_contents(
+                code_mapping, use_project_repository_fk=use_fk
+            )
         except (NotImplementedError, NotFound):
             logger.warning(
                 "code_owners_auto_sync.fetch_error",

--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from rest_framework.exceptions import NotFound
 from taskbroker_client.retry import Retry
 
+from sentry import features
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.commit import Commit
 from sentry.models.organization import Organization
@@ -35,12 +36,20 @@ def code_owners_auto_sync(commit_id: int, **kwargs: Any) -> None:
 
     commit = Commit.objects.get(id=commit_id)
 
-    code_mappings = list(
-        RepositoryProjectPathConfig.objects.filter(
+    org = Organization.objects.get(id=commit.organization_id)
+    use_fk = features.has("organizations:project-repository-fk-reads", org)
+    if use_fk:
+        base_qs = RepositoryProjectPathConfig.objects.filter(
+            project_repository__repository_id=commit.repository_id,
+            project_repository__project__organization_id=commit.organization_id,
+        ).select_related("project", "project_repository__project")
+    else:
+        base_qs = RepositoryProjectPathConfig.objects.filter(
             repository_id=commit.repository_id,
             project__organization_id=commit.organization_id,
-        )
-        .annotate(
+        ).select_related("project", "project_repository__project")
+    code_mappings = list(
+        base_qs.annotate(
             # By default, we don't create a ProjectOwnership record (bc we treat as a negative cache) when we create ProjectCodeOwners records.
             ownership_exists=Exists(
                 ProjectOwnership.objects.filter(
@@ -89,7 +98,11 @@ def code_owners_auto_sync(commit_id: int, **kwargs: Any) -> None:
                 "code_owners_auto_sync.fetch_failed",
                 extra={"commit_id": commit_id, "code_mapping_id": code_mapping.id},
             )
-            AutoSyncNotification(code_mapping.project).send()
+            if use_fk:
+                project = code_mapping.project_repository.project
+            else:
+                project = code_mapping.project
+            AutoSyncNotification(project).send()
             return
 
         try:

--- a/src/sentry/tasks/seer/night_shift/triage_tools.py
+++ b/src/sentry/tasks/seer/night_shift/triage_tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from django.core.exceptions import BadRequest
 from pydantic import BaseModel, Field
 
+from sentry import features
 from sentry.integrations.models.repository_project_path_config import (
     RepositoryProjectPathConfig,
 )
@@ -181,7 +182,7 @@ class get_issue_details_agentic_triage(  # noqa: N801
             return "Issue not found. Check the issue_id and time range."
 
         project_id = result.get("project_id")
-        linked_repos = _format_linked_repos(project_id) if project_id else ""
+        linked_repos = _format_linked_repos(project_id, organization) if project_id else ""
         body = format_issue_output(result)
         return (
             f"Issue ID: {params.issue_id}\n"
@@ -192,21 +193,29 @@ class get_issue_details_agentic_triage(  # noqa: N801
         )
 
 
-def _format_linked_repos(project_id: int) -> str:
+def _format_linked_repos(project_id: int, organization: Organization) -> str:
     """Render the project's linked GitHub repos + source-root mappings.
 
     Surfaces the actual repo name (e.g. `getsentry/seer-test-sandbox`) so the
     agent doesn't have to guess it from the project slug. Includes source_root
     because many repos place app code under a subdirectory (e.g. `python/`).
     """
-    configs = (
-        RepositoryProjectPathConfig.objects.filter(project_id=project_id)
-        .select_related("repository")
-        .order_by("id")
-    )
+    use_fk = features.has("organizations:project-repository-fk-reads", organization)
+    if use_fk:
+        configs = (
+            RepositoryProjectPathConfig.objects.filter(project_repository__project_id=project_id)
+            .select_related("project_repository__repository")
+            .order_by("id")
+        )
+    else:
+        configs = (
+            RepositoryProjectPathConfig.objects.filter(project_id=project_id)
+            .select_related("repository")
+            .order_by("id")
+        )
     lines: list[str] = []
     for cfg in configs:
-        repo_name = cfg.repository.name
+        repo_name = cfg.project_repository.repository.name if use_fk else cfg.repository.name
         source_root = cfg.source_root or ""
         stack_root = cfg.stack_root or ""
         parts = [f"- {repo_name}"]


### PR DESCRIPTION
This switches over `SeerProjectRepository` to start querying repos and projects via `ProjectRepository`. Also switches over attribute use.

<!-- Describe your PR here. -->