### PR TITLE
fix(members): Ignore detail responses in member cache scan

### DIFF
--- a/static/app/utils/members/useMembers.spec.tsx
+++ b/static/app/utils/members/useMembers.spec.tsx
@@ -1,3 +1,4 @@
+import {useQueryClient} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -63,5 +64,35 @@ describe('useMembers', () => {
 
     expect(mockRequest).toHaveBeenCalled();
     expect(result.current.data).toEqual(expect.arrayContaining([userFoo]));
+  });
+
+  it('ignores cached user detail responses when looking for members by id', async () => {
+    const userFoo = UserFixture({id: '10'});
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/members/`,
+      method: 'GET',
+      body: [{user: userFoo}],
+    });
+
+    function SeedUserDetailCache({children}: {children?: React.ReactNode}) {
+      const queryClient = useQueryClient();
+
+      queryClient.setQueryData([`/organizations/${org.slug}/users/10/`], {
+        headers: {},
+        json: userFoo,
+      });
+
+      return children;
+    }
+
+    const {result} = renderHookWithProviders(useMembers, {
+      additionalWrapper: SeedUserDetailCache,
+      initialProps: {ids: ['10']},
+      organization: org,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual([userFoo]));
+
+    expect(mockRequest).toHaveBeenCalled();
   });
 });

--- a/static/app/utils/members/useMembers.tsx
+++ b/static/app/utils/members/useMembers.tsx
@@ -24,7 +24,7 @@ function findMembersInCache(
   ids: string[]
 ): ApiResponse<Member[]> | undefined {
   const idSet = new Set(ids);
-  const prefixes = [
+  const memberListUrls = [
     `/organizations/${orgSlug}/members/`,
     `/organizations/${orgSlug}/users/`,
   ];
@@ -32,12 +32,12 @@ function findMembersInCache(
   const cached = queryClient.getQueriesData<ApiResponse<Member[]>>({
     predicate: query => {
       const url = query.queryKey[0];
-      return typeof url === 'string' && prefixes.some(prefix => url.startsWith(prefix));
+      return typeof url === 'string' && memberListUrls.includes(url);
     },
   });
 
   for (const [, data] of cached) {
-    if (!data?.json) {
+    if (!Array.isArray(data?.json)) {
       continue;
     }
     const matchedMembers = data.json.filter(m => m.user && idSet.has(m.user.id));


### PR DESCRIPTION
#115554 added a cache scan for member lookups, but it matched any `/members/` or `/users/` prefix. That meant cached detail responses like `/organizations/:org/users/:id/` could get treated like member arrays and crash on `.filter()`.

This keeps the scan to the list endpoints and skips non-array payloads, so the avatar fallback still reuses cached member lists without blowing up on detail cache entries.

fixes JAVASCRIPT-39P3