### PR TITLE
feat(preprod): Add snapshot_status search field with comparison state filters

### DIFF
--- a/src/sentry/preprod/artifact_search.py
+++ b/src/sentry/preprod/artifact_search.py
@@ -23,6 +23,7 @@ from sentry.preprod.models import (
     PreprodArtifactSizeMetrics,
     PreprodComparisonApproval,
 )
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison
 
 search_config = SearchConfig.create_from(
     SearchConfig(),
@@ -64,7 +65,7 @@ search_config = SearchConfig.create_from(
     allowed_keys={
         "app_id",
         "app_name",
-        "approval_status",
+        "snapshot_status",
         "build_configuration_name",
         "build_number",
         "build_version",
@@ -164,15 +165,25 @@ def _translate_size_state(value: object) -> int:
     return SIZE_STATE_VALUES[raw]
 
 
-APPROVAL_STATUS_VALUES = frozenset({"approved", "auto_approved", "requires_approval"})
+SNAPSHOT_STATUS_VALUES = frozenset(
+    {
+        "approved",
+        "auto_approved",
+        "base",
+        "failed",
+        "no_base",
+        "pending",
+        "processing",
+        "requires_approval",
+    }
+)
 
 
-def _validate_approval_status(value: object) -> str:
+def _validate_snapshot_status(value: object) -> str:
     raw = str(value).lower()
-    if raw not in APPROVAL_STATUS_VALUES:
+    if raw not in SNAPSHOT_STATUS_VALUES:
         raise InvalidSearchQuery(
-            f"Invalid approval_status value: {value}. "
-            f"Valid values: {', '.join(sorted(APPROVAL_STATUS_VALUES))}"
+            f"Invalid status value: {value}. Valid values: {', '.join(sorted(SNAPSHOT_STATUS_VALUES))}"
         )
     return raw
 
@@ -337,21 +348,57 @@ def apply_filters(
                 queryset = queryset.filter(~Exists(approved_exists))
             continue
 
-        if name == "approval_status":
+        if name == "snapshot_status":
             values = token.value.value if token.is_in_filter else [token.value.value]
-            validated = [_validate_approval_status(v) for v in values]
+            validated = [_validate_snapshot_status(v) for v in values]
 
-            base_qs = PreprodComparisonApproval.objects.filter(
+            approval_base_qs = PreprodComparisonApproval.objects.filter(
                 preprod_artifact=OuterRef("pk"),
                 preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
             )
+            comparison_exists = PreprodSnapshotComparison.objects.filter(
+                head_snapshot_metrics__preprod_artifact=OuterRef("pk"),
+            )
+
             subqueries: list[Q] = []
             for val in validated:
-                if val == "approved":
+                if val == "base":
+                    subqueries.append(
+                        Q(preprodsnapshotmetrics__isnull=False)
+                        & (
+                            Q(commit_comparison__isnull=True)
+                            | Q(commit_comparison__base_sha__isnull=True)
+                        )
+                    )
+                elif val == "no_base":
+                    subqueries.append(
+                        Q(preprodsnapshotmetrics__isnull=False)
+                        & Q(commit_comparison__base_sha__isnull=False)
+                        & ~Q(Exists(comparison_exists))
+                    )
+                elif val == "pending":
+                    subqueries.append(
+                        Q(
+                            preprodsnapshotmetrics__snapshot_comparisons_head_metrics__state=PreprodSnapshotComparison.State.PENDING
+                        )
+                    )
+                elif val == "processing":
+                    subqueries.append(
+                        Q(
+                            preprodsnapshotmetrics__snapshot_comparisons_head_metrics__state=PreprodSnapshotComparison.State.PROCESSING
+                        )
+                    )
+                elif val == "failed":
+                    subqueries.append(
+                        Q(
+                            preprodsnapshotmetrics__snapshot_comparisons_head_metrics__state=PreprodSnapshotComparison.State.FAILED
+                        )
+                    )
+                elif val == "approved":
                     subqueries.append(
                         Q(
                             Exists(
-                                base_qs.filter(
+                                approval_base_qs.filter(
                                     approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
                                 ).exclude(extras__auto_approval=True)
                             )
@@ -361,7 +408,7 @@ def apply_filters(
                     subqueries.append(
                         Q(
                             Exists(
-                                base_qs.filter(
+                                approval_base_qs.filter(
                                     approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
                                     extras__auto_approval=True,
                                 )
@@ -372,7 +419,7 @@ def apply_filters(
                     subqueries.append(
                         Q(
                             Exists(
-                                base_qs.exclude(
+                                approval_base_qs.exclude(
                                     approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
                                 )
                             )

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -930,7 +930,7 @@ class BuildsEndpointTest(APITestCase):
         app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
         assert app_ids == {"com.approved.app"}
 
-    def test_query_approval_status(self) -> None:
+    def test_query_snapshot_status(self) -> None:
         manual_artifact = self.create_preprod_artifact(app_id="com.manual.app")
         self.create_preprod_snapshot_metrics(preprod_artifact=manual_artifact)
         self.create_preprod_comparison_approval(
@@ -956,27 +956,27 @@ class BuildsEndpointTest(APITestCase):
             approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
         )
 
-        response = self._request({"display": "snapshot", "query": "approval_status:approved"})
+        response = self._request({"display": "snapshot", "query": "snapshot_status:approved"})
         self._assert_is_successful(response)
         app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
         assert app_ids == {"com.manual.app"}
 
-        response = self._request({"display": "snapshot", "query": "approval_status:auto_approved"})
+        response = self._request({"display": "snapshot", "query": "snapshot_status:auto_approved"})
         self._assert_is_successful(response)
         app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
         assert app_ids == {"com.auto.app"}
 
         response = self._request(
-            {"display": "snapshot", "query": "approval_status:requires_approval"}
+            {"display": "snapshot", "query": "snapshot_status:requires_approval"}
         )
         self._assert_is_successful(response)
         app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
         assert app_ids == {"com.pending.app"}
 
-    def test_query_approval_status_invalid_value(self) -> None:
+    def test_query_snapshot_status_invalid_value(self) -> None:
         self.create_preprod_artifact(app_id="com.test.app")
 
-        response = self._request({"display": "snapshot", "query": "approval_status:bogus"})
+        response = self._request({"display": "snapshot", "query": "snapshot_status:bogus"})
         assert response.status_code == 400
 
     def test_snapshot_comparison_info_auto_approved(self) -> None:

--- a/tests/sentry/preprod/test_artifact_search.py
+++ b/tests/sentry/preprod/test_artifact_search.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.artifact_search import (
     artifact_matches_query,
     get_sequential_base_artifact,
@@ -13,6 +14,7 @@ from sentry.preprod.models import (
     PreprodComparisonApproval,
     PreprodSnapshotMetrics,
 )
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison
 from sentry.testutils.cases import TestCase
 
 
@@ -329,7 +331,7 @@ class ArtifactMatchesQueryIsApprovedFilterTest(TestCase):
         assert artifact_matches_query(pending_artifact, "!is_approved:true", self.organization)
 
 
-class ArtifactMatchesQueryApprovalStatusFilterTest(TestCase):
+class ArtifactMatchesQuerySnapshotStatusFilterTest(TestCase):
     def _create_artifact_with_approval(
         self,
         feature_type: int = PreprodComparisonApproval.FeatureType.SNAPSHOTS,
@@ -347,18 +349,18 @@ class ArtifactMatchesQueryApprovalStatusFilterTest(TestCase):
             )
         return artifact
 
-    def test_approval_status_approved_matches_manual_only(self) -> None:
+    def test_snapshot_status_approved_matches_manual_only(self) -> None:
         manual = self._create_artifact_with_approval()
         auto = self._create_artifact_with_approval(extras={"auto_approval": True})
         pending = self._create_artifact_with_approval(
             status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
         )
 
-        assert artifact_matches_query(manual, "approval_status:approved", self.organization)
-        assert not artifact_matches_query(auto, "approval_status:approved", self.organization)
-        assert not artifact_matches_query(pending, "approval_status:approved", self.organization)
+        assert artifact_matches_query(manual, "snapshot_status:approved", self.organization)
+        assert not artifact_matches_query(auto, "snapshot_status:approved", self.organization)
+        assert not artifact_matches_query(pending, "snapshot_status:approved", self.organization)
 
-    def test_approval_status_auto_approved(self) -> None:
+    def test_snapshot_status_auto_approved(self) -> None:
         manual = self._create_artifact_with_approval()
         auto = self._create_artifact_with_approval(extras={"auto_approval": True})
         pending = self._create_artifact_with_approval(
@@ -366,45 +368,45 @@ class ArtifactMatchesQueryApprovalStatusFilterTest(TestCase):
         )
 
         assert not artifact_matches_query(
-            manual, "approval_status:auto_approved", self.organization
+            manual, "snapshot_status:auto_approved", self.organization
         )
-        assert artifact_matches_query(auto, "approval_status:auto_approved", self.organization)
+        assert artifact_matches_query(auto, "snapshot_status:auto_approved", self.organization)
         assert not artifact_matches_query(
-            pending, "approval_status:auto_approved", self.organization
+            pending, "snapshot_status:auto_approved", self.organization
         )
 
-    def test_approval_status_requires_approval(self) -> None:
+    def test_snapshot_status_requires_approval(self) -> None:
         manual = self._create_artifact_with_approval()
         pending = self._create_artifact_with_approval(
             status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
         )
 
         assert not artifact_matches_query(
-            manual, "approval_status:requires_approval", self.organization
+            manual, "snapshot_status:requires_approval", self.organization
         )
         assert artifact_matches_query(
-            pending, "approval_status:requires_approval", self.organization
+            pending, "snapshot_status:requires_approval", self.organization
         )
 
-    def test_approval_status_no_record_matches_nothing(self) -> None:
+    def test_snapshot_status_no_record_matches_nothing(self) -> None:
         no_row = self._create_artifact_with_approval(with_approval_row=False)
 
-        assert not artifact_matches_query(no_row, "approval_status:approved", self.organization)
+        assert not artifact_matches_query(no_row, "snapshot_status:approved", self.organization)
         assert not artifact_matches_query(
-            no_row, "approval_status:auto_approved", self.organization
+            no_row, "snapshot_status:auto_approved", self.organization
         )
         assert not artifact_matches_query(
-            no_row, "approval_status:requires_approval", self.organization
+            no_row, "snapshot_status:requires_approval", self.organization
         )
 
-    def test_approval_status_scoped_to_snapshots(self) -> None:
+    def test_snapshot_status_scoped_to_snapshots(self) -> None:
         artifact = self._create_artifact_with_approval(
             feature_type=PreprodComparisonApproval.FeatureType.SIZE,
         )
 
-        assert not artifact_matches_query(artifact, "approval_status:approved", self.organization)
+        assert not artifact_matches_query(artifact, "snapshot_status:approved", self.organization)
 
-    def test_approval_status_in_filter(self) -> None:
+    def test_snapshot_status_in_filter(self) -> None:
         manual = self._create_artifact_with_approval()
         auto = self._create_artifact_with_approval(extras={"auto_approval": True})
         pending = self._create_artifact_with_approval(
@@ -412,27 +414,27 @@ class ArtifactMatchesQueryApprovalStatusFilterTest(TestCase):
         )
 
         assert artifact_matches_query(
-            manual, "approval_status:[approved, auto_approved]", self.organization
+            manual, "snapshot_status:[approved, auto_approved]", self.organization
         )
         assert artifact_matches_query(
-            auto, "approval_status:[approved, auto_approved]", self.organization
+            auto, "snapshot_status:[approved, auto_approved]", self.organization
         )
         assert not artifact_matches_query(
-            pending, "approval_status:[approved, auto_approved]", self.organization
+            pending, "snapshot_status:[approved, auto_approved]", self.organization
         )
 
-    def test_approval_status_negation(self) -> None:
+    def test_snapshot_status_negation(self) -> None:
         manual = self._create_artifact_with_approval()
         auto = self._create_artifact_with_approval(extras={"auto_approval": True})
         pending = self._create_artifact_with_approval(
             status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
         )
 
-        assert not artifact_matches_query(manual, "!approval_status:approved", self.organization)
-        assert artifact_matches_query(auto, "!approval_status:approved", self.organization)
-        assert artifact_matches_query(pending, "!approval_status:approved", self.organization)
+        assert not artifact_matches_query(manual, "!snapshot_status:approved", self.organization)
+        assert artifact_matches_query(auto, "!snapshot_status:approved", self.organization)
+        assert artifact_matches_query(pending, "!snapshot_status:approved", self.organization)
 
-    def test_approval_status_invalid_value(self) -> None:
+    def test_snapshot_status_invalid_value(self) -> None:
         import pytest
 
         from sentry.exceptions import InvalidSearchQuery
@@ -440,4 +442,126 @@ class ArtifactMatchesQueryApprovalStatusFilterTest(TestCase):
         artifact = self._create_artifact_with_approval()
 
         with pytest.raises(InvalidSearchQuery):
-            artifact_matches_query(artifact, "approval_status:bogus", self.organization)
+            artifact_matches_query(artifact, "snapshot_status:bogus", self.organization)
+
+    def _create_artifact_with_comparison_state(
+        self,
+        state: int,
+        commit_comparison: CommitComparison | None = None,
+    ) -> PreprodArtifact:
+        if commit_comparison is None:
+            commit_comparison = self.create_commit_comparison(organization=self.organization)
+        artifact = self.create_preprod_artifact(
+            project=self.project, commit_comparison=commit_comparison
+        )
+        head_metrics = self.create_preprod_snapshot_metrics(
+            preprod_artifact=artifact, image_count=5
+        )
+        base_artifact = self.create_preprod_artifact(project=self.project)
+        base_metrics = self.create_preprod_snapshot_metrics(
+            preprod_artifact=base_artifact, image_count=5
+        )
+        self.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=state,
+        )
+        return artifact
+
+    def test_snapshot_status_base(self) -> None:
+        cc = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha=None,
+            head_repo_name="owner/repo",
+        )
+        base_artifact = self.create_preprod_artifact(project=self.project, commit_comparison=cc)
+        self.create_preprod_snapshot_metrics(preprod_artifact=base_artifact, image_count=5)
+
+        no_cc_artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_snapshot_metrics(preprod_artifact=no_cc_artifact, image_count=5)
+
+        pr_cc = self.create_commit_comparison(organization=self.organization)
+        pr_artifact = self._create_artifact_with_comparison_state(
+            state=PreprodSnapshotComparison.State.SUCCESS,
+            commit_comparison=pr_cc,
+        )
+
+        assert artifact_matches_query(base_artifact, "snapshot_status:base", self.organization)
+        assert artifact_matches_query(no_cc_artifact, "snapshot_status:base", self.organization)
+        assert not artifact_matches_query(pr_artifact, "snapshot_status:base", self.organization)
+
+    def test_snapshot_status_no_base(self) -> None:
+        cc = self.create_commit_comparison(organization=self.organization)
+        artifact = self.create_preprod_artifact(project=self.project, commit_comparison=cc)
+        self.create_preprod_snapshot_metrics(preprod_artifact=artifact, image_count=5)
+
+        base_cc = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha=None,
+            head_repo_name="owner/repo",
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project, commit_comparison=base_cc
+        )
+        self.create_preprod_snapshot_metrics(preprod_artifact=base_artifact, image_count=5)
+
+        assert artifact_matches_query(artifact, "snapshot_status:no_base", self.organization)
+        assert not artifact_matches_query(
+            base_artifact, "snapshot_status:no_base", self.organization
+        )
+
+    def test_snapshot_status_pending(self) -> None:
+        pending = self._create_artifact_with_comparison_state(
+            state=PreprodSnapshotComparison.State.PENDING
+        )
+        success = self._create_artifact_with_comparison_state(
+            state=PreprodSnapshotComparison.State.SUCCESS
+        )
+
+        assert artifact_matches_query(pending, "snapshot_status:pending", self.organization)
+        assert not artifact_matches_query(success, "snapshot_status:pending", self.organization)
+
+    def test_snapshot_status_processing(self) -> None:
+        processing = self._create_artifact_with_comparison_state(
+            state=PreprodSnapshotComparison.State.PROCESSING
+        )
+        success = self._create_artifact_with_comparison_state(
+            state=PreprodSnapshotComparison.State.SUCCESS
+        )
+
+        assert artifact_matches_query(processing, "snapshot_status:processing", self.organization)
+        assert not artifact_matches_query(success, "snapshot_status:processing", self.organization)
+
+    def test_snapshot_status_failed(self) -> None:
+        failed = self._create_artifact_with_comparison_state(
+            state=PreprodSnapshotComparison.State.FAILED
+        )
+        success = self._create_artifact_with_comparison_state(
+            state=PreprodSnapshotComparison.State.SUCCESS
+        )
+
+        assert artifact_matches_query(failed, "snapshot_status:failed", self.organization)
+        assert not artifact_matches_query(success, "snapshot_status:failed", self.organization)
+
+    def test_snapshot_status_in_filter_mixed(self) -> None:
+        pending = self._create_artifact_with_comparison_state(
+            state=PreprodSnapshotComparison.State.PENDING
+        )
+        failed = self._create_artifact_with_comparison_state(
+            state=PreprodSnapshotComparison.State.FAILED
+        )
+        success = self._create_artifact_with_comparison_state(
+            state=PreprodSnapshotComparison.State.SUCCESS
+        )
+
+        assert artifact_matches_query(
+            pending, "snapshot_status:[pending, failed]", self.organization
+        )
+        assert artifact_matches_query(
+            failed, "snapshot_status:[pending, failed]", self.organization
+        )
+        assert not artifact_matches_query(
+            success, "snapshot_status:[pending, failed]", self.organization
+        )


### PR DESCRIPTION
Replaces the `approval_status` search field with `snapshot_status`, adding support for filtering by all snapshot comparison states visible in the Status column: `base`, `no_base`, `pending`, `processing`, `failed`, plus the existing approval values (`approved`, `auto_approved`, `requires_approval`).

**New comparison state filters**

`base` matches main-branch builds (no `base_sha` on the commit comparison). `no_base` matches PR builds where the base artifact hasn't been found (combines the `waiting_for_base` and `no_base_build` UI states into one searchable value). `pending`, `processing`, and `failed` filter by `PreprodSnapshotComparison.State` directly.

**Breaking change**: `approval_status` is removed. Use `snapshot_status` instead — the three approval values are unchanged.

Refs EME-1147