### PR TITLE
fix(dashboards): Use span.op for MCP pre-built dashboard filters

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpOverview.ts
@@ -6,7 +6,7 @@ import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfig
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
-const MCP_SERVER_FILTER = `${SpanFields.NAME}:mcp.server`;
+const MCP_SERVER_FILTER = `${SpanFields.SPAN_OP}:mcp.server`;
 const MCP_TOOL_FILTER = `${MCP_SERVER_FILTER} has:${SpanFields.MCP_TOOL_NAME}`;
 const MCP_RESOURCE_FILTER = `${MCP_SERVER_FILTER} has:${SpanFields.MCP_RESOURCE_URI}`;
 const MCP_PROMPT_FILTER = `${MCP_SERVER_FILTER} has:${SpanFields.MCP_PROMPT_NAME}`;

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpPrompts.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpPrompts.ts
@@ -7,7 +7,7 @@ import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfig
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
-const MCP_PROMPT_FILTER = `${SpanFields.NAME}:mcp.server has:${SpanFields.MCP_PROMPT_NAME}`;
+const MCP_PROMPT_FILTER = `${SpanFields.SPAN_OP}:mcp.server has:${SpanFields.MCP_PROMPT_NAME}`;
 
 const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpResources.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpResources.ts
@@ -7,7 +7,7 @@ import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfig
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
-const MCP_RESOURCE_FILTER = `${SpanFields.NAME}:mcp.server has:${SpanFields.MCP_RESOURCE_URI}`;
+const MCP_RESOURCE_FILTER = `${SpanFields.SPAN_OP}:mcp.server has:${SpanFields.MCP_RESOURCE_URI}`;
 
 const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpTools.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpTools.ts
@@ -7,7 +7,7 @@ import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfig
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
-const MCP_TOOL_FILTER = `${SpanFields.NAME}:mcp.server has:${SpanFields.MCP_TOOL_NAME}`;
+const MCP_TOOL_FILTER = `${SpanFields.SPAN_OP}:mcp.server has:${SpanFields.MCP_TOOL_NAME}`;
 
 const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/5961 correctly (but unexpectedly) changed the `name` attribute for MCP spans, which caused our pre-built dashboards to stop loading data, because the `span.name:mcp.server` filter is no longer valid. Instead, we need to use `span.op` which is less semantic but is actually correct!

I also have a migration to repair existing widgets, there are only ~100: https://github.com/getsentry/sentry/pull/115543

References [DAIN-1673](https://linear.app/getsentry/issue/DAIN-1673/mcp-pre-built-dashboards-use-incorrect-filters).