### PR TITLE
ref(seer): Remove dead ISSUE_SUMMARY_FIXABILITY referrer

### DIFF
--- a/src/sentry/seer/autofix/constants.py
+++ b/src/sentry/seer/autofix/constants.py
@@ -49,7 +49,6 @@ class AutofixStatus(str, enum.Enum):
 
 class AutofixReferrer(enum.StrEnum):
     GROUP_AUTOFIX_ENDPOINT = "api.group_ai_autofix"
-    ISSUE_SUMMARY_FIXABILITY = "issue_summary.fixability"
     ISSUE_SUMMARY_POST_PROCESS_FIXABILITY = "issue_summary.post_process_fixability"
     SLACK = "slack"
     ON_COMPLETION_HOOK = "autofix.on_completion_hook"

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -60,13 +60,11 @@ from sentry.utils.locking import UnableToAcquireLock
 logger = logging.getLogger(__name__)
 
 auto_run_source_map = {
-    SeerAutomationSource.ISSUE_DETAILS: "issue_summary_fixability",
     SeerAutomationSource.POST_PROCESS: "issue_summary_on_post_process_fixability",
     SeerAutomationSource.NIGHT_SHIFT: "night_shift",
 }
 
 referrer_map = {
-    SeerAutomationSource.ISSUE_DETAILS: AutofixReferrer.ISSUE_SUMMARY_FIXABILITY,
     SeerAutomationSource.POST_PROCESS: AutofixReferrer.ISSUE_SUMMARY_POST_PROCESS_FIXABILITY,
     SeerAutomationSource.NIGHT_SHIFT: AutofixReferrer.NIGHT_SHIFT,
 }


### PR DESCRIPTION
## Summary

- `run_automation` and `_log_seer_scanner_billing_event` both return early when the source is `SeerAutomationSource.ISSUE_DETAILS`, so the `referrer_map` and `auto_run_source_map` entries for that source were never reached.
- Drop the `ISSUE_SUMMARY_FIXABILITY = "issue_summary.fixability"` enum value and both map entries.


Agent transcript: https://claudescope.sentry.dev/share/VAVJZI_KagnL2RmsrDtjzSgMT1rfgntI_1XCzkfvmRU