### PR TITLE
Add eval seed timing logs and devservices mode

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -108,6 +108,14 @@ x-sentry-service-config:
     # Taskworker services
     taskworker:
       description: Workers that process tasks from the taskbroker
+    taskworker-evals-ingest-errors:
+      description: Dedicated taskworker for eval error ingest tasks
+    taskworker-evals-ingest-errors-postprocess:
+      description: Dedicated taskworker for eval error post-processing tasks
+    taskworker-evals-issues:
+      description: Dedicated taskworker for eval issue-side tasks
+    taskworker-evals-relay:
+      description: Dedicated taskworker for eval Relay project config tasks
     taskworker-scheduler:
       description: Task scheduler that can spawn tasks based on their schedules
     # Kafka consumer services for event ingestion
@@ -257,6 +265,21 @@ x-sentry-service-config:
         post-process-forwarder-transactions,
         post-process-forwarder-issue-platform,
       ]
+    evals:
+      [
+        snuba,
+        postgres,
+        relay,
+        spotlight,
+        objectstore,
+        taskbroker,
+        taskworker-evals-relay,
+        taskworker-evals-ingest-errors,
+        taskworker-evals-ingest-errors-postprocess,
+        taskworker-evals-issues,
+        ingest-events,
+        post-process-forwarder-errors,
+      ]
     minimal: [postgres, snuba]
     # The minimal set of services Symbolicator needs to run
     # Sentry integration tests.
@@ -344,6 +367,14 @@ x-programs:
     command: sentry devserver
   taskworker:
     command: sentry run taskworker
+  taskworker-evals-ingest-errors:
+    command: sentry run taskworker --namespace ingest.errors --concurrency 2 --processing-pool-name eval-ingest-errors
+  taskworker-evals-ingest-errors-postprocess:
+    command: sentry run taskworker --namespace ingest.errors.postprocess --concurrency 1 --processing-pool-name eval-ingest-errors-postprocess
+  taskworker-evals-issues:
+    command: sentry run taskworker --namespace issues --concurrency 1 --processing-pool-name eval-issues
+  taskworker-evals-relay:
+    command: sentry run taskworker --namespace relay --concurrency 1 --processing-pool-name eval-relay
   taskworker-scheduler:
     command: sentry run taskworker-scheduler
   ingest-events:

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import os
+import time
 from collections.abc import Mapping, MutableMapping
 from typing import Any
 
@@ -87,6 +88,19 @@ def process_event(
     project_id = int(message["project_id"])
     remote_addr = message.get("remote_addr")
     attachments = message.get("attachments") or ()
+
+    if project.slug.startswith("eval-"):
+        logger.info(
+            "seer_eval_seed.ingest_event",
+            extra={
+                "project_slug": project.slug,
+                "project_id": project_id,
+                "event_id": event_id,
+                "consumer_type": consumer_type,
+                "queue_lag_seconds": round(time.time() - start_time, 3),
+                "attachment_count": len(attachments),
+            },
+        )
 
     sentry_sdk.set_extra("event_id", event_id)
     sentry_sdk.set_extra("len_attachments", len(attachments))

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Mapping
 from enum import StrEnum
 from typing import Any
@@ -59,19 +60,29 @@ def process_event(
     """
     project = Project.objects.get(id=project_id)
     org = Organization.objects.get(id=project.organization_id)
+    task_start = time.monotonic()
+    is_eval_project = project.slug.startswith("eval-")
     set_tag("organization.slug", org.slug)
     # When you look at the performance page the user is a default column
     set_user({"username": org.slug})
     set_tag("project.slug", project.slug)
     extra = {
         "organization.slug": org.slug,
+        "project_slug": project.slug,
         "project_id": project_id,
         "group_id": group_id,
         "event_id": event_id,
     }
+    if is_eval_project:
+        logger.info("seer_eval_seed.auto_source_code_config_start", extra=extra)
 
     event = fetch_event(project_id, event_id, group_id, extra)
     if event is None:
+        if is_eval_project:
+            logger.info(
+                "seer_eval_seed.auto_source_code_config_done",
+                extra={**extra, "status": "event_not_found", "duration_ms": 0.0},
+            )
         return [], []
 
     platform = event.platform
@@ -84,13 +95,32 @@ def process_event(
 
     frames_to_process = get_frames_to_process(event.data, platform)
     if not frames_to_process:
+        if is_eval_project:
+            logger.info(
+                "seer_eval_seed.auto_source_code_config_done",
+                extra={
+                    **extra,
+                    "status": "no_frames",
+                    "duration_ms": round((time.monotonic() - task_start) * 1000, 2),
+                },
+            )
         return [], []
 
     code_mappings: list[CodeMapping] = []
     in_app_stack_trace_rules: list[str] = []
     try:
         installation = get_installation(org)
+        tree_start = time.monotonic()
         trees = get_trees_for_org(installation, org, extra)
+        if is_eval_project:
+            logger.info(
+                "seer_eval_seed.auto_source_code_config_trees",
+                extra={
+                    **extra,
+                    "tree_count": len(trees),
+                    "duration_ms": round((time.monotonic() - tree_start) * 1000, 2),
+                },
+            )
         trees_helper = CodeMappingTreesHelper(trees)
         code_mappings = trees_helper.generate_code_mappings(frames_to_process, platform)
         _, in_app_stack_trace_rules = create_configurations(
@@ -99,6 +129,18 @@ def process_event(
 
     except (InstallationNotFoundError, InstallationCannotGetTreesError):
         pass
+
+    if is_eval_project:
+        logger.info(
+            "seer_eval_seed.auto_source_code_config_done",
+            extra={
+                **extra,
+                "status": "ok",
+                "code_mapping_count": len(code_mappings),
+                "in_app_stack_trace_rule_count": len(in_app_stack_trace_rules),
+                "duration_ms": round((time.monotonic() - task_start) * 1000, 2),
+            },
+        )
 
     return code_mappings, in_app_stack_trace_rules
 

--- a/src/sentry/issues/endpoints/project_events.py
+++ b/src/sentry/issues/endpoints/project_events.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from functools import partial
 
 from drf_spectacular.utils import extend_schema
@@ -24,6 +26,8 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.services import eventstore
 from sentry.snuba.events import Columns
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+logger = logging.getLogger(__name__)
 
 
 @extend_schema(tags=["Events"])
@@ -72,6 +76,7 @@ class ProjectEventsEndpoint(ProjectEndpoint):
         """
         from sentry.api.paginator import GenericOffsetPaginator
 
+        request_start = time.monotonic()
         query = request.GET.get("query")
         conditions = []
         eap_conditions = TraceItemFilter()
@@ -118,8 +123,25 @@ class ProjectEventsEndpoint(ProjectEndpoint):
             data_fn = partial(data_fn, orderby=[Columns.EVENT_ID.value.alias])
 
         serializer = EventSerializer() if full else SimpleEventSerializer()
+
+        def serialize_and_log_results(results):
+            serialized = serialize(results, request.user, serializer)
+            if project.slug.startswith("eval-"):
+                logger.info(
+                    "seer_eval_seed.project_events_query",
+                    extra={
+                        "project_slug": project.slug,
+                        "project_id": project.id,
+                        "query": query,
+                        "result_count": len(results),
+                        "response_count": len(serialized),
+                        "duration_ms": round((time.monotonic() - request_start) * 1000, 2),
+                    },
+                )
+            return serialized
+
         return self.paginate(
             request=request,
-            on_results=lambda results: serialize(results, request.user, serializer),
+            on_results=serialize_and_log_results,
             paginator=GenericOffsetPaginator(data_fn=data_fn),
         )

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import time
 
 import sentry_sdk
 from rest_framework.request import Request
@@ -100,6 +101,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                                      belong to.
         :auth: required
         """
+        request_start = time.monotonic()
         stats_period = request.GET.get("statsPeriod")
         if stats_period not in (None, "", "24h", "14d"):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
@@ -195,6 +197,19 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         if status and (GroupStatus.UNRESOLVED in status[0].value.raw_value):
             status_labels = {QUERY_STATUS_LOOKUP[s] for s in status[0].value.raw_value}
             context = [r for r in context if "status" not in r or r["status"] in status_labels]
+
+        if project.slug.startswith("eval-"):
+            logger.info(
+                "seer_eval_seed.project_issues_query",
+                extra={
+                    "project_slug": project.slug,
+                    "project_id": project.id,
+                    "query": query,
+                    "raw_result_count": len(results),
+                    "response_count": len(context),
+                    "duration_ms": round((time.monotonic() - request_start) * 1000, 2),
+                },
+            )
 
         response = Response(context)
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -990,11 +990,39 @@ def process_code_mappings(job: PostProcessJob) -> None:
         # issue for at least 24 hours.
         project_cache_key = f"code-mappings:project:{project.id}"
         issue_cache_key = f"code-mappings:group:{group_id}"
-        if cache.get(project_cache_key) is None and cache.get(issue_cache_key) is None:
+        project_cache_hit = cache.get(project_cache_key) is not None
+        issue_cache_hit = cache.get(issue_cache_key) is not None
+        if project.slug.startswith("eval-"):
+            logger.info(
+                "seer_eval_seed.code_mapping_consider",
+                extra={
+                    "project_slug": project.slug,
+                    "project_id": project.id,
+                    "event_id": event.event_id,
+                    "group_id": group_id,
+                    "platform": platform,
+                    "frame_count": len(frames_to_process),
+                    "project_cache_hit": project_cache_hit,
+                    "issue_cache_hit": issue_cache_hit,
+                },
+            )
+
+        if not project_cache_hit and not issue_cache_hit:
             cache.set(project_cache_key, True, 3600)  # 1 hour
             cache.set(issue_cache_key, True, 86400)  # 24 hours
         else:
             return
+
+        if project.slug.startswith("eval-"):
+            logger.info(
+                "seer_eval_seed.code_mapping_queued",
+                extra={
+                    "project_slug": project.slug,
+                    "project_id": project.id,
+                    "event_id": event.event_id,
+                    "group_id": group_id,
+                },
+            )
 
         auto_source_code_config.delay(project.id, event_id=event.event_id, group_id=group_id)
 

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -48,7 +48,11 @@ def build_project_config(public_key=None, **kwargs):
     Do not invoke this task directly, instead use :func:`schedule_build_project_config`.
     """
     sentry_sdk.set_tag("public_key", public_key)
-
+    task_start = time.monotonic()
+    tmp_scheduled = kwargs.get("tmp_scheduled")
+    scheduled_delay_ms = (
+        round((time.time() - tmp_scheduled) * 1000, 2) if isinstance(tmp_scheduled, float) else None
+    )
     try:
         from sentry.models.projectkey import ProjectKey
 
@@ -60,8 +64,32 @@ def build_project_config(public_key=None, **kwargs):
             # avoid creating more tasks for it.
             projectconfig_cache.backend.set_many({public_key: {"disabled": True}})
         else:
+            project = key.project
+            is_eval_project = project.slug.startswith("eval-")
+            if is_eval_project:
+                logger.info(
+                    "seer_eval_seed.projectconfig_build_start",
+                    extra={
+                        "public_key": public_key,
+                        "project_id": project.id,
+                        "project_slug": project.slug,
+                        "scheduled_delay_ms": scheduled_delay_ms,
+                    },
+                )
             config = compute_projectkey_config(key)
             projectconfig_cache.backend.set_many({public_key: config})
+            if is_eval_project:
+                logger.info(
+                    "seer_eval_seed.projectconfig_build_done",
+                    extra={
+                        "public_key": public_key,
+                        "status": "ok",
+                        "project_id": project.id,
+                        "project_slug": project.slug,
+                        "duration_ms": round((time.monotonic() - task_start) * 1000, 2),
+                        "scheduled_delay_ms": scheduled_delay_ms,
+                    },
+                )
 
     finally:
         # Delete the key in this `finally` block to make sure the debouncing key

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import random
+import time
 from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import Any
@@ -510,6 +511,7 @@ def _do_save_event(
     Saves an event to the database.
     """
 
+    task_start = time.monotonic()
     set_current_event_project(project_id)
 
     from sentry.event_manager import EventManager, resolve_project
@@ -582,6 +584,7 @@ def _do_save_event(
 
             manager = EventManager(data)
             # event.project.organization is populated after this statement.
+            manager_save_start = time.monotonic()
             manager.save(
                 project=project,
                 assume_normalized=True,
@@ -589,6 +592,7 @@ def _do_save_event(
                 cache_key=cache_key,
                 attachments=attachments,
             )
+            manager_save_elapsed = time.monotonic() - manager_save_start
             # Put the updated event back into the cache so that post_process
             # has the most recent data.
 
@@ -599,6 +603,23 @@ def _do_save_event(
                 if not isinstance(data, dict):
                     data = dict(data.items())
                 processing_store.store(data)
+
+            if project.slug.startswith("eval-"):
+                info_logger.info(
+                    "seer_eval_seed.save_event",
+                    extra={
+                        "project_slug": project.slug,
+                        "project_id": project_id,
+                        "event_id": event_id,
+                        "event_type": event_type,
+                        "group_id": data.get("group_id") or data.get("group"),
+                        "manager_save_ms": round(manager_save_elapsed * 1000, 2),
+                        "task_elapsed_ms": round((time.monotonic() - task_start) * 1000, 2),
+                        "since_received_seconds": round(time.time() - start_time, 3)
+                        if start_time is not None
+                        else None,
+                    },
+                )
 
         except HashDiscarded:
             # Delete the event payload from cache since it won't show up in post-processing.


### PR DESCRIPTION
## Summary

- add an `evals` devservices mode for seeded local evals
- keep the mode focused on error-event eval ingestion: Relay, Snuba/Postgres, taskbroker, `ingest-events`, `post-process-forwarder-errors`, and dedicated taskworkers for `relay`, `ingest.errors`, `ingest.errors.postprocess`, and `issues`
- add `seer_eval_seed.*` timing logs for eval project ingest, save, post-process/code-mapping enqueue, polling endpoints, auto source-code config, and Relay project-config builds
- scope logs to `eval-*` projects where the code path has project context

## Why

This is a draft/debug PR for the local seeded Seer eval bottleneck. The logs showed `ingest-events` consuming the 50 events within a few seconds, while `sentry.tasks.store.save_event` could start roughly 63s later because `ingest.errors` work was competing with `issues` tasks on the catch-all taskworker.

The new `evals` mode moves the queue topology into Sentry instead of requiring Seer to run manual taskworker commands. It avoids the broad `ingest` mode’s extra transactions/attachments workers and avoids a generic catch-all taskworker for the eval path.

## Verification

- Sentry pre-commit hooks on commit and push
- `git diff --check`
- `.venv/bin/prek run -q check-yaml --files devservices/config.yml`
- devservices config loader check for `evals` mode and supervisor dependency types
- Used local logs to identify:
  - ingest consumer queue lag around `3.2-3.8s` in the slow run
  - `save_event` `since_received_seconds` around `63s` in the slow run
  - improved seed probe after dedicated workers: `11.93s`, then `18.72s`
