### PR TITLE
feat(issues): GA new stack trace frontend

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -217,7 +217,7 @@ const Wrapper = styled('div')`
   position: relative;
 `;
 
-export const StackTraceContentPanel = styled(Panel)`
+const StackTraceContentPanel = styled(Panel)`
   position: relative;
   overflow: hidden;
 `;

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -4,8 +4,6 @@ import styled from '@emotion/styled';
 import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
-import {StackTraceContent} from 'sentry/components/events/interfaces/crashContent/stackTrace';
-import {StackTraceContentPanel} from 'sentry/components/events/interfaces/crashContent/stackTrace/content';
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {FrameContent} from 'sentry/components/stackTrace/frame/frameContent';
 import {IssueFrameActions} from 'sentry/components/stackTrace/issueStackTrace/issueFrameActions';
@@ -17,7 +15,6 @@ import {t, tct} from 'sentry/locale';
 import {EntryType, type EventTransaction, type Frame} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey, Project} from 'sentry/types/project';
-import {StackView} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
@@ -303,41 +300,24 @@ export function SpanProfileDetails({
           </LinkButton>
         </SpanDetailsItem>
       </SpanDetails>
-      {organization.features.includes('issue-details-new-stack-trace') ? (
-        <StackTraceViewStateProvider platform={event.platform || 'other'}>
-          <StackTraceProvider
-            event={processedEvent}
-            stacktrace={{
-              framesOmitted: null,
-              hasSystemFrames: false,
-              registers: null,
-              frames,
-            }}
-            maxDepth={MAX_STACK_DEPTH}
-          >
-            <StackTraceFrames
-              borderless
-              frameActionsComponent={IssueFrameActions}
-              frameContextComponent={FrameContent}
-            />
-          </StackTraceProvider>
-        </StackTraceViewStateProvider>
-      ) : (
-        <StackTraceContent
+      <StackTraceViewStateProvider platform={event.platform || 'other'}>
+        <StackTraceProvider
           event={processedEvent}
-          newestFirst
-          platform={event.platform || 'other'}
           stacktrace={{
             framesOmitted: null,
             hasSystemFrames: false,
             registers: null,
             frames,
           }}
-          stackView={StackView.APP}
-          inlined
           maxDepth={MAX_STACK_DEPTH}
-        />
-      )}
+        >
+          <StackTraceFrames
+            borderless
+            frameActionsComponent={IssueFrameActions}
+            frameContextComponent={FrameContent}
+          />
+        </StackTraceProvider>
+      </StackTraceViewStateProvider>
     </SpanContainer>
   );
 }
@@ -474,11 +454,6 @@ const SpanContainer = styled('div')`
   border: 1px solid ${p => p.theme.tokens.border.secondary};
   border-radius: ${p => p.theme.radius.md};
   overflow: hidden;
-
-  ${StackTraceContentPanel} {
-    margin-bottom: 0;
-    box-shadow: none;
-  }
 `;
 const SpanDetails = styled('div')`
   padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
@@ -43,7 +43,7 @@ describe('StackTracePreview', () => {
     ).toBeInTheDocument();
   });
 
-  it.each([['stack-trace-content', []]])('renders %s', async (component, features) => {
+  it('renders stack trace frames', async () => {
     const frame: Frame = {
       colNo: 0,
       filename: 'file.js',
@@ -98,14 +98,12 @@ describe('StackTracePreview', () => {
       body: EventFixture(errorEvent),
     });
 
-    render(<StackTracePreview groupId="123">Preview Trigger</StackTracePreview>, {
-      organization: {features},
-    });
+    render(<StackTracePreview groupId="123">Preview Trigger</StackTracePreview>);
 
     await userEvent.hover(screen.getByText(/Preview Trigger/));
 
-    expect(await screen.findByTestId(component)).toBeInTheDocument();
+    expect(await screen.findByTestId('core-stacktrace-frame-row')).toBeInTheDocument();
     // Hide the platform icon for stack trace previews
-    expect(screen.queryAllByRole('img')).toHaveLength(1);
+    expect(screen.queryAllByRole('img')).toHaveLength(0);
   });
 });

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
@@ -19,7 +19,6 @@ import {EntryType} from 'sentry/types/event';
 import type {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {isNativePlatform} from 'sentry/utils/platform';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function getStacktrace(event: Event): StacktraceType | null {
   const exceptionsWithStacktrace =
@@ -61,8 +60,6 @@ export function StackTracePreviewContent({
   stacktrace: StacktraceType;
   groupingCurrentLevel?: number;
 }) {
-  const organization = useOrganization();
-
   const includeSystemFrames = useMemo(() => {
     return stacktrace?.frames?.every(frame => !frame.inApp) ?? false;
   }, [stacktrace]);
@@ -86,11 +83,7 @@ export function StackTracePreviewContent({
     return <NativeContent {...commonProps} groupingCurrentLevel={groupingCurrentLevel} />;
   }
 
-  if (organization.features.includes('issue-details-new-stack-trace')) {
-    return <IssueStackTracePreview event={event} stacktrace={stacktrace} />;
-  }
-
-  return <StackTraceContent {...commonProps} expandFirstFrame={false} />;
+  return <IssueStackTracePreview event={event} stacktrace={stacktrace} />;
 }
 
 type StackTracePreviewProps = {

--- a/static/app/views/discover/table/quickContext/eventContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/eventContext.spec.tsx
@@ -171,6 +171,6 @@ describe('Quick Context Content: Event ID Column', () => {
 
     renderEventContext(mockedLocation);
 
-    expect(await screen.findByTestId('stack-trace-content')).toBeInTheDocument();
+    expect(await screen.findByTestId('core-stacktrace-frame-row')).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -100,7 +100,6 @@ export function EventDetailsContent({
 }: Required<Pick<EventDetailsContentProps, 'group' | 'event' | 'project'>>) {
   const organization = useOrganization();
   const shouldUseNewStackTrace =
-    organization.features.includes('issue-details-new-stack-trace') &&
     // New stack trace is currently only non-native platforms.
     !isNativePlatform(event.platform);
   const tagsRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
make the new stack trace the default frontend path for non-native issue details, hover previews, and span profile stacks.

going to reuse the flag for threaded stack traces. There isn't much to remove yet because the threaded stack trace shares all the code with the old non-threaded stack traces.