### PR TITLE
ref(flags): Remove organizations:performance-remove-metrics-compatibility-fallback

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -194,8 +194,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-issues-spans", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
     # Re-enable histograms for Metrics Enhanced Performance Views
     manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable removing the fallback for metrics compatibility
-    manager.add("organizations:performance-remove-metrics-compatibility-fallback", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+
     # Enable AI and MCP module dashboards on dashboards platform
     manager.add("organizations:insights-ai-and-mcp-dashboard-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable all registered prebuilt dashboards to be synced to the database

--- a/static/app/utils/performance/contexts/metricsCardinality.tsx
+++ b/static/app/utils/performance/contexts/metricsCardinality.tsx
@@ -70,27 +70,6 @@ export function MetricsCardinalityProvider(props: {
   eventView.dataset = DiscoverDatasets.TRANSACTIONS;
   const _eventView = adjustEventViewTime(eventView);
 
-  if (
-    props.organization.features.includes(
-      'performance-remove-metrics-compatibility-fallback'
-    )
-  ) {
-    return (
-      <Provider
-        sendOutcomeAnalytics={props.sendOutcomeAnalytics}
-        organization={props.organization}
-        value={{
-          isLoading: false,
-          outcome: {
-            forceTransactionsOnly: false,
-          },
-        }}
-      >
-        {props.children}
-      </Provider>
-    );
-  }
-
   return (
     <Fragment>
       <MetricsCompatibilityQuery eventView={_eventView} {...baseDiscoverProps}>


### PR DESCRIPTION
Dev-only flag registered Nov 2023, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.