### PR TITLE
ref(seer): Remove alert source from autofix automation

### DIFF
--- a/src/sentry/apidocs/examples/autofix_examples.py
+++ b/src/sentry/apidocs/examples/autofix_examples.py
@@ -48,7 +48,7 @@ AUTOFIX_GET_RESPONSE = [
                         ]
                     },
                     "options": {
-                        "auto_run_source": "issue_summary_on_alert_fixability",
+                        "auto_run_source": "issue_summary_on_post_process_fixability",
                     },
                 },
                 "updated_at": "2025-09-23T21:02:18.160885",

--- a/src/sentry/seer/autofix/constants.py
+++ b/src/sentry/seer/autofix/constants.py
@@ -50,7 +50,6 @@ class AutofixStatus(str, enum.Enum):
 class AutofixReferrer(enum.StrEnum):
     GROUP_AUTOFIX_ENDPOINT = "api.group_ai_autofix"
     ISSUE_SUMMARY_FIXABILITY = "issue_summary.fixability"
-    ISSUE_SUMMARY_ALERT_FIXABILITY = "issue_summary.alert_fixability"
     ISSUE_SUMMARY_POST_PROCESS_FIXABILITY = "issue_summary.post_process_fixability"
     SLACK = "slack"
     ON_COMPLETION_HOOK = "autofix.on_completion_hook"
@@ -64,6 +63,5 @@ class AutofixReferrer(enum.StrEnum):
 
 class SeerAutomationSource(enum.Enum):
     ISSUE_DETAILS = "issue_details"
-    ALERT = "alert"
     POST_PROCESS = "post_process"
     NIGHT_SHIFT = "night_shift"

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -25,7 +25,6 @@ from sentry.seer.autofix.autofix_agent import (
     trigger_autofix_agent,
 )
 from sentry.seer.autofix.constants import (
-    AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD,
     AutofixAutomationTuningSettings,
     AutofixReferrer,
     FixabilityScoreThresholds,
@@ -62,14 +61,12 @@ logger = logging.getLogger(__name__)
 
 auto_run_source_map = {
     SeerAutomationSource.ISSUE_DETAILS: "issue_summary_fixability",
-    SeerAutomationSource.ALERT: "issue_summary_on_alert_fixability",
     SeerAutomationSource.POST_PROCESS: "issue_summary_on_post_process_fixability",
     SeerAutomationSource.NIGHT_SHIFT: "night_shift",
 }
 
 referrer_map = {
     SeerAutomationSource.ISSUE_DETAILS: AutofixReferrer.ISSUE_SUMMARY_FIXABILITY,
-    SeerAutomationSource.ALERT: AutofixReferrer.ISSUE_SUMMARY_ALERT_FIXABILITY,
     SeerAutomationSource.POST_PROCESS: AutofixReferrer.ISSUE_SUMMARY_POST_PROCESS_FIXABILITY,
     SeerAutomationSource.NIGHT_SHIFT: AutofixReferrer.NIGHT_SHIFT,
 }
@@ -401,17 +398,6 @@ def run_automation(
 ) -> None:
     if source == SeerAutomationSource.ISSUE_DETAILS:
         return
-
-    # Check event count for ALERT source with seat-based tier
-    if is_seer_seat_based_tier_enabled(group.organization) and source == SeerAutomationSource.ALERT:
-        # Use times_seen_with_pending if available (set by post_process), otherwise fall back
-        times_seen = (
-            group.times_seen_with_pending
-            if hasattr(group, "_times_seen_pending")
-            else group.times_seen
-        )
-        if times_seen < AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD:
-            return
 
     user_id = user.id if user else None
     auto_run_source = auto_run_source_map.get(source, "unknown_source")

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -876,9 +876,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
             possible_cause="c",
             scores=SummarizeIssueScores(fixability_score=0.70),
         )
-        self.group.times_seen = 10
-        self.group.times_seen_pending = 0
-        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.POST_PROCESS)
         mock_trigger.assert_called_once()
         assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.CODE_CHANGES
 
@@ -902,9 +900,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
             possible_cause="c",
             scores=SummarizeIssueScores(fixability_score=0.50),
         )
-        self.group.times_seen = 10
-        self.group.times_seen_pending = 0
-        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.POST_PROCESS)
         mock_trigger.assert_called_once()
         assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.ROOT_CAUSE
 
@@ -925,7 +921,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     ):
         mock_seat_based_tier.return_value = False
         with self.feature({"organizations:gen-ai-features": True}):
-            run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+            run_automation(self.group, self.user, self.event, SeerAutomationSource.POST_PROCESS)
 
         mock_trigger.assert_called_once()
         assert mock_trigger.call_args[1]["stopping_point"] is None
@@ -939,7 +935,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         """run_automation skips triggering autofix when one is already in progress"""
         mock_state.return_value = {"status": "in_progress"}
 
-        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.POST_PROCESS)
 
         mock_trigger.assert_not_called()
 
@@ -1045,10 +1041,8 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
             possible_cause="c",
             scores=SummarizeIssueScores(fixability_score=0.80),  # High = OPEN_PR
         )
-        self.group.times_seen = 10
-        self.group.times_seen_pending = 0
 
-        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.POST_PROCESS)
 
         mock_trigger.assert_called_once()
         # Should be limited to SOLUTION by user preference
@@ -1082,87 +1076,12 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
             possible_cause="c",
             scores=SummarizeIssueScores(fixability_score=0.50),  # Medium = ROOT_CAUSE
         )
-        self.group.times_seen = 10
-        self.group.times_seen_pending = 0
 
-        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.POST_PROCESS)
 
         mock_trigger.assert_called_once()
         # Should use ROOT_CAUSE from fixability, not OPEN_PR from user
         assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.ROOT_CAUSE
-
-
-@patch("sentry.seer.autofix.issue_summary.is_seer_seat_based_tier_enabled", return_value=True)
-@with_feature("organizations:gen-ai-features")
-class TestRunAutomationAlertEventCount(APITestCase, SnubaTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.group = self.create_group()
-        event_data = load_data("python")
-        self.event = self.store_event(data=event_data, project_id=self.project.id)
-        self.user = self.create_user()
-
-    @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task")
-    @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
-    @patch("sentry.seer.autofix.issue_summary.quotas.backend.check_seer_quota")
-    def test_alert_skips_automation_below_threshold(
-        self, mock_budget, mock_state, mock_fixability, mock_trigger, mock_seat_based_tier
-    ):
-        """Alert automation should skip when event count < 10"""
-        self.project.update_option("sentry:autofix_automation_tuning", "always")
-        mock_budget.return_value = True
-        mock_state.return_value = None
-        mock_fixability.return_value = SummarizeIssueResponse(
-            group_id=str(self.group.id),
-            headline="Test",
-            scores=SummarizeIssueScores(fixability_score=0.70),
-        )
-
-        # Set event count to 5
-        self.group.times_seen = 5
-        self.group.times_seen_pending = 0
-
-        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
-
-        # Should not trigger automation
-        mock_trigger.delay.assert_not_called()
-
-    @patch(
-        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
-        return_value=False,
-    )
-    @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task")
-    @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
-    @patch("sentry.seer.autofix.issue_summary.quotas.backend.check_seer_quota")
-    def test_alert_runs_automation_above_threshold(
-        self,
-        mock_budget,
-        mock_state,
-        mock_fixability,
-        mock_trigger,
-        mock_rate_limit,
-        mock_seat_based_tier,
-    ):
-        """Alert automation should run when event count >= 10"""
-        self.project.update_option("sentry:autofix_automation_tuning", "always")
-        mock_budget.return_value = True
-        mock_state.return_value = None
-        mock_fixability.return_value = SummarizeIssueResponse(
-            group_id=str(self.group.id),
-            headline="Test",
-            scores=SummarizeIssueScores(fixability_score=0.70),
-        )
-
-        # Set event count to 10
-        self.group.times_seen = 10
-        self.group.times_seen_pending = 0
-
-        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
-
-        # Should trigger automation
-        mock_trigger.delay.assert_called_once()
 
 
 @with_feature("organizations:gen-ai-features")


### PR DESCRIPTION
## Summary

- Drop `SeerAutomationSource.ALERT` and the `issue_summary.alert_fixability` referrer from autofix automation.
- No production code triggered automation from the ALERT source; only tests did.
- Removes the seat-based-tier event-count guard that only applied to the ALERT path.
- Frontend pattern in `autofixReferrer.tsx` is intentionally left in place so the tooltip still resolves for historical autofix runs.


Agent transcript: https://claudescope.sentry.dev/share/LPgIOjEs6UPmYmUWBlOdqVPF2qBDMCwO_RSZhprv-3A