### PR TITLE
fix(alerts): Return 400 when trigger IDs don't belong to the alert rule being updated

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -43,6 +43,7 @@ from sentry.search.eap.trace_metrics.validator import validate_trace_metrics_agg
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
 from sentry.snuba.snuba_query_validator import SnubaQueryValidator
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id_list
 from sentry.workflow_engine.migration_helpers.alert_rule import (
     dual_delete_migrated_alert_rule_trigger,
     dual_update_alert_rule,
@@ -420,7 +421,19 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
         channel_lookup_timeout_error = None
         if triggers is not None:
             # Delete triggers we don't have present in the incoming data
-            trigger_ids = [x["id"] for x in triggers if "id" in x]
+            raw_trigger_ids = [x["id"] for x in triggers if "id" in x]
+            trigger_ids = to_valid_int_id_list("triggers", raw_trigger_ids)
+            if trigger_ids:
+                existing_trigger_ids = set(
+                    AlertRuleTrigger.objects.filter(
+                        alert_rule=alert_rule, id__in=trigger_ids
+                    ).values_list("id", flat=True)
+                )
+                missing_ids = [tid for tid in trigger_ids if tid not in existing_trigger_ids]
+                if missing_ids:
+                    raise serializers.ValidationError(
+                        f"Trigger IDs do not belong to this alert rule: {missing_ids}"
+                    )
             triggers_to_delete = AlertRuleTrigger.objects.filter(alert_rule=alert_rule).exclude(
                 id__in=trigger_ids
             )

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1224,6 +1224,28 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             )
             assert resp.data == {"nonFieldErrors": ['Trigger 2 must be labeled "warning"']}
 
+    def test_update_trigger_id_not_belonging_to_alert_rule(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+
+        alert_rule = self.alert_rule
+        other_alert_rule = self.new_alert_rule(
+            data={**deepcopy(self.alert_rule_dict), "name": "other rule"}
+        )
+        other_trigger = AlertRuleTrigger.objects.filter(alert_rule=other_alert_rule).first()
+        assert other_trigger is not None
+
+        serialized_alert_rule = self.get_serialized_alert_rule()
+        serialized_alert_rule["triggers"][0]["id"] = other_trigger.id
+
+        with self.feature("organizations:incidents"):
+            resp = self.get_error_response(
+                self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
+            )
+            assert "do not belong to this alert rule" in str(resp.data)
+
     def test_update_trigger_alert_threshold(self) -> None:
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]


### PR DESCRIPTION
It's deprecated code, but it'll be around for months yet, so better to fail more helpfully if we can.

Fixes SENTRY-5NJ6