### PR TITLE
fix(relocations) Use str instead of uuid task parameter

### DIFF
--- a/src/sentry/api/endpoints/organization_fork.py
+++ b/src/sentry/api/endpoints/organization_fork.py
@@ -174,7 +174,7 @@ class OrganizationForkEndpoint(Endpoint):
         # When we received this back (via RPC call), we'll be able to continue with the usual
         # relocation flow, picking up from the `uploading_complete` task.
         uploading_start.apply_async(
-            args=[new_relocation.uuid, replying_cell_name, org_mapping.slug]
+            args=[str(new_relocation.uuid), replying_cell_name, org_mapping.slug]
         )
 
         try:

--- a/src/sentry/relocation/api/endpoints/retry.py
+++ b/src/sentry/relocation/api/endpoints/retry.py
@@ -132,7 +132,7 @@ class RelocationRetryEndpoint(Endpoint):
                 kind=RelocationFile.Kind.RAW_USER_DATA.value,
             )
 
-        uploading_start.delay(new_relocation.uuid, None, None)
+        uploading_start.delay(str(new_relocation.uuid), None, None)
         try:
             analytics.record(
                 RelocationCreatedEvent(

--- a/tests/sentry/api/endpoints/test_organization_fork.py
+++ b/tests/sentry/api/endpoints/test_organization_fork.py
@@ -1,5 +1,4 @@
 from unittest.mock import Mock, patch
-from uuid import UUID
 
 from sentry.analytics.events.relocation_forked import RelocationForkedEvent
 from sentry.api.endpoints.organization_fork import (
@@ -80,7 +79,7 @@ class OrganizationForkTest(APITestCase):
 
         assert uploading_start_mock.call_count == 1
         uploading_start_mock.assert_called_with(
-            args=[UUID(response.data["uuid"]), EXPORTING_TEST_REGION, self.requested_org_slug]
+            args=[response.data["uuid"], EXPORTING_TEST_REGION, self.requested_org_slug]
         )
 
         assert analytics_record_mock.call_count == 1
@@ -121,7 +120,7 @@ class OrganizationForkTest(APITestCase):
 
         assert uploading_start_mock.call_count == 1
         uploading_start_mock.assert_called_with(
-            args=[UUID(response.data["uuid"]), EXPORTING_TEST_REGION, self.requested_org_slug]
+            args=[response.data["uuid"], EXPORTING_TEST_REGION, self.requested_org_slug]
         )
 
         assert analytics_record_mock.call_count == 1
@@ -161,7 +160,7 @@ class OrganizationForkTest(APITestCase):
 
         assert uploading_start_mock.call_count == 1
         uploading_start_mock.assert_called_with(
-            args=[UUID(response.data["uuid"]), EXPORTING_TEST_REGION, self.requested_org_slug]
+            args=[response.data["uuid"], EXPORTING_TEST_REGION, self.requested_org_slug]
         )
 
         assert analytics_record_mock.call_count == 1
@@ -201,7 +200,7 @@ class OrganizationForkTest(APITestCase):
 
         assert uploading_start_mock.call_count == 1
         uploading_start_mock.assert_called_with(
-            args=[UUID(response.data["uuid"]), EXPORTING_TEST_REGION, self.requested_org_slug]
+            args=[response.data["uuid"], EXPORTING_TEST_REGION, self.requested_org_slug]
         )
 
         assert analytics_record_mock.call_count == 1
@@ -251,7 +250,7 @@ class OrganizationForkTest(APITestCase):
 
         assert uploading_start_mock.call_count == 1
         uploading_start_mock.assert_called_with(
-            args=[UUID(response.data["uuid"]), EXPORTING_TEST_REGION, self.requested_org_slug]
+            args=[response.data["uuid"], EXPORTING_TEST_REGION, self.requested_org_slug]
         )
 
         assert analytics_record_mock.call_count == 1
@@ -299,7 +298,7 @@ class OrganizationForkTest(APITestCase):
 
         assert uploading_start_mock.call_count == 1
         uploading_start_mock.assert_called_with(
-            args=[UUID(response.data["uuid"]), EXPORTING_TEST_REGION, self.requested_org_slug]
+            args=[response.data["uuid"], EXPORTING_TEST_REGION, self.requested_org_slug]
         )
 
         assert analytics_record_mock.call_count == 1
@@ -481,7 +480,7 @@ class OrganizationForkTest(APITestCase):
 
             assert uploading_start_mock.call_count == 1
             uploading_start_mock.assert_called_with(
-                args=[UUID(response.data["uuid"]), EXPORTING_TEST_REGION, self.requested_org_slug]
+                args=[response.data["uuid"], EXPORTING_TEST_REGION, self.requested_org_slug]
             )
 
             assert analytics_record_mock.call_count == 1
@@ -566,7 +565,7 @@ class OrganizationForkTest(APITestCase):
 
         assert uploading_start_mock.call_count == 1
         uploading_start_mock.assert_called_with(
-            args=[UUID(response.data["uuid"]), EXPORTING_TEST_REGION, self.requested_org_slug]
+            args=[response.data["uuid"], EXPORTING_TEST_REGION, self.requested_org_slug]
         )
 
         assert analytics_record_mock.call_count == 1
@@ -617,7 +616,7 @@ class OrganizationForkTest(APITestCase):
 
         assert uploading_start_mock.call_count == 1
         uploading_start_mock.assert_called_with(
-            args=[UUID(response.data["uuid"]), EXPORTING_TEST_REGION, self.requested_org_slug]
+            args=[response.data["uuid"], EXPORTING_TEST_REGION, self.requested_org_slug]
         )
 
         assert analytics_record_mock.call_count == 1


### PR DESCRIPTION
While the UUID can be json encoded, it is not msgpack compatible. Casting the uuid to a str ensures compatibility with both task message transports.

Fixes SENTRY-5PRH