### PR TITLE
fix(seer): Prevent duplicate assisted-query submissions

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -82,6 +82,7 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
   const [runId, setRunId] = useState<number | null>(null);
   const [waitingForResponse, setWaitingForResponse] = useState(false);
   const [startFailed, setStartFailed] = useState(false);
+  const inFlightQueryRef = useRef<string | null>(null);
 
   const queryKey = makeAskSeerQueryKey(orgSlug, runId ?? undefined);
 
@@ -107,9 +108,10 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
   // Start a new search
   const submitQuery = useCallback(
     async (query: string) => {
-      if (waitingForResponse) {
+      if (inFlightQueryRef.current === query) {
         return;
       }
+      inFlightQueryRef.current = query;
       setWaitingForResponse(true);
 
       try {
@@ -136,14 +138,21 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
           });
         }
       } catch (error) {
+        inFlightQueryRef.current = null;
         setWaitingForResponse(false);
         setStartFailed(true);
         addErrorMessage((error as Error)?.message ?? 'Failed to start AI search');
         options.onError?.(error as Error);
       }
     },
-    [api, orgSlug, options, queryClient, waitingForResponse]
+    [api, orgSlug, options, queryClient]
   );
+
+  useEffect(() => {
+    if (!waitingForResponse) {
+      inFlightQueryRef.current = null;
+    }
+  }, [waitingForResponse]);
 
   // Handle completion callback
   useEffect(() => {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -46,7 +46,7 @@ const isPolling = <T extends QueryTokensProps>(
   }
 
   // Poll while status is processing or there's a current step in progress
-  return sessionData.status === 'processing' || sessionData.current_step !== null;
+  return sessionData.status === 'processing' || !!sessionData.current_step;
 };
 
 const makeInitialAskSeerData = <
@@ -158,7 +158,7 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
   useEffect(() => {
     if (waitingForResponse && sessionData) {
       const isStillProcessing =
-        sessionData.status === 'processing' || sessionData.current_step !== null;
+        sessionData.status === 'processing' || !!sessionData.current_step;
       if (!isStillProcessing) {
         setWaitingForResponse(false);
         if (sessionData.status === 'completed' && sessionData.final_response) {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -170,6 +170,7 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
 
   // Reset function
   const reset = useCallback(() => {
+    inFlightQueryRef.current = null;
     setRunId(null);
     setWaitingForResponse(false);
     setStartFailed(false);

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -107,6 +107,9 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
   // Start a new search
   const submitQuery = useCallback(
     async (query: string) => {
+      if (waitingForResponse) {
+        return;
+      }
       setWaitingForResponse(true);
 
       try {
@@ -139,7 +142,7 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
         options.onError?.(error as Error);
       }
     },
-    [api, orgSlug, options, queryClient]
+    [api, orgSlug, options, queryClient, waitingForResponse]
   );
 
   // Handle completion callback


### PR DESCRIPTION
## Summary

Pressing Enter twice with the same query (or any re-trigger before the previous run completes) fires two POSTs to `/search-agent/start/`, producing duplicate `SeerRun` rows for the same NL query.

Fix: track the in-flight NL query string in a ref and bail if a resubmit comes in with the same string. Distinct queries still go through so users can change their mind mid-run.

I added some debug logs, made a query and hit enter again afterwards, and it seems to work:
```
[askSeer] submit: is unresolved and old
3useAskSeerPolling.tsx:113 [askSeer] BLOCKED duplicate submit: is unresolved and old
```