### PR TITLE
fix(releases): Pass Environment objects to get_latest_release

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -135,7 +135,7 @@ def _filter_releases_by_query(queryset, organization, query, filter_params):
             elif value_o == "latest":
                 latest_releases = get_latest_release(
                     projects=filter_params["project_id"],
-                    environments=filter_params.get("environment"),
+                    environments=filter_params.get("environment_objects"),
                     organization_id=organization.id,
                 )
                 query_q = Q(version__in=latest_releases)

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -447,6 +447,33 @@ class OrganizationReleaseListTest(APITestCase, BaseMetricsTestCase):
             ],
         )
 
+    def test_latest_release_filter_with_environment(self) -> None:
+        self.login_as(user=self.user)
+
+        project = self.create_project(teams=[self.team], organization=self.organization)
+        environment = self.create_environment(name="prod", project=project)
+
+        older_release = self.create_release(version="test@1.0.0", project=project)
+        latest_release = self.create_release(version="test@2.0.0", project=project)
+
+        ReleaseProjectEnvironment.objects.create(
+            project_id=project.id,
+            release_id=older_release.id,
+            environment_id=environment.id,
+        )
+        ReleaseProjectEnvironment.objects.create(
+            project_id=project.id,
+            release_id=latest_release.id,
+            environment_id=environment.id,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            query=f"{RELEASE_ALIAS}:latest",
+            environment=environment.name,
+        )
+        self.assert_expected_versions(response, [latest_release])
+
     def test_query_filter_suffix(self) -> None:
         user = self.create_user(is_staff=False, is_superuser=False)
         org = self.organization


### PR DESCRIPTION
The releases list endpoint passed `filter_params["environment"]` (a list of environment name strings) to `get_latest_release` when resolving `release:latest` filters. `get_latest_release` expects `Sequence[Environment]` and dereferences `e.id` on each item, raising `AttributeError: 'str' object has no attribute 'id'` whenever the request also specified an environment.

Switch to `filter_params["environment_objects"]`, which is populated alongside `environment` and contains the resolved Environment objects. Other call sites in this file correctly pass name strings to APIs that accept names, so they are unchanged.

Fixes SENTRY-548A