### PR TITLE
feat(issues): Implement UI for new Seer actions included in issue activity

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -615,7 +615,24 @@ export enum GroupActivityType {
   SET_ESCALATING = 'set_escalating',
   SET_PRIORITY = 'set_priority',
   DELETED_ATTACHMENT = 'deleted_attachment',
+  SEER_RCA_STARTED = 'seer_rca_started',
+  SEER_RCA_COMPLETED = 'seer_rca_completed',
+  SEER_SOLUTION_STARTED = 'seer_solution_started',
+  SEER_SOLUTION_COMPLETED = 'seer_solution_completed',
+  SEER_CODING_STARTED = 'seer_coding_started',
+  SEER_CODING_COMPLETED = 'seer_coding_completed',
+  SEER_PR_CREATED = 'seer_pr_created',
 }
+
+export const SEER_ACTIVITY_TYPES = new Set<GroupActivityType>([
+  GroupActivityType.SEER_RCA_STARTED,
+  GroupActivityType.SEER_RCA_COMPLETED,
+  GroupActivityType.SEER_SOLUTION_STARTED,
+  GroupActivityType.SEER_SOLUTION_COMPLETED,
+  GroupActivityType.SEER_CODING_STARTED,
+  GroupActivityType.SEER_CODING_COMPLETED,
+  GroupActivityType.SEER_PR_CREATED,
+]);
 
 interface GroupActivityBase {
   dateCreated: string;
@@ -894,6 +911,66 @@ interface GroupActivityDeletedAttachment extends GroupActivityBase {
   type: GroupActivityType.DELETED_ATTACHMENT;
 }
 
+interface GroupActivitySeerRcaStarted extends GroupActivityBase {
+  data: {
+    run_id?: number;
+  };
+  type: GroupActivityType.SEER_RCA_STARTED;
+}
+
+interface GroupActivitySeerRcaCompleted extends GroupActivityBase {
+  data: {
+    root_cause?: Record<string, any>;
+    run_id?: number;
+  };
+  type: GroupActivityType.SEER_RCA_COMPLETED;
+}
+
+interface GroupActivitySeerSolutionStarted extends GroupActivityBase {
+  data: {
+    run_id?: number;
+  };
+  type: GroupActivityType.SEER_SOLUTION_STARTED;
+}
+
+interface GroupActivitySeerSolutionCompleted extends GroupActivityBase {
+  data: {
+    run_id?: number;
+    solution?: Record<string, any>;
+  };
+  type: GroupActivityType.SEER_SOLUTION_COMPLETED;
+}
+
+interface GroupActivitySeerCodingStarted extends GroupActivityBase {
+  data: {
+    run_id?: number;
+  };
+  type: GroupActivityType.SEER_CODING_STARTED;
+}
+
+interface GroupActivitySeerCodingCompleted extends GroupActivityBase {
+  data: {
+    changes?: Array<Record<string, any>>;
+    run_id?: number;
+  };
+  type: GroupActivityType.SEER_CODING_COMPLETED;
+}
+
+export interface GroupActivitySeerPrCreated extends GroupActivityBase {
+  data: {
+    pull_requests?: Array<{
+      provider: string;
+      pull_request: {
+        pr_number: number;
+        pr_url: string;
+      };
+      repo_name: string;
+    }>;
+    run_id?: number;
+  };
+  type: GroupActivityType.SEER_PR_CREATED;
+}
+
 export type GroupActivity =
   | GroupActivityNote
   | GroupActivitySetResolved
@@ -923,7 +1000,14 @@ export type GroupActivity =
   | GroupActivityAutoSetOngoing
   | GroupActivitySetEscalating
   | GroupActivitySetPriority
-  | GroupActivityDeletedAttachment;
+  | GroupActivityDeletedAttachment
+  | GroupActivitySeerRcaStarted
+  | GroupActivitySeerRcaCompleted
+  | GroupActivitySeerSolutionStarted
+  | GroupActivitySeerSolutionCompleted
+  | GroupActivitySeerCodingStarted
+  | GroupActivitySeerCodingCompleted
+  | GroupActivitySeerPrCreated;
 
 export type Activity = GroupActivity;
 

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -956,7 +956,7 @@ interface GroupActivitySeerCodingCompleted extends GroupActivityBase {
   type: GroupActivityType.SEER_CODING_COMPLETED;
 }
 
-export interface GroupActivitySeerPrCreated extends GroupActivityBase {
+interface GroupActivitySeerPrCreated extends GroupActivityBase {
   data: {
     pull_requests?: Array<{
       provider: string;

--- a/static/app/views/issueDetails/activitySection.tsx
+++ b/static/app/views/issueDetails/activitySection.tsx
@@ -7,7 +7,7 @@ import {NoteInputWithStorage} from 'sentry/components/activity/note/inputWithSto
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import type {NoteType} from 'sentry/types/alerts';
 import type {Group, GroupActivity} from 'sentry/types/group';
-import {GroupActivityType} from 'sentry/types/group';
+import {GroupActivityType, SEER_ACTIVITY_TYPES} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {uniqueId} from 'sentry/utils/guid';
@@ -59,63 +59,69 @@ export function ActivitySection(props: Props) {
         />
       </ActivityItem>
 
-      {group.activity.map(item => {
-        const authorName = item.user ? item.user.name : 'Sentry';
+      {group.activity
+        .filter(
+          item =>
+            !SEER_ACTIVITY_TYPES.has(item.type) ||
+            organization.features.includes('seer-activity-timeline')
+        )
+        .map(item => {
+          const authorName = item.user ? item.user.name : 'Sentry';
 
-        if (item.type === GroupActivityType.NOTE) {
+          if (item.type === GroupActivityType.NOTE) {
+            return (
+              <ErrorBoundary mini key={`note-${item.id}`}>
+                <Note
+                  showTime={false}
+                  text={item.data.text}
+                  noteId={item.id}
+                  user={item.user!}
+                  dateCreated={item.dateCreated}
+                  authorName={authorName}
+                  onDelete={() => {
+                    onDelete(item);
+                    trackAnalytics('issue_details.comment_deleted', {
+                      organization,
+                      streamline: false,
+                      org_streamline_only: organization.streamlineOnly ?? undefined,
+                    });
+                  }}
+                  onUpdate={n => {
+                    item.data.text = n.text;
+                    onUpdate(item, n);
+                    trackAnalytics('issue_details.comment_updated', {
+                      organization,
+                      streamline: false,
+                      org_streamline_only: organization.streamlineOnly ?? undefined,
+                    });
+                  }}
+                  {...noteProps}
+                />
+              </ErrorBoundary>
+            );
+          }
+
           return (
-            <ErrorBoundary mini key={`note-${item.id}`}>
-              <Note
-                showTime={false}
-                text={item.data.text}
-                noteId={item.id}
-                user={item.user!}
-                dateCreated={item.dateCreated}
-                authorName={authorName}
-                onDelete={() => {
-                  onDelete(item);
-                  trackAnalytics('issue_details.comment_deleted', {
-                    organization,
-                    streamline: false,
-                    org_streamline_only: organization.streamlineOnly ?? undefined,
-                  });
+            <ErrorBoundary mini key={`item-${item.id}`}>
+              <ActivityItem
+                author={{
+                  type: item.user ? 'user' : 'system',
+                  user: item.user ?? undefined,
                 }}
-                onUpdate={n => {
-                  item.data.text = n.text;
-                  onUpdate(item, n);
-                  trackAnalytics('issue_details.comment_updated', {
-                    organization,
-                    streamline: false,
-                    org_streamline_only: organization.streamlineOnly ?? undefined,
-                  });
-                }}
-                {...noteProps}
+                date={item.dateCreated}
+                header={
+                  <GroupActivityItem
+                    author={<ActivityAuthor>{authorName}</ActivityAuthor>}
+                    activity={item}
+                    organization={organization}
+                    projectId={group.project.id}
+                    group={group}
+                  />
+                }
               />
             </ErrorBoundary>
           );
-        }
-
-        return (
-          <ErrorBoundary mini key={`item-${item.id}`}>
-            <ActivityItem
-              author={{
-                type: item.user ? 'user' : 'system',
-                user: item.user ?? undefined,
-              }}
-              date={item.dateCreated}
-              header={
-                <GroupActivityItem
-                  author={<ActivityAuthor>{authorName}</ActivityAuthor>}
-                  activity={item}
-                  organization={organization}
-                  projectId={group.project.id}
-                  group={group}
-                />
-              }
-            />
-          </ErrorBoundary>
-        );
-      })}
+        })}
     </Fragment>
   );
 }

--- a/static/app/views/issueDetails/activitySection.tsx
+++ b/static/app/views/issueDetails/activitySection.tsx
@@ -29,6 +29,10 @@ export function ActivitySection(props: Props) {
 
   const [inputId, setInputId] = useState(uniqueId());
 
+  const visibleActivities = organization.features.includes('seer-activity-timeline')
+    ? group.activity
+    : group.activity.filter(item => !SEER_ACTIVITY_TYPES.has(item.type));
+
   const me = useUser();
   const projectSlugs = group?.project ? [group.project.slug] : [];
   const noteProps = {
@@ -59,69 +63,63 @@ export function ActivitySection(props: Props) {
         />
       </ActivityItem>
 
-      {group.activity
-        .filter(
-          item =>
-            !SEER_ACTIVITY_TYPES.has(item.type) ||
-            organization.features.includes('seer-activity-timeline')
-        )
-        .map(item => {
-          const authorName = item.user ? item.user.name : 'Sentry';
+      {visibleActivities.map(item => {
+        const authorName = item.user ? item.user.name : 'Sentry';
 
-          if (item.type === GroupActivityType.NOTE) {
-            return (
-              <ErrorBoundary mini key={`note-${item.id}`}>
-                <Note
-                  showTime={false}
-                  text={item.data.text}
-                  noteId={item.id}
-                  user={item.user!}
-                  dateCreated={item.dateCreated}
-                  authorName={authorName}
-                  onDelete={() => {
-                    onDelete(item);
-                    trackAnalytics('issue_details.comment_deleted', {
-                      organization,
-                      streamline: false,
-                      org_streamline_only: organization.streamlineOnly ?? undefined,
-                    });
-                  }}
-                  onUpdate={n => {
-                    item.data.text = n.text;
-                    onUpdate(item, n);
-                    trackAnalytics('issue_details.comment_updated', {
-                      organization,
-                      streamline: false,
-                      org_streamline_only: organization.streamlineOnly ?? undefined,
-                    });
-                  }}
-                  {...noteProps}
-                />
-              </ErrorBoundary>
-            );
-          }
-
+        if (item.type === GroupActivityType.NOTE) {
           return (
-            <ErrorBoundary mini key={`item-${item.id}`}>
-              <ActivityItem
-                author={{
-                  type: item.user ? 'user' : 'system',
-                  user: item.user ?? undefined,
+            <ErrorBoundary mini key={`note-${item.id}`}>
+              <Note
+                showTime={false}
+                text={item.data.text}
+                noteId={item.id}
+                user={item.user!}
+                dateCreated={item.dateCreated}
+                authorName={authorName}
+                onDelete={() => {
+                  onDelete(item);
+                  trackAnalytics('issue_details.comment_deleted', {
+                    organization,
+                    streamline: false,
+                    org_streamline_only: organization.streamlineOnly ?? undefined,
+                  });
                 }}
-                date={item.dateCreated}
-                header={
-                  <GroupActivityItem
-                    author={<ActivityAuthor>{authorName}</ActivityAuthor>}
-                    activity={item}
-                    organization={organization}
-                    projectId={group.project.id}
-                    group={group}
-                  />
-                }
+                onUpdate={n => {
+                  item.data.text = n.text;
+                  onUpdate(item, n);
+                  trackAnalytics('issue_details.comment_updated', {
+                    organization,
+                    streamline: false,
+                    org_streamline_only: organization.streamlineOnly ?? undefined,
+                  });
+                }}
+                {...noteProps}
               />
             </ErrorBoundary>
           );
-        })}
+        }
+
+        return (
+          <ErrorBoundary mini key={`item-${item.id}`}>
+            <ActivityItem
+              author={{
+                type: item.user ? 'user' : 'system',
+                user: item.user ?? undefined,
+              }}
+              date={item.dateCreated}
+              header={
+                <GroupActivityItem
+                  author={<ActivityAuthor>{authorName}</ActivityAuthor>}
+                  activity={item}
+                  organization={organization}
+                  projectId={group.project.id}
+                  group={group}
+                />
+              }
+            />
+          </ErrorBoundary>
+        );
+      })}
     </Fragment>
   );
 }

--- a/static/app/views/issueDetails/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/groupActivityItem.tsx
@@ -634,8 +634,8 @@ export function GroupActivityItem({
         return t('Seer completed implementing a fix');
       case GroupActivityType.SEER_PR_CREATED: {
         const {data: prData} = activity;
-        if (prData.pull_requests?.length) {
-          const pr = prData.pull_requests[0]!;
+        const pr = prData.pull_requests?.[0];
+        if (pr) {
           return tct('Seer created a [link:pull request] in [repo]', {
             link: <ExternalLink href={pr.pull_request.pr_url} />,
             repo: pr.repo_name,

--- a/static/app/views/issueDetails/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/groupActivityItem.tsx
@@ -620,6 +620,29 @@ export function GroupActivityItem({
       }
       case GroupActivityType.DELETED_ATTACHMENT:
         return tct('[author] deleted an attachment', {author});
+      case GroupActivityType.SEER_RCA_STARTED:
+        return t('Seer started analyzing the root cause');
+      case GroupActivityType.SEER_RCA_COMPLETED:
+        return t('Seer completed root cause analysis');
+      case GroupActivityType.SEER_SOLUTION_STARTED:
+        return t('Seer started developing a solution');
+      case GroupActivityType.SEER_SOLUTION_COMPLETED:
+        return t('Seer completed developing a solution');
+      case GroupActivityType.SEER_CODING_STARTED:
+        return t('Seer started implementing a fix');
+      case GroupActivityType.SEER_CODING_COMPLETED:
+        return t('Seer completed implementing a fix');
+      case GroupActivityType.SEER_PR_CREATED: {
+        const {data: prData} = activity;
+        if (prData.pull_requests?.length) {
+          const pr = prData.pull_requests[0]!;
+          return tct('Seer created a [link:pull request] in [repo]', {
+            link: <ExternalLink href={pr.pull_request.pr_url} />,
+            repo: pr.repo_name,
+          });
+        }
+        return t('Seer created a pull request');
+      }
       default:
         return ''; // should never hit (?)
     }

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
@@ -1,5 +1,6 @@
 import {CommitFixture} from 'sentry-fixture/commit';
 import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 import {UserFixture} from 'sentry-fixture/user';
@@ -440,5 +441,87 @@ describe('StreamlinedActivitySection', () => {
     render(<StreamlinedActivitySection group={referencedGroup} />);
     expect(await screen.findByText('Referenced in Commit')).toBeInTheDocument();
     expect(screen.getByText('f7f395d')).toBeInTheDocument();
+  });
+
+  it('renders Seer activity when feature flag is enabled', async () => {
+    const seerGroup = GroupFixture({
+      id: '1342',
+      activity: [
+        {
+          type: GroupActivityType.SEER_RCA_COMPLETED,
+          id: 'seer-rca-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {run_id: 123},
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    const org = OrganizationFixture({features: ['seer-activity-timeline']});
+
+    render(<StreamlinedActivitySection group={seerGroup} />, {organization: org});
+    expect(await screen.findByText('Root Cause Analysis')).toBeInTheDocument();
+    expect(screen.getByText('Seer completed root cause analysis')).toBeInTheDocument();
+  });
+
+  it('hides Seer activity when feature flag is disabled', () => {
+    const seerGroup = GroupFixture({
+      id: '1343',
+      activity: [
+        {
+          type: GroupActivityType.SEER_RCA_COMPLETED,
+          id: 'seer-rca-2',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {run_id: 123},
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(<StreamlinedActivitySection group={seerGroup} />);
+    expect(screen.queryByText('Root Cause Analysis')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Seer completed root cause analysis')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders Seer PR created activity with link', async () => {
+    const seerPrGroup = GroupFixture({
+      id: '1344',
+      activity: [
+        {
+          type: GroupActivityType.SEER_PR_CREATED,
+          id: 'seer-pr-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            run_id: 456,
+            pull_requests: [
+              {
+                provider: 'github',
+                pull_request: {
+                  pr_number: 42,
+                  pr_url: 'https://github.com/org/repo/pull/42',
+                },
+                repo_name: 'org/repo',
+              },
+            ],
+          },
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    const org = OrganizationFixture({features: ['seer-activity-timeline']});
+
+    render(<StreamlinedActivitySection group={seerPrGroup} />, {organization: org});
+    expect(await screen.findByText('Pull Request Created')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'pull request'})).toHaveAttribute(
+      'href',
+      'https://github.com/org/repo/pull/42'
+    );
+    expect(screen.getByText(/org\/repo/)).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -18,7 +18,7 @@ import {GroupStore} from 'sentry/stores/groupStore';
 import {textStyles} from 'sentry/styles/text';
 import type {NoteType} from 'sentry/types/alerts';
 import type {Group, GroupActivity, GroupActivityNote} from 'sentry/types/group';
-import {GroupActivityType} from 'sentry/types/group';
+import {GroupActivityType, SEER_ACTIVITY_TYPES} from 'sentry/types/group';
 import type {Team} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -250,6 +250,11 @@ export function StreamlinedActivitySection({
     },
   };
 
+  const showSeerActivities = organization.features.includes('seer-activity-timeline');
+  const visibleActivities = showSeerActivities
+    ? group.activity
+    : group.activity.filter(item => !SEER_ACTIVITY_TYPES.has(item.type));
+
   return isDrawer ? (
     <Timeline.Container>
       <NoteInputWithStorage
@@ -263,7 +268,7 @@ export function StreamlinedActivitySection({
         source="issue-details"
         {...noteProps}
       />
-      {group.activity
+      {visibleActivities
         .filter(item => !filterComments || item.type === GroupActivityType.NOTE)
         .map(item => {
           return (
@@ -300,8 +305,8 @@ export function StreamlinedActivitySection({
           source="issue-details"
           {...noteProps}
         />
-        {group.activity.length < 5 ? (
-          group.activity
+        {visibleActivities.length < 5 ? (
+          visibleActivities
             .filter(item => !filterComments || item.type === GroupActivityType.NOTE)
             .map(item => {
               return (
@@ -318,7 +323,7 @@ export function StreamlinedActivitySection({
             })
         ) : (
           <Fragment>
-            {group.activity.slice(0, 3).map(item => {
+            {visibleActivities.slice(0, 3).map(item => {
               return (
                 <TimelineItem
                   item={item}
@@ -342,10 +347,10 @@ export function StreamlinedActivitySection({
                   analyticsEventKey="issue_details.activity_expanded"
                   analyticsEventName="Issue Details: Activity Expanded"
                   analyticsParams={{
-                    num_activities_hidden: group.activity.length - 3,
+                    num_activities_hidden: visibleActivities.length - 3,
                   }}
                 >
-                  {t('View %s more', group.activity.length - 3)}
+                  {t('View %s more', visibleActivities.length - 3)}
                 </LinkButton>
               }
               icon={<RotatedEllipsisIcon direction="up" />}

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
@@ -138,13 +138,41 @@ export const groupActivityTypeIconMapping: Record<
     },
   },
   [GroupActivityType.DELETED_ATTACHMENT]: {Component: IconDelete, defaultProps: {}},
-  [GroupActivityType.SEER_RCA_STARTED]: {Component: IconSeer, defaultProps: {}},
-  [GroupActivityType.SEER_RCA_COMPLETED]: {Component: IconSeer, defaultProps: {}},
-  [GroupActivityType.SEER_SOLUTION_STARTED]: {Component: IconSeer, defaultProps: {}},
-  [GroupActivityType.SEER_SOLUTION_COMPLETED]: {Component: IconSeer, defaultProps: {}},
-  [GroupActivityType.SEER_CODING_STARTED]: {Component: IconSeer, defaultProps: {}},
-  [GroupActivityType.SEER_CODING_COMPLETED]: {Component: IconSeer, defaultProps: {}},
-  [GroupActivityType.SEER_PR_CREATED]: {Component: IconSeer, defaultProps: {}},
+  [GroupActivityType.SEER_RCA_STARTED]: {
+    Component: IconSeer,
+    defaultProps: {},
+    propsFunction: () => ({animation: 'waiting'}),
+  },
+  [GroupActivityType.SEER_RCA_COMPLETED]: {
+    Component: IconSeer,
+    defaultProps: {},
+    propsFunction: () => ({variant: 'success'}),
+  },
+  [GroupActivityType.SEER_SOLUTION_STARTED]: {
+    Component: IconSeer,
+    defaultProps: {},
+    propsFunction: () => ({animation: 'waiting'}),
+  },
+  [GroupActivityType.SEER_SOLUTION_COMPLETED]: {
+    Component: IconSeer,
+    defaultProps: {},
+    propsFunction: () => ({variant: 'success'}),
+  },
+  [GroupActivityType.SEER_CODING_STARTED]: {
+    Component: IconSeer,
+    defaultProps: {},
+    propsFunction: () => ({animation: 'waiting'}),
+  },
+  [GroupActivityType.SEER_CODING_COMPLETED]: {
+    Component: IconSeer,
+    defaultProps: {},
+    propsFunction: () => ({variant: 'success'}),
+  },
+  [GroupActivityType.SEER_PR_CREATED]: {
+    Component: IconSeer,
+    defaultProps: {},
+    propsFunction: () => ({variant: 'success'}),
+  },
 };
 
 const StyledUserAvatar = styled(UserAvatar)`

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
@@ -25,6 +25,7 @@ import {
   IconPlay,
   IconPrevious,
   IconRefresh,
+  IconSeer,
   IconUnsubscribed,
   IconUser,
 } from 'sentry/icons';
@@ -137,6 +138,13 @@ export const groupActivityTypeIconMapping: Record<
     },
   },
   [GroupActivityType.DELETED_ATTACHMENT]: {Component: IconDelete, defaultProps: {}},
+  [GroupActivityType.SEER_RCA_STARTED]: {Component: IconSeer, defaultProps: {}},
+  [GroupActivityType.SEER_RCA_COMPLETED]: {Component: IconSeer, defaultProps: {}},
+  [GroupActivityType.SEER_SOLUTION_STARTED]: {Component: IconSeer, defaultProps: {}},
+  [GroupActivityType.SEER_SOLUTION_COMPLETED]: {Component: IconSeer, defaultProps: {}},
+  [GroupActivityType.SEER_CODING_STARTED]: {Component: IconSeer, defaultProps: {}},
+  [GroupActivityType.SEER_CODING_COMPLETED]: {Component: IconSeer, defaultProps: {}},
+  [GroupActivityType.SEER_PR_CREATED]: {Component: IconSeer, defaultProps: {}},
 };
 
 const StyledUserAvatar = styled(UserAvatar)`

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
@@ -724,6 +724,53 @@ export function getGroupActivityItem(
           title: t('Attachment Deleted'),
           message: tct('by [author]', {author}),
         };
+      case GroupActivityType.SEER_RCA_STARTED:
+        return {
+          title: t('Root Cause Analysis'),
+          message: t('Seer started analyzing the root cause'),
+        };
+      case GroupActivityType.SEER_RCA_COMPLETED:
+        return {
+          title: t('Root Cause Analysis'),
+          message: t('Seer completed root cause analysis'),
+        };
+      case GroupActivityType.SEER_SOLUTION_STARTED:
+        return {
+          title: t('Solution'),
+          message: t('Seer started developing a solution'),
+        };
+      case GroupActivityType.SEER_SOLUTION_COMPLETED:
+        return {
+          title: t('Solution'),
+          message: t('Seer completed developing a solution'),
+        };
+      case GroupActivityType.SEER_CODING_STARTED:
+        return {
+          title: t('Autofix'),
+          message: t('Seer started implementing a fix'),
+        };
+      case GroupActivityType.SEER_CODING_COMPLETED:
+        return {
+          title: t('Autofix'),
+          message: t('Seer completed implementing a fix'),
+        };
+      case GroupActivityType.SEER_PR_CREATED: {
+        const {data: prData} = activity;
+        if (prData.pull_requests?.length) {
+          const pr = prData.pull_requests[0]!;
+          return {
+            title: t('Pull Request Created'),
+            message: tct('Seer created a [link:pull request] in [repo]', {
+              link: <ExternalLink href={pr.pull_request.pr_url} />,
+              repo: pr.repo_name,
+            }),
+          };
+        }
+        return {
+          title: t('Pull Request Created'),
+          message: t('Seer created a pull request'),
+        };
+      }
       default:
         return {title: '', message: ''}; // should never hit (?)
     }

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
@@ -756,8 +756,8 @@ export function getGroupActivityItem(
         };
       case GroupActivityType.SEER_PR_CREATED: {
         const {data: prData} = activity;
-        if (prData.pull_requests?.length) {
-          const pr = prData.pull_requests[0]!;
+        const pr = prData.pull_requests?.[0];
+        if (pr) {
           return {
             title: t('Pull Request Created'),
             message: tct('Seer created a [link:pull request] in [repo]', {


### PR DESCRIPTION
Resolves [ID-1527](https://linear.app/getsentry/issue/ID-1527/update-the-issue-details-ui-to-support-display-of-new-seer-actions).

Follow-up to https://github.com/getsentry/sentry/pull/115486.

Adds 7 new `GroupActivityType` enum values for Seer pipeline stages, to match the backend updates previously made in the above PR. These Seer actions are then rendered as part of issue activity in both the classic and streamlined issue detail views (using `IconSeer`).

Gated behind an organization-level feature flag for initial rollout: `organizations:seer-activity-timeline`.