### PR TITLE
fix(trace-meta): Fix types for EAP Trace Meta

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceApi/types.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/types.tsx
@@ -119,13 +119,12 @@ export type EAPTraceMeta = {
   spansCount: number;
   spansCountMap: Record<string, number>;
   transactionChildCountMap: Record<string, number>;
-  transactionsCount: number;
   uptimeCount: number;
 };
 
 type ResponseEAPTraceMetaTransactionChildCount = {
   'count()': number;
-  'transaction.event_id': string;
+  'transaction.event_id': string | null;
 };
 
 export type ResponseEAPTraceMeta = {
@@ -136,6 +135,5 @@ export type ResponseEAPTraceMeta = {
   spansCount: number;
   spansCountMap: Record<string, number>;
   transactionChildCountMap: ResponseEAPTraceMetaTransactionChildCount[];
-  transactionsCount: number;
-  uptimeCount: number;
+  uptimeCount?: number;
 };

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -142,8 +142,7 @@ describe('useTraceMeta', () => {
         spansCountMap: {
           op1: 1,
         },
-        transactionChildCountMap: {'1': 1},
-        transactionsCount: 1,
+        transactionChildCountMap: [{'transaction.event_id': '1', 'count()': 1}],
         uptimeCount: 0,
       },
     });
@@ -160,8 +159,7 @@ describe('useTraceMeta', () => {
           op1: 1,
           op2: 1,
         },
-        transactionChildCountMap: {'2': 2},
-        transactionsCount: 1,
+        transactionChildCountMap: [{'transaction.event_id': '2', 'count()': 2}],
         uptimeCount: 0,
       },
     });
@@ -177,8 +175,7 @@ describe('useTraceMeta', () => {
         spansCountMap: {
           op3: 1,
         },
-        transactionChildCountMap: {'3': 1},
-        transactionsCount: 1,
+        transactionChildCountMap: [{'transaction.event_id': '3', 'count()': 1}],
         uptimeCount: 1,
       },
     });
@@ -214,7 +211,6 @@ describe('useTraceMeta', () => {
           '2': 2,
           '3': 1,
         },
-        transactionsCount: 3,
         uptimeCount: 1,
       },
       errors: [],
@@ -288,8 +284,7 @@ describe('useTraceMeta', () => {
       performanceIssuesCount: 0,
       spansCount: 0,
       spansCountMap: {},
-      transactionChildCountMap: {},
-      transactionsCount: 0,
+      transactionChildCountMap: [],
       uptimeCount: 0,
     };
 
@@ -313,8 +308,7 @@ describe('useTraceMeta', () => {
       performanceIssuesCount: 1,
       spansCount: 1,
       spansCountMap: {op1: 1},
-      transactionChildCountMap: {tx1: 1},
-      transactionsCount: 1,
+      transactionChildCountMap: [{'transaction.event_id': 'tx1', 'count()': 1}],
       uptimeCount: 0,
     };
 
@@ -364,8 +358,7 @@ describe('useTraceMeta', () => {
         performanceIssuesCount: 1,
         spansCount: 1,
         spansCountMap: {op1: 1},
-        transactionChildCountMap: {},
-        transactionsCount: 1,
+        transactionChildCountMap: [],
         uptimeCount: 0,
       },
     });
@@ -381,8 +374,7 @@ describe('useTraceMeta', () => {
         performanceIssuesCount: 2,
         spansCount: 2,
         spansCountMap: {},
-        transactionChildCountMap: {},
-        transactionsCount: 2,
+        transactionChildCountMap: [],
         uptimeCount: 0,
       },
     });
@@ -413,8 +405,7 @@ describe('useTraceMeta', () => {
         performanceIssuesCount: 0,
         spansCount: 0,
         spansCountMap: {},
-        transactionChildCountMap: {},
-        transactionsCount: 0,
+        transactionChildCountMap: [],
         uptimeCount: 0,
       },
     });
@@ -430,8 +421,7 @@ describe('useTraceMeta', () => {
         performanceIssuesCount: 1,
         spansCount: 1,
         spansCountMap: {},
-        transactionChildCountMap: {},
-        transactionsCount: 1,
+        transactionChildCountMap: [],
         uptimeCount: 0,
       },
     });

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -219,6 +219,57 @@ describe('useTraceMeta', () => {
     });
   });
 
+  it('EAP - accepts trace meta without transactionsCount', async () => {
+    const org = OrganizationFixture({
+      features: ['trace-spans-format'],
+    });
+    const trace = {traceSlug: 'slug-without-transactions-count', timestamp: 1};
+
+    jest.mocked(useSyncedLocalStorageState).mockReturnValue(['eap', jest.fn()]);
+
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/trace-meta/slug-without-transactions-count/',
+      body: {
+        errorsCount: 0,
+        logsCount: 5,
+        metricsCount: 1,
+        performanceIssuesCount: 0,
+        spansCount: 529,
+        transactionChildCountMap: [
+          {'transaction.event_id': '2b6107aa9d5f49c7a100babc02e903a0', 'count()': 62},
+          {'transaction.event_id': null, 'count()': 1},
+        ],
+        spansCountMap: {
+          processor: 113,
+        },
+        uptimeCount: 0,
+      },
+    });
+
+    const {result} = renderHookWithProviders(useTraceMeta, {
+      organization: org,
+      initialProps: [trace],
+    });
+
+    await waitFor(() => expect(result.current.status === 'success').toBe(true));
+
+    expect(result.current.data).toEqual({
+      errorsCount: 0,
+      logsCount: 5,
+      metricsCount: 1,
+      performanceIssuesCount: 0,
+      spansCount: 529,
+      spansCountMap: {
+        processor: 113,
+      },
+      transactionChildCountMap: {
+        '2b6107aa9d5f49c7a100babc02e903a0': 62,
+      },
+      uptimeCount: 0,
+    });
+  });
+
   it('Collects errors from rejected api calls', async () => {
     const mockRequest1 = MockApiClient.addMockResponse({
       method: 'GET',

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -77,7 +77,7 @@ function isEAPTraceMeta(meta: MetaArg): meta is EAPTraceMeta {
 
 function isResponseEAPTraceMeta(meta: ResponseMetaArg): meta is ResponseEAPTraceMeta {
   if (!meta) return false;
-  return 'transactionsCount' in meta;
+  return 'spansCount' in meta;
 }
 
 export function getTraceMetaErrorCount(meta: MetaArg) {
@@ -128,6 +128,10 @@ function mergeTransactionChildCountMap(
         'transaction.id' in row ? row['transaction.id'] : row['transaction.event_id'];
       const count = 'count' in row ? row.count : row['count()'];
 
+      if (!id) {
+        return;
+      }
+
       acc[id] = (acc[id] ?? 0) + count;
     });
     return;
@@ -156,7 +160,6 @@ async function fetchTraceMetaInBatches(
           spansCount: 0,
           spansCountMap: {},
           transactionChildCountMap: {},
-          transactionsCount: 0,
           uptimeCount: 0,
         }
       : {
@@ -213,8 +216,7 @@ async function fetchTraceMetaInBatches(
           acc.metricsCount += result.value.metricsCount;
           acc.performanceIssuesCount += result.value.performanceIssuesCount;
           acc.spansCount += result.value.spansCount;
-          acc.transactionsCount += result.value.transactionsCount;
-          acc.uptimeCount += result.value.uptimeCount;
+          acc.uptimeCount += result.value.uptimeCount ?? 0;
           mergeCountMap(acc.spansCountMap, result.value.spansCountMap);
           mergeTransactionChildCountMap(
             acc.transactionChildCountMap,
@@ -335,7 +337,6 @@ export function useTraceMeta(options: UseTraceMetaOptions): TraceMetaQueryResult
             spansCount: 0,
             spansCountMap: {},
             transactionChildCountMap: {},
-            transactionsCount: 0,
             uptimeCount: 0,
           }
         : {


### PR DESCRIPTION
There was a small regression added in #115179, where the types didn't align properly causing an issue of meta counts to be zero.

This PR resolves it by re-aligning the types so that they get properly counted.