### PR TITLE
ref(flags): Remove organizations:ingest-through-trusted-relays-only

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -144,6 +144,10 @@ def register_permanent_features(manager: FeatureManager) -> None:
 
     # Permanent organization features that are controlled via flagpole
     permanent_flagpole_organization_features: dict[str, FlagpoleFeature] = {
+        # Enable ingestion through trusted relays only
+        "organizations:ingest-through-trusted-relays-only": FlagpoleFeature(
+            default=False, api_expose=True
+        ),
         # Enable the rendering of @sentry/toolbar inside the sentry app. See `useInitSentryToolbar()`
         "organizations:init-sentry-toolbar": FlagpoleFeature(default=False, api_expose=True),
         # Opt orgs in to logging workflow evaluations (bypasses sample rate when enabled).

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -405,8 +405,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:workflow-engine-process-workflows-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine
     manager.add("organizations:workflow-engine-metric-alert-group-by-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable ingestion through trusted relays only
-    manager.add("organizations:ingest-through-trusted-relays-only", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Disable issue stream detector notifications for metric issues
     manager.add("organizations:workflow-engine-metric-issue-disable-issue-detector-notifications", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable new workflow_engine UI (see: alerts create issues)


### PR DESCRIPTION
Dev-only flag registered Jun 2025, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.