### PR TITLE
feat(conversations): Add Amplitude analytics to conversation pages

### DIFF
--- a/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
@@ -19,16 +19,12 @@ export type ConversationsEventParameters = {
   'conversations.table.paginate': {
     direction: 'next' | 'previous';
   };
-  'conversations.table.search': {
-    hasQuery: boolean;
-  };
 };
 
 export const conversationsEventMap: Record<keyof ConversationsEventParameters, string> = {
   'conversations.page-view': 'Conversations: Page View',
   'conversations.table.open': 'Conversations: Table Open',
   'conversations.table.paginate': 'Conversations: Table Paginate',
-  'conversations.table.search': 'Conversations: Table Search',
   'conversations.detail.page-view': 'Conversations: Detail Page View',
   'conversations.detail.tab-switch': 'Conversations: Detail Tab Switch',
   'conversations.detail.select-span': 'Conversations: Detail Select Span',

--- a/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
@@ -1,25 +1,41 @@
-type ConversationDrawerOpenSource =
-  | 'direct_link'
-  | 'table_conversation_id'
-  | 'table_input'
-  | 'table_output'
-  | 'table_tool_tag';
+type ConversationOpenSource = 'table_conversation_id' | 'table_input' | 'table_output';
 
 export type ConversationsEventParameters = {
-  'conversations.drawer.open': {
-    source: ConversationDrawerOpenSource;
-  };
-  'conversations.drawer.span-select': Record<string, unknown>;
-  'conversations.drawer.tab-switch': {
+  'conversations.detail.click-errors-link': Record<string, unknown>;
+  'conversations.detail.click-trace-link': Record<string, unknown>;
+  'conversations.detail.copy-conversation-id': Record<string, unknown>;
+  'conversations.detail.page-view': Record<string, unknown>;
+  'conversations.detail.select-span': Record<string, unknown>;
+  'conversations.detail.tab-switch': {
     fromTab: string;
     toTab: string;
   };
+  'conversations.message.click': Record<string, unknown>;
+  'conversations.message.click-tool-call': Record<string, unknown>;
   'conversations.page-view': Record<string, unknown>;
+  'conversations.table.open': {
+    source: ConversationOpenSource;
+  };
+  'conversations.table.paginate': {
+    direction: 'next' | 'previous';
+  };
+  'conversations.table.search': {
+    hasQuery: boolean;
+  };
 };
 
 export const conversationsEventMap: Record<keyof ConversationsEventParameters, string> = {
   'conversations.page-view': 'Conversations: Page View',
-  'conversations.drawer.open': 'Conversations: Drawer Open',
-  'conversations.drawer.tab-switch': 'Conversations: Drawer Tab Switch',
-  'conversations.drawer.span-select': 'Conversations: Drawer Span Select',
+  'conversations.table.open': 'Conversations: Table Open',
+  'conversations.table.paginate': 'Conversations: Table Paginate',
+  'conversations.table.search': 'Conversations: Table Search',
+  'conversations.detail.page-view': 'Conversations: Detail Page View',
+  'conversations.detail.tab-switch': 'Conversations: Detail Tab Switch',
+  'conversations.detail.select-span': 'Conversations: Detail Select Span',
+  'conversations.detail.copy-conversation-id':
+    'Conversations: Detail Copy Conversation ID',
+  'conversations.detail.click-trace-link': 'Conversations: Detail Click Trace Link',
+  'conversations.detail.click-errors-link': 'Conversations: Detail Click Errors Link',
+  'conversations.message.click': 'Conversations: Message Click',
+  'conversations.message.click-tool-call': 'Conversations: Message Click Tool Call',
 };

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -112,11 +112,13 @@ export function ConversationAggregatesBar({
   conversationId,
   isLoading,
   lastMessageDate,
+  onErrorsLinkClick,
 }: {
   conversationId: string;
   nodes: AITraceSpanNode[];
   isLoading?: boolean;
   lastMessageDate?: Date | null;
+  onErrorsLinkClick?: () => void;
 }) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
@@ -140,12 +142,7 @@ export function ConversationAggregatesBar({
         value={<Count value={aggregates.errorCount} />}
         to={aggregates.errorCount > 0 ? errorsUrl : undefined}
         isLoading={isLoading}
-        onClick={
-          aggregates.errorCount > 0
-            ? () =>
-                trackAnalytics('conversations.detail.click-errors-link', {organization})
-            : undefined
-        }
+        onClick={aggregates.errorCount > 0 ? onErrorsLinkClick : undefined}
       />
       <AggregateItem
         label={t('Tokens')}
@@ -321,6 +318,9 @@ export function ConversationSummary({
         conversationId={conversationId}
         isLoading={isLoading}
         lastMessageDate={lastMessageDate}
+        onErrorsLinkClick={() =>
+          trackAnalytics('conversations.detail.click-errors-link', {organization})
+        }
       />
     </Flex>
   );

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -17,6 +17,7 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -139,6 +140,12 @@ export function ConversationAggregatesBar({
         value={<Count value={aggregates.errorCount} />}
         to={aggregates.errorCount > 0 ? errorsUrl : undefined}
         isLoading={isLoading}
+        onClick={
+          aggregates.errorCount > 0
+            ? () =>
+                trackAnalytics('conversations.detail.click-errors-link', {organization})
+            : undefined
+        }
       />
       <AggregateItem
         label={t('Tokens')}
@@ -223,6 +230,7 @@ export function ConversationSummary({
   }, [nodes]);
 
   const handleCopyConversationId = () => {
+    trackAnalytics('conversations.detail.copy-conversation-id', {organization});
     copyToClipboard(conversationId, {
       successMessage: t('Copied conversation ID to clipboard'),
     });
@@ -268,6 +276,11 @@ export function ConversationSummary({
                 )}
                 <StyledLink
                   to={getTraceUrl(organization.slug, trace.traceId, trace.spanId)}
+                  onClick={() =>
+                    trackAnalytics('conversations.detail.click-trace-link', {
+                      organization,
+                    })
+                  }
                 >
                   <Text size="sm" monospace variant="accent">
                     {trace.traceId.slice(0, 8)}
@@ -318,10 +331,12 @@ function AggregateItem({
   value,
   to,
   isLoading,
+  onClick,
 }: {
   label: string;
   value: React.ReactNode;
   isLoading?: boolean;
+  onClick?: () => void;
   to?: string;
 }) {
   const isInteractive = !!to && !isLoading;
@@ -342,7 +357,11 @@ function AggregateItem({
   );
 
   if (isInteractive) {
-    return <StyledLink to={to}>{content}</StyledLink>;
+    return (
+      <StyledLink to={to} onClick={onClick}>
+        {content}
+      </StyledLink>
+    );
   }
 
   return content;

--- a/static/app/views/explore/conversations/components/conversationView.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.tsx
@@ -96,7 +96,7 @@ function ConversationView({
 
   const handleTabChange = (newTab: ConversationTab) => {
     if (activeTab !== newTab) {
-      trackAnalytics('conversations.drawer.tab-switch', {
+      trackAnalytics('conversations.detail.tab-switch', {
         organization,
         fromTab: activeTab,
         toTab: newTab,

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -19,6 +19,7 @@ import {useStateBasedColumnResize} from 'sentry/components/tables/gridEditable/u
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconArrow, IconUser} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {isUUID} from 'sentry/utils/string/isUUID';
@@ -86,11 +87,20 @@ const defaultColumnOrder: Array<GridColumnOrder<string>> = [
 const rightAlignColumns = new Set(['steps', 'tokensAndCost', 'timestamp']);
 
 function ConversationsTableInner() {
+  const organization = useOrganization();
   const {columns: columnOrder, handleResizeColumn} = useStateBasedColumnResize({
     columns: defaultColumnOrder,
   });
 
   const {data, isLoading, error, pageLinks, setCursor} = useConversations();
+
+  const handlePaginate: typeof setCursor = (cursor, path, query, pageDelta) => {
+    trackAnalytics('conversations.table.paginate', {
+      organization,
+      direction: pageDelta > 0 ? 'next' : 'previous',
+    });
+    setCursor(cursor, path, query, pageDelta);
+  };
 
   const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
     return (
@@ -137,7 +147,7 @@ function ConversationsTableInner() {
           }}
         />
       </Container>
-      <Pagination pageLinks={pageLinks} onCursor={setCursor} />
+      <Pagination pageLinks={pageLinks} onCursor={handlePaginate} />
     </Fragment>
   );
 }
@@ -220,15 +230,28 @@ const BodyCell = memo(function BodyCell({
   const navigate = useNavigate();
   const {selection} = usePageFilters();
 
-  const navigateToDetail = useCallback(() => {
-    navigate(getConversationDetailUrl(organization.slug, dataRow, selection.projects));
-  }, [navigate, organization.slug, dataRow, selection.projects]);
+  const detailUrl = getConversationDetailUrl(
+    organization.slug,
+    dataRow,
+    selection.projects
+  );
+
+  const navigateToDetail = (source: 'table_input' | 'table_output') => {
+    trackAnalytics('conversations.table.open', {organization, source});
+    navigate(detailUrl);
+  };
 
   switch (column.key) {
     case 'conversationId':
       return (
         <ConversationIdLink
-          to={getConversationDetailUrl(organization.slug, dataRow, selection.projects)}
+          to={detailUrl}
+          onClick={() =>
+            trackAnalytics('conversations.table.open', {
+              organization,
+              source: 'table_conversation_id',
+            })
+          }
         >
           {isUUID(dataRow.conversationId) ? (
             dataRow.conversationId.slice(0, 8)
@@ -260,7 +283,7 @@ const BodyCell = memo(function BodyCell({
     case 'inputOutput': {
       return (
         <Stack width="100%">
-          <InputOutputRow type="button" onClick={navigateToDetail}>
+          <InputOutputRow type="button" onClick={() => navigateToDetail('table_input')}>
             <InputOutputLabel variant="muted">{t('Input')}</InputOutputLabel>
             <Flex flex="1" minWidth="0">
               {dataRow.firstInput ? (
@@ -270,7 +293,7 @@ const BodyCell = memo(function BodyCell({
               )}
             </Flex>
           </InputOutputRow>
-          <InputOutputRow type="button" onClick={navigateToDetail}>
+          <InputOutputRow type="button" onClick={() => navigateToDetail('table_output')}>
             <InputOutputLabel variant="muted">{t('Output')}</InputOutputLabel>
             <Flex flex="1" minWidth="0">
               {dataRow.lastOutput ? (

--- a/static/app/views/explore/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCalls.tsx
@@ -6,6 +6,8 @@ import {Text} from '@sentry/scraps/text';
 
 import {IconFire} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import type {ToolCall} from 'sentry/views/explore/conversations/utils/conversationMessages';
 import {getFirstToolInputValue} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
@@ -23,6 +25,7 @@ export function MessageToolCalls({
   nodeMap,
   onSelectNode,
 }: MessageToolCallsProps) {
+  const organization = useOrganization();
   return (
     <Flex direction="column" gap="xs" padding="sm md xs md">
       {toolCalls.map(tool => {
@@ -37,6 +40,7 @@ export function MessageToolCalls({
             cursor="pointer"
             onClick={(e: React.MouseEvent) => {
               e.stopPropagation();
+              trackAnalytics('conversations.message.click-tool-call', {organization});
               if (toolNode) {
                 onSelectNode(toolNode);
               }

--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -7,7 +7,9 @@ import {Text} from '@sentry/scraps/text';
 import {ClippedBox} from 'sentry/components/clippedBox';
 import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getDuration} from 'sentry/utils/duration/getDuration';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {MessageToolCalls} from 'sentry/views/explore/conversations/components/messageToolCalls';
 import type {ConversationMessage} from 'sentry/views/explore/conversations/utils/conversationMessages';
 import {extractMessagesFromNodes} from 'sentry/views/explore/conversations/utils/conversationMessages';
@@ -21,6 +23,7 @@ interface MessagesPanelProps {
 }
 
 export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPanelProps) {
+  const organization = useOrganization();
   const messages = useMemo(() => extractMessagesFromNodes(nodes), [nodes]);
   const [clickedMessageId, setClickedMessageId] = useState<string | null>(null);
 
@@ -50,13 +53,16 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
 
   const handleMessageClick = useCallback(
     (message: ConversationMessage) => {
+      trackAnalytics('conversations.message.click', {
+        organization,
+      });
       setClickedMessageId(message.id);
       const node = nodeMap.get(message.nodeId);
       if (node) {
         onSelectNode(node);
       }
     },
-    [nodeMap, onSelectNode]
+    [nodeMap, onSelectNode, organization]
   );
 
   if (messages.length === 0) {

--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -1,8 +1,10 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import {parseAsString, useQueryStates} from 'nuqs';
 
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {ViewportConstrainedPage} from 'sentry/views/explore/components/viewportConstrainedPage';
 import {ConversationSummary} from 'sentry/views/explore/conversations/components/conversationSummary';
@@ -20,6 +22,7 @@ function useConversationDetailQueryState() {
 }
 
 function ConversationDetailPage() {
+  const organization = useOrganization();
   const {conversationId} = useParams<{conversationId: string}>();
   const [queryState, setQueryState] = useConversationDetailQueryState();
 
@@ -27,11 +30,20 @@ function ConversationDetailPage() {
 
   const {nodes, nodeTraceMap, isLoading} = useConversation(conversation);
 
+  useEffect(() => {
+    trackAnalytics('conversations.detail.page-view', {
+      organization,
+    });
+  }, [organization]);
+
   const handleSelectSpan = useCallback(
     (spanId: string) => {
+      trackAnalytics('conversations.detail.select-span', {
+        organization,
+      });
       setQueryState({spanId, focusedTool: null});
     },
-    [setQueryState]
+    [organization, setQueryState]
   );
 
   return (

--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -34,7 +34,7 @@ function ConversationDetailPage() {
     trackAnalytics('conversations.detail.page-view', {
       organization,
     });
-  }, [organization]);
+  }, [organization, conversationId]);
 
   const handleSelectSpan = useCallback(
     (spanId: string) => {

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -80,10 +80,6 @@ function ConversationsOverviewPage() {
     () => ({
       initialQuery: searchQuery ?? '',
       onSearch: (newQuery: string) => {
-        trackAnalytics('conversations.table.search', {
-          organization,
-          hasQuery: newQuery.trim().length > 0,
-        });
         setSearchQuery(newQuery);
         unsetCursor();
       },
@@ -94,7 +90,7 @@ function ConversationsOverviewPage() {
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
       ],
     }),
-    [hasRawSearchReplacement, organization, searchQuery, setSearchQuery, unsetCursor]
+    [hasRawSearchReplacement, searchQuery, setSearchQuery, unsetCursor]
   );
 
   const {spanSearchQueryBuilderProviderProps, spanSearchQueryBuilderProps} =

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -80,6 +80,10 @@ function ConversationsOverviewPage() {
     () => ({
       initialQuery: searchQuery ?? '',
       onSearch: (newQuery: string) => {
+        trackAnalytics('conversations.table.search', {
+          organization,
+          hasQuery: newQuery.trim().length > 0,
+        });
         setSearchQuery(newQuery);
         unsetCursor();
       },
@@ -90,7 +94,7 @@ function ConversationsOverviewPage() {
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
       ],
     }),
-    [hasRawSearchReplacement, searchQuery, setSearchQuery, unsetCursor]
+    [hasRawSearchReplacement, organization, searchQuery, setSearchQuery, unsetCursor]
   );
 
   const {spanSearchQueryBuilderProviderProps, spanSearchQueryBuilderProps} =


### PR DESCRIPTION
Add comprehensive Amplitude analytics tracking to the conversations feature to understand how users interact with the conversations table and detail pages.

Remove unused `drawer.open` and `drawer.span-select` event definitions that were never wired up, and rename `drawer.tab-switch` to `detail.tab-switch` since the drawer no longer exists.

Closes TET-2351