### PR TITLE
perf(searchQueryBuilder): Avoid full filter parse for free text

### DIFF
--- a/fixtures/search-syntax/aggregate_duration_filter.json
+++ b/fixtures/search-syntax/aggregate_duration_filter.json
@@ -36,5 +36,73 @@
       },
       {"type": "spaces", "value": ""}
     ]
+  },
+  {
+    "query": "TypeError avg(transaction.duration):>500s",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {"type": "freeText", "value": "TypeError ", "quoted": false, "invalid": null},
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateDuration",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "avg", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "transaction.duration",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueDuration",
+          "value": "500",
+          "unit": "s",
+          "parsed": {"value": 500000}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "TypeError count():>10",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {"type": "freeText", "value": "TypeError ", "quoted": false, "invalid": null},
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "count", "quoted": false},
+          "args": null,
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "10",
+          "unit": null,
+          "parsed": {"value": 10}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
   }
 ]

--- a/fixtures/search-syntax/aggregate_duration_filter.json
+++ b/fixtures/search-syntax/aggregate_duration_filter.json
@@ -76,33 +76,5 @@
       },
       {"type": "spaces", "value": ""}
     ]
-  },
-  {
-    "query": "TypeError count():>10",
-    "result": [
-      {"type": "spaces", "value": ""},
-      {"type": "freeText", "value": "TypeError ", "quoted": false, "invalid": null},
-      {"type": "spaces", "value": ""},
-      {
-        "type": "filter",
-        "filter": "aggregateNumeric",
-        "negated": false,
-        "key": {
-          "type": "keyAggregate",
-          "name": {"type": "keySimple", "value": "count", "quoted": false},
-          "args": null,
-          "argsSpaceBefore": {"type": "spaces", "value": ""},
-          "argsSpaceAfter": {"type": "spaces", "value": ""}
-        },
-        "operator": ">",
-        "value": {
-          "type": "valueNumber",
-          "value": "10",
-          "unit": null,
-          "parsed": {"value": 10}
-        }
-      },
-      {"type": "spaces", "value": ""}
-    ]
   }
 ]

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -47,7 +47,13 @@ free_parens
 // All key:value filter types
 
 filter_start
-  = negation? (text_key / search_key) sep
+  = negation? ((text_key / search_key) sep / aggregate_filter_start)
+
+aggregate_filter_start
+  = &aggregate_key_start &aggregate_filter
+
+aggregate_key_start
+  = [a-zA-Z0-9_.-]+ "("
 
 filter
   = date_filter
@@ -58,16 +64,19 @@ filter
   / boolean_filter
   / numeric_in_filter
   / numeric_filter
-  / aggregate_duration_filter
+  / aggregate_filter
+  / has_filter
+  / is_filter
+  / text_in_filter
+  / text_filter
+
+aggregate_filter
+  = aggregate_duration_filter
   / aggregate_size_filter
   / aggregate_numeric_filter
   / aggregate_percentage_filter
   / aggregate_date_filter
   / aggregate_rel_date_filter
-  / has_filter
-  / is_filter
-  / text_in_filter
-  / text_filter
 
 // filter for dates
 date_filter

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -32,7 +32,7 @@ free_text
   = free_text_quoted / free_text_unquoted
 
 free_text_unquoted
-  = (!filter !boolean_operator (free_parens / [^()\n ]+) spaces)+ {
+  = (!filter_start !boolean_operator (free_parens / [^()\n ]+) spaces)+ {
       return tc.tokenFreeText(text(), false);
     }
 
@@ -45,6 +45,9 @@ free_parens
   = open_paren free_text? closed_paren
 
 // All key:value filter types
+
+filter_start
+  = negation? (text_key / search_key) sep
 
 filter
   = date_filter

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -191,6 +191,43 @@ describe('searchSyntax/parser', () => {
     })
   );
 
+  it('handles no-argument aggregate filters after free text', () => {
+    const result = parseSearch('TypeError count():>10');
+
+    if (result === null) {
+      throw new Error('Parsed result as null');
+    }
+
+    expect(result.map(token => token.type)).toEqual([
+      Token.SPACES,
+      Token.FREE_TEXT,
+      Token.SPACES,
+      Token.FILTER,
+      Token.SPACES,
+    ]);
+
+    expect(result[1]).toMatchObject({
+      type: Token.FREE_TEXT,
+      value: 'TypeError ',
+    });
+
+    const filter = result[3] as TokenResult<Token.FILTER>;
+    expect(filter).toMatchObject({
+      type: Token.FILTER,
+      filter: 'aggregateNumeric',
+      operator: '>',
+      key: {
+        type: Token.KEY_AGGREGATE,
+        name: {type: Token.KEY_SIMPLE, value: 'count'},
+        args: null,
+      },
+      value: {
+        type: Token.VALUE_NUMBER,
+        value: '10',
+      },
+    });
+  });
+
   it('returns token warnings', () => {
     const result = parseSearch('foo:bar bar:baz tags[foo]:bar tags[bar]:baz', {
       getFilterTokenWarning: key => (key === 'foo' ? 'foo warning' : null),


### PR DESCRIPTION
Free text was using a full negative filter parse to prove each chunk was not a filter. That means plain words pay for all the typed filter alternatives before they can become text.

This adds a cheap filter-start lookahead for the free-text path instead. Typed filters still go through the normal parser, and aggregate filters still split correctly after free text, but plain text avoids a lot of failed work.

| Case | Master | After | Delta |
|---|---:|---:|---:|
| plain words | 190.1 ms | 77.5 ms | -59.2% |
| common text filters | 211.3 ms | 209.5 ms | -0.8% |
| common tags | 212.3 ms | 207.2 ms | -2.4% |
| numeric filters | 135.0 ms | 129.4 ms | -4.2% |
| date filters | 52.2 ms | 47.0 ms | -10.0% |
| duration and size | 88.9 ms | 83.7 ms | -5.9% |
| lists | 102.4 ms | 99.6 ms | -2.7% |
| aggregates | 92.1 ms | 88.1 ms | -4.3% |
| boolean group | 151.7 ms | 142.2 ms | -6.2% |
| long mixed | 1567.1 ms | 1549.0 ms | -1.2% |
| total | 2803.1 ms | 2633.2 ms | -6.1% |

Benchmark is 8k parses per case, 7 rounds, comparing master grammar to this branch.