### PR TITLE
ref(preprod): Remove deprecated comparison_run_info and approval_info from snapshot detail API

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -33,9 +33,7 @@ from sentry.preprod.api.models.project_preprod_build_details_models import (
     BuildDetailsVcsInfo,
 )
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
-    SnapshotApprovalInfo,
     SnapshotApprover,
-    SnapshotComparisonRunInfo,
     SnapshotDetailsApiResponse,
     SnapshotImageResponse,
 )
@@ -359,7 +357,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         }
 
         base_artifact_id: str | None = None
-        comparison_state: str | None = None
 
         if comparison_manifest is not None:
             base_artifact_id = str(comparison_manifest.base_artifact_id)
@@ -383,9 +380,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 ),
                 None,
             )
-            if pending_or_failed_state is not None:
-                comparison_state = PreprodSnapshotComparison.State(pending_or_failed_state).name
-
         if comparison_manifest is not None:
             comparison_type = "diff"
         elif commit_comparison and commit_comparison.base_sha and pending_or_failed_state is None:
@@ -393,18 +387,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         else:
             comparison_type = "solo"
 
-        run_info: SnapshotComparisonRunInfo | None = None
-        if comparison_state is not None:
-            run_info = SnapshotComparisonRunInfo(state=comparison_state)
-        elif comparison is not None:
-            duration = comparison.date_updated - comparison.date_added
-            run_info = SnapshotComparisonRunInfo(
-                state=PreprodSnapshotComparison.State(comparison.state).name,
-                completed_at=comparison.date_updated.isoformat(),
-                duration_ms=int(duration.total_seconds() * 1000),
-            )
-
-        approval_info: SnapshotApprovalInfo | None = None
         all_approvals = list(
             PreprodComparisonApproval.objects.filter(
                 preprod_artifact=artifact,
@@ -464,19 +446,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                             source="github",
                         )
                     )
-            is_auto_approved = any((a.extras or {}).get("auto_approval") is True for a in approved)
-            approval_info = SnapshotApprovalInfo(
-                status="approved",
-                approvers=approver_list,
-                is_auto_approved=is_auto_approved,
-            )
-        elif all_approvals:
-            # If records exist but none are APPROVED, they must be NEEDS_APPROVAL
-            approval_info = SnapshotApprovalInfo(
-                status="requires_approval",
-                approvers=[],
-            )
-
         sorted_approvals = sorted(all_approvals, key=lambda a: a.id, reverse=True)
         derived_status = derive_snapshot_status(
             SnapshotStatusInput(
@@ -512,8 +481,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             errored_count=len(categorized.errored),
             skipped=categorized.skipped,
             skipped_count=len(categorized.skipped),
-            comparison_run_info=run_info,
-            approval_info=approval_info,
             diff_threshold=manifest.diff_threshold,
             comparison_state=derived_status.comparison_state,
             approval_status=derived_status.approval_status,

--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -73,12 +73,6 @@ class SnapshotImageDetailResponse(BaseModel):
     previous_image_file_name: str | None = None
 
 
-class SnapshotComparisonRunInfo(BaseModel):
-    state: str | None = None
-    completed_at: str | None = None
-    duration_ms: int | None = None
-
-
 class SnapshotApprover(BaseModel):
     id: str | None = None
     name: str | None = None
@@ -87,12 +81,6 @@ class SnapshotApprover(BaseModel):
     avatar_url: str | None = None
     approved_at: str | None = None
     source: Literal["sentry", "github"] = "sentry"
-
-
-class SnapshotApprovalInfo(BaseModel):
-    status: Literal["approved", "requires_approval"]
-    approvers: list[SnapshotApprover] = []
-    is_auto_approved: bool = False
 
 
 class SnapshotDetailsApiResponse(BaseModel):
@@ -129,10 +117,6 @@ class SnapshotDetailsApiResponse(BaseModel):
 
     skipped: list[SnapshotImageResponse] = []
     skipped_count: int = 0
-
-    comparison_run_info: SnapshotComparisonRunInfo | None = None
-
-    approval_info: SnapshotApprovalInfo | None = None
 
     diff_threshold: float | None = None
 

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -667,8 +667,6 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.data["approval_status"] == "approved"
         assert len(response.data["approvers"]) == 1
         assert response.data["approvers"][0]["source"] == "sentry"
-        assert response.data["approval_info"] is not None
-        assert response.data["approval_info"]["status"] == "approved"
 
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
     def test_get_snapshot_flat_fields_auto_approved(self, mock_get_session):


### PR DESCRIPTION
The flat fields (`comparison_state`, `approval_status`, `comparison_error_message`, `approvers`) added in #115604 fully replace the nested `comparison_run_info` and `approval_info` objects. The frontend migrated to the flat fields in #115633. This removes the dead nested fields and the code that built them.

**Removed from the API response**

`SnapshotComparisonRunInfo` (state, completed_at, duration_ms) and `SnapshotApprovalInfo` (status, approvers, is_auto_approved) Pydantic classes are deleted along with their fields on `SnapshotDetailsApiResponse`. The endpoint code that assembled these objects is removed. The approver-building loop and `derive_snapshot_status()` call are kept — they feed the flat `approvers` and status fields.

`comparison_type` is intentionally kept — the frontend still uses it for the diff view toggle and analytics.

Refs EME-1149