### PR TITLE
feat(webhooks): Register legacy webhook migration feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -151,6 +151,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:invite-members", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable rate limits for inviting members.
     manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
+    manager.add("organizations:legacy-webhook-disable-old-path", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:legacy-webhook-dry-run", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:legacy-webhook-new-path", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable flamegraph visualization for MetricKit hang diagnostic stack traces
     manager.add("organizations:metrickit-flamegraph", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables higher limit for alert rules


### PR DESCRIPTION
See below for how each of the feature flags will be used
<h3>Feature flags (3 flags for phased rollout)</h3>

Flag | Purpose
-- | --
organizations:legacy-webhook-new-path | Enables the new code path to execute (either dry-run or live)
organizations:legacy-webhook-dry-run | When new path is enabled, only log header + payload (don't send)
organizations:legacy-webhook-disable-old-path | Stops the old plugin path from firing

<p><strong>Routing truth table:</strong></p>

new-path | dry-run | disable-old | Result
-- | -- | -- | --
OFF | * | OFF | Old path only (default, no change)
ON | ON | OFF | Old path sends + new path logs only (shadow validation)
ON | OFF | OFF | Both paths send (dual-write for HTTP delivery validation)
ON | OFF | ON | New path only (cutover)
OFF | * | ON | Guard: old path still fires (prevents accidental silence)
