### PR TITLE
ref(flags): Remove organizations:on-demand-metrics-extraction-experimental

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -117,7 +117,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             "organizations:dynamic-sampling",
             "organizations:on-demand-metrics-extraction",
             "organizations:on-demand-metrics-extraction-widgets",
-            "organizations:on-demand-metrics-extraction-experimental",
         ]
         batch_features = features.batch_has(
             feature_names,

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -41,7 +41,6 @@ from sentry.tasks.on_demand_metrics import (
     check_field_cardinality,
     set_or_create_on_demand_state,
 )
-from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.strings import oxfordize_list
 
@@ -823,8 +822,6 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
         self.update_permissions(self.instance, validated_data)
 
-        schedule_update_project_configs(self.instance)
-
         return self.instance
 
     def update(self, instance, validated_data):
@@ -847,8 +844,6 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         self.update_dashboard_filters(instance, validated_data)
 
         self.update_permissions(instance, validated_data)
-
-        schedule_update_project_configs(instance)
 
         return instance
 
@@ -1255,22 +1250,3 @@ class DashboardStarredOrderSerializer(serializers.Serializer):
         if len(dashboard_ids) != len(set(dashboard_ids)):
             raise serializers.ValidationError("Single dashboard cannot take up multiple positions")
         return dashboard_ids
-
-
-def schedule_update_project_configs(dashboard: Dashboard):
-    """
-    Schedule a task to update project configs for all projects of an organization when a dashboard is updated.
-    """
-    org = dashboard.organization
-
-    on_demand_metrics = features.has("organizations:on-demand-metrics-extraction", org)
-    dashboard_on_demand_metrics = features.has(
-        "organizations:on-demand-metrics-extraction-experimental", org
-    )
-
-    if not on_demand_metrics or not dashboard_on_demand_metrics:
-        return
-
-    schedule_invalidate_project_config(
-        trigger="dashboards:create-on-demand-metric", organization_id=org.id
-    )

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -163,8 +163,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:more-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Extract on demand metrics
     manager.add("organizations:on-demand-metrics-extraction", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Extract on demand metrics (experimental features)
-    manager.add("organizations:on-demand-metrics-extraction-experimental", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+
     # Extract on demand metrics (widget extraction)
     manager.add("organizations:on-demand-metrics-extraction-widgets", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Display on demand metrics related UI elements

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -159,7 +159,6 @@ def on_demand_metrics_feature_flags(organization: Organization) -> set[str]:
     feature_names = [
         "organizations:on-demand-metrics-extraction",
         "organizations:on-demand-metrics-extraction-widgets",  # Controls extraction for widgets
-        "organizations:on-demand-metrics-extraction-experimental",
         "organizations:on-demand-metrics-prefill",
     ]
 

--- a/static/app/utils/onDemandMetrics/features.tsx
+++ b/static/app/utils/onDemandMetrics/features.tsx
@@ -15,7 +15,6 @@ export function shouldShowOnDemandMetricAlertUI(organization: Organization) {
 export function hasOnDemandMetricWidgetFeature(organization: Organization) {
   return (
     organization.features.includes('on-demand-metrics-extraction') &&
-    (organization.features.includes('on-demand-metrics-extraction-experimental') ||
-      organization.features.includes('on-demand-metrics-ui-widgets'))
+    organization.features.includes('on-demand-metrics-ui-widgets')
   );
 }

--- a/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
@@ -1,13 +1,11 @@
 import type {ReactNode} from 'react';
 import {createContext, useCallback, useContext, useState} from 'react';
 
-import {useOrganization} from 'sentry/utils/useOrganization';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {WIDGET_MAP_DENY_LIST} from 'sentry/views/performance/landing/widgets/utils';
 import type {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets/widgetDefinitions';
 
 import {AutoSampleState, useMEPSettingContext} from './metricsEnhancedSetting';
-import {useOnDemandControl} from './onDemandControl';
 
 export type MetricsResultsMetaMapKey = Widget;
 type ExtractedDataMap = Map<string, boolean | undefined>;
@@ -119,33 +117,8 @@ export function getIsMetricsDataFromResults(
 
 type ExtractionStatus = 'extracted' | 'not-extracted' | null;
 
-export function useExtractionStatus(props: {
+export function useExtractionStatus(_props: {
   queryKey: MetricsResultsMetaMapKey;
 }): ExtractionStatus {
-  const resultsMeta = useMetricsResultsMeta();
-  const organization = useOrganization();
-  const _onDemandControl = useOnDemandControl();
-
-  if (!_onDemandControl) {
-    return null;
-  }
-
-  const {forceOnDemand} = _onDemandControl;
-
-  const isMetricsExtractedData =
-    resultsMeta?.metricsExtractedDataMap.get(props.queryKey.id ?? '') || undefined;
-
-  if (!organization.features.includes('on-demand-metrics-extraction-experimental')) {
-    // Separate if for easier flag deletion
-    return null;
-  }
-
-  if (!forceOnDemand || isMetricsExtractedData === undefined) {
-    return null;
-  }
-
-  if (!isMetricsExtractedData) {
-    return 'not-extracted';
-  }
-  return 'extracted';
+  return null;
 }

--- a/static/app/utils/performance/contexts/onDemandControl.tsx
+++ b/static/app/utils/performance/contexts/onDemandControl.tsx
@@ -1,17 +1,11 @@
 import type {ReactNode} from 'react';
 import {createContext, useCallback, useContext, useState} from 'react';
-import {useTheme} from '@emotion/react';
 import type {Location} from 'history';
 
-import {Switch} from '@sentry/scraps/switch';
-
-import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import {FlexContainer} from 'sentry/utils/discover/styles';
 import {isOnDemandQueryString} from 'sentry/utils/onDemandMetrics';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {WidgetType} from 'sentry/views/dashboards/types';
 
@@ -136,33 +130,3 @@ export const shouldUseOnDemandMetrics = (
 
   return isOnDemandMetricWidget(widget);
 };
-
-export function ToggleOnDemand() {
-  const theme = useTheme();
-  const org = useOrganization();
-  const onDemand = useOnDemandControl();
-
-  if (!onDemand) {
-    return null;
-  }
-
-  const toggle = () => {
-    onDemand.setForceOnDemand(!onDemand.forceOnDemand);
-  };
-
-  if (!org.features.includes('on-demand-metrics-extraction-experimental')) {
-    return null;
-  }
-
-  return (
-    <FlexContainer
-      style={{
-        opacity: onDemand.isControlEnabled ? 1 : 0.5,
-        gap: theme.space.md,
-      }}
-    >
-      {t('On-demand metrics')}
-      <Switch checked={onDemand.forceOnDemand} size="sm" onChange={toggle} />
-    </FlexContainer>
-  );
-}

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -27,7 +27,6 @@ import {DataCategory} from 'sentry/types/core';
 import type {User} from 'sentry/types/user';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {ToggleOnDemand} from 'sentry/utils/performance/contexts/onDemandControl';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
@@ -396,7 +395,6 @@ export function FiltersBar({
               </Button>
             </Grid>
           )}
-        <ToggleOnDemand />
       </FiltersRow>
       <Grid flow="column" align="center" gap="md">
         <CompactSelect

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -20,7 +20,6 @@ pytestmark = [requires_snuba]
 ONDEMAND_FEATURES = [
     "organizations:on-demand-metrics-extraction",
     "organizations:on-demand-metrics-extraction-widgets",
-    "organizations:on-demand-metrics-extraction-experimental",
     "organizations:on-demand-metrics-prefill",
 ]
 


### PR DESCRIPTION
Dev-only flag registered Jun 2023, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.