### PR TITLE
fix(ourlogs): use `replaceMerge` for time series visualization axes

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -246,6 +246,7 @@ export interface BaseChartProps {
    * See: https://ecomfe.github.io/echarts-doc/public/en/tutorial.html#Render%20by%20Canvas%20or%20SVG
    */
   renderer?: ReactEChartOpts['renderer'];
+  replaceMerge?: string[];
   /**
    * Chart Series
    * This is different than the interface to higher level charts, these need to
@@ -388,6 +389,7 @@ export function BaseChart({
   width,
   renderer = 'svg',
   notMerge = true,
+  replaceMerge,
   lazyUpdate = false,
   isGroupedByDate = false,
   transformSinglePointToBar = false,
@@ -690,6 +692,7 @@ export function BaseChart({
         ref={ref}
         echarts={echarts}
         notMerge={notMerge}
+        replaceMerge={replaceMerge}
         lazyUpdate={lazyUpdate}
         theme={echartsTheme ?? 'v5'}
         onChartReady={onChartReady}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -31,7 +31,6 @@ import type {
   ReactEchartsRef,
 } from 'sentry/types/echarts';
 import {defined, escape} from 'sentry/utils';
-import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {RangeMap, type Range} from 'sentry/utils/number/rangeMap';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -163,13 +162,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const pageFilters = usePageFilters();
   const {start, end, period, utc} =
     props.pageFilters?.datetime || pageFilters.selection.datetime;
-
-  const xAxisMin = start
-    ? new Date(start).getTime()
-    : period
-      ? Date.now() - parsePeriodToHours(period) * 60 * 60 * 1000
-      : undefined;
-  const xAxisMax = end ? new Date(end).getTime() : period ? Date.now() : undefined;
 
   const theme = useTheme();
   const navigate = useNavigate();
@@ -449,8 +441,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           },
         },
         splitNumber: 5,
-        ...(xAxisMin && {min: xAxisMin}),
-        ...(xAxisMax && {max: xAxisMax}),
         ...releaseBubbleXAxis,
       }
     : HIDDEN_AXIS;
@@ -624,6 +614,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           ref={mergeRefs(props.ref, props.chartRef, chartRef, handleChartRef)}
           autoHeightResize
           notMerge={props.notMerge}
+          replaceMerge={['xAxis', 'yAxis']}
           series={allSeries}
           grid={{
             // NOTE: Adding a few pixels of left padding prevents ECharts from

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -31,6 +31,7 @@ import type {
   ReactEchartsRef,
 } from 'sentry/types/echarts';
 import {defined, escape} from 'sentry/utils';
+import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {RangeMap, type Range} from 'sentry/utils/number/rangeMap';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -162,6 +163,13 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const pageFilters = usePageFilters();
   const {start, end, period, utc} =
     props.pageFilters?.datetime || pageFilters.selection.datetime;
+
+  const xAxisMin = start
+    ? new Date(start).getTime()
+    : period
+      ? Date.now() - parsePeriodToHours(period) * 60 * 60 * 1000
+      : undefined;
+  const xAxisMax = end ? new Date(end).getTime() : period ? Date.now() : undefined;
 
   const theme = useTheme();
   const navigate = useNavigate();
@@ -441,6 +449,8 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           },
         },
         splitNumber: 5,
+        ...(xAxisMin && {min: xAxisMin}),
+        ...(xAxisMax && {max: xAxisMax}),
         ...releaseBubbleXAxis,
       }
     : HIDDEN_AXIS;


### PR DESCRIPTION
#113434 made merging more automatic/seamless for the time series charts by disabling `notMerge`. Unfortunately, a side effect of that was ECharts auto-computing the x-axis range from combined (merged) series data. Going from a large range like 24h to a small one like 1h kept the 24h range in the x-axis.

This uses [EChart's `replaceMerge`](https://echarts.apache.org/en/api.html#%2Fsearch%2FreplaceMerge:~:text=replaceMerge%20Optional) (shoutout @k-fish for pointing me there) to recompute on x-axis and y-axis changes.

Aside: in the initial investigation I spent 15 minutes poking through code while Claude investigated. I didn't figure it out, but Claude did. rip.

Fixes LOGS-802.