### PR TITLE
chore(source-map-processing-errors): Emitting metric irrespective of …

### DIFF
--- a/src/sentry/processing_errors/detection.py
+++ b/src/sentry/processing_errors/detection.py
@@ -145,9 +145,6 @@ def _detect_for_config(
     errors: Sequence[Mapping[str, Any]],
     config: DetectorConfig,
 ) -> None:
-    if config.feature_flag and not features.has(config.feature_flag, event.project.organization):
-        return
-
     if not any(e.get("type") in config.handler_cls.error_types for e in errors):
         return
 
@@ -166,6 +163,9 @@ def _detect_for_config(
             "project_age_bucket": _project_age_bucket(event.project),
         },
     )
+
+    if config.feature_flag and not features.has(config.feature_flag, event.project.organization):
+        return
 
     project_id = event.project.id
 


### PR DESCRIPTION
Move the `processing_errors.sourcemap_configuration.event_with_errors` metric emission above the `organizations:sourcemap-issue-detection` feature flag gate in `_detect_for_config`, so it fires for **every** org that ingests a JS event with a sourcemap processing error — not just internal Sentry orgs

The detector flow itself (`ensure_detector`, `process_detectors`, `DetectorState` writes, `IssueOccurrence` creation, refresh task updates) is still gated on the feature flag exactly as before, so no hidden issues get created for non‑enrolled orgs.