### PR TITLE
ref(flags): Remove organizations:starfish-mobile-ui-module

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -375,8 +375,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Render Sentry App schema-backed forms using the backend JSON form adapter.
     manager.add("organizations:sentry-app-schema-form-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new SentryApp webhook request endpoint
-    # Enable mobile starfish ui module view
-    manager.add("organizations:starfish-mobile-ui-module", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable static ClickHouse sampling for `OrganizationTagsEndpoint`
     manager.add("organizations:tag-key-sample-n", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dynamic grouping UI (top issues)

--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -39,7 +39,6 @@ export type ModulesWithOnboarding = Exclude<
   | ModuleName.MCP_TOOLS
   | ModuleName.MCP_RESOURCES
   | ModuleName.MCP_PROMPTS
-  | ModuleName.MOBILE_UI
   | ModuleName.OTHER
 >;
 

--- a/static/app/views/insights/common/queries/useHasFirstSpan.tsx
+++ b/static/app/views/insights/common/queries/useHasFirstSpan.tsx
@@ -4,11 +4,7 @@ import type {Project} from 'sentry/types/project';
 import {useProjects} from 'sentry/utils/useProjects';
 import {ModuleName} from 'sentry/views/insights/types';
 
-const excludedModuleNames = [
-  ModuleName.OTHER,
-  ModuleName.MOBILE_UI,
-  ModuleName.SESSIONS,
-] as const;
+const excludedModuleNames = [ModuleName.OTHER, ModuleName.SESSIONS] as const;
 
 type ExcludedModuleNames = (typeof excludedModuleNames)[number];
 
@@ -44,7 +40,6 @@ export function useHasFirstSpan(module: ModuleName, projects?: Project[]): boole
   const {projects: allProjects} = useProjects();
   const pageFilters = usePageFilters();
 
-  // Unsupported modules. Remove MOBILE_UI from this list once released.
   if ((excludedModuleNames as readonly ModuleName[]).includes(module)) {
     return false;
   }

--- a/static/app/views/insights/common/utils/useModuleURL.tsx
+++ b/static/app/views/insights/common/utils/useModuleURL.tsx
@@ -14,7 +14,6 @@ import {BASE_URL as APP_STARTS_BASE_URL} from 'sentry/views/insights/mobile/appS
 import {BASE_URL as SCREEN_LOADS_BASE_URL} from 'sentry/views/insights/mobile/screenload/settings';
 import {BASE_URL as SCREEN_RENDERING_BASE_URL} from 'sentry/views/insights/mobile/screenRendering/settings';
 import {BASE_URL as MOBILE_SCREENS_BASE_URL} from 'sentry/views/insights/mobile/screens/settings';
-import {BASE_URL as MOBILE_UI_BASE_URL} from 'sentry/views/insights/mobile/ui/settings';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import {
   useDomainViewFilters,
@@ -39,7 +38,6 @@ export const MODULE_BASE_URLS: Record<ModuleName, string> = {
   [ModuleName.MCP_TOOLS]: MCP_TOOLS_BASE_URL,
   [ModuleName.MCP_RESOURCES]: MCP_RESOURCES_BASE_URL,
   [ModuleName.MCP_PROMPTS]: MCP_PROMPTS_BASE_URL,
-  [ModuleName.MOBILE_UI]: MOBILE_UI_BASE_URL,
   [ModuleName.MOBILE_VITALS]: MOBILE_SCREENS_BASE_URL,
   [ModuleName.SCREEN_RENDERING]: SCREEN_RENDERING_BASE_URL,
   [ModuleName.SESSIONS]: SESSIONS_BASE_URL,

--- a/static/app/views/insights/mobile/ui/settings.ts
+++ b/static/app/views/insights/mobile/ui/settings.ts
@@ -1,8 +1,0 @@
-import {t} from 'sentry/locale';
-
-export const MODULE_TITLE = t('Mobile UI');
-export const BASE_URL = 'ui';
-
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile/';
-
-export const MODULE_FEATURES = ['insight-modules', 'starfish-mobile-ui-module'];

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -98,11 +98,6 @@ import {
   MODULE_TITLE as MOBILE_SCREENS_MODULE_TITLE,
   MODULE_DOC_LINK as MODULE_SCREENS_DOC_LINK,
 } from 'sentry/views/insights/mobile/screens/settings';
-import {
-  MODULE_FEATURES as MOBILE_UI_MODULE_FEATURES,
-  MODULE_TITLE as MOBILE_UI_MODULE_TITLE,
-  MODULE_DOC_LINK as MODULE_UI_DOC_LINK,
-} from 'sentry/views/insights/mobile/ui/settings';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
@@ -145,7 +140,6 @@ export const MODULE_TITLES: Record<ModuleName, string> = {
   [ModuleName.MCP_TOOLS]: MCP_TOOLS_MODULE_TITLE,
   [ModuleName.MCP_RESOURCES]: MCP_RESOURCES_MODULE_TITLE,
   [ModuleName.MCP_PROMPTS]: MCP_PROMPTS_MODULE_TITLE,
-  [ModuleName.MOBILE_UI]: MOBILE_UI_MODULE_TITLE,
   [ModuleName.MOBILE_VITALS]: MOBILE_SCREENS_MODULE_TITLE,
   [ModuleName.SCREEN_RENDERING]: SCREEN_RENDERING_MODULE_TITLE,
   [ModuleName.SESSIONS]: SESSIONS_MODULE_TITLE,
@@ -166,7 +160,6 @@ export const MODULE_DATA_TYPES: Record<ModuleName, string> = {
   [ModuleName.MCP_TOOLS]: MCP_TOOLS_DATA_TYPE,
   [ModuleName.MCP_RESOURCES]: MCP_RESOURCES_DATA_TYPE,
   [ModuleName.MCP_PROMPTS]: MCP_PROMPTS_DATA_TYPE,
-  [ModuleName.MOBILE_UI]: t('Mobile UI'),
   [ModuleName.MOBILE_VITALS]: MOBILE_SCREENS_DATA_TYPE,
   [ModuleName.SCREEN_RENDERING]: SCREEN_RENDERING_DATA_TYPE,
   [ModuleName.SESSIONS]: SESSIONS_DATA_TYPE,
@@ -187,7 +180,6 @@ export const MODULE_DATA_TYPES_PLURAL: Record<ModuleName, string> = {
   [ModuleName.MCP_TOOLS]: MCP_TOOLS_DATA_TYPE_PLURAL,
   [ModuleName.MCP_RESOURCES]: MCP_RESOURCES_DATA_TYPE_PLURAL,
   [ModuleName.MCP_PROMPTS]: MCP_PROMPTS_DATA_TYPE_PLURAL,
-  [ModuleName.MOBILE_UI]: t('Mobile UI'),
   [ModuleName.MOBILE_VITALS]: MOBILE_SCREENS_DATA_TYPE_PLURAL,
   [ModuleName.SCREEN_RENDERING]: SCREEN_RENDERING_DATA_TYPE_PLURAL,
   [ModuleName.SESSIONS]: SESSIONS_DATA_TYPE_PLURAL,
@@ -211,7 +203,6 @@ export const MODULE_PRODUCT_DOC_LINKS = {
   [ModuleName.MCP_TOOLS]: MCP_TOOLS_MODULE_DOC_LINK,
   [ModuleName.MCP_RESOURCES]: MCP_RESOURCES_MODULE_DOC_LINK,
   [ModuleName.MCP_PROMPTS]: MCP_PROMPTS_MODULE_DOC_LINK,
-  [ModuleName.MOBILE_UI]: MODULE_UI_DOC_LINK,
   [ModuleName.MOBILE_VITALS]: MODULE_SCREENS_DOC_LINK,
   [ModuleName.SCREEN_RENDERING]: SCREEN_RENDERING_MODULE_DOC_LINK,
   [ModuleName.SESSIONS]: {
@@ -238,7 +229,6 @@ export const MODULE_FEATURE_MAP: Record<ModuleName, string[]> = {
   [ModuleName.MCP_TOOLS]: MCP_TOOLS_MODULE_FEATURES,
   [ModuleName.MCP_RESOURCES]: MCP_RESOURCES_MODULE_FEATURES,
   [ModuleName.MCP_PROMPTS]: MCP_PROMPTS_MODULE_FEATURES,
-  [ModuleName.MOBILE_UI]: MOBILE_UI_MODULE_FEATURES,
   [ModuleName.MOBILE_VITALS]: [MOBILE_SCREENS_MODULE_FEATURE],
   [ModuleName.SCREEN_RENDERING]: SCREEN_RENDERING_MODULE_FEATURES,
   [ModuleName.SESSIONS]: [],
@@ -262,7 +252,6 @@ export const MODULE_FEATURE_VISIBLE_MAP: Record<ModuleName, string[]> = {
   [ModuleName.MCP_TOOLS]: ['insight-modules'],
   [ModuleName.MCP_RESOURCES]: ['insight-modules'],
   [ModuleName.MCP_PROMPTS]: ['insight-modules'],
-  [ModuleName.MOBILE_UI]: ['insight-modules'],
   [ModuleName.MOBILE_VITALS]: ['insight-modules'],
   [ModuleName.SCREEN_RENDERING]: ['insight-modules'],
   [ModuleName.SESSIONS]: ['insight-modules'],

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -17,7 +17,6 @@ export enum ModuleName {
   MCP_TOOLS = 'mcp-tools',
   MCP_RESOURCES = 'mcp-resources',
   MCP_PROMPTS = 'mcp-prompts',
-  MOBILE_UI = 'mobile-ui',
   MOBILE_VITALS = 'mobile-vitals',
   SCREEN_RENDERING = 'screen-rendering',
   SESSIONS = 'sessions',


### PR DESCRIPTION
Dev-only flag registered Jun 2024, never rolled out to customers. Remove the flag registration and the unreleased gated code paths.