### PR TITLE
chore: Add simple dashboard generation instructions

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -64,8 +64,6 @@ Limits:
 set. The maximum is 10 for most chart types, 25 for categorical bar charts, and 20 for table widgets.
 
 User Query:
-{query}
-
 """
 
 
@@ -121,7 +119,7 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
             return Response(serializer.errors, status=400)
 
         validated_data = serializer.validated_data
-        prompt = DASHBOARD_INSTRUCTIONS.format(query=validated_data["prompt"])
+        prompt = DASHBOARD_INSTRUCTIONS + validated_data["prompt"] + "\n"
         current_dashboard = validated_data.get("current_dashboard")
 
         # If current_dashboard is provided, we're editing; otherwise generating a new dashboard.

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -34,6 +34,39 @@ EDIT_ON_PAGE_CONTEXT_TEMPLATE = """The user is editing an existing dashboard. Th
 
 This session must ONLY modify the dashboard artifact. Produce a COMPLETE dashboard artifact that incorporates the requested changes while preserving widgets the user did not ask to change. Do not perform code changes or any tasks unrelated to dashboard editing."""
 
+DASHBOARD_INSTRUCTIONS = """\
+You are generating a Sentry dashboard. Follow these rules strictly:
+
+Data accuracy:
+- Every field name, span description, span op, tag key, or attribute value you use in a widget \
+query must either come from an actual tool call result or be a field documented in the system prompt.
+- Do not invent or guess values that have not been confirmed via a tool call or the system prompt.
+
+Grid layout (6-column grid):
+- The grid is 6 columns wide. Every widget's x + w must be <= 6.
+- Each row of widgets should have widths that sum to exactly 6.
+
+Queries:
+- All queries on a single widget must share the same aggregates, columns, and orderby. Only \
+conditions and name may differ between queries on the same widget.
+- Never use these aggregate functions — they are denylisted: spm, apdex, http_error_count, \
+http_error_count_percent.
+- Do not use widget_type "discover" or "transaction-like" — they are deprecated. Use "spans" or \
+"error-events" instead.
+
+Widget-type-specific rules:
+- For text widgets, widget_type must be null and queries must be empty.
+- description must not exceed 255 characters for non-text widgets.
+
+Limits:
+- For non-table, non-big_number chart widgets that have group-by columns, limit must be explicitly \
+set. The maximum is 10 for most chart types, 25 for bar charts, and 20 for table widgets.
+
+User Query:
+{query}
+
+"""
+
 
 class DashboardGenerateSerializer(serializers.Serializer[dict[str, Any]]):
     prompt = serializers.CharField(
@@ -87,7 +120,7 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
             return Response(serializer.errors, status=400)
 
         validated_data = serializer.validated_data
-        prompt = validated_data["prompt"]
+        prompt = DASHBOARD_INSTRUCTIONS.format(query=validated_data["prompt"])
         current_dashboard = validated_data.get("current_dashboard")
 
         # If current_dashboard is provided, we're editing; otherwise generating a new dashboard.

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -60,7 +60,7 @@ Widget-type-specific rules:
 
 Limits:
 - For non-table, non-big_number chart widgets that have group-by columns, limit must be explicitly \
-set. The maximum is 10 for most chart types, 25 for bar charts, and 20 for table widgets.
+set. The maximum is 10 for most chart types, 25 for categorical bar charts, and 20 for table widgets.
 
 User Query:
 {query}

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -47,7 +47,7 @@ Grid layout (6-column grid):
 - Each row of widgets should have widths that sum to exactly 6.
 
 Queries:
-- All queries on a single widget must share the same aggregates, columns, and orderby. Only \
+- All queries on a single widget must share the same aggregates,fields, columns, and orderby. Only \
 conditions and name may differ between queries on the same widget.
 - Never use these aggregate functions — they are denylisted: spm, apdex, http_error_count, \
 http_error_count_percent.
@@ -61,6 +61,7 @@ Widget-type-specific rules:
 Limits:
 - For non-table, non-big_number chart widgets that have group-by columns, limit must be explicitly \
 set. The maximum is 10 for most chart types, 25 for categorical bar charts, and 20 for table widgets.
+- For text widgets, character limit is 15,000 characters.
 
 User Query:
 {query}

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -47,7 +47,7 @@ Grid layout (6-column grid):
 - Each row of widgets should have widths that sum to exactly 6.
 
 Queries:
-- All queries on a single widget must share the same aggregates,fields, columns, and orderby. Only \
+- All queries on a single widget must share the same aggregates, fields, columns, and orderby. Only \
 conditions and name may differ between queries on the same widget.
 - Never use these aggregate functions — they are denylisted: spm, apdex, http_error_count, \
 http_error_count_percent.
@@ -56,12 +56,12 @@ http_error_count_percent.
 
 Widget-type-specific rules:
 - For text widgets, widget_type must be null and queries must be empty.
-- description must not exceed 255 characters for non-text widgets.
+- Description must not exceed 255 characters for non-text widgets. For text widgets,
+description must not exceed 15,000 characters.
 
 Limits:
 - For non-table, non-big_number chart widgets that have group-by columns, limit must be explicitly \
 set. The maximum is 10 for most chart types, 25 for categorical bar charts, and 20 for table widgets.
-- For text widgets, character limit is 15,000 characters.
 
 User Query:
 {query}

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -49,13 +49,9 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
             category_value=str(self.organization.id),
             reasoning_effort="medium",
         )
-        mock_client.start_run.assert_called_once_with(
-            prompt="Show me error rates by project",
-            on_page_context=ANY,
-            artifact_key="dashboard",
-            artifact_schema=ANY,
-            request=ANY,
-        )
+        call_kwargs = mock_client.start_run.call_args[1]
+        assert "Show me error rates by project" in call_kwargs["prompt"]
+        assert call_kwargs["artifact_key"] == "dashboard"
 
     @with_feature({"organizations:dashboards-ai-generate": False})
     def test_post_without_feature_flag_returns_403(self) -> None:


### PR DESCRIPTION
Adds some steering so the agent verifies values before generating 
the artifact. Also adds the post creation validation as instructions
in the prompt.

I validated it by running some evals for complex dashboard cases
locally - went through the tool calls and made sure that the agent
generates widgets with fields returned from tool calls.