### PR TITLE
ref(flags): Remove organizations:dashboards-import

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -144,6 +144,8 @@ def register_permanent_features(manager: FeatureManager) -> None:
 
     # Permanent organization features that are controlled via flagpole
     permanent_flagpole_organization_features: dict[str, FlagpoleFeature] = {
+        # Enables import/export functionality for dashboards
+        "organizations:dashboards-import": FlagpoleFeature(default=False, api_expose=True),
         # Enable various explore related dev features, may be used by internal branches for testing.
         "organizations:explore-dev-features": FlagpoleFeature(default=False, api_expose=True),
         # Enable ingestion through trusted relays only

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -68,8 +68,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-edit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
     # Enable unfurling of dashboard widgets in Slack
     manager.add("organizations:dashboards-widget-unfurl", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enables import/export functionality for dashboards
-    manager.add("organizations:dashboards-import", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable metrics enhanced performance for AM2+ customers as they transition from AM2 to AM3
     manager.add("organizations:dashboards-metrics-transition", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable drilldown flow for dashboards


### PR DESCRIPTION
Dev-only flag registered Mar 2024, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.