### PR TITLE
feat(preprod): Handle no_base_build comparison state in snapshot table

### DIFF
--- a/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
@@ -124,6 +124,26 @@ describe('PreprodBuildsSnapshotTable', () => {
     );
 
     it.snapshot(
+      'status-no-base-build',
+      () =>
+        renderTable(
+          makeBuild({
+            snapshot_comparison_info: {
+              image_count: 24,
+              comparison_state: 'no_base_build',
+              approval_status: null,
+              comparison_error_message: null,
+              images_added: 0,
+              images_removed: 0,
+              images_changed: 0,
+              images_unchanged: 0,
+            },
+          })
+        ),
+      {theme: themeName, state: 'status-no-base-build'}
+    );
+
+    it.snapshot(
       'status-no-comparison',
       () =>
         renderTable(

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -53,11 +53,7 @@ function ApprovalBadge({
   }
   if (comparisonState === 'no_base_build') {
     return (
-      <Tooltip
-        title={t(
-          'No base snapshot was found for comparison. Ensure a build exists for the base commit.'
-        )}
-      >
+      <Tooltip title={t('No base snapshot was found for comparison.')}>
         <Tag variant="danger">{t('No base build')}</Tag>
       </Tooltip>
     );

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -51,6 +51,17 @@ function ApprovalBadge({
       </Tooltip>
     );
   }
+  if (comparisonState === 'no_base_build') {
+    return (
+      <Tooltip
+        title={t(
+          'No base snapshot was found for comparison. Ensure a build exists for the base commit.'
+        )}
+      >
+        <Tag variant="danger">{t('No base build')}</Tag>
+      </Tooltip>
+    );
+  }
   if (comparisonState === 'pending') {
     return (
       <Tooltip title={t('Waiting to start comparison')}>

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -199,7 +199,8 @@ export type SnapshotComparisonState =
   | 'processing'
   | 'success'
   | 'failed'
-  | 'waiting_for_base';
+  | 'waiting_for_base'
+  | 'no_base_build';
 export type SnapshotApprovalStatus = 'approved' | 'auto_approved' | 'requires_approval';
 
 interface SnapshotComparisonInfo {


### PR DESCRIPTION
When the backend determines no base snapshot exists after the grace period, it returns `comparison_state: "no_base_build"`. This PR handles that new state in the snapshot table.

**No base build badge**

Adds a `danger`-variant `Tag` with a tooltip explaining no base build was found. This matches the visual weight of the `failed` state since both are terminal error states — unlike `waiting_for_base` which is transient and uses `muted`.

Refs EME-1144