### PR TITLE
fix(auth): Verify primary email on password reset

### DIFF
--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -247,12 +247,7 @@ def recover_confirm(
                     organization_id=membership.organization_id
                 )
 
-                # These service calls need to be outside of the transaction block. Claiming an
-                # account constitutes an email verifying action. We'll verify the primary email
-                # associated with this account in particular, since that is the only one the user
-                # claiming email could have been sent to.
                 rpc_user = user_service.get_user(user_id=user.id)
-                user_service.verify_user_email(email=user.email, user_id=user.id)
                 orgs = organization_service.get_organizations_by_user_and_scope(
                     cell_name=mapping.cell_name, user=rpc_user
                 )
@@ -263,6 +258,10 @@ def recover_confirm(
                         ip_address=request.META["REMOTE_ADDR"],
                         sender=recover_confirm,
                     )
+
+            # Completing a password reset proves the user controls the email
+            # the reset link was sent to, so verify it.
+            user_service.verify_user_email(email=user.email, user_id=user.id)
 
             with transaction.atomic(router.db_for_write(User)):
                 if mode == "relocate":

--- a/tests/sentry/users/web/test_accounts.py
+++ b/tests/sentry/users/web/test_accounts.py
@@ -104,6 +104,23 @@ class TestAccounts(TestCase):
         assert resp.has_header(header_name)
         assert resp[header_name] == "strict-origin-when-cross-origin"
 
+    def test_recover_verifies_primary_email(self) -> None:
+        user = self.create_user()
+        user_email = UserEmail.objects.get(email=user.email)
+        user_email.is_verified = False
+        user_email.save()
+
+        lost_password = LostPasswordHash.objects.create(user=user)
+
+        resp = self.client.post(
+            self.password_recover_path(lost_password.user_id, lost_password.hash),
+            {"password": "test_password"},
+        )
+        assert resp.status_code == 302
+
+        user_email.refresh_from_db()
+        assert user_email.is_verified
+
     @override_settings(
         AUTH_PASSWORD_VALIDATORS=[
             {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"}


### PR DESCRIPTION
Completing a password reset proves the user controls the inbox the reset link was sent to. Move the verify_user_email call out of the relocate-only block so it runs for all recovery modes, matching the reasoning already documented for the relocation flow.

I've confirmed that the one potential exploit is not actually exploitable (user changes their primary email to another email before password reset completes, which verifies that other email instead of the one they sent). However, you can't promote an unverified email to primary, so we're safe.