### PR TITLE
fix(attributes): Remove duplicate string is_transaction

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -35,7 +35,6 @@ export const SENTRY_SEARCHABLE_SPAN_STRING_TAGS: string[] = [
   SpanFields.USER_ID,
   SpanFields.USER_IP,
   SpanFields.USER_USERNAME,
-  SpanFields.IS_TRANSACTION, // boolean field but we can expose it as a string
   SpanFields.NORMALIZED_DESCRIPTION,
   SpanFields.CACHE_HIT,
 ];
@@ -53,7 +52,6 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
   SpanFields.TIMESTAMP,
   SpanFields.TRANSACTION,
   SpanFields.TRACE,
-  SpanFields.IS_TRANSACTION, // boolean field but keep for non-boolean queries
   SpanFields.NORMALIZED_DESCRIPTION,
   SpanFields.RELEASE, // temporary as orgs with >1k keys still want releases
   SpanFields.PROJECT_ID,
@@ -70,7 +68,6 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
 export const SENTRY_SPAN_NUMBER_TAGS: string[] = [...SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS];
 
 export const SENTRY_SPAN_BOOLEAN_TAGS: string[] = [
-  // duplicating until we've fully rolled out boolean attributes
   SpanFields.IS_TRANSACTION,
   SpanFields.IS_STARRED_TRANSACTION,
 ];


### PR DESCRIPTION
Since we've fully rolled out boolean attributes, we can remove this duplicate string version.

Closes EXP-953