### PR TITLE
fix(rate-limit): tighten rate limits on test notification endpoints

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -12,11 +12,13 @@ from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers.rest_framework import DummyRuleSerializer
 from sentry.models.rule import Rule
 from sentry.notifications.types import TEST_NOTIFICATION_ID
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import (
     IntegrationConfigurationError,
     IntegrationFormError,
 )
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.samples import create_sample_event
 from sentry.workflow_engine.endpoints.utils.test_fire_action import test_fire_action
 from sentry.workflow_engine.migration_helpers.rule_action import (
@@ -36,8 +38,16 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ISSUES
-
     permission_classes = (ProjectAlertRulePermission,)
+    enforce_rate_limit = True
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.USER: RateLimit(limit=10, window=60),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=50, window=60),
+            }
+        }
+    )
 
     def post(self, request: Request, project) -> Response:
         """

--- a/src/sentry/notifications/notification_action/grouptype.py
+++ b/src/sentry/notifications/notification_action/grouptype.py
@@ -27,7 +27,7 @@ class SendTestNotification(GroupType):
     enable_auto_resolve = True
     enable_escalation_detection = False
     enable_status_change_workflow_notifications = True
-    creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds
+    creation_quota = Quota(3600, 60, 100)  # 100 per hour, sliding window of 60 seconds
 
     @classmethod
     def allow_post_process_group(cls, organization: Organization) -> bool:

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -19,6 +19,8 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.notification_action.grouptype import get_test_notification_event_data
 from sentry.notifications.types import TEST_NOTIFICATION_ID
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.workflow_engine.endpoints.organization_workflow_index import (
     OrganizationWorkflowPermission,
 )
@@ -57,6 +59,15 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.ALERTS_MONITORS
     permission_classes = (OrganizationWorkflowPermission,)
+    enforce_rate_limit = True
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.USER: RateLimit(limit=10, window=60),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=50, window=60),
+            }
+        }
+    )
 
     @extend_schema(
         operation_id="Test Fire Actions",


### PR DESCRIPTION
The `test-fire-action` endpoints had no meaningful rate limiting to prevent abuse, let's tighten this up.

### Before
| Layer | Limit | Scope |
|-------|-------|-------|
| Endpoint-level | Default (999/sec) | Per-user |
| `creation_quota` | 1000/hr | Per-project |

### After
| Layer | Limit | Scope |
|-------|-------|-------|
| Endpoint-level | **10/min** | **Per-user** |
| Endpoint-level | **50/min** | **Per-org** |
| `creation_quota` | **100/hr** | Per-project |

The new `creation_quota` aligns with other low-volume issue types (metric alerts, processing errors) that also use 100/hr.