### PR TITLE
feat(seer): Pass api.web referrer from autofix UI

### DIFF
--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -257,6 +257,7 @@ export const useAiAutofix = (
             data: {
               event_id: event.id,
               instruction,
+              referrer: 'api.web',
               ...(stoppingPoint && {stopping_point: stoppingPoint}),
             },
           }

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -420,7 +420,7 @@ describe('useExplorerAutofix - createPR', () => {
       expect.objectContaining({
         method: 'POST',
         query: {mode: 'explorer'},
-        data: {step: 'open_pr', run_id: 42},
+        data: {step: 'open_pr', run_id: 42, referrer: 'api.web'},
       })
     );
   });
@@ -441,7 +441,7 @@ describe('useExplorerAutofix - createPR', () => {
       expect.objectContaining({
         method: 'POST',
         query: {mode: 'explorer'},
-        data: {step: 'open_pr', run_id: 42, repo_name: 'org/repo'},
+        data: {step: 'open_pr', run_id: 42, repo_name: 'org/repo', referrer: 'api.web'},
       })
     );
   });

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -580,7 +580,7 @@ export function useExplorerAutofix(
       setWaitingForResponse(true);
 
       try {
-        const data: Record<string, any> = {step};
+        const data: Record<string, any> = {step, referrer: 'api.web'};
 
         if (defined(startStepOptions?.insertIndex)) {
           data.insert_index = startStepOptions.insertIndex;
@@ -640,6 +640,7 @@ export function useExplorerAutofix(
         const data: Record<string, any> = {
           step: 'open_pr',
           run_id: runId,
+          referrer: 'api.web',
         };
         if (repoName) {
           data.repo_name = repoName;
@@ -699,6 +700,7 @@ export function useExplorerAutofix(
       const data: Record<string, string | number> = {
         step: 'coding_agent_handoff',
         run_id: runId,
+        referrer: 'api.web',
       };
 
       if (integration.id === null) {


### PR DESCRIPTION
Pass `referrer: 'api.web'` from the four `GroupAutofixEndpoint` POSTs in the
legacy and explorer autofix UI hooks (`useAutofix`, `useExplorerAutofix`) so
issue fixes triggered from the web app are attributed to the `WEB` surface in
downstream analytics, metrics tags, and the Seer service.

Builds on:
- #115497 — adds the `referrer` input on `GroupAutofixEndpoint`
- #115514 — registers the `WEB = "api.web"` value on `AutofixReferrer`

Agent transcript: https://claudescope.sentry.dev/share/l5rQSNZ5nBbr5HdRzfGMvxTvj5EutRNnDKB7PB6FZ3Y