### PR TITLE
fix(ui): allow tooltips inside hovercard

### DIFF
--- a/static/app/components/hovercard.spec.tsx
+++ b/static/app/components/hovercard.spec.tsx
@@ -1,5 +1,7 @@
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {Tooltip} from '@sentry/scraps/tooltip';
+
 import {Hovercard} from 'sentry/components/hovercard';
 
 describe('Hovercard', () => {
@@ -93,5 +95,28 @@ describe('Hovercard', () => {
 
     expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
+  });
+
+  it('does not snap-close when a tooltip inside the body is hovered', async () => {
+    render(
+      <Hovercard
+        position="top"
+        body={
+          <Tooltip title="Inner tooltip content">
+            <span>Inner trigger</span>
+          </Tooltip>
+        }
+        header="Hovercard Header"
+      >
+        Hovercard Trigger
+      </Hovercard>
+    );
+
+    await userEvent.hover(screen.getByText('Hovercard Trigger'));
+    expect(await screen.findByText(/Hovercard Header/)).toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('Inner trigger'));
+    expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
+    expect(await screen.findByText('Inner tooltip content')).toBeInTheDocument();
   });
 });

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -8,7 +8,7 @@ import {AnimatePresence} from 'framer-motion';
 
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import type {UseHoverOverlayProps} from 'sentry/utils/useHoverOverlay';
-import {useHoverOverlay} from 'sentry/utils/useHoverOverlay';
+import {HoverOverlayGroupProvider, useHoverOverlay} from 'sentry/utils/useHoverOverlay';
 
 interface HovercardProps extends Omit<UseHoverOverlayProps, 'isHoverable'> {
   /**
@@ -181,7 +181,10 @@ function Hovercard({
   return (
     <HovercardContext.Provider value={contextValue}>
       {wrapTrigger(children)}
-      {createPortal(hovercard, portalContainer)}
+      {createPortal(
+        <HoverOverlayGroupProvider>{hovercard}</HoverOverlayGroupProvider>,
+        portalContainer
+      )}
     </HovercardContext.Provider>
   );
 }


### PR DESCRIPTION
When https://github.com/getsentry/sentry/pull/113628 was merged, we caused a regression for Hovercards that contained Tooltips internally. Namely, the Stack Trace overlay in the Issues Feed.

The root cause is that `useHoverOverlay` now has a mechanism that snaps sibling overlays closed, but Hovercard and Tooltip belong to the same sibling group by default.

Similar to the fix in #115576, the fix here is to create a new HoverOverlayGroup by wrapping he contents of Hovercard in `HoverOverlayGroupProvider`. We apply this fix on the component level to fix all instances of similar recursive patterns rather than just the Stack Trace overlay.