### PR TITLE
fix(seer): Sort autofix project table by slug instead of name

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -170,8 +170,8 @@ export function SeerProjectTable() {
     return projects.toSorted((a, b) => {
       if (sort.field === 'project') {
         return sort.kind === 'asc'
-          ? a.name.localeCompare(b.name)
-          : b.name.localeCompare(a.name);
+          ? a.slug.localeCompare(b.slug)
+          : b.slug.localeCompare(a.slug);
       }
 
       const aSettings = autofixSettingsByProjectId?.[a.id];


### PR DESCRIPTION
The Seer Autofix settings table displays each project's slug via ProjectBadge but sorted rows by project.name, which can diverge from the slug when a project has been renamed. This made the visible order appear non-alphabetical (e.g. a project with slug "sentry" and name "Backend" sorted between "apple-macos" and "engineering-blog").

Sort by slug so the order matches what's rendered, and stays consistent with the search filter which already matches against slug.

See the "sentry" project here as a live example: https://sentry.sentry.io/settings/seer/projects/