### PR TITLE
ref(flags): Remove organizations:update-action-status

### DIFF
--- a/src/sentry/deletions/defaults/organizationintegration.py
+++ b/src/sentry/deletions/defaults/organizationintegration.py
@@ -1,11 +1,8 @@
-from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.repository import repository_service
-from sentry.organizations.services.organization import organization_service
 from sentry.types.cell import CellMappingNotFound
-from sentry.workflow_engine.service.action import action_service
 
 
 class OrganizationIntegrationDeletionTask(ModelDeletionTask[OrganizationIntegration]):
@@ -30,16 +27,6 @@ class OrganizationIntegrationDeletionTask(ModelDeletionTask[OrganizationIntegrat
                 organization_integration_id=instance.id,
                 integration_id=instance.integration_id,
             )
-
-            organization = organization_service.get(id=instance.organization_id)
-
-            if organization and features.has("organizations:update-action-status", organization):
-                # Disable all actions for the organization integration
-                action_service.update_action_status_for_organization_integration(
-                    organization_id=instance.organization_id,
-                    integration_id=instance.integration_id,
-                    status=ObjectStatus.DISABLED,
-                )
 
         except CellMappingNotFound:
             # This can happen when an organization has been deleted already.

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -406,8 +406,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:visibility-explore-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable high date range options on new explore page
     manager.add("organizations:visibility-explore-range-high", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Update action status when integration is installed/deleted
-    manager.add("organizations:update-action-status", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+
     # Enable logging to debug workflow engine process workflows
     manager.add("organizations:workflow-engine-process-workflows-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -43,7 +43,6 @@ from sentry.shared_integrations.exceptions import IntegrationError, IntegrationP
 from sentry.users.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.utils import metrics
 from sentry.web.helpers import render_to_response
-from sentry.workflow_engine.service.action import action_service
 
 __all__ = ["IntegrationPipeline", "IntegrationPipelineError", "initialize_integration_pipeline"]
 
@@ -228,7 +227,6 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
             self.provider.create_audit_log_entry(
                 self.integration, self.organization, self.request, "install", extra=extra
             )
-            self._enable_actions()
             self.provider.post_install(self.integration, self.organization, extra=extra)
             self.clear_session()
 
@@ -373,19 +371,6 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
         )
         return render_to_response("sentry/integrations/dialog-complete.html", context, self.request)
 
-    def _enable_actions(self) -> None:
-        """
-        Enables all disabled actions for the integration.
-        """
-        if not features.has("organizations:update-action-status", self.organization):
-            return
-
-        action_service.update_action_status_for_organization_integration(
-            organization_id=self.organization.id,
-            integration_id=self.integration.id,
-            status=ObjectStatus.ACTIVE,
-        )
-
     def api_finish_pipeline(self) -> PipelineStepResult:
         with IntegrationPipelineViewEvent(
             interaction_type=IntegrationPipelineViewType.FINISH_PIPELINE,
@@ -423,7 +408,6 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
             self.provider.create_audit_log_entry(
                 self.integration, self.organization, self.request, "install", extra=extra
             )
-            self._enable_actions()
             self.provider.post_install(self.integration, self.organization, extra=extra)
             self.clear_session()
 

--- a/tests/sentry/integrations/models/deletions/test_organizationintegration.py
+++ b/tests/sentry/integrations/models/deletions/test_organizationintegration.py
@@ -9,16 +9,13 @@ from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.repository import Repository
-from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TransactionTestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.identity import Identity
-from sentry.workflow_engine.models import Action
 
 
 @control_silo_test
@@ -189,42 +186,3 @@ class DeleteOrganizationIntegrationTest(TransactionTestCase, HybridCloudTestMixi
                 == other_integration.id
             )
             assert other_project.get_option("sentry:seer_automation_handoff_point") == "root_cause"
-
-    @with_feature("organizations:update-action-status")
-    def test_actions_disabled_on_integration_delete(self) -> None:
-        """Test that actions are actually disabled when organization integration is deleted."""
-        org = self.create_organization()
-        integration, organization_integration = self.create_provider_integration_for(
-            org, self.user, provider="slack", name="Test Integration"
-        )
-
-        # Create a data condition group
-        condition_group = self.create_data_condition_group(organization=org)
-
-        # Create an action linked to this integration
-        action = self.create_action(
-            type=Action.Type.SLACK,
-            integration_id=integration.id,
-            config={
-                "target_type": ActionTarget.SPECIFIC,
-                "target_identifier": "123",
-                "target_display": "Test Integration",
-            },
-        )
-
-        # Link action to condition group
-        self.create_data_condition_group_action(condition_group=condition_group, action=action)
-
-        organization_integration.update(status=ObjectStatus.PENDING_DELETION)
-        ScheduledDeletion.schedule(instance=organization_integration, days=0)
-
-        with self.tasks(), outbox_runner():
-            run_scheduled_deletions_control()
-
-        # Verify organization integration is deleted
-        assert not OrganizationIntegration.objects.filter(id=organization_integration.id).exists()
-
-        with assume_test_silo_mode(SiloMode.CELL):
-            # Verify action is also deleted
-            action = Action.objects.get(id=action.id)
-            assert action.status == ObjectStatus.DISABLED

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import pytest
 from django.http.response import HttpResponse
 
-from sentry.constants import ObjectStatus
 from sentry.integrations.example import AliasedIntegrationProvider, ExampleIntegrationProvider
 from sentry.integrations.gitlab.integration import GitlabIntegrationProvider
 from sentry.integrations.models.integration import Integration
@@ -15,7 +14,6 @@ from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.repository import Repository
-from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization.serial import serialize_rpc_organization
 from sentry.pipeline.types import PipelineStepAction
@@ -25,11 +23,9 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_count_of_metric, assert_success_metric
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.helpers import override_options
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 from sentry.users.models.identity import Identity
-from sentry.workflow_engine.models.action import Action
 
 
 class ExamplePlugin(IssuePlugin2):
@@ -544,64 +540,6 @@ class FinishPipelineTestCase(IntegrationTestCase):
         assert_count_of_metric(
             mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=1
         )
-
-    @with_feature("organizations:update-action-status")
-    def test_enable_actions_called_on_successful_install(self, *args) -> None:
-        """Test that actions are enabled when integration is successfully installed."""
-        org = self.create_organization()
-        integration, _ = self.create_provider_integration_for(
-            org, self.user, provider="slack", name="Test Integration"
-        )
-        # Create a second integration to ensure that actions are not enabled for it
-        integration2, _ = self.create_provider_integration_for(
-            org, self.user, provider="slack", name="Test Integration 2", external_id="123456"
-        )
-
-        # Create a data condition group
-        condition_group = self.create_data_condition_group(organization=org)
-
-        # Create an action linked to this integration
-        action = self.create_action(
-            type=Action.Type.SLACK,
-            integration_id=integration.id,
-            config={
-                "target_type": ActionTarget.SPECIFIC,
-                "target_identifier": "123",
-                "target_display": "Test Integration",
-            },
-        )
-
-        # Create an action linked to the second integration
-        action2 = self.create_action(
-            type=Action.Type.SLACK,
-            integration_id=integration2.id,
-            config={
-                "target_type": ActionTarget.SPECIFIC,
-                "target_identifier": "123",
-                "target_display": "Test Integration 2",
-            },
-            status=ObjectStatus.DISABLED,
-        )
-
-        # Link action to condition group
-        self.create_data_condition_group_action(condition_group=condition_group, action=action)
-        self.create_data_condition_group_action(condition_group=condition_group, action=action2)
-
-        data = {
-            "external_id": self.external_id,
-            "name": "Name",
-            "metadata": {"url": "https://example.com"},
-        }
-        self.pipeline.state.data = data
-        resp = self.pipeline.finish_pipeline()
-
-        self.assertDialogSuccess(resp)
-
-        with assume_test_silo_mode(SiloMode.CELL):
-            action = Action.objects.get(id=action.id)
-            assert action.status == ObjectStatus.ACTIVE
-            # Ensure that the second action is still disabled
-            assert action2.status == ObjectStatus.DISABLED
 
 
 @control_silo_test


### PR DESCRIPTION
Dev-only flag registered Sep 2025, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.