### PR TITLE
ref(flags): Remove organizations:init-sentry-toolbar

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -339,8 +339,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:session-replay-recording-scrubbing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable core Session Replay link in the sidebar
     manager.add("organizations:session-replay-ui", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
-    # Enable the rendering of @sentry/toolbar inside the sentry app. See `useInitSentryToolbar()`
-    manager.add("organizations:init-sentry-toolbar", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
+
     # Enable new stack trace component for issue details
     manager.add("organizations:issue-details-new-stack-trace", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable double-reading from EAP for issue feed search queries

--- a/static/app/utils/useInitSentryToolbar.tsx
+++ b/static/app/utils/useInitSentryToolbar.tsx
@@ -9,13 +9,11 @@ import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 
 export function useInitSentryToolbar(organization: null | Organization) {
   const isEnvEnabled = !!process.env.ENABLE_SENTRY_TOOLBAR;
-  const showDevToolbar =
-    !!organization && !!organization.features.includes('init-sentry-toolbar');
   const isEmployee = useIsSentryEmployee();
   const config = useLegacyStore(ConfigStore);
 
   useSentryToolbar({
-    enabled: showDevToolbar && isEmployee && isEnvEnabled,
+    enabled: !!organization && isEmployee && isEnvEnabled,
     version: '1.0.0-beta.23',
     initProps: {
       organizationSlug: organization?.slug ?? 'sentry',


### PR DESCRIPTION
Dev-only flag registered Jun 2024, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.