### PR TITLE
ref(flags): Remove organizations:ourlogs-stats, replace with `organizations:explore-dev-features` and move it to a permanent flag

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -144,6 +144,8 @@ def register_permanent_features(manager: FeatureManager) -> None:
 
     # Permanent organization features that are controlled via flagpole
     permanent_flagpole_organization_features: dict[str, FlagpoleFeature] = {
+        # Enable various explore related dev features, may be used by internal branches for testing.
+        "organizations:explore-dev-features": FlagpoleFeature(default=False, api_expose=True),
         # Enable ingestion through trusted relays only
         "organizations:ingest-through-trusted-relays-only": FlagpoleFeature(
             default=False, api_expose=True

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -425,16 +425,12 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.
     manager.add("organizations:ourlogs-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable our logs stats to be displayed in the UI.
-    manager.add("organizations:ourlogs-stats", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the export modal (rather than direct button click) in the logs UI
     manager.add("organizations:ourlogs-modal-export", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable pinning logs to the top of the table in the logs UI and query parameters
     manager.add("organizations:ourlogs-pinning", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable removing the schema hints section to declutter the logs UI
     manager.add("organizations:ourlogs-schema-hints-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable various explore related dev features, may be used by internal branches for testing.
-    manager.add("organizations:explore-dev-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable alerting on trace metrics
     manager.add("organizations:tracemetrics-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics product (known internally as tracemetrics) in UI and backend

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -277,7 +277,7 @@ export class OrganizationStatsInner extends Component<OrganizationStatsProps> {
         return organization.features.includes('ourlogs-enabled');
       }
       if ([DataCategory.LOG_ITEM].includes(opt.value)) {
-        return organization.features.includes('ourlogs-stats');
+        return organization.features.includes('explore-dev-features');
       }
       if ([DataCategory.TRACE_METRICS].includes(opt.value)) {
         return canUseMetricsStatsUI(organization);


### PR DESCRIPTION
Dev-only flag registered Apr 2025, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.

Keep the path and migrate over to `organizations:explore-dev-features`