### PR TITLE
test(seer): pin handoff regression when stopping_point=root_cause

### DIFF
--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -17,7 +17,7 @@ from sentry.seer.autofix.on_completion_hook import (
     STOPPING_POINT_TO_STEP,
     AutofixOnCompletionHook,
 )
-from sentry.seer.autofix.utils import AutofixStoppingPoint
+from sentry.seer.autofix.utils import AutofixStoppingPoint, read_preference_from_sentry_db
 from sentry.seer.models import AutofixHandoffPoint, SeerAutomationHandoffConfiguration
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
@@ -568,6 +568,73 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
         assert call_kwargs["run_id"] == 123
         assert call_kwargs["integration_id"] == 123
         assert call_kwargs["referrer"] == AutofixReferrer.NIGHT_SHIFT
+
+
+class TestHandoffRegressionRootCauseStoppingPoint(TestCase):
+    """Regression: new-autofix path drops handoff when stopping_point=root_cause.
+
+    Legacy seer-side gate (seer/automation/autofix/steps/root_cause_step.py
+    _check_and_trigger_coding_agent_handoff) fires handoff whenever
+    automation_handoff is configured with handoff_point=ROOT_CAUSE — it does not
+    look at the run's stopping_point. The new sentry-side gate
+    (on_completion_hook._get_handoff_config_if_applicable) returns None when
+    stopping_point is ROOT_CAUSE, silently skipping the case "let seer find the
+    root cause, then hand off to an external coding agent to do the fix" —
+    which is a coherent, expected configuration.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        self.group = self.create_group(project=self.project)
+
+        # Customer-impacting config: stop seer at root cause, then external
+        # coding agent takes over.
+        self.project.update_option(
+            "sentry:seer_automated_run_stopping_point",
+            AutofixStoppingPoint.ROOT_CAUSE.value,
+        )
+        self.project.update_option(
+            "sentry:seer_automation_handoff_point", AutofixHandoffPoint.ROOT_CAUSE.value
+        )
+        self.project.update_option(
+            "sentry:seer_automation_handoff_target", "cursor_background_agent"
+        )
+        self.project.update_option("sentry:seer_automation_handoff_integration_id", 123)
+        self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
+
+    def test_legacy_gate_fires_handoff(self) -> None:
+        # The legacy seer-side gate's full check, reproduced from
+        # seer/automation/autofix/steps/root_cause_step.py:184. It reads the
+        # same preference that the new path reads, then trusts
+        # handoff_point alone. No stopping_point check.
+        preference = read_preference_from_sentry_db(self.project)
+        handoff_config = preference.automation_handoff
+        auto_run_source = True  # automation-triggered run
+
+        would_handoff = (
+            auto_run_source
+            and handoff_config is not None
+            and handoff_config.handoff_point == AutofixHandoffPoint.ROOT_CAUSE
+        )
+
+        assert would_handoff is True
+        assert handoff_config is not None
+        assert handoff_config.target == "cursor_background_agent"
+
+    def test_new_gate_silently_skips_handoff(self) -> None:
+        # Same config, same group, run completed root_cause step. The new gate
+        # returns None because stopping_point == ROOT_CAUSE — even though
+        # handoff_point is ROOT_CAUSE and a target is configured. After the
+        # fix, this assertion should flip to assert a non-None config.
+        result = AutofixOnCompletionHook._get_handoff_config_if_applicable(
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
+            current_step=AutofixStep.ROOT_CAUSE,
+            group=self.group,
+        )
+
+        assert result is None
 
 
 class AutofixOnCompletionHookTest(TestCase):


### PR DESCRIPTION
## Summary

Adds a paired test class `TestHandoffRegressionRootCauseStoppingPoint` in `tests/sentry/seer/autofix/test_autofix_on_completion_hook.py` that pins the behavioral difference between the legacy seer-side gate and the new sentry-side `_get_handoff_config_if_applicable` for the configuration `automation_handoff.handoff_point=root_cause + automated_run_stopping_point=root_cause + automation_handoff configured`.

This combination — "let seer find the root cause, then hand off to an external coding agent to do the fix" — is a coherent customer configuration. The legacy path supports it; the new path silently drops it.

## Legacy path trace (verified end-to-end in `~/code/seer`)

1. **`run_autofix_root_cause`** (`seer/automation/autofix/tasks.py:278-326`) queues `RootCauseStep` unconditionally. `stopping_point` only changes the task's time limits, not whether the step runs.
2. **`RootCauseStep._invoke`** (`seer/automation/autofix/steps/root_cause_step.py:85-182`) runs root cause analysis, then at line 165 calls `_check_and_trigger_coding_agent_handoff` **before** `_should_auto_run_solution_step` (the only place that gates on `stopping_point`).
3. **`_check_and_trigger_coding_agent_handoff`** (lines 184-229) has exactly three gates:
   - `state.request.options.auto_run_source` (line 190)
   - `preference.automation_handoff` is not None (lines 193-199)
   - `handoff_config.handoff_point == AutofixHandoffPoint.ROOT_CAUSE` (lines 201-203)

   No reference to `stopping_point` anywhere in the function. None.

A full grep of `stopping_point` usage across the legacy autofix tree confirms it gates: time limits (`tasks.py:147`), PR creation (`change_describer_step.py:213`), and the *next step after root cause / solution* (`root_cause_step.py:234,245`, `solution_step.py:166,181`). None of these touch the handoff decision.

## Behavioral contrast

| Path | Behavior with the same configured preference |
|---|---|
| Legacy seer | Root cause runs → handoff check fires → solution never reached. **Handoff fires.** |
| New sentry | Hook reaches `_get_handoff_config_if_applicable`, sees `stopping_point=root_cause`, returns `None`. **Handoff dropped.** |

## What the tests do

- **`test_legacy_gate_fires_handoff`** reproduces the legacy seer-side gate's logic against the same `automation_handoff` preference (read through `read_preference_from_sentry_db`). Asserts the legacy gate would have fired a handoff.
- **`test_new_gate_silently_skips_handoff`** calls the production `AutofixOnCompletionHook._get_handoff_config_if_applicable(stopping_point=ROOT_CAUSE, current_step=ROOT_CAUSE, group=...)` and asserts it returns `None`.

## Follow-up

This PR is a draft so the regression is reviewable as a concrete behavioral assertion before the fix is sent. The fix will drop the `stopping_point` filter from `_get_handoff_config_if_applicable`, at which point Case 2 will flip to assert a non-None config and the pre-existing `test_get_handoff_config_returns_none_when_stopping_at_root_cause` test (which currently pins the regressed behavior) will be removed.

## Test plan

- [x] `pytest tests/sentry/seer/autofix/test_autofix_on_completion_hook.py::TestHandoffRegressionRootCauseStoppingPoint` — both cases pass and demonstrate the contrast.
- [x] `prek` clean on the modified file.