### PR TITLE
fix(issues): Search org members for note mentions

### DIFF
--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -13,7 +13,7 @@ import {t} from 'sentry/locale';
 import {textStyles} from 'sentry/styles/text';
 import type {NoteType} from 'sentry/types/alerts';
 import {MarkedText} from 'sentry/utils/marked/markedText';
-import {useMembers} from 'sentry/utils/members/useMembers';
+import {useMemberMentionData} from 'sentry/utils/members/useMemberMentionData';
 import {useTeams} from 'sentry/utils/useTeams';
 
 import {mentionStyle} from './mentionStyle';
@@ -63,13 +63,8 @@ function NoteInput({
 }: Props) {
   const theme = useTheme();
 
-  const {data: members = []} = useMembers();
+  const {getMemberSuggestions} = useMemberMentionData();
   const {teams} = useTeams();
-
-  const suggestMembers = members.map(member => ({
-    id: `user:${member.id}`,
-    display: member.name,
-  }));
 
   const suggestTeams = teams.map(team => ({
     id: `team:${team.id}`,
@@ -177,7 +172,7 @@ function NoteInput({
             >
               <Mention
                 trigger="@"
-                data={suggestMembers}
+                data={getMemberSuggestions}
                 onAdd={handleAddMember}
                 displayTransform={(_id, display) => `@${display}`}
                 markup="**[sentry.strip:member]__display__**"

--- a/static/app/utils/members/useMemberMentionData.spec.tsx
+++ b/static/app/utils/members/useMemberMentionData.spec.tsx
@@ -1,0 +1,45 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useMemberMentionData} from 'sentry/utils/members/useMemberMentionData';
+
+describe('useMemberMentionData', () => {
+  const org = OrganizationFixture();
+
+  it('fetches member mention suggestions from search results', async () => {
+    const defaultUser = UserFixture({
+      id: '1',
+      name: 'Foo Bar',
+      email: 'foo@example.com',
+    });
+    const searchedUser = UserFixture({
+      id: '2',
+      name: 'Nick Search',
+      email: 'nick@example.com',
+    });
+    const defaultRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/members/`,
+      method: 'GET',
+      body: [{user: defaultUser}],
+    });
+    const searchRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/members/`,
+      method: 'GET',
+      body: [{user: searchedUser}],
+      match: [MockApiClient.matchQuery({query: 'nick'})],
+    });
+
+    const {result} = renderHookWithProviders(useMemberMentionData, {
+      organization: org,
+    });
+    const callback = jest.fn();
+
+    await waitFor(() => expect(defaultRequest).toHaveBeenCalled());
+    await act(() => result.current.getMemberSuggestions('nick', callback));
+
+    expect(searchRequest).toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith([{id: 'user:2', display: 'Nick Search'}]);
+  });
+});

--- a/static/app/utils/members/useMemberMentionData.tsx
+++ b/static/app/utils/members/useMemberMentionData.tsx
@@ -1,0 +1,68 @@
+import {useCallback, useMemo} from 'react';
+import type {DataFunc, SuggestionDataItem} from 'react-mentions';
+import {useQueryClient} from '@tanstack/react-query';
+import uniqBy from 'lodash/uniqBy';
+
+import type {Member} from 'sentry/types/organization';
+import type {User} from 'sentry/types/user';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
+import {memberUsersQueryOptions} from 'sentry/utils/members/shared';
+import {useOrganizationMemberSearch} from 'sentry/utils/members/useOrganizationMemberSearch';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+function userToSuggestion(user: User): SuggestionDataItem {
+  return {
+    id: `user:${user.id}`,
+    display: user.name || user.email || user.username || user.id,
+  };
+}
+
+function getUsersFromResponse(response: ApiResponse<Member[]> | User[]) {
+  if (Array.isArray(response)) {
+    return response;
+  }
+
+  return response.json.map(member => member.user).filter((user): user is User => !!user);
+}
+
+/**
+ * Adapts organization member search to react-mentions' async callback API.
+ * When mentions move to the modern member selector flow, this hook can go away.
+ */
+export function useMemberMentionData() {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const {members} = useOrganizationMemberSearch();
+
+  const memberSuggestions = useMemo(() => members.map(userToSuggestion), [members]);
+
+  const getMemberSuggestions = useCallback<DataFunc>(
+    async (query, callback) => {
+      const search = query.trim();
+
+      if (!search) {
+        callback(memberSuggestions);
+        return;
+      }
+
+      try {
+        const response = await queryClient.fetchQuery(
+          memberUsersQueryOptions({
+            orgSlug: organization.slug,
+            search,
+          })
+        );
+        const matchingMembers = getUsersFromResponse(response);
+
+        callback(
+          uniqBy([...matchingMembers, ...members], ({id}) => id).map(userToSuggestion)
+        );
+      } catch {
+        callback(memberSuggestions);
+      }
+    },
+    [memberSuggestions, members, organization.slug, queryClient]
+  );
+
+  return {getMemberSuggestions};
+}

--- a/static/app/views/issueDetails/streamline/sidebar/note.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/note.spec.tsx
@@ -28,6 +28,31 @@ describe('StreamlinedNoteInput', () => {
     });
   });
 
+  it('can mention a member from search results', async () => {
+    const searchedUser = UserFixture({
+      id: '2',
+      name: 'Nick Search',
+      email: 'nick@example.com',
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      method: 'GET',
+      body: [{user: searchedUser}],
+      match: [MockApiClient.matchQuery({query: 'nick'})],
+    });
+
+    const onCreate = jest.fn();
+    render(<StreamlinedNoteInput onCreate={onCreate} />);
+    await userEvent.type(screen.getByRole('textbox', {name: 'Add a comment'}), '@nick');
+    await userEvent.click(await screen.findByRole('option', {name: 'Nick Search'}));
+
+    await userEvent.click(screen.getByRole('button', {name: 'Submit comment'}));
+    expect(onCreate).toHaveBeenCalledWith({
+      text: '**@Nick Search** ',
+      mentions: ['user:2'],
+    });
+  });
+
   it('can mention a team', async () => {
     TeamStore.loadInitialData([TeamFixture()]);
     const onCreate = jest.fn();

--- a/static/app/views/issueDetails/streamline/sidebar/note.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/note.tsx
@@ -16,7 +16,7 @@ import type {
 } from 'sentry/components/activity/note/types';
 import {t} from 'sentry/locale';
 import type {NoteType} from 'sentry/types/alerts';
-import {useMembers} from 'sentry/utils/members/useMembers';
+import {useMemberMentionData} from 'sentry/utils/members/useMemberMentionData';
 import {useTeams} from 'sentry/utils/useTeams';
 
 type Props = {
@@ -49,13 +49,8 @@ function StreamlinedNoteInput({
 }: Props) {
   const theme = useTheme();
 
-  const {data: members = []} = useMembers();
+  const {getMemberSuggestions} = useMemberMentionData();
   const {teams} = useTeams();
-
-  const suggestMembers = members.map(member => ({
-    id: `user:${member.id}`,
-    display: member.name,
-  }));
 
   const suggestTeams = teams.map(team => ({
     id: `team:${team.id}`,
@@ -160,7 +155,7 @@ function StreamlinedNoteInput({
       >
         <Mention
           trigger="@"
-          data={suggestMembers}
+          data={getMemberSuggestions}
           onAdd={handleAddMember}
           displayTransform={(_id, display) => `@${display}`}
           markup="**[sentry.strip:member]__display__**"


### PR DESCRIPTION
The note mention inputs only had the first loaded member page, so people outside that initial list never showed up in the @ menu.

Adds a small member mention hook that uses the org member search endpoint for typed queries and shares it between the activity input and issue sidebar input.

fixes JAVASCRIPT-39PB