### PR TITLE
feat(seer): Populate SeerAgentRun alongside SeerRun in agent client

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -392,7 +392,7 @@ class SeerAgentClient:
                         )
                     SeerAgentRun.objects.create(
                         run=run,
-                        title=prompt[:253] + "..." if len(prompt) > 256 else prompt,
+                        title=prompt[:255] + "…" if len(prompt) > 256 else prompt,
                         source=source,
                         project=self.project,
                         extras=(

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -45,7 +45,7 @@ from sentry.seer.agent.on_completion_hook import (
     extract_hook_definition,
 )
 from sentry.seer.models import SeerApiError, SeerPermissionError, SeerRepoDefinition
-from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
+from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.tasks.seer.context_engine_index import build_service_map, index_org_project_knowledge
@@ -379,6 +379,25 @@ class SeerAgentClient:
                         user_id=user_id,
                         type=SeerRunType.EXPLORER,
                         last_triggered_at=now(),
+                    )
+                    source = self.category_key or ""
+                    if not source:
+                        logger.warning(
+                            "seer_agent_run.missing_source",
+                            extra={
+                                "organization_id": self.organization.id,
+                                "seer_run_id": run.id,
+                                "user_id": user_id,
+                            },
+                        )
+                    SeerAgentRun.objects.create(
+                        run=run,
+                        title=prompt[:253] + "..." if len(prompt) > 256 else prompt,
+                        source=source,
+                        project=self.project,
+                        extras=(
+                            {"category_value": self.category_value} if self.category_value else {}
+                        ),
                     )
                     CellOutbox(
                         shard_scope=OutboxScope.SEER_SCOPE,

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, MagicMock, Mock, patch
 import pytest
 
 from sentry.seer.endpoints.organization_seer_agent_chat import SeerAgentChatSerializer
-from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
+from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
@@ -360,6 +360,12 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         assert run.seer_run_state_id == 99
         assert run.user_id == self.user.id
 
+        agent_run = SeerAgentRun.objects.get(run=run)
+        assert agent_run.title == "What happened?"
+        assert agent_run.source == ""
+        assert agent_run.project is None
+        assert agent_run.extras == {}
+
         sent_body = mock_request.call_args[0][0]
         assert sent_body["query"] == "What happened?"
         assert sent_body["organization_id"] == self.organization.id
@@ -391,6 +397,9 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
 
         run = SeerRun.objects.get(organization_id=self.organization.id)
         assert run.mirror_status == SeerRunMirrorStatus.FAILED
+        # SeerAgentRun commits with SeerRun before the outbox drain runs, so
+        # it persists even when the drain fails.
+        assert SeerAgentRun.objects.filter(run=run).exists()
 
 
 @with_feature("organizations:seer-explorer")


### PR DESCRIPTION
## Summary
`SeerAgentRun` had no writers. Create it alongside `SeerRun` in `SeerAgentClient.start_run`, inside the same atomic+outbox block so both rows live or die together.

`source` falls back to `""` with a `seer_agent_run.missing_source` warning so we can find callers that don't set `category_key`.

Scope: only the `SeerAgentClient` flow (chat + v3 explorer-based autofix). Legacy `_call_autofix` and assisted-query are untouched.

## Test plan
- [ ] Chat / v3 autofix in dev creates a `SeerAgentRun` with the right `source`, `title`, `project`
- [ ] Watch `seer_agent_run.missing_source` in GCP after deploy