### PR TITLE
chore(alerts): Move spike protection API docs to their own section

### DIFF
--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -145,9 +145,9 @@ OPENAPI_TAGS = [
         },
     },
     {
-        "name": "Alerts",
-        "x-sidebar-name": "Alerts & Notifications",
-        "description": "Endpoints for Alerts and Notifications",
+        "name": "Spike Protection",
+        "x-sidebar-name": "Spike Protection Notifications",
+        "description": "Endpoints for Spike Protection Notifications",
         "x-display-description": False,
         "externalDocs": {
             "description": "Found an error? Let us know.",

--- a/src/sentry/notifications/api/endpoints/notification_actions_details.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_details.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 @cell_silo_endpoint
-@extend_schema(tags=["Alerts"])
+@extend_schema(tags=["Spike Protection"])
 class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ECOSYSTEM
     publish_status = {

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -39,7 +39,7 @@ class NotificationActionsPermission(OrganizationPermission):
 
 
 @cell_silo_endpoint
-@extend_schema(tags=["Alerts"])
+@extend_schema(tags=["Spike Protection"])
 class NotificationActionsIndexEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ECOSYSTEM
     publish_status = {


### PR DESCRIPTION
Now that we've unpublished the old alerts API documentation the only things in the "Alerts & Notifications" sidebar are spike protection notification action docs. Make this it's own section so it's not confusing to choose between "Alerts & Notifications" and "Monitors & Alerts". 