### PR TITLE
feat(trace-waterfall): Small tweaks to trace-waterfall tab

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -153,6 +153,7 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
   });
 
   const {tabOptions, currentTab, onTabChange} = useTraceLayoutTabs({
+    isLoading: meta.status === 'pending' || tree.type === 'loading',
     tree,
     logs: logsData,
     meta: meta.data,

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -35,6 +35,7 @@ import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLM
 import {useTrace} from './traceApi/useTrace';
 import {
   getTraceMetaErrorCount,
+  getTraceMetaMetricsCount,
   getTraceMetaPerformanceIssueCount,
   getTraceMetaSpanCount,
   useTraceMeta,
@@ -115,14 +116,17 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
   const queryParams = useTraceQueryParams();
   const traceEventView = useTraceEventView(traceSlug, queryParams);
   const logsData = useInitialLogsData();
+  const meta = useTraceMeta({traceSlug, timestamp: queryParams.timestamp});
+  const metaMetricsCount = getTraceMetaMetricsCount(meta.data);
   const {metricsData} = useInitialTraceMetricData({
     traceId: traceSlug,
     queryParams,
-    enabled: true,
+    enabled: meta.status !== 'pending' && metaMetricsCount === undefined,
   });
+  const traceMetricsData =
+    metaMetricsCount === undefined ? metricsData : {count: metaMetricsCount};
   const hideTraceWaterfallIfEmpty = (logsData?.length ?? 0) > 0;
 
-  const meta = useTraceMeta({traceSlug, timestamp: queryParams.timestamp});
   const trace = useTrace({
     traceSlug,
     timestamp: queryParams.timestamp,
@@ -151,7 +155,8 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
   const {tabOptions, currentTab, onTabChange} = useTraceLayoutTabs({
     tree,
     logs: logsData,
-    metrics: metricsData,
+    meta: meta.data,
+    metrics: traceMetricsData,
   });
 
   // Push trace metadata into the LLM context tree for Seer Explorer.
@@ -193,7 +198,7 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
             traceSlug={traceSlug}
             traceEventView={traceEventView}
             logs={logsData}
-            metrics={metricsData}
+            metrics={traceMetricsData}
           />
           <TraceInnerLayout>
             <ErrorsOnlyWarnings

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -10,7 +10,9 @@ import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
+import {isLogsEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import {canUseMetricsUI} from 'sentry/views/explore/metrics/metricsFlags';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {TraceAiTab} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceAiTab';
 import {TraceProfiles} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceProfiles';
@@ -113,6 +115,8 @@ function useInitialLogsData(): OurLogsResponseItem[] | undefined {
 
 function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
   const organization = useOrganization();
+  const logsEnabled = isLogsEnabled(organization);
+  const metricsEnabled = canUseMetricsUI(organization);
   const queryParams = useTraceQueryParams();
   const traceEventView = useTraceEventView(traceSlug, queryParams);
   const logsData = useInitialLogsData();
@@ -158,6 +162,8 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
     logs: logsData,
     meta: meta.data,
     metrics: traceMetricsData,
+    logsEnabled,
+    metricsEnabled,
   });
 
   // Push trace metadata into the LLM context tree for Seer Explorer.

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -95,9 +95,33 @@ export function getTraceMetaSpanCount(meta: MetaArg) {
   return isEAPTraceMeta(meta) ? meta.spansCount : meta.span_count;
 }
 
+export function getTraceMetaMetricsCount(meta: MetaArg) {
+  if (!meta) return;
+  return isEAPTraceMeta(meta) ? meta.metricsCount : undefined;
+}
+
 export function getTraceMetaLogsCount(meta: MetaArg) {
   if (!meta) return;
   return isEAPTraceMeta(meta) ? meta.logsCount : undefined;
+}
+
+export function getTraceMetaTransactionCount(meta: MetaArg) {
+  if (!meta) return;
+  return isEAPTraceMeta(meta) ? undefined : meta.transactions;
+}
+
+export function getTraceMetaUptimeCount(meta: MetaArg) {
+  if (!meta) return;
+  return isEAPTraceMeta(meta) ? meta.uptimeCount : undefined;
+}
+
+export function getTraceMetaAiSpanCount(meta: MetaArg) {
+  if (!meta) return;
+  const spansCountMap = isEAPTraceMeta(meta) ? meta.spansCountMap : meta.span_count_map;
+
+  return Object.entries(spansCountMap).reduce((count, [op, opCount]) => {
+    return op.startsWith('gen_ai') ? count + opCount : count;
+  }, 0);
 }
 
 export function getTraceMetaTransactionChildCountMap(meta: MetaArg) {

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -117,9 +117,9 @@ export function getTraceMetaUptimeCount(meta: MetaArg) {
 
 export function getTraceMetaAiSpanCount(meta: MetaArg) {
   if (!meta) return;
-  const spansCountMap = isEAPTraceMeta(meta) ? meta.spansCountMap : meta.span_count_map;
+  if (!isEAPTraceMeta(meta)) return;
 
-  return Object.entries(spansCountMap).reduce((count, [op, opCount]) => {
+  return Object.entries(meta.spansCountMap).reduce((count, [op, opCount]) => {
     return op.startsWith('gen_ai') ? count + opCount : count;
   }, 0);
 }

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -280,6 +280,40 @@ describe('TraceMetaDataHeader', () => {
   });
 
   describe('meta', () => {
+    it('should render logs count from trace meta before logs have loaded', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/traces/trace/trace-slug',
+        })
+      );
+      const logsOrganization = OrganizationFixture({
+        features: ['ourlogs-enabled'],
+      });
+
+      const props = {
+        ...baseProps,
+        logs: undefined,
+        metaResults: {
+          ...baseProps.metaResults,
+          data: {
+            errorsCount: 0,
+            logsCount: 5,
+            metricsCount: 0,
+            performanceIssuesCount: 0,
+            spansCount: 0,
+            spansCountMap: {},
+            transactionChildCountMap: {},
+            uptimeCount: 0,
+          },
+        },
+      } as TraceMetadataHeaderProps;
+
+      render(<TraceMetaDataHeader {...props} organization={logsOrganization} />);
+
+      expect(screen.getByText('Logs')).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+
     it('should render metrics count', () => {
       useLocationMock.mockReturnValue(
         LocationFixture({

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -280,6 +280,37 @@ describe('TraceMetaDataHeader', () => {
   });
 
   describe('meta', () => {
+    it('should render metrics count', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/traces/trace/trace-slug',
+        })
+      );
+
+      const props = {
+        ...baseProps,
+        metrics: {count: 5},
+        metaResults: {
+          ...baseProps.metaResults,
+          data: {
+            errorsCount: 0,
+            logsCount: 0,
+            metricsCount: 5,
+            performanceIssuesCount: 0,
+            spansCount: 0,
+            spansCountMap: {},
+            transactionChildCountMap: {},
+            uptimeCount: 0,
+          },
+        },
+      } as TraceMetadataHeaderProps;
+
+      render(<TraceMetaDataHeader {...props} organization={organization} />);
+
+      expect(screen.getByText('Metrics')).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+
     it('should render meta with different spans count', async () => {
       useLocationMock.mockReturnValue(
         LocationFixture({

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -286,6 +286,40 @@ describe('TraceMetaDataHeader', () => {
           pathname: '/organizations/org-slug/traces/trace/trace-slug',
         })
       );
+      const metricsOrganization = OrganizationFixture({
+        features: ['tracemetrics-enabled'],
+      });
+
+      const props = {
+        ...baseProps,
+        metrics: {count: 5},
+        metaResults: {
+          ...baseProps.metaResults,
+          data: {
+            errorsCount: 0,
+            logsCount: 0,
+            metricsCount: 5,
+            performanceIssuesCount: 0,
+            spansCount: 0,
+            spansCountMap: {},
+            transactionChildCountMap: {},
+            uptimeCount: 0,
+          },
+        },
+      } as TraceMetadataHeaderProps;
+
+      render(<TraceMetaDataHeader {...props} organization={metricsOrganization} />);
+
+      expect(screen.getByText('Metrics')).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+
+    it('does not render metrics count when the metrics feature is disabled', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/traces/trace/trace-slug',
+        })
+      );
 
       const props = {
         ...baseProps,
@@ -307,8 +341,7 @@ describe('TraceMetaDataHeader', () => {
 
       render(<TraceMetaDataHeader {...props} organization={organization} />);
 
-      expect(screen.getByText('Metrics')).toBeInTheDocument();
-      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
     });
 
     it('should render meta with different spans count', async () => {

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -63,6 +63,7 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
     tree: props.tree,
     logs: props.logs,
     metrics: props.metrics,
+    meta: props.metaResults.data,
     logsEnabled,
     metricsEnabled,
   });

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -8,10 +8,12 @@ import type {Project} from 'sentry/types/project';
 import type {EventView} from 'sentry/utils/discover/eventView';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useProjects} from 'sentry/utils/useProjects';
+import {isLogsEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
 import {
   OurLogKnownFieldKey,
   type OurLogsResponseItem,
 } from 'sentry/views/explore/logs/types';
+import {canUseMetricsUI} from 'sentry/views/explore/metrics/metricsFlags';
 import {useModuleURLBuilder} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -51,6 +53,8 @@ const traceViewFeedbackOptions = {
 
 export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
   const location = useLocation();
+  const logsEnabled = isLogsEnabled(props.organization);
+  const metricsEnabled = canUseMetricsUI(props.organization);
   const {view} = useDomainViewFilters();
   const moduleURLBuilder = useModuleURLBuilder(true);
   const {projects} = useProjects();
@@ -59,6 +63,8 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
     tree: props.tree,
     logs: props.logs,
     metrics: props.metrics,
+    logsEnabled,
+    metricsEnabled,
   });
 
   const isLoading =
@@ -139,6 +145,8 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
             representativeEvent={rep}
             logs={props.logs}
             metrics={props.metrics}
+            logsEnabled={logsEnabled}
+            metricsEnabled={metricsEnabled}
           />
         </TraceHeaderComponents.HeaderRow>
         <TraceHeaderComponents.StyledBreak />

--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -55,8 +55,10 @@ const SectionBody = styled('div')<{alignment?: boolean}>`
 
 interface MetaProps {
   logs: OurLogsResponseItem[] | undefined;
+  logsEnabled: boolean;
   meta: TraceMetaQueryResults['data'];
   metrics: {count: number} | undefined;
+  metricsEnabled: boolean;
   organization: Organization;
   representativeEvent: TraceTree.RepresentativeTraceEvent | null;
   tree: TraceTree;
@@ -104,9 +106,9 @@ export function Meta(props: MetaProps) {
 
   const hasDifferentSpansCount = loadedSpansCount !== 0 && totalSpansCount !== 0;
   const hasSpans = spansCount > 0 || loadedSpansCount > 0 || totalSpansCount > 0;
-  const hasLogs = (props.logs?.length ?? 0) > 0;
+  const hasLogs = props.logsEnabled && (props.logs?.length ?? 0) > 0;
   const metricsCount = getTraceMetaMetricsCount(props.meta) ?? props.metrics?.count ?? 0;
-  const hasMetrics = metricsCount > 0;
+  const hasMetrics = props.metricsEnabled && metricsCount > 0;
 
   const repEvent = props.representativeEvent?.event;
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -13,6 +13,7 @@ import {
 } from 'sentry/views/explore/logs/types';
 import {
   getTraceMetaLogsCount,
+  getTraceMetaMetricsCount,
   getTraceMetaSpanCount,
   type TraceMetaQueryResults,
 } from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
@@ -104,6 +105,8 @@ export function Meta(props: MetaProps) {
   const hasDifferentSpansCount = loadedSpansCount !== 0 && totalSpansCount !== 0;
   const hasSpans = spansCount > 0 || loadedSpansCount > 0 || totalSpansCount > 0;
   const hasLogs = (props.logs?.length ?? 0) > 0;
+  const metricsCount = getTraceMetaMetricsCount(props.meta) ?? props.metrics?.count ?? 0;
+  const hasMetrics = metricsCount > 0;
 
   const repEvent = props.representativeEvent?.event;
 
@@ -150,6 +153,11 @@ export function Meta(props: MetaProps) {
       ) : hasLogs ? (
         <MetaSection rightAlignBody headingText={t('Logs')}>
           {getTraceMetaLogsCount(props.meta) ?? props.logs?.length ?? 0}
+        </MetaSection>
+      ) : null}
+      {hasMetrics ? (
+        <MetaSection rightAlignBody headingText={t('Metrics')}>
+          {metricsCount}
         </MetaSection>
       ) : null}
     </MetaWrapper>

--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -153,7 +153,8 @@ export function Meta(props: MetaProps) {
               : getRootDuration(repEvent)
             : '\u2014'}
         </MetaSection>
-      ) : hasLogs ? (
+      ) : null}
+      {hasLogs ? (
         <MetaSection rightAlignBody headingText={t('Logs')}>
           {logsCount}
         </MetaSection>

--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -106,7 +106,8 @@ export function Meta(props: MetaProps) {
 
   const hasDifferentSpansCount = loadedSpansCount !== 0 && totalSpansCount !== 0;
   const hasSpans = spansCount > 0 || loadedSpansCount > 0 || totalSpansCount > 0;
-  const hasLogs = props.logsEnabled && (props.logs?.length ?? 0) > 0;
+  const logsCount = getTraceMetaLogsCount(props.meta) ?? props.logs?.length ?? 0;
+  const hasLogs = props.logsEnabled && logsCount > 0;
   const metricsCount = getTraceMetaMetricsCount(props.meta) ?? props.metrics?.count ?? 0;
   const hasMetrics = props.metricsEnabled && metricsCount > 0;
 
@@ -154,7 +155,7 @@ export function Meta(props: MetaProps) {
         </MetaSection>
       ) : hasLogs ? (
         <MetaSection rightAlignBody headingText={t('Logs')}>
-          {getTraceMetaLogsCount(props.meta) ?? props.logs?.length ?? 0}
+          {logsCount}
         </MetaSection>
       ) : null}
       {hasMetrics ? (

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
@@ -6,6 +6,7 @@ import type {
   TraceMeta,
 } from 'sentry/views/performance/newTraceDetails/traceApi/types';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 
 import {useTraceContextSections} from './useTraceContextSections';
 
@@ -13,7 +14,7 @@ function makeTree(overrides: Partial<TraceTree> = {}): TraceTree {
   return {
     type: 'empty',
     root: {
-      findChild: () => false,
+      findChild: () => null,
     },
     vitals: new Map(),
     profiled_events: new Set(),
@@ -62,8 +63,8 @@ describe('useTraceContextSections', () => {
       useTraceContextSections({
         tree: makeTree({
           root: {
-            findChild: () => true,
-          },
+            findChild: () => ({}) as BaseNode,
+          } as unknown as TraceTree['root'],
         }),
         logs: [{}] as unknown as OurLogsResponseItem[],
         metrics: {count: 1},

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
@@ -90,7 +90,11 @@ describe('useTraceContextSections', () => {
 
     const {result} = renderHook(() =>
       useTraceContextSections({
-        tree: makeTree(),
+        tree: makeTree({
+          root: {
+            findChild: () => ({}) as BaseNode,
+          } as unknown as TraceTree['root'],
+        }),
         logs: [{}] as unknown as OurLogsResponseItem[],
         metrics: {count: 1},
         meta: legacyMeta,
@@ -99,6 +103,7 @@ describe('useTraceContextSections', () => {
 
     expect(result.current.hasLogs).toBe(true);
     expect(result.current.hasMetrics).toBe(true);
+    expect(result.current.hasAiSpans).toBe(true);
     expect(result.current.hasTraceEvents).toBe(true);
   });
 });

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
@@ -1,0 +1,103 @@
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import type {
+  EAPTraceMeta,
+  TraceMeta,
+} from 'sentry/views/performance/newTraceDetails/traceApi/types';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+import {useTraceContextSections} from './useTraceContextSections';
+
+function makeTree(overrides: Partial<TraceTree> = {}): TraceTree {
+  return {
+    type: 'empty',
+    root: {
+      findChild: () => false,
+    },
+    vitals: new Map(),
+    profiled_events: new Set(),
+    ...overrides,
+  } as TraceTree;
+}
+
+function makeEapMeta(overrides: Partial<EAPTraceMeta> = {}): EAPTraceMeta {
+  return {
+    errorsCount: 0,
+    logsCount: 0,
+    metricsCount: 0,
+    performanceIssuesCount: 0,
+    spansCount: 0,
+    spansCountMap: {},
+    transactionChildCountMap: {},
+    uptimeCount: 0,
+    ...overrides,
+  };
+}
+
+describe('useTraceContextSections', () => {
+  it('uses trace meta counts to show tabs before tab data has loaded', () => {
+    const {result} = renderHook(() =>
+      useTraceContextSections({
+        tree: makeTree(),
+        logs: undefined,
+        metrics: undefined,
+        meta: makeEapMeta({
+          logsCount: 2,
+          metricsCount: 3,
+          spansCount: 4,
+          spansCountMap: {'gen_ai.chat': 1},
+        }),
+      })
+    );
+
+    expect(result.current.hasLogs).toBe(true);
+    expect(result.current.hasMetrics).toBe(true);
+    expect(result.current.hasAiSpans).toBe(true);
+    expect(result.current.hasTraceEvents).toBe(true);
+  });
+
+  it('treats zero trace meta counts as authoritative for covered sections', () => {
+    const {result} = renderHook(() =>
+      useTraceContextSections({
+        tree: makeTree({
+          root: {
+            findChild: () => true,
+          },
+        }),
+        logs: [{}] as unknown as OurLogsResponseItem[],
+        metrics: {count: 1},
+        meta: makeEapMeta(),
+      })
+    );
+
+    expect(result.current.hasLogs).toBe(false);
+    expect(result.current.hasMetrics).toBe(false);
+    expect(result.current.hasAiSpans).toBe(false);
+  });
+
+  it('falls back to loaded data for sections not covered by legacy trace meta', () => {
+    const legacyMeta: TraceMeta = {
+      errors: 0,
+      performance_issues: 0,
+      projects: 0,
+      span_count: 1,
+      span_count_map: {},
+      transaction_child_count_map: {},
+      transactions: 0,
+    };
+
+    const {result} = renderHook(() =>
+      useTraceContextSections({
+        tree: makeTree(),
+        logs: [{}] as unknown as OurLogsResponseItem[],
+        metrics: {count: 1},
+        meta: legacyMeta,
+      })
+    );
+
+    expect(result.current.hasLogs).toBe(true);
+    expect(result.current.hasMetrics).toBe(true);
+    expect(result.current.hasTraceEvents).toBe(true);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
@@ -58,7 +58,7 @@ describe('useTraceContextSections', () => {
     expect(result.current.hasTraceEvents).toBe(true);
   });
 
-  it('treats zero trace meta counts as authoritative for covered sections', () => {
+  it('treats zero trace meta counts as authoritative for logs and metrics', () => {
     const {result} = renderHook(() =>
       useTraceContextSections({
         tree: makeTree({
@@ -74,7 +74,43 @@ describe('useTraceContextSections', () => {
 
     expect(result.current.hasLogs).toBe(false);
     expect(result.current.hasMetrics).toBe(false);
-    expect(result.current.hasAiSpans).toBe(false);
+    expect(result.current.hasAiSpans).toBe(true);
+  });
+
+  it('falls back to tree data for AI spans when EAP trace meta has no gen_ai span op count', () => {
+    const {result} = renderHook(() =>
+      useTraceContextSections({
+        tree: makeTree({
+          root: {
+            findChild: () => ({}) as BaseNode,
+          } as unknown as TraceTree['root'],
+        }),
+        logs: undefined,
+        metrics: undefined,
+        meta: makeEapMeta({spansCountMap: {http: 1}}),
+      })
+    );
+
+    expect(result.current.hasAiSpans).toBe(true);
+  });
+
+  it('does not show logs or metrics from trace meta when the product features are disabled', () => {
+    const {result} = renderHook(() =>
+      useTraceContextSections({
+        tree: makeTree(),
+        logs: [{}] as unknown as OurLogsResponseItem[],
+        metrics: {count: 1},
+        meta: makeEapMeta({
+          logsCount: 2,
+          metricsCount: 3,
+        }),
+        logsEnabled: false,
+        metricsEnabled: false,
+      })
+    );
+
+    expect(result.current.hasLogs).toBe(false);
+    expect(result.current.hasMetrics).toBe(false);
   });
 
   it('falls back to loaded data for sections not covered by legacy trace meta', () => {

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.tsx
@@ -3,21 +3,41 @@ import {useMemo} from 'react';
 import {VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {getIsAiNode} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import {
+  getTraceMetaAiSpanCount,
+  getTraceMetaErrorCount,
+  getTraceMetaLogsCount,
+  getTraceMetaMetricsCount,
+  getTraceMetaPerformanceIssueCount,
+  getTraceMetaSpanCount,
+  getTraceMetaTransactionCount,
+  getTraceMetaUptimeCount,
+  type TraceMetaQueryResults,
+} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+function hasCount(count: number | undefined, fallback: boolean): boolean {
+  return count === undefined ? fallback : count > 0;
+}
 
 export function useTraceContextSections({
   tree,
   logs,
   metrics,
+  meta,
 }: {
   logs: OurLogsResponseItem[] | undefined;
   metrics: {count: number} | undefined;
   tree: TraceTree;
+  meta?: TraceMetaQueryResults['data'];
 }) {
   const hasProfiles = tree.type === 'trace' && tree.profiled_events.size > 0;
 
-  const hasLogs = !!(logs && logs?.length > 0);
-  const hasMetrics = !!(metrics && metrics.count > 0);
+  const hasLogs = hasCount(getTraceMetaLogsCount(meta), !!(logs && logs?.length > 0));
+  const hasMetrics = hasCount(
+    getTraceMetaMetricsCount(meta),
+    !!(metrics && metrics.count > 0)
+  );
   const hasOnlyLogs = tree.type === 'empty' && hasLogs;
 
   const allowedVitals = Object.keys(VITAL_DETAILS);
@@ -25,17 +45,30 @@ export function useTraceContextSections({
     vitalGroup.some(vital => allowedVitals.includes(`measurements.${vital.key}`))
   );
 
-  const hasAiSpans = !!tree.root.findChild(getIsAiNode);
+  const hasAiSpans = hasCount(
+    getTraceMetaAiSpanCount(meta),
+    !!tree.root.findChild(getIsAiNode)
+  );
+
+  const traceEventCount =
+    (getTraceMetaSpanCount(meta) ?? 0) +
+    (getTraceMetaErrorCount(meta) ?? 0) +
+    (getTraceMetaPerformanceIssueCount(meta) ?? 0) +
+    (getTraceMetaTransactionCount(meta) ?? 0) +
+    (getTraceMetaUptimeCount(meta) ?? 0);
+
+  const hasTraceEvents =
+    meta === undefined ? !hasOnlyLogs : traceEventCount > 0 || !hasOnlyLogs;
 
   return useMemo(
     () => ({
       hasProfiles,
-      hasTraceEvents: !hasOnlyLogs,
+      hasTraceEvents,
       hasLogs,
       hasVitals,
       hasAiSpans,
       hasMetrics,
     }),
-    [hasProfiles, hasOnlyLogs, hasLogs, hasVitals, hasAiSpans, hasMetrics]
+    [hasProfiles, hasTraceEvents, hasLogs, hasVitals, hasAiSpans, hasMetrics]
   );
 }

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.tsx
@@ -25,19 +25,23 @@ export function useTraceContextSections({
   logs,
   metrics,
   meta,
+  logsEnabled = true,
+  metricsEnabled = true,
 }: {
   logs: OurLogsResponseItem[] | undefined;
   metrics: {count: number} | undefined;
   tree: TraceTree;
+  logsEnabled?: boolean;
   meta?: TraceMetaQueryResults['data'];
+  metricsEnabled?: boolean;
 }) {
   const hasProfiles = tree.type === 'trace' && tree.profiled_events.size > 0;
 
-  const hasLogs = hasCount(getTraceMetaLogsCount(meta), !!(logs && logs?.length > 0));
-  const hasMetrics = hasCount(
-    getTraceMetaMetricsCount(meta),
-    !!(metrics && metrics.count > 0)
-  );
+  const hasLogs =
+    logsEnabled && hasCount(getTraceMetaLogsCount(meta), !!(logs && logs?.length > 0));
+  const hasMetrics =
+    metricsEnabled &&
+    hasCount(getTraceMetaMetricsCount(meta), !!(metrics && metrics.count > 0));
   const hasOnlyLogs = tree.type === 'empty' && hasLogs;
 
   const allowedVitals = Object.keys(VITAL_DETAILS);
@@ -45,10 +49,8 @@ export function useTraceContextSections({
     vitalGroup.some(vital => allowedVitals.includes(`measurements.${vital.key}`))
   );
 
-  const hasAiSpans = hasCount(
-    getTraceMetaAiSpanCount(meta),
-    !!tree.root.findChild(getIsAiNode)
-  );
+  const hasAiSpans =
+    (getTraceMetaAiSpanCount(meta) ?? 0) > 0 || !!tree.root.findChild(getIsAiNode);
 
   const traceEventCount =
     (getTraceMetaSpanCount(meta) ?? 0) +

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
@@ -16,6 +16,7 @@ describe('getInitialTab', () => {
   it.each([
     [TraceLayoutTabKeys.LOGS, TraceLayoutTabKeys.LOGS],
     [TraceLayoutTabKeys.METRICS, TraceLayoutTabKeys.METRICS],
+    [TraceLayoutTabKeys.AI_SPANS, TraceLayoutTabKeys.AI_SPANS],
   ])(
     'keeps %s selected from the URL while tab data is loading',
     (tabSlugFromUrl, expectedTab) => {

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
@@ -42,6 +42,24 @@ describe('getInitialTab', () => {
     ).toBe(TraceLayoutTabKeys.WATERFALL);
   });
 
+  it.each([
+    [TraceLayoutTabKeys.LOGS, {logsEnabled: false}],
+    [TraceLayoutTabKeys.METRICS, {metricsEnabled: false}],
+  ])(
+    'does not preserve %s while loading when the product feature is disabled',
+    (tabSlugFromUrl, featureOptions) => {
+      expect(
+        getInitialTab({
+          isLoading: true,
+          sections,
+          tabOptions: [],
+          tabSlugFromUrl,
+          ...featureOptions,
+        }).slug
+      ).toBe(TraceLayoutTabKeys.WATERFALL);
+    }
+  );
+
   it('does not preserve trace-dependent tabs while loading', () => {
     expect(
       getInitialTab({

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
@@ -1,3 +1,4 @@
+import type {EAPTraceMeta} from 'sentry/views/performance/newTraceDetails/traceApi/types';
 import {
   getInitialTab,
   TraceLayoutTabKeys,
@@ -11,6 +12,20 @@ const sections = {
   hasTraceEvents: true,
   hasVitals: false,
 };
+
+function makeEapMeta(overrides: Partial<EAPTraceMeta> = {}): EAPTraceMeta {
+  return {
+    errorsCount: 0,
+    logsCount: 0,
+    metricsCount: 0,
+    performanceIssuesCount: 0,
+    spansCount: 0,
+    spansCountMap: {},
+    transactionChildCountMap: {},
+    uptimeCount: 0,
+    ...overrides,
+  };
+}
 
 describe('getInitialTab', () => {
   it.each([
@@ -55,6 +70,24 @@ describe('getInitialTab', () => {
           tabOptions: [],
           tabSlugFromUrl,
           ...featureOptions,
+        }).slug
+      ).toBe(TraceLayoutTabKeys.WATERFALL);
+    }
+  );
+
+  it.each([
+    [TraceLayoutTabKeys.LOGS, makeEapMeta({logsCount: 0, metricsCount: 1})],
+    [TraceLayoutTabKeys.METRICS, makeEapMeta({logsCount: 1, metricsCount: 0})],
+  ])(
+    'does not preserve %s while loading when trace meta reports no tab data',
+    (tabSlugFromUrl, meta) => {
+      expect(
+        getInitialTab({
+          isLoading: true,
+          meta,
+          sections,
+          tabOptions: [],
+          tabSlugFromUrl,
         }).slug
       ).toBe(TraceLayoutTabKeys.WATERFALL);
     }

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
@@ -1,0 +1,54 @@
+import {
+  getInitialTab,
+  TraceLayoutTabKeys,
+} from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
+
+const sections = {
+  hasAiSpans: false,
+  hasLogs: false,
+  hasMetrics: false,
+  hasProfiles: false,
+  hasTraceEvents: true,
+  hasVitals: false,
+};
+
+describe('getInitialTab', () => {
+  it.each([
+    [TraceLayoutTabKeys.LOGS, TraceLayoutTabKeys.LOGS],
+    [TraceLayoutTabKeys.METRICS, TraceLayoutTabKeys.METRICS],
+  ])(
+    'keeps %s selected from the URL while tab data is loading',
+    (tabSlugFromUrl, expectedTab) => {
+      expect(
+        getInitialTab({
+          isLoading: true,
+          sections,
+          tabOptions: [],
+          tabSlugFromUrl,
+        }).slug
+      ).toBe(expectedTab);
+    }
+  );
+
+  it('falls back to waterfall after loading when the URL tab is unavailable', () => {
+    expect(
+      getInitialTab({
+        isLoading: false,
+        sections,
+        tabOptions: [],
+        tabSlugFromUrl: TraceLayoutTabKeys.LOGS,
+      }).slug
+    ).toBe(TraceLayoutTabKeys.WATERFALL);
+  });
+
+  it('does not preserve trace-dependent tabs while loading', () => {
+    expect(
+      getInitialTab({
+        isLoading: true,
+        sections,
+        tabOptions: [],
+        tabSlugFromUrl: TraceLayoutTabKeys.PROFILES,
+      }).slug
+    ).toBe(TraceLayoutTabKeys.WATERFALL);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -4,6 +4,7 @@ import * as qs from 'query-string';
 import {t} from 'sentry/locale';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import type {TraceMetaQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {useTraceContextSections} from 'sentry/views/performance/newTraceDetails/useTraceContextSections';
 
@@ -80,17 +81,20 @@ interface UseTraceLayoutTabsProps {
   logs: OurLogsResponseItem[] | undefined;
   metrics: {count: number} | undefined;
   tree: TraceTree;
+  meta?: TraceMetaQueryResults['data'];
 }
 
 export function useTraceLayoutTabs({
   tree,
   logs,
+  meta,
   metrics,
 }: UseTraceLayoutTabsProps): TraceLayoutTabsConfig {
   const navigate = useNavigate();
   const sections = useTraceContextSections({
     tree,
     logs,
+    meta,
     metrics,
   });
   const tabOptions = getTabOptions({sections: {...sections}});

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -79,6 +79,8 @@ function getTabOptions({
 
 export function getInitialTab({
   isLoading,
+  logsEnabled = true,
+  metricsEnabled = true,
   sections,
   tabOptions,
   tabSlugFromUrl,
@@ -87,11 +89,13 @@ export function getInitialTab({
   sections: ReturnType<typeof useTraceContextSections>;
   tabOptions: Tab[];
   tabSlugFromUrl: unknown;
+  logsEnabled?: boolean;
+  metricsEnabled?: boolean;
 }): Tab {
   if (
     isLoading &&
-    (tabSlugFromUrl === TraceLayoutTabKeys.LOGS ||
-      tabSlugFromUrl === TraceLayoutTabKeys.METRICS ||
+    ((logsEnabled && tabSlugFromUrl === TraceLayoutTabKeys.LOGS) ||
+      (metricsEnabled && tabSlugFromUrl === TraceLayoutTabKeys.METRICS) ||
       tabSlugFromUrl === TraceLayoutTabKeys.AI_SPANS)
   ) {
     return TAB_DEFINITIONS[tabSlugFromUrl];
@@ -139,6 +143,8 @@ export function useTraceLayoutTabs({
   const tabSlugFromUrl = queryParams.tab;
   const initialTab = getInitialTab({
     isLoading,
+    logsEnabled,
+    metricsEnabled,
     sections,
     tabOptions,
     tabSlugFromUrl,

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -4,7 +4,11 @@ import * as qs from 'query-string';
 import {t} from 'sentry/locale';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
-import type {TraceMetaQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
+import {
+  getTraceMetaLogsCount,
+  getTraceMetaMetricsCount,
+  type TraceMetaQueryResults,
+} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {useTraceContextSections} from 'sentry/views/performance/newTraceDetails/useTraceContextSections';
 
@@ -81,6 +85,7 @@ export function getInitialTab({
   isLoading,
   logsEnabled = true,
   metricsEnabled = true,
+  meta,
   sections,
   tabOptions,
   tabSlugFromUrl,
@@ -90,12 +95,22 @@ export function getInitialTab({
   tabOptions: Tab[];
   tabSlugFromUrl: unknown;
   logsEnabled?: boolean;
+  meta?: TraceMetaQueryResults['data'];
   metricsEnabled?: boolean;
 }): Tab {
+  const hasAuthoritativeNoLogs =
+    logsEnabled && getTraceMetaLogsCount(meta) === 0 && !sections.hasLogs;
+  const hasAuthoritativeNoMetrics =
+    metricsEnabled && getTraceMetaMetricsCount(meta) === 0 && !sections.hasMetrics;
+
   if (
     isLoading &&
-    ((logsEnabled && tabSlugFromUrl === TraceLayoutTabKeys.LOGS) ||
-      (metricsEnabled && tabSlugFromUrl === TraceLayoutTabKeys.METRICS) ||
+    ((logsEnabled &&
+      !hasAuthoritativeNoLogs &&
+      tabSlugFromUrl === TraceLayoutTabKeys.LOGS) ||
+      (metricsEnabled &&
+        !hasAuthoritativeNoMetrics &&
+        tabSlugFromUrl === TraceLayoutTabKeys.METRICS) ||
       tabSlugFromUrl === TraceLayoutTabKeys.AI_SPANS)
   ) {
     return TAB_DEFINITIONS[tabSlugFromUrl];
@@ -145,6 +160,7 @@ export function useTraceLayoutTabs({
     isLoading,
     logsEnabled,
     metricsEnabled,
+    meta,
     sections,
     tabOptions,
     tabSlugFromUrl,

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -77,7 +77,35 @@ function getTabOptions({
   return tabOptions;
 }
 
+export function getInitialTab({
+  isLoading,
+  sections,
+  tabOptions,
+  tabSlugFromUrl,
+}: {
+  isLoading: boolean;
+  sections: ReturnType<typeof useTraceContextSections>;
+  tabOptions: Tab[];
+  tabSlugFromUrl: unknown;
+}): Tab {
+  if (
+    isLoading &&
+    (tabSlugFromUrl === TraceLayoutTabKeys.LOGS ||
+      tabSlugFromUrl === TraceLayoutTabKeys.METRICS)
+  ) {
+    return TAB_DEFINITIONS[tabSlugFromUrl];
+  }
+
+  return (
+    tabOptions.find(tab => tab.slug === tabSlugFromUrl) ??
+    (sections.hasTraceEvents
+      ? TAB_DEFINITIONS[TraceLayoutTabKeys.WATERFALL]
+      : TAB_DEFINITIONS[TraceLayoutTabKeys.LOGS])
+  );
+}
+
 interface UseTraceLayoutTabsProps {
+  isLoading: boolean;
   logs: OurLogsResponseItem[] | undefined;
   metrics: {count: number} | undefined;
   tree: TraceTree;
@@ -85,6 +113,7 @@ interface UseTraceLayoutTabsProps {
 }
 
 export function useTraceLayoutTabs({
+  isLoading,
   tree,
   logs,
   meta,
@@ -101,11 +130,12 @@ export function useTraceLayoutTabs({
 
   const queryParams = qs.parse(window.location.search);
   const tabSlugFromUrl = queryParams.tab;
-  const initialTab =
-    tabOptions.find(tab => tab.slug === tabSlugFromUrl) ??
-    (sections.hasTraceEvents
-      ? TAB_DEFINITIONS[TraceLayoutTabKeys.WATERFALL]
-      : TAB_DEFINITIONS[TraceLayoutTabKeys.LOGS]);
+  const initialTab = getInitialTab({
+    isLoading,
+    sections,
+    tabOptions,
+    tabSlugFromUrl,
+  });
 
   const [currentTab, setCurrentTab] = useState(initialTab.slug);
 

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -108,7 +108,9 @@ export function getInitialTab({
 interface UseTraceLayoutTabsProps {
   isLoading: boolean;
   logs: OurLogsResponseItem[] | undefined;
+  logsEnabled: boolean;
   metrics: {count: number} | undefined;
+  metricsEnabled: boolean;
   tree: TraceTree;
   meta?: TraceMetaQueryResults['data'];
 }
@@ -119,6 +121,8 @@ export function useTraceLayoutTabs({
   logs,
   meta,
   metrics,
+  logsEnabled,
+  metricsEnabled,
 }: UseTraceLayoutTabsProps): TraceLayoutTabsConfig {
   const navigate = useNavigate();
   const sections = useTraceContextSections({
@@ -126,6 +130,8 @@ export function useTraceLayoutTabs({
     logs,
     meta,
     metrics,
+    logsEnabled,
+    metricsEnabled,
   });
   const tabOptions = getTabOptions({sections: {...sections}});
 

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -98,30 +98,40 @@ export function getInitialTab({
   meta?: TraceMetaQueryResults['data'];
   metricsEnabled?: boolean;
 }): Tab {
-  const hasAuthoritativeNoLogs =
-    logsEnabled && getTraceMetaLogsCount(meta) === 0 && !sections.hasLogs;
-  const hasAuthoritativeNoMetrics =
+  const hasNoLogs = logsEnabled && getTraceMetaLogsCount(meta) === 0 && !sections.hasLogs;
+  const hasNoMetrics =
     metricsEnabled && getTraceMetaMetricsCount(meta) === 0 && !sections.hasMetrics;
 
-  if (
-    isLoading &&
-    ((logsEnabled &&
-      !hasAuthoritativeNoLogs &&
-      tabSlugFromUrl === TraceLayoutTabKeys.LOGS) ||
-      (metricsEnabled &&
-        !hasAuthoritativeNoMetrics &&
-        tabSlugFromUrl === TraceLayoutTabKeys.METRICS) ||
-      tabSlugFromUrl === TraceLayoutTabKeys.AI_SPANS)
-  ) {
-    return TAB_DEFINITIONS[tabSlugFromUrl];
+  const shouldKeepLogsTabWhileLoading =
+    logsEnabled && !hasNoLogs && tabSlugFromUrl === TraceLayoutTabKeys.LOGS;
+
+  const shouldKeepMetricsTabWhileLoading =
+    metricsEnabled && !hasNoMetrics && tabSlugFromUrl === TraceLayoutTabKeys.METRICS;
+
+  if (isLoading) {
+    if (shouldKeepLogsTabWhileLoading) {
+      return TAB_DEFINITIONS[TraceLayoutTabKeys.LOGS];
+    }
+
+    if (shouldKeepMetricsTabWhileLoading) {
+      return TAB_DEFINITIONS[TraceLayoutTabKeys.METRICS];
+    }
+
+    if (tabSlugFromUrl === TraceLayoutTabKeys.AI_SPANS) {
+      return TAB_DEFINITIONS[TraceLayoutTabKeys.AI_SPANS];
+    }
   }
 
-  return (
-    tabOptions.find(tab => tab.slug === tabSlugFromUrl) ??
-    (sections.hasTraceEvents
-      ? TAB_DEFINITIONS[TraceLayoutTabKeys.WATERFALL]
-      : TAB_DEFINITIONS[TraceLayoutTabKeys.LOGS])
-  );
+  const tabFromUrl = tabOptions.find(tab => tab.slug === tabSlugFromUrl);
+  if (tabFromUrl) {
+    return tabFromUrl;
+  }
+
+  if (sections.hasTraceEvents) {
+    return TAB_DEFINITIONS[TraceLayoutTabKeys.WATERFALL];
+  }
+
+  return TAB_DEFINITIONS[TraceLayoutTabKeys.LOGS];
 }
 
 interface UseTraceLayoutTabsProps {

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -93,7 +93,7 @@ export function getInitialTab({
   isLoading: boolean;
   sections: ReturnType<typeof useTraceContextSections>;
   tabOptions: Tab[];
-  tabSlugFromUrl: unknown;
+  tabSlugFromUrl: string | undefined;
   logsEnabled?: boolean;
   meta?: TraceMetaQueryResults['data'];
   metricsEnabled?: boolean;
@@ -165,7 +165,7 @@ export function useTraceLayoutTabs({
   const tabOptions = getTabOptions({sections: {...sections}});
 
   const queryParams = qs.parse(window.location.search);
-  const tabSlugFromUrl = queryParams.tab;
+
   const initialTab = getInitialTab({
     isLoading,
     logsEnabled,
@@ -173,7 +173,7 @@ export function useTraceLayoutTabs({
     meta,
     sections,
     tabOptions,
-    tabSlugFromUrl,
+    tabSlugFromUrl: typeof queryParams.tab === 'string' ? queryParams.tab : undefined,
   });
 
   const [currentTab, setCurrentTab] = useState(initialTab.slug);

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -91,7 +91,8 @@ export function getInitialTab({
   if (
     isLoading &&
     (tabSlugFromUrl === TraceLayoutTabKeys.LOGS ||
-      tabSlugFromUrl === TraceLayoutTabKeys.METRICS)
+      tabSlugFromUrl === TraceLayoutTabKeys.METRICS ||
+      tabSlugFromUrl === TraceLayoutTabKeys.AI_SPANS)
   ) {
     return TAB_DEFINITIONS[tabSlugFromUrl];
   }


### PR DESCRIPTION
### Summary

Render trace detail tabs from trace meta counts instead of waiting for each tab’s backing data to load. This lets Logs, Application Metrics, and AI appear earlier when trace meta already knows those sections have data, while preserving existing fallbacks for legacy meta responses.

#### Trace Tab Visibility

The trace tab list now uses `useTraceMeta` counts for supported sections and falls back to loaded tab data where meta does not provide a definitive value. Logs and metrics still respect their product feature gates, and URL tab preservation during loading is also gated.

#### Header Counts

The trace header now shows the Application Metrics count from trace meta and uses meta-backed Logs counts before logs have loaded. This keeps the header in sync with tab visibility for logs-only and metrics-backed traces.

#### AI Span Detection

AI tab visibility can use positive meta counts, but still falls back to tree-based detection so traces with AI spans identified by `gen_ai.operation.type` are not hidden when `span.op` counts are incomplete.

Closes EXP-927