### PR TITLE
ref(onboarding): Decouple SCM step components from OnboardingContext

### DIFF
--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -34,7 +34,7 @@ type OnboardingContextProps = {
   selectedRepository?: Repository;
 };
 
-export type OnboardingSessionState = {
+type OnboardingSessionState = {
   createdProjectSlug?: string;
   projectDetailsForm?: ProjectDetailsFormState;
   selectedFeatures?: ProductSolution[];

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -12,7 +12,7 @@ import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptio
  * Cleared by the platform features step when the platform changes, so
  * stale inputs don't carry across platform selections.
  */
-interface ProjectDetailsFormState {
+export interface ProjectDetailsFormState {
   alertRuleConfig?: AlertRuleOptions;
   projectName?: string;
   teamSlug?: string;

--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -4,11 +4,6 @@ import {RepositoryFixture} from 'sentry-fixture/repository';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {
-  OnboardingContextProvider,
-  type OnboardingSessionState,
-} from 'sentry/components/onboarding/onboardingContext';
-
 import {ScmRepoSelector} from './scmRepoSelector';
 
 // Mock the virtualizer so all items render in JSDOM (no layout engine).
@@ -25,16 +20,6 @@ jest.mock('@tanstack/react-virtual', () => ({
     measureElement: jest.fn(),
   })),
 }));
-
-function makeOnboardingWrapper(initialState?: OnboardingSessionState) {
-  return function OnboardingWrapper({children}: {children?: React.ReactNode}) {
-    return (
-      <OnboardingContextProvider initialValue={initialState}>
-        {children}
-      </OnboardingContextProvider>
-    );
-  };
-}
 
 describe('ScmRepoSelector', () => {
   const organization = OrganizationFixture();
@@ -56,7 +41,6 @@ describe('ScmRepoSelector', () => {
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
-    sessionStorage.clear();
   });
 
   it('renders search placeholder', () => {
@@ -65,10 +49,14 @@ describe('ScmRepoSelector', () => {
       body: {repos: []},
     });
 
-    render(<ScmRepoSelector integration={mockIntegration} />, {
-      organization,
-      wrapper: makeOnboardingWrapper(),
-    });
+    render(
+      <ScmRepoSelector
+        integration={mockIntegration}
+        selectedRepository={undefined}
+        onRepositoryChange={jest.fn()}
+      />,
+      {organization}
+    );
 
     expect(screen.getByText('Search repositories')).toBeInTheDocument();
   });
@@ -79,10 +67,14 @@ describe('ScmRepoSelector', () => {
       body: {repos: []},
     });
 
-    render(<ScmRepoSelector integration={mockIntegration} />, {
-      organization,
-      wrapper: makeOnboardingWrapper(),
-    });
+    render(
+      <ScmRepoSelector
+        integration={mockIntegration}
+        selectedRepository={undefined}
+        onRepositoryChange={jest.fn()}
+      />,
+      {organization}
+    );
 
     await userEvent.click(screen.getByRole('textbox'));
 
@@ -100,10 +92,14 @@ describe('ScmRepoSelector', () => {
       body: {detail: 'Internal Error'},
     });
 
-    render(<ScmRepoSelector integration={mockIntegration} />, {
-      organization,
-      wrapper: makeOnboardingWrapper(),
-    });
+    render(
+      <ScmRepoSelector
+        integration={mockIntegration}
+        selectedRepository={undefined}
+        onRepositoryChange={jest.fn()}
+      />,
+      {organization}
+    );
 
     await userEvent.click(screen.getByRole('textbox'));
 
@@ -123,10 +119,14 @@ describe('ScmRepoSelector', () => {
       },
     });
 
-    render(<ScmRepoSelector integration={mockIntegration} />, {
-      organization,
-      wrapper: makeOnboardingWrapper(),
-    });
+    render(
+      <ScmRepoSelector
+        integration={mockIntegration}
+        selectedRepository={undefined}
+        onRepositoryChange={jest.fn()}
+      />,
+      {organization}
+    );
 
     await userEvent.click(screen.getByRole('textbox'));
 
@@ -136,7 +136,7 @@ describe('ScmRepoSelector', () => {
     expect(screen.getByRole('menuitemradio', {name: 'relay'})).toBeInTheDocument();
   });
 
-  it('shows selected repo value when one is in context', () => {
+  it('shows selected repo value when one is provided', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
       body: {repos: []},
@@ -147,10 +147,14 @@ describe('ScmRepoSelector', () => {
       externalSlug: 'getsentry/old-repo',
     });
 
-    render(<ScmRepoSelector integration={mockIntegration} />, {
-      organization,
-      wrapper: makeOnboardingWrapper({selectedRepository: selectedRepo}),
-    });
+    render(
+      <ScmRepoSelector
+        integration={mockIntegration}
+        selectedRepository={selectedRepo}
+        onRepositoryChange={jest.fn()}
+      />,
+      {organization}
+    );
 
     expect(screen.getByText('getsentry/old-repo')).toBeInTheDocument();
   });
@@ -180,15 +184,21 @@ describe('ScmRepoSelector', () => {
       ],
     });
 
-    render(<ScmRepoSelector integration={mockIntegration} />, {
-      organization,
-      wrapper: makeOnboardingWrapper(),
-    });
+    const onRepositoryChange = jest.fn();
+    render(
+      <ScmRepoSelector
+        integration={mockIntegration}
+        selectedRepository={undefined}
+        onRepositoryChange={onRepositoryChange}
+      />,
+      {organization}
+    );
 
     await userEvent.click(screen.getByRole('textbox'));
     await userEvent.click(await screen.findByRole('menuitemradio', {name: 'sentry'}));
 
     await waitFor(() => expect(reposLookup).toHaveBeenCalled());
+    expect(onRepositoryChange).toHaveBeenCalled();
   });
 
   it('clears the selected repo', async () => {
@@ -202,18 +212,21 @@ describe('ScmRepoSelector', () => {
       externalSlug: 'getsentry/old-repo',
     });
 
-    render(<ScmRepoSelector integration={mockIntegration} />, {
-      organization,
-      wrapper: makeOnboardingWrapper({selectedRepository: selectedRepo}),
-    });
+    const onRepositoryChange = jest.fn();
+    render(
+      <ScmRepoSelector
+        integration={mockIntegration}
+        selectedRepository={selectedRepo}
+        onRepositoryChange={onRepositoryChange}
+      />,
+      {organization}
+    );
 
     expect(screen.getByText('getsentry/old-repo')).toBeInTheDocument();
 
     await userEvent.click(await screen.findByTestId('icon-close'));
 
-    await waitFor(() => {
-      expect(screen.queryByText('getsentry/old-repo')).not.toBeInTheDocument();
-    });
+    await waitFor(() => expect(onRepositoryChange).toHaveBeenCalledWith(undefined));
   });
 
   it('does not duplicate selected repo when it appears in results', async () => {
@@ -232,10 +245,14 @@ describe('ScmRepoSelector', () => {
       },
     });
 
-    render(<ScmRepoSelector integration={mockIntegration} />, {
-      organization,
-      wrapper: makeOnboardingWrapper({selectedRepository: selectedRepo}),
-    });
+    render(
+      <ScmRepoSelector
+        integration={mockIntegration}
+        selectedRepository={selectedRepo}
+        onRepositoryChange={jest.fn()}
+      />,
+      {organization}
+    );
 
     await userEvent.click(screen.getByRole('textbox'));
 

--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -4,6 +4,8 @@ import {RepositoryFixture} from 'sentry-fixture/repository';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import type {Integration, Repository} from 'sentry/types/integrations';
+
 import {ScmRepoSelector} from './scmRepoSelector';
 
 // Mock the virtualizer so all items render in JSDOM (no layout engine).
@@ -20,6 +22,27 @@ jest.mock('@tanstack/react-virtual', () => ({
     measureElement: jest.fn(),
   })),
 }));
+
+interface DefaultPropsOverrides {
+  integration: Integration;
+  onClearDerivedState?: jest.Mock;
+  onRepositoryChange?: jest.Mock;
+  selectedRepository?: Repository;
+}
+
+function defaultProps({
+  integration,
+  onClearDerivedState = jest.fn(),
+  onRepositoryChange = jest.fn(),
+  selectedRepository,
+}: DefaultPropsOverrides) {
+  return {
+    integration,
+    selectedRepository,
+    onRepositoryChange,
+    onClearDerivedState,
+  };
+}
 
 describe('ScmRepoSelector', () => {
   const organization = OrganizationFixture();
@@ -49,14 +72,9 @@ describe('ScmRepoSelector', () => {
       body: {repos: []},
     });
 
-    render(
-      <ScmRepoSelector
-        integration={mockIntegration}
-        selectedRepository={undefined}
-        onRepositoryChange={jest.fn()}
-      />,
-      {organization}
-    );
+    render(<ScmRepoSelector {...defaultProps({integration: mockIntegration})} />, {
+      organization,
+    });
 
     expect(screen.getByText('Search repositories')).toBeInTheDocument();
   });
@@ -67,14 +85,9 @@ describe('ScmRepoSelector', () => {
       body: {repos: []},
     });
 
-    render(
-      <ScmRepoSelector
-        integration={mockIntegration}
-        selectedRepository={undefined}
-        onRepositoryChange={jest.fn()}
-      />,
-      {organization}
-    );
+    render(<ScmRepoSelector {...defaultProps({integration: mockIntegration})} />, {
+      organization,
+    });
 
     await userEvent.click(screen.getByRole('textbox'));
 
@@ -92,14 +105,9 @@ describe('ScmRepoSelector', () => {
       body: {detail: 'Internal Error'},
     });
 
-    render(
-      <ScmRepoSelector
-        integration={mockIntegration}
-        selectedRepository={undefined}
-        onRepositoryChange={jest.fn()}
-      />,
-      {organization}
-    );
+    render(<ScmRepoSelector {...defaultProps({integration: mockIntegration})} />, {
+      organization,
+    });
 
     await userEvent.click(screen.getByRole('textbox'));
 
@@ -119,14 +127,9 @@ describe('ScmRepoSelector', () => {
       },
     });
 
-    render(
-      <ScmRepoSelector
-        integration={mockIntegration}
-        selectedRepository={undefined}
-        onRepositoryChange={jest.fn()}
-      />,
-      {organization}
-    );
+    render(<ScmRepoSelector {...defaultProps({integration: mockIntegration})} />, {
+      organization,
+    });
 
     await userEvent.click(screen.getByRole('textbox'));
 
@@ -149,9 +152,10 @@ describe('ScmRepoSelector', () => {
 
     render(
       <ScmRepoSelector
-        integration={mockIntegration}
-        selectedRepository={selectedRepo}
-        onRepositoryChange={jest.fn()}
+        {...defaultProps({
+          integration: mockIntegration,
+          selectedRepository: selectedRepo,
+        })}
       />,
       {organization}
     );
@@ -187,9 +191,7 @@ describe('ScmRepoSelector', () => {
     const onRepositoryChange = jest.fn();
     render(
       <ScmRepoSelector
-        integration={mockIntegration}
-        selectedRepository={undefined}
-        onRepositoryChange={onRepositoryChange}
+        {...defaultProps({integration: mockIntegration, onRepositoryChange})}
       />,
       {organization}
     );
@@ -215,9 +217,11 @@ describe('ScmRepoSelector', () => {
     const onRepositoryChange = jest.fn();
     render(
       <ScmRepoSelector
-        integration={mockIntegration}
-        selectedRepository={selectedRepo}
-        onRepositoryChange={onRepositoryChange}
+        {...defaultProps({
+          integration: mockIntegration,
+          selectedRepository: selectedRepo,
+          onRepositoryChange,
+        })}
       />,
       {organization}
     );
@@ -247,9 +251,10 @@ describe('ScmRepoSelector', () => {
 
     render(
       <ScmRepoSelector
-        integration={mockIntegration}
-        selectedRepository={selectedRepo}
-        onRepositoryChange={jest.fn()}
+        {...defaultProps({
+          integration: mockIntegration,
+          selectedRepository: selectedRepo,
+        })}
       />,
       {organization}
     );
@@ -265,5 +270,50 @@ describe('ScmRepoSelector', () => {
     expect(
       screen.queryByRole('menuitemradio', {name: 'getsentry/sentry'})
     ).not.toBeInTheDocument();
+  });
+
+  it('fires onClearDerivedState exactly once per user-driven repo change', async () => {
+    // The underlying selection hook calls onRepositoryChange multiple times for
+    // a single user click (optimistic + resolved/created paths). The derived-
+    // state callback must only fire once per click so it isn't redundantly
+    // wiping flow state on every internal update.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
+      body: {
+        repos: [
+          {
+            externalId: '1',
+            identifier: 'getsentry/sentry',
+            name: 'sentry',
+            isInstalled: false,
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      body: [
+        RepositoryFixture({name: 'getsentry/sentry', externalSlug: 'getsentry/sentry'}),
+      ],
+    });
+
+    const onClearDerivedState = jest.fn();
+    const onRepositoryChange = jest.fn();
+    render(
+      <ScmRepoSelector
+        {...defaultProps({
+          integration: mockIntegration,
+          onClearDerivedState,
+          onRepositoryChange,
+        })}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'sentry'}));
+
+    await waitFor(() => expect(onRepositoryChange).toHaveBeenCalled());
+    expect(onClearDerivedState).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -14,14 +14,19 @@ import {useScmRepoSelection} from './useScmRepoSelection';
 
 interface ScmRepoSelectorProps {
   integration: Integration;
-  // Callers are responsible for clearing any state derived from the repo
-  // (platform, features, created project) when the repo changes.
+  // Fired once per user-driven change (select or clear) so callers can
+  // invalidate state derived from the repo (platform, features, created
+  // project). Distinct from onRepositoryChange because the underlying repo
+  // selection hook can fire that callback multiple times for one user action
+  // (optimistic + resolved + error paths).
+  onClearDerivedState: () => void;
   onRepositoryChange: (repo: Repository | undefined) => void;
   selectedRepository: Repository | undefined;
 }
 
 export function ScmRepoSelector({
   integration,
+  onClearDerivedState,
   onRepositoryChange,
   selectedRepository,
 }: ScmRepoSelectorProps) {
@@ -55,6 +60,8 @@ export function ScmRepoSelector({
   }, [dropdownItems, selectedRepository]);
 
   function handleChange(option: {value: string} | null) {
+    onClearDerivedState();
+
     if (option === null) {
       handleRemove();
     } else {

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -2,9 +2,8 @@ import {useMemo} from 'react';
 
 import {Select} from '@sentry/scraps/select';
 
-import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {t} from 'sentry/locale';
-import type {Integration} from 'sentry/types/integrations';
+import type {Integration, Repository} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -15,12 +14,18 @@ import {useScmRepoSelection} from './useScmRepoSelection';
 
 interface ScmRepoSelectorProps {
   integration: Integration;
+  // Callers are responsible for clearing any state derived from the repo
+  // (platform, features, created project) when the repo changes.
+  onRepositoryChange: (repo: Repository | undefined) => void;
+  selectedRepository: Repository | undefined;
 }
 
-export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
+export function ScmRepoSelector({
+  integration,
+  onRepositoryChange,
+  selectedRepository,
+}: ScmRepoSelectorProps) {
   const organization = useOrganization();
-  const {selectedRepository, setSelectedRepository, clearDerivedState} =
-    useOnboardingContext();
   const {reposByIdentifier, dropdownItems, isFetching, isError} = useScmRepos(
     integration.id,
     selectedRepository
@@ -28,7 +33,7 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
 
   const {busy, handleSelect, handleRemove} = useScmRepoSelection({
     integration,
-    onSelect: setSelectedRepository,
+    onSelect: onRepositoryChange,
     reposByIdentifier,
   });
 
@@ -50,10 +55,6 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
   }, [dropdownItems, selectedRepository]);
 
   function handleChange(option: {value: string} | null) {
-    // Changing or clearing the repo invalidates downstream state (platform,
-    // features, created project) which are all derived from the selected repo.
-    clearDerivedState();
-
     if (option === null) {
       handleRemove();
     } else {

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -19,7 +19,6 @@ import {categoryList} from 'sentry/data/platformPickerCategories';
 import {allPlatforms as platforms} from 'sentry/data/platforms';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformKey} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
@@ -84,22 +83,13 @@ function ScmConnectAdapter({onComplete, genBackButton}: StepProps) {
     clearDerivedState,
   } = useOnboardingContext();
 
-  const handleRepositoryChange = useCallback(
-    (repo: Repository | undefined) => {
-      // Changing or clearing the repo invalidates downstream state (platform,
-      // features, created project) which are all derived from the repo.
-      clearDerivedState();
-      setSelectedRepository(repo);
-    },
-    [clearDerivedState, setSelectedRepository]
-  );
-
   return (
     <ScmConnect
       selectedIntegration={selectedIntegration}
       selectedRepository={selectedRepository}
       onIntegrationChange={setSelectedIntegration}
-      onRepositoryChange={handleRepositoryChange}
+      onRepositoryChange={setSelectedRepository}
+      onClearDerivedState={clearDerivedState}
       onComplete={onComplete}
       genBackButton={genBackButton}
     />

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -19,6 +19,7 @@ import {categoryList} from 'sentry/data/platformPickerCategories';
 import {allPlatforms as platforms} from 'sentry/data/platforms';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformKey} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
@@ -69,6 +70,99 @@ const legacyOnboardingSteps: StepDescriptor[] = [
   },
 ];
 
+// Adapters bridge the SCM step components — which accept all flow state via
+// props — to the onboarding flow's OnboardingContext. They let the same step
+// components be reused by other flows (e.g. project creation) that source
+// state from somewhere other than session storage.
+
+function ScmConnectAdapter({onComplete, genBackButton}: StepProps) {
+  const {
+    selectedIntegration,
+    setSelectedIntegration,
+    selectedRepository,
+    setSelectedRepository,
+    clearDerivedState,
+  } = useOnboardingContext();
+
+  const handleRepositoryChange = useCallback(
+    (repo: Repository | undefined) => {
+      // Changing or clearing the repo invalidates downstream state (platform,
+      // features, created project) which are all derived from the repo.
+      clearDerivedState();
+      setSelectedRepository(repo);
+    },
+    [clearDerivedState, setSelectedRepository]
+  );
+
+  return (
+    <ScmConnect
+      selectedIntegration={selectedIntegration}
+      selectedRepository={selectedRepository}
+      onIntegrationChange={setSelectedIntegration}
+      onRepositoryChange={handleRepositoryChange}
+      onComplete={onComplete}
+      genBackButton={genBackButton}
+    />
+  );
+}
+
+function ScmPlatformFeaturesAdapter({onComplete, genBackButton}: StepProps) {
+  const {
+    selectedRepository,
+    selectedPlatform,
+    setSelectedPlatform,
+    selectedFeatures,
+    setSelectedFeatures,
+    setProjectDetailsForm,
+    createdProjectSlug,
+    setCreatedProjectSlug,
+  } = useOnboardingContext();
+
+  const handleClearProjectDetailsForm = useCallback(
+    () => setProjectDetailsForm(undefined),
+    [setProjectDetailsForm]
+  );
+
+  return (
+    <ScmPlatformFeatures
+      selectedRepository={selectedRepository}
+      selectedPlatform={selectedPlatform}
+      selectedFeatures={selectedFeatures}
+      createdProjectSlug={createdProjectSlug}
+      onPlatformChange={setSelectedPlatform}
+      onFeaturesChange={setSelectedFeatures}
+      onClearProjectDetailsForm={handleClearProjectDetailsForm}
+      onProjectCreated={setCreatedProjectSlug}
+      onComplete={onComplete}
+      genBackButton={genBackButton}
+    />
+  );
+}
+
+function ScmProjectDetailsAdapter({onComplete, genBackButton}: StepProps) {
+  const {
+    selectedPlatform,
+    selectedFeatures,
+    createdProjectSlug,
+    setCreatedProjectSlug,
+    projectDetailsForm,
+    setProjectDetailsForm,
+  } = useOnboardingContext();
+
+  return (
+    <ScmProjectDetails
+      selectedPlatform={selectedPlatform}
+      selectedFeatures={selectedFeatures}
+      createdProjectSlug={createdProjectSlug}
+      projectDetailsForm={projectDetailsForm}
+      onProjectCreated={setCreatedProjectSlug}
+      onProjectDetailsFormChange={setProjectDetailsForm}
+      onComplete={onComplete}
+      genBackButton={genBackButton}
+    />
+  );
+}
+
 const scmOnboardingSteps: StepDescriptor[] = [
   {
     id: OnboardingStepId.WELCOME,
@@ -79,19 +173,19 @@ const scmOnboardingSteps: StepDescriptor[] = [
   {
     id: OnboardingStepId.SCM_CONNECT,
     title: t('Connect repository'),
-    Component: ScmConnect,
+    Component: ScmConnectAdapter,
     cornerVariant: 'top-left',
   },
   {
     id: OnboardingStepId.SCM_PLATFORM_FEATURES,
     title: t('Create your first project'),
-    Component: ScmPlatformFeatures,
+    Component: ScmPlatformFeaturesAdapter,
     cornerVariant: 'top-left',
   },
   {
     id: OnboardingStepId.SCM_PROJECT_DETAILS,
     title: t('Project details'),
-    Component: ScmProjectDetails,
+    Component: ScmProjectDetailsAdapter,
     hasFooter: true,
     cornerVariant: 'top-left',
   },

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -133,6 +133,7 @@ function ScmProjectDetailsAdapter({onComplete, genBackButton}: StepProps) {
   const {
     selectedPlatform,
     selectedFeatures,
+    selectedRepository,
     createdProjectSlug,
     setCreatedProjectSlug,
     projectDetailsForm,
@@ -143,6 +144,7 @@ function ScmProjectDetailsAdapter({onComplete, genBackButton}: StepProps) {
     <ScmProjectDetails
       selectedPlatform={selectedPlatform}
       selectedFeatures={selectedFeatures}
+      selectedRepository={selectedRepository}
       createdProjectSlug={createdProjectSlug}
       projectDetailsForm={projectDetailsForm}
       onProjectCreated={setCreatedProjectSlug}

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -108,11 +108,6 @@ function ScmPlatformFeaturesAdapter({onComplete, genBackButton}: StepProps) {
     setCreatedProjectSlug,
   } = useOnboardingContext();
 
-  const handleClearProjectDetailsForm = useCallback(
-    () => setProjectDetailsForm(undefined),
-    [setProjectDetailsForm]
-  );
-
   return (
     <ScmPlatformFeatures
       selectedRepository={selectedRepository}
@@ -121,7 +116,7 @@ function ScmPlatformFeaturesAdapter({onComplete, genBackButton}: StepProps) {
       createdProjectSlug={createdProjectSlug}
       onPlatformChange={setSelectedPlatform}
       onFeaturesChange={setSelectedFeatures}
-      onClearProjectDetailsForm={handleClearProjectDetailsForm}
+      onClearProjectDetailsForm={() => setProjectDetailsForm(undefined)}
       onProjectCreated={setCreatedProjectSlug}
       onComplete={onComplete}
       genBackButton={genBackButton}

--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -22,10 +22,12 @@ import {SCM_STEP_CONTENT_WIDTH} from './consts';
 import type {StepProps} from './types';
 
 interface ScmConnectProps {
+  // Fired once per user-driven repo change so callers can invalidate state
+  // derived from the repo (platform, features, created project). See
+  // ScmRepoSelector for why this is separate from onRepositoryChange.
+  onClearDerivedState: () => void;
   onComplete: StepProps['onComplete'];
   onIntegrationChange: (integration: Integration | undefined) => void;
-  // Callers are responsible for clearing any state derived from the repo
-  // (platform, features, created project) when the repo changes.
   onRepositoryChange: (repo: Repository | undefined) => void;
   selectedIntegration: Integration | undefined;
   selectedRepository: Repository | undefined;
@@ -58,6 +60,7 @@ const SCM_INFO_SECTIONS = [
 ];
 
 export function ScmConnect({
+  onClearDerivedState,
   onComplete,
   onIntegrationChange,
   onRepositoryChange,
@@ -132,6 +135,7 @@ export function ScmConnect({
                 integration={effectiveIntegration}
                 selectedRepository={selectedRepository}
                 onRepositoryChange={onRepositoryChange}
+                onClearDerivedState={onClearDerivedState}
               />
             </Stack>
           </MotionStack>

--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -7,10 +7,9 @@ import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {IconCheckmark, IconClose, IconLock} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Integration} from 'sentry/types/integrations';
+import type {Integration, Repository} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -21,6 +20,17 @@ import {useScmPlatformDetection} from './components/useScmPlatformDetection';
 import {useScmProviders} from './components/useScmProviders';
 import {SCM_STEP_CONTENT_WIDTH} from './consts';
 import type {StepProps} from './types';
+
+interface ScmConnectProps {
+  onComplete: StepProps['onComplete'];
+  onIntegrationChange: (integration: Integration | undefined) => void;
+  // Callers are responsible for clearing any state derived from the repo
+  // (platform, features, created project) when the repo changes.
+  onRepositoryChange: (repo: Repository | undefined) => void;
+  selectedIntegration: Integration | undefined;
+  selectedRepository: Repository | undefined;
+  genBackButton?: StepProps['genBackButton'];
+}
 
 const SCM_INFO_SECTIONS = [
   {
@@ -47,14 +57,15 @@ const SCM_INFO_SECTIONS = [
   },
 ];
 
-export function ScmConnect({onComplete, genBackButton}: StepProps) {
+export function ScmConnect({
+  onComplete,
+  onIntegrationChange,
+  onRepositoryChange,
+  selectedIntegration,
+  selectedRepository,
+  genBackButton,
+}: ScmConnectProps) {
   const organization = useOrganization();
-  const {
-    selectedIntegration,
-    setSelectedIntegration,
-    selectedRepository,
-    setSelectedRepository,
-  } = useOnboardingContext();
   const {
     scmProviders,
     isPending,
@@ -76,11 +87,11 @@ export function ScmConnect({onComplete, genBackButton}: StepProps) {
 
   const handleInstall = useCallback(
     (data: Integration) => {
-      setSelectedIntegration(data);
-      setSelectedRepository(undefined);
+      onIntegrationChange(data);
+      onRepositoryChange(undefined);
       refetchIntegrations();
     },
-    [setSelectedIntegration, setSelectedRepository, refetchIntegrations]
+    [onIntegrationChange, onRepositoryChange, refetchIntegrations]
   );
 
   return (
@@ -117,7 +128,11 @@ export function ScmConnect({onComplete, genBackButton}: StepProps) {
                   effectiveIntegration.name
                 )}
               </Text>
-              <ScmRepoSelector integration={effectiveIntegration} />
+              <ScmRepoSelector
+                integration={effectiveIntegration}
+                selectedRepository={selectedRepository}
+                onRepositoryChange={onRepositoryChange}
+              />
             </Stack>
           </MotionStack>
         ) : (
@@ -212,7 +227,7 @@ export function ScmConnect({onComplete, genBackButton}: StepProps) {
               }}
               onClick={() => {
                 if (effectiveIntegration && !selectedIntegration) {
-                  setSelectedIntegration(effectiveIntegration);
+                  onIntegrationChange(effectiveIntegration);
                 }
                 onComplete();
               }}

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -14,14 +14,11 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {
-  OnboardingContextProvider,
-  type OnboardingSessionState,
-} from 'sentry/components/onboarding/onboardingContext';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
+import type {Repository} from 'sentry/types/integrations';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import * as analytics from 'sentry/utils/analytics';
-import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 import {ScmPlatformFeatures} from './scmPlatformFeatures';
 
@@ -57,13 +54,24 @@ jest.mock('sentry/data/platforms', () => {
   };
 });
 
-function makeOnboardingWrapper(initialState?: OnboardingSessionState) {
-  return function OnboardingWrapper({children}: {children?: React.ReactNode}) {
-    return (
-      <OnboardingContextProvider initialValue={initialState}>
-        {children}
-      </OnboardingContextProvider>
-    );
+interface StateOverrides {
+  createdProjectSlug?: string;
+  selectedFeatures?: ProductSolution[];
+  selectedPlatform?: OnboardingSelectedSDK;
+  selectedRepository?: Repository;
+}
+
+function defaultProps(state: StateOverrides = {}) {
+  return {
+    selectedRepository: state.selectedRepository,
+    selectedPlatform: state.selectedPlatform,
+    selectedFeatures: state.selectedFeatures,
+    createdProjectSlug: state.createdProjectSlug,
+    onPlatformChange: jest.fn(),
+    onFeaturesChange: jest.fn(),
+    onClearProjectDetailsForm: jest.fn(),
+    onProjectCreated: jest.fn(),
+    onComplete: jest.fn(),
   };
 }
 
@@ -79,7 +87,6 @@ describe('ScmPlatformFeatures', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    sessionStorageWrapper.clear();
     ProjectsStore.loadInitialData([]);
     TeamStore.loadInitialData([]);
   });
@@ -104,17 +111,8 @@ describe('ScmPlatformFeatures', () => {
     });
 
     render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedRepository: mockRepository,
-        }),
-      }
+      <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+      {organization}
     );
 
     const radioGroup = await screen.findByRole('radiogroup');
@@ -138,17 +136,8 @@ describe('ScmPlatformFeatures', () => {
     });
 
     render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedRepository: mockRepository,
-        }),
-      }
+      <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+      {organization}
     );
 
     expect(
@@ -164,17 +153,8 @@ describe('ScmPlatformFeatures', () => {
       });
 
       render(
-        <ScmPlatformFeatures
-          onComplete={jest.fn()}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedRepository: mockRepository,
-          }),
-        }
+        <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+        {organization}
       );
 
       expect(
@@ -198,17 +178,8 @@ describe('ScmPlatformFeatures', () => {
       });
 
       render(
-        <ScmPlatformFeatures
-          onComplete={jest.fn()}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedRepository: mockRepository,
-          }),
-        }
+        <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+        {organization}
       );
 
       expect(
@@ -228,13 +199,7 @@ describe('ScmPlatformFeatures', () => {
 
       render(
         <ScmPlatformFeatures
-          onComplete={jest.fn()}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
+          {...defaultProps({
             selectedRepository: mockRepository,
             selectedPlatform: {
               key: 'nintendo-switch',
@@ -244,8 +209,9 @@ describe('ScmPlatformFeatures', () => {
               link: null,
               category: 'all',
             },
-          }),
-        }
+          })}
+        />,
+        {organization}
       );
 
       await screen.findByRole('button', {name: 'Continue'});
@@ -276,17 +242,8 @@ describe('ScmPlatformFeatures', () => {
     });
 
     render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedRepository: mockRepository,
-        }),
-      }
+      <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+      {organization}
     );
 
     const changeButton = await screen.findByRole('button', {
@@ -305,17 +262,8 @@ describe('ScmPlatformFeatures', () => {
     });
 
     render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedRepository: mockRepository,
-        }),
-      }
+      <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+      {organization}
     );
 
     expect(await screen.findByText('Select a platform')).toBeInTheDocument();
@@ -325,17 +273,7 @@ describe('ScmPlatformFeatures', () => {
   });
 
   it('renders manual picker when no repository in context', async () => {
-    render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper(),
-      }
-    );
+    render(<ScmPlatformFeatures {...defaultProps()} />, {organization});
 
     expect(await screen.findByText('Select a platform')).toBeInTheDocument();
     expect(
@@ -344,17 +282,7 @@ describe('ScmPlatformFeatures', () => {
   });
 
   it('continue button is disabled when no platform selected', async () => {
-    render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper(),
-      }
-    );
+    render(<ScmPlatformFeatures {...defaultProps()} />, {organization});
 
     // Wait for the component to fully settle (CompactSelect triggers async popper updates)
     await screen.findByText('Select a platform');
@@ -371,17 +299,8 @@ describe('ScmPlatformFeatures', () => {
     });
 
     render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedRepository: mockRepository,
-        }),
-      }
+      <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+      {organization}
     );
 
     // Wait for auto-select of first detected platform
@@ -401,47 +320,29 @@ describe('ScmPlatformFeatures', () => {
       body: {platforms: [pythonPlatform]},
     });
 
-    render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedRepository: mockRepository,
-          selectedFeatures: [ProductSolution.ERROR_MONITORING],
-        }),
-      }
-    );
+    const props = defaultProps({
+      selectedRepository: mockRepository,
+      selectedFeatures: [ProductSolution.ERROR_MONITORING],
+    });
+    render(<ScmPlatformFeatures {...props} />, {organization});
 
     // Wait for feature cards to appear
     await screen.findByText('What do you want to instrument?');
 
-    // Neither profiling nor tracing should be checked initially
-    expect(screen.getByRole('checkbox', {name: /Profiling/})).not.toBeChecked();
-    expect(screen.getByRole('checkbox', {name: /Tracing/})).not.toBeChecked();
-
-    // Enable profiling — tracing should auto-enable
+    // Enable profiling — onFeaturesChange should be called with tracing also enabled
     await userEvent.click(screen.getByRole('checkbox', {name: /Profiling/}));
 
-    expect(screen.getByRole('checkbox', {name: /Profiling/})).toBeChecked();
-    expect(screen.getByRole('checkbox', {name: /Tracing/})).toBeChecked();
+    expect(props.onFeaturesChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PROFILING,
+        ProductSolution.PERFORMANCE_MONITORING,
+      ])
+    );
   });
 
   it('shows framework suggestion modal when selecting a base language', async () => {
-    render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper(),
-      }
-    );
+    render(<ScmPlatformFeatures {...defaultProps()} />, {organization});
     renderGlobalModal();
 
     await screen.findByText('Select a platform');
@@ -454,20 +355,12 @@ describe('ScmPlatformFeatures', () => {
   });
 
   it('opens console modal when selecting a disabled gaming platform', async () => {
-    render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        // No enabledConsolePlatforms — all console platforms are blocked
-        organization: OrganizationFixture({
-          features: ['performance-view', 'session-replay', 'profiling-view'],
-        }),
-        additionalWrapper: makeOnboardingWrapper(),
-      }
-    );
+    render(<ScmPlatformFeatures {...defaultProps()} />, {
+      // No enabledConsolePlatforms — all console platforms are blocked
+      organization: OrganizationFixture({
+        features: ['performance-view', 'session-replay', 'profiling-view'],
+      }),
+    });
     renderGlobalModal();
 
     await screen.findByText('Select a platform');
@@ -490,45 +383,36 @@ describe('ScmPlatformFeatures', () => {
       body: {platforms: [pythonPlatform]},
     });
 
-    render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedRepository: mockRepository,
-          selectedPlatform: {
-            key: 'python',
-            name: 'Python',
-            language: 'python',
-            type: 'language',
-            link: 'https://docs.sentry.io/platforms/python/',
-            category: 'popular',
-          },
-          selectedFeatures: [
-            ProductSolution.ERROR_MONITORING,
-            ProductSolution.PERFORMANCE_MONITORING,
-            ProductSolution.PROFILING,
-          ],
-        }),
-      }
-    );
+    const props = defaultProps({
+      selectedRepository: mockRepository,
+      selectedPlatform: {
+        key: 'python',
+        name: 'Python',
+        language: 'python',
+        type: 'language',
+        link: 'https://docs.sentry.io/platforms/python/',
+        category: 'popular',
+      },
+      selectedFeatures: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+        ProductSolution.PROFILING,
+      ],
+    });
+    render(<ScmPlatformFeatures {...props} />, {organization});
 
     // Wait for feature cards to appear
     await screen.findByText('What do you want to instrument?');
 
-    // Both should be checked initially
-    expect(screen.getByRole('checkbox', {name: /Tracing/})).toBeChecked();
-    expect(screen.getByRole('checkbox', {name: /Profiling/})).toBeChecked();
-
-    // Disable tracing — profiling should auto-disable
+    // Disable tracing — onFeaturesChange should drop both tracing and profiling
     await userEvent.click(screen.getByRole('checkbox', {name: /Tracing/}));
 
-    expect(screen.getByRole('checkbox', {name: /Tracing/})).not.toBeChecked();
-    expect(screen.getByRole('checkbox', {name: /Profiling/})).not.toBeChecked();
+    expect(props.onFeaturesChange).toHaveBeenCalledWith(
+      expect.not.arrayContaining([
+        ProductSolution.PERFORMANCE_MONITORING,
+        ProductSolution.PROFILING,
+      ])
+    );
   });
 
   it('clears persisted project details form when detected platform changes', async () => {
@@ -546,31 +430,15 @@ describe('ScmPlatformFeatures', () => {
       },
     });
 
-    render(
-      <ScmPlatformFeatures
-        onComplete={jest.fn()}
-        stepIndex={2}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedRepository: mockRepository,
-          projectDetailsForm: {
-            projectName: 'stale-name',
-            teamSlug: 'stale-team',
-          },
-        }),
-      }
-    );
+    // The component is stateless w.r.t. the form, so we just verify it calls
+    // the clear callback when the user changes the detected platform.
+    const props = defaultProps({selectedRepository: mockRepository});
+    render(<ScmPlatformFeatures {...props} />, {organization});
 
     const djangoCard = await screen.findByRole('radio', {name: /Django/});
     await userEvent.click(djangoCard);
 
-    await waitFor(() => {
-      const stored = JSON.parse(sessionStorageWrapper.getItem('onboarding') ?? '{}');
-      expect(stored.projectDetailsForm).toBeUndefined();
-    });
+    expect(props.onClearProjectDetailsForm).toHaveBeenCalled();
   });
 
   describe('analytics', () => {
@@ -581,17 +449,7 @@ describe('ScmPlatformFeatures', () => {
     });
 
     it('fires step viewed event on mount', async () => {
-      render(
-        <ScmPlatformFeatures
-          onComplete={jest.fn()}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper(),
-        }
-      );
+      render(<ScmPlatformFeatures {...defaultProps()} />, {organization});
 
       await screen.findByText('Select a platform');
 
@@ -617,17 +475,8 @@ describe('ScmPlatformFeatures', () => {
       });
 
       render(
-        <ScmPlatformFeatures
-          onComplete={jest.fn()}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedRepository: mockRepository,
-          }),
-        }
+        <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+        {organization}
       );
 
       // Wait for detected platforms, then click the second one
@@ -659,17 +508,8 @@ describe('ScmPlatformFeatures', () => {
       });
 
       render(
-        <ScmPlatformFeatures
-          onComplete={jest.fn()}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedRepository: mockRepository,
-          }),
-        }
+        <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+        {organization}
       );
 
       await screen.findByRole('heading', {level: 3, name: 'Available with Next.js'});
@@ -693,17 +533,12 @@ describe('ScmPlatformFeatures', () => {
 
       render(
         <ScmPlatformFeatures
-          onComplete={jest.fn()}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
+          {...defaultProps({
             selectedRepository: mockRepository,
             selectedFeatures: [ProductSolution.ERROR_MONITORING],
-          }),
-        }
+          })}
+        />,
+        {organization}
       );
 
       await screen.findByText('What do you want to instrument?');
@@ -727,17 +562,8 @@ describe('ScmPlatformFeatures', () => {
       });
 
       render(
-        <ScmPlatformFeatures
-          onComplete={jest.fn()}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedRepository: mockRepository,
-          }),
-        }
+        <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+        {organization}
       );
 
       const changeButton = await screen.findByRole('button', {
@@ -780,7 +606,6 @@ describe('ScmPlatformFeatures', () => {
     });
 
     it('auto-creates the project on Continue and forwards selected features', async () => {
-      const onComplete = jest.fn();
       const createdProject = ProjectFixture({
         slug: 'javascript-nextjs',
         platform: 'javascript-nextjs',
@@ -791,20 +616,11 @@ describe('ScmPlatformFeatures', () => {
         body: createdProject,
       });
 
-      render(
-        <ScmPlatformFeatures
-          onComplete={onComplete}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedPlatform: nextJsPlatform,
-            selectedFeatures: [ProductSolution.ERROR_MONITORING],
-          }),
-        }
-      );
+      const props = defaultProps({
+        selectedPlatform: nextJsPlatform,
+        selectedFeatures: [ProductSolution.ERROR_MONITORING],
+      });
+      render(<ScmPlatformFeatures {...props} />, {organization});
 
       await waitFor(() => {
         expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
@@ -824,9 +640,10 @@ describe('ScmPlatformFeatures', () => {
           })
         );
       });
-      expect(onComplete).toHaveBeenCalledWith(nextJsPlatform, {
+      expect(props.onComplete).toHaveBeenCalledWith(nextJsPlatform, {
         product: [ProductSolution.ERROR_MONITORING],
       });
+      expect(props.onProjectCreated).toHaveBeenCalledWith(createdProject.slug);
     });
 
     it('links selected repository to project after creation', async () => {
@@ -892,7 +709,6 @@ describe('ScmPlatformFeatures', () => {
     });
 
     it('reuses the existing project when the platform is unchanged', async () => {
-      const onComplete = jest.fn();
       const existingProject = ProjectFixture({
         slug: 'javascript-nextjs',
         platform: 'javascript-nextjs',
@@ -904,21 +720,12 @@ describe('ScmPlatformFeatures', () => {
         body: existingProject,
       });
 
-      render(
-        <ScmPlatformFeatures
-          onComplete={onComplete}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedPlatform: nextJsPlatform,
-            selectedFeatures: [ProductSolution.ERROR_MONITORING],
-            createdProjectSlug: existingProject.slug,
-          }),
-        }
-      );
+      const props = defaultProps({
+        selectedPlatform: nextJsPlatform,
+        selectedFeatures: [ProductSolution.ERROR_MONITORING],
+        createdProjectSlug: existingProject.slug,
+      });
+      render(<ScmPlatformFeatures {...props} />, {organization});
 
       await waitFor(() => {
         expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
@@ -926,7 +733,7 @@ describe('ScmPlatformFeatures', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       await waitFor(() => {
-        expect(onComplete).toHaveBeenCalledWith(nextJsPlatform, {
+        expect(props.onComplete).toHaveBeenCalledWith(nextJsPlatform, {
           product: [ProductSolution.ERROR_MONITORING],
         });
       });
@@ -934,7 +741,6 @@ describe('ScmPlatformFeatures', () => {
     });
 
     it('creates a new project when the platform changed from the existing one', async () => {
-      const onComplete = jest.fn();
       const stalePythonProject = ProjectFixture({
         slug: 'python',
         platform: 'python',
@@ -950,21 +756,12 @@ describe('ScmPlatformFeatures', () => {
         body: newProject,
       });
 
-      render(
-        <ScmPlatformFeatures
-          onComplete={onComplete}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedPlatform: nextJsPlatform,
-            selectedFeatures: [ProductSolution.ERROR_MONITORING],
-            createdProjectSlug: stalePythonProject.slug,
-          }),
-        }
-      );
+      const props = defaultProps({
+        selectedPlatform: nextJsPlatform,
+        selectedFeatures: [ProductSolution.ERROR_MONITORING],
+        createdProjectSlug: stalePythonProject.slug,
+      });
+      render(<ScmPlatformFeatures {...props} />, {organization});
 
       await waitFor(() => {
         expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
@@ -974,7 +771,7 @@ describe('ScmPlatformFeatures', () => {
       await waitFor(() => {
         expect(createRequest).toHaveBeenCalled();
       });
-      expect(onComplete).toHaveBeenCalledWith(nextJsPlatform, {
+      expect(props.onComplete).toHaveBeenCalledWith(nextJsPlatform, {
         product: [ProductSolution.ERROR_MONITORING],
       });
     });
@@ -985,7 +782,6 @@ describe('ScmPlatformFeatures', () => {
       // currentPlatformKey falls back to the detected key. Passing undefined
       // to onComplete here would trip goNextStep's SETUP_DOCS guard because
       // the captured closure still sees selectedPlatform as undefined.
-      const onComplete = jest.fn();
       const createdProject = ProjectFixture({
         slug: 'javascript-nextjs',
         platform: 'javascript-nextjs',
@@ -1012,19 +808,8 @@ describe('ScmPlatformFeatures', () => {
         body: {},
       });
 
-      render(
-        <ScmPlatformFeatures
-          onComplete={onComplete}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedRepository: mockRepository,
-          }),
-        }
-      );
+      const props = defaultProps({selectedRepository: mockRepository});
+      render(<ScmPlatformFeatures {...props} />, {organization});
 
       await screen.findByRole('radio', {name: /Next.js/});
       await waitFor(() => {
@@ -1033,7 +818,7 @@ describe('ScmPlatformFeatures', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       await waitFor(() => {
-        expect(onComplete).toHaveBeenCalledWith(
+        expect(props.onComplete).toHaveBeenCalledWith(
           expect.objectContaining({key: 'javascript-nextjs'}),
           {product: [ProductSolution.ERROR_MONITORING]}
         );
@@ -1060,27 +845,19 @@ describe('ScmPlatformFeatures', () => {
     };
 
     it('advances without creating a project on Continue', async () => {
-      const onComplete = jest.fn();
       const createRequest = MockApiClient.addMockResponse({
         url: `/teams/${experimentOrganization.slug}/team-slug/projects/`,
         method: 'POST',
         body: ProjectFixture(),
       });
 
-      render(
-        <ScmPlatformFeatures
-          onComplete={onComplete}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization: experimentOrganization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedPlatform: nextJsPlatform,
-            selectedFeatures: [ProductSolution.ERROR_MONITORING],
-          }),
-        }
-      );
+      const props = defaultProps({
+        selectedPlatform: nextJsPlatform,
+        selectedFeatures: [ProductSolution.ERROR_MONITORING],
+      });
+      render(<ScmPlatformFeatures {...props} />, {
+        organization: experimentOrganization,
+      });
 
       await waitFor(() => {
         expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
@@ -1088,7 +865,7 @@ describe('ScmPlatformFeatures', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       await waitFor(() => {
-        expect(onComplete).toHaveBeenCalledWith();
+        expect(props.onComplete).toHaveBeenCalledWith();
       });
       expect(createRequest).not.toHaveBeenCalled();
     });

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -647,7 +647,6 @@ describe('ScmPlatformFeatures', () => {
     });
 
     it('links selected repository to project after creation', async () => {
-      const onComplete = jest.fn();
       const createdProject = ProjectFixture({
         slug: 'javascript-nextjs',
         platform: 'javascript-nextjs',
@@ -674,21 +673,12 @@ describe('ScmPlatformFeatures', () => {
         },
       });
 
-      render(
-        <ScmPlatformFeatures
-          onComplete={onComplete}
-          stepIndex={2}
-          genSkipOnboardingLink={() => null}
-        />,
-        {
-          organization,
-          additionalWrapper: makeOnboardingWrapper({
-            selectedPlatform: nextJsPlatform,
-            selectedRepository: mockRepository,
-            selectedFeatures: [ProductSolution.ERROR_MONITORING],
-          }),
-        }
-      );
+      const props = defaultProps({
+        selectedPlatform: nextJsPlatform,
+        selectedRepository: mockRepository,
+        selectedFeatures: [ProductSolution.ERROR_MONITORING],
+      });
+      render(<ScmPlatformFeatures {...props} />, {organization});
 
       await waitFor(() => {
         expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
@@ -696,7 +686,7 @@ describe('ScmPlatformFeatures', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       await waitFor(() => {
-        expect(onComplete).toHaveBeenCalled();
+        expect(props.onComplete).toHaveBeenCalled();
       });
 
       expect(repoLinkRequest).toHaveBeenCalledWith(

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -14,7 +14,6 @@ import {closeModal, openConsoleModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {
   getDisabledProducts,
   platformProductAvailability,
@@ -24,6 +23,7 @@ import {PLATFORM_PRODUCT_INFO} from 'sentry/data/platformProductInfo.generated';
 import {platforms} from 'sentry/data/platforms';
 import {IconBroadcast, IconBusiness, IconGeneric} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {Team} from 'sentry/types/organization';
 import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
@@ -100,20 +100,34 @@ function getPlatformName(platformKey: PlatformKey | undefined) {
   return getPlatformInfo(platformKey)?.name;
 }
 
-export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
+interface ScmPlatformFeaturesProps {
+  createdProjectSlug: string | undefined;
+  onClearProjectDetailsForm: () => void;
+  onComplete: StepProps['onComplete'];
+  onFeaturesChange: (features: ProductSolution[] | undefined) => void;
+  onPlatformChange: (platform: OnboardingSelectedSDK | undefined) => void;
+  onProjectCreated: (slug: string | undefined) => void;
+  selectedFeatures: ProductSolution[] | undefined;
+  selectedPlatform: OnboardingSelectedSDK | undefined;
+  selectedRepository: Repository | undefined;
+  genBackButton?: StepProps['genBackButton'];
+}
+
+export function ScmPlatformFeatures({
+  createdProjectSlug,
+  onClearProjectDetailsForm,
+  onComplete,
+  onFeaturesChange,
+  onPlatformChange,
+  onProjectCreated,
+  selectedFeatures,
+  selectedPlatform,
+  selectedRepository,
+  genBackButton,
+}: ScmPlatformFeaturesProps) {
   const {openModal} = useModal();
 
   const organization = useOrganization();
-  const {
-    selectedRepository,
-    selectedPlatform,
-    setSelectedPlatform,
-    selectedFeatures,
-    setSelectedFeatures,
-    setProjectDetailsForm,
-    createdProjectSlug,
-    setCreatedProjectSlug,
-  } = useOnboardingContext();
 
   const {teams, fetching: isLoadingTeams} = useTeams();
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
@@ -138,10 +152,10 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
     (platformKey: PlatformKey) => {
       const info = getPlatformInfo(platformKey);
       if (info) {
-        setSelectedPlatform(toSelectedSdk(info));
+        onPlatformChange(toSelectedSdk(info));
       }
     },
-    [setSelectedPlatform]
+    [onPlatformChange]
   );
 
   const hasScmConnected = !!selectedRepository;
@@ -260,7 +274,7 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
         }
       }
 
-      setSelectedFeatures(Array.from(newFeatures));
+      onFeaturesChange(Array.from(newFeatures));
 
       trackAnalytics('onboarding.scm_platform_feature_toggled', {
         organization,
@@ -271,7 +285,7 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
     },
     [
       currentFeatures,
-      setSelectedFeatures,
+      onFeaturesChange,
       disabledProducts,
       availableFeatures,
       organization,
@@ -280,9 +294,9 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
   );
 
   const applyPlatformSelection = (sdk: OnboardingSelectedSDK) => {
-    setSelectedPlatform(sdk);
-    setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
-    setProjectDetailsForm(undefined);
+    onPlatformChange(sdk);
+    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+    onClearProjectDetailsForm();
   };
 
   const handleManualPlatformSelect = async (option: {value: string}) => {
@@ -340,8 +354,8 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
     }
 
     setPlatform(platformKey);
-    setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
-    setProjectDetailsForm(undefined);
+    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+    onClearProjectDetailsForm();
 
     trackAnalytics('onboarding.scm_platform_selected', {
       organization,
@@ -355,8 +369,8 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
       return;
     }
     setPlatform(platformKey);
-    setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
-    setProjectDetailsForm(undefined);
+    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+    onClearProjectDetailsForm();
 
     trackAnalytics('onboarding.scm_platform_selected', {
       organization,
@@ -378,8 +392,8 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
     setShowManualPicker(false);
     if (detectedPlatformKey) {
       setPlatform(detectedPlatformKey);
-      setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
-      setProjectDetailsForm(undefined);
+      onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+      onClearProjectDetailsForm();
     }
   }
 
@@ -398,7 +412,7 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
       setPlatform(currentPlatformKey);
     }
     if (!selectedFeatures) {
-      setSelectedFeatures(currentFeatures);
+      onFeaturesChange(currentFeatures);
     }
 
     if (!hasProjectDetailsStep) {
@@ -435,7 +449,7 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
           default_rules: true,
           firstTeamSlug: firstAdminTeam?.slug,
         });
-        setCreatedProjectSlug(project.slug);
+        onProjectCreated(project.slug);
 
         if (selectedRepository?.id) {
           try {

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -407,7 +407,7 @@ export function ScmPlatformFeatures({
     !hasProjectDetailsStep && (isLoadingTeams || !projectsLoaded);
 
   async function handleContinue() {
-    // Persist derived defaults to context if user accepted them
+    // Persist derived defaults if the user accepted them without an explicit click
     if (currentPlatformKey && !selectedPlatform?.key) {
       setPlatform(currentPlatformKey);
     }

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -1,30 +1,35 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RepositoryFixture} from 'sentry-fixture/repository';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {
-  OnboardingContextProvider,
-  type OnboardingSessionState,
-} from 'sentry/components/onboarding/onboardingContext';
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboardingContext';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import * as analytics from 'sentry/utils/analytics';
-import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 import {MetricValues, RuleAction} from 'sentry/views/projectInstall/issueAlertOptions';
 
 import {ScmProjectDetails} from './scmProjectDetails';
 
-function makeOnboardingWrapper(initialState?: OnboardingSessionState) {
-  return function OnboardingWrapper({children}: {children?: React.ReactNode}) {
-    return (
-      <OnboardingContextProvider initialValue={initialState}>
-        {children}
-      </OnboardingContextProvider>
-    );
+interface StateOverrides {
+  createdProjectSlug?: string;
+  projectDetailsForm?: ProjectDetailsFormState;
+  selectedFeatures?: ProductSolution[];
+  selectedPlatform?: OnboardingSelectedSDK;
+}
+
+function defaultProps(state: StateOverrides = {}) {
+  return {
+    selectedPlatform: state.selectedPlatform,
+    selectedFeatures: state.selectedFeatures,
+    createdProjectSlug: state.createdProjectSlug,
+    projectDetailsForm: state.projectDetailsForm,
+    onProjectCreated: jest.fn(),
+    onProjectDetailsFormChange: jest.fn(),
+    onComplete: jest.fn(),
   };
 }
 
@@ -37,14 +42,11 @@ const mockPlatform: OnboardingSelectedSDK = {
   type: 'framework',
 };
 
-const mockRepository = RepositoryFixture({id: '42', name: 'getsentry/sentry'});
-
 describe('ScmProjectDetails', () => {
   const organization = OrganizationFixture();
   const teamWithAccess = TeamFixture({slug: 'my-team', access: ['team:admin']});
 
   beforeEach(() => {
-    sessionStorageWrapper.clear();
     TeamStore.loadInitialData([teamWithAccess]);
     ProjectsStore.loadInitialData([]);
 
@@ -67,37 +69,17 @@ describe('ScmProjectDetails', () => {
   });
 
   it('renders step header with heading', async () => {
-    render(
-      <ScmProjectDetails
-        onComplete={jest.fn()}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
+    render(<ScmProjectDetails {...defaultProps({selectedPlatform: mockPlatform})} />, {
+      organization,
+    });
 
     expect(await screen.findByText('Project details')).toBeInTheDocument();
   });
 
   it('renders section headers with icons', async () => {
-    render(
-      <ScmProjectDetails
-        onComplete={jest.fn()}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
+    render(<ScmProjectDetails {...defaultProps({selectedPlatform: mockPlatform})} />, {
+      organization,
+    });
 
     expect(await screen.findByText('Give your project a name')).toBeInTheDocument();
     expect(screen.getByText('Assign a team')).toBeInTheDocument();
@@ -106,83 +88,31 @@ describe('ScmProjectDetails', () => {
   });
 
   it('renders project name defaulted from platform key', async () => {
-    render(
-      <ScmProjectDetails
-        onComplete={jest.fn()}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
-
-    const input = await screen.findByPlaceholderText('project-name');
-    expect(input).toHaveValue('javascript-nextjs');
-  });
-
-  it('uses platform key as default name even when repository is in context', async () => {
-    render(
-      <ScmProjectDetails
-        onComplete={jest.fn()}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-          selectedRepository: mockRepository,
-        }),
-      }
-    );
+    render(<ScmProjectDetails {...defaultProps({selectedPlatform: mockPlatform})} />, {
+      organization,
+    });
 
     const input = await screen.findByPlaceholderText('project-name');
     expect(input).toHaveValue('javascript-nextjs');
   });
 
   it('renders card-style alert frequency options', async () => {
-    render(
-      <ScmProjectDetails
-        onComplete={jest.fn()}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
+    render(<ScmProjectDetails {...defaultProps({selectedPlatform: mockPlatform})} />, {
+      organization,
+    });
 
     expect(await screen.findByText('High priority issues')).toBeInTheDocument();
     expect(screen.getByText('Custom')).toBeInTheDocument();
     expect(screen.getByText("I'll create my own alerts later")).toBeInTheDocument();
   });
 
-  it('create project button is disabled without platform in context', async () => {
-    render(
-      <ScmProjectDetails
-        onComplete={jest.fn()}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper(),
-      }
-    );
+  it('create project button is disabled without platform', async () => {
+    render(<ScmProjectDetails {...defaultProps()} />, {organization});
 
     expect(await screen.findByRole('button', {name: 'Create project'})).toBeDisabled();
   });
 
   it('create project button calls API and completes on success', async () => {
-    const onComplete = jest.fn();
-
     const projectCreationRequest = MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
       method: 'POST',
@@ -203,19 +133,8 @@ describe('ScmProjectDetails', () => {
       body: [teamWithAccess],
     });
 
-    render(
-      <ScmProjectDetails
-        onComplete={onComplete}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
+    const props = defaultProps({selectedPlatform: mockPlatform});
+    render(<ScmProjectDetails {...props} />, {organization});
 
     const createButton = await screen.findByRole('button', {name: 'Create project'});
     await userEvent.click(createButton);
@@ -225,7 +144,7 @@ describe('ScmProjectDetails', () => {
     });
 
     await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
+      expect(props.onComplete).toHaveBeenCalled();
     });
   });
 
@@ -297,25 +216,15 @@ describe('ScmProjectDetails', () => {
   });
 
   it('defaults team selector to first admin team', async () => {
-    render(
-      <ScmProjectDetails
-        onComplete={jest.fn()}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
+    render(<ScmProjectDetails {...defaultProps({selectedPlatform: mockPlatform})} />, {
+      organization,
+    });
 
     // TeamSelector renders the team slug as the selected value
     expect(await screen.findByText(`#${teamWithAccess.slug}`)).toBeInTheDocument();
   });
 
-  it('updates context with project slug after creation', async () => {
+  it('stores project slug via onProjectCreated after creation', async () => {
     const createdProject = ProjectFixture({
       slug: 'my-custom-project',
       name: 'my-custom-project',
@@ -339,60 +248,37 @@ describe('ScmProjectDetails', () => {
       body: [teamWithAccess],
     });
 
-    const onComplete = jest.fn();
-
-    render(
-      <ScmProjectDetails
-        onComplete={onComplete}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
+    const props = defaultProps({selectedPlatform: mockPlatform});
+    render(<ScmProjectDetails {...props} />, {organization});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
 
     await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
+      expect(props.onComplete).toHaveBeenCalled();
     });
 
-    // Verify the project slug was stored separately in context (not overwriting
-    // selectedPlatform.key) so onboarding.tsx can find the project via
-    // useRecentCreatedProject while preserving the original platform selection.
-    const stored = JSON.parse(sessionStorageWrapper.getItem('onboarding') ?? '{}');
-    expect(stored.createdProjectSlug).toBe('my-custom-project');
-    expect(stored.selectedPlatform?.key).toBe('javascript-nextjs');
+    expect(props.onProjectCreated).toHaveBeenCalledWith('my-custom-project');
   });
 
-  it('restores form inputs from persisted projectDetailsForm', async () => {
+  it('restores form inputs from projectDetailsForm prop', async () => {
     render(
       <ScmProjectDetails
-        onComplete={jest.fn()}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
+        {...defaultProps({
           selectedPlatform: mockPlatform,
           projectDetailsForm: {
             projectName: 'my-saved-name',
             teamSlug: teamWithAccess.slug,
           },
-        }),
-      }
+        })}
+      />,
+      {organization}
     );
 
     const input = await screen.findByPlaceholderText('project-name');
     expect(input).toHaveValue('my-saved-name');
   });
 
-  it('persists form state to context on successful creation', async () => {
+  it('persists form state on successful creation', async () => {
     MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
       method: 'POST',
@@ -411,36 +297,21 @@ describe('ScmProjectDetails', () => {
       body: [teamWithAccess],
     });
 
-    const onComplete = jest.fn();
-
-    render(
-      <ScmProjectDetails
-        onComplete={onComplete}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
+    const props = defaultProps({selectedPlatform: mockPlatform});
+    render(<ScmProjectDetails {...props} />, {organization});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
 
     await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
+      expect(props.onComplete).toHaveBeenCalled();
     });
 
-    const stored = JSON.parse(sessionStorageWrapper.getItem('onboarding') ?? '{}');
-    expect(stored.projectDetailsForm).toEqual(
+    expect(props.onProjectDetailsFormChange).toHaveBeenCalledWith(
       expect.objectContaining({
         projectName: 'javascript-nextjs',
         teamSlug: teamWithAccess.slug,
       })
     );
-    expect(stored.projectDetailsForm.alertRuleConfig).toBeDefined();
   });
 
   it('reuses existing project when nothing changed on back-nav', async () => {
@@ -458,37 +329,26 @@ describe('ScmProjectDetails', () => {
       body: existingProject,
     });
 
-    const onComplete = jest.fn();
-
-    render(
-      <ScmProjectDetails
-        onComplete={onComplete}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-          createdProjectSlug: existingProject.slug,
-          projectDetailsForm: {
-            projectName: 'javascript-nextjs',
-            teamSlug: teamWithAccess.slug,
-            alertRuleConfig: {
-              alertSetting: RuleAction.DEFAULT_ALERT,
-              interval: '1m',
-              metric: MetricValues.ERRORS,
-              threshold: '10',
-            },
-          },
-        }),
-      }
-    );
+    const props = defaultProps({
+      selectedPlatform: mockPlatform,
+      createdProjectSlug: existingProject.slug,
+      projectDetailsForm: {
+        projectName: 'javascript-nextjs',
+        teamSlug: teamWithAccess.slug,
+        alertRuleConfig: {
+          alertSetting: RuleAction.DEFAULT_ALERT,
+          interval: '1m',
+          metric: MetricValues.ERRORS,
+          threshold: '10',
+        },
+      },
+    });
+    render(<ScmProjectDetails {...props} />, {organization});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
 
     await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
+      expect(props.onComplete).toHaveBeenCalled();
     });
     expect(createRequest).not.toHaveBeenCalled();
     expect(trackAnalyticsSpy).toHaveBeenCalledWith(
@@ -522,32 +382,21 @@ describe('ScmProjectDetails', () => {
       body: [teamWithAccess],
     });
 
-    const onComplete = jest.fn();
-
-    render(
-      <ScmProjectDetails
-        onComplete={onComplete}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-          createdProjectSlug: existingProject.slug,
-          projectDetailsForm: {
-            projectName: 'javascript-nextjs',
-            teamSlug: teamWithAccess.slug,
-            alertRuleConfig: {
-              alertSetting: RuleAction.DEFAULT_ALERT,
-              interval: '1m',
-              metric: MetricValues.ERRORS,
-              threshold: '10',
-            },
-          },
-        }),
-      }
-    );
+    const props = defaultProps({
+      selectedPlatform: mockPlatform,
+      createdProjectSlug: existingProject.slug,
+      projectDetailsForm: {
+        projectName: 'javascript-nextjs',
+        teamSlug: teamWithAccess.slug,
+        alertRuleConfig: {
+          alertSetting: RuleAction.DEFAULT_ALERT,
+          interval: '1m',
+          metric: MetricValues.ERRORS,
+          threshold: '10',
+        },
+      },
+    });
+    render(<ScmProjectDetails {...props} />, {organization});
 
     const input = await screen.findByPlaceholderText('project-name');
     await userEvent.clear(input);
@@ -559,7 +408,7 @@ describe('ScmProjectDetails', () => {
       expect(createRequest).toHaveBeenCalled();
     });
     await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
+      expect(props.onComplete).toHaveBeenCalled();
     });
   });
 
@@ -593,32 +442,21 @@ describe('ScmProjectDetails', () => {
       body: [teamWithAccess],
     });
 
-    const onComplete = jest.fn();
-
-    render(
-      <ScmProjectDetails
-        onComplete={onComplete}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-          createdProjectSlug: stalePythonProject.slug,
-          projectDetailsForm: {
-            projectName: 'javascript-nextjs',
-            teamSlug: teamWithAccess.slug,
-            alertRuleConfig: {
-              alertSetting: RuleAction.DEFAULT_ALERT,
-              interval: '1m',
-              metric: MetricValues.ERRORS,
-              threshold: '10',
-            },
-          },
-        }),
-      }
-    );
+    const props = defaultProps({
+      selectedPlatform: mockPlatform,
+      createdProjectSlug: stalePythonProject.slug,
+      projectDetailsForm: {
+        projectName: 'javascript-nextjs',
+        teamSlug: teamWithAccess.slug,
+        alertRuleConfig: {
+          alertSetting: RuleAction.DEFAULT_ALERT,
+          interval: '1m',
+          metric: MetricValues.ERRORS,
+          threshold: '10',
+        },
+      },
+    });
+    render(<ScmProjectDetails {...props} />, {organization});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
 
@@ -626,7 +464,7 @@ describe('ScmProjectDetails', () => {
       expect(createRequest).toHaveBeenCalled();
     });
     await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
+      expect(props.onComplete).toHaveBeenCalled();
     });
   });
 
@@ -651,32 +489,21 @@ describe('ScmProjectDetails', () => {
       body: [teamWithAccess],
     });
 
-    const onComplete = jest.fn();
-
-    render(
-      <ScmProjectDetails
-        onComplete={onComplete}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-          createdProjectSlug: 'javascript-nextjs',
-          projectDetailsForm: {
-            projectName: 'javascript-nextjs',
-            teamSlug: teamWithAccess.slug,
-            alertRuleConfig: {
-              alertSetting: RuleAction.DEFAULT_ALERT,
-              interval: '1m',
-              metric: MetricValues.ERRORS,
-              threshold: '10',
-            },
-          },
-        }),
-      }
-    );
+    const props = defaultProps({
+      selectedPlatform: mockPlatform,
+      createdProjectSlug: 'javascript-nextjs',
+      projectDetailsForm: {
+        projectName: 'javascript-nextjs',
+        teamSlug: teamWithAccess.slug,
+        alertRuleConfig: {
+          alertSetting: RuleAction.DEFAULT_ALERT,
+          interval: '1m',
+          metric: MetricValues.ERRORS,
+          threshold: '10',
+        },
+      },
+    });
+    render(<ScmProjectDetails {...props} />, {organization});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
 
@@ -684,13 +511,11 @@ describe('ScmProjectDetails', () => {
       expect(createRequest).toHaveBeenCalled();
     });
     await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
+      expect(props.onComplete).toHaveBeenCalled();
     });
   });
 
   it('shows error message on project creation failure', async () => {
-    const onComplete = jest.fn();
-
     MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
       method: 'POST',
@@ -698,44 +523,23 @@ describe('ScmProjectDetails', () => {
       body: {detail: 'Internal Error'},
     });
 
-    render(
-      <ScmProjectDetails
-        onComplete={onComplete}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
+    const props = defaultProps({selectedPlatform: mockPlatform});
+    render(<ScmProjectDetails {...props} />, {organization});
 
     const createButton = await screen.findByRole('button', {name: 'Create project'});
     await userEvent.click(createButton);
 
     await waitFor(() => {
-      expect(onComplete).not.toHaveBeenCalled();
+      expect(props.onComplete).not.toHaveBeenCalled();
     });
   });
 
   it('fires step viewed analytics on mount', async () => {
     const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
 
-    render(
-      <ScmProjectDetails
-        onComplete={jest.fn()}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
+    render(<ScmProjectDetails {...defaultProps({selectedPlatform: mockPlatform})} />, {
+      organization,
+    });
 
     await screen.findByText('Project details');
 
@@ -766,26 +570,13 @@ describe('ScmProjectDetails', () => {
       body: [teamWithAccess],
     });
 
-    const onComplete = jest.fn();
-
-    render(
-      <ScmProjectDetails
-        onComplete={onComplete}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-        }),
-      }
-    );
+    const props = defaultProps({selectedPlatform: mockPlatform});
+    render(<ScmProjectDetails {...props} />, {organization});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
 
     await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
+      expect(props.onComplete).toHaveBeenCalled();
     });
 
     const eventKeys = trackAnalyticsSpy.mock.calls.map(call => call[0]);

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RepositoryFixture} from 'sentry-fixture/repository';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -8,6 +9,7 @@ import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedD
 import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboardingContext';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
+import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import * as analytics from 'sentry/utils/analytics';
 import {MetricValues, RuleAction} from 'sentry/views/projectInstall/issueAlertOptions';
@@ -19,12 +21,14 @@ interface StateOverrides {
   projectDetailsForm?: ProjectDetailsFormState;
   selectedFeatures?: ProductSolution[];
   selectedPlatform?: OnboardingSelectedSDK;
+  selectedRepository?: Repository;
 }
 
 function defaultProps(state: StateOverrides = {}) {
   return {
     selectedPlatform: state.selectedPlatform,
     selectedFeatures: state.selectedFeatures,
+    selectedRepository: state.selectedRepository,
     createdProjectSlug: state.createdProjectSlug,
     projectDetailsForm: state.projectDetailsForm,
     onProjectCreated: jest.fn(),
@@ -41,6 +45,8 @@ const mockPlatform: OnboardingSelectedSDK = {
   link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
   type: 'framework',
 };
+
+const mockRepository = RepositoryFixture({id: '42', name: 'getsentry/sentry'});
 
 describe('ScmProjectDetails', () => {
   const organization = OrganizationFixture();
@@ -149,7 +155,6 @@ describe('ScmProjectDetails', () => {
   });
 
   it('links selected repository to project after creation', async () => {
-    const onComplete = jest.fn();
     const createdProject = ProjectFixture({
       slug: 'javascript-nextjs',
       name: 'javascript-nextjs',
@@ -185,25 +190,16 @@ describe('ScmProjectDetails', () => {
       },
     });
 
-    render(
-      <ScmProjectDetails
-        onComplete={onComplete}
-        stepIndex={3}
-        genSkipOnboardingLink={() => null}
-      />,
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedPlatform: mockPlatform,
-          selectedRepository: mockRepository,
-        }),
-      }
-    );
+    const props = defaultProps({
+      selectedPlatform: mockPlatform,
+      selectedRepository: mockRepository,
+    });
+    render(<ScmProjectDetails {...props} />, {organization});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
 
     await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
+      expect(props.onComplete).toHaveBeenCalled();
     });
 
     expect(repoLinkRequest).toHaveBeenCalledWith(

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -7,11 +7,14 @@ import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboardingContext';
 import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
 import {TeamSelector} from 'sentry/components/teamSelector';
 import {IconGroup, IconProject, IconSiren} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {Repository} from 'sentry/types/integrations';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {Team} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -32,17 +35,30 @@ import {ScmAlertFrequency} from './components/scmAlertFrequency';
 import {ScmStepHeader} from './components/scmStepHeader';
 import type {StepProps} from './types';
 
-export function ScmProjectDetails({onComplete, genBackButton}: StepProps) {
+interface ScmProjectDetailsProps {
+  createdProjectSlug: string | undefined;
+  onComplete: StepProps['onComplete'];
+  onProjectCreated: (slug: string | undefined) => void;
+  onProjectDetailsFormChange: (form: ProjectDetailsFormState | undefined) => void;
+  projectDetailsForm: ProjectDetailsFormState | undefined;
+  selectedFeatures: ProductSolution[] | undefined;
+  selectedPlatform: OnboardingSelectedSDK | undefined;
+  selectedRepository: Repository | undefined;
+  genBackButton?: StepProps['genBackButton'];
+}
+
+export function ScmProjectDetails({
+  createdProjectSlug,
+  onComplete,
+  onProjectCreated,
+  onProjectDetailsFormChange,
+  projectDetailsForm,
+  selectedFeatures,
+  selectedPlatform,
+  selectedRepository,
+  genBackButton,
+}: ScmProjectDetailsProps) {
   const organization = useOrganization();
-  const {
-    selectedPlatform,
-    selectedFeatures,
-    selectedRepository,
-    createdProjectSlug,
-    setCreatedProjectSlug,
-    projectDetailsForm,
-    setProjectDetailsForm,
-  } = useOnboardingContext();
   const {teams, fetching: isLoadingTeams} = useTeams();
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const createProjectAndRules = useCreateProjectAndRules();
@@ -160,7 +176,7 @@ export function ScmProjectDetails({onComplete, genBackButton}: StepProps) {
       // Store the project slug separately so onboarding.tsx can find
       // the project via useRecentCreatedProject without corrupting
       // selectedPlatform.key (which the platform features step needs).
-      setCreatedProjectSlug(project.slug);
+      onProjectCreated(project.slug);
 
       if (selectedRepository?.id) {
         try {
@@ -174,7 +190,7 @@ export function ScmProjectDetails({onComplete, genBackButton}: StepProps) {
         }
       }
 
-      setProjectDetailsForm({
+      onProjectDetailsFormChange({
         projectName: projectNameResolved,
         teamSlug: teamSlugResolved,
         alertRuleConfig,


### PR DESCRIPTION
## TL;DR

Decouples the four SCM onboarding step components from `OnboardingContext` so they accept all flow state via props. Adapter wrappers in `onboarding.tsx` source those props from context, preserving today's behavior. Unblocks the project creation variant of SCM onboarding.

---

Refactor `ScmConnect`, `ScmPlatformFeatures`, `ScmProjectDetails`, and `ScmRepoSelector` to read and write all flow state via props. Three adapter wrappers in `onboarding.tsx` (`ScmConnectAdapter`, `ScmPlatformFeaturesAdapter`, `ScmProjectDetailsAdapter`) source those props from `OnboardingContext`, preserving today's behavior.

This unblocks the project creation variant of SCM onboarding (VDY-73 through VDY-78), which needs the same components driven from local wizard state instead of session-storage-backed context.

`clearDerivedState` moves out of `ScmRepoSelector` and into the onboarding adapter so callers in other flows can pick their own invalidation strategy. `ProjectDetailsFormState` is now exported from `onboardingContext` so the project-details prop interface can name it.

Alternative considered: a shared `ScmFlowContext` that both flows would populate. Rejected for two-consumer scope because it reintroduces a provider wrapper in tests (the simplification this PR delivers) and adds an abstraction layer with marginal payoff at this size.

Supersedes #112948.

Refs VDY-72