### PR TITLE
ref(preprod): Add no_base_build comparison state for snapshots

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any, Literal
 
+from django.utils import timezone
 from pydantic import BaseModel, Field
 
 from sentry.preprod.build_distribution_utils import (
@@ -15,7 +16,9 @@ from sentry.preprod.models import (
     PreprodArtifactSizeMetrics,
     PreprodComparisonApproval,
 )
+from sentry.preprod.snapshots.constants import MISSING_BASE_GRACE_PERIOD_SECONDS
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.snapshots.utils import find_base_snapshot_artifact
 from sentry.preprod.vcs.status_checks.utils import StatusCheckErrorType
 
 logger = logging.getLogger(__name__)
@@ -92,7 +95,8 @@ class PostedStatusChecks(BaseModel):
 class SnapshotComparisonInfo(BaseModel):
     image_count: int
     comparison_state: (
-        Literal["pending", "processing", "success", "failed", "waiting_for_base"] | None
+        Literal["pending", "processing", "success", "failed", "waiting_for_base", "no_base_build"]
+        | None
     ) = None
     comparison_error_message: str | None = None
     images_added: int = 0
@@ -304,7 +308,26 @@ def to_snapshot_comparison_info(head_artifact: PreprodArtifact) -> SnapshotCompa
     if not comparison:
         cc = head_artifact.commit_comparison
         if cc and cc.base_sha:
-            comparison_state = "waiting_for_base"
+            grace_period_expired = (
+                timezone.now() - head_artifact.date_added
+            ).total_seconds() > MISSING_BASE_GRACE_PERIOD_SECONDS
+
+            if (
+                grace_period_expired
+                and find_base_snapshot_artifact(
+                    organization_id=cc.organization_id,
+                    base_sha=cc.base_sha,
+                    base_repo_name=cc.base_repo_name or cc.head_repo_name,
+                    project_id=head_artifact.project_id,
+                    app_id=head_artifact.app_id,
+                    artifact_type=head_artifact.artifact_type,
+                    build_configuration=head_artifact.build_configuration,
+                )
+                is None
+            ):
+                comparison_state = "no_base_build"
+            else:
+                comparison_state = "waiting_for_base"
     elif comparison:
         comparison_state = PreprodSnapshotComparison.State(comparison.state).name.lower()
         if comparison.state == PreprodSnapshotComparison.State.SUCCESS:

--- a/src/sentry/preprod/snapshots/constants.py
+++ b/src/sentry/preprod/snapshots/constants.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+MISSING_BASE_GRACE_PERIOD_SECONDS = 600

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -13,6 +13,7 @@ from sentry.preprod.models import (
     PreprodArtifact,
     PreprodComparisonApproval,
 )
+from sentry.preprod.snapshots.constants import MISSING_BASE_GRACE_PERIOD_SECONDS
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.snapshots.utils import build_changes_map
 from sentry.preprod.url_utils import get_preprod_artifact_url
@@ -47,7 +48,6 @@ FAIL_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_added"
 FAIL_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_removed"
 FAIL_ON_CHANGED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_changed"
 FAIL_ON_RENAMED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_renamed"
-MISSING_BASE_GRACE_PERIOD_SECONDS = 600
 
 
 @instrumented_task(

--- a/tests/sentry/preprod/api/models/test_project_preprod_build_details_models.py
+++ b/tests/sentry/preprod/api/models/test_project_preprod_build_details_models.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
+from django.utils import timezone
 
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     SizeInfoCompleted,
@@ -15,6 +18,7 @@ from sentry.preprod.models import (
     PreprodArtifactSizeMetrics,
     PreprodComparisonApproval,
 )
+from sentry.preprod.snapshots.constants import MISSING_BASE_GRACE_PERIOD_SECONDS
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
 
@@ -325,3 +329,64 @@ class TestToSnapshotComparisonInfoApprovalStatus(TestCase):
 
         assert result is not None
         assert result.approval_status == "approved"
+
+
+@cell_silo_test
+class TestToSnapshotComparisonInfoNoBaseBuild(TestCase):
+    def _create_artifact_with_snapshot_metrics(
+        self, commit_comparison=None, date_added=None
+    ) -> PreprodArtifact:
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=commit_comparison,
+            date_added=date_added,
+        )
+        self.create_preprod_snapshot_metrics(preprod_artifact=artifact, image_count=1)
+        return PreprodArtifact.objects.select_related("preprodsnapshotmetrics").get(pk=artifact.pk)
+
+    def test_waiting_for_base_within_grace_period(self) -> None:
+        cc = self.create_commit_comparison(organization=self.organization)
+        artifact = self._create_artifact_with_snapshot_metrics(commit_comparison=cc)
+
+        result = to_snapshot_comparison_info(artifact)
+
+        assert result is not None
+        assert result.comparison_state == "waiting_for_base"
+
+    def test_no_base_build_after_grace_period(self) -> None:
+        cc = self.create_commit_comparison(organization=self.organization)
+        expired_date = timezone.now() - timedelta(seconds=MISSING_BASE_GRACE_PERIOD_SECONDS + 1)
+        artifact = self._create_artifact_with_snapshot_metrics(
+            commit_comparison=cc, date_added=expired_date
+        )
+
+        result = to_snapshot_comparison_info(artifact)
+
+        assert result is not None
+        assert result.comparison_state == "no_base_build"
+
+    def test_waiting_for_base_after_grace_period_when_base_artifact_exists(self) -> None:
+        cc = self.create_commit_comparison(organization=self.organization)
+        expired_date = timezone.now() - timedelta(seconds=MISSING_BASE_GRACE_PERIOD_SECONDS + 1)
+        artifact = self._create_artifact_with_snapshot_metrics(
+            commit_comparison=cc, date_added=expired_date
+        )
+
+        base_cc = self.create_commit_comparison(
+            organization=self.organization,
+            head_sha=cc.base_sha,
+            base_sha=None,
+            head_repo_name=cc.base_repo_name or cc.head_repo_name,
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=base_cc,
+            app_id=artifact.app_id,
+            artifact_type=artifact.artifact_type,
+        )
+        self.create_preprod_snapshot_metrics(preprod_artifact=base_artifact, image_count=1)
+
+        result = to_snapshot_comparison_info(artifact)
+
+        assert result is not None
+        assert result.comparison_state == "waiting_for_base"


### PR DESCRIPTION
When a head artifact has a `base_sha` but no base snapshot artifact was ever uploaded for that SHA, the table previously showed `waiting_for_base` indefinitely — even after the 10-minute grace period expired and the status check already posted a "missing base" failure. Now the API returns `no_base_build` after the grace period expires and no base artifact is found, matching the status check evaluation.

**Shared grace period constant**

Extracts `MISSING_BASE_GRACE_PERIOD_SECONDS` from the status check task into `snapshots/constants.py` so both the task and the API model layer use the same value without coupling.

**`to_snapshot_comparison_info()` logic**

When no comparison exists and `base_sha` is set, checks whether the grace period has expired. If expired and `find_base_snapshot_artifact()` returns `None`, returns `"no_base_build"`. The DB lookup is short-circuited — it only runs when the grace period has already elapsed.

Backend-only change. Frontend will handle the new state string in a separate PR.

Refs EME-1144