### PR TITLE
perf(searchQueryBuilder): Reorder filter alternatives by parse cost

### DIFF
--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -56,17 +56,17 @@ aggregate_key_start
   = [a-zA-Z0-9_.-]+ "("
 
 filter
-  = date_filter
-  / specific_date_filter
-  / rel_date_filter
+  = has_filter
+  / is_filter
   / duration_filter
   / size_filter
   / boolean_filter
   / numeric_in_filter
   / numeric_filter
+  / date_filter
+  / specific_date_filter
+  / rel_date_filter
   / aggregate_filter
-  / has_filter
-  / is_filter
   / text_in_filter
   / text_filter
 


### PR DESCRIPTION
Follow-up to #115563.

Date filters are expensive and less frequently used than `is:` `has:` or boolean based search filters which are cheap.

Moves has/is to the top and date filters below the common typed filters.

| Case | Before | After | Delta |
|---|---:|---:|---:|
| plain words | 423.6 ms | 414.7 ms | -2.1% |
| common text | 373.0 ms | 366.4 ms | -1.8% |
| numeric filters | 322.7 ms | 274.5 ms | -14.9% |
| duration and size | 288.8 ms | 245.1 ms | -15.1% |
| boolean group | 440.8 ms | 359.9 ms | -18.3% |
| long mixed | 515.2 ms | 465.3 ms | -9.7% |
| total | 3677 ms | 3514 ms | -4.4% |

Benchmark is 8k parses per case, 7 rounds. Date filters regress ~58% since they're now tried later.