### PR TITLE
fix(replays): Use Spans dataset when fetching contents of "Trace" tab

### DIFF
--- a/static/app/views/explore/replays/detail/trace/useReplayTraces.spec.tsx
+++ b/static/app/views/explore/replays/detail/trace/useReplayTraces.spec.tsx
@@ -25,14 +25,17 @@ describe('useTraceMeta', () => {
         data: [
           {
             trace: 'trace1',
-            'min(timestamp)': 1,
+            'min(precise.start_ts)': 1,
+            'max(precise.finish_ts)': 1.5,
           },
           {
             trace: 'trace2',
-            'min(timestamp)': 2,
+            'min(precise.start_ts)': 2,
+            'max(precise.finish_ts)': 2.5,
           },
         ],
       },
+      match: [MockApiClient.matchQuery({dataset: 'spans'})],
     });
 
     const {result} = renderHookWithProviders(() => useReplayTraces({replayRecord}));
@@ -59,6 +62,7 @@ describe('useTraceMeta', () => {
       headers: {Link: pageLinks},
       url: '/organizations/org-slug/events/',
       statusCode: 400,
+      match: [MockApiClient.matchQuery({dataset: 'spans'})],
     });
 
     const {result} = renderHookWithProviders(() => useReplayTraces({replayRecord}));

--- a/static/app/views/explore/replays/detail/trace/useReplayTraces.spec.tsx
+++ b/static/app/views/explore/replays/detail/trace/useReplayTraces.spec.tsx
@@ -26,12 +26,10 @@ describe('useTraceMeta', () => {
           {
             trace: 'trace1',
             'min(precise.start_ts)': 1,
-            'max(precise.finish_ts)': 1.5,
           },
           {
             trace: 'trace2',
             'min(precise.start_ts)': 2,
-            'max(precise.finish_ts)': 2.5,
           },
         ],
       },

--- a/static/app/views/explore/replays/detail/trace/useReplayTraces.tsx
+++ b/static/app/views/explore/replays/detail/trace/useReplayTraces.tsx
@@ -5,6 +5,7 @@ import {getTimeStampFromTableDateField, getUtcDateString} from 'sentry/utils/dat
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {EventView} from 'sentry/utils/discover/eventView';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {ParsedHeader} from 'sentry/utils/parseLinkHeader';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 import {useApi} from 'sentry/utils/useApi';
@@ -61,8 +62,8 @@ export function useReplayTraces({
     return EventView.fromSavedQuery({
       id: undefined,
       name: `Traces in replay ${replayId}`,
-      fields: ['trace', 'min(timestamp)', 'max(transaction.duration)'],
-      orderby: 'min_timestamp',
+      fields: ['trace', 'min(precise.start_ts)', 'max(precise.finish_ts)'],
+      orderby: 'min(precise.start_ts)',
       query: `replayId:${replayId}`,
       projects: [Number(projectId)],
       version: 2,
@@ -95,7 +96,8 @@ export function useReplayTraces({
           end,
           limit: 10,
         } as unknown as Location),
-        sort: ['min_timestamp'],
+        dataset: DiscoverDatasets.SPANS,
+        referrer: 'api.replays.replay-traces',
         cursor: cursor.cursor,
       };
 
@@ -109,10 +111,14 @@ export function useReplayTraces({
         const parsedData = data
           .filter(row => row.trace) // Filter out items where trace is not truthy
           .sort((a, b) => {
-            const aDuration = a['max(transaction.duration)'];
-            const bDuration = b['max(transaction.duration)'];
-            const aMinTimestamp = getTimeStampFromTableDateField(a['min(timestamp)']);
-            const bMinTimestamp = getTimeStampFromTableDateField(b['min(timestamp)']);
+            const aDuration = a['max(precise.finish_ts)'];
+            const bDuration = b['max(precise.finish_ts)'];
+            const aMinTimestamp = getTimeStampFromTableDateField(
+              a['min(precise.start_ts)']
+            );
+            const bMinTimestamp = getTimeStampFromTableDateField(
+              b['min(precise.start_ts)']
+            );
 
             if (
               !aMinTimestamp ||
@@ -132,7 +138,7 @@ export function useReplayTraces({
           })
           .map(row => ({
             traceSlug: row.trace!.toString(),
-            timestamp: getTimeStampFromTableDateField(row['min(timestamp)']),
+            timestamp: getTimeStampFromTableDateField(row['min(precise.start_ts)']),
           }));
 
         const pageLinks = listResp?.getResponseHeader('Link') ?? null;

--- a/static/app/views/explore/replays/detail/trace/useReplayTraces.tsx
+++ b/static/app/views/explore/replays/detail/trace/useReplayTraces.tsx
@@ -62,7 +62,7 @@ export function useReplayTraces({
     return EventView.fromSavedQuery({
       id: undefined,
       name: `Traces in replay ${replayId}`,
-      fields: ['trace', 'min(precise.start_ts)', 'max(precise.finish_ts)'],
+      fields: ['trace', 'min(precise.start_ts)'],
       orderby: 'min(precise.start_ts)',
       query: `replayId:${replayId}`,
       projects: [Number(projectId)],
@@ -111,8 +111,6 @@ export function useReplayTraces({
         const parsedData = data
           .filter(row => row.trace) // Filter out items where trace is not truthy
           .sort((a, b) => {
-            const aDuration = a['max(precise.finish_ts)'];
-            const bDuration = b['max(precise.finish_ts)'];
             const aMinTimestamp = getTimeStampFromTableDateField(
               a['min(precise.start_ts)']
             );
@@ -120,21 +118,11 @@ export function useReplayTraces({
               b['min(precise.start_ts)']
             );
 
-            if (
-              !aMinTimestamp ||
-              !bMinTimestamp ||
-              typeof aDuration !== 'number' ||
-              typeof bDuration !== 'number'
-            ) {
+            if (!aMinTimestamp || !bMinTimestamp) {
               return 0;
             }
 
-            // We don't have a way to get the min start time of a trace, so we'll use the min timestamp and subtract the max duration
-            // of a transaction in that trace, to make the best guess.
-            const aMinStart = aMinTimestamp - aDuration / 1000;
-            const bMinStart = bMinTimestamp - bDuration / 1000;
-
-            return aMinStart - bMinStart;
+            return aMinTimestamp - bMinTimestamp;
           })
           .map(row => ({
             traceSlug: row.trace!.toString(),

--- a/static/app/views/explore/replays/detail/trace/useReplayTraces.tsx
+++ b/static/app/views/explore/replays/detail/trace/useReplayTraces.tsx
@@ -63,7 +63,7 @@ export function useReplayTraces({
       id: undefined,
       name: `Traces in replay ${replayId}`,
       fields: ['trace', 'min(precise.start_ts)'],
-      orderby: 'min(precise.start_ts)',
+      orderby: 'min_precise_start_ts',
       query: `replayId:${replayId}`,
       projects: [Number(projectId)],
       version: 2,


### PR DESCRIPTION
The SDK team found in REPLAY-915 that the "Trace" tab of a Replay never loads anything when a streaming SDK is used. This is because that tab us implicitly using the "Discover" (i.e., Transactions) dataset, and the transaction dataset fields.

This PR updates the fetch request to use the "spans" dataset. That dataset doesn't support the `min()` function on the `timestamp` field nor the `max()` function on the `transaction.duration` field, so I updated them both to use the precise timestamp field instead. That also makes the hack that subtracts the duration from the timestamp irrelevant, since we can explicitly ask for min start and max finish.

Closes REPLAY-915.
