### PR TITLE
fix(cells) Move metric collection for outbox backfill

### DIFF
--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -64,12 +64,6 @@ def get_processing_state(table_name: str) -> tuple[int, int]:
         if not (isinstance(lower, int) and isinstance(version, int)):
             raise TypeError("Expected processing data to be a tuple of (int, int)")
         result = lower, version
-    metrics.gauge(
-        "backfill_outboxes.low_bound",
-        result[0],
-        tags=dict(table_name=table_name, version=result[1]),
-        sample_rate=1.0,
-    )
     return result
 
 
@@ -122,6 +116,12 @@ def _chunk_processing_batch(
         .order_by("id")[: batch_size + 1]
         .aggregate(Max("id"))["id__max"]
         or 0
+    )
+    metrics.gauge(
+        "backfill_outboxes.low_bound",
+        lower,
+        tags=dict(table_name=model._meta.db_table, version=version),
+        sample_rate=1.0,
     )
 
     return BackfillBatch(low=lower, up=upper, version=version, has_more=upper > lower)


### PR DESCRIPTION
In one of our production cells, this metric is continually emit for the Team model despite all the backfills on it being complete. My current theory is that we are able to load the backfill state in redis, but the version recorded in redis is higher than the model/option so _chunk_processing_batch returns None, but the metric has already been collected.

With the metric in its new location we'll only collect the metric if a backfill is going to make progress.