### PR TITLE
fix(traces): add null state to application metrics dropdown

### DIFF
--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -60,7 +60,9 @@ function isCrossEvent(value: any): value is CrossEvent {
       typeof value.metric === 'object' &&
       typeof value.metric.name === 'string' &&
       typeof value.metric.type === 'string' &&
-      (value.metric.unit === undefined || typeof value.metric.unit === 'string')
+      (value.metric.unit === undefined ||
+        value.metric.unit === null ||
+        typeof value.metric.unit === 'string')
     );
   }
 


### PR DESCRIPTION
When you click +, "application metrics" and select a metric in the traces page, sometimes the metric you click glitches and your selection is cancelled. This happens because certain metrics you chose have a type and a unit associated to them, and certain just have a type and their units set to `null`. The current code only contemplated that state being a string or undefined, not null, which led `isCrossEvent` to evaluate to false, filtering out the entry and "kicking you out". 

This PR adds null as a valid state for the unit, see the vids for the before + after.

https://github.com/user-attachments/assets/e75dc55a-04da-4ef0-ad7a-ed48203e16d2


https://github.com/user-attachments/assets/91a99c6f-68d9-44c7-ad20-25c2cfa2aa59

