### PR TITLE
ref(flags): Remove organizations:performance-transaction-name-only-search

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -205,8 +205,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-sync-all-registered-prebuilt-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable sentry convention fields
     manager.add("organizations:performance-sentry-conventions-fields", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable transaction name only search
-    manager.add("organizations:performance-transaction-name-only-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Suggestions for Web Vitals Module
     manager.add("organizations:performance-web-vitals-seer-suggestions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset

--- a/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
@@ -58,9 +58,6 @@ const METRIC_SETTING_PARAM = 'metricSetting';
 export const METRIC_SEARCH_SETTING_PARAM = 'metricSearchSetting'; // TODO: Clean this up since we don't need multiple params in practice.
 
 export function canUseMetricsData(organization: Organization) {
-  const isInternalViewOn = organization.features.includes(
-    'performance-transaction-name-only-search'
-  );
   const isRollingOut = organization.features.includes('dynamic-sampling'); // Exists on AM2 plans only.
 
   // For plans transitioning from AM2 to AM3, we still want to show metrics
@@ -70,7 +67,7 @@ export function canUseMetricsData(organization: Organization) {
     'dashboards-metrics-transition'
   );
 
-  return isInternalViewOn || isRollingOut || isTransitioningPlan;
+  return isRollingOut || isTransitioningPlan;
 }
 
 export function MEPSettingProvider({


### PR DESCRIPTION
Dev-only flag registered Jan 2023, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.