### PR TITLE
feat(autofix): Add UI labels for missing AutofixReferrer values

### DIFF
--- a/static/app/components/events/autofix/autofixReferrer.tsx
+++ b/static/app/components/events/autofix/autofixReferrer.tsx
@@ -33,6 +33,11 @@ const REFERRER_CONFIG: ReferrerConfig[] = [
     pattern: /^autofix\.on_completion_hook$/,
     tooltip: t('Triggered from completion hook'),
   },
+  {pattern: /^night_shift$/, tooltip: t('Triggered by agentic triage')},
+  {pattern: /^api\.cli$/, tooltip: t('Triggered by the Sentry CLI')},
+  {pattern: /^api\.linear_agent$/, tooltip: t('Triggered from Linear')},
+  {pattern: /^api\.mcp$/, tooltip: t('Triggered by the Sentry MCP')},
+  {pattern: /^api\.web$/, tooltip: t('Manually triggered')},
   FALLBACK_CONFIG,
 ];
 


### PR DESCRIPTION
Add tooltip configs in `autofixReferrer.tsx` for the `AutofixReferrer` enum values that did not have a UI label yet: `night_shift`, `api.cli`, `api.linear_agent`, `api.mcp`, and `api.web`. The Seer drawer header now shows a human-readable description for runs triggered from these sources instead of falling through to the raw referrer string.

Agent transcript: https://claudescope.sentry.dev/share/3iB5_-OLKXWVTb1atSKi3crQwCae4rjBkOZRxFYN_EE