### PR TITLE
o11y(preprod): Add context to snapshot status check and PR comment logs

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -326,6 +326,9 @@ def post_snapshot_pr_comment_task(
                         "organization_id": organization_id,
                         "preprod_artifact_id": artifact_id,
                         "comment_id": comment_id,
+                        "repo_name": repo_name,
+                        "pr_number": pr_number,
+                        "is_update": existing_comment_id is not None,
                     },
                 )
     except CommitComparison.DoesNotExist:

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -474,5 +474,9 @@ def post_snapshot_status_check_task(
             "preprod_artifact_id": preprod_artifact.id,
             "organization_id": preprod_artifact.project.organization_id,
             "check_id": check_id,
+            "status": status,
+            "subtitle": subtitle,
+            "repo": commit_comparison.head_repo_name,
+            "sha": commit_comparison.head_sha,
         },
     )


### PR DESCRIPTION
Add structured log fields to the success events for both snapshot
status check posts and PR comment posts.

When a user reports that their GitHub status check or PR comment
wasn't updated, we can see the post succeeded but have no way to
tell *what* was posted. These fields close that gap without
introducing high-cardinality metric tags (log extras only).

**Status checks** (`preprod.snapshot_status_checks.post.success`):
adds `status`, `subtitle`, `repo`, `sha`

**PR comments** (`preprod.snapshot_pr_comments.post.success`):
adds `repo_name`, `pr_number`, `is_update`