### PR TITLE
feat(cells) Provision new orgs through control with feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -503,6 +503,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sentry-app-webhook-circuit-breaker", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Override dry-run to enable real blocking per app-owner org during rollout
     manager.add("organizations:sentry-app-webhook-circuit-breaker-live-run", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Create organiations via control-scoped domains in saas.
+    manager.add("organizations:create-org-control", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # Enables organization access to the new notification platform
     manager.add("organizations:notification-platform.internal-testing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -225,6 +225,10 @@ class _ClientConfig:
             yield "relocation:enabled"
         if features.has("system:multi-region"):
             yield "system:multi-region"
+        if self.last_org and features.has(
+            "organizations:create-org-control", self.last_org, actor=self.user
+        ):
+            yield "organizations:create-org-control"
         # TODO @athena: remove this feature flag after development is done
         # this is a temporary hack to be able to used flagpole in a case where there's no organization
         # availble on the frontend

--- a/static/app/utils/regions/index.tsx
+++ b/static/app/utils/regions/index.tsx
@@ -74,6 +74,26 @@ export function getRegionChoices(exclude: RegionData[] = []): Array<[string, str
     });
 }
 
+export function getRegionNameChoices(): Array<[string, string]> {
+  const regions = getRegions();
+
+  return regions.map(region => {
+    return [
+      region.name,
+      `${getRegionFlagIndicator(region) || ''} ${getRegionDisplayName(region)}`,
+    ];
+  });
+}
+
+export function getRegionUrl(name: string): string | null {
+  const regions = getRegions();
+  const found = regions.find(item => item.name === name);
+  if (found) {
+    return found.url;
+  }
+  return null;
+}
+
 export function shouldDisplayRegions(): boolean {
   return getRegions().length > 1;
 }

--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -244,4 +244,51 @@ describe('OrganizationCreate', () => {
       'https://org-slug.sentry.io/projects/new/'
     );
   });
+
+  it('submits to the control URL when create-org-control is active', async () => {
+    ConfigStore.set(
+      'features',
+      new Set(['system:multi-region', 'organizations:create-org-control'])
+    );
+    ConfigStore.set('urlPrefix', 'https://sentry.io');
+    ConfigStore.set('regions', [
+      {url: 'https://us.example.com', name: 'us'},
+      {
+        url: 'https://de.example.com',
+        name: 'de',
+      },
+    ]);
+    const orgCreateMock = MockApiClient.addMockResponse({
+      url: '/organizations/',
+      method: 'POST',
+      body: OrganizationFixture(),
+    });
+
+    render(<OrganizationCreate />);
+    expect(screen.getByLabelText('Data Storage Location')).toBeInTheDocument();
+    const link = screen.getByText<HTMLAnchorElement>('Learn More');
+    expect(link).toBeInTheDocument();
+    expect(link.href).toBe(DATA_STORAGE_DOCS_LINK);
+    await userEvent.type(screen.getByPlaceholderText('e.g. My Company'), 'Good Burger');
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Data Storage Location'}),
+      '🇪🇺 European Union (EU)'
+    );
+    await userEvent.click(screen.getByText('Create Organization'));
+
+    await waitFor(() => {
+      expect(orgCreateMock).toHaveBeenCalledWith('/organizations/', {
+        success: expect.any(Function),
+        error: expect.any(Function),
+        method: 'POST',
+        host: 'https://sentry.io',
+        data: {defaultTeam: true, name: 'Good Burger', dataStorageLocation: 'de'},
+      });
+    });
+
+    expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
+    expect(testableWindowLocation.assign).toHaveBeenCalledWith(
+      'https://org-slug.sentry.io/projects/new/'
+    );
+  });
 });

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -16,7 +16,11 @@ import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {HookStore} from 'sentry/stores/hookStore';
 import type {OrganizationSummary} from 'sentry/types/organization';
-import {getRegionChoices, shouldDisplayRegions} from 'sentry/utils/regions';
+import {
+  getRegionUrl,
+  getRegionNameChoices,
+  shouldDisplayRegions,
+} from 'sentry/utils/regions';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
@@ -42,8 +46,9 @@ function OrganizationCreate() {
   const privacyUrl = ConfigStore.get('privacyUrl');
   const isSelfHosted = ConfigStore.get('isSelfHosted');
   const relocationUrl = normalizeUrl('/relocation/');
-  const regionChoices = getRegionChoices();
+  const regionChoices = getRegionNameChoices();
   const client = useApi();
+  const useControl = ConfigStore.get('features').has('organizations:create-org-control');
 
   const hasDataConsent =
     HookStore.get('component:data-consent-org-creation-checkbox').length !== 0;
@@ -56,20 +61,30 @@ function OrganizationCreate() {
       if (!formModel.validateForm()) {
         return;
       }
-      const regionUrl = data.dataStorageLocation;
+
+      let host: string | undefined;
+      if (data.dataStorageLocation) {
+        if (useControl) {
+          host = ConfigStore.get('links').sentryUrl;
+        } else {
+          const storageLocation = data.dataStorageLocation;
+          host = getRegionUrl(storageLocation) ?? host;
+          data = removeDataStorageLocationFromFormData(data);
+        }
+      }
 
       addLoadingMessage(t('Creating Organization\u2026'));
       formModel.setFormSaving();
 
       client.request('/organizations/', {
         method: 'POST',
-        data: removeDataStorageLocationFromFormData(data),
-        host: regionUrl,
+        data,
+        host,
         success: onSubmitSuccess,
         error: onSubmitError,
       });
     },
-    [client]
+    [client, useControl]
   );
 
   return (

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -141,13 +141,20 @@ def test_client_config_features() -> None:
 
     with (
         override_options({"auth.allow-registration": True}),
-        Feature({"auth:register": True, "system:multi-region": True}),
+        Feature(
+            {
+                "auth:register": True,
+                "system:multi-region": True,
+                "organizations:create-org-control": True,
+            }
+        ),
     ):
         result = get_client_config(request)
 
         assert "features" in result
         assert "system:multi-region" in result["features"]
         assert "auth:register" in result["features"]
+        assert "organizations:create-org-control" in result["features"]
 
 
 @no_silo_test


### PR DESCRIPTION
Add a feature flag that when active will enable new organizations to be created through the control scoped API endpoint instead of going to the cell domains.

Refs INFRENG-187