### PR TITLE
feat(webhooks): Add standalone legacy webhook service module

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -930,6 +930,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.scm.private.ipc",
     "sentry.sentry_apps.tasks.sentry_apps",
     "sentry.sentry_apps.tasks.service_hooks",
+    "sentry.sentry_apps.services.legacy_webhook.tasks",
     "sentry.seer.autofix.issue_summary",
     "sentry.seer.code_review.webhooks.task",
     "sentry.seer.entrypoints.operator",

--- a/src/sentry/sentry_apps/services/legacy_webhook/__init__.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/__init__.py
@@ -1,0 +1,3 @@
+from .tasks import send_legacy_webhook_task
+
+__all__ = ("send_legacy_webhook_task",)

--- a/src/sentry/sentry_apps/services/legacy_webhook/client.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/client.py
@@ -1,17 +1,20 @@
+from requests import Response
+
+from sentry.sentry_apps.services.legacy_webhook.service import LegacyWebhookPayload
 from sentry.shared_integrations.client.base import BaseApiClient
 
 
 class LegacyWebhookClient(BaseApiClient):
     integration_type = "legacy_webhook"
-    integration_name = "legacy_webhook"
+    legacy_webhook_name = "legacy_webhook"
     allow_redirects = False
     metrics_prefix = "integrations.legacy_webhook"
 
-    def __init__(self, data: dict) -> None:
+    def __init__(self, data: LegacyWebhookPayload) -> None:
         self.data = data
         super().__init__(verify_ssl=False)
 
-    def request(self, url: str):
+    def request(self, url: str) -> Response:
         return self._request(
             path=url,
             method="post",

--- a/src/sentry/sentry_apps/services/legacy_webhook/client.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/client.py
@@ -1,0 +1,23 @@
+from sentry.shared_integrations.client.base import BaseApiClient
+
+
+class LegacyWebhookClient(BaseApiClient):
+    integration_type = "legacy_webhook"
+    integration_name = "legacy_webhook"
+    allow_redirects = False
+    metrics_prefix = "integrations.legacy_webhook"
+
+    def __init__(self, data: dict) -> None:
+        self.data = data
+        super().__init__(verify_ssl=False)
+
+    def request(self, url: str):
+        return self._request(
+            path=url,
+            method="post",
+            data=self.data,
+            json=True,
+            timeout=5,
+            allow_text=True,
+            ignore_webhook_errors=True,
+        )

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -72,4 +72,4 @@ def send_legacy_webhooks_for_project(
 
     payload = build_legacy_webhook_payload(group, event, triggering_rules)
     for url in urls:
-        send_legacy_webhook_task.delay(url=url, payload=payload, project_id=project.id)
+        send_legacy_webhook_task.delay(url=url, payload=payload)

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -62,7 +62,8 @@ def send_legacy_webhooks_for_project(
     event: GroupEvent | Event,
     triggering_rules: list[str],
 ) -> None:
-    from .tasks import send_legacy_webhook_task
+    # Delayed import to avoid circular dependency (tasks imports LegacyWebhookPayload from here)
+    from sentry.sentry_apps.services.legacy_webhook.tasks import send_legacy_webhook_task
 
     urls_raw = ProjectOption.objects.get_value(project, "webhooks:urls", default="")
     urls = split_urls(urls_raw)
@@ -71,6 +72,4 @@ def send_legacy_webhooks_for_project(
 
     payload = build_legacy_webhook_payload(group, event, triggering_rules)
     for url in urls:
-        send_legacy_webhook_task.delay(
-            url=url, payload=payload, organization_id=project.organization_id
-        )
+        send_legacy_webhook_task.delay(url=url, payload=payload, project_id=project.id)

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -1,14 +1,28 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from typing import Any, TypedDict
 
 from sentry.models.group import Group
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
-from sentry.services.eventstore.models import GroupEvent
+from sentry.services.eventstore.models import Event, GroupEvent
 
 logger = logging.getLogger("sentry.legacy_webhook")
+
+
+class LegacyWebhookPayload(TypedDict):
+    id: str
+    project: str
+    project_name: str
+    project_slug: str
+    logger: str | None
+    level: str | None
+    culprit: str | None
+    message: str
+    url: str
+    triggering_rules: list[str]
+    event: dict[str, Any]
 
 
 def split_urls(value: str) -> list[str]:
@@ -18,9 +32,10 @@ def split_urls(value: str) -> list[str]:
 
 
 def build_legacy_webhook_payload(
-    group: Group, event: GroupEvent, triggering_rules: Sequence[str]
-) -> dict:
-    data = {
+    group: Group, event: GroupEvent | Event, triggering_rules: list[str]
+) -> LegacyWebhookPayload:
+    event_data = dict(event.data or {})
+    data: LegacyWebhookPayload = {
         "id": str(group.id),
         "project": group.project.slug,
         "project_name": group.project.name,
@@ -31,19 +46,21 @@ def build_legacy_webhook_payload(
         "message": event.message,
         "url": group.get_absolute_url(params={"referrer": "webhooks_plugin"}),
         "triggering_rules": list(triggering_rules),
+        "event": {
+            **event_data,
+            "tags": event.tags,
+            "event_id": event.event_id,
+            "id": event.event_id,
+        },
     }
-    data["event"] = dict(event.data or {})
-    data["event"]["tags"] = event.tags
-    data["event"]["event_id"] = event.event_id
-    data["event"]["id"] = event.event_id
     return data
 
 
 def send_legacy_webhooks_for_project(
     project: Project,
     group: Group,
-    event: GroupEvent,
-    triggering_rules: Sequence[str],
+    event: GroupEvent | Event,
+    triggering_rules: list[str],
 ) -> None:
     from .tasks import send_legacy_webhook_task
 
@@ -60,8 +77,8 @@ def send_legacy_webhooks_for_project(
 def log_legacy_webhook_dry_run(
     project: Project,
     group: Group,
-    event: GroupEvent,
-    triggering_rules: Sequence[str],
+    event: GroupEvent | Event,
+    triggering_rules: list[str],
 ) -> None:
     urls_raw = ProjectOption.objects.get_value(project, "webhooks:urls", default="")
     urls = split_urls(urls_raw)

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+from sentry.models.group import Group
+from sentry.models.options.project_option import ProjectOption
+from sentry.models.project import Project
+from sentry.services.eventstore.models import GroupEvent
+
+logger = logging.getLogger("sentry.legacy_webhook")
+
+
+def split_urls(value: str) -> list[str]:
+    if not value:
+        return []
+    return list(filter(bool, (url.strip() for url in value.splitlines())))
+
+
+def build_legacy_webhook_payload(
+    group: Group, event: GroupEvent, triggering_rules: Sequence[str]
+) -> dict:
+    data = {
+        "id": str(group.id),
+        "project": group.project.slug,
+        "project_name": group.project.name,
+        "project_slug": group.project.slug,
+        "logger": event.get_tag("logger"),
+        "level": event.get_tag("level"),
+        "culprit": group.culprit,
+        "message": event.message,
+        "url": group.get_absolute_url(params={"referrer": "webhooks_plugin"}),
+        "triggering_rules": list(triggering_rules),
+    }
+    data["event"] = dict(event.data or {})
+    data["event"]["tags"] = event.tags
+    data["event"]["event_id"] = event.event_id
+    data["event"]["id"] = event.event_id
+    return data
+
+
+def send_legacy_webhooks_for_project(
+    project: Project,
+    group: Group,
+    event: GroupEvent,
+    triggering_rules: Sequence[str],
+) -> None:
+    from .tasks import send_legacy_webhook_task
+
+    urls_raw = ProjectOption.objects.get_value(project, "webhooks:urls", default="")
+    urls = split_urls(urls_raw)
+    if not urls:
+        return
+
+    payload = build_legacy_webhook_payload(group, event, triggering_rules)
+    for url in urls:
+        send_legacy_webhook_task.delay(url=url, payload=payload)
+
+
+def log_legacy_webhook_dry_run(
+    project: Project,
+    group: Group,
+    event: GroupEvent,
+    triggering_rules: Sequence[str],
+) -> None:
+    urls_raw = ProjectOption.objects.get_value(project, "webhooks:urls", default="")
+    urls = split_urls(urls_raw)
+    if not urls:
+        return
+
+    payload = build_legacy_webhook_payload(group, event, triggering_rules)
+    logger.info(
+        "legacy_webhook.dry_run",
+        extra={
+            "project_id": project.id,
+            "group_id": group.id,
+            "urls": urls,
+            "payload_keys": list(payload.keys()),
+        },
+    )

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -71,27 +71,6 @@ def send_legacy_webhooks_for_project(
 
     payload = build_legacy_webhook_payload(group, event, triggering_rules)
     for url in urls:
-        send_legacy_webhook_task.delay(url=url, payload=payload)
-
-
-def log_legacy_webhook_dry_run(
-    project: Project,
-    group: Group,
-    event: GroupEvent | Event,
-    triggering_rules: list[str],
-) -> None:
-    urls_raw = ProjectOption.objects.get_value(project, "webhooks:urls", default="")
-    urls = split_urls(urls_raw)
-    if not urls:
-        return
-
-    payload = build_legacy_webhook_payload(group, event, triggering_rules)
-    logger.info(
-        "legacy_webhook.dry_run",
-        extra={
-            "project_id": project.id,
-            "group_id": group.id,
-            "urls": urls,
-            "payload_keys": list(payload.keys()),
-        },
-    )
+        send_legacy_webhook_task.delay(
+            url=url, payload=payload, organization_id=project.organization_id
+        )

--- a/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from requests.exceptions import ConnectionError, ReadTimeout, RequestException
+from taskbroker_client.retry import Retry
+
+from sentry.exceptions import RestrictedIPAddress
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import sentryapp_tasks
+
+logger = logging.getLogger("sentry.legacy_webhook")
+
+
+@instrumented_task(
+    name="sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
+    namespace=sentryapp_tasks,
+    retry=Retry(
+        times=3,
+        delay=60 * 5,
+        on=(RequestException,),
+        ignore=(RestrictedIPAddress, ConnectionError, ReadTimeout, ApiError),
+    ),
+    silo_mode=SiloMode.CELL,
+)
+def send_legacy_webhook_task(url: str, payload: dict[str, Any], **kwargs: Any) -> None:
+    from .client import LegacyWebhookClient
+
+    client = LegacyWebhookClient(payload)
+    client.request(url)

--- a/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
@@ -3,15 +3,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from requests.exceptions import ConnectionError, ReadTimeout, RequestException
 from taskbroker_client.retry import Retry
 
 from sentry import features
-from sentry.exceptions import RestrictedIPAddress
-from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.sentry_apps.services.legacy_webhook.client import LegacyWebhookClient
 from sentry.sentry_apps.services.legacy_webhook.service import LegacyWebhookPayload
-from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import sentryapp_tasks
@@ -25,26 +22,23 @@ logger = logging.getLogger("sentry.legacy_webhook")
     retry=Retry(
         times=3,
         delay=60 * 5,
-        on=(RequestException,),
-        ignore=(RestrictedIPAddress, ConnectionError, ReadTimeout, ApiError),
+        on=(Exception,),
     ),
     silo_mode=SiloMode.CELL,
 )
 def send_legacy_webhook_task(
-    url: str, payload: LegacyWebhookPayload, organization_id: int, **kwargs: Any
+    url: str, payload: LegacyWebhookPayload, project_id: int, **kwargs: Any
 ) -> None:
-    try:
-        organization = Organization.objects.get_from_cache(id=organization_id)
-    except Organization.DoesNotExist:
-        return
+    project = Project.objects.get_from_cache(id=project_id)
+    organization = project.organization
 
     if features.has("organizations:legacy-webhook-dry-run", organization):
         logger.info(
             "legacy_webhook.dry_run",
             extra={
-                "organization_id": organization_id,
+                "project_id": project_id,
                 "url": url,
-                "payload_keys": list(payload.keys()),
+                "payload": payload,
             },
         )
         return

--- a/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
@@ -32,7 +32,14 @@ logger = logging.getLogger("sentry.legacy_webhook")
     silo_mode=SiloMode.CELL,
 )
 def send_legacy_webhook_task(url: str, payload: LegacyWebhookPayload, **kwargs: Any) -> None:
-    group = Group.objects.get(id=int(payload["id"]))
+    try:
+        group = Group.objects.get(id=int(payload["id"]))
+    except Group.DoesNotExist:
+        logger.warning(
+            "legacy_webhook.group_not_found",
+            extra={"group_id": payload["id"], "url": url},
+        )
+        return
     organization = group.project.organization
 
     if features.has("organizations:legacy-webhook-dry-run", organization):

--- a/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from requests.exceptions import ConnectionError, ReadTimeout
 from taskbroker_client.retry import Retry
 
 from sentry import features
-from sentry.models.project import Project
+from sentry.exceptions import RestrictedIPAddress
+from sentry.models.group import Group
 from sentry.sentry_apps.services.legacy_webhook.client import LegacyWebhookClient
 from sentry.sentry_apps.services.legacy_webhook.service import LegacyWebhookPayload
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import sentryapp_tasks
@@ -23,20 +26,19 @@ logger = logging.getLogger("sentry.legacy_webhook")
         times=3,
         delay=60 * 5,
         on=(Exception,),
+        ignore=(RestrictedIPAddress, ConnectionError, ReadTimeout, ApiError),
     ),
+    silenced_exceptions=(RestrictedIPAddress, ConnectionError, ReadTimeout, ApiError),
     silo_mode=SiloMode.CELL,
 )
-def send_legacy_webhook_task(
-    url: str, payload: LegacyWebhookPayload, project_id: int, **kwargs: Any
-) -> None:
-    project = Project.objects.get_from_cache(id=project_id)
-    organization = project.organization
+def send_legacy_webhook_task(url: str, payload: LegacyWebhookPayload, **kwargs: Any) -> None:
+    group = Group.objects.get(id=int(payload["id"]))
+    organization = group.project.organization
 
     if features.has("organizations:legacy-webhook-dry-run", organization):
         logger.info(
             "legacy_webhook.dry_run",
             extra={
-                "project_id": project_id,
                 "url": url,
                 "payload": payload,
             },

--- a/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
@@ -6,7 +6,9 @@ from typing import Any
 from requests.exceptions import ConnectionError, ReadTimeout, RequestException
 from taskbroker_client.retry import Retry
 
+from sentry import features
 from sentry.exceptions import RestrictedIPAddress
+from sentry.models.organization import Organization
 from sentry.sentry_apps.services.legacy_webhook.client import LegacyWebhookClient
 from sentry.sentry_apps.services.legacy_webhook.service import LegacyWebhookPayload
 from sentry.shared_integrations.exceptions import ApiError
@@ -28,6 +30,24 @@ logger = logging.getLogger("sentry.legacy_webhook")
     ),
     silo_mode=SiloMode.CELL,
 )
-def send_legacy_webhook_task(url: str, payload: LegacyWebhookPayload, **kwargs: Any) -> None:
+def send_legacy_webhook_task(
+    url: str, payload: LegacyWebhookPayload, organization_id: int, **kwargs: Any
+) -> None:
+    try:
+        organization = Organization.objects.get_from_cache(id=organization_id)
+    except Organization.DoesNotExist:
+        return
+
+    if features.has("organizations:legacy-webhook-dry-run", organization):
+        logger.info(
+            "legacy_webhook.dry_run",
+            extra={
+                "organization_id": organization_id,
+                "url": url,
+                "payload_keys": list(payload.keys()),
+            },
+        )
+        return
+
     client = LegacyWebhookClient(payload)
     client.request(url)

--- a/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
@@ -7,6 +7,8 @@ from requests.exceptions import ConnectionError, ReadTimeout, RequestException
 from taskbroker_client.retry import Retry
 
 from sentry.exceptions import RestrictedIPAddress
+from sentry.sentry_apps.services.legacy_webhook.client import LegacyWebhookClient
+from sentry.sentry_apps.services.legacy_webhook.service import LegacyWebhookPayload
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -26,8 +28,6 @@ logger = logging.getLogger("sentry.legacy_webhook")
     ),
     silo_mode=SiloMode.CELL,
 )
-def send_legacy_webhook_task(url: str, payload: dict[str, Any], **kwargs: Any) -> None:
-    from .client import LegacyWebhookClient
-
+def send_legacy_webhook_task(url: str, payload: LegacyWebhookPayload, **kwargs: Any) -> None:
     client = LegacyWebhookClient(payload)
     client.request(url)

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_client.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_client.py
@@ -1,0 +1,48 @@
+import responses
+
+from sentry.sentry_apps.services.legacy_webhook.client import LegacyWebhookClient
+from sentry.testutils.cases import TestCase
+from sentry.utils import json
+
+
+class TestLegacyWebhookClient(TestCase):
+    @responses.activate
+    def test_posts_json_payload(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        payload = {"id": "123", "message": "test event"}
+        client = LegacyWebhookClient(payload)
+        client.request("http://example.com/hook")
+
+        assert len(responses.calls) == 1
+        request = responses.calls[0].request
+        assert request.method == "POST"
+        body = json.loads(request.body)
+        assert body["id"] == "123"
+        assert body["message"] == "test event"
+
+    @responses.activate
+    def test_no_redirects(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook", status=301)
+
+        client = LegacyWebhookClient({"id": "1"})
+        client.request("http://example.com/hook")
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].response.status_code == 301
+
+    @responses.activate
+    def test_handles_timeout_and_connection_errors(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://example.com/hook",
+            body=ConnectionError("connection refused"),
+        )
+
+        client = LegacyWebhookClient({"id": "1"})
+        try:
+            client.request("http://example.com/hook")
+        except Exception:
+            pass
+
+        assert len(responses.calls) == 1

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_client.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_client.py
@@ -1,6 +1,7 @@
 import responses
 
 from sentry.sentry_apps.services.legacy_webhook.client import LegacyWebhookClient
+from sentry.sentry_apps.services.legacy_webhook.service import build_legacy_webhook_payload
 from sentry.testutils.cases import TestCase
 from sentry.utils import json
 
@@ -10,7 +11,9 @@ class TestLegacyWebhookClient(TestCase):
     def test_posts_json_payload(self) -> None:
         responses.add(responses.POST, "http://example.com/hook")
 
-        payload = {"id": "123", "message": "test event"}
+        payload = build_legacy_webhook_payload(
+            group=self.group, event=self.event, triggering_rules=["test-rule"]
+        )
         client = LegacyWebhookClient(payload)
         client.request("http://example.com/hook")
 
@@ -18,14 +21,17 @@ class TestLegacyWebhookClient(TestCase):
         request = responses.calls[0].request
         assert request.method == "POST"
         body = json.loads(request.body)
-        assert body["id"] == "123"
-        assert body["message"] == "test event"
+        assert body["id"] == str(self.group.id)
+        assert body["message"] == self.event.message
 
     @responses.activate
     def test_no_redirects(self) -> None:
         responses.add(responses.POST, "http://example.com/hook", status=301)
 
-        client = LegacyWebhookClient({"id": "1"})
+        payload = build_legacy_webhook_payload(
+            group=self.group, event=self.event, triggering_rules=["test-rule"]
+        )
+        client = LegacyWebhookClient(payload)
         client.request("http://example.com/hook")
 
         assert len(responses.calls) == 1
@@ -39,7 +45,10 @@ class TestLegacyWebhookClient(TestCase):
             body=ConnectionError("connection refused"),
         )
 
-        client = LegacyWebhookClient({"id": "1"})
+        payload = build_legacy_webhook_payload(
+            group=self.group, event=self.event, triggering_rules=["test-rule"]
+        )
+        client = LegacyWebhookClient(payload)
         try:
             client.request("http://example.com/hook")
         except Exception:

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
@@ -70,7 +70,7 @@ class TestSendLegacyWebhooksForProject(TestCase):
         urls_called = {call.kwargs["url"] for call in mock_task.delay.call_args_list}
         assert urls_called == {"http://a.com", "http://b.com"}
         for call in mock_task.delay.call_args_list:
-            assert call.kwargs["organization_id"] == self.project.organization_id
+            assert call.kwargs["project_id"] == self.project.id
 
     @mock.patch(
         "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
@@ -69,8 +69,6 @@ class TestSendLegacyWebhooksForProject(TestCase):
         assert mock_task.delay.call_count == 2
         urls_called = {call.kwargs["url"] for call in mock_task.delay.call_args_list}
         assert urls_called == {"http://a.com", "http://b.com"}
-        for call in mock_task.delay.call_args_list:
-            assert call.kwargs["project_id"] == self.project.id
 
     @mock.patch(
         "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
@@ -3,7 +3,6 @@ from unittest import mock
 from sentry.models.options.project_option import ProjectOption
 from sentry.sentry_apps.services.legacy_webhook.service import (
     build_legacy_webhook_payload,
-    log_legacy_webhook_dry_run,
     send_legacy_webhooks_for_project,
     split_urls,
 )
@@ -70,6 +69,8 @@ class TestSendLegacyWebhooksForProject(TestCase):
         assert mock_task.delay.call_count == 2
         urls_called = {call.kwargs["url"] for call in mock_task.delay.call_args_list}
         assert urls_called == {"http://a.com", "http://b.com"}
+        for call in mock_task.delay.call_args_list:
+            assert call.kwargs["organization_id"] == self.project.organization_id
 
     @mock.patch(
         "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
@@ -84,23 +85,3 @@ class TestSendLegacyWebhooksForProject(TestCase):
         send_legacy_webhooks_for_project(self.project, group, event, ["rule1"])
 
         assert mock_task.delay.call_count == 0
-
-
-class TestLogLegacyWebhookDryRun(TestCase):
-    @mock.patch("sentry.sentry_apps.services.legacy_webhook.service.logger")
-    def test_dry_run_logs_without_sending(self, mock_logger: mock.MagicMock) -> None:
-        event = self.store_event(
-            data={"message": "test", "level": "error"}, project_id=self.project.id
-        )
-        group = event.group
-        assert group is not None
-
-        ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://example.com")
-
-        log_legacy_webhook_dry_run(self.project, group, event, ["rule1"])
-
-        mock_logger.info.assert_called_once()
-        call_args = mock_logger.info.call_args
-        assert call_args[0][0] == "legacy_webhook.dry_run"
-        assert call_args[1]["extra"]["project_id"] == self.project.id
-        assert call_args[1]["extra"]["urls"] == ["http://example.com"]

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
@@ -1,0 +1,106 @@
+from unittest import mock
+
+from sentry.models.options.project_option import ProjectOption
+from sentry.sentry_apps.services.legacy_webhook.service import (
+    build_legacy_webhook_payload,
+    log_legacy_webhook_dry_run,
+    send_legacy_webhooks_for_project,
+    split_urls,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.skips import requires_snuba
+
+pytestmark = [requires_snuba]
+
+
+class TestSplitUrls(TestCase):
+    def test_splits_newline_separated(self) -> None:
+        assert split_urls("http://a.com\nhttp://b.com") == ["http://a.com", "http://b.com"]
+
+    def test_empty_string(self) -> None:
+        assert split_urls("") == []
+
+    def test_strips_whitespace(self) -> None:
+        assert split_urls("  http://a.com  \n  http://b.com  ") == [
+            "http://a.com",
+            "http://b.com",
+        ]
+
+    def test_filters_blank_lines(self) -> None:
+        assert split_urls("http://a.com\n\nhttp://b.com\n") == ["http://a.com", "http://b.com"]
+
+
+class TestBuildLegacyWebhookPayload(TestCase):
+    def test_build_payload_matches_legacy_plugin(self) -> None:
+        event = self.store_event(
+            data={"message": "Hello world", "level": "warning"}, project_id=self.project.id
+        )
+        group = event.group
+        assert group is not None
+
+        payload = build_legacy_webhook_payload(group, event, ["my rule"])
+
+        assert payload["id"] == str(group.id)
+        assert payload["project"] == self.project.slug
+        assert payload["project_name"] == self.project.name
+        assert payload["project_slug"] == self.project.slug
+        assert payload["level"] == "warning"
+        assert payload["message"] == "Hello world"
+        assert payload["triggering_rules"] == ["my rule"]
+        assert payload["event"]["event_id"] == event.event_id
+        assert payload["event"]["id"] == event.event_id
+        assert "tags" in payload["event"]
+
+
+class TestSendLegacyWebhooksForProject(TestCase):
+    @mock.patch(
+        "sentry.sentry_apps.services.legacy_webhook.service.send_legacy_webhook_task",
+    )
+    def test_dispatches_task_per_url(self, mock_task) -> None:
+        event = self.store_event(
+            data={"message": "test", "level": "error"}, project_id=self.project.id
+        )
+        group = event.group
+        assert group is not None
+
+        ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://a.com\nhttp://b.com")
+
+        send_legacy_webhooks_for_project(self.project, group, event, ["rule1"])
+
+        assert mock_task.delay.call_count == 2
+        urls_called = {call.kwargs["url"] for call in mock_task.delay.call_args_list}
+        assert urls_called == {"http://a.com", "http://b.com"}
+
+    @mock.patch(
+        "sentry.sentry_apps.services.legacy_webhook.service.send_legacy_webhook_task",
+    )
+    def test_no_urls_configured_is_noop(self, mock_task) -> None:
+        event = self.store_event(
+            data={"message": "test", "level": "error"}, project_id=self.project.id
+        )
+        group = event.group
+        assert group is not None
+
+        send_legacy_webhooks_for_project(self.project, group, event, ["rule1"])
+
+        assert mock_task.delay.call_count == 0
+
+
+class TestLogLegacyWebhookDryRun(TestCase):
+    @mock.patch("sentry.sentry_apps.services.legacy_webhook.service.logger")
+    def test_dry_run_logs_without_sending(self, mock_logger) -> None:
+        event = self.store_event(
+            data={"message": "test", "level": "error"}, project_id=self.project.id
+        )
+        group = event.group
+        assert group is not None
+
+        ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://example.com")
+
+        log_legacy_webhook_dry_run(self.project, group, event, ["rule1"])
+
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "legacy_webhook.dry_run"
+        assert call_args[1]["extra"]["project_id"] == self.project.id
+        assert call_args[1]["extra"]["urls"] == ["http://example.com"]

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
@@ -54,9 +54,9 @@ class TestBuildLegacyWebhookPayload(TestCase):
 
 class TestSendLegacyWebhooksForProject(TestCase):
     @mock.patch(
-        "sentry.sentry_apps.services.legacy_webhook.service.send_legacy_webhook_task",
+        "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
     )
-    def test_dispatches_task_per_url(self, mock_task) -> None:
+    def test_dispatches_task_per_url(self, mock_task: mock.MagicMock) -> None:
         event = self.store_event(
             data={"message": "test", "level": "error"}, project_id=self.project.id
         )
@@ -72,9 +72,9 @@ class TestSendLegacyWebhooksForProject(TestCase):
         assert urls_called == {"http://a.com", "http://b.com"}
 
     @mock.patch(
-        "sentry.sentry_apps.services.legacy_webhook.service.send_legacy_webhook_task",
+        "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
     )
-    def test_no_urls_configured_is_noop(self, mock_task) -> None:
+    def test_no_urls_configured_is_noop(self, mock_task: mock.MagicMock) -> None:
         event = self.store_event(
             data={"message": "test", "level": "error"}, project_id=self.project.id
         )
@@ -88,7 +88,7 @@ class TestSendLegacyWebhooksForProject(TestCase):
 
 class TestLogLegacyWebhookDryRun(TestCase):
     @mock.patch("sentry.sentry_apps.services.legacy_webhook.service.logger")
-    def test_dry_run_logs_without_sending(self, mock_logger) -> None:
+    def test_dry_run_logs_without_sending(self, mock_logger: mock.MagicMock) -> None:
         event = self.store_event(
             data={"message": "test", "level": "error"}, project_id=self.project.id
         )

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
@@ -1,8 +1,11 @@
+from unittest import mock
+
 import responses
 
 from sentry.sentry_apps.services.legacy_webhook.service import build_legacy_webhook_payload
 from sentry.sentry_apps.services.legacy_webhook.tasks import send_legacy_webhook_task
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
 
 
@@ -14,9 +17,35 @@ class TestSendLegacyWebhookTask(TestCase):
         payload = build_legacy_webhook_payload(
             group=self.group, event=self.event, triggering_rules=["test-rule"]
         )
-        send_legacy_webhook_task(url="http://example.com/hook", payload=payload)
+        send_legacy_webhook_task(
+            url="http://example.com/hook",
+            payload=payload,
+            organization_id=self.organization.id,
+        )
 
         assert len(responses.calls) == 1
         body = json.loads(responses.calls[0].request.body)
         assert body["id"] == str(self.group.id)
         assert body["message"] == self.event.message
+
+    @responses.activate
+    @mock.patch("sentry.sentry_apps.services.legacy_webhook.tasks.logger")
+    @with_feature("organizations:legacy-webhook-dry-run")
+    def test_task_dry_run_logs_instead_of_sending(self, mock_logger: mock.MagicMock) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        payload = build_legacy_webhook_payload(
+            group=self.group, event=self.event, triggering_rules=["test-rule"]
+        )
+        send_legacy_webhook_task(
+            url="http://example.com/hook",
+            payload=payload,
+            organization_id=self.organization.id,
+        )
+
+        assert len(responses.calls) == 0
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "legacy_webhook.dry_run"
+        assert call_args[1]["extra"]["organization_id"] == self.organization.id
+        assert call_args[1]["extra"]["url"] == "http://example.com/hook"

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
@@ -1,0 +1,19 @@
+import responses
+
+from sentry.sentry_apps.services.legacy_webhook.tasks import send_legacy_webhook_task
+from sentry.testutils.cases import TestCase
+from sentry.utils import json
+
+
+class TestSendLegacyWebhookTask(TestCase):
+    @responses.activate
+    def test_task_sends_webhook(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        payload = {"id": "123", "message": "test"}
+        send_legacy_webhook_task(url="http://example.com/hook", payload=payload)
+
+        assert len(responses.calls) == 1
+        body = json.loads(responses.calls[0].request.body)
+        assert body["id"] == "123"
+        assert body["message"] == "test"

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
@@ -1,5 +1,6 @@
 import responses
 
+from sentry.sentry_apps.services.legacy_webhook.service import build_legacy_webhook_payload
 from sentry.sentry_apps.services.legacy_webhook.tasks import send_legacy_webhook_task
 from sentry.testutils.cases import TestCase
 from sentry.utils import json
@@ -10,10 +11,12 @@ class TestSendLegacyWebhookTask(TestCase):
     def test_task_sends_webhook(self) -> None:
         responses.add(responses.POST, "http://example.com/hook")
 
-        payload = {"id": "123", "message": "test"}
+        payload = build_legacy_webhook_payload(
+            group=self.group, event=self.event, triggering_rules=["test-rule"]
+        )
         send_legacy_webhook_task(url="http://example.com/hook", payload=payload)
 
         assert len(responses.calls) == 1
         body = json.loads(responses.calls[0].request.body)
-        assert body["id"] == "123"
-        assert body["message"] == "test"
+        assert body["id"] == str(self.group.id)
+        assert body["message"] == self.event.message

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
@@ -17,11 +17,7 @@ class TestSendLegacyWebhookTask(TestCase):
         payload = build_legacy_webhook_payload(
             group=self.group, event=self.event, triggering_rules=["test-rule"]
         )
-        send_legacy_webhook_task(
-            url="http://example.com/hook",
-            payload=payload,
-            project_id=self.project.id,
-        )
+        send_legacy_webhook_task(url="http://example.com/hook", payload=payload)
 
         assert len(responses.calls) == 1
         body = json.loads(responses.calls[0].request.body)
@@ -37,16 +33,11 @@ class TestSendLegacyWebhookTask(TestCase):
         payload = build_legacy_webhook_payload(
             group=self.group, event=self.event, triggering_rules=["test-rule"]
         )
-        send_legacy_webhook_task(
-            url="http://example.com/hook",
-            payload=payload,
-            project_id=self.project.id,
-        )
+        send_legacy_webhook_task(url="http://example.com/hook", payload=payload)
 
         assert len(responses.calls) == 0
         mock_logger.info.assert_called_once()
         call_args = mock_logger.info.call_args
         assert call_args[0][0] == "legacy_webhook.dry_run"
-        assert call_args[1]["extra"]["project_id"] == self.project.id
         assert call_args[1]["extra"]["url"] == "http://example.com/hook"
         assert call_args[1]["extra"]["payload"] == payload

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
@@ -20,7 +20,7 @@ class TestSendLegacyWebhookTask(TestCase):
         send_legacy_webhook_task(
             url="http://example.com/hook",
             payload=payload,
-            organization_id=self.organization.id,
+            project_id=self.project.id,
         )
 
         assert len(responses.calls) == 1
@@ -40,12 +40,13 @@ class TestSendLegacyWebhookTask(TestCase):
         send_legacy_webhook_task(
             url="http://example.com/hook",
             payload=payload,
-            organization_id=self.organization.id,
+            project_id=self.project.id,
         )
 
         assert len(responses.calls) == 0
         mock_logger.info.assert_called_once()
         call_args = mock_logger.info.call_args
         assert call_args[0][0] == "legacy_webhook.dry_run"
-        assert call_args[1]["extra"]["organization_id"] == self.organization.id
+        assert call_args[1]["extra"]["project_id"] == self.project.id
         assert call_args[1]["extra"]["url"] == "http://example.com/hook"
+        assert call_args[1]["extra"]["payload"] == payload


### PR DESCRIPTION
Spin out 
- webhook payload building
- url construction from project options
- api client
into separate files under `src/sentry/sentry_apps/services/legacy_webhook/` <- honestly could change the location but wasn't sure which of sentry_apps/ , integrations/ or a whole new module made the most sense

### Context
[spec](https://www.notion.so/sentry/Migrate-Legacy-Webhooks-Plugin-to-Separate-Service-35e8b10e4b5d807eb020ca089cf82604?source=copy_link#3618b10e4b5d808b8454ea12b16434fb) 
PR 2 of the legacy webhook plugin migration. Depends on PR 1 (#115669) for feature flags
