### PR TITLE
fix(codeowners): Return owner names on sync

### DIFF
--- a/src/sentry/issues/endpoints/project_codeowners_details.py
+++ b/src/sentry/issues/endpoints/project_codeowners_details.py
@@ -93,7 +93,12 @@ class ProjectCodeOwnersDetailsEndpoint(ProjectCodeOwnersBase):
                     updated_codeowners,
                     request.user,
                     serializer=projectcodeowners_serializers.ProjectCodeOwnersSerializer(
-                        expand=["ownershipSyntax", "errors"]
+                        expand=[
+                            "ownershipSyntax",
+                            "errors",
+                            "renameIdentifier",
+                            "hasTargetingContext",
+                        ]
                     ),
                 ),
                 status=status.HTTP_200_OK,

--- a/src/sentry/issues/endpoints/project_codeowners_index.py
+++ b/src/sentry/issues/endpoints/project_codeowners_index.py
@@ -87,7 +87,12 @@ class ProjectCodeOwnersEndpoint(ProjectCodeOwnersBase):
             except Exception as e:
                 sentry_sdk.capture_exception(e)
 
-            expand = ["ownershipSyntax", "errors", "hasTargetingContext"]
+            expand = [
+                "ownershipSyntax",
+                "errors",
+                "renameIdentifier",
+                "hasTargetingContext",
+            ]
 
             return Response(
                 serialize(

--- a/tests/sentry/issues/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/issues/endpoints/test_project_codeowners_details.py
@@ -87,6 +87,12 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         assert response.data["id"] == str(self.codeowners.id)
         assert response.data["raw"] == raw.strip()
         assert response.data["dateSynced"] is not None
+        assert response.data["codeOwnersUrl"] == "https://github.com/test/CODEOWNERS"
+        assert response.data["schema"]["rules"]
+        for rule in response.data["schema"]["rules"]:
+            for owner in rule["owners"]:
+                assert "name" in owner
+                assert "identifier" not in owner
         codeowner = ProjectCodeOwners.objects.get(id=self.codeowners.id)
         assert codeowner.date_updated.strftime("%Y-%m-%d %H:%M:%S") == "2023-10-03 00:00:00"
         assert codeowner.date_synced is not None

--- a/tests/sentry/issues/endpoints/test_project_codeowners_index.py
+++ b/tests/sentry/issues/endpoints/test_project_codeowners_index.py
@@ -546,8 +546,8 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 {
                     "matcher": {"type": "codeowners", "pattern": "docs/*"},
                     "owners": [
-                        {"type": "user", "id": str(self.user.id), "identifier": "admin@sentry.io"},
-                        {"type": "team", "id": str(self.team.id), "identifier": "tiger-team"},
+                        {"type": "user", "id": str(self.user.id), "name": "admin@sentry.io"},
+                        {"type": "team", "id": str(self.team.id), "name": "tiger-team"},
                     ],
                 }
             ],


### PR DESCRIPTION
The parsed codeowners schema was added for the ownership rules table back in #45533, but only the GET path got the backend identifier -> frontend name conversion. POST and PUT still returned the stored schema shape, and the settings UI writes those mutation responses straight into the codeowners cache.

fixes an issue where the new owners show up as "unknown" because the shape of the object has changed