### PR TITLE
feat(data-export): Add Sentry trace metrics for export outcomes

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -71,6 +71,35 @@ def _export_metric_tags(data_export: ExportedData) -> dict[str, str]:
     }
 
 
+def _requested_rows_bucket(export_limit: int | None) -> str:
+    if export_limit is None:
+        return "unknown"
+    if export_limit < 1_000:
+        return "0-1k"
+    if export_limit < 10_000:
+        return "1k-10k"
+    if export_limit < 100_000:
+        return "10k-100k"
+    if export_limit < 1_000_000:
+        return "100k-1M"
+    return "1M-10M"
+
+
+def _sentry_metric_attrs(
+    data_export: ExportedData,
+    export_limit: int | None,
+    *,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    attrs = {
+        **_export_metric_tags(data_export),
+        "requested_rows_bucket": _requested_rows_bucket(export_limit),
+    }
+    if extra:
+        attrs.update(extra)
+    return attrs
+
+
 def _page_token_b64_from_processor(
     processor: IssuesByTagProcessor | DiscoverProcessor | ExploreProcessor,
 ) -> str | None:
@@ -271,7 +300,10 @@ def _schedule_next_task(
     else:
         metrics.distribution("dataexport.row_count", next_offset, sample_rate=1.0)
         metrics.distribution("dataexport.file_size", bytes_written, sample_rate=1.0, unit="byte")
-        merge_export_blobs.delay(data_export_id)
+        merge_export_blobs.apply_async(
+            args=[data_export_id],
+            kwargs={"export_limit": export_limit, "actual_rows": next_offset},
+        )
 
 
 @instrumented_task(
@@ -298,7 +330,12 @@ def assemble_download(
 ) -> None:
     # The API response to export the data contains the ID which you can use
     # to filter the GCP logs
-    extra: dict[str, Any] = {"data_export_id": data_export_id}
+    export_limit = _normalize_export_limit(export_limit)
+    extra: dict[str, Any] = {
+        "data_export_id": data_export_id,
+        "requested_rows": export_limit,
+        "offset_in": offset,
+    }
     with sentry_sdk.start_span(op="assemble", name="Async Export Data"):
         first_page = offset == 0
         data_export = _fetch_exported_data_req_obj(data_export_id, first_page, extra)
@@ -310,10 +347,11 @@ def assemble_download(
         base_bytes_written = bytes_written
 
         extra.update(
-            {"query": str(data_export.payload), "organization_id": data_export.organization_id}
+            {
+                "query": str(data_export.payload),
+                "organization_id": data_export.organization_id,
+            }
         )
-
-        export_limit = _normalize_export_limit(export_limit)
 
         try:
             chunk = export_chunk_to_stored_blobs(
@@ -345,6 +383,29 @@ def assemble_download(
                     tags={**_export_metric_tags(data_export), "error": str(error)},
                     sample_rate=1.0,
                 )
+                metrics.incr(
+                    "dataexport.end",
+                    tags={
+                        **_export_metric_tags(data_export),
+                        "success": False,
+                        "error": str(error),
+                    },
+                    sample_rate=1.0,
+                )
+                sentry_sdk.metrics.count(
+                    "dataexport.completed",
+                    1,
+                    attributes=_sentry_metric_attrs(
+                        data_export,
+                        export_limit,
+                        extra={"success": "false", "error_type": type(error).__name__},
+                    ),
+                )
+                sentry_sdk.metrics.distribution(
+                    "dataexport.rows",
+                    offset,
+                    attributes=_sentry_metric_attrs(data_export, export_limit),
+                )
                 logger.exception("assemble_download: ExportError", extra=extra)
                 return data_export.email_failure(message=str(error))
         except Exception as error:
@@ -366,6 +427,20 @@ def assemble_download(
                         "error": str(error),
                     },
                     sample_rate=1.0,
+                )
+                sentry_sdk.metrics.count(
+                    "dataexport.completed",
+                    1,
+                    attributes=_sentry_metric_attrs(
+                        data_export,
+                        export_limit,
+                        extra={"success": "false", "error_type": type(error).__name__},
+                    ),
+                )
+                sentry_sdk.metrics.distribution(
+                    "dataexport.rows",
+                    offset,
+                    attributes=_sentry_metric_attrs(data_export, export_limit),
                 )
                 return data_export.email_failure(message="Internal processing failure")
         else:
@@ -389,6 +464,7 @@ def export_data_to_stored_blobs_sync(
         "query": str(data_export.payload),
         "organization_id": data_export.organization_id,
         "download_type": "sync",
+        "requested_rows": export_limit,
     }
     sentry_sdk.set_tag("download_type", "sync")
     sentry_sdk.set_context("data_export", extra)
@@ -413,20 +489,51 @@ def export_data_to_stored_blobs_sync(
                 sample_rate=1.0,
                 unit="byte",
             )
-            merge_export_blobs(data_export_id=data_export.id, email_notif=False)
+            merge_export_blobs(
+                data_export_id=data_export.id,
+                email_notif=False,
+                export_limit=export_limit,
+                actual_rows=chunk.next_offset,
+            )
+            sentry_sdk.metrics.count(
+                "dataexport.completed",
+                1,
+                attributes=_sentry_metric_attrs(
+                    data_export,
+                    export_limit,
+                    extra={"success": "true", "download_type": "sync"},
+                ),
+            )
+            sentry_sdk.metrics.distribution(
+                "dataexport.rows",
+                chunk.next_offset,
+                attributes=_sentry_metric_attrs(data_export, export_limit),
+            )
 
         except Exception as error:
+            error_type = "ExportError" if isinstance(error, ExportError) else type(error).__name__
             metrics.incr(
                 "dataexport.error",
                 tags={
                     **_export_metric_tags(data_export),
                     "error": str(error),
                     "download_type": "sync",
-                    "error_type": "ExportError"
-                    if isinstance(error, ExportError)
-                    else type(error).__name__,
+                    "error_type": error_type,
                 },
                 sample_rate=1.0,
+            )
+            sentry_sdk.metrics.count(
+                "dataexport.completed",
+                1,
+                attributes=_sentry_metric_attrs(
+                    data_export,
+                    export_limit,
+                    extra={
+                        "success": "false",
+                        "error_type": error_type,
+                        "download_type": "sync",
+                    },
+                ),
             )
             logger.exception("export_data_sync", extra=extra)
             raise
@@ -571,8 +678,19 @@ def store_export_chunk_as_blob(
     namespace=export_tasks,
     silo_mode=SiloMode.CELL,
 )
-def merge_export_blobs(data_export_id: int, *, email_notif: bool = True, **kwargs: Any) -> None:
-    extra: dict[str, Any] = {"data_export_id": data_export_id}
+def merge_export_blobs(
+    data_export_id: int,
+    *,
+    email_notif: bool = True,
+    export_limit: int | None = None,
+    actual_rows: int | None = None,
+    **kwargs: Any,
+) -> None:
+    extra: dict[str, Any] = {
+        "data_export_id": data_export_id,
+        "requested_rows": export_limit,
+        "actual_rows": actual_rows,
+    }
     with sentry_sdk.start_span(op="merge"):
         try:
             data_export = ExportedData.objects.get(id=data_export_id)
@@ -640,6 +758,22 @@ def merge_export_blobs(data_export_id: int, *, email_notif: bool = True, **kwarg
                     tags={**_export_metric_tags(data_export), "success": True},
                     sample_rate=1.0,
                 )
+                # Sync caller owns its own terminal Sentry metric emission to avoid
+                # double-counting; emit only on the async path.
+                if email_notif:
+                    sentry_sdk.metrics.count(
+                        "dataexport.completed",
+                        1,
+                        attributes=_sentry_metric_attrs(
+                            data_export, export_limit, extra={"success": "true"}
+                        ),
+                    )
+                    if actual_rows is not None:
+                        sentry_sdk.metrics.distribution(
+                            "dataexport.rows",
+                            actual_rows,
+                            attributes=_sentry_metric_attrs(data_export, export_limit),
+                        )
         except Exception as error:
             metrics.incr(
                 "dataexport.error",
@@ -651,6 +785,22 @@ def merge_export_blobs(data_export_id: int, *, email_notif: bool = True, **kwarg
                 tags={**_export_metric_tags(data_export), "success": False, "error": str(error)},
                 sample_rate=1.0,
             )
+            if email_notif:
+                sentry_sdk.metrics.count(
+                    "dataexport.completed",
+                    1,
+                    attributes=_sentry_metric_attrs(
+                        data_export,
+                        export_limit,
+                        extra={"success": "false", "error_type": type(error).__name__},
+                    ),
+                )
+                if actual_rows is not None:
+                    sentry_sdk.metrics.distribution(
+                        "dataexport.rows",
+                        actual_rows,
+                        attributes=_sentry_metric_attrs(data_export, export_limit),
+                    )
             logger.exception("merge_export_blobs: Exception", extra=extra)
             if isinstance(error, IntegrityError):
                 message = "Failed to save the assembled file."

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -404,7 +404,11 @@ def assemble_download(
                 sentry_sdk.metrics.distribution(
                     "dataexport.rows",
                     offset,
-                    attributes=_sentry_metric_attrs(data_export, export_limit),
+                    attributes=_sentry_metric_attrs(
+                        data_export,
+                        export_limit,
+                        extra={"success": "false", "error_type": type(error).__name__},
+                    ),
                 )
                 logger.exception("assemble_download: ExportError", extra=extra)
                 return data_export.email_failure(message=str(error))
@@ -440,7 +444,11 @@ def assemble_download(
                 sentry_sdk.metrics.distribution(
                     "dataexport.rows",
                     offset,
-                    attributes=_sentry_metric_attrs(data_export, export_limit),
+                    attributes=_sentry_metric_attrs(
+                        data_export,
+                        export_limit,
+                        extra={"success": "false", "error_type": type(error).__name__},
+                    ),
                 )
                 return data_export.email_failure(message="Internal processing failure")
         else:
@@ -476,13 +484,15 @@ def export_data_to_stored_blobs_sync(
             tags={**_export_metric_tags(data_export), "success": True},
             sample_rate=1.0,
         )
+        actual_rows: int | None = None
         try:
             chunk = export_chunk_to_stored_blobs(
                 data_export=data_export,
                 export_limit=export_limit,
                 environment_id=environment_id,
             )
-            metrics.distribution("dataexport.row_count", chunk.next_offset, sample_rate=1.0)
+            actual_rows = chunk.next_offset
+            metrics.distribution("dataexport.row_count", actual_rows, sample_rate=1.0)
             metrics.distribution(
                 "dataexport.file_size",
                 chunk.bytes_written_after_chunk,
@@ -493,7 +503,7 @@ def export_data_to_stored_blobs_sync(
                 data_export_id=data_export.id,
                 email_notif=False,
                 export_limit=export_limit,
-                actual_rows=chunk.next_offset,
+                actual_rows=actual_rows,
             )
             sentry_sdk.metrics.count(
                 "dataexport.completed",
@@ -506,8 +516,12 @@ def export_data_to_stored_blobs_sync(
             )
             sentry_sdk.metrics.distribution(
                 "dataexport.rows",
-                chunk.next_offset,
-                attributes=_sentry_metric_attrs(data_export, export_limit),
+                actual_rows,
+                attributes=_sentry_metric_attrs(
+                    data_export,
+                    export_limit,
+                    extra={"success": "true", "download_type": "sync"},
+                ),
             )
 
         except Exception as error:
@@ -522,6 +536,7 @@ def export_data_to_stored_blobs_sync(
                 },
                 sample_rate=1.0,
             )
+            extra["actual_rows"] = actual_rows
             sentry_sdk.metrics.count(
                 "dataexport.completed",
                 1,
@@ -535,6 +550,20 @@ def export_data_to_stored_blobs_sync(
                     },
                 ),
             )
+            if actual_rows is not None:
+                sentry_sdk.metrics.distribution(
+                    "dataexport.rows",
+                    actual_rows,
+                    attributes=_sentry_metric_attrs(
+                        data_export,
+                        export_limit,
+                        extra={
+                            "success": "false",
+                            "error_type": error_type,
+                            "download_type": "sync",
+                        },
+                    ),
+                )
             logger.exception("export_data_sync", extra=extra)
             raise
 
@@ -772,7 +801,9 @@ def merge_export_blobs(
                         sentry_sdk.metrics.distribution(
                             "dataexport.rows",
                             actual_rows,
-                            attributes=_sentry_metric_attrs(data_export, export_limit),
+                            attributes=_sentry_metric_attrs(
+                                data_export, export_limit, extra={"success": "true"}
+                            ),
                         )
         except Exception as error:
             metrics.incr(
@@ -799,7 +830,11 @@ def merge_export_blobs(
                     sentry_sdk.metrics.distribution(
                         "dataexport.rows",
                         actual_rows,
-                        attributes=_sentry_metric_attrs(data_export, export_limit),
+                        attributes=_sentry_metric_attrs(
+                            data_export,
+                            export_limit,
+                            extra={"success": "false", "error_type": type(error).__name__},
+                        ),
                     )
             logger.exception("merge_export_blobs: Exception", extra=extra)
             if isinstance(error, IntegrityError):


### PR DESCRIPTION
Emit `dataexport.completed` (count) and `dataexport.rows` (distribution) via the Sentry SDK at every terminal point of the export pipeline. Attributes include `success`, `error_type`, and a `requested_rows_bucket` covering 0-1k through 1M-10M so success rate can be sliced by requested size in a single query.

