### PR TITLE
fix(preprod): Change snapshot image tags from list to dict

### DIFF
--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -50,7 +50,7 @@ class SnapshotImageDetailImageInfo(BaseModel):
     height: int
     diff_threshold: float | None = None
     description: str | None = None
-    tags: list[str] | None = None
+    tags: dict[str, str] | None = None
     image_url: str
 
     class Config:

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 
 class ImageMetadata(BaseModel):
@@ -13,7 +13,17 @@ class ImageMetadata(BaseModel):
     height: int = Field(ge=0)
     diff_threshold: float | None = Field(default=None, ge=0.0, lt=1.0)
     description: str | None = None
-    tags: list[str] | None = None
+    tags: dict[str, str] | None = None
+
+    @validator("tags", pre=True)
+    def coerce_tags(cls, v: object) -> dict[str, str] | None:
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v
+        if isinstance(v, list):
+            return {str(tag): str(tag) for tag in v}
+        return None
 
     class Config:
         extra = "allow"

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 
 class ImageMetadata(BaseModel):
@@ -14,6 +14,16 @@ class ImageMetadata(BaseModel):
     diff_threshold: float | None = Field(default=None, ge=0.0, lt=1.0)
     description: str | None = None
     tags: dict[str, str] | None = None
+
+    @validator("tags", pre=True)
+    def coerce_tags(cls, v: object) -> dict[str, str] | None:
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v
+        if isinstance(v, list):
+            return {str(tag): str(tag) for tag in v}
+        return None
 
     class Config:
         extra = "allow"

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field
 
 
 class ImageMetadata(BaseModel):
@@ -14,16 +14,6 @@ class ImageMetadata(BaseModel):
     diff_threshold: float | None = Field(default=None, ge=0.0, lt=1.0)
     description: str | None = None
     tags: dict[str, str] | None = None
-
-    @validator("tags", pre=True)
-    def coerce_tags(cls, v: object) -> dict[str, str] | None:
-        if v is None:
-            return None
-        if isinstance(v, dict):
-            return v
-        if isinstance(v, list):
-            return {str(tag): str(tag) for tag in v}
-        return None
 
     class Config:
         extra = "allow"

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -7,6 +7,7 @@ export interface SnapshotImage {
   group?: string | null;
   height: number;
   key: string;
+  tags?: Record<string, string> | null;
   width: number;
 }
 

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -7,7 +7,6 @@ export interface SnapshotImage {
   group?: string | null;
   height: number;
   key: string;
-  tags?: Record<string, string> | null;
   width: number;
 }
 

--- a/tests/sentry/preprod/snapshots/test_manifest.py
+++ b/tests/sentry/preprod/snapshots/test_manifest.py
@@ -1,0 +1,58 @@
+from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
+
+
+def _meta(**kwargs: object) -> dict:
+    defaults: dict = {"content_hash": "abc123", "width": 100, "height": 200}
+    defaults.update(kwargs)
+    return defaults
+
+
+class TestImageMetadataTagsCoercion:
+    def test_tags_none(self) -> None:
+        meta = ImageMetadata(**_meta())
+        assert meta.tags is None
+
+    def test_tags_dict_passthrough(self) -> None:
+        tags = {"theme": "dark", "device": "phone"}
+        meta = ImageMetadata(**_meta(tags=tags))
+        assert meta.tags == tags
+
+    def test_tags_list_converted_to_dict(self) -> None:
+        meta = ImageMetadata(**_meta(tags=["dark", "mobile"]))
+        assert meta.tags == {"dark": "dark", "mobile": "mobile"}
+
+    def test_tags_single_item_list(self) -> None:
+        meta = ImageMetadata(**_meta(tags=["solo"]))
+        assert meta.tags == {"solo": "solo"}
+
+    def test_tags_empty_list(self) -> None:
+        meta = ImageMetadata(**_meta(tags=[]))
+        assert meta.tags == {}
+
+    def test_tags_empty_dict(self) -> None:
+        meta = ImageMetadata(**_meta(tags={}))
+        assert meta.tags == {}
+
+    def test_tags_unexpected_type_becomes_none(self) -> None:
+        meta = ImageMetadata(**_meta(tags=42))
+        assert meta.tags is None
+
+    def test_tags_string_becomes_none(self) -> None:
+        meta = ImageMetadata(**_meta(tags="not_a_dict_or_list"))
+        assert meta.tags is None
+
+    def test_manifest_with_dict_tags(self) -> None:
+        manifest = SnapshotManifest(
+            images={
+                "screen.png": _meta(tags={"theme": "dark", "size": "large"}),
+            }
+        )
+        assert manifest.images["screen.png"].tags == {"theme": "dark", "size": "large"}
+
+    def test_manifest_with_legacy_list_tags(self) -> None:
+        manifest = SnapshotManifest(
+            images={
+                "screen.png": _meta(tags=["dark", "mobile"]),
+            }
+        )
+        assert manifest.images["screen.png"].tags == {"dark": "dark", "mobile": "mobile"}

--- a/tests/sentry/preprod/snapshots/test_manifest.py
+++ b/tests/sentry/preprod/snapshots/test_manifest.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
 
 
@@ -7,39 +10,31 @@ def _meta(**kwargs: object) -> dict:
     return defaults
 
 
-class TestImageMetadataTagsCoercion:
+class TestImageMetadataTags:
     def test_tags_none(self) -> None:
         meta = ImageMetadata(**_meta())
         assert meta.tags is None
 
-    def test_tags_dict_passthrough(self) -> None:
+    def test_tags_dict(self) -> None:
         tags = {"theme": "dark", "device": "phone"}
         meta = ImageMetadata(**_meta(tags=tags))
         assert meta.tags == tags
-
-    def test_tags_list_converted_to_dict(self) -> None:
-        meta = ImageMetadata(**_meta(tags=["dark", "mobile"]))
-        assert meta.tags == {"dark": "dark", "mobile": "mobile"}
-
-    def test_tags_single_item_list(self) -> None:
-        meta = ImageMetadata(**_meta(tags=["solo"]))
-        assert meta.tags == {"solo": "solo"}
-
-    def test_tags_empty_list(self) -> None:
-        meta = ImageMetadata(**_meta(tags=[]))
-        assert meta.tags == {}
 
     def test_tags_empty_dict(self) -> None:
         meta = ImageMetadata(**_meta(tags={}))
         assert meta.tags == {}
 
-    def test_tags_unexpected_type_becomes_none(self) -> None:
-        meta = ImageMetadata(**_meta(tags=42))
-        assert meta.tags is None
+    def test_tags_list_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ImageMetadata(**_meta(tags=["dark", "mobile"]))
 
-    def test_tags_string_becomes_none(self) -> None:
-        meta = ImageMetadata(**_meta(tags="not_a_dict_or_list"))
-        assert meta.tags is None
+    def test_tags_string_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ImageMetadata(**_meta(tags="not_a_dict"))
+
+    def test_tags_int_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ImageMetadata(**_meta(tags=42))
 
     def test_manifest_with_dict_tags(self) -> None:
         manifest = SnapshotManifest(
@@ -48,11 +43,3 @@ class TestImageMetadataTagsCoercion:
             }
         )
         assert manifest.images["screen.png"].tags == {"theme": "dark", "size": "large"}
-
-    def test_manifest_with_legacy_list_tags(self) -> None:
-        manifest = SnapshotManifest(
-            images={
-                "screen.png": _meta(tags=["dark", "mobile"]),
-            }
-        )
-        assert manifest.images["screen.png"].tags == {"dark": "dark", "mobile": "mobile"}

--- a/tests/sentry/preprod/snapshots/test_manifest.py
+++ b/tests/sentry/preprod/snapshots/test_manifest.py
@@ -1,6 +1,3 @@
-import pytest
-from pydantic import ValidationError
-
 from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
 
 
@@ -10,31 +7,39 @@ def _meta(**kwargs: object) -> dict:
     return defaults
 
 
-class TestImageMetadataTags:
+class TestImageMetadataTagsCoercion:
     def test_tags_none(self) -> None:
         meta = ImageMetadata(**_meta())
         assert meta.tags is None
 
-    def test_tags_dict(self) -> None:
+    def test_tags_dict_passthrough(self) -> None:
         tags = {"theme": "dark", "device": "phone"}
         meta = ImageMetadata(**_meta(tags=tags))
         assert meta.tags == tags
+
+    def test_tags_list_converted_to_dict(self) -> None:
+        meta = ImageMetadata(**_meta(tags=["dark", "mobile"]))
+        assert meta.tags == {"dark": "dark", "mobile": "mobile"}
+
+    def test_tags_single_item_list(self) -> None:
+        meta = ImageMetadata(**_meta(tags=["solo"]))
+        assert meta.tags == {"solo": "solo"}
+
+    def test_tags_empty_list(self) -> None:
+        meta = ImageMetadata(**_meta(tags=[]))
+        assert meta.tags == {}
 
     def test_tags_empty_dict(self) -> None:
         meta = ImageMetadata(**_meta(tags={}))
         assert meta.tags == {}
 
-    def test_tags_list_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            ImageMetadata(**_meta(tags=["dark", "mobile"]))
+    def test_tags_unexpected_type_becomes_none(self) -> None:
+        meta = ImageMetadata(**_meta(tags=42))
+        assert meta.tags is None
 
-    def test_tags_string_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            ImageMetadata(**_meta(tags="not_a_dict"))
-
-    def test_tags_int_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            ImageMetadata(**_meta(tags=42))
+    def test_tags_string_becomes_none(self) -> None:
+        meta = ImageMetadata(**_meta(tags="not_a_dict_or_list"))
+        assert meta.tags is None
 
     def test_manifest_with_dict_tags(self) -> None:
         manifest = SnapshotManifest(
@@ -43,3 +48,11 @@ class TestImageMetadataTags:
             }
         )
         assert manifest.images["screen.png"].tags == {"theme": "dark", "size": "large"}
+
+    def test_manifest_with_legacy_list_tags(self) -> None:
+        manifest = SnapshotManifest(
+            images={
+                "screen.png": _meta(tags=["dark", "mobile"]),
+            }
+        )
+        assert manifest.images["screen.png"].tags == {"dark": "dark", "mobile": "mobile"}


### PR DESCRIPTION
## Summary
- Changes `ImageMetadata.tags` type from `list[str]` to `dict[str, str]` to support key-value pair tag searching
- Adds a Pydantic `@validator` for backward compatibility with any existing list-format tags in stored manifests
- Updates the `SnapshotImageDetailImageInfo` response model and frontend `SnapshotImage` TypeScript interface to match

Fixes SENTRY-5PV6
Fixes EME-1153