### PR TITLE
fix(preprod): Restore extra field passthrough in snapshot image responses

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -53,6 +53,7 @@ from sentry.preprod.snapshots.manifest import (
     ComparisonManifest,
     ImageMetadata,
     SnapshotManifest,
+    image_metadata_extras,
 )
 from sentry.preprod.snapshots.models import (
     PreprodSnapshotComparison,
@@ -120,6 +121,7 @@ def build_snapshot_image_response(
     global_diff_threshold: float | None,
 ) -> SnapshotImageResponse:
     return SnapshotImageResponse(
+        **image_metadata_extras(metadata, exclude={"key", "image_file_name"}),
         key=metadata.content_hash,
         display_name=metadata.display_name,
         image_file_name=image_file_name,

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
@@ -28,6 +28,7 @@ from sentry.preprod.snapshots.manifest import (
     ComparisonManifest,
     ImageMetadata,
     SnapshotManifest,
+    image_metadata_extras,
 )
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 
@@ -63,10 +64,9 @@ def _build_image_info(
     org_slug: str,
     project_slug: str,
 ) -> SnapshotImageDetailImageInfo:
-    known_fields = set(ImageMetadata.__fields__.keys()) | set(
-        SnapshotImageDetailImageInfo.__fields__.keys()
+    extra_fields = image_metadata_extras(
+        metadata, exclude=frozenset(SnapshotImageDetailImageInfo.__fields__)
     )
-    extra_fields = {k: v for k, v in metadata.dict().items() if k not in known_fields}
     return SnapshotImageDetailImageInfo(
         content_hash=metadata.content_hash,
         display_name=metadata.display_name,

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -11,6 +11,7 @@ from sentry.preprod.snapshots.manifest import (
     ComparisonManifest,
     ImageMetadata,
     SnapshotManifest,
+    image_metadata_extras,
 )
 
 
@@ -40,6 +41,7 @@ def _build_base_images(
     result: dict[str, SnapshotImageResponse] = {}
     for key, meta in base_images.items():
         result[key] = SnapshotImageResponse(
+            **image_metadata_extras(meta, exclude={"key", "image_file_name"}),
             key=meta.content_hash,
             display_name=meta.display_name,
             image_file_name=key,

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Set
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, validator
@@ -39,6 +40,16 @@ class ImageMetadata(BaseModel):
                         {"type": "null"},
                     ]
                 }
+
+
+_SCHEMA_FIELDS = frozenset(ImageMetadata.__fields__)
+
+
+def image_metadata_extras(
+    metadata: ImageMetadata, exclude: Set[str] | None = None
+) -> dict[str, Any]:
+    skip = _SCHEMA_FIELDS | exclude if exclude else _SCHEMA_FIELDS
+    return {k: v for k, v in metadata.dict().items() if k not in skip}
 
 
 class SnapshotManifest(BaseModel):


### PR DESCRIPTION
Commit 5bfbd25 (`ref(preprod): Remove redundant content_hash and fix extra field leakage`) replaced the `**metadata.dict()` spread with explicit field assignment in `build_snapshot_image_response` and `_build_base_images`. This correctly removed unwanted leakage of declared fields like `content_hash`, but also dropped legitimate user-supplied extras (e.g. `context`) that were being forwarded via Pydantic's `extra="allow"` on both `ImageMetadata` and `SnapshotImageResponse`.

Adds an `image_metadata_extras()` helper in `manifest.py` that extracts only the dynamically-added extra fields from an `ImageMetadata` instance — fields that aren't part of the declared schema but were stored via `extra="allow"`. Both `build_snapshot_image_response` (detail endpoint) and `_build_base_images` (comparison categorizer) now spread these extras into `SnapshotImageResponse`, restoring the passthrough behavior for fields like `context` while keeping the explicit assignment for all declared fields.