### PR TITLE
fix(preprod): Change snapshot image tags from list to dict

### DIFF
--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -54,7 +54,7 @@ class SnapshotImageDetailImageInfo(BaseModel):
     height: int
     diff_threshold: float | None = None
     description: str | None = None
-    tags: list[str] | None = None
+    tags: dict[str, str] | None = None
     image_url: str
 
     class Config:

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 
 class ImageMetadata(BaseModel):
@@ -13,7 +13,17 @@ class ImageMetadata(BaseModel):
     height: int = Field(ge=0)
     diff_threshold: float | None = Field(default=None, ge=0.0, lt=1.0)
     description: str | None = None
-    tags: list[str] | None = None
+    tags: dict[str, str] | None = None
+
+    @validator("tags", pre=True)
+    def coerce_tags(cls, v: object) -> dict[str, str] | None:
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v
+        if isinstance(v, list):
+            return {str(tag): str(tag) for tag in v}
+        return None
 
     class Config:
         extra = "allow"

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -28,6 +28,17 @@ class ImageMetadata(BaseModel):
     class Config:
         extra = "allow"
 
+        @staticmethod
+        def schema_extra(schema: dict, model: type) -> None:
+            tags = schema.get("properties", {}).get("tags")
+            if tags:
+                schema["properties"]["tags"] = {
+                    "anyOf": [
+                        {"type": "object", "additionalProperties": {"type": "string"}},
+                        {"type": "array", "items": {"type": "string"}},
+                    ]
+                }
+
 
 class SnapshotManifest(BaseModel):
     images: dict[str, ImageMetadata]

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, validator
 
@@ -29,7 +29,7 @@ class ImageMetadata(BaseModel):
         extra = "allow"
 
         @staticmethod
-        def schema_extra(schema: dict, model: type) -> None:
+        def schema_extra(schema: dict[str, Any], model: type) -> None:
             tags = schema.get("properties", {}).get("tags")
             if tags:
                 schema["properties"]["tags"] = {

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -36,6 +36,7 @@ class ImageMetadata(BaseModel):
                     "anyOf": [
                         {"type": "object", "additionalProperties": {"type": "string"}},
                         {"type": "array", "items": {"type": "string"}},
+                        {"type": "null"},
                     ]
                 }
 

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_image_detail.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_image_detail.py
@@ -147,7 +147,7 @@ class OrganizationPreprodSnapshotImageDetailTest(APITestCase):
         assert head["height"] == 200
         assert head["diff_threshold"] == 0.01
         assert head["description"] == "An alert component"
-        assert head["tags"] == ["dark"]
+        assert head["tags"] == {"dark": "dark"}
         assert "image_url" in head
         assert (
             head["image_url"]

--- a/tests/sentry/preprod/snapshots/test_manifest.py
+++ b/tests/sentry/preprod/snapshots/test_manifest.py
@@ -1,0 +1,58 @@
+from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
+
+
+def _meta(**kwargs: object) -> dict:
+    defaults: dict = {"content_hash": "abc123", "width": 100, "height": 200}
+    defaults.update(kwargs)
+    return defaults
+
+
+class TestImageMetadataTagsCoercion:
+    def test_tags_none(self) -> None:
+        meta = ImageMetadata(**_meta())
+        assert meta.tags is None
+
+    def test_tags_dict_passthrough(self) -> None:
+        tags = {"theme": "dark", "device": "phone"}
+        meta = ImageMetadata(**_meta(tags=tags))
+        assert meta.tags == tags
+
+    def test_tags_list_converted_to_dict(self) -> None:
+        meta = ImageMetadata(**_meta(tags=["dark", "mobile"]))
+        assert meta.tags == {"dark": "dark", "mobile": "mobile"}
+
+    def test_tags_single_item_list(self) -> None:
+        meta = ImageMetadata(**_meta(tags=["solo"]))
+        assert meta.tags == {"solo": "solo"}
+
+    def test_tags_empty_list(self) -> None:
+        meta = ImageMetadata(**_meta(tags=[]))
+        assert meta.tags == {}
+
+    def test_tags_empty_dict(self) -> None:
+        meta = ImageMetadata(**_meta(tags={}))
+        assert meta.tags == {}
+
+    def test_tags_unexpected_type_becomes_none(self) -> None:
+        meta = ImageMetadata(**_meta(tags=42))
+        assert meta.tags is None
+
+    def test_tags_string_becomes_none(self) -> None:
+        meta = ImageMetadata(**_meta(tags="not_a_dict_or_list"))
+        assert meta.tags is None
+
+    def test_manifest_with_dict_tags(self) -> None:
+        manifest = SnapshotManifest(
+            images={
+                "screen.png": _meta(tags={"theme": "dark", "size": "large"}),
+            }
+        )
+        assert manifest.images["screen.png"].tags == {"theme": "dark", "size": "large"}
+
+    def test_manifest_with_legacy_list_tags(self) -> None:
+        manifest = SnapshotManifest(
+            images={
+                "screen.png": _meta(tags=["dark", "mobile"]),
+            }
+        )
+        assert manifest.images["screen.png"].tags == {"dark": "dark", "mobile": "mobile"}

--- a/tests/sentry/preprod/snapshots/test_manifest.py
+++ b/tests/sentry/preprod/snapshots/test_manifest.py
@@ -1,3 +1,5 @@
+import jsonschema
+
 from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
 
 
@@ -56,3 +58,17 @@ class TestImageMetadataTagsCoercion:
             }
         )
         assert manifest.images["screen.png"].tags == {"dark": "dark", "mobile": "mobile"}
+
+
+class TestImageMetadataJsonSchema:
+    def test_schema_accepts_dict_tags(self) -> None:
+        schema = ImageMetadata.schema()
+        jsonschema.validate(_meta(tags={"theme": "dark"}), schema)
+
+    def test_schema_accepts_list_tags(self) -> None:
+        schema = ImageMetadata.schema()
+        jsonschema.validate(_meta(tags=["dark", "mobile"]), schema)
+
+    def test_schema_accepts_no_tags(self) -> None:
+        schema = ImageMetadata.schema()
+        jsonschema.validate(_meta(), schema)

--- a/tests/sentry/preprod/snapshots/test_manifest.py
+++ b/tests/sentry/preprod/snapshots/test_manifest.py
@@ -69,6 +69,10 @@ class TestImageMetadataJsonSchema:
         schema = ImageMetadata.schema()
         jsonschema.validate(_meta(tags=["dark", "mobile"]), schema)
 
+    def test_schema_accepts_null_tags(self) -> None:
+        schema = ImageMetadata.schema()
+        jsonschema.validate(_meta(tags=None), schema)
+
     def test_schema_accepts_no_tags(self) -> None:
         schema = ImageMetadata.schema()
         jsonschema.validate(_meta(), schema)


### PR DESCRIPTION
## Summary

Changes the `tags` field on snapshot image metadata from `list[str]` to `dict[str, str]`, enabling key-value tag semantics (e.g. `{"theme": "dark"}` instead of `["dark"]`).

- Updates `ImageMetadata` and `SnapshotImageDetailImageInfo` types from `list[str]` to `dict[str, str]`
- Adds a Pydantic `validator` on `ImageMetadata.tags` to gracefully coerce legacy `list` payloads into `dict` form (`["dark"] → {"dark": "dark"}`)
- Adds test coverage for tag coercion edge cases (dict passthrough, list conversion, empty values, unexpected types)

This is a re-land of #115628, which was reverted and then re-applied with a test fix.