### PR TITLE
feat(workflow_engine): Update delayed processing and add evaluation logs

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -574,14 +574,18 @@ class DelayedWorkflowEvaluationResult:
     when_dcg_missing: dict[WorkflowId, list[GroupId]]
     when_failed_untainted: dict[WorkflowId, list[GroupId]]
     when_failed_tainted: dict[WorkflowId, list[GroupId]]
-    fired: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]]
-    not_fired: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]]
+    # workflow_id -> group_id -> {dcg_id: [condition_ids that passed]}
+    # Includes both re-evaluated DCGs and pre-passing DCGs.
+    if_dcg_passed: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]]
+    # workflow_id -> group_id -> [dcg_ids that failed]
+    # Condition-level detail is omitted; all conditions not in if_dcg_passed are assumed failed.
+    if_dcg_failed: dict[WorkflowId, dict[GroupId, list[DataConditionGroupId]]]
 
     def to_log_dict(self) -> dict[str, Any]:
         return {
             "workflow_ids": sorted(self.workflow_ids),
-            "fired": self.fired,
-            "not_fired": self.not_fired,
+            "if_dcg_passed": self.if_dcg_passed,
+            "if_dcg_failed": self.if_dcg_failed,
             "when_failed_untainted": self.when_failed_untainted,
             "when_failed_tainted": self.when_failed_tainted,
             "when_dcg_missing": self.when_dcg_missing,
@@ -606,11 +610,11 @@ def get_groups_to_fire(
     when_dcg_missing: dict[WorkflowId, list[GroupId]] = defaultdict(list)
     when_failed_untainted: dict[WorkflowId, list[GroupId]] = defaultdict(list)
     when_failed_tainted: dict[WorkflowId, list[GroupId]] = defaultdict(list)
-    fired: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]] = defaultdict(
-        lambda: defaultdict(dict)
+    if_dcg_passed: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]] = (
+        defaultdict(lambda: defaultdict(dict))
     )
-    not_fired: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]] = defaultdict(
-        lambda: defaultdict(dict)
+    if_dcg_failed: dict[WorkflowId, dict[GroupId, list[DataConditionGroupId]]] = defaultdict(
+        lambda: defaultdict(list)
     )
 
     tainted, untainted = 0, 0
@@ -666,12 +670,13 @@ def get_groups_to_fire(
                     tainted += 1
                 else:
                     untainted += 1
-                condition_ids = [pc.condition.id for pc in if_group.condition_results]
                 if if_result.triggered:
                     groups_to_fire[group_id].add(dcg)
-                    fired[workflow_id][group_id][dcg.id] = condition_ids
+                    if_dcg_passed[workflow_id][group_id][dcg.id] = [
+                        pc.condition.id for pc in if_group.condition_results
+                    ]
                 else:
-                    not_fired[workflow_id][group_id][dcg.id] = condition_ids
+                    if_dcg_failed[workflow_id][group_id].append(dcg.id)
 
         for if_dcg_id in event_key.passing_dcg_ids:
             if dcg := data_condition_group_mapping.get(if_dcg_id):
@@ -681,7 +686,7 @@ def get_groups_to_fire(
                 else:
                     untainted += 1
                 groups_to_fire[group_id].add(dcg)
-                fired[workflow_id][group_id][dcg.id] = [
+                if_dcg_passed[workflow_id][group_id][dcg.id] = [
                     c.id for c in dcg_to_slow_conditions.get(dcg.id, [])
                 ]
 
@@ -692,8 +697,8 @@ def get_groups_to_fire(
         when_dcg_missing=when_dcg_missing,
         when_failed_untainted=when_failed_untainted,
         when_failed_tainted=when_failed_tainted,
-        fired=fired,
-        not_fired=not_fired,
+        if_dcg_passed=if_dcg_passed,
+        if_dcg_failed=if_dcg_failed,
     )
 
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -1001,8 +1001,10 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
         project,
     )
 
-    if groups_to_dcgs and group_to_groupevent:
-        fire_actions_for_groups(project.organization, groups_to_dcgs, group_to_groupevent)
+    if evaluation.groups_to_fire and group_to_groupevent:
+        fire_actions_for_groups(
+            project.organization, evaluation.groups_to_fire, group_to_groupevent
+        )
 
     for workflow_log in evaluation.iter_per_workflow_log_dicts():
         logger.debug(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from functools import cached_property
@@ -581,14 +581,22 @@ class DelayedWorkflowEvaluationResult:
     # Condition-level detail is omitted; all conditions not in if_dcg_passed are assumed failed.
     if_dcg_failed: dict[WorkflowId, dict[GroupId, list[DataConditionGroupId]]]
 
-    def to_log_dict(self) -> dict[str, Any]:
+    def iter_per_workflow_log_dicts(self) -> Iterator[dict[str, Any]]:
+        """Yield one log-ready dict per workflow, keeping each entry bounded in size."""
+        for workflow_id in sorted(self.workflow_ids):
+            yield {
+                "workflow_id": workflow_id,
+                "if_dcg_passed": self.if_dcg_passed.get(workflow_id, {}),
+                "if_dcg_failed": self.if_dcg_failed.get(workflow_id, {}),
+                "when_failed_untainted": self.when_failed_untainted.get(workflow_id, []),
+                "when_failed_tainted": self.when_failed_tainted.get(workflow_id, []),
+                "when_dcg_missing": self.when_dcg_missing.get(workflow_id, []),
+            }
+
+    def summary_log_dict(self) -> dict[str, Any]:
+        """Return bounded aggregate stats for a single summary log entry."""
         return {
-            "workflow_ids": sorted(self.workflow_ids),
-            "if_dcg_passed": self.if_dcg_passed,
-            "if_dcg_failed": self.if_dcg_failed,
-            "when_failed_untainted": self.when_failed_untainted,
-            "when_failed_tainted": self.when_failed_tainted,
-            "when_dcg_missing": self.when_dcg_missing,
+            "workflows": sorted(self.workflow_ids),
             "tainted_conditions": self.stats.tainted,
             "untainted_conditions": self.stats.untainted,
         }
@@ -996,10 +1004,11 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
     if groups_to_dcgs and group_to_groupevent:
         fire_actions_for_groups(project.organization, groups_to_dcgs, group_to_groupevent)
 
-    logger.debug(
-        "workflow_engine.process_workflows.delayed_workflow.evaluation_result",
-        extra=evaluation.to_log_dict(),
-    )
+    for workflow_log in evaluation.iter_per_workflow_log_dicts():
+        logger.debug(
+            "workflow_engine.delayed_workflow.evaluation_result",
+            extra=workflow_log,
+        )
 
 
 @sentry_sdk.trace

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -44,6 +44,7 @@ from sentry.workflow_engine.models.data_condition import (
     Condition,
 )
 from sentry.workflow_engine.processors.data_condition_group import (
+    ProcessedDataConditionGroup,
     TriggerResult,
     evaluate_data_conditions,
     get_slow_conditions_for_groups,
@@ -512,7 +513,7 @@ def _evaluate_group_result_for_dcg(
     group_id: GroupId,
     workflow_env: int | None,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
-) -> TriggerResult:
+) -> ProcessedDataConditionGroup:
     slow_conditions = dcg_to_slow_conditions[dcg.id]
     try:
         return _group_result_for_dcg(
@@ -526,7 +527,12 @@ def _evaluate_group_result_for_dcg(
             sample_rate=1.0,
         )
         logger.warning("workflow_engine.delayed_workflow.missing_query_result", exc_info=True)
-        return TriggerResult(triggered=False, error=ConditionError(msg="Missing query result"))
+        return ProcessedDataConditionGroup(
+            logic_result=TriggerResult(
+                triggered=False, error=ConditionError(msg="Missing query result")
+            ),
+            condition_results=[],
+        )
 
 
 def _group_result_for_dcg(
@@ -535,7 +541,7 @@ def _group_result_for_dcg(
     workflow_env: int | None,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
     slow_conditions: list[DataCondition],
-) -> TriggerResult:
+) -> ProcessedDataConditionGroup:
     conditions_to_evaluate: list[tuple[DataCondition, list[int | float]]] = []
     for condition in slow_conditions:
         query_values = []
@@ -547,15 +553,41 @@ def _group_result_for_dcg(
             query_values.append(query_result[group_id])
         conditions_to_evaluate.append((condition, query_values))
 
-    return evaluate_data_conditions(
-        conditions_to_evaluate, DataConditionGroup.Type(dcg.logic_type)
-    ).logic_result
+    return evaluate_data_conditions(conditions_to_evaluate, DataConditionGroup.Type(dcg.logic_type))
 
 
 @dataclass(frozen=True)
 class _ConditionEvaluationStats:
     tainted: int
     untainted: int
+
+
+@dataclass(frozen=True)
+class DelayedWorkflowEvaluationResult:
+    groups_to_fire: dict[GroupId, set[DataConditionGroup]]
+    stats: _ConditionEvaluationStats
+
+    # All workflow IDs evaluated (for log filtering)
+    workflow_ids: set[WorkflowId]
+
+    # Per-evaluation outcomes
+    when_dcg_missing: dict[WorkflowId, list[GroupId]]
+    when_failed_untainted: dict[WorkflowId, list[GroupId]]
+    when_failed_tainted: dict[WorkflowId, list[GroupId]]
+    fired: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]]
+    not_fired: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]]
+
+    def to_log_dict(self) -> dict[str, Any]:
+        return {
+            "workflow_ids": sorted(self.workflow_ids),
+            "fired": self.fired,
+            "not_fired": self.not_fired,
+            "when_failed_untainted": self.when_failed_untainted,
+            "when_failed_tainted": self.when_failed_tainted,
+            "when_dcg_missing": self.when_dcg_missing,
+            "tainted_conditions": self.stats.tainted,
+            "untainted_conditions": self.stats.untainted,
+        }
 
 
 @sentry_sdk.trace
@@ -565,30 +597,46 @@ def get_groups_to_fire(
     event_data: EventRedisData,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
     dcg_to_slow_conditions: dict[DataConditionGroupId, list[DataCondition]],
-) -> tuple[dict[GroupId, set[DataConditionGroup]], _ConditionEvaluationStats]:
+) -> DelayedWorkflowEvaluationResult:
     data_condition_group_mapping = {dcg.id: dcg for dcg in data_condition_groups}
     groups_to_fire: dict[GroupId, set[DataConditionGroup]] = defaultdict(set)
+
+    # Mutable outcome tracking
+    evaluated_workflow_ids: set[WorkflowId] = set()
+    when_dcg_missing: dict[WorkflowId, list[GroupId]] = defaultdict(list)
+    when_failed_untainted: dict[WorkflowId, list[GroupId]] = defaultdict(list)
+    when_failed_tainted: dict[WorkflowId, list[GroupId]] = defaultdict(list)
+    fired: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
+    not_fired: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
 
     tainted, untainted = 0, 0
     for event_key in event_data.events:
         group_id = event_key.group_id
-        if event_key.workflow_id not in workflows_to_envs:
+        workflow_id = event_key.workflow_id
+        if workflow_id not in workflows_to_envs:
             # The workflow is deleted, so we can skip it
             continue
 
-        workflow_env = workflows_to_envs[event_key.workflow_id]
+        evaluated_workflow_ids.add(workflow_id)
+        workflow_env = workflows_to_envs[workflow_id]
         when_result = TriggerResult.TRUE
         if when_dcg_id := event_key.when_dcg_id:
             when_dcg = data_condition_group_mapping.get(when_dcg_id)
             if not when_dcg:
+                when_dcg_missing[workflow_id].append(group_id)
                 continue
-            when_result = _evaluate_group_result_for_dcg(
+            when_group = _evaluate_group_result_for_dcg(
                 when_dcg,
                 dcg_to_slow_conditions,
                 group_id,
                 workflow_env,
                 condition_group_results,
             )
+            when_result = when_group.logic_result
             if not when_result.triggered:
                 # If we're not triggering, all action-y if conditions need to be treated
                 # as tainted or not based on the when condition result.
@@ -597,26 +645,33 @@ def get_groups_to_fire(
                 if_cond_count = len(if_conds & data_condition_group_mapping.keys())
                 if when_result.is_tainted():
                     tainted += if_cond_count
+                    when_failed_tainted[workflow_id].append(group_id)
                 else:
                     untainted += if_cond_count
+                    when_failed_untainted[workflow_id].append(group_id)
                 continue
 
         # the WHEN condition passed / was not evaluated, so we can now check the IF conditions
         for if_dcg_id in event_key.if_dcg_ids:
             if dcg := data_condition_group_mapping.get(if_dcg_id):
-                if_result = when_result & _evaluate_group_result_for_dcg(
+                if_group = _evaluate_group_result_for_dcg(
                     dcg,
                     dcg_to_slow_conditions,
                     group_id,
                     workflow_env,
                     condition_group_results,
                 )
+                if_result = when_result & if_group.logic_result
                 if if_result.is_tainted():
                     tainted += 1
                 else:
                     untainted += 1
+                condition_ids = [pc.condition.id for pc in if_group.condition_results]
                 if if_result.triggered:
                     groups_to_fire[group_id].add(dcg)
+                    fired[workflow_id][group_id][dcg.id] = condition_ids
+                else:
+                    not_fired[workflow_id][group_id][dcg.id] = condition_ids
 
         for if_dcg_id in event_key.passing_dcg_ids:
             if dcg := data_condition_group_mapping.get(if_dcg_id):
@@ -626,8 +681,20 @@ def get_groups_to_fire(
                 else:
                     untainted += 1
                 groups_to_fire[group_id].add(dcg)
+                fired[workflow_id][group_id][dcg.id] = [
+                    c.id for c in dcg_to_slow_conditions.get(dcg.id, [])
+                ]
 
-    return groups_to_fire, _ConditionEvaluationStats(tainted=tainted, untainted=untainted)
+    return DelayedWorkflowEvaluationResult(
+        groups_to_fire=groups_to_fire,
+        stats=_ConditionEvaluationStats(tainted=tainted, untainted=untainted),
+        workflow_ids=evaluated_workflow_ids,
+        when_dcg_missing=when_dcg_missing,
+        when_failed_untainted=when_failed_untainted,
+        when_failed_tainted=when_failed_tainted,
+        fired=fired,
+        not_fired=not_fired,
+    )
 
 
 @sentry_sdk.trace
@@ -886,7 +953,7 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
     )
 
     # Evaluate DCGs
-    groups_to_dcgs, trigger_stats = get_groups_to_fire(
+    evaluation = get_groups_to_fire(
         data_condition_groups,
         workflows_to_envs,
         event_data,
@@ -895,13 +962,13 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
     )
     metrics.incr(
         "workflow_engine.delayed_workflow.workflow_if_conditions_evaluated",
-        amount=trigger_stats.tainted,
+        amount=evaluation.stats.tainted,
         tags={"tainted": True},
         sample_rate=1.0,
     )
     metrics.incr(
         "workflow_engine.delayed_workflow.workflow_if_conditions_evaluated",
-        amount=trigger_stats.untainted,
+        amount=evaluation.stats.untainted,
         tags={"tainted": False},
         sample_rate=1.0,
     )
@@ -910,19 +977,24 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
         extra={
             "groups_to_dcgs": {
                 group_id: sorted(dcg.id for dcg in dcgs)
-                for group_id, dcgs in groups_to_dcgs.items()
+                for group_id, dcgs in evaluation.groups_to_fire.items()
             },
         },
     )
 
     group_to_groupevent = get_group_to_groupevent(
         event_data,
-        groups_to_dcgs,
+        evaluation.groups_to_fire,
         project,
     )
 
     if groups_to_dcgs and group_to_groupevent:
         fire_actions_for_groups(project.organization, groups_to_dcgs, group_to_groupevent)
+
+    logger.debug(
+        "workflow_engine.process_workflows.delayed_workflow.evaluation_result",
+        extra=evaluation.to_log_dict(),
+    )
 
 
 @sentry_sdk.trace

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -721,7 +721,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         self.dcg_to_slow_conditions = get_slow_conditions_for_groups(list(self.event_data.dcg_ids))
 
     def test_simple(self) -> None:
-        result, _ = get_groups_to_fire(
+        eval_result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -731,7 +731,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
 
         # NOTE: no WHEN DCGs. We only collect IF DCGs here to fire their actions in the fire_actions_for_groups function
         assert (
-            result
+            eval_result.groups_to_fire
             == {
                 self.group1.id: set(self.workflow1_if_dcgs),
                 self.group2.id: {
@@ -750,7 +750,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             self.group1.id: existing_result[self.group1.id]
         }
 
-        result, _ = get_groups_to_fire(
+        eval_result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -759,7 +759,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
 
         # group2 should be excluded because it's missing from the query result
-        assert result == {
+        assert eval_result.groups_to_fire == {
             self.group1.id: set(self.workflow1_if_dcgs),
         }
 
@@ -774,7 +774,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             }
         )
 
-        result, _ = get_groups_to_fire(
+        eval_result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -782,7 +782,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             self.dcg_to_slow_conditions,
         )
 
-        assert result == {
+        assert eval_result.groups_to_fire == {
             self.group1.id: {self.workflow1_if_dcgs[1]},
             self.group2.id: {self.workflow2_if_dcgs[1]},
         }
@@ -796,7 +796,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             }
         )
 
-        result, _ = get_groups_to_fire(
+        eval_result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -804,7 +804,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             self.dcg_to_slow_conditions,
         )
 
-        assert result == {
+        assert eval_result.groups_to_fire == {
             self.group1.id: set(self.workflow1_if_dcgs),
         }
 
@@ -824,7 +824,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             + [self.workflow2_if_dcgs[0]]
         )
 
-        result, _ = get_groups_to_fire(
+        eval_result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -833,7 +833,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
 
         # NOTE: same result as test_simple but without the deleted DCGs
-        assert result == {
+        assert eval_result.groups_to_fire == {
             self.group1.id: {self.workflow1_if_dcgs[1]},
         }
 
@@ -842,7 +842,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
 
         self.workflows_to_envs = {self.workflow2.id: None}
 
-        result, _ = get_groups_to_fire(
+        eval_result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -851,7 +851,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
 
         # NOTE: same result as test_simple but without the deleted workflow
-        assert result == {self.group2.id: {self.workflow2_if_dcgs[1]}}
+        assert eval_result.groups_to_fire == {self.group2.id: {self.workflow2_if_dcgs[1]}}
 
     def test_tainted_when_condition_doesnt_trigger(self) -> None:
         query_for_when = UniqueConditionQuery(
@@ -861,7 +861,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
         self.condition_group_results[query_for_when] = {self.group2.id: 101}
 
-        result, stats = get_groups_to_fire(
+        eval_result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -869,11 +869,11 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             self.dcg_to_slow_conditions,
         )
 
-        assert result == {
+        assert eval_result.groups_to_fire == {
             self.group2.id: {self.workflow2_if_dcgs[1]},
         }
-        assert stats.tainted == 2
-        assert stats.untainted == 2
+        assert eval_result.stats.tainted == 2
+        assert eval_result.stats.untainted == 2
 
     def test_when_untainted_doesnt_trigger(self) -> None:
         query_for_when = UniqueConditionQuery(
@@ -883,7 +883,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
         self.condition_group_results[query_for_when] = {self.group1.id: 99, self.group2.id: 101}
 
-        result, stats = get_groups_to_fire(
+        eval_result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -891,11 +891,11 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             self.dcg_to_slow_conditions,
         )
 
-        assert result == {
+        assert eval_result.groups_to_fire == {
             self.group2.id: {self.workflow2_if_dcgs[1]},
         }
-        assert stats.tainted == 0
-        assert stats.untainted == 4
+        assert eval_result.stats.tainted == 0
+        assert eval_result.stats.untainted == 4
 
     def test_tainted_if_condition_counts(self) -> None:
         query_for_if = UniqueConditionQuery(
@@ -905,7 +905,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
         self.condition_group_results[query_for_if] = {self.group2.id: 101}
 
-        result, stats = get_groups_to_fire(
+        eval_result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -913,12 +913,12 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             self.dcg_to_slow_conditions,
         )
 
-        assert result == {
+        assert eval_result.groups_to_fire == {
             self.group1.id: {self.workflow1_if_dcgs[1]},
             self.group2.id: {self.workflow2_if_dcgs[1]},
         }
-        assert stats.tainted == 1
-        assert stats.untainted == 3
+        assert eval_result.stats.tainted == 1
+        assert eval_result.stats.untainted == 3
 
 
 class TestFireActionsForGroups(TestDelayedWorkflowBase):


### PR DESCRIPTION
# Description
It's really difficult for us to debug delayed workflows for a number of reasons. This PR aims to close that gap, adding information about each condition being evaluated in the delayed processor.

Eventually, it'd be nice to update this so there's a single `WorkflowEvaulationResult` that is share between processors/workflow.py and processors/delayed_workflow.py.