### PR TITLE
ref(preprod): Remove approval_status from frontend search attributes

### DIFF
--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -42,5 +42,4 @@ export const SNAPSHOT_ALLOWED_KEYS = [
   'images_renamed',
   'images_skipped',
   'images_unchanged',
-  'approval_status',
 ];

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -144,6 +144,7 @@ export const HIDDEN_PREPROD_ATTRIBUTES = [
   'tags[metrics_artifact_type,number]',
   'tags[artifact_type,number]',
   ...PREPROD_IMAGE_FIELDS,
+  'approval_status',
 ];
 
 export const SENTRY_TRACEMETRIC_STRING_TAGS: string[] = [

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -96,7 +96,6 @@ export const SENTRY_LOG_NUMBER_TAGS: string[] = [OurLogKnownFieldKey.SEVERITY_NU
 export const SENTRY_PREPROD_STRING_TAGS: string[] = [
   'app_id',
   'app_name',
-  'approval_status',
   'artifact_type',
   'build_configuration_name',
   'build_number',
@@ -145,7 +144,6 @@ export const HIDDEN_PREPROD_ATTRIBUTES = [
   'tags[metrics_artifact_type,number]',
   'tags[artifact_type,number]',
   ...PREPROD_IMAGE_FIELDS,
-  'approval_status',
 ];
 
 export const SENTRY_TRACEMETRIC_STRING_TAGS: string[] = [


### PR DESCRIPTION
Remove `approval_status` from preprod frontend search and filter constants while the backend transitions to the new `snapshot_status` field.

**Removed from three constant lists**

`SENTRY_PREPROD_STRING_TAGS`, `HIDDEN_PREPROD_ATTRIBUTES` in explore constants, and `SNAPSHOT_ALLOWED_KEYS` in preprod constants. Data display and analytics references are left intact since they read from the API response and don't depend on the search field existing.

Refs EME-1147