### PR TITLE
Add evals devservices mode

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -108,6 +108,14 @@ x-sentry-service-config:
     # Taskworker services
     taskworker:
       description: Workers that process tasks from the taskbroker
+    taskworker-evals-ingest-errors:
+      description: Dedicated taskworker for eval error ingest tasks
+    taskworker-evals-ingest-errors-postprocess:
+      description: Dedicated taskworker for eval error post-processing tasks
+    taskworker-evals-issues:
+      description: Dedicated taskworker for eval issue-side tasks
+    taskworker-evals-relay:
+      description: Dedicated taskworker for eval Relay project config tasks
     taskworker-scheduler:
       description: Task scheduler that can spawn tasks based on their schedules
     # Kafka consumer services for event ingestion
@@ -257,6 +265,21 @@ x-sentry-service-config:
         post-process-forwarder-transactions,
         post-process-forwarder-issue-platform,
       ]
+    evals:
+      [
+        snuba,
+        postgres,
+        relay,
+        spotlight,
+        objectstore,
+        taskbroker,
+        taskworker-evals-relay,
+        taskworker-evals-ingest-errors,
+        taskworker-evals-ingest-errors-postprocess,
+        taskworker-evals-issues,
+        ingest-events,
+        post-process-forwarder-errors,
+      ]
     minimal: [postgres, snuba]
     # The minimal set of services Symbolicator needs to run
     # Sentry integration tests.
@@ -344,6 +367,14 @@ x-programs:
     command: sentry devserver
   taskworker:
     command: sentry run taskworker
+  taskworker-evals-ingest-errors:
+    command: sentry run taskworker --namespace ingest.errors --concurrency 2 --processing-pool-name eval-ingest-errors
+  taskworker-evals-ingest-errors-postprocess:
+    command: sentry run taskworker --namespace ingest.errors.postprocess --concurrency 1 --processing-pool-name eval-ingest-errors-postprocess
+  taskworker-evals-issues:
+    command: sentry run taskworker --namespace issues --concurrency 1 --processing-pool-name eval-issues
+  taskworker-evals-relay:
+    command: sentry run taskworker --namespace relay --concurrency 1 --processing-pool-name eval-relay
   taskworker-scheduler:
     command: sentry run taskworker-scheduler
   ingest-events:


### PR DESCRIPTION
## Summary

- add an `evals` devservices mode for local seeded eval ingestion
- keep the mode focused on error-event evals: Relay, Snuba/Postgres, objectstore, taskbroker, `ingest-events`, `post-process-forwarder-errors`, and dedicated taskworkers for `relay`, `ingest.errors`, `ingest.errors.postprocess`, and `issues`
- avoid using the broader `ingest` mode or a catch-all taskworker for this local eval path

## Why

Seeded Seer evals need enough of local Sentry ingestion to accept error events, save them, post-process them, and handle issue-side work such as auto source-code config. The existing `ingest` mode is broader than this path needs, while the generic taskworker can let slower issue-side work starve `ingest.errors` saves. This mode keeps that topology in Sentry devservices rather than in Seer helper scripts.

## Verification

- `git diff --check origin/master..HEAD`
- `.venv/bin/prek run -q check-yaml --files devservices/config.yml`
- devservices config loader check for `evals` mode and supervisor dependency types
- pre-push hooks
