### PR TITLE
ref(flags): Remove organizations:view-hierarchies-options-dev

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -398,8 +398,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:uptime-response-capture", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable auto spam classification at User Feedback ingest time
     manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable view hierarchies options
-    manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+
     # Enable an async queue for dashboard widget queries
     manager.add("organizations:visibility-dashboards-async-queue", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the new explore page

--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -1,4 +1,3 @@
-import Feature from 'sentry/components/acl/feature';
 import {Form} from 'sentry/components/forms/form';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -89,11 +88,6 @@ export default function AdminSettings() {
           <PanelHeader>{t('Beacon')}</PanelHeader>
           {fields['beacon.anonymous']}
         </Panel>
-        <Feature features="organizations:view-hierarchies-options-dev">
-          <Panel>
-            <PanelHeader>{t('View Hierarchy')}</PanelHeader>
-          </Panel>
-        </Feature>
       </Form>
     </div>
   );


### PR DESCRIPTION
Dev-only flag registered Feb 2023, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.