### PR TITLE
fix(preprod): Eliminate race condition in snapshot status check posting

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import Any
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,11 +17,8 @@ from sentry.api.bases.organization import (
 from sentry.auth.staff import is_active_staff
 from sentry.models.organization import Organization
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
-from sentry.preprod.vcs.pr_comments.snapshot_tasks import create_preprod_snapshot_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
-from sentry.preprod.vcs.status_checks.snapshots.tasks import (
-    create_preprod_snapshot_status_check_task,
-)
+from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +27,9 @@ FEATURE_TYPE_MAP = {
     "size": PreprodComparisonApproval.FeatureType.SIZE,
 }
 
-STATUS_CHECK_TASK_MAP: dict[PreprodComparisonApproval.FeatureType, Callable[..., Any]] = {
-    PreprodComparisonApproval.FeatureType.SNAPSHOTS: create_preprod_snapshot_status_check_task,
-    PreprodComparisonApproval.FeatureType.SIZE: create_preprod_status_check_task,
+VCS_UPDATE_MAP: dict[PreprodComparisonApproval.FeatureType, Callable[..., None]] = {
+    PreprodComparisonApproval.FeatureType.SNAPSHOTS: lambda **kw: update_preprod_snapshot_vcs(**kw),
+    PreprodComparisonApproval.FeatureType.SIZE: lambda **kw: create_preprod_status_check_task(**kw),
 }
 
 
@@ -92,18 +88,10 @@ class OrganizationPreprodArtifactApproveEndpoint(OrganizationEndpoint):
             approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
         ).delete()
 
-        task = STATUS_CHECK_TASK_MAP[feature_type]
-        task(
+        update_vcs = VCS_UPDATE_MAP[feature_type]
+        update_vcs(
             preprod_artifact_id=artifact.id,
             caller="approval_endpoint",
         )
-
-        if feature_type == PreprodComparisonApproval.FeatureType.SNAPSHOTS:
-            create_preprod_snapshot_pr_comment_task.apply_async(
-                kwargs={
-                    "preprod_artifact_id": artifact.id,
-                    "caller": "approval_endpoint",
-                },
-            )
 
         return Response({"detail": "Approved"}, status=201)

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
 from datetime import datetime, timezone
 
 from rest_framework.request import Request
@@ -25,11 +24,6 @@ logger = logging.getLogger(__name__)
 FEATURE_TYPE_MAP = {
     "snapshots": PreprodComparisonApproval.FeatureType.SNAPSHOTS,
     "size": PreprodComparisonApproval.FeatureType.SIZE,
-}
-
-VCS_UPDATE_MAP: dict[PreprodComparisonApproval.FeatureType, Callable[..., None]] = {
-    PreprodComparisonApproval.FeatureType.SNAPSHOTS: lambda **kw: update_preprod_snapshot_vcs(**kw),
-    PreprodComparisonApproval.FeatureType.SIZE: lambda **kw: create_preprod_status_check_task(**kw),
 }
 
 
@@ -88,10 +82,11 @@ class OrganizationPreprodArtifactApproveEndpoint(OrganizationEndpoint):
             approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
         ).delete()
 
-        update_vcs = VCS_UPDATE_MAP[feature_type]
-        update_vcs(
-            preprod_artifact_id=artifact.id,
-            caller="approval_endpoint",
-        )
+        if feature_type == PreprodComparisonApproval.FeatureType.SNAPSHOTS:
+            update_preprod_snapshot_vcs(preprod_artifact_id=artifact.id, caller="approval_endpoint")
+        elif feature_type == PreprodComparisonApproval.FeatureType.SIZE:
+            create_preprod_status_check_task(
+                preprod_artifact_id=artifact.id, caller="approval_endpoint"
+            )
 
         return Response({"detail": "Approved"}, status=201)

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_status_checks.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_status_checks.py
@@ -13,11 +13,8 @@ from sentry.models.project import Project
 from sentry.preprod.analytics import PreprodArtifactApiRerunStatusChecksEvent
 from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
 from sentry.preprod.models import PreprodArtifact
-from sentry.preprod.vcs.pr_comments.snapshot_tasks import create_preprod_snapshot_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
-from sentry.preprod.vcs.status_checks.snapshots.tasks import (
-    create_preprod_snapshot_status_check_task,
-)
+from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 
 logger = logging.getLogger(__name__)
 
@@ -98,10 +95,7 @@ class PreprodArtifactRerunStatusChecksEndpoint(PreprodArtifactEndpoint):
                             preprod_artifact_id=head_artifact.id, caller="rerun_endpoint"
                         )
                     case "snapshots":
-                        create_preprod_snapshot_status_check_task.delay(
-                            preprod_artifact_id=head_artifact.id, caller="rerun_endpoint"
-                        )
-                        create_preprod_snapshot_pr_comment_task.delay(
+                        update_preprod_snapshot_vcs(
                             preprod_artifact_id=head_artifact.id, caller="rerun_endpoint"
                         )
                     case _:

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -711,12 +711,6 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             except Exception:
                 logger.exception("Failed to record bundles_per_commit metric")
 
-        create_preprod_snapshot_status_check_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": artifact.id,
-                "caller": "upload_completion",
-            },
-        )
         create_preprod_snapshot_pr_comment_task.apply_async(
             kwargs={
                 "preprod_artifact_id": artifact.id,
@@ -724,6 +718,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             },
         )
 
+        comparison_starting = False
         if base_sha and base_repo_name:
             try:
                 base_artifact = find_base_snapshot_artifact(
@@ -766,6 +761,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                             "base_artifact_id": base_artifact.id,
                         },
                     )
+                    comparison_starting = True
 
                 else:
                     logger.info(
@@ -785,6 +781,17 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                         "base_sha": base_sha,
                     },
                 )
+
+        # When a comparison is starting, the compare_snapshots task owns the
+        # status check lifecycle (IN_PROGRESS -> COMPLETED) to avoid a race
+        # where an async IN_PROGRESS update overwrites an already-COMPLETED one.
+        if not comparison_starting:
+            create_preprod_snapshot_status_check_task.apply_async(
+                kwargs={
+                    "preprod_artifact_id": artifact.id,
+                    "caller": "upload_completion",
+                },
+            )
 
         # Trigger comparisons for any head artifacts that were uploaded before this base.
         # Handles possible out-of-order uploads where heads arrive before their base build.

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -66,10 +66,7 @@ from sentry.preprod.snapshots.utils import (
     find_head_snapshot_artifacts_awaiting_base,
 )
 from sentry.preprod.url_utils import get_preprod_artifact_url
-from sentry.preprod.vcs.pr_comments.snapshot_tasks import create_preprod_snapshot_pr_comment_task
-from sentry.preprod.vcs.status_checks.snapshots.tasks import (
-    create_preprod_snapshot_status_check_task,
-)
+from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.services.user.service import user_service
@@ -711,13 +708,6 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             except Exception:
                 logger.exception("Failed to record bundles_per_commit metric")
 
-        create_preprod_snapshot_pr_comment_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": artifact.id,
-                "caller": "upload_completion",
-            },
-        )
-
         comparison_starting = False
         if base_sha and base_repo_name:
             try:
@@ -782,16 +772,13 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                     },
                 )
 
-        # Only post a status check when no comparison was kicked off. When a
-        # comparison starts, compare_snapshots owns the full status check
-        # lifecycle itself; posting one here too would race with it.
-        if not comparison_starting:
-            create_preprod_snapshot_status_check_task.apply_async(
-                kwargs={
-                    "preprod_artifact_id": artifact.id,
-                    "caller": "upload_completion",
-                },
-            )
+        # When a comparison starts, compare_snapshots owns the status-check
+        # lifecycle; posting one here too would race with it.
+        update_preprod_snapshot_vcs(
+            preprod_artifact_id=artifact.id,
+            caller="upload_completion",
+            update_status_check=not comparison_starting,
+        )
 
         # Trigger comparisons for any head artifacts that were uploaded before this base.
         # Handles possible out-of-order uploads where heads arrive before their base build.

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -782,9 +782,9 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                     },
                 )
 
-        # When a comparison is starting, the compare_snapshots task owns the
-        # status check lifecycle (IN_PROGRESS -> COMPLETED) to avoid a race
-        # where an async IN_PROGRESS update overwrites an already-COMPLETED one.
+        # Only post a status check when no comparison was kicked off. When a
+        # comparison starts, compare_snapshots owns the full status check
+        # lifecycle itself; posting one here too would race with it.
         if not comparison_starting:
             create_preprod_snapshot_status_check_task.apply_async(
                 kwargs={

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -375,6 +375,12 @@ def compare_snapshots(
             "Snapshot comparison artifact not found",
             extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
         )
+        create_preprod_snapshot_status_check_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": head_artifact_id,
+                "caller": "compare_failure",
+            },
+        )
         return
 
     try:
@@ -386,6 +392,12 @@ def compare_snapshots(
             extra={
                 "head_artifact_id": head_artifact_id,
                 "base_artifact_id": base_artifact_id,
+            },
+        )
+        create_preprod_snapshot_status_check_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": head_artifact_id,
+                "caller": "compare_failure",
             },
         )
         return

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -414,6 +414,10 @@ def compare_snapshots(
                     "base_artifact_id": base_artifact_id,
                 },
             )
+            update_preprod_snapshot_vcs(
+                preprod_artifact_id=head_artifact_id,
+                caller="compare_failure",
+            )
             return
         created = False
 

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -23,10 +23,7 @@ from sentry.preprod.snapshots.manifest import (
     SnapshotManifest,
 )
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
-from sentry.preprod.vcs.pr_comments.snapshot_tasks import create_preprod_snapshot_pr_comment_task
-from sentry.preprod.vcs.status_checks.snapshots.tasks import (
-    create_preprod_snapshot_status_check_task,
-)
+from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
@@ -352,11 +349,10 @@ def compare_snapshots(
         },
     )
 
-    create_preprod_snapshot_status_check_task.apply_async(
-        kwargs={
-            "preprod_artifact_id": head_artifact_id,
-            "caller": "compare_start",
-        },
+    update_preprod_snapshot_vcs(
+        preprod_artifact_id=head_artifact_id,
+        caller="compare_start",
+        update_pr_comment=False,
     )
 
     try:
@@ -375,17 +371,9 @@ def compare_snapshots(
             "Snapshot comparison artifact not found",
             extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
         )
-        create_preprod_snapshot_status_check_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": head_artifact_id,
-                "caller": "compare_failure",
-            },
-        )
-        create_preprod_snapshot_pr_comment_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": head_artifact_id,
-                "caller": "compare_failure",
-            },
+        update_preprod_snapshot_vcs(
+            preprod_artifact_id=head_artifact_id,
+            caller="compare_failure",
         )
         return
 
@@ -400,17 +388,9 @@ def compare_snapshots(
                 "base_artifact_id": base_artifact_id,
             },
         )
-        create_preprod_snapshot_status_check_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": head_artifact_id,
-                "caller": "compare_failure",
-            },
-        )
-        create_preprod_snapshot_pr_comment_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": head_artifact_id,
-                "caller": "compare_failure",
-            },
+        update_preprod_snapshot_vcs(
+            preprod_artifact_id=head_artifact_id,
+            caller="compare_failure",
         )
         return
 
@@ -503,17 +483,9 @@ def compare_snapshots(
             comparison.state = PreprodSnapshotComparison.State.FAILED
             comparison.error_code = PreprodSnapshotComparison.ErrorCode.INTERNAL_ERROR
             comparison.save(update_fields=["state", "error_code", "date_updated"])
-            create_preprod_snapshot_status_check_task.apply_async(
-                kwargs={
-                    "preprod_artifact_id": head_artifact_id,
-                    "caller": "compare_failure",
-                },
-            )
-            create_preprod_snapshot_pr_comment_task.apply_async(
-                kwargs={
-                    "preprod_artifact_id": head_artifact_id,
-                    "caller": "compare_failure",
-                },
+            update_preprod_snapshot_vcs(
+                preprod_artifact_id=head_artifact_id,
+                caller="compare_failure",
             )
             return
 
@@ -877,17 +849,9 @@ def compare_snapshots(
                 extra={"head_artifact_id": head_artifact_id},
             )
 
-        create_preprod_snapshot_status_check_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": head_artifact_id,
-                "caller": "compare_completion",
-            },
-        )
-        create_preprod_snapshot_pr_comment_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": head_artifact_id,
-                "caller": "compare_completion",
-            },
+        update_preprod_snapshot_vcs(
+            preprod_artifact_id=head_artifact_id,
+            caller="compare_completion",
         )
 
         logger.info(
@@ -925,16 +889,8 @@ def compare_snapshots(
                     extra={"comparison_id": comparison.id},
                 )
 
-        create_preprod_snapshot_status_check_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": head_artifact_id,
-                "caller": "compare_failure",
-            },
-        )
-        create_preprod_snapshot_pr_comment_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": head_artifact_id,
-                "caller": "compare_failure",
-            },
+        update_preprod_snapshot_vcs(
+            preprod_artifact_id=head_artifact_id,
+            caller="compare_failure",
         )
         raise

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -352,6 +352,13 @@ def compare_snapshots(
         },
     )
 
+    create_preprod_snapshot_status_check_task.apply_async(
+        kwargs={
+            "preprod_artifact_id": head_artifact_id,
+            "caller": "compare_start",
+        },
+    )
+
     try:
         head_artifact = PreprodArtifact.objects.select_related("project__organization").get(
             id=head_artifact_id,
@@ -472,6 +479,18 @@ def compare_snapshots(
             comparison.state = PreprodSnapshotComparison.State.FAILED
             comparison.error_code = PreprodSnapshotComparison.ErrorCode.INTERNAL_ERROR
             comparison.save(update_fields=["state", "error_code", "date_updated"])
+            create_preprod_snapshot_status_check_task.apply_async(
+                kwargs={
+                    "preprod_artifact_id": head_artifact_id,
+                    "caller": "compare_failure",
+                },
+            )
+            create_preprod_snapshot_pr_comment_task.apply_async(
+                kwargs={
+                    "preprod_artifact_id": head_artifact_id,
+                    "caller": "compare_failure",
+                },
+            )
             return
 
         diff_threshold = head_manifest.diff_threshold

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -381,6 +381,12 @@ def compare_snapshots(
                 "caller": "compare_failure",
             },
         )
+        create_preprod_snapshot_pr_comment_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": head_artifact_id,
+                "caller": "compare_failure",
+            },
+        )
         return
 
     try:
@@ -395,6 +401,12 @@ def compare_snapshots(
             },
         )
         create_preprod_snapshot_status_check_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": head_artifact_id,
+                "caller": "compare_failure",
+            },
+        )
+        create_preprod_snapshot_pr_comment_task.apply_async(
             kwargs={
                 "preprod_artifact_id": head_artifact_id,
                 "caller": "compare_failure",

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -349,12 +349,6 @@ def compare_snapshots(
         },
     )
 
-    update_preprod_snapshot_vcs(
-        preprod_artifact_id=head_artifact_id,
-        caller="compare_start",
-        update_pr_comment=False,
-    )
-
     try:
         head_artifact = PreprodArtifact.objects.select_related("project__organization").get(
             id=head_artifact_id,
@@ -449,6 +443,12 @@ def compare_snapshots(
             comparison.id,
             extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
         )
+
+    update_preprod_snapshot_vcs(
+        preprod_artifact_id=head_artifact_id,
+        caller="compare_start",
+        update_pr_comment=False,
+    )
 
     try:
         session = get_preprod_session(org_id, project_id)

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -17,7 +17,6 @@ from sentry.preprod.snapshots.constants import MISSING_BASE_GRACE_PERIOD_SECONDS
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.snapshots.utils import build_changes_map
 from sentry.preprod.url_utils import get_preprod_artifact_url
-from sentry.preprod.vcs.pr_comments.snapshot_tasks import create_preprod_snapshot_pr_comment_task
 from sentry.preprod.vcs.status_checks.snapshots.config import (
     ENABLED_DEFAULT,
     ENABLED_OPTION_KEY,
@@ -45,6 +44,7 @@ from sentry.preprod.vcs.status_checks.utils import (
     get_status_check_provider,
     update_posted_status_check,
 )
+from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -328,20 +328,10 @@ def create_preprod_snapshot_status_check_task(
     )
 
     if waiting_for_base:
-        create_preprod_snapshot_status_check_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": preprod_artifact_id,
-                "caller": "missing_base_timeout",
-                "is_timeout_check": True,
-            },
-            countdown=MISSING_BASE_GRACE_PERIOD_SECONDS,
-        )
-        create_preprod_snapshot_pr_comment_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": preprod_artifact_id,
-                "caller": "missing_base_timeout",
-                "is_timeout_check": True,
-            },
+        update_preprod_snapshot_vcs(
+            preprod_artifact_id=preprod_artifact_id,
+            caller="missing_base_timeout",
+            is_timeout_check=True,
             countdown=MISSING_BASE_GRACE_PERIOD_SECONDS,
         )
 

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -444,6 +444,21 @@ def post_snapshot_status_check_task(
     completed_at = datetime.fromisoformat(completed_at_iso) if completed_at_iso else None
     status_enum = StatusCheckStatus(status)
 
+    if status_enum == StatusCheckStatus.IN_PROGRESS:
+        has_terminal_comparison = PreprodSnapshotComparison.objects.filter(
+            head_snapshot_metrics__preprod_artifact_id=preprod_artifact_id,
+            state__in=[
+                PreprodSnapshotComparison.State.SUCCESS,
+                PreprodSnapshotComparison.State.FAILED,
+            ],
+        ).exists()
+        if has_terminal_comparison:
+            logger.info(
+                "preprod.snapshot_status_checks.post.skipped_stale_in_progress",
+                extra={"preprod_artifact_id": preprod_artifact_id},
+            )
+            return
+
     try:
         check_id = provider.create_status_check(
             repo=commit_comparison.head_repo_name,

--- a/src/sentry/preprod/vcs/tasks.py
+++ b/src/sentry/preprod/vcs/tasks.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def update_preprod_snapshot_vcs(
+    *,
+    preprod_artifact_id: int,
+    caller: str | None = None,
+    is_timeout_check: bool = False,
+    update_status_check: bool = True,
+    update_pr_comment: bool = True,
+    countdown: int | None = None,
+) -> None:
+    # Lazy imports to avoid circular dependency: the status-check task module
+    # imports this function, and we import the task back.
+    from sentry.preprod.vcs.pr_comments.snapshot_tasks import (
+        create_preprod_snapshot_pr_comment_task,
+    )
+    from sentry.preprod.vcs.status_checks.snapshots.tasks import (
+        create_preprod_snapshot_status_check_task,
+    )
+
+    task_kwargs: dict[str, Any] = {
+        "preprod_artifact_id": preprod_artifact_id,
+        "caller": caller,
+        "is_timeout_check": is_timeout_check,
+    }
+    apply_kwargs: dict[str, Any] = {}
+    if countdown is not None:
+        apply_kwargs["countdown"] = countdown
+
+    if update_status_check:
+        create_preprod_snapshot_status_check_task.apply_async(kwargs=task_kwargs, **apply_kwargs)
+    if update_pr_comment:
+        create_preprod_snapshot_pr_comment_task.apply_async(kwargs=task_kwargs, **apply_kwargs)

--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -16,15 +16,14 @@ from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.preprod.analytics import PreprodStatusCheckApprovalCreatedEvent
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
-from sentry.preprod.vcs.pr_comments.snapshot_tasks import create_preprod_snapshot_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import (
     APPROVE_SIZE_ACTION_IDENTIFIER,
     create_preprod_status_check_task,
 )
 from sentry.preprod.vcs.status_checks.snapshots.tasks import (
     APPROVE_SNAPSHOT_ACTION_IDENTIFIER,
-    create_preprod_snapshot_status_check_task,
 )
+from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -221,15 +220,9 @@ def handle_preprod_check_run_event(
             caller="github_approve_webhook",
         )
     elif identifier == APPROVE_SNAPSHOT_ACTION_IDENTIFIER:
-        create_preprod_snapshot_status_check_task(
+        update_preprod_snapshot_vcs(
             preprod_artifact_id=artifact.id,
             caller="github_approve_webhook",
-        )
-        create_preprod_snapshot_pr_comment_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": artifact.id,
-                "caller": "github_approve_webhook",
-            },
         )
     else:
         raise ValueError(f"Unknown identifier: {identifier}")

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
@@ -388,6 +388,67 @@ class PostSnapshotStatusCheckTaskTest(TestCase):
         mock_get_provider.return_value = None
         self._call_task()
 
+    @patch(f"{TASK_MODULE}.get_status_check_provider")
+    @patch(f"{TASK_MODULE}.get_status_check_client")
+    def test_skips_stale_in_progress_when_comparison_succeeded(
+        self, mock_get_client, mock_get_provider
+    ):
+        mock_provider = Mock()
+        mock_get_client.return_value = (Mock(), Mock())
+        mock_get_provider.return_value = mock_provider
+
+        head_metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=self.artifact, image_count=10
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project, commit_comparison=self.commit_comparison
+        )
+        base_metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=base_artifact, image_count=10
+        )
+        PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.SUCCESS,
+            images_changed=0,
+            images_unchanged=10,
+        )
+
+        self._call_task(status=StatusCheckStatus.IN_PROGRESS.value)
+
+        mock_provider.create_status_check.assert_not_called()
+
+    @patch(f"{TASK_MODULE}.get_status_check_provider")
+    @patch(f"{TASK_MODULE}.get_status_check_client")
+    def test_allows_in_progress_when_comparison_still_pending(
+        self, mock_get_client, mock_get_provider
+    ):
+        mock_provider = Mock()
+        mock_provider.create_status_check.return_value = "check_456"
+        mock_get_client.return_value = (Mock(), Mock())
+        mock_get_provider.return_value = mock_provider
+
+        head_metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=self.artifact, image_count=10
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project, commit_comparison=self.commit_comparison
+        )
+        base_metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=base_artifact, image_count=10
+        )
+        PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.PROCESSING,
+            images_changed=0,
+            images_unchanged=10,
+        )
+
+        self._call_task(status=StatusCheckStatus.IN_PROGRESS.value)
+
+        mock_provider.create_status_check.assert_called_once()
+
 
 @cell_silo_test
 class CreateSnapshotStatusCheckGracePeriodTest(SnapshotTasksTestBase):

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
@@ -484,12 +484,10 @@ class CreateSnapshotStatusCheckGracePeriodTest(SnapshotTasksTestBase):
     @patch(f"{TASK_MODULE}.post_snapshot_status_check_task")
     @patch(f"{TASK_MODULE}.get_status_check_provider")
     @patch(f"{TASK_MODULE}.get_status_check_client")
-    @patch(f"{TASK_MODULE}.create_preprod_snapshot_pr_comment_task")
-    @patch(f"{TASK_MODULE}.create_preprod_snapshot_status_check_task.apply_async")
+    @patch(f"{TASK_MODULE}.update_preprod_snapshot_vcs")
     def test_missing_base_first_attempt_posts_in_progress(
         self,
-        mock_status_apply_async,
-        mock_pr_comment_task,
+        mock_update_vcs,
         mock_get_client,
         mock_get_provider,
         mock_post_task,
@@ -508,18 +506,12 @@ class CreateSnapshotStatusCheckGracePeriodTest(SnapshotTasksTestBase):
         call_kwargs = mock_post_task.delay.call_args[1]
         assert call_kwargs["status"] == StatusCheckStatus.IN_PROGRESS.value
 
-        mock_status_apply_async.assert_called_once()
-        status_kwargs = mock_status_apply_async.call_args[1]
-        assert status_kwargs["kwargs"]["is_timeout_check"] is True
-        assert status_kwargs["kwargs"]["preprod_artifact_id"] == artifact.id
-        assert status_kwargs["countdown"] == 600
-
-        mock_pr_comment_task.apply_async.assert_called_once()
-        pr_kwargs = mock_pr_comment_task.apply_async.call_args[1]
-        assert pr_kwargs["kwargs"]["is_timeout_check"] is True
-        assert pr_kwargs["kwargs"]["preprod_artifact_id"] == artifact.id
-        assert pr_kwargs["kwargs"]["caller"] == "missing_base_timeout"
-        assert pr_kwargs["countdown"] == 600
+        mock_update_vcs.assert_called_once_with(
+            preprod_artifact_id=artifact.id,
+            caller="missing_base_timeout",
+            is_timeout_check=True,
+            countdown=600,
+        )
 
     @patch(f"{TASK_MODULE}.post_snapshot_status_check_task")
     @patch(f"{TASK_MODULE}.get_status_check_provider")


### PR DESCRIPTION
## Summary

Fixes a race condition where a snapshot GitHub status check gets permanently stuck at "Processing."

**Root cause:** When a snapshot is uploaded and a base exists, two independent paths fire status check posts:
1. The **upload endpoint** enqueues `create_preprod_snapshot_status_check_task` (computes IN_PROGRESS)
2. The **upload endpoint** also enqueues `compare_snapshots`, which on completion enqueues another status check post (computes SUCCESS/FAILURE)

Since `post_snapshot_status_check_task` always creates a **new** GitHub check run (POST, not PATCH), Celery task ordering determines which one GitHub shows last. If the IN_PROGRESS post lands after the COMPLETED post, the check reverts to "Processing" permanently.

### Changes

**1. Structural fix — consolidate status check ownership** (`preprod_artifact_snapshot.py`)

When a comparison is starting, the upload endpoint no longer fires its own status check. Instead, `compare_snapshots` owns the full lifecycle: it posts IN_PROGRESS at the start and SUCCESS/FAILURE on completion. The upload endpoint only posts a status check when no comparison will happen (no base artifact, first upload, etc.).

**2. Handle early failures in `compare_snapshots`** (`snapshots/tasks.py`)

- Post the IN_PROGRESS status check at the very top of `compare_snapshots`, before any DB lookups, so even if artifact/metrics lookup fails the check is posted.
- Add status check + PR comment posts to the manifest parse error handler (`JSONDecodeError`, `RequestError`, `ValidationError`, `TypeError`), which previously returned silently leaving the check stuck.

**3. Staleness guard as safety net** (`status_checks/snapshots/tasks.py`)

Belt-and-suspenders: before `post_snapshot_status_check_task` posts an IN_PROGRESS status, it re-queries the DB to check if the artifact's comparison has already reached a terminal state (SUCCESS or FAILED). If so, the post is skipped — the comparison result is authoritative.

## Test plan

- [x] `test_skips_stale_in_progress_when_comparison_succeeded` — verifies guard skips posting when a completed comparison exists
- [x] `test_allows_in_progress_when_comparison_still_pending` — verifies legitimate IN_PROGRESS posts still go through
- [x] All existing tests pass (32 total in test file)