### PR TITLE
feat(viewer-context): Add seer_rpc_in + org_seer_rpc_in chokepoints

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -72,6 +72,7 @@ from sentry.seer.endpoints.seer_rpc import (
 from sentry.seer.endpoints.utils import accept_organization_id_param, map_org_id_param
 from sentry.seer.fetch_issues import by_error_type, by_function_name, by_text_query, utils
 from sentry.utils.env import in_test_environment
+from sentry.viewer_context import get_viewer_context, observe_viewer_context_propagation
 
 logger = logging.getLogger(__name__)
 
@@ -243,6 +244,18 @@ class OrganizationSeerRpcEndpoint(OrganizationEndpoint):
         seer_referrer = request.headers.get("X-Seer-Referrer")
         if seer_referrer is not None:
             sentry_sdk.set_tag("rpc.referrer", seer_referrer)
+
+        # Observe whether the caller (seer) propagated X-Viewer-Context for this
+        # method. ViewerContextMiddleware has already decoded the header into the
+        # contextvar; we pass ctx=None explicitly when the header was absent so
+        # the missing-VC signal fires (the middleware always falls back to an
+        # empty-USER ctx, which would mask "header not sent").
+        has_vc_header = bool(request.META.get("HTTP_X_VIEWER_CONTEXT"))
+        observe_viewer_context_propagation(
+            "org_seer_rpc_in",
+            ctx=get_viewer_context() if has_vc_header else None,
+            extra_attributes={"method": method_name},
+        )
 
         if not self._is_allowed(organization):
             raise NotFound()

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -125,6 +125,7 @@ from sentry.snuba.referrer import Referrer
 from sentry.utils import snuba_rpc
 from sentry.utils.env import in_test_environment
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
+from sentry.viewer_context import get_viewer_context, observe_viewer_context_propagation
 
 logger = logging.getLogger(__name__)
 
@@ -245,6 +246,18 @@ class SeerRpcServiceEndpoint(Endpoint):
         seer_referrer = request.headers.get("X-Seer-Referrer")
         if seer_referrer is not None:
             sentry_sdk.set_tag("rpc.referrer", seer_referrer)
+
+        # Observe whether the caller (seer) propagated X-Viewer-Context for this
+        # method. ViewerContextMiddleware has already decoded the header into the
+        # contextvar; we pass ctx=None explicitly when the header was absent so
+        # the missing-VC signal fires (the middleware always falls back to an
+        # empty-USER ctx, which would mask "header not sent").
+        has_vc_header = bool(request.META.get("HTTP_X_VIEWER_CONTEXT"))
+        observe_viewer_context_propagation(
+            "seer_rpc_in",
+            ctx=get_viewer_context() if has_vc_header else None,
+            extra_attributes={"method": method_name},
+        )
 
         if not self._is_authorized(request):
             raise PermissionDenied

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -7,7 +7,7 @@ import enum
 import hashlib
 import logging
 import time
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 from typing import TYPE_CHECKING, Any
 
 import jwt as pyjwt
@@ -111,11 +111,17 @@ def observe_viewer_context_propagation(
     *,
     ctx: ViewerContext | None | Any = _OBSERVE_USE_CONTEXTVAR,
     expected: bool = True,
+    extra_attributes: Mapping[str, str] | None = None,
 ) -> None:
     """Emit a ``viewer_context.observation`` counter for the current ViewerContext at *point*.
 
-    Tags: ``point``, ``actor_type``, ``has_user_id``, ``has_org_id``, ``expected``.
-    Cardinality stays bounded: never tag user/org ids themselves, only their presence.
+    Tags: ``point``, ``actor_type``, ``has_user_id``, ``has_org_id``, ``expected``,
+    plus any *extra_attributes* the caller provides (e.g. ``method`` for RPC dispatch
+    points where we want per-method breakdown). Callers are responsible for keeping
+    extra-attribute cardinality bounded — values must come from a closed set.
+
+    Cardinality stays bounded otherwise: never tag user/org ids themselves, only
+    their presence.
 
     By default reads the current ContextVar. Pass *ctx* explicitly when the value
     being observed is a just-resolved override that hasn't entered a scope yet
@@ -137,20 +143,25 @@ def observe_viewer_context_propagation(
         has_user = ctx.user_id is not None
         has_org = ctx.organization_id is not None
 
-    sentry_sdk.metrics.count(
-        "viewer_context.observation",
-        1,
-        attributes={
+    # Fixed tags layered on top of extras so callers can't accidentally swap
+    # `point` / `actor_type` / etc. and corrupt the metric's cardinality story.
+    attributes: dict[str, str] = dict(extra_attributes) if extra_attributes else {}
+    attributes.update(
+        {
             "point": point,
             "actor_type": actor_type,
             "has_user_id": str(has_user).lower(),
             "has_org_id": str(has_org).lower(),
             "expected": str(expected).lower(),
-        },
+        }
     )
 
+    sentry_sdk.metrics.count("viewer_context.observation", 1, attributes=attributes)
+
     if expected and ctx is None:
-        logger.warning("viewer_context.missing", extra={"point": point})
+        log_extra: dict[str, Any] = dict(extra_attributes) if extra_attributes else {}
+        log_extra["point"] = point
+        logger.warning("viewer_context.missing", extra=log_extra)
 
 
 def set_viewer_context_organization(organization_id: int) -> None:

--- a/tests/sentry/test_viewer_context.py
+++ b/tests/sentry/test_viewer_context.py
@@ -225,3 +225,36 @@ class TestObserve:
         with viewer_context_scope(ctx):
             observe_viewer_context_propagation("rpc_inbound")
         assert all(r.message != "viewer_context.missing" for r in caplog.records)
+
+    def test_extra_attributes_merged_into_metric_tags(self, patch_metrics):
+        observe_viewer_context_propagation(
+            "seer_rpc_in", extra_attributes={"method": "get_organization_slug"}
+        )
+        tags = self._tags(patch_metrics)
+        assert tags["point"] == "seer_rpc_in"
+        assert tags["method"] == "get_organization_slug"
+
+    def test_extra_attributes_cannot_override_fixed_tags(self, patch_metrics):
+        # Fixed tags must take precedence so callers can't accidentally swap
+        # `point` or `actor_type` and corrupt the metric's cardinality story.
+        ctx = ViewerContext(user_id=1, actor_type=ActorType.USER)
+        with viewer_context_scope(ctx):
+            observe_viewer_context_propagation(
+                "seer_rpc_in",
+                extra_attributes={"point": "hijacked", "method": "real_method"},
+            )
+        tags = self._tags(patch_metrics)
+        assert tags["point"] == "seer_rpc_in"
+        assert tags["method"] == "real_method"
+
+    def test_extra_attributes_propagate_to_missing_log(self, patch_metrics, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="sentry.viewer_context"):
+            observe_viewer_context_propagation(
+                "seer_rpc_in", extra_attributes={"method": "ghost_method"}
+            )
+        missing_records = [r for r in caplog.records if r.message == "viewer_context.missing"]
+        assert len(missing_records) == 1
+        assert missing_records[0].method == "ghost_method"
+        assert missing_records[0].point == "seer_rpc_in"


### PR DESCRIPTION
Adds the missing `seer_rpc_in` and `org_seer_rpc_in` inbound chokepoints to the viewer-context observation framework. These were called out in #113237's description ("Companion to seer-side PR with matching `seer_rpc_in` + `sentry_rpc_out` instrumentation") but never landed in that PR — only the helper and three other chokepoints did.

The seer-side outbound RPC client (in getsentry/seer) already conditionally sends `X-Viewer-Context` when its contextvar is populated, but there was no Sentry-side observability for the inbound side. With this PR, `rate(viewer_context.observation{point="seer_rpc_in", actor_type="none"}) by (method)` shows per-method how often the header is missing — letting us iterate on which seer-side call sites still need to populate the contextvar (most likely Celery / background worker paths).

`ctx=None` is passed explicitly when `X-Viewer-Context` is absent from the request, because `ViewerContextMiddleware` otherwise falls back to an empty USER ctx, which would mask "header not sent" as "header sent but empty."

`observe_viewer_context_propagation` gains an optional `extra_attributes` kwarg so each observation can be tagged with the RPC `method` name. Fixed tags are layered on top of extras so callers can't accidentally swap `point` or `actor_type` and corrupt the metric's cardinality contract. The seer RPC registries are closed sets (~100 method names total), so cardinality stays bounded.

No behavior change: the header is silently dropped by Sentry today if no method reads it, so this is purely additive.

Refs #113237