### PR TITLE
ref(slack): Move ephemeral message sending to workspace module

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -186,48 +186,13 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
         renderable: SlackRenderable,
         thread_ts: str,
     ) -> None:
-        client = self.get_client()
-        try:
-            client.chat_postEphemeral(
-                channel=channel_id,
-                blocks=renderable["blocks"] if len(renderable["blocks"]) > 0 else None,
-                attachments=renderable.get("attachments"),
-                text=renderable["text"],
-                thread_ts=thread_ts,
-                user=slack_user_id,
-            )
-        except SlackApiError as e:
-            translate_slack_api_error(e)
-
-    @staticmethod
-    def send_threaded_ephemeral_message_static(
-        *,
-        integration_id: int,
-        channel_id: str,
-        renderable: SlackRenderable,
-        slack_user_id: str,
-        thread_ts: str | None,
-    ) -> None:
-        """
-        In most cases, you should use the instance method instead, so an organization is associated
-        with the message.
-
-        In rare cases where we cannot infer an organization, but need to invoke a Slack API, use this.
-        For example, when linking a Slack identity to a Sentry user, there could be multiple organizations
-        attached to the Slack Workspace. We cannot infer which the user may link to.
-        """
-        client = SlackSdkClient(integration_id=integration_id)
-        try:
-            client.chat_postEphemeral(
-                channel=channel_id,
-                blocks=renderable["blocks"] if len(renderable["blocks"]) > 0 else None,
-                attachments=renderable.get("attachments"),
-                text=renderable["text"],
-                thread_ts=thread_ts,
-                user=slack_user_id,
-            )
-        except SlackApiError as e:
-            translate_slack_api_error(e)
+        workspace.send_threaded_ephemeral_message(
+            integration_id=self.model.id,
+            channel_id=channel_id,
+            renderable=renderable,
+            slack_user_id=slack_user_id,
+            thread_ts=thread_ts,
+        )
 
     def update_message(
         self,

--- a/src/sentry/integrations/slack/workspace.py
+++ b/src/sentry/integrations/slack/workspace.py
@@ -16,8 +16,10 @@ from slack_sdk.errors import SlackApiError
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.slack.metrics import translate_slack_api_error
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.utils.constants import SlackScope
+from sentry.notifications.platform.slack.provider import SlackRenderable
 
 _logger = logging.getLogger("sentry.integrations.slack")
 
@@ -141,3 +143,25 @@ def get_thread_history(
             extra={"integration_id": integration_id, "error": str(e)},
         )
         return []
+
+
+def send_threaded_ephemeral_message(
+    *,
+    integration_id: int,
+    channel_id: str,
+    renderable: SlackRenderable,
+    slack_user_id: str,
+    thread_ts: str | None,
+) -> None:
+    client = SlackSdkClient(integration_id=integration_id)
+    try:
+        client.chat_postEphemeral(
+            channel=channel_id,
+            blocks=renderable["blocks"] if len(renderable["blocks"]) > 0 else None,
+            attachments=renderable.get("attachments"),
+            text=renderable["text"],
+            thread_ts=thread_ts,
+            user=slack_user_id,
+        )
+    except SlackApiError as e:
+        translate_slack_api_error(e)

--- a/src/sentry/seer/entrypoints/slack/messaging.py
+++ b/src/sentry/seer/entrypoints/slack/messaging.py
@@ -13,6 +13,7 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.messaging.metrics import SeerSlackHaltReason
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
+from sentry.integrations.slack.workspace import send_threaded_ephemeral_message
 from sentry.notifications.platform.registry import provider_registry, template_registry
 from sentry.notifications.platform.service import (
     NotificationService,
@@ -298,7 +299,6 @@ def send_halt_message(
     thread_ts: str | None,
     halt_reason: SeerSlackHaltReason,
 ) -> None:
-    from sentry.integrations.slack.integration import SlackIntegration
     from sentry.integrations.slack.message_builder.types import SlackAction
     from sentry.integrations.slack.views.link_identity import build_linking_url
 
@@ -365,7 +365,7 @@ def send_halt_message(
         text=message,
     )
     try:
-        SlackIntegration.send_threaded_ephemeral_message_static(
+        send_threaded_ephemeral_message(
             integration_id=integration.id,
             channel_id=channel_id,
             thread_ts=thread_ts,

--- a/src/sentry/seer/entrypoints/slack/messaging.py
+++ b/src/sentry/seer/entrypoints/slack/messaging.py
@@ -13,7 +13,6 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.messaging.metrics import SeerSlackHaltReason
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
-from sentry.integrations.slack.workspace import send_threaded_ephemeral_message
 from sentry.notifications.platform.registry import provider_registry, template_registry
 from sentry.notifications.platform.service import (
     NotificationService,
@@ -301,6 +300,7 @@ def send_halt_message(
 ) -> None:
     from sentry.integrations.slack.message_builder.types import SlackAction
     from sentry.integrations.slack.views.link_identity import build_linking_url
+    from sentry.integrations.slack.workspace import send_threaded_ephemeral_message
 
     link_button: LinkButtonElement
     message: str


### PR DESCRIPTION
Extracts `send_threaded_ephemeral_message` from the `SlackIntegration` class into `workspace.py`, a module of other methods that aren't org-based but before I had put that module together