### PR TITLE
feat(preprod): Wire up snapshot_status search field in frontend

### DIFF
--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -42,4 +42,5 @@ export const SNAPSHOT_ALLOWED_KEYS = [
   'images_renamed',
   'images_skipped',
   'images_unchanged',
+  'snapshot_status',
 ];

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2700,11 +2700,20 @@ const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.INTEGER,
   },
-  approval_status: {
-    desc: t('Approval status of the snapshot comparison'),
+  snapshot_status: {
+    desc: t('Status of the snapshot in the comparison pipeline'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
-    values: ['approved', 'auto_approved', 'requires_approval'],
+    values: [
+      'approved',
+      'auto_approved',
+      'base',
+      'failed',
+      'no_base',
+      'pending',
+      'processing',
+      'requires_approval',
+    ],
   },
 };
 

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -103,6 +103,7 @@ export const SENTRY_PREPROD_STRING_TAGS: string[] = [
   'git_base_ref',
   'git_head_ref',
   'platform_name',
+  'snapshot_status',
 ];
 
 const PREPROD_IMAGE_FIELDS = [
@@ -144,7 +145,7 @@ export const HIDDEN_PREPROD_ATTRIBUTES = [
   'tags[metrics_artifact_type,number]',
   'tags[artifact_type,number]',
   ...PREPROD_IMAGE_FIELDS,
-  'approval_status',
+  'snapshot_status',
 ];
 
 export const SENTRY_TRACEMETRIC_STRING_TAGS: string[] = [


### PR DESCRIPTION
Add `snapshot_status` to the frontend search bar for snapshots, completing the frontend half of the `approval_status` → `snapshot_status` search rename.

**New search field with all comparison states**

`snapshot_status` is now searchable in the snapshot view with values: `approved`, `auto_approved`, `base`, `failed`, `no_base`, `pending`, `processing`, `requires_approval`. This matches the backend values added in #115580.

**Hidden in general Explore UI**

The field is added to `HIDDEN_PREPROD_ATTRIBUTES` so it only appears in the snapshot-specific search bar (via `SNAPSHOT_ALLOWED_KEYS`), not in the general Explore interface.

Refs EME-1147