### PR TITLE
ref(preprod): Unify snapshot detail header badges with table status column

### DIFF
--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -1,19 +1,17 @@
 import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
-import {Tag} from '@sentry/scraps/badge';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
-import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {SnapshotStatusBadge} from 'sentry/components/preprod/snapshotStatusBadge';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconCommit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {
   BuildDetailsApiResponse,
-  SnapshotApprovalStatus,
   SnapshotComparisonState,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import {getSnapshotPath} from 'sentry/views/preprod/utils/buildLinkUtils';
@@ -26,69 +24,6 @@ interface PreprodBuildsSnapshotTableProps {
   showProjectColumn: boolean;
   content?: ReactNode;
   onRowClick?: (build: BuildDetailsApiResponse) => void;
-}
-
-function ApprovalBadge({
-  comparisonState,
-  approvalStatus,
-  errorMessage,
-}: {
-  approvalStatus: SnapshotApprovalStatus | null | undefined;
-  comparisonState: SnapshotComparisonState | null | undefined;
-  errorMessage: string | null | undefined;
-}) {
-  if (!comparisonState) {
-    return <Tag variant="info">{t('Base')}</Tag>;
-  }
-  if (comparisonState === 'waiting_for_base') {
-    return (
-      <Tooltip
-        title={t(
-          "Base snapshots haven't been uploaded yet. This will resolve automatically within ~10 minutes or fail."
-        )}
-      >
-        <Tag variant="muted">{t('Waiting for base')}</Tag>
-      </Tooltip>
-    );
-  }
-  if (comparisonState === 'no_base_build') {
-    return (
-      <Tooltip title={t('No base snapshot was found for comparison.')}>
-        <Tag variant="danger">{t('No base build')}</Tag>
-      </Tooltip>
-    );
-  }
-  if (comparisonState === 'pending') {
-    return (
-      <Tooltip title={t('Waiting to start comparison')}>
-        <Tag variant="muted">{t('Pending')}</Tag>
-      </Tooltip>
-    );
-  }
-  if (comparisonState === 'processing') {
-    return (
-      <Tooltip title={t('Comparing against base snapshot')}>
-        <Tag variant="muted">{t('Processing')}</Tag>
-      </Tooltip>
-    );
-  }
-  if (comparisonState === 'failed') {
-    return (
-      <Tooltip title={errorMessage || t('Comparison failed')}>
-        <Tag variant="danger">{t('Failed')}</Tag>
-      </Tooltip>
-    );
-  }
-  if (approvalStatus === 'approved') {
-    return <Tag variant="success">{t('Approved')}</Tag>;
-  }
-  if (approvalStatus === 'auto_approved') {
-    return <Tag variant="success">{t('Auto Approved')}</Tag>;
-  }
-  if (approvalStatus === 'requires_approval') {
-    return <Tag variant="warning">{t('Needs Approval')}</Tag>;
-  }
-  return <Text variant="muted">{'–'}</Text>;
 }
 
 function ChangeCounts({
@@ -166,7 +101,7 @@ export function PreprodBuildsSnapshotTable({
             </SimpleTable.RowCell>
           )}
           <SimpleTable.RowCell>
-            <ApprovalBadge
+            <SnapshotStatusBadge
               comparisonState={info?.comparison_state}
               approvalStatus={info?.approval_status}
               errorMessage={info?.comparison_error_message}

--- a/static/app/components/preprod/snapshotStatusBadge.tsx
+++ b/static/app/components/preprod/snapshotStatusBadge.tsx
@@ -1,0 +1,74 @@
+import {Tag} from '@sentry/scraps/badge';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {t} from 'sentry/locale';
+import type {
+  SnapshotApprovalStatus,
+  SnapshotComparisonState,
+} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+interface SnapshotStatusBadgeProps {
+  approvalStatus: SnapshotApprovalStatus | null | undefined;
+  comparisonState: SnapshotComparisonState | null | undefined;
+  errorMessage: string | null | undefined;
+}
+
+export function SnapshotStatusBadge({
+  comparisonState,
+  approvalStatus,
+  errorMessage,
+}: SnapshotStatusBadgeProps) {
+  if (!comparisonState) {
+    return <Tag variant="info">{t('Base')}</Tag>;
+  }
+  if (comparisonState === 'waiting_for_base') {
+    return (
+      <Tooltip
+        title={t(
+          "Base snapshots haven't been uploaded yet. This will resolve automatically within ~10 minutes or fail."
+        )}
+      >
+        <Tag variant="muted">{t('Waiting for base')}</Tag>
+      </Tooltip>
+    );
+  }
+  if (comparisonState === 'no_base_build') {
+    return (
+      <Tooltip title={t('No base snapshot was found for comparison.')}>
+        <Tag variant="danger">{t('No base build')}</Tag>
+      </Tooltip>
+    );
+  }
+  if (comparisonState === 'pending') {
+    return (
+      <Tooltip title={t('Waiting to start comparison')}>
+        <Tag variant="muted">{t('Pending')}</Tag>
+      </Tooltip>
+    );
+  }
+  if (comparisonState === 'processing') {
+    return (
+      <Tooltip title={t('Comparing against base snapshot')}>
+        <Tag variant="muted">{t('Processing')}</Tag>
+      </Tooltip>
+    );
+  }
+  if (comparisonState === 'failed') {
+    return (
+      <Tooltip title={errorMessage || t('Comparison failed')}>
+        <Tag variant="danger">{t('Failed')}</Tag>
+      </Tooltip>
+    );
+  }
+  if (approvalStatus === 'approved') {
+    return <Tag variant="success">{t('Approved')}</Tag>;
+  }
+  if (approvalStatus === 'auto_approved') {
+    return <Tag variant="success">{t('Auto Approved')}</Tag>;
+  }
+  if (approvalStatus === 'requires_approval') {
+    return <Tag variant="warning">{t('Needs Approval')}</Tag>;
+  }
+  return <Text variant="muted">{'–'}</Text>;
+}

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -13,6 +13,7 @@ import {Client} from 'sentry/api';
 import {ConfirmDelete} from 'sentry/components/confirmDelete';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
+import {SnapshotStatusBadge} from 'sentry/components/preprod/snapshotStatusBadge';
 import {
   IconCheckmark,
   IconDelete,
@@ -62,9 +63,11 @@ export function SnapshotHeaderActions({
   const [isApproving, setIsApproving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  const isApproved = data.approval_info?.status === 'approved';
-  const isAutoApproved = data.approval_info?.is_auto_approved ?? false;
-  const approvers: AvatarUser[] = (data.approval_info?.approvers ?? []).map((a, i) => ({
+  const comparisonState = data.comparison_state;
+  const approvalStatus = data.approval_status;
+  const isApproved = approvalStatus === 'approved' || approvalStatus === 'auto_approved';
+  const isAutoApproved = approvalStatus === 'auto_approved';
+  const approvers: AvatarUser[] = (data.approvers ?? []).map((a, i) => ({
     id: a.id ?? `approver-${i}`,
     name: a.name ?? '',
     email: a.email ?? '',
@@ -194,8 +197,8 @@ export function SnapshotHeaderActions({
 
   return (
     <Flex align="center" gap="md">
-      {data.approval_info &&
-        (isApproved ? (
+      {comparisonState === 'success' ? (
+        isApproved ? (
           <Flex align="center" gap="xl">
             <Flex align="center" gap="xs">
               <Tag variant="success" icon={<IconCheckmark />}>
@@ -219,7 +222,7 @@ export function SnapshotHeaderActions({
               </Container>
             )}
           </Flex>
-        ) : (
+        ) : approvalStatus === 'requires_approval' ? (
           <Flex align="center" gap="sm">
             <Container display={{'2xs': 'none', lg: 'block'}}>
               <Tag variant="warning" icon={<IconTimer />}>
@@ -236,7 +239,14 @@ export function SnapshotHeaderActions({
               {t('Approve')}
             </Button>
           </Flex>
-        ))}
+        ) : null
+      ) : (
+        <SnapshotStatusBadge
+          comparisonState={comparisonState}
+          approvalStatus={approvalStatus}
+          errorMessage={data.comparison_error_message}
+        />
+      )}
 
       <ConfirmDelete
         message={t(

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -3,7 +3,6 @@ import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -185,24 +184,9 @@ export function SnapshotMainContent({
       <DiffModeToggle diffMode={diffMode} onDiffModeChange={onDiffModeChange} />
     </Fragment>
   ) : null;
-  let soloDiffToggle: React.ReactNode = null;
-  if (hasDiffComparison) {
-    soloDiffToggle = (
-      <SoloDiffToggle isSoloView={isSoloView} onToggleSoloView={onToggleSoloView} />
-    );
-  } else if (comparisonType === 'solo') {
-    soloDiffToggle = <Tag variant="promotion">{t('Base')}</Tag>;
-  } else if (comparisonType === 'waiting_for_base') {
-    soloDiffToggle = (
-      <Tooltip
-        title={t(
-          "Base snapshots haven't been uploaded yet. This will resolve automatically within ~10 minutes or fail."
-        )}
-      >
-        <Tag variant="muted">{t('Waiting for base')}</Tag>
-      </Tooltip>
-    );
-  }
+  const soloDiffToggle = hasDiffComparison ? (
+    <SoloDiffToggle isSoloView={isSoloView} onToggleSoloView={onToggleSoloView} />
+  ) : null;
 
   if (viewMode === 'list') {
     return (

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -157,7 +157,7 @@ export default function SnapshotsPage() {
       organization,
       comparison_type: data.comparison_type,
       image_count: data.image_count,
-      approval_status: data.approval_info?.status ?? null,
+      approval_status: data.approval_status ?? null,
       has_base_build: !!data.base_artifact_id,
       project_id: data.project_id,
     });

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -31,11 +31,7 @@ import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {BuildProcessing} from 'sentry/views/preprod/components/buildProcessing';
-import {
-  ComparisonState,
-  DiffStatus,
-  getImageName,
-} from 'sentry/views/preprod/types/snapshotTypes';
+import {DiffStatus, getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
   SidebarItem,
   SnapshotDetailsApiResponse,
@@ -145,10 +141,8 @@ export default function SnapshotsPage() {
       // Skip retries on 4xx so error pages render instantly
       retry: (count, err) => count < 3 && (!err?.status || err.status >= 500),
       refetchInterval: query => {
-        const state = query.state.data?.json?.comparison_run_info?.state;
-        return state === ComparisonState.PENDING || state === ComparisonState.PROCESSING
-          ? 5_000
-          : false;
+        const state = query.state.data?.json?.comparison_state;
+        return state === 'pending' || state === 'processing' ? 5_000 : false;
       },
     }
   );
@@ -264,7 +258,6 @@ export default function SnapshotsPage() {
   const hasDiffComparison = data?.comparison_type === 'diff';
   const comparisonType =
     viewOverride === 'solo' ? 'solo' : (data?.comparison_type ?? 'solo');
-  const comparisonRunInfo = data?.comparison_run_info;
 
   const isSoloView = comparisonType === 'solo' || comparisonType === 'waiting_for_base';
   const handleToggleView = useCallback(() => {
@@ -650,10 +643,7 @@ export default function SnapshotsPage() {
   ]);
 
   const isComparisonProcessing =
-    !!comparisonRunInfo?.state &&
-    [ComparisonState.PENDING, ComparisonState.PROCESSING].includes(
-      comparisonRunInfo.state
-    );
+    data?.comparison_state === 'pending' || data?.comparison_state === 'processing';
 
   const imageBaseUrl = `/api/0/projects/${organization.slug}/${data?.project_id ?? ''}/files/images/`;
   const diffImageBaseUrl = imageBaseUrl;

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -27,7 +27,7 @@ interface SnapshotComparisonRunInfo {
   state?: ComparisonState;
 }
 
-export interface SnapshotApprover {
+interface SnapshotApprover {
   source: 'sentry' | 'github';
   approved_at?: string | null;
   avatar_url?: string | null;
@@ -79,7 +79,7 @@ export interface SnapshotDetailsApiResponse {
   unchanged_count: number;
 }
 
-export enum ComparisonState {
+enum ComparisonState {
   PENDING = 'PENDING',
   PROCESSING = 'PROCESSING',
   SUCCESS = 'SUCCESS',

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -24,7 +24,7 @@ export interface SnapshotDiffPair {
 interface SnapshotComparisonRunInfo {
   completed_at?: string;
   duration_ms?: number;
-  state?: ComparisonState;
+  state?: SnapshotComparisonState;
 }
 
 interface SnapshotApprover {

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -79,13 +79,6 @@ export interface SnapshotDetailsApiResponse {
   unchanged_count: number;
 }
 
-enum ComparisonState {
-  PENDING = 'PENDING',
-  PROCESSING = 'PROCESSING',
-  SUCCESS = 'SUCCESS',
-  FAILED = 'FAILED',
-}
-
 export enum DiffStatus {
   CHANGED = 'changed',
   ADDED = 'added',

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -1,5 +1,9 @@
 /* eslint-disable typescript-sort-keys/interface */
-import type {BuildDetailsVcsInfo} from './buildDetailsTypes';
+import type {
+  BuildDetailsVcsInfo,
+  SnapshotApprovalStatus,
+  SnapshotComparisonState,
+} from './buildDetailsTypes';
 
 export interface SnapshotImage {
   display_name: string | null;
@@ -23,7 +27,7 @@ interface SnapshotComparisonRunInfo {
   state?: ComparisonState;
 }
 
-interface SnapshotApprover {
+export interface SnapshotApprover {
   source: 'sentry' | 'github';
   approved_at?: string | null;
   avatar_url?: string | null;
@@ -53,6 +57,11 @@ export interface SnapshotDetailsApiResponse {
   comparison_run_info?: SnapshotComparisonRunInfo | null;
 
   approval_info?: SnapshotApprovalInfo | null;
+
+  comparison_state?: SnapshotComparisonState | null;
+  approval_status?: SnapshotApprovalStatus | null;
+  comparison_error_message?: string | null;
+  approvers?: SnapshotApprover[];
 
   diff_threshold?: number | null;
 


### PR DESCRIPTION
Extract `SnapshotStatusBadge` from the snapshot table into a shared component and reuse it in the snapshot detail header, so both views show the same status badges (Base, Waiting for base, No base build, Pending, Processing, Failed, Approved, Auto Approved, Needs Approval).

**Shared `SnapshotStatusBadge` component**

Moves the status-to-badge mapping out of `preprodBuildsSnapshotTable.tsx` into `snapshotStatusBadge.tsx`. Both the table and the detail header now import the same component.

**Header uses new flat API fields**

The header switches from the nested `approval_info` object to the flat `comparison_state`, `approval_status`, and `approvers` fields added in #115604. When comparison hasn't succeeded, the shared badge renders; when it has, the header's richer approval UI (approver avatars, Approve button, auto-approval tooltip) takes over.

**Toolbar tags removed**

The "Base" and "Waiting for base" tags in the snapshot content toolbar are removed since the header now covers those states.

**Refetch logic simplified**

Auto-refetch and `isComparisonProcessing` now use the flat `comparison_state` field instead of `comparison_run_info.state` with the UPPERCASE `ComparisonState` enum.

Refs EME-1145

Examples

Waiting for base
<img width="2942" height="180" alt="CleanShot 2026-05-15 at 11 28 34@2x" src="https://github.com/user-attachments/assets/c9f42a38-993f-40a4-9249-b3b546991459" />

Base
<img width="2978" height="204" alt="CleanShot 2026-05-15 at 11 28 54@2x" src="https://github.com/user-attachments/assets/388a4caf-d18b-45db-b9e0-db0623778ac3" />

No base build
<img width="2966" height="204" alt="CleanShot 2026-05-15 at 11 36 14@2x" src="https://github.com/user-attachments/assets/0f337638-dae6-4fa3-8588-255870d4d842" />

