### PR TITLE
ref(preprod): Remove deprecated snapshot detail TS types and update debug modal

### DIFF
--- a/static/app/views/preprod/snapshots/header/buildDebugInfoModal.tsx
+++ b/static/app/views/preprod/snapshots/header/buildDebugInfoModal.tsx
@@ -13,7 +13,7 @@ import type {SnapshotDetailsApiResponse} from 'sentry/views/preprod/types/snapsh
 const VISIBLE_FIELDS: Array<keyof SnapshotDetailsApiResponse> = [
   'app_id',
   'base_artifact_id',
-  'comparison_run_info',
+  'comparison_state',
   'comparison_type',
   'diff_threshold',
   'head_artifact_id',

--- a/static/app/views/preprod/snapshots/header/buildDebugInfoModal.tsx
+++ b/static/app/views/preprod/snapshots/header/buildDebugInfoModal.tsx
@@ -14,7 +14,6 @@ const VISIBLE_FIELDS: Array<keyof SnapshotDetailsApiResponse> = [
   'app_id',
   'base_artifact_id',
   'comparison_state',
-  'comparison_type',
   'diff_threshold',
   'head_artifact_id',
   'project_id',

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -21,12 +21,6 @@ export interface SnapshotDiffPair {
   head_image: SnapshotImage;
 }
 
-interface SnapshotComparisonRunInfo {
-  completed_at?: string;
-  duration_ms?: number;
-  state?: SnapshotComparisonState;
-}
-
 interface SnapshotApprover {
   source: 'sentry' | 'github';
   approved_at?: string | null;
@@ -35,12 +29,6 @@ interface SnapshotApprover {
   id?: string | null;
   name?: string | null;
   username?: string | null;
-}
-
-interface SnapshotApprovalInfo {
-  approvers: SnapshotApprover[];
-  status: 'approved' | 'requires_approval';
-  is_auto_approved?: boolean;
 }
 
 export interface SnapshotDetailsApiResponse {
@@ -53,10 +41,6 @@ export interface SnapshotDetailsApiResponse {
   vcs_info: BuildDetailsVcsInfo;
 
   app_id?: string | null;
-
-  comparison_run_info?: SnapshotComparisonRunInfo | null;
-
-  approval_info?: SnapshotApprovalInfo | null;
 
   comparison_state?: SnapshotComparisonState | null;
   approval_status?: SnapshotApprovalStatus | null;


### PR DESCRIPTION
Remove the `SnapshotComparisonRunInfo` and `SnapshotApprovalInfo` TypeScript interfaces and their fields from `SnapshotDetailsApiResponse`, matching the backend removal in #115652. The debug modal now shows `comparison_state` instead of `comparison_run_info`.

Depends on #115652.

Refs EME-1145