### PR TITLE
devservices: add eval taskworker offset reset target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ install-py-dev :
 devenv-sync:
 	devenv sync
 
+.PHONY: devservices-evals-reset-taskworker-offset
+devservices-evals-reset-taskworker-offset:
+	@./scripts/devservices/reset-evals-taskworker-offset.sh
+
 build-js-po:
 	mkdir -p build
 	pnpm run build-js-po

--- a/scripts/devservices/reset-evals-taskworker-offset.sh
+++ b/scripts/devservices/reset-evals-taskworker-offset.sh
@@ -43,7 +43,7 @@ taskbroker_was_running=0
 if docker ps --format '{{.Names}}' | grep -qx "$TASKBROKER_CONTAINER"; then
   taskbroker_was_running=1
   echo "Clearing $TASKBROKER_CONTAINER inflight task store..."
-  docker exec "$TASKBROKER_CONTAINER" rm -f "$TASKBROKER_INFLIGHT_DB" "$TASKBROKER_INFLIGHT_DB"-* >/dev/null
+  docker exec "$TASKBROKER_CONTAINER" sh -c 'rm -f "$1" "$1"-*' sh "$TASKBROKER_INFLIGHT_DB" >/dev/null
   echo "Stopping $TASKBROKER_CONTAINER so Kafka will allow a consumer-group reset..."
   docker stop --time 10 "$TASKBROKER_CONTAINER" >/dev/null
 fi
@@ -63,8 +63,10 @@ restart_eval_taskworkers() {
 }
 
 cleanup() {
-  restart_taskbroker
-  restart_eval_taskworkers
+  local status=0
+  restart_taskbroker || status=$?
+  restart_eval_taskworkers || status=$?
+  return "$status"
 }
 trap cleanup EXIT
 
@@ -77,7 +79,11 @@ docker exec "$KAFKA_CONTAINER" kafka-consumer-groups \
   --to-latest \
   --execute
 
-trap - EXIT
-restart_taskbroker
-restart_eval_taskworkers
+if cleanup; then
+  trap - EXIT
+else
+  cleanup_status=$?
+  trap - EXIT
+  exit "$cleanup_status"
+fi
 echo "Local eval taskworker offset is clean."

--- a/scripts/devservices/reset-evals-taskworker-offset.sh
+++ b/scripts/devservices/reset-evals-taskworker-offset.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly KAFKA_CONTAINER="${KAFKA_CONTAINER:-kafka-kafka-1}"
+readonly TASKBROKER_CONTAINER="${TASKBROKER_CONTAINER:-taskbroker-taskbroker-1}"
+readonly TASKWORKER_GROUP="${TASKWORKER_GROUP:-taskworker}"
+readonly TASKWORKER_TOPIC="${TASKWORKER_TOPIC:-taskworker}"
+readonly SUPERVISOR_CONFIG="${SUPERVISOR_CONFIG:-$HOME/.local/share/sentry-devservices/supervisor/sentry.processes.conf}"
+readonly TASKBROKER_INFLIGHT_DB="${TASKBROKER_INFLIGHT_DB:-/opt/taskbroker-inflight.sqlite}"
+
+EVAL_TASKWORKERS=(
+  taskworker-evals-relay
+  taskworker-evals-ingest-errors
+  taskworker-evals-ingest-errors-postprocess
+  taskworker-evals-issues
+)
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required to reset the local taskworker offset." >&2
+  exit 1
+fi
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$KAFKA_CONTAINER"; then
+  echo "Kafka container '$KAFKA_CONTAINER' is not running. Start local devservices first." >&2
+  exit 1
+fi
+
+running_eval_taskworkers=()
+if [[ -f "$SUPERVISOR_CONFIG" ]]; then
+  for taskworker in "${EVAL_TASKWORKERS[@]}"; do
+    if supervisorctl -c "$SUPERVISOR_CONFIG" status "$taskworker" 2>/dev/null | grep -q RUNNING; then
+      running_eval_taskworkers+=("$taskworker")
+    fi
+  done
+fi
+
+if [[ "${#running_eval_taskworkers[@]}" -gt 0 ]]; then
+  echo "Stopping eval taskworkers so they reconnect after taskbroker restarts..."
+  supervisorctl -c "$SUPERVISOR_CONFIG" stop "${running_eval_taskworkers[@]}" >/dev/null
+fi
+
+taskbroker_was_running=0
+if docker ps --format '{{.Names}}' | grep -qx "$TASKBROKER_CONTAINER"; then
+  taskbroker_was_running=1
+  echo "Clearing $TASKBROKER_CONTAINER inflight task store..."
+  docker exec "$TASKBROKER_CONTAINER" rm -f "$TASKBROKER_INFLIGHT_DB" "$TASKBROKER_INFLIGHT_DB"-* >/dev/null
+  echo "Stopping $TASKBROKER_CONTAINER so Kafka will allow a consumer-group reset..."
+  docker stop --time 10 "$TASKBROKER_CONTAINER" >/dev/null
+fi
+
+restart_taskbroker() {
+  if [[ "$taskbroker_was_running" == "1" ]]; then
+    echo "Restarting $TASKBROKER_CONTAINER..."
+    docker start "$TASKBROKER_CONTAINER" >/dev/null
+  fi
+}
+
+restart_eval_taskworkers() {
+  if [[ "${#running_eval_taskworkers[@]}" -gt 0 ]]; then
+    echo "Restarting eval taskworkers..."
+    supervisorctl -c "$SUPERVISOR_CONFIG" start "${running_eval_taskworkers[@]}" >/dev/null
+  fi
+}
+
+cleanup() {
+  restart_taskbroker
+  restart_eval_taskworkers
+}
+trap cleanup EXIT
+
+echo "Resetting consumer group '$TASKWORKER_GROUP' on topic '$TASKWORKER_TOPIC' to latest..."
+docker exec "$KAFKA_CONTAINER" kafka-consumer-groups \
+  --bootstrap-server localhost:9092 \
+  --group "$TASKWORKER_GROUP" \
+  --topic "$TASKWORKER_TOPIC" \
+  --reset-offsets \
+  --to-latest \
+  --execute
+
+trap - EXIT
+restart_taskbroker
+restart_eval_taskworkers
+echo "Local eval taskworker offset is clean."


### PR DESCRIPTION
## Summary
- add `make devservices-evals-reset-taskworker-offset` for local seeded eval runs
- reset the local taskworker Kafka consumer group to latest after stopping taskbroker
- clear taskbroker's local inflight store and restart eval taskworkers/taskbroker that were running

While debugging slow evals it was noticed sometimes the queues can get backlogged from old runs. this command helps us reset the queues before kicking off a fresh eval run


## Verification
- `bash -n scripts/devservices/reset-evals-taskworker-offset.sh`
- `make -n devservices-evals-reset-taskworker-offset`
