### PR TITLE
feat(autofix): Render line numbers in autofix evidence

### DIFF
--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -281,7 +281,7 @@ function getCodeSearchEvidenceProps({
       return null;
     }
 
-    const hash =
+    const lines =
       start_line && end_line
         ? start_line === end_line
           ? `L${start_line}`
@@ -289,10 +289,20 @@ function getCodeSearchEvidenceProps({
         : undefined;
 
     return {
-      href: hash ? `${code_url}#${hash}` : code_url,
+      href: lines ? `${code_url}#${lines}` : code_url,
       icon: <IconFile />,
-      label: t('File: %s', truncateText(filename)),
-      tooltip: path,
+      label: t('File: %s%s', truncateText(filename), lines ? ` ${lines}` : ''),
+      tooltip: (
+        <Fragment>
+          {path}
+          {lines && (
+            <Fragment>
+              <br />
+              {lines}
+            </Fragment>
+          )}
+        </Fragment>
+      ),
     };
   }
 


### PR DESCRIPTION
The same file appears multiple times for different lines so rendering the line number helps users visually distinguish which lines it looked at.

<img width="1006" height="334" alt="image" src="https://github.com/user-attachments/assets/3be14840-4eea-4a54-964a-630fd5ae06f9" />
