### PR TITLE
chore(autofix): Emit seer opened event when starting analysis

### DIFF
--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -85,6 +85,12 @@ export type SeerAnalyticsEventsParameters = {
     mode?: 'explorer' | 'legacy';
     referrer?: string;
   };
+  'autofix.start_fix_clicked': {
+    group_id: string;
+    organization: Organization;
+    mode?: 'explorer' | 'legacy';
+    referrer?: string;
+  };
   'coding_integration.install_clicked': {
     organization: Organization;
     project_slug: string;
@@ -168,6 +174,7 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'autofix.root_cause.re_run': 'Autofix: Root Cause Re-run',
   'autofix.solution.code': 'Autofix: Code It Up',
   'autofix.solution.re_run': 'Autofix: Solution Re-run',
+  'autofix.start_fix_clicked': 'Autofix: Start Fix Clicked',
   'coding_integration.install_clicked': 'Coding Integration: Install Clicked',
   'coding_integration.send_to_agent_clicked': 'Coding Integration: Send to Agent Clicked',
   'coding_integration.setup_handoff_clicked': 'Coding Integration: Setup Handoff Clicked',

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -324,6 +324,8 @@ function AutofixEmptyState({
           has_solution: false,
           has_coded_solution: false,
           has_pr: false,
+          mode: 'explorer',
+          referrer,
         }}
         disabled={startingRun}
       >

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -41,6 +41,7 @@ import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getSeerOnboardingCheckQueryOptions} from 'sentry/utils/getSeerOnboardingCheckQueryOptions';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -249,6 +250,7 @@ function AutofixEmptyState({
   project,
   referrer,
 }: AutofixEmptyStateProps) {
+  const organization = useOrganization();
   const {openSeerDrawer} = useOpenSeerDrawer({
     group,
     project,
@@ -260,6 +262,12 @@ function AutofixEmptyState({
 
   const [startingRun, setStartingRun] = useState(false);
   const handleStartRootCause = async () => {
+    trackAnalytics('autofix.start_fix_clicked', {
+      organization,
+      group_id: group.id,
+      mode: 'explorer',
+      referrer,
+    });
     setStartingRun(true);
     try {
       await startStep('root_cause');
@@ -304,9 +312,19 @@ function AutofixEmptyState({
         aria-label={t('Start Analysis')}
         variant="primary"
         onClick={handleStartRootCause}
-        analyticsEventKey="autofix.start_fix_clicked"
-        analyticsEventName="Autofix: Start Fix Clicked"
-        analyticsParams={{group_id: group.id, mode: 'explorer', referrer}}
+        analyticsEventKey="issue_details.seer_opened"
+        analyticsEventName="Issue Details: Seer Opened"
+        analyticsParams={{
+          group_id: group.id,
+          has_streamlined_ui: true,
+          autofix_exists: false,
+          autofix_step_type: null,
+          has_summary: false,
+          has_root_cause: false,
+          has_solution: false,
+          has_coded_solution: false,
+          has_pr: false,
+        }}
         disabled={startingRun}
       >
         {t('Start Analysis')}


### PR DESCRIPTION
Starting the analysis also opens the drawer so make sure to emit the same event.