### PR TITLE
chore(jira): Add Forge app manifest for Connect-to-Forge migration

### DIFF
--- a/src/sentry/integrations/jira/forge/manifest.yml
+++ b/src/sentry/integrations/jira/forge/manifest.yml
@@ -43,11 +43,15 @@ connectModules:
     - event: jira:issue_updated
       url: /extensions/jira/issue-updated/
       excludeBody: false
-      key: webhook-1
+      key: sentry-issue-updated-webhook
 permissions:
   scopes:
     - read:connect-jira
     - write:connect-jira
     - act-as-user:connect-jira
+    # The Connect descriptor conditionally includes this scope based on
+    # JIRA_USE_EMAIL_SCOPE. This Forge manifest is only used for the
+    # sentry.io Marketplace listing where that setting is enabled;
+    # self-hosted installs use their own Connect descriptor.
     - access-email-addresses:connect-jira
 modules: {}

--- a/src/sentry/integrations/jira/forge/manifest.yml
+++ b/src/sentry/integrations/jira/forge/manifest.yml
@@ -28,15 +28,14 @@ connectModules:
     - icon:
         width: 24
         height: 24
-        url: >-
-          https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints-hashed/logo-sentry-QTEJGwEA3CwTRmciYcDeXRro9qpAkv9Rj2BG8UkIm0c.svg
+        url: https://sentry.io/_static/dist/sentry/entrypoints/logo-sentry.svg
       content:
         type: label
         label:
           value: Linked Issues
       target:
         type: web_panel
-        url: /extensions/jira/issue/{issue.key}/
+        url: /extensions/jira/issue-details/{issue.key}/
       name:
         value: 'Sentry '
       key: sentry-issues-glance

--- a/src/sentry/integrations/jira/forge/manifest.yml
+++ b/src/sentry/integrations/jira/forge/manifest.yml
@@ -1,0 +1,54 @@
+app:
+  id: ari:cloud:ecosystem::app/b48115c6-8f4c-4bb6-9bbe-f20c25f26bcf
+  connect:
+    key: sentry.io.jira
+    remote: connect
+    authentication: jwt
+  runtime:
+    name: nodejs22.x
+remotes:
+  - key: connect
+    baseUrl: https://sentry.io
+connectModules:
+  jira:lifecycle:
+    - key: lifecycle-events
+      installed: /extensions/jira/installed/
+      uninstalled: /extensions/jira/uninstalled/
+  jira:postInstallPage:
+    - url: /extensions/jira/ui-hook/
+      name:
+        value: Configure Sentry Add-on
+      key: post-install-sentry
+  jira:configurePage:
+    - url: /extensions/jira/ui-hook/
+      name:
+        value: Configure Sentry Add-on
+      key: configure-sentry
+  jira:jiraIssueContexts:
+    - icon:
+        width: 24
+        height: 24
+        url: >-
+          https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints-hashed/logo-sentry-QTEJGwEA3CwTRmciYcDeXRro9qpAkv9Rj2BG8UkIm0c.svg
+      content:
+        type: label
+        label:
+          value: Linked Issues
+      target:
+        type: web_panel
+        url: /extensions/jira/issue/{issue.key}/
+      name:
+        value: 'Sentry '
+      key: sentry-issues-glance
+  jira:webhooks:
+    - event: jira:issue_updated
+      url: /extensions/jira/issue-updated/
+      excludeBody: false
+      key: webhook-1
+permissions:
+  scopes:
+    - read:connect-jira
+    - write:connect-jira
+    - act-as-user:connect-jira
+    - access-email-addresses:connect-jira
+modules: {}


### PR DESCRIPTION
Add the Atlassian Forge `manifest.yml` for the Jira Cloud integration, co-located with the existing integration code at `src/sentry/integrations/jira/forge/`.

Atlassian is sunsetting Connect apps and requiring migration to Forge. This manifest wraps the existing Connect app ("Sentry for Jira", key `sentry.io.jira`) as a Forge remote app, proxying all requests back to sentry.io. It has already been deployed to production and linked to the existing Marketplace listing as a private version (v2.0.0) pending validation before public rollout.

The manifest defines:
- Lifecycle hooks (install/uninstall)
- Configuration and post-install pages
- Jira issue context panel (linked issues glance)
- Webhook for issue updates
- Connect-compatible scopes