### PR TITLE
fix(seer): Restore automated Explorer handoffs

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -397,6 +397,8 @@ def run_automation(
     if source == SeerAutomationSource.ISSUE_DETAILS:
         return
 
+    is_seat_based_tier = is_seer_seat_based_tier_enabled(group.organization)
+
     user_id = user.id if user else None
     auto_run_source = auto_run_source_map.get(source, "unknown_source")
     referrer = referrer_map.get(source, AutofixReferrer.UNKNOWN)
@@ -424,7 +426,7 @@ def run_automation(
         return
 
     stopping_point = None
-    if is_seer_seat_based_tier_enabled(group.organization):
+    if is_seat_based_tier or features.has("organizations:autofix-on-explorer", group.organization):
         stopping_point = get_automation_stopping_point(group)
 
     _trigger_autofix_task.delay(

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -320,12 +320,6 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             )
             return
 
-        # Check if we've reached the stopping point
-        stopping_step = STOPPING_POINT_TO_STEP.get(stopping_point)
-        if stopping_step and current_step == stopping_step:
-            # We've reached the stopping point
-            return
-
         # Check if we should trigger coding agent handoff instead of continuing
         handoff_config = cls._get_handoff_config_if_applicable(stopping_point, current_step, group)
         if handoff_config:
@@ -336,6 +330,12 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 handoff_config,
                 referrer or AutofixReferrer.ON_COMPLETION_HOOK,
             )
+            return
+
+        # Check if we've reached the stopping point
+        stopping_step = STOPPING_POINT_TO_STEP.get(stopping_point)
+        if stopping_step and current_step == stopping_step:
+            # We've reached the stopping point
             return
 
         # Special case: if stopping_point is open_pr and we just finished code_changes, push changes
@@ -450,19 +450,10 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
 
         Handoff is triggered when:
         - current_step is ROOT_CAUSE
-        - stopping_point is SOLUTION, CODE_CHANGES, or OPEN_PR
         - automation_handoff is configured with handoff_point = ROOT_CAUSE
         """
         # Only trigger handoff after root cause is completed
         if current_step != AutofixStep.ROOT_CAUSE:
-            return None
-
-        # Only trigger handoff when continuing beyond root cause
-        if stopping_point not in [
-            AutofixStoppingPoint.SOLUTION,
-            AutofixStoppingPoint.CODE_CHANGES,
-            AutofixStoppingPoint.OPEN_PR,
-        ]:
             return None
 
         return read_preference_from_sentry_db(group.project).automation_handoff

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -463,19 +463,17 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
         assert result is None
         mock_read_pref.assert_not_called()
 
-    @patch("sentry.seer.autofix.on_completion_hook.read_preference_from_sentry_db")
-    def test_get_handoff_config_returns_none_when_stopping_at_root_cause(
-        self, mock_read_pref
-    ) -> None:
-        """Returns None without reading preferences when stopping point is ROOT_CAUSE."""
+    def test_get_handoff_config_returns_config_when_stopping_at_root_cause(self) -> None:
+        """Returns handoff config even when root cause is the stopping point."""
+        expected_handoff_config = self._make_handoff_config()
+
         result = AutofixOnCompletionHook._get_handoff_config_if_applicable(
             stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
             current_step=AutofixStep.ROOT_CAUSE,
             group=self.group,
         )
 
-        assert result is None
-        mock_read_pref.assert_not_called()
+        assert result == expected_handoff_config
 
     def test_get_handoff_config_returns_none_when_no_handoff_configured(self) -> None:
         """Returns None when project has no automation handoff configured."""
@@ -499,8 +497,11 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
 
         assert result == expected_handoff_config
 
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_autofix_agent")
     @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
-    def test_maybe_continue_pipeline_triggers_handoff_when_configured(self, mock_trigger_handoff):
+    def test_maybe_continue_pipeline_triggers_handoff_when_configured(
+        self, mock_trigger_handoff, mock_trigger_autofix
+    ):
         """Triggers handoff instead of continuing pipeline when handoff is configured."""
         self._make_handoff_config()
         mock_trigger_handoff.return_value = {"successes": [], "failures": []}
@@ -520,10 +521,81 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
         AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
 
         mock_trigger_handoff.assert_called_once()
+        call_kwargs = mock_trigger_handoff.call_args.kwargs
+        assert call_kwargs["group"] == self.group
+        assert call_kwargs["run_id"] == 123
+        assert call_kwargs["integration_id"] == 123
         assert (
-            mock_trigger_handoff.call_args.kwargs["referrer"]
-            == AutofixReferrer.ISSUE_SUMMARY_POST_PROCESS_FIXABILITY
+            call_kwargs["referrer"] == AutofixReferrer.ISSUE_SUMMARY_POST_PROCESS_FIXABILITY
         )
+        mock_trigger_autofix.assert_not_called()
+
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_autofix_agent")
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
+    def test_maybe_continue_pipeline_triggers_handoff_when_stopping_at_root_cause(
+        self, mock_trigger_handoff, mock_trigger_autofix
+    ):
+        """Triggers configured root-cause handoff before treating root cause as terminal."""
+        self._make_handoff_config()
+        mock_trigger_handoff.return_value = {"successes": [], "failures": []}
+
+        state = run_state(
+            blocks=[root_cause_memory_block()],
+            metadata={
+                "group_id": self.group.id,
+                "stopping_point": AutofixStoppingPoint.ROOT_CAUSE.value,
+            },
+        )
+
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+
+        mock_trigger_handoff.assert_called_once()
+        call_kwargs = mock_trigger_handoff.call_args.kwargs
+        assert call_kwargs["group"] == self.group
+        assert call_kwargs["run_id"] == 123
+        assert call_kwargs["integration_id"] == 123
+        assert call_kwargs["referrer"] == AutofixReferrer.ON_COMPLETION_HOOK
+        mock_trigger_autofix.assert_not_called()
+
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_autofix_agent")
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
+    def test_maybe_continue_pipeline_continues_when_handoff_not_configured(
+        self, mock_trigger_handoff, mock_trigger_autofix
+    ):
+        """Continues to solution when no automation handoff is configured."""
+        state = run_state(
+            blocks=[root_cause_memory_block()],
+            metadata={
+                "group_id": self.group.id,
+                "stopping_point": AutofixStoppingPoint.CODE_CHANGES.value,
+            },
+        )
+
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+
+        mock_trigger_handoff.assert_not_called()
+        mock_trigger_autofix.assert_called_once()
+        call_kwargs = mock_trigger_autofix.call_args.kwargs
+        assert call_kwargs["group"] == self.group
+        assert call_kwargs["step"] == AutofixStep.SOLUTION
+        assert call_kwargs["run_id"] == 123
+
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_autofix_agent")
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
+    def test_maybe_continue_pipeline_missing_stopping_point_skips_configured_handoff(
+        self, mock_trigger_handoff, mock_trigger_autofix
+    ):
+        """Does not trigger handoff without stopping_point metadata, even when configured."""
+        self._make_handoff_config()
+        state = run_state(
+            blocks=[root_cause_memory_block()],
+            metadata={"group_id": self.group.id},
+        )
+
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+
+        mock_trigger_handoff.assert_not_called()
+        mock_trigger_autofix.assert_not_called()
 
     @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
     def test_trigger_coding_agent_handoff_clears_preference_on_not_found(self, mock_trigger):

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -525,9 +525,7 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
         assert call_kwargs["group"] == self.group
         assert call_kwargs["run_id"] == 123
         assert call_kwargs["integration_id"] == 123
-        assert (
-            call_kwargs["referrer"] == AutofixReferrer.ISSUE_SUMMARY_POST_PROCESS_FIXABILITY
-        )
+        assert call_kwargs["referrer"] == AutofixReferrer.ISSUE_SUMMARY_POST_PROCESS_FIXABILITY
         mock_trigger_autofix.assert_not_called()
 
     @patch("sentry.seer.autofix.on_completion_hook.trigger_autofix_agent")

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -926,6 +926,34 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         mock_trigger.assert_called_once()
         assert mock_trigger.call_args[1]["stopping_point"] is None
 
+    @patch(
+        "sentry.seer.autofix.issue_summary.get_automation_stopping_point",
+        return_value=AutofixStoppingPoint.CODE_CHANGES,
+    )
+    @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
+    @patch(
+        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
+        return_value=False,
+    )
+    @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
+    def test_without_seat_based_tier_with_explorer_uses_stopping_point(
+        self,
+        mock_state,
+        mock_triggering,
+        mock_rate,
+        mock_trigger,
+        mock_get_stopping_point,
+        mock_seat_based_tier,
+    ):
+        mock_seat_based_tier.return_value = False
+        with self.feature("organizations:autofix-on-explorer"):
+            run_automation(self.group, self.user, self.event, SeerAutomationSource.POST_PROCESS)
+
+        mock_get_stopping_point.assert_called_once_with(self.group)
+        mock_trigger.assert_called_once()
+        assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.CODE_CHANGES
+
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state")


### PR DESCRIPTION
## Why

Explorer-backed automated Autofix relies on `AutofixOnCompletionHook` in Sentry to continue after each Seer step. That hook needs `stopping_point` metadata to distinguish automated runs from manual runs; without it, non-seat-based Explorer automation can finish root cause and return without continuing or handing off.

The production shape also shows many projects with external `automation_handoff` configured while their stored automated stopping point is `root_cause`. That combination is valid for the old handoff setup: Seer should stop its own work at root cause and hand the issue to the configured coding agent. The hook previously checked "we reached root cause" before checking handoff config, so those projects were treated as terminal and never launched the agent.

Together this explains why downstream Autofix steps can stay healthy globally while coding-agent handoffs are low: unconfigured projects keep continuing through Seer, but configured root-cause handoff projects exit before handoff.

## Summary

- compute automation stopping-point metadata for automated runs that route through Explorer
- preserve legacy non-Explorer launches by leaving their stopping point unset
- trigger configured root-cause handoff before treating root cause as terminal
- add regression coverage for missing stopping-point metadata and root-cause handoff