### PR TITLE
fix(issue-detection): Remove 200-char subtitle truncation for AI-detected issues

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -215,7 +215,7 @@ def create_issue_occurrence_from_detection(
         issue_title=(
             FALLBACK_ISSUE_TITLE if detected_issue.title == "Other" else detected_issue.title
         ),
-        subtitle=detected_issue.explanation[:200],  # Truncate for subtitle
+        subtitle=detected_issue.explanation,
         resource_id=None,
         evidence_data=evidence_data,
         evidence_display=evidence_display,


### PR DESCRIPTION
Remove the `[:200]` hard slice on `detected_issue.explanation` when setting the issue subtitle - the LLM detection prompt already constrains explanations to 40 words, making the truncation redundant. 