### PR TITLE
fix(traces): Hide project icon overlap border

### DIFF
--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -135,8 +135,9 @@ const ProjectList = styled('div')`
   padding-right: 8px;
 `;
 
-const AvatarStyle = (p: any) => css`
-  border: 2px solid ${p.theme.tokens.border.primary};
+const AvatarStyle = (p: {theme: Theme}) => css`
+  /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
+  border: 2px solid ${p.theme.tokens.background.primary};
   margin-right: -8px;
   cursor: default;
 


### PR DESCRIPTION
Removing a border around project icons on explore pages

|Before | After |
| - | - |
| <img width="102" height="58" alt="Screenshot 2026-05-14 at 12 01 30" src="https://github.com/user-attachments/assets/982a7634-ff96-4b8c-adcd-6e3bf69713d7" /> | <img width="75" height="47" alt="Screenshot 2026-05-14 at 12 01 34" src="https://github.com/user-attachments/assets/238f78bb-5c71-4dd5-8d5b-949983998a63" />|
 | <img width="150" height="56" alt="Screenshot 2026-05-14 at 13 19 48" src="https://github.com/user-attachments/assets/d21743f8-024c-4796-856f-0e5ced3152f9" />|<img width="365" height="45" alt="Screenshot 2026-05-14 at 12 02 11" src="https://github.com/user-attachments/assets/67c90c0d-b648-4ce8-b848-23f4eb444d57" />|