### PR TITLE
ref: Replace browserHistory with useNavigate in useCleanQueryParamsOnRouteLeave

### DIFF
--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx
@@ -98,7 +98,7 @@ describe('useCleanQueryParamsOnRouteLeave', () => {
     expect(router.location.query.cursor).toBe('0:1:0');
   });
 
-  it('should clean query params when navigating to a new path', async () => {
+  it('should clean query params when navigating to a new path', () => {
     const {router, rerender} = renderHookWithProviders(useCleanQueryParamsOnRouteLeave, {
       initialProps: {
         fieldsToClean: ['cursor'],

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx
@@ -1,75 +1,17 @@
 import type {Location} from 'history';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 
-import {renderHook} from 'sentry-test/reactTestingLibrary';
-
-import {browserHistory} from 'sentry/utils/browserHistory';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {
-  handleRouteLeave,
+  getCleanLocationIfNeeded,
   useCleanQueryParamsOnRouteLeave,
 } from './useCleanQueryParamsOnRouteLeave';
-import {useLocation} from './useLocation';
-
-jest.mock('./useLocation');
-
-const MockBrowserHistoryListen = jest.mocked(browserHistory.listen);
-const MockBrowserHistoryReplace = jest.mocked(browserHistory.replace);
-
-jest.mocked(useLocation).mockReturnValue({pathname: '/home'} as Location);
 
 type QueryParams = {cursor: string; limit: number; project: string};
 
-describe('useCleanQueryParamsOnRouteLeave', () => {
-  beforeEach(() => {
-    MockBrowserHistoryListen.mockReset();
-    MockBrowserHistoryReplace.mockReset();
-  });
-
-  it('should listen to browserHistory changes and stop on unmount', () => {
-    const unsubscriber = jest.fn();
-    MockBrowserHistoryListen.mockReturnValue(unsubscriber);
-
-    const {unmount} = renderHook(useCleanQueryParamsOnRouteLeave, {
-      initialProps: {
-        fieldsToClean: ['cursor'],
-      },
-    });
-
-    expect(MockBrowserHistoryListen).toHaveBeenCalled();
-    expect(unsubscriber).not.toHaveBeenCalled();
-
-    unmount();
-
-    expect(unsubscriber).toHaveBeenCalled();
-  });
-
-  it('should not update the history if shouldLeave returns false', () => {
-    MockBrowserHistoryListen.mockImplementation(onRouteLeave => {
-      onRouteLeave(
-        LocationFixture({
-          pathname: '/next',
-          query: {
-            cursor: '0:1:0',
-            limit: '5',
-          },
-        })
-      );
-      return () => {};
-    });
-
-    renderHook(useCleanQueryParamsOnRouteLeave, {
-      initialProps: {
-        fieldsToClean: ['cursor'],
-        shouldClean: () => false,
-      },
-    });
-
-    expect(MockBrowserHistoryReplace).not.toHaveBeenCalled();
-  });
-
-  it('should not update the history if the pathname is unchanged', () => {
-    handleRouteLeave({
+describe('getCleanLocationIfNeeded', () => {
+  it('should return null if the pathname is unchanged', () => {
+    const result = getCleanLocationIfNeeded({
       fieldsToClean: ['cursor'],
       newLocation: {
         pathname: '/home',
@@ -78,11 +20,11 @@ describe('useCleanQueryParamsOnRouteLeave', () => {
       oldPathname: '/home',
     });
 
-    expect(MockBrowserHistoryReplace).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 
-  it('should not update the history if the pathname is changing, but fieldsToClean are undefined', () => {
-    handleRouteLeave({
+  it('should return null if the pathname is changing, but fieldsToClean are undefined', () => {
+    const result = getCleanLocationIfNeeded({
       fieldsToClean: ['cursor'],
       newLocation: {
         pathname: '/next',
@@ -91,11 +33,11 @@ describe('useCleanQueryParamsOnRouteLeave', () => {
       oldPathname: '/home',
     });
 
-    expect(MockBrowserHistoryReplace).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 
-  it('should update the history when the path is changing and some fieldsToClean are set', () => {
-    handleRouteLeave({
+  it('should return cleaned location when the path is changing and some fieldsToClean are set', () => {
+    const result = getCleanLocationIfNeeded({
       fieldsToClean: ['cursor', 'limit'],
       newLocation: {
         pathname: '/next',
@@ -107,14 +49,14 @@ describe('useCleanQueryParamsOnRouteLeave', () => {
       oldPathname: '/home',
     });
 
-    expect(MockBrowserHistoryReplace).toHaveBeenCalledWith({
+    expect(result).toEqual({
       pathname: '/next',
       query: {},
     });
   });
 
   it('should leave other query params alone when the path is changing and something is filtered out', () => {
-    handleRouteLeave({
+    const result = getCleanLocationIfNeeded({
       fieldsToClean: ['cursor', 'limit'],
       newLocation: {
         pathname: '/next',
@@ -127,11 +69,51 @@ describe('useCleanQueryParamsOnRouteLeave', () => {
       oldPathname: '/home',
     });
 
-    expect(MockBrowserHistoryReplace).toHaveBeenCalledWith({
+    expect(result).toEqual({
       pathname: '/next',
       query: {
         project: '123',
       },
     });
+  });
+});
+
+describe('useCleanQueryParamsOnRouteLeave', () => {
+  it('should not navigate when shouldClean returns false', () => {
+    const {router} = renderHookWithProviders(useCleanQueryParamsOnRouteLeave, {
+      initialProps: {
+        fieldsToClean: ['cursor'],
+        shouldClean: () => false,
+      },
+      initialRouterConfig: {
+        location: {
+          pathname: '/home/',
+          query: {cursor: '0:1:0'},
+        },
+      },
+    });
+
+    router.navigate('/next/?cursor=0:1:0');
+
+    expect(router.location.query.cursor).toBe('0:1:0');
+  });
+
+  it('should clean query params when navigating to a new path', async () => {
+    const {router, rerender} = renderHookWithProviders(useCleanQueryParamsOnRouteLeave, {
+      initialProps: {
+        fieldsToClean: ['cursor'],
+      },
+      initialRouterConfig: {
+        location: {
+          pathname: '/home/',
+        },
+      },
+    });
+
+    router.navigate('/next/?cursor=0:1:0');
+
+    rerender({fieldsToClean: ['cursor']});
+
+    expect(router.location.query.cursor).toBeUndefined();
   });
 });

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
@@ -1,15 +1,15 @@
-import {useCallback, useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import type {Location} from 'history';
 
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 type Opts<Q> = {
   fieldsToClean: string[];
   shouldClean?: (newLocation: Location<Q>) => boolean;
 };
 
-export function handleRouteLeave<Q extends Record<PropertyKey, unknown>>({
+export function getCleanLocationIfNeeded<Q extends Record<PropertyKey, unknown>>({
   fieldsToClean,
   newLocation,
   oldPathname,
@@ -17,17 +17,15 @@ export function handleRouteLeave<Q extends Record<PropertyKey, unknown>>({
   fieldsToClean: string[];
   newLocation: Location<Q>;
   oldPathname: string;
-}) {
+}): {pathname: string; query: Record<string, unknown>} | null {
   const hasSomeValues = fieldsToClean.some(
     field => newLocation.query[field] !== undefined
   );
 
   if (newLocation.pathname === oldPathname || !hasSomeValues) {
-    return;
+    return null;
   }
 
-  // Removes fields from the URL on route leave so that the parameters will
-  // not interfere with other pages
   const query = fieldsToClean.reduce(
     (newQuery, field) => {
       // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
@@ -37,10 +35,7 @@ export function handleRouteLeave<Q extends Record<PropertyKey, unknown>>({
     {...newLocation.query}
   );
 
-  browserHistory.replace({
-    pathname: newLocation.pathname,
-    query,
-  });
+  return {pathname: newLocation.pathname, query};
 }
 
 export function useCleanQueryParamsOnRouteLeave<Q>({
@@ -48,21 +43,23 @@ export function useCleanQueryParamsOnRouteLeave<Q>({
   shouldClean,
 }: Opts<Q>) {
   const location = useLocation();
-
-  const onRouteLeave = useCallback(
-    (newLocation: any) => {
-      if (!shouldClean || shouldClean(newLocation)) {
-        handleRouteLeave({
-          fieldsToClean,
-          newLocation,
-          oldPathname: location.pathname,
-        });
-      }
-    },
-    [shouldClean, fieldsToClean, location.pathname]
-  );
+  const navigate = useNavigate();
+  const previousPathnameRef = useRef(location.pathname);
 
   useEffect(() => {
-    return browserHistory.listen(onRouteLeave);
-  }, [onRouteLeave]);
+    const oldPathname = previousPathnameRef.current;
+    previousPathnameRef.current = location.pathname;
+
+    if (!shouldClean || shouldClean(location as Location<Q>)) {
+      const cleanLocation = getCleanLocationIfNeeded({
+        fieldsToClean,
+        newLocation: location as Location<Q & Record<PropertyKey, unknown>>,
+        oldPathname,
+      });
+
+      if (cleanLocation) {
+        navigate(cleanLocation, {replace: true});
+      }
+    }
+  }, [location, fieldsToClean, shouldClean, navigate]);
 }

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
@@ -46,20 +46,49 @@ export function useCleanQueryParamsOnRouteLeave<Q>({
   const navigate = useNavigate();
   const previousPathnameRef = useRef(location.pathname);
 
+  const fieldsToCleanRef = useRef(fieldsToClean);
+  fieldsToCleanRef.current = fieldsToClean;
+  const shouldCleanRef = useRef(shouldClean);
+  shouldCleanRef.current = shouldClean;
+
   useEffect(() => {
     const oldPathname = previousPathnameRef.current;
     previousPathnameRef.current = location.pathname;
 
-    if (!shouldClean || shouldClean(location as Location<Q>)) {
+    if (!shouldCleanRef.current || shouldCleanRef.current(location as Location<Q>)) {
       const cleanLocation = getCleanLocationIfNeeded({
-        fieldsToClean,
+        fieldsToClean: fieldsToCleanRef.current,
         newLocation: location as Location<Q & Record<PropertyKey, unknown>>,
         oldPathname,
       });
 
       if (cleanLocation) {
-        navigate(cleanLocation, {replace: true});
+        navigate(cleanLocation, {replace: true, preventScrollReset: true});
       }
     }
-  }, [location, fieldsToClean, shouldClean, navigate]);
+  }, [location, navigate]);
+
+  // When the component unmounts due to route change, the effect above won't
+  // fire because React unmounts the component before re-rendering with the
+  // new location. Fall back to window.history to clean params directly.
+  useEffect(() => {
+    return () => {
+      const oldPathname = previousPathnameRef.current;
+      const newUrl = new URL(window.location.href);
+
+      if (newUrl.pathname === oldPathname) {
+        return;
+      }
+
+      const fields = fieldsToCleanRef.current;
+      if (!fields.some(f => newUrl.searchParams.has(f))) {
+        return;
+      }
+
+      for (const f of fields) {
+        newUrl.searchParams.delete(f);
+      }
+      window.history.replaceState(window.history.state, '', newUrl.toString());
+    };
+  }, []);
 }

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
@@ -68,12 +68,9 @@ export function useCleanQueryParamsOnRouteLeave<Q>({
     }
   }, [location, navigate]);
 
-  const navigateRef = useRef(navigate);
-  navigateRef.current = navigate;
-
   // When the component unmounts due to route change, the effect above won't
   // fire because React unmounts the component before re-rendering with the
-  // new location. Use navigate via ref to stay in sync with React Router.
+  // new location. Use navigate to stay in sync with React Router.
   useEffect(() => {
     return () => {
       const oldPathname = previousPathnameRef.current;
@@ -104,7 +101,7 @@ export function useCleanQueryParamsOnRouteLeave<Q>({
       });
 
       if (cleanLocation) {
-        navigateRef.current(cleanLocation, {
+        navigate(cleanLocation, {
           replace: true,
           preventScrollReset: true,
         });

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
@@ -83,9 +83,7 @@ export function useCleanQueryParamsOnRouteLeave<Q>({
         return;
       }
 
-      const query: Record<string, string> = Object.fromEntries(
-        newUrl.searchParams.entries()
-      );
+      const query = Object.fromEntries(newUrl.searchParams.entries());
       const newLocation = {
         pathname: newUrl.pathname,
         search: newUrl.search,

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
@@ -80,6 +80,21 @@ export function useCleanQueryParamsOnRouteLeave<Q>({
         return;
       }
 
+      if (shouldCleanRef.current) {
+        const query = Object.fromEntries(newUrl.searchParams.entries());
+        const newLocation = {
+          pathname: newUrl.pathname,
+          search: newUrl.search,
+          hash: newUrl.hash,
+          state: null,
+          query,
+          key: '',
+        } as Location<Q>;
+        if (!shouldCleanRef.current(newLocation)) {
+          return;
+        }
+      }
+
       const fields = fieldsToCleanRef.current;
       if (!fields.some(f => newUrl.searchParams.has(f))) {
         return;

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
@@ -28,7 +28,7 @@ export function getCleanLocationIfNeeded<Q extends Record<PropertyKey, unknown>>
 
   const query = fieldsToClean.reduce(
     (newQuery, field) => {
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+      // @ts-expect-error TS(2862): Type 'Q' is generic and can only be indexed for reading.
       newQuery[field] = undefined;
       return newQuery;
     },
@@ -68,9 +68,12 @@ export function useCleanQueryParamsOnRouteLeave<Q>({
     }
   }, [location, navigate]);
 
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+
   // When the component unmounts due to route change, the effect above won't
   // fire because React unmounts the component before re-rendering with the
-  // new location. Fall back to window.history to clean params directly.
+  // new location. Use navigate via ref to stay in sync with React Router.
   useEffect(() => {
     return () => {
       const oldPathname = previousPathnameRef.current;
@@ -80,30 +83,34 @@ export function useCleanQueryParamsOnRouteLeave<Q>({
         return;
       }
 
-      if (shouldCleanRef.current) {
-        const query = Object.fromEntries(newUrl.searchParams.entries());
-        const newLocation = {
-          pathname: newUrl.pathname,
-          search: newUrl.search,
-          hash: newUrl.hash,
-          state: null,
-          query,
-          key: '',
-        } as Location<Q>;
-        if (!shouldCleanRef.current(newLocation)) {
-          return;
-        }
-      }
+      const query: Record<string, string> = Object.fromEntries(
+        newUrl.searchParams.entries()
+      );
+      const newLocation = {
+        pathname: newUrl.pathname,
+        search: newUrl.search,
+        hash: newUrl.hash,
+        state: null,
+        query,
+        key: '',
+      } as Location<Q>;
 
-      const fields = fieldsToCleanRef.current;
-      if (!fields.some(f => newUrl.searchParams.has(f))) {
+      if (shouldCleanRef.current && !shouldCleanRef.current(newLocation)) {
         return;
       }
 
-      for (const f of fields) {
-        newUrl.searchParams.delete(f);
+      const cleanLocation = getCleanLocationIfNeeded({
+        fieldsToClean: fieldsToCleanRef.current,
+        newLocation: newLocation as Location<Q & Record<PropertyKey, unknown>>,
+        oldPathname,
+      });
+
+      if (cleanLocation) {
+        navigateRef.current(cleanLocation, {
+          replace: true,
+          preventScrollReset: true,
+        });
       }
-      window.history.replaceState(window.history.state, '', newUrl.toString());
     };
   }, []);
 }

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
@@ -107,5 +107,5 @@ export function useCleanQueryParamsOnRouteLeave<Q>({
         });
       }
     };
-  }, []);
+  }, [navigate]);
 }


### PR DESCRIPTION
## Summary
- Replace `browserHistory.listen`/`replace` with `useNavigate` + `useEffect`/`useRef` to remove the react-router 3 shim dependency from `useCleanQueryParamsOnRouteLeave`
- Rename `handleRouteLeave` to `getCleanLocationIfNeeded` — now a pure function returning the cleaned location instead of performing side effects
- Update tests to use `renderHookWithProviders` with `initialRouterConfig` instead of mocking `browserHistory`

## Test plan
- [x] TypeScript typecheck passes
- [x] `pnpm test-ci static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx` passes
- [x] Verify replays issue detail tab still cleans query params on route leave
    - [x] Visit Issue Details > Replay
    - [x] Click to watch a replay that is not the first
    - [x] Notice how `selected_replay_index` is added to the query string
    - [x] Navigate back to the normal Issue Details page
    - [x] Notice how `selected_replay_index` is cleaned from the query string ✅ 


[![View Interactive Review](https://img.shields.io/badge/Review-html_summary-D97757?style=for-the-badge&logo=claude&logoColor=D97757)](https://insecure-html-azure.vercel.app/?pr-url=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry%2Fpull%2F115695)
<!-- html-preview:start
<!DOCTYPE html> <html lang="en"> <head> <meta charset="UTF-8"> <meta name="viewport" content="width=device-width, initial-scale=1.0"> <title>PR #115695 Review — ref: Replace browserHistory with useNavigate in useCleanQueryParamsOnRouteLeave</title> <style> :root { --bg: #0d1117; --surface: #161b22; --border: #30363d; --text: #e6edf3; --text-muted: #8b949e; --add-bg: #12261e; --add-text: #3fb950; --del-bg: #2d1214; --del-text: #f85149; --accent: #58a6ff; --purple: #bc8cff; --orange: #d29922; --teal: #39d353; } * { margin: 0; padding: 0; box-sizing: border-box; } body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; line-height: 1.6; padding: 2rem 1rem; } .container { max-width: 1200px; margin: 0 auto; } .pr-header { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; } .pr-header h1 { font-size: 1.35rem; font-weight: 600; margin-bottom: 0.5rem; } .pr-header h1 .muted { color: var(--text-muted); font-weight: 400; } .meta-row { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; font-size: 0.85rem; color: var(--text-muted); } .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 6px; font-size: 0.75rem; font-family: 'SFMono-Regular', Consolas, monospace; background: rgba(88, 166, 255, 0.1); color: var(--accent); border: 1px solid rgba(88, 166, 255, 0.2); } .stat-add { color: var(--add-text); } .stat-del { color: var(--del-text); } .summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; } .summary-card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.25rem; } .summary-card .label { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin-bottom: 0.25rem; } .summary-card .value { font-size: 1.75rem; font-weight: 700; } .summary-card .desc { font-size: 0.8rem; color: var(--text-muted); margin-top: 0.25rem; } .verdict { display: flex; align-items: flex-start; gap: 1rem; background: var(--surface); border: 1px solid var(--teal); border-radius: 10px; padding: 1.25rem; margin-bottom: 1.5rem; } .verdict .icon { font-size: 1.5rem; flex-shrink: 0; } .verdict h2 { font-size: 1.1rem; margin-bottom: 0.25rem; } .verdict p { font-size: 0.85rem; color: var(--text-muted); } .section-title { font-size: 1.1rem; font-weight: 600; margin-bottom: 1rem; } .finding { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; margin-bottom: 0.75rem; overflow: hidden; } .finding-header { display: flex; align-items: center; gap: 0.75rem; padding: 0.85rem 1rem; cursor: pointer; user-select: none; } .finding-header:hover { background: rgba(255, 255, 255, 0.02); } .finding-header .title { font-weight: 500; font-size: 0.9rem; } .finding-header .file-ref { margin-left: auto; font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.75rem; color: var(--text-muted); flex-shrink: 0; } .finding-body { padding: 0 1rem 1rem 1rem; font-size: 0.85rem; color: var(--text-muted); line-height: 1.65; } .finding-body code { font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.8rem; background: rgba(255, 255, 255, 0.06); padding: 0.15rem 0.4rem; border-radius: 4px; } .finding.collapsed .finding-body { display: none; } .severity { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 12px; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; flex-shrink: 0; } .severity.positive { background: rgba(57, 211, 83, 0.15); color: var(--teal); border: 1px solid rgba(57, 211, 83, 0.3); } .severity.info { background: rgba(88, 166, 255, 0.15); color: var(--accent); border: 1px solid rgba(88, 166, 255, 0.3); } .severity.low { background: rgba(210, 153, 34, 0.15); color: var(--orange); border: 1px solid rgba(210, 153, 34, 0.3); } .severity.medium { background: rgba(248, 81, 73, 0.15); color: var(--del-text); border: 1px solid rgba(248, 81, 73, 0.3); } .diff-section { margin-top: 1.5rem; } .diff-controls { display: flex; gap: 0.5rem; margin-bottom: 1rem; } .diff-controls button { background: var(--surface); border: 1px solid var(--border); color: var(--text-muted); padding: 0.35rem 0.85rem; border-radius: 6px; font-size: 0.8rem; cursor: pointer; } .diff-controls button:hover { border-color: var(--accent); color: var(--text); } .diff-file { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; margin-bottom: 0.75rem; overflow: hidden; } .diff-file-header { display: flex; align-items: center; gap: 0.6rem; padding: 0.7rem 1rem; cursor: pointer; user-select: none; font-size: 0.85rem; } .diff-file-header:hover { background: rgba(255, 255, 255, 0.02); } .chevron { display: inline-block; transition: transform 0.15s; font-size: 0.7rem; color: var(--text-muted); } .diff-file.collapsed .chevron { transform: rotate(-90deg); } .diff-file.collapsed .diff-body { display: none; } .diff-file-header .path { font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.8rem; } .diff-file-header .change-badge { font-size: 0.65rem; padding: 0.1rem 0.4rem; border-radius: 4px; text-transform: uppercase; font-weight: 600; background: rgba(88, 166, 255, 0.1); color: var(--accent); border: 1px solid rgba(88, 166, 255, 0.2); } .diff-file-header .stats { margin-left: auto; font-size: 0.8rem; } .diff-table { width: 100%; border-collapse: collapse; font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.78rem; line-height: 1.55; } .diff-table td { padding: 0 0.75rem; white-space: pre; vertical-align: top; } .diff-table .ln { width: 1px; text-align: right; color: var(--text-muted); opacity: 0.4; padding: 0 0.5rem; user-select: none; } .diff-table tr.add { background: var(--add-bg); } .diff-table tr.add td.code { color: var(--add-text); } .diff-table tr.del { background: var(--del-bg); } .diff-table tr.del td.code { color: var(--del-text); } .diff-table tr.hunk td { color: var(--purple); padding: 0.3rem 0.75rem; background: rgba(188, 140, 255, 0.08); font-style: italic; } .annotation { display: block; background: var(--surface); border: 1px solid var(--border); border-left: 3px solid; border-radius: 6px; padding: 0.5rem 0.75rem; margin: 0.35rem 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 0.8rem; line-height: 1.5; white-space: normal; color: var(--text-muted); } .annotation.positive { border-left-color: var(--teal); } .annotation.info { border-left-color: var(--accent); } .annotation.low { border-left-color: var(--orange); } .annotation.medium { border-left-color: var(--del-text); } .ann-label { font-weight: 700; text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.04em; margin-right: 0.4rem; } .ann-label.positive { color: var(--teal); } .ann-label.info { color: var(--accent); } .ann-label.low { color: var(--orange); } .ann-label.medium { color: var(--del-text); } .file-list { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.25rem; margin-top: 1.5rem; } .file-list h3 { font-size: 0.9rem; margin-bottom: 0.75rem; } .file-pill { display: inline-block; padding: 0.2rem 0.6rem; margin: 0.2rem; border-radius: 6px; font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.72rem; background: rgba(255, 255, 255, 0.04); border: 1px solid var(--border); color: var(--text-muted); } </style> </head> <body> <div class="container"> <div class="pr-header"> <h1>Replace browserHistory with useNavigate in useCleanQueryParamsOnRouteLeave <span class="muted">#115695</span></h1> <div class="meta-row"> <span>by <strong>ryan953</strong></span> <span class="badge">ryan953/ref/remove-browserhistory-from-clean-query-params</span> <span>&#8594;</span> <span class="badge">master</span> <span class="stat-add">+104</span> <span class="stat-del">-96</span> <span>2 files</span> <span>2 commits</span> </div> </div> <div class="summary-grid"> <div class="summary-card"> <div class="label">Migration Type</div> <div class="value" style="color: var(--accent);">RR3 &#8594; RR6</div> <div class="desc">React Router 3 shim removal</div> </div> <div class="summary-card"> <div class="label">Shim Imports Removed</div> <div class="value" style="color: var(--teal);">2</div> <div class="desc">browserHistory import eliminated from hook + spec</div> </div> <div class="summary-card"> <div class="label">Test Approach</div> <div class="value" style="font-size: 1.1rem; color: var(--purple);">No Mocks</div> <div class="desc">Tests use renderHookWithProviders with real router</div> </div> <div class="summary-card"> <div class="label">Net Change</div> <div class="value" style="color: var(--add-text);">+8</div> <div class="desc">104 additions, 96 deletions across 2 files</div> </div> </div> <div class="verdict"> <div class="icon">&#9989;</div> <div> <h2>Approve with Notes</h2> <p>Solid migration from browserHistory shim to native React Router 6 hooks. The unmount cleanup via <code style="font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.8rem; background: rgba(255,255,255,0.06); padding: 0.15rem 0.4rem; border-radius: 4px;">window.history.replaceState</code> correctly handles the edge case where the component unmounts before the location-change effect fires. Tests remove all mocks in favor of real router context.</p> </div> </div> <div class="section-title">Findings</div> <div class="finding" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity positive">positive</span> <span class="title">Pure function extraction improves testability</span> <span class="file-ref">useCleanQueryParamsOnRouteLeave.tsx:12</span> </div> <div class="finding-body"> Renaming <code>handleRouteLeave</code> to <code>getCleanLocationIfNeeded</code> and making it return a value instead of calling <code>browserHistory.replace</code> directly is a clean separation. The function is now a pure computation that can be tested without any mocking, and the side effect (navigation) is handled by the hook caller. </div> </div> <div class="finding" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity positive">positive</span> <span class="title">Unmount cleanup handles route-change edge case</span> <span class="file-ref">useCleanQueryParamsOnRouteLeave.tsx:68-84</span> </div> <div class="finding-body"> The second <code>useEffect([], ...)</code> with a cleanup function correctly addresses the behavioral difference between <code>browserHistory.listen</code> (synchronous, fires before unmount) and <code>useEffect</code> (fires after render, skipped on unmount). Using <code>window.history.replaceState</code> in cleanup is the right escape hatch since React Router has already updated the URL by cleanup time. </div> </div> <div class="finding" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity positive">positive</span> <span class="title">preventScrollReset preserves shim behavior</span> <span class="file-ref">useCleanQueryParamsOnRouteLeave.tsx:61</span> </div> <div class="finding-body"> Adding <code>preventScrollReset: true</code> to the <code>navigate()</code> call matches the behavior of the old <code>browserHistory.replace</code> shim, which always set this flag. Without it, cleaning query params would cause an unwanted scroll-to-top. </div> </div> <div class="finding" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity positive">positive</span> <span class="title">Tests remove all browserHistory mocking</span> <span class="file-ref">useCleanQueryParamsOnRouteLeave.spec.tsx</span> </div> <div class="finding-body"> The spec file eliminates <code>jest.mock</code>, <code>jest.mocked(browserHistory.listen)</code>, and <code>jest.mocked(browserHistory.replace)</code> in favor of <code>renderHookWithProviders</code> with <code>initialRouterConfig</code>. The pure function tests use direct assertions on return values instead of mock call checks. </div> </div> <div class="finding collapsed" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity info">info</span> <span class="title">Refs used to break effect dependency cycles</span> <span class="file-ref">useCleanQueryParamsOnRouteLeave.tsx:48-51</span> </div> <div class="finding-body"> <code>fieldsToCleanRef</code> and <code>shouldCleanRef</code> are updated on every render and read inside the effect, avoiding <code>fieldsToClean</code> and <code>shouldClean</code> as effect dependencies. This prevents the effect from re-running when callback identity changes (common with inline arrow functions) while still reading the latest values. Standard React pattern for this scenario. </div> </div> <div class="finding collapsed" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity info">info</span> <span class="title">shouldClean not checked in unmount cleanup</span> <span class="file-ref">useCleanQueryParamsOnRouteLeave.tsx:68-84</span> </div> <div class="finding-body"> The unmount cleanup skips the <code>shouldClean</code> guard. In the current consumers (<code>groupReplays</code> and <code>useReplaysFromIssue</code>), <code>shouldClean</code> checks whether the new pathname is within the same issue. On unmount, the params being cleaned (cursor, selected_replay_index) are harmless to remove from any URL, so this is acceptable. If a future consumer relied on <code>shouldClean</code> to prevent cleanup in certain transitions, this would need revisiting. </div> </div> <div class="diff-section"> <div class="section-title">Annotated Diff</div> <div class="diff-controls"> <button onclick="toggleAll(true)">Expand All</button> <button onclick="toggleAll(false)">Collapse All</button> </div> <div class="diff-file"> <div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#9660;</span> <span class="path">static/app/utils/useCleanQueryParamsOnRouteLeave.tsx</span> <span class="change-badge">modified</span> <span class="stats"><span class="stat-add">+50</span> <span class="stat-del">-24</span></span> </div> <div class="diff-body"> <table class="diff-table"> <tr class="hunk"><td colspan="3">@@ Imports @@</td></tr> <tr class="del"><td class="ln">1</td><td class="ln"></td><td class="code">import {useCallback, useEffect} from 'react';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">1</td><td class="code">import {useEffect, useRef} from 'react';</td></tr> <tr><td class="ln">2</td><td class="ln">2</td><td class="code">import type {Location} from 'history';</td></tr> <tr class="del"><td class="ln">4</td><td class="ln"></td><td class="code">import {browserHistory} from 'sentry/utils/browserHistory';</td></tr> <tr><td class="ln">5</td><td class="ln">4</td><td class="code">import {useLocation} from 'sentry/utils/useLocation';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">5</td><td class="code">import {useNavigate} from 'sentry/utils/useNavigate';</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> Clean import swap: browserHistory out, useNavigate in. useCallback replaced by useRef for the ref-based pattern.</div></td></tr> <tr class="hunk"><td colspan="3">@@ handleRouteLeave &#8594; getCleanLocationIfNeeded @@</td></tr> <tr class="del"><td class="ln">12</td><td class="ln"></td><td class="code">export function handleRouteLeave&lt;Q extends Record&lt;...&gt;&gt;({</td></tr> <tr class="add"><td class="ln"></td><td class="ln">12</td><td class="code">export function getCleanLocationIfNeeded&lt;Q extends Record&lt;...&gt;&gt;({</td></tr> <tr class="del"><td class="ln">19</td><td class="ln"></td><td class="code">}) {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">19</td><td class="code">}): {pathname: string; query: Record&lt;string, unknown&gt;} | null {</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> Return type is now explicit: either a cleaned location or null. No side effects.</div></td></tr> <tr class="del"><td class="ln">24</td><td class="ln"></td><td class="code"> return;</td></tr> <tr class="add"><td class="ln"></td><td class="ln">24</td><td class="code"> return null;</td></tr> <tr class="del"><td class="ln">40</td><td class="ln"></td><td class="code"> browserHistory.replace({ pathname: newLocation.pathname, query });</td></tr> <tr class="add"><td class="ln"></td><td class="ln">38</td><td class="code"> return {pathname: newLocation.pathname, query};</td></tr> <tr class="hunk"><td colspan="3">@@ useCleanQueryParamsOnRouteLeave hook body @@</td></tr> <tr class="add"><td class="ln"></td><td class="ln">46</td><td class="code"> const navigate = useNavigate();</td></tr> <tr class="add"><td class="ln"></td><td class="ln">47</td><td class="code"> const previousPathnameRef = useRef(location.pathname);</td></tr> <tr class="add"><td class="ln"></td><td class="ln">48</td><td class="code"> const fieldsToCleanRef = useRef(fieldsToClean);</td></tr> <tr class="add"><td class="ln"></td><td class="ln">49</td><td class="code"> fieldsToCleanRef.current = fieldsToClean;</td></tr> <tr class="add"><td class="ln"></td><td class="ln">50</td><td class="code"> const shouldCleanRef = useRef(shouldClean);</td></tr> <tr class="add"><td class="ln"></td><td class="ln">51</td><td class="code"> shouldCleanRef.current = shouldClean;</td></tr> <tr><td colspan="3"><div class="annotation info"><span class="ann-label info">info</span> Refs avoid stale closures and prevent unnecessary effect re-runs from callback identity changes.</div></td></tr> <tr class="add"><td class="ln"></td><td class="ln">61</td><td class="code"> navigate(cleanLocation, {replace: true, preventScrollReset: true});</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> <code>preventScrollReset: true</code> matches the old browserHistory.replace shim behavior.</div></td></tr> <tr class="hunk"><td colspan="3">@@ Unmount cleanup effect @@</td></tr> <tr class="add"><td class="ln"></td><td class="ln">68</td><td class="code"> useEffect(() =&gt; {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">69</td><td class="code"> return () =&gt; {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">70</td><td class="code"> const oldPathname = previousPathnameRef.current;</td></tr> <tr class="add"><td class="ln"></td><td class="ln">71</td><td class="code"> const newUrl = new URL(window.location.href);</td></tr> <tr class="add"><td class="ln"></td><td class="ln">72</td><td class="code"> if (newUrl.pathname === oldPathname) return;</td></tr> <tr class="add"><td class="ln"></td><td class="ln">73</td><td class="code"> const fields = fieldsToCleanRef.current;</td></tr> <tr class="add"><td class="ln"></td><td class="ln">74</td><td class="code"> if (!fields.some(f =&gt; newUrl.searchParams.has(f))) return;</td></tr> <tr class="add"><td class="ln"></td><td class="ln">75</td><td class="code"> for (const f of fields) newUrl.searchParams.delete(f);</td></tr> <tr class="add"><td class="ln"></td><td class="ln">76</td><td class="code"> window.history.replaceState(window.history.state, '', newUrl.toString());</td></tr> <tr class="add"><td class="ln"></td><td class="ln">77</td><td class="code"> };</td></tr> <tr class="add"><td class="ln"></td><td class="ln">78</td><td class="code"> }, []);</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> Handles the unmount-during-route-change case that useEffect alone would miss. Reads the URL directly since React Router has already updated it by cleanup time.</div></td></tr> </table> </div> </div> <div class="diff-file"> <div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#9660;</span> <span class="path">static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx</span> <span class="change-badge">modified</span> <span class="stats"><span class="stat-add">+54</span> <span class="stat-del">-72</span></span> </div> <div class="diff-body"> <table class="diff-table"> <tr class="hunk"><td colspan="3">@@ Imports @@</td></tr> <tr class="del"><td class="ln">2</td><td class="ln"></td><td class="code">import {LocationFixture} from 'sentry-fixture/locationFixture';</td></tr> <tr class="del"><td class="ln">4</td><td class="ln"></td><td class="code">import {renderHook} from 'sentry-test/reactTestingLibrary';</td></tr> <tr class="del"><td class="ln">6</td><td class="ln"></td><td class="code">import {browserHistory} from 'sentry/utils/browserHistory';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">3</td><td class="code">import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';</td></tr> <tr class="del"><td class="ln">8</td><td class="ln"></td><td class="code"> handleRouteLeave,</td></tr> <tr class="add"><td class="ln"></td><td class="ln">6</td><td class="code"> getCleanLocationIfNeeded,</td></tr> <tr class="del"><td class="ln">11</td><td class="ln"></td><td class="code">import {useLocation} from './useLocation';</td></tr> <tr class="del"><td class="ln">13</td><td class="ln"></td><td class="code">jest.mock('./useLocation');</td></tr> <tr class="del"><td class="ln">15</td><td class="ln"></td><td class="code">const MockBrowserHistoryListen = jest.mocked(browserHistory.listen);</td></tr> <tr class="del"><td class="ln">16</td><td class="ln"></td><td class="code">const MockBrowserHistoryReplace = jest.mocked(browserHistory.replace);</td></tr> <tr class="del"><td class="ln">18</td><td class="ln"></td><td class="code">jest.mocked(useLocation).mockReturnValue({pathname: '/home'} as Location);</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> All mock infrastructure removed: no jest.mock, no jest.mocked, no manual mock setup/teardown. Tests use real router context via renderHookWithProviders.</div></td></tr> <tr class="hunk"><td colspan="3">@@ Pure function tests @@</td></tr> <tr class="del"><td class="ln">71</td><td class="ln"></td><td class="code"> it('should not update the history if the pathname is unchanged', () =&gt; {</td></tr> <tr class="del"><td class="ln">72</td><td class="ln"></td><td class="code"> handleRouteLeave({</td></tr> <tr class="add"><td class="ln"></td><td class="ln">14</td><td class="code"> it('should return null if the pathname is unchanged', () =&gt; {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">15</td><td class="code"> const result = getCleanLocationIfNeeded({</td></tr> <tr><td colspan="3"><div class="annotation info"><span class="ann-label info">info</span> Tests now assert on return values (<code>expect(result).toBeNull()</code>, <code>expect(result).toEqual({...})</code>) instead of checking mock call args. More direct and less brittle.</div></td></tr> <tr class="hunk"><td colspan="3">@@ Hook integration tests @@</td></tr> <tr class="add"><td class="ln"></td><td class="ln">80</td><td class="code">describe('useCleanQueryParamsOnRouteLeave', () =&gt; {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">81</td><td class="code"> it('should not navigate when shouldClean returns false', () =&gt; {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">82</td><td class="code"> const {router} = renderHookWithProviders(useCleanQueryParamsOnRouteLeave, {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">83</td><td class="code"> initialProps: { fieldsToClean: ['cursor'], shouldClean: () =&gt; false },</td></tr> <tr class="add"><td class="ln"></td><td class="ln">84</td><td class="code"> initialRouterConfig: { location: { pathname: '/home/', query: {cursor: '0:1:0'} } },</td></tr> <tr class="add"><td class="ln"></td><td class="ln">85</td><td class="code"> });</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> Hook tests use <code>renderHookWithProviders</code> with <code>initialRouterConfig</code> for real router context, and <code>router.navigate()</code> for programmatic navigation.</div></td></tr> </table> </div> </div> </div> <div class="file-list"> <h3>Changed Files</h3> <span class="file-pill">static/app/utils/useCleanQueryParamsOnRouteLeave.tsx</span> <span class="file-pill">static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx</span> </div> </div> <script> function toggleAll(expand) { document.querySelectorAll('.diff-file').forEach(function(el) { if (expand) { el.classList.remove('collapsed'); } else { el.classList.add('collapsed'); } }); } </script> </body> </html> 
html-preview:end -->
