### PR TITLE
chore(issues): Remove stray `use_flagpole_for_all_features` usage

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -379,7 +379,6 @@ class PerformanceRenderBlockingAssetSpanGroupType(GroupType):
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = True
-    use_flagpole_for_all_features = True
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The last use of the `use_flagpole_for_all_features` flag on group types was removed [a year ago](https://github.com/getsentry/sentry/pull/89451), but we missed cleaning up one spot where we set it. This does so.