### PR TITLE
test(dashboards): wrap DataWidgetViewerModal test render with WidgetQueryQueueProvider

### DIFF
--- a/static/app/components/modals/dataWidgetViewerModal.spec.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.spec.tsx
@@ -23,6 +23,7 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {DashboardFilters, Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {performanceScoreTooltip} from 'sentry/views/dashboards/utils';
+import {WidgetQueryQueueProvider} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
 
 jest.mock('echarts-for-react/lib/core', () => {
@@ -83,18 +84,20 @@ async function renderModal({
     navigate: jest.fn(),
   });
   const rendered = render(
-    <DataWidgetViewerModal
-      Header={stubEl}
-      Footer={stubEl as ModalRenderProps['Footer']}
-      Body={stubEl as ModalRenderProps['Body']}
-      CloseButton={stubEl}
-      closeModal={() => {}}
-      organization={organization}
-      widget={widget}
-      onEdit={() => {}}
-      dashboardFilters={dashboardFilters}
-      widgetLegendState={widgetLegendState}
-    />,
+    <WidgetQueryQueueProvider>
+      <DataWidgetViewerModal
+        Header={stubEl}
+        Footer={stubEl as ModalRenderProps['Footer']}
+        Body={stubEl as ModalRenderProps['Body']}
+        CloseButton={stubEl}
+        closeModal={() => {}}
+        organization={organization}
+        widget={widget}
+        onEdit={() => {}}
+        dashboardFilters={dashboardFilters}
+        widgetLegendState={widgetLegendState}
+      />
+    </WidgetQueryQueueProvider>,
     {
       organization,
       initialRouterConfig: routerConfig,


### PR DESCRIPTION
## Summary

Diagnosed 4 high-actionability Sentry Jest issues (runtime: node v24.14.0) from the `jest` project:

| Issue | File | Root cause |
|-------|------|-----------|
| JEST-22BR / JEST-22BQ / JEST-22C9 / JEST-22BS | `dataWidgetViewerModal.spec.tsx` | Missing `WidgetQueryQueueProvider` around `DataWidgetViewerModal` in test render |
| JEST-22CF | `mobileVitals.ts` | Typographic apostrophe syntax error — already clean on `main` |
| JEST-22D1 / JEST-22D0 | `metricPanel/index.spec.tsx` | `useAiQueryContext` needs `AiQueryProvider` — feature hook not yet in `main` |
| JEST-22CS | `logsToolbar.spec.tsx` | nuqs array serialisation mismatch — lives on feature branch only |

**This PR fixes JEST-22BR and its duplicates.**

The `DataWidgetViewerModal` renders a full widget query chain:
`WidgetQueriesWithOnDemandControl` → `useGenericWidgetQueries` → `useSpansWidgetQuery` → `useWidgetQueryQueue`

In production the modal is always launched from inside the dashboard component tree, which already provides `WidgetQueryQueueProvider` (see `detail.tsx`). The test previously rendered the modal in isolation without this provider. When `useWidgetQueryQueue` is changed to require the provider (rather than silently returning `{queue: undefined}`), all four related tests break.

The fix mirrors the production context in the test, consistent with the pattern already used in `widgetQueries.spec.tsx`.

## Test plan

- [ ] Existing `dataWidgetViewerModal.spec.tsx` tests continue to pass
- [ ] No new provider nesting issues — `WidgetQueryQueueProvider` is a pure React context provider with no side effects when nested

https://claude.ai/code/session_01RNPVZzqpnSrc7y6WNBsKcn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNPVZzqpnSrc7y6WNBsKcn)_