### PR TITLE
fix(issues): Render assigned user avatars from member list

### DIFF
--- a/static/app/components/assigneeBadge.spec.tsx
+++ b/static/app/components/assigneeBadge.spec.tsx
@@ -1,0 +1,31 @@
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import {AssigneeBadge} from 'sentry/components/assigneeBadge';
+
+describe('AssigneeBadge', () => {
+  it('renders a hydrated user avatar when available', () => {
+    const user = UserFixture({
+      id: '1',
+      name: 'Jane Bloggs',
+      email: 'jane@example.com',
+      avatar: {
+        avatarType: 'upload',
+        avatarUrl: 'https://example.com/avatar.jpg',
+        avatarUuid: '123',
+      },
+    });
+
+    render(
+      <AssigneeBadge
+        assignedTo={{id: user.id, name: user.name, type: 'user'}}
+        assignedUser={user}
+      />
+    );
+
+    expect(
+      within(screen.getByTestId('assigned-avatar')).getByRole('img')
+    ).toHaveAttribute('src', 'https://example.com/avatar.jpg?s=120');
+  });
+});

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {ActorAvatar} from '@sentry/scraps/avatar';
+import {ActorAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {Tag} from '@sentry/scraps/badge';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -13,12 +13,13 @@ import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Actor} from 'sentry/types/core';
 import type {SuggestedOwnerReason} from 'sentry/types/group';
+import type {User} from 'sentry/types/user';
 
 type AssigneeBadgeProps = {
   assignedTo?: Actor | undefined;
+  assignedUser?: User | undefined;
   assignmentReason?: SuggestedOwnerReason;
   chevronDirection?: 'up' | 'down';
-  isTooltipDisabled?: boolean;
   loading?: boolean;
   showLabel?: boolean;
 };
@@ -27,11 +28,11 @@ const AVATAR_SIZE = 16;
 
 export function AssigneeBadge({
   assignedTo,
+  assignedUser,
   assignmentReason,
   showLabel = false,
   chevronDirection = 'down',
   loading = false,
-  isTooltipDisabled,
 }: AssigneeBadgeProps) {
   const theme = useTheme();
   const suggestedReasons: Record<SuggestedOwnerReason, React.ReactNode> = {
@@ -46,20 +47,29 @@ export function AssigneeBadge({
   };
 
   const makeAssignedIcon = (actor: Actor) => {
-    return (
-      <Fragment>
+    const avatar =
+      actor.type === 'user' ? (
+        <UserAvatar
+          user={assignedUser ?? actor}
+          className="avatar"
+          size={AVATAR_SIZE}
+          hasTooltip={false}
+          data-test-id="assigned-avatar"
+        />
+      ) : (
         <ActorAvatar
           actor={actor}
           className="avatar"
           size={AVATAR_SIZE}
           hasTooltip={false}
           data-test-id="assigned-avatar"
-          // Team avatars need extra left margin since the
-          // square team avatar is being fit into a rounded borders
-          style={{
-            marginLeft: actor.type === 'team' ? theme.space.xs : '0',
-          }}
+          style={{marginLeft: theme.space.xs}}
         />
+      );
+
+    return (
+      <Fragment>
+        {avatar}
         {showLabel && (
           <StyledText>{`${actor.type === 'team' ? '#' : ''}${actor.name}`}</StyledText>
         )}
@@ -94,7 +104,6 @@ export function AssigneeBadge({
   ) : assignedTo ? (
     <Tooltip
       isHoverable
-      disabled={isTooltipDisabled}
       title={
         <TooltipWrapper>
           {t('Assigned to ')}
@@ -111,7 +120,6 @@ export function AssigneeBadge({
   ) : (
     <Tooltip
       isHoverable
-      disabled={isTooltipDisabled}
       title={
         <TooltipWrapper>
           <div>{t('Unassigned')}</div>

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -110,6 +110,10 @@ export function AssigneeSelector({
     enabled: memberList === undefined,
   });
   const currentMemberList = memberList ?? defaultMemberList;
+  const assignedUser =
+    group.assignedTo?.type === 'user'
+      ? currentMemberList.find(user => user.id === group.assignedTo?.id)
+      : undefined;
 
   return (
     <AssigneeSelectorDropdown
@@ -130,6 +134,7 @@ export function AssigneeSelector({
         >
           <AssigneeBadge
             assignedTo={group.assignedTo ?? undefined}
+            assignedUser={assignedUser}
             assignmentReason={
               group.owners?.find(owner => {
                 const [_ownershipType, ownerId] = owner.owner.split(':');

--- a/static/app/utils/members/useMembers.tsx
+++ b/static/app/utils/members/useMembers.tsx
@@ -1,8 +1,6 @@
 import {useMemo} from 'react';
-import {useQuery, useQueryClient} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 
-import type {Member} from 'sentry/types/organization';
-import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {memberUsersQueryOptions, normalizeMemberValues} from './shared';
@@ -13,55 +11,11 @@ interface UseMembersOptions {
   limit?: number;
 }
 
-/**
- * Scan existing query cache entries for member/user list responses that
- * already contain the requested user IDs. This avoids redundant fetches
- * when the data is already loaded by another hook (e.g. useProjectMembersQueryOptions).
- */
-function findMembersInCache(
-  queryClient: ReturnType<typeof useQueryClient>,
-  orgSlug: string,
-  ids: string[]
-): ApiResponse<Member[]> | undefined {
-  const idSet = new Set(ids);
-  const prefixes = [
-    `/organizations/${orgSlug}/members/`,
-    `/organizations/${orgSlug}/users/`,
-  ];
-
-  const cached = queryClient.getQueriesData<ApiResponse<Member[]>>({
-    predicate: query => {
-      const url = query.queryKey[0];
-      return typeof url === 'string' && prefixes.some(prefix => url.startsWith(prefix));
-    },
-  });
-
-  for (const [, data] of cached) {
-    if (!data?.json) {
-      continue;
-    }
-    const matchedMembers = data.json.filter(m => m.user && idSet.has(m.user.id));
-    if (matchedMembers.length === ids.length) {
-      return {json: matchedMembers, headers: data.headers};
-    }
-  }
-
-  return undefined;
-}
-
 export function useMembers({enabled = true, ids, limit}: UseMembersOptions = {}) {
   const organization = useOrganization();
-  const queryClient = useQueryClient();
   const normalizedIds = useMemo(() => normalizeMemberValues(ids), [ids]);
   const hasIdFilter = ids !== undefined;
   const hasIds = normalizedIds.length > 0;
-
-  const cachedData = useMemo(() => {
-    if (!hasIdFilter || !hasIds) {
-      return;
-    }
-    return findMembersInCache(queryClient, organization.slug, normalizedIds);
-  }, [queryClient, organization.slug, normalizedIds, hasIdFilter, hasIds]);
 
   return useQuery({
     ...memberUsersQueryOptions({
@@ -69,7 +23,6 @@ export function useMembers({enabled = true, ids, limit}: UseMembersOptions = {})
       ids: hasIdFilter ? normalizedIds : undefined,
       limit,
     }),
-    enabled: enabled && (!hasIdFilter || hasIds) && !cachedData,
-    initialData: cachedData,
+    enabled: enabled && (!hasIdFilter || hasIds),
   });
 }


### PR DESCRIPTION
#114658 stopped resolving named issue assignees through the full member payload, so custom avatars fell back to initials; #115554 tried to recover that by scanning the global member query cache, which made unrelated cached user detail responses crash in `useMembers`.

This removes that cache scan and hydrates the assignee badge from the member list `AssigneeSelector` already has. fixes JAVASCRIPT-39P3