### PR TITLE
feat(preprod): Add Snapshot status check rules API

### DIFF
--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -222,4 +222,13 @@ OPENAPI_TAGS = [
             "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/organizations/preprodartifacts/size-analysis/&template=api_error_template.md",
         },
     },
+    {
+        "name": "Snapshots",
+        "description": "Endpoints for snapshot testing",
+        "x-display-description": False,
+        "externalDocs": {
+            "description": "Found an error? Let us know.",
+            "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/snapshots/&template=api_error_template.md",
+        },
+    },
 ]

--- a/src/sentry/apidocs/examples/preprod_examples.py
+++ b/src/sentry/apidocs/examples/preprod_examples.py
@@ -256,6 +256,16 @@ class PreprodExamples:
         ],
     }
 
+    EXAMPLE_SNAPSHOT_STATUS_CHECK_RULES = {
+        "enabled": True,
+        "rules": {
+            "failOnAdded": False,
+            "failOnRemoved": True,
+            "failOnChanged": True,
+            "failOnRenamed": False,
+        },
+    }
+
     GET_LATEST_BUILD = [
         OpenApiExample(
             "Latest Build Only",
@@ -308,6 +318,15 @@ class PreprodExamples:
         OpenApiExample(
             "Configured Size Analysis Status Check Rules",
             value=EXAMPLE_SIZE_STATUS_CHECK_RULES,
+            status_codes=["200"],
+            response_only=True,
+        ),
+    ]
+
+    GET_SNAPSHOT_STATUS_CHECK_RULES = [
+        OpenApiExample(
+            "Configured Snapshot Status Check Rules",
+            value=EXAMPLE_SNAPSHOT_STATUS_CHECK_RULES,
             status_codes=["200"],
             response_only=True,
         ),

--- a/src/sentry/preprod/api/endpoints/public/project_preprod_snapshot_status_check_rules.py
+++ b/src/sentry/preprod/api/endpoints/public/project_preprod_snapshot_status_check_rules.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.examples.preprod_examples import PreprodExamples
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.models.project import Project
+from sentry.preprod.api.models.public.snapshot_status_check_rules import (
+    ProjectSnapshotStatusCheckRulesResponseDict,
+    create_project_snapshot_status_check_rules_response,
+)
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+
+@extend_schema(tags=["Snapshots"])
+@cell_silo_endpoint
+class ProjectPreprodSnapshotStatusCheckRulesEndpoint(ProjectEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
+    permission_classes = (ProjectPermission,)
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=100, window=60),
+            }
+        }
+    )
+
+    @extend_schema(
+        operation_id="Retrieve Snapshot status check rules for a project",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+        ],
+        request=None,
+        responses={
+            200: inline_sentry_response_serializer(
+                "ProjectSnapshotStatusCheckRulesResponse",
+                ProjectSnapshotStatusCheckRulesResponseDict,
+            ),
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=PreprodExamples.GET_SNAPSHOT_STATUS_CHECK_RULES,
+    )
+    def get(self, request: Request, project: Project) -> Response:
+        r"""
+        Retrieve the current Snapshot status check rules configured for a project.
+
+        Use this endpoint when external CI needs to evaluate the same Snapshot
+        change-type rules that Sentry uses. The endpoint returns the current
+        project configuration, not a historical snapshot from when a build was
+        processed.
+
+        The response includes whether status check enforcement is enabled and the
+        Snapshot change types that fail the status check.
+
+        This endpoint requires a bearer token with `project:read` access. Project
+        distribution tokens are not supported.
+
+        Response notes:
+
+        - `enabled: false` means status-check enforcement is disabled for the project.
+        - `rules` contains one boolean per Snapshot change type.
+        - `failOnAdded`, `failOnRemoved`, `failOnChanged`, and `failOnRenamed`
+          indicate which unapproved change types fail the status check.
+        """
+        return Response(create_project_snapshot_status_check_rules_response(project))

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -54,6 +54,9 @@ from .public.project_preprod_build_distribution_latest import (
 from .public.project_preprod_size_analysis_status_check_rules import (
     ProjectPreprodSizeAnalysisStatusCheckRulesEndpoint,
 )
+from .public.project_preprod_snapshot_status_check_rules import (
+    ProjectPreprodSnapshotStatusCheckRulesEndpoint,
+)
 from .pull_request.organization_pullrequest_comments import OrganizationPrCommentsEndpoint
 from .pull_request.organization_pullrequest_details import OrganizationPullRequestDetailsEndpoint
 from .pull_request.organization_pullrequest_size_analysis_download import (
@@ -126,6 +129,11 @@ preprod_project_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprod/size-analysis/status-check-rules/$",
         ProjectPreprodSizeAnalysisStatusCheckRulesEndpoint.as_view(),
         name="sentry-api-0-project-preprod-size-analysis-status-check-rules",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprod/snapshots/status-check-rules/$",
+        ProjectPreprodSnapshotStatusCheckRulesEndpoint.as_view(),
+        name="sentry-api-0-project-preprod-snapshot-status-check-rules",
     ),
 ]
 

--- a/src/sentry/preprod/api/models/public/snapshot_status_check_rules.py
+++ b/src/sentry/preprod/api/models/public/snapshot_status_check_rules.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import TypedDict
+
+from sentry.models.project import Project
+from sentry.preprod.vcs.status_checks.snapshots.config import (
+    ENABLED_DEFAULT,
+    ENABLED_OPTION_KEY,
+    FAIL_ON_ADDED_DEFAULT,
+    FAIL_ON_ADDED_OPTION_KEY,
+    FAIL_ON_CHANGED_DEFAULT,
+    FAIL_ON_CHANGED_OPTION_KEY,
+    FAIL_ON_REMOVED_DEFAULT,
+    FAIL_ON_REMOVED_OPTION_KEY,
+    FAIL_ON_RENAMED_DEFAULT,
+    FAIL_ON_RENAMED_OPTION_KEY,
+)
+
+
+class SnapshotStatusCheckRulesResponseDict(TypedDict):
+    failOnAdded: bool
+    failOnRemoved: bool
+    failOnChanged: bool
+    failOnRenamed: bool
+
+
+class ProjectSnapshotStatusCheckRulesResponseDict(TypedDict):
+    enabled: bool
+    rules: SnapshotStatusCheckRulesResponseDict
+
+
+def create_project_snapshot_status_check_rules_response(
+    project: Project,
+) -> ProjectSnapshotStatusCheckRulesResponseDict:
+    return {
+        "enabled": project.get_option(ENABLED_OPTION_KEY, default=ENABLED_DEFAULT),
+        "rules": {
+            "failOnAdded": project.get_option(
+                FAIL_ON_ADDED_OPTION_KEY, default=FAIL_ON_ADDED_DEFAULT
+            ),
+            "failOnRemoved": project.get_option(
+                FAIL_ON_REMOVED_OPTION_KEY, default=FAIL_ON_REMOVED_DEFAULT
+            ),
+            "failOnChanged": project.get_option(
+                FAIL_ON_CHANGED_OPTION_KEY, default=FAIL_ON_CHANGED_DEFAULT
+            ),
+            "failOnRenamed": project.get_option(
+                FAIL_ON_RENAMED_OPTION_KEY, default=FAIL_ON_RENAMED_DEFAULT
+            ),
+        },
+    }

--- a/src/sentry/preprod/vcs/status_checks/snapshots/config.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/config.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+ENABLED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_enabled"
+FAIL_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_added"
+FAIL_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_removed"
+FAIL_ON_CHANGED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_changed"
+FAIL_ON_RENAMED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_renamed"
+
+ENABLED_DEFAULT = True
+FAIL_ON_ADDED_DEFAULT = False
+FAIL_ON_REMOVED_DEFAULT = True
+FAIL_ON_CHANGED_DEFAULT = True
+FAIL_ON_RENAMED_DEFAULT = False

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -18,6 +18,18 @@ from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSn
 from sentry.preprod.snapshots.utils import build_changes_map
 from sentry.preprod.url_utils import get_preprod_artifact_url
 from sentry.preprod.vcs.pr_comments.snapshot_tasks import create_preprod_snapshot_pr_comment_task
+from sentry.preprod.vcs.status_checks.snapshots.config import (
+    ENABLED_DEFAULT,
+    ENABLED_OPTION_KEY,
+    FAIL_ON_ADDED_DEFAULT,
+    FAIL_ON_ADDED_OPTION_KEY,
+    FAIL_ON_CHANGED_DEFAULT,
+    FAIL_ON_CHANGED_OPTION_KEY,
+    FAIL_ON_REMOVED_DEFAULT,
+    FAIL_ON_REMOVED_OPTION_KEY,
+    FAIL_ON_RENAMED_DEFAULT,
+    FAIL_ON_RENAMED_OPTION_KEY,
+)
 from sentry.preprod.vcs.status_checks.snapshots.templates import (
     format_first_snapshot_status_check_messages,
     format_generated_snapshot_status_check_messages,
@@ -42,13 +54,6 @@ logger = logging.getLogger(__name__)
 
 # Action identifier for the "Approve" button on snapshot GitHub check runs.
 APPROVE_SNAPSHOT_ACTION_IDENTIFIER = "approve_snapshots"
-
-ENABLED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_enabled"
-FAIL_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_added"
-FAIL_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_removed"
-FAIL_ON_CHANGED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_changed"
-FAIL_ON_RENAMED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_renamed"
-
 
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_snapshot_status_check",
@@ -107,7 +112,9 @@ def create_preprod_snapshot_status_check_task(
         )
         return
 
-    status_checks_enabled = preprod_artifact.project.get_option(ENABLED_OPTION_KEY, default=True)
+    status_checks_enabled = preprod_artifact.project.get_option(
+        ENABLED_OPTION_KEY, default=ENABLED_DEFAULT
+    )
     if not status_checks_enabled:
         logger.info(
             "preprod.snapshot_status_checks.create.disabled",
@@ -118,10 +125,18 @@ def create_preprod_snapshot_status_check_task(
         )
         return
 
-    fail_on_added = preprod_artifact.project.get_option(FAIL_ON_ADDED_OPTION_KEY, default=False)
-    fail_on_removed = preprod_artifact.project.get_option(FAIL_ON_REMOVED_OPTION_KEY, default=True)
-    fail_on_changed = preprod_artifact.project.get_option(FAIL_ON_CHANGED_OPTION_KEY, default=True)
-    fail_on_renamed = preprod_artifact.project.get_option(FAIL_ON_RENAMED_OPTION_KEY, default=False)
+    fail_on_added = preprod_artifact.project.get_option(
+        FAIL_ON_ADDED_OPTION_KEY, default=FAIL_ON_ADDED_DEFAULT
+    )
+    fail_on_removed = preprod_artifact.project.get_option(
+        FAIL_ON_REMOVED_OPTION_KEY, default=FAIL_ON_REMOVED_DEFAULT
+    )
+    fail_on_changed = preprod_artifact.project.get_option(
+        FAIL_ON_CHANGED_OPTION_KEY, default=FAIL_ON_CHANGED_DEFAULT
+    )
+    fail_on_renamed = preprod_artifact.project.get_option(
+        FAIL_ON_RENAMED_OPTION_KEY, default=FAIL_ON_RENAMED_DEFAULT
+    )
 
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 # Action identifier for the "Approve" button on snapshot GitHub check runs.
 APPROVE_SNAPSHOT_ACTION_IDENTIFIER = "approve_snapshots"
 
+
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_snapshot_status_check",
     namespace=preprod_tasks,

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -682,6 +682,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/plugins/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/plugins/$pluginId/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprod/size-analysis/status-check-rules/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprod/snapshots/status-check-rules/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/build-distribution/latest/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/check-for-updates/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/size-analysis/compare/$headSizeMetricId/$baseSizeMetricId/download/'

--- a/tests/sentry/preprod/api/endpoints/public/test_project_preprod_snapshot_status_check_rules.py
+++ b/tests/sentry/preprod/api/endpoints/public/test_project_preprod_snapshot_status_check_rules.py
@@ -1,0 +1,151 @@
+from django.urls import reverse
+
+from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.preprod.api.models.public.snapshot_status_check_rules import (
+    ENABLED_DEFAULT,
+    ENABLED_OPTION_KEY,
+    FAIL_ON_ADDED_DEFAULT,
+    FAIL_ON_ADDED_OPTION_KEY,
+    FAIL_ON_CHANGED_DEFAULT,
+    FAIL_ON_CHANGED_OPTION_KEY,
+    FAIL_ON_REMOVED_DEFAULT,
+    FAIL_ON_REMOVED_OPTION_KEY,
+    FAIL_ON_RENAMED_DEFAULT,
+    FAIL_ON_RENAMED_OPTION_KEY,
+)
+from sentry.preprod.vcs.status_checks.snapshots import tasks as snapshot_status_check_tasks
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
+
+
+class ProjectPreprodSnapshotStatusCheckRulesEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-project-preprod-snapshot-status-check-rules"
+
+    def setUp(self) -> None:
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+
+    def _get_url(self, organization_slug=None, project_slug=None):
+        return reverse(
+            self.endpoint,
+            args=[organization_slug or self.organization.slug, project_slug or self.project.slug],
+        )
+
+    def _get_with_user_token(self, scope_list=None, user=None, url=None):
+        token = self.create_user_auth_token(
+            user or self.user,
+            scope_list=scope_list or ["project:read"],
+        )
+        return self.client.get(url or self._get_url(), HTTP_AUTHORIZATION=f"Bearer {token.token}")
+
+    def _get_with_org_token(self, scope_list=None):
+        token_str = generate_token(self.organization.slug, "")
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            OrgAuthToken.objects.create(
+                organization_id=self.organization.id,
+                name="Test Token",
+                token_hashed=hash_token(token_str),
+                scope_list=scope_list or ["project:distribution"],
+            )
+        return self.client.get(self._get_url(), HTTP_AUTHORIZATION=f"Bearer {token_str}")
+
+    def test_default_config_returns_snapshot_rules_with_runtime_defaults(self) -> None:
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "enabled": True,
+            "rules": {
+                "failOnAdded": False,
+                "failOnRemoved": True,
+                "failOnChanged": True,
+                "failOnRenamed": False,
+            },
+        }
+
+    def test_returns_explicit_non_default_values(self) -> None:
+        self.project.update_option(ENABLED_OPTION_KEY, False)
+        self.project.update_option(FAIL_ON_ADDED_OPTION_KEY, True)
+        self.project.update_option(FAIL_ON_REMOVED_OPTION_KEY, False)
+        self.project.update_option(FAIL_ON_CHANGED_OPTION_KEY, False)
+        self.project.update_option(FAIL_ON_RENAMED_OPTION_KEY, True)
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "enabled": False,
+            "rules": {
+                "failOnAdded": True,
+                "failOnRemoved": False,
+                "failOnChanged": False,
+                "failOnRenamed": True,
+            },
+        }
+
+    def test_partial_config_falls_back_to_runtime_defaults(self) -> None:
+        self.project.update_option(FAIL_ON_ADDED_OPTION_KEY, True)
+        self.project.update_option(FAIL_ON_CHANGED_OPTION_KEY, False)
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "enabled": True,
+            "rules": {
+                "failOnAdded": True,
+                "failOnRemoved": True,
+                "failOnChanged": False,
+                "failOnRenamed": False,
+            },
+        }
+
+    def test_denies_unauthenticated_request(self) -> None:
+        response = self.client.get(self._get_url())
+
+        assert response.status_code == 401
+
+    def test_denies_token_without_expected_scope(self) -> None:
+        response = self._get_with_user_token(scope_list=["event:read"])
+
+        assert response.status_code == 403
+
+    def test_allows_project_read_bearer_token(self) -> None:
+        response = self._get_with_user_token(scope_list=["project:read"])
+
+        assert response.status_code == 200
+
+    def test_allows_project_read_org_token(self) -> None:
+        response = self._get_with_org_token(scope_list=["project:read"])
+
+        assert response.status_code == 200
+
+    def test_denies_project_distribution_org_token(self) -> None:
+        response = self._get_with_org_token(scope_list=["project:distribution"])
+
+        assert response.status_code == 403
+
+    def test_denies_other_organization_access(self) -> None:
+        other_user = self.create_user()
+        other_organization = self.create_organization(owner=other_user)
+        other_project = self.create_project(organization=other_organization)
+        url = self._get_url(other_organization.slug, other_project.slug)
+
+        response = self._get_with_user_token(user=self.user, url=url)
+
+        assert response.status_code == 403
+
+    def test_public_option_config_matches_snapshot_status_check_task(self) -> None:
+        assert ENABLED_OPTION_KEY == snapshot_status_check_tasks.ENABLED_OPTION_KEY
+        assert FAIL_ON_ADDED_OPTION_KEY == snapshot_status_check_tasks.FAIL_ON_ADDED_OPTION_KEY
+        assert FAIL_ON_REMOVED_OPTION_KEY == snapshot_status_check_tasks.FAIL_ON_REMOVED_OPTION_KEY
+        assert FAIL_ON_CHANGED_OPTION_KEY == snapshot_status_check_tasks.FAIL_ON_CHANGED_OPTION_KEY
+        assert FAIL_ON_RENAMED_OPTION_KEY == snapshot_status_check_tasks.FAIL_ON_RENAMED_OPTION_KEY
+        assert ENABLED_DEFAULT == snapshot_status_check_tasks.ENABLED_DEFAULT
+        assert FAIL_ON_ADDED_DEFAULT == snapshot_status_check_tasks.FAIL_ON_ADDED_DEFAULT
+        assert FAIL_ON_REMOVED_DEFAULT == snapshot_status_check_tasks.FAIL_ON_REMOVED_DEFAULT
+        assert FAIL_ON_CHANGED_DEFAULT == snapshot_status_check_tasks.FAIL_ON_CHANGED_DEFAULT
+        assert FAIL_ON_RENAMED_DEFAULT == snapshot_status_check_tasks.FAIL_ON_RENAMED_DEFAULT

--- a/tests/sentry/preprod/api/endpoints/public/test_project_preprod_snapshot_status_check_rules.py
+++ b/tests/sentry/preprod/api/endpoints/public/test_project_preprod_snapshot_status_check_rules.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 
 from sentry.models.orgauthtoken import OrgAuthToken
-from sentry.preprod.api.models.public.snapshot_status_check_rules import (
+from sentry.preprod.vcs.status_checks.snapshots.config import (
     ENABLED_DEFAULT,
     ENABLED_OPTION_KEY,
     FAIL_ON_ADDED_DEFAULT,
@@ -13,7 +13,6 @@ from sentry.preprod.api.models.public.snapshot_status_check_rules import (
     FAIL_ON_RENAMED_DEFAULT,
     FAIL_ON_RENAMED_OPTION_KEY,
 )
-from sentry.preprod.vcs.status_checks.snapshots import tasks as snapshot_status_check_tasks
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -138,14 +137,14 @@ class ProjectPreprodSnapshotStatusCheckRulesEndpointTest(APITestCase):
 
         assert response.status_code == 403
 
-    def test_public_option_config_matches_snapshot_status_check_task(self) -> None:
-        assert ENABLED_OPTION_KEY == snapshot_status_check_tasks.ENABLED_OPTION_KEY
-        assert FAIL_ON_ADDED_OPTION_KEY == snapshot_status_check_tasks.FAIL_ON_ADDED_OPTION_KEY
-        assert FAIL_ON_REMOVED_OPTION_KEY == snapshot_status_check_tasks.FAIL_ON_REMOVED_OPTION_KEY
-        assert FAIL_ON_CHANGED_OPTION_KEY == snapshot_status_check_tasks.FAIL_ON_CHANGED_OPTION_KEY
-        assert FAIL_ON_RENAMED_OPTION_KEY == snapshot_status_check_tasks.FAIL_ON_RENAMED_OPTION_KEY
-        assert ENABLED_DEFAULT == snapshot_status_check_tasks.ENABLED_DEFAULT
-        assert FAIL_ON_ADDED_DEFAULT == snapshot_status_check_tasks.FAIL_ON_ADDED_DEFAULT
-        assert FAIL_ON_REMOVED_DEFAULT == snapshot_status_check_tasks.FAIL_ON_REMOVED_DEFAULT
-        assert FAIL_ON_CHANGED_DEFAULT == snapshot_status_check_tasks.FAIL_ON_CHANGED_DEFAULT
-        assert FAIL_ON_RENAMED_DEFAULT == snapshot_status_check_tasks.FAIL_ON_RENAMED_DEFAULT
+    def test_shared_status_check_config_defines_expected_runtime_defaults(self) -> None:
+        assert ENABLED_OPTION_KEY == "sentry:preprod_snapshot_status_checks_enabled"
+        assert FAIL_ON_ADDED_OPTION_KEY == "sentry:preprod_snapshot_status_checks_fail_on_added"
+        assert FAIL_ON_REMOVED_OPTION_KEY == "sentry:preprod_snapshot_status_checks_fail_on_removed"
+        assert FAIL_ON_CHANGED_OPTION_KEY == "sentry:preprod_snapshot_status_checks_fail_on_changed"
+        assert FAIL_ON_RENAMED_OPTION_KEY == "sentry:preprod_snapshot_status_checks_fail_on_renamed"
+        assert ENABLED_DEFAULT is True
+        assert FAIL_ON_ADDED_DEFAULT is False
+        assert FAIL_ON_REMOVED_DEFAULT is True
+        assert FAIL_ON_CHANGED_DEFAULT is True
+        assert FAIL_ON_RENAMED_DEFAULT is False

--- a/tests/sentry/preprod/api/endpoints/public/test_project_preprod_snapshot_status_check_rules.py
+++ b/tests/sentry/preprod/api/endpoints/public/test_project_preprod_snapshot_status_check_rules.py
@@ -136,15 +136,3 @@ class ProjectPreprodSnapshotStatusCheckRulesEndpointTest(APITestCase):
         response = self._get_with_user_token(user=self.user, url=url)
 
         assert response.status_code == 403
-
-    def test_shared_status_check_config_defines_expected_runtime_defaults(self) -> None:
-        assert ENABLED_OPTION_KEY == "sentry:preprod_snapshot_status_checks_enabled"
-        assert FAIL_ON_ADDED_OPTION_KEY == "sentry:preprod_snapshot_status_checks_fail_on_added"
-        assert FAIL_ON_REMOVED_OPTION_KEY == "sentry:preprod_snapshot_status_checks_fail_on_removed"
-        assert FAIL_ON_CHANGED_OPTION_KEY == "sentry:preprod_snapshot_status_checks_fail_on_changed"
-        assert FAIL_ON_RENAMED_OPTION_KEY == "sentry:preprod_snapshot_status_checks_fail_on_renamed"
-        assert ENABLED_DEFAULT is True
-        assert FAIL_ON_ADDED_DEFAULT is False
-        assert FAIL_ON_REMOVED_DEFAULT is True
-        assert FAIL_ON_CHANGED_DEFAULT is True
-        assert FAIL_ON_RENAMED_DEFAULT is False

--- a/tests/sentry/preprod/api/endpoints/public/test_project_preprod_snapshot_status_check_rules.py
+++ b/tests/sentry/preprod/api/endpoints/public/test_project_preprod_snapshot_status_check_rules.py
@@ -2,15 +2,10 @@ from django.urls import reverse
 
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.preprod.vcs.status_checks.snapshots.config import (
-    ENABLED_DEFAULT,
     ENABLED_OPTION_KEY,
-    FAIL_ON_ADDED_DEFAULT,
     FAIL_ON_ADDED_OPTION_KEY,
-    FAIL_ON_CHANGED_DEFAULT,
     FAIL_ON_CHANGED_OPTION_KEY,
-    FAIL_ON_REMOVED_DEFAULT,
     FAIL_ON_REMOVED_OPTION_KEY,
-    FAIL_ON_RENAMED_DEFAULT,
     FAIL_ON_RENAMED_OPTION_KEY,
 )
 from sentry.silo.base import SiloMode


### PR DESCRIPTION
Expose Snapshot status-check rule configuration through a public project API endpoint. External CI can retrieve the current enforcement state and change-type rules with `project:read` tokens, while project distribution tokens remain unsupported.

**Shared Snapshot Check Config**

Moves Snapshot status-check option keys and defaults into a shared config module used by both runtime task evaluation and API serialization, keeping the public response aligned with the status-check behavior.

**Example**
```
/api/0/projects/sentry/internal/preprod/snapshots/status-check-rules/
```

Returns:
```json
{
  "enabled": true,
  "rules": {
    "failOnAdded": false,
    "failOnRemoved": true,
    "failOnChanged": true,
    "failOnRenamed": false
  }
}
```

**API Documentation**

Adds the Snapshots OpenAPI tag, example response, and route metadata for `/preprod/snapshots/status-check-rules/`.