### PR TITLE
ref(flags): Remove organizations:performance-mep-reintroduce-histograms

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -194,9 +194,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-discover-get-custom-measurements-reduced-range", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Detect performance issues in the new standalone spans pipeline instead of on transactions
     manager.add("organizations:performance-issues-spans", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
-    # Re-enable histograms for Metrics Enhanced Performance Views
-    manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-
     # Enable AI and MCP module dashboards on dashboards platform
     manager.add("organizations:insights-ai-and-mcp-dashboard-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable all registered prebuilt dashboards to be synced to the database

--- a/static/app/views/performance/landing/widgets/utils.tsx
+++ b/static/app/views/performance/landing/widgets/utils.tsx
@@ -144,7 +144,6 @@ export function filterAllowedChartsMetrics(
 ) {
   if (
     !canUseMetricsData(organization) ||
-    organization.features.includes('performance-mep-reintroduce-histograms') ||
     mepSetting.metricSettingState === MEPState.TRANSACTIONS_ONLY
   ) {
     return allowedCharts;


### PR DESCRIPTION
Dev-only flag registered Oct 2022, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.