### PR TITLE
ref(seer): Remove gap and use transparent buttons in explorer drawer header

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
@@ -171,54 +171,56 @@ export function ExplorerDrawerHeader({
             </Flex>
           </Tooltip>
         )}
-        <InlineActions>
-          <Button
-            icon={<IconCopy />}
-            onClick={onCopySessionClick}
-            disabled={!onCopySessionClick}
-            variant="secondary"
-            size="xs"
-            aria-label={t('Copy conversation to clipboard')}
-            tooltipProps={{title: t('Copy conversation to clipboard')}}
-          />
-          <Button
-            icon={<IconLink />}
-            onClick={onCopyLinkClick}
-            disabled={!onCopyLinkClick}
-            variant="secondary"
-            size="xs"
-            aria-label={t('Copy link to current chat and web page')}
-            tooltipProps={{title: t('Copy link to current chat and web page')}}
-          />
-        </InlineActions>
-        <OverflowActions>
+        <Flex gap="0" align="center">
+          <InlineActions>
+            <Button
+              icon={<IconCopy />}
+              onClick={onCopySessionClick}
+              disabled={!onCopySessionClick}
+              variant="transparent"
+              size="xs"
+              aria-label={t('Copy conversation to clipboard')}
+              tooltipProps={{title: t('Copy conversation to clipboard')}}
+            />
+            <Button
+              icon={<IconLink />}
+              onClick={onCopyLinkClick}
+              disabled={!onCopyLinkClick}
+              variant="transparent"
+              size="xs"
+              aria-label={t('Copy link to current chat and web page')}
+              tooltipProps={{title: t('Copy link to current chat and web page')}}
+            />
+          </InlineActions>
+          <OverflowActions>
+            <DropdownMenu
+              items={overflowMenuItems}
+              size="xs"
+              position="bottom-end"
+              triggerProps={{
+                'aria-label': t('More actions'),
+                icon: <IconEllipsis />,
+                showChevron: false,
+                variant: 'transparent',
+                size: 'xs',
+              }}
+            />
+          </OverflowActions>
           <DropdownMenu
-            items={overflowMenuItems}
+            items={sessionMenuItems}
             size="xs"
             position="bottom-end"
+            onOpenChange={onHistoryOpenChange}
             triggerProps={{
-              'aria-label': t('More actions'),
-              icon: <IconEllipsis />,
+              'aria-label': t('Chat history'),
+              tooltipProps: {title: t('Chat history')},
+              icon: <IconClock />,
               showChevron: false,
-              variant: 'secondary',
+              variant: 'transparent',
               size: 'xs',
             }}
           />
-        </OverflowActions>
-        <DropdownMenu
-          items={sessionMenuItems}
-          size="xs"
-          position="bottom-end"
-          onOpenChange={onHistoryOpenChange}
-          triggerProps={{
-            'aria-label': t('Chat history'),
-            tooltipProps: {title: t('Chat history')},
-            icon: <IconClock />,
-            showChevron: false,
-            variant: 'secondary',
-            size: 'xs',
-          }}
-        />
+        </Flex>
         <OverflowActions>
           <Button
             icon={<IconAdd />}
@@ -293,7 +295,7 @@ function useSessionMenuItems({
 }
 
 const InlineActions = styled(Flex)`
-  gap: ${p => p.theme.space.md};
+  gap: 0;
 
   @container seer-explorer-root (max-width: 500px) {
     display: none;


### PR DESCRIPTION
## Summary
- Use `variant="transparent"` for the copy, link, overflow menu, and chat history buttons in the Seer explorer drawer header
- Remove the gap between these action buttons by wrapping them in a `Flex` with `gap="0"`
- Keep the "New chat" button as `variant="secondary"` with spacing from the action group

## Test plan
- Open the Seer explorer drawer and verify the action buttons (copy, link, history) render without gaps and with transparent styling
- Verify the "New chat" button retains its secondary styling and spacing
- Verify responsive behavior at narrow widths (overflow menu replaces inline actions)