### PR TITLE
chore(lint): Enable eslint curly rule and auto-fix all violations

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -915,6 +915,7 @@ export default typescript.config([
     name: 'plugin/prettier',
     extends: [prettier],
     rules: {
+      curly: 'error',
       // import sorting is handled by oxfmt
       'import/order': 'off',
       'sort-imports': 'off',

--- a/static/app/components/acl/useRole.tsx
+++ b/static/app/components/acl/useRole.tsx
@@ -28,7 +28,9 @@ function getProjectRole(
   project: DetailedProject | undefined,
   role: 'debugFilesRole' | 'attachmentsRole'
 ): string | undefined {
-  if (!project) return undefined;
+  if (!project) {
+    return undefined;
+  }
 
   if (role === 'debugFilesRole') {
     return project.debugFilesRole ?? undefined;

--- a/static/app/components/charts/useChartXRangeSelection.spec.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.spec.tsx
@@ -133,9 +133,15 @@ describe('useChartXRangeSelection', () => {
           }),
         }),
         convertToPixel: jest.fn((_config, value) => {
-          if (value === 100) return 500;
-          if (value === 90) return 450;
-          if (value === 10) return 50;
+          if (value === 100) {
+            return 500;
+          }
+          if (value === 90) {
+            return 450;
+          }
+          if (value === 10) {
+            return 50;
+          }
           return 0;
         }),
       } as any;
@@ -380,8 +386,12 @@ describe('useChartXRangeSelection', () => {
           }),
         }),
         convertToPixel: jest.fn((_config, value) => {
-          if (value === 100) return 500; // xMax
-          if (value === 90) return 480; // Above 60% threshold
+          if (value === 100) {
+            return 500;
+          } // xMax
+          if (value === 90) {
+            return 480;
+          } // Above 60% threshold
           return 0;
         }),
       } as any;
@@ -694,10 +704,18 @@ describe('useChartXRangeSelection', () => {
         convertToPixel: jest.fn((_config, value) => {
           // Selection range pixels: xMin=50, xMax=150
           // yMin pixel = 200
-          if (value === 100) return 200; // xMax extent
-          if (value === 0) return 200; // yMin extent
-          if (value === 10) return 50; // selection xMin
-          if (value === 90) return 150; // selection xMax
+          if (value === 100) {
+            return 200;
+          } // xMax extent
+          if (value === 0) {
+            return 200;
+          } // yMin extent
+          if (value === 10) {
+            return 50;
+          } // selection xMin
+          if (value === 90) {
+            return 150;
+          } // selection xMax
           return 100;
         }),
         getDom: jest.fn().mockReturnValue({
@@ -775,10 +793,18 @@ describe('useChartXRangeSelection', () => {
         convertToPixel: jest.fn((_config, value) => {
           // Selection range pixels: xMin=50, xMax=150
           // yMin pixel = 200
-          if (value === 100) return 200; // xMax extent
-          if (value === 0) return 200; // yMin extent
-          if (value === 10) return 50; // selection xMin
-          if (value === 90) return 150; // selection xMax
+          if (value === 100) {
+            return 200;
+          } // xMax extent
+          if (value === 0) {
+            return 200;
+          } // yMin extent
+          if (value === 10) {
+            return 50;
+          } // selection xMin
+          if (value === 90) {
+            return 150;
+          } // selection xMax
           return 100;
         }),
         getDom: jest.fn().mockReturnValue({
@@ -854,10 +880,18 @@ describe('useChartXRangeSelection', () => {
           }),
         }),
         convertToPixel: jest.fn((_config, value) => {
-          if (value === 100) return 200;
-          if (value === 0) return 200;
-          if (value === 10) return 50;
-          if (value === 90) return 150;
+          if (value === 100) {
+            return 200;
+          }
+          if (value === 0) {
+            return 200;
+          }
+          if (value === 10) {
+            return 50;
+          }
+          if (value === 90) {
+            return 150;
+          }
           return 100;
         }),
         getDom: jest.fn().mockReturnValue({

--- a/static/app/components/charts/useChartXRangeSelection.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.tsx
@@ -156,14 +156,18 @@ export function useChartXRangeSelection({
   const previousInitialSelection = usePrevious(initialSelection);
 
   const clearSelection = useCallback(() => {
-    if (!selectionState?.selection) return;
+    if (!selectionState?.selection) {
+      return;
+    }
 
     const chartInstance = chartRef.current?.getEchartsInstance();
 
     chartInstance?.dispatchAction({type: 'brush', areas: []});
 
     // Restore the tooltip as we clear selection
-    if (tooltipFrameRef.current) cancelAnimationFrame(tooltipFrameRef.current);
+    if (tooltipFrameRef.current) {
+      cancelAnimationFrame(tooltipFrameRef.current);
+    }
 
     tooltipFrameRef.current = requestAnimationFrame(() => {
       chartInstance?.setOption({tooltip: {show: true}}, {silent: true});
@@ -192,7 +196,9 @@ export function useChartXRangeSelection({
 
       // Disable the tooltip as we start dragging, as it covers regions of the chart that the user
       // may want to select. The tooltip remains hidden until the box is cleared.
-      if (tooltipFrameRef.current) cancelAnimationFrame(tooltipFrameRef.current);
+      if (tooltipFrameRef.current) {
+        cancelAnimationFrame(tooltipFrameRef.current);
+      }
 
       tooltipFrameRef.current = requestAnimationFrame(() => {
         chartInstance.setOption(
@@ -210,7 +216,9 @@ export function useChartXRangeSelection({
 
   const onBrushEnd = useCallback<EChartBrushEndHandler>(
     (evt, chartInstance) => {
-      if (!chartInstance) return;
+      if (!chartInstance) {
+        return;
+      }
 
       const area = evt.areas[0];
 
@@ -251,7 +259,9 @@ export function useChartXRangeSelection({
   }, [chartRef]);
 
   const syncSelectionStates = useCallback(() => {
-    if (disabled) return;
+    if (disabled) {
+      return;
+    }
 
     const chartInstance = chartRef.current?.getEchartsInstance();
 
@@ -312,10 +322,14 @@ export function useChartXRangeSelection({
   ]);
 
   useEffect(() => {
-    if (disabled || !selectionState?.selection) return;
+    if (disabled || !selectionState?.selection) {
+      return;
+    }
 
     const chartInstance = chartRef.current?.getEchartsInstance();
-    if (!chartInstance) return;
+    if (!chartInstance) {
+      return;
+    }
 
     const handleInsideSelectionClick = (event: MouseEvent) => {
       const [selectedMin, selectedMax] = selectionState.selection.range;
@@ -326,7 +340,9 @@ export function useChartXRangeSelection({
       // @ts-expect-error TODO Abdullah Khan: chartInstance.getModel is a private method, but we access it to get the axis extremes
       // could not find a better way, this works out perfectly for now. Passing down the entire series data to the hook is more gross.
       const yAxis = chartInstance.getModel()?.getComponent?.('yAxis', 0);
-      if (!yAxis) return;
+      if (!yAxis) {
+        return;
+      }
 
       const yMin = yAxis.axis.scale.getExtent()[0];
       const yMinPixel = chartInstance.convertToPixel({yAxisIndex: 0}, yMin);
@@ -467,8 +483,9 @@ export function useChartXRangeSelection({
       !selectionState?.actionMenuPosition ||
       !actionMenuRenderer ||
       !selectionState.isActionMenuVisible
-    )
+    ) {
       return null;
+    }
 
     // We want the top right corner of the action menu to be aligned with the bottom left
     // corner of the selection box, when the menu is positioned to the left. Using a transform, saves us

--- a/static/app/components/commandPalette/ui/cmdk.tsx
+++ b/static/app/components/commandPalette/ui/cmdk.tsx
@@ -121,7 +121,9 @@ function CMDKActionWithResource<TData = unknown>({
       ? data.map((item, i) => {
           // CommandPaletteActionGroup has an `actions` prop that CMDKAction doesn't
           // accept, so we skip groups here — they can't be auto-rendered as leaf nodes.
-          if ('actions' in item) return null;
+          if ('actions' in item) {
+            return null;
+          }
           return <CMDKAction key={i} {...item} />;
         })
       : null;

--- a/static/app/components/commandPalette/ui/collection.tsx
+++ b/static/app/components/commandPalette/ui/collection.tsx
@@ -87,7 +87,9 @@ export function makeCollection<T>(): CollectionInstance<T> {
 
         unregister(key) {
           const node = nodes.current.get(key);
-          if (!node) return;
+          if (!node) {
+            return;
+          }
           nodes.current.delete(key);
           childIndex.current.get(node.parent)?.delete(key);
           childIndex.current.delete(key);

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -177,7 +177,9 @@ export function CommandPalette({
       !isLoading &&
       !isEmptyPromptQuery;
 
-    if (!showSeerFallback) return [scored, scoredPrefixMap, false];
+    if (!showSeerFallback) {
+      return [scored, scoredPrefixMap, false];
+    }
 
     const truncated =
       state.query.length > 24 ? state.query.slice(0, 24) + '...' : state.query;
@@ -690,10 +692,16 @@ function presortBySlotRef(
     const aEl = a.ref?.current ?? null;
     const bEl = b.ref?.current ?? null;
 
-    if (aEl === bEl) return 0; // both null, or same outlet element — preserve order
+    if (aEl === bEl) {
+      return 0;
+    } // both null, or same outlet element — preserve order
 
-    if (!aEl) return 1; // a has no slot ref → sort after b
-    if (!bEl) return -1; // b has no slot ref → sort a before b
+    if (!aEl) {
+      return 1;
+    } // a has no slot ref → sort after b
+    if (!bEl) {
+      return -1;
+    } // b has no slot ref → sort a before b
     return aEl.compareDocumentPosition(bEl) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
   });
 }
@@ -713,7 +721,9 @@ function scoreNode(
   let bestLength = Infinity;
   let matched = false;
   for (const candidate of [label, details, ...keywords]) {
-    if (!candidate) continue;
+    if (!candidate) {
+      continue;
+    }
     const result = fzf(candidate, query, false);
     if (result.end !== -1 && result.score > best) {
       best = result.score;
@@ -856,7 +866,9 @@ function flattenActions(
     let root: CollectionTreeNode<CMDKActionData> = item;
     while (root.parent !== null) {
       const parent = nodeMap.get(root.parent);
-      if (!parent) break;
+      if (!parent) {
+        break;
+      }
       root = parent;
     }
     nodeRootKey.set(item.key, root.key);
@@ -871,9 +883,13 @@ function flattenActions(
   const rootBestScore = new Map<string, CommandPaletteScore>();
   for (const [key, score] of scores) {
     const node = nodeMap.get(key);
-    if (node?.parent === null && node.children.length === 0) continue;
+    if (node?.parent === null && node.children.length === 0) {
+      continue;
+    }
     const rootKey = nodeRootKey.get(key);
-    if (rootKey === undefined) continue;
+    if (rootKey === undefined) {
+      continue;
+    }
     const current = rootBestScore.get(rootKey);
     if (current === undefined || compareCommandPaletteScores(score, current) < 0) {
       rootBestScore.set(rootKey, score);
@@ -914,7 +930,9 @@ function flattenActions(
   const usedSectionHeaders = new Set<string>();
 
   const flattened = collected.flatMap((item): CMDKFlatItem[] => {
-    if (seen.has(item.key)) return [];
+    if (seen.has(item.key)) {
+      return [];
+    }
     seen.add(item.key);
 
     if (item.children.length > 0) {
@@ -927,7 +945,9 @@ function flattenActions(
       const shouldUseFallbackChildren =
         matched.length === 0 && scores.get(item.key)?.matched;
       const candidateChildren = shouldUseFallbackChildren ? fallbackChildren : matched;
-      if (!candidateChildren.length) return [];
+      if (!candidateChildren.length) {
+        return [];
+      }
       const sortedMatches = shouldUseFallbackChildren
         ? candidateChildren
         : candidateChildren.sort((a, b) =>
@@ -945,7 +965,9 @@ function flattenActions(
       const intermediatePath: string[] = [];
       while (root.parent !== null) {
         const parent = nodeMap.get(root.parent);
-        if (!parent) break;
+        if (!parent) {
+          break;
+        }
         intermediatePath.unshift(root.display.label);
         root = parent;
       }
@@ -1045,7 +1067,9 @@ function getSourceAction(
   const headerMatch = actions.find(
     candidate => candidate.key === `${sourceActionKey}:header`
   );
-  if (headerMatch) return headerMatch;
+  if (headerMatch) {
+    return headerMatch;
+  }
 
   // For nested groups the original header was replaced by the root ancestor header.
   // The prefix map stores the group label under a distinct `:source-label` key.

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -282,7 +282,9 @@ export function GlobalCommandPaletteActions() {
     })
       .flatMap(section =>
         section.items.filter(navItem => {
-          if (navItem.show === undefined) return true;
+          if (navItem.show === undefined) {
+            return true;
+          }
           return typeof navItem.show === 'function'
             ? navItem.show({...context, ...section})
             : navItem.show;

--- a/static/app/components/core/avatar/sentryAppAvatar.tsx
+++ b/static/app/components/core/avatar/sentryAppAvatar.tsx
@@ -59,7 +59,9 @@ function getSentryAppAvatarProps(
   )?.avatarUrl;
 
   // If there is no upload URL, return null and fall
-  if (!uploadUrl) return null;
+  if (!uploadUrl) {
+    return null;
+  }
 
   return {
     type: 'upload',

--- a/static/app/components/core/avatarButton/avatarButton.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.tsx
@@ -141,24 +141,25 @@ function shouldPadImage(data: Uint8ClampedArray): 'fill' | 'padded' {
   if (!(data[3]!>=128   || data[51]!>=128  || data[99]!>=128  ||
         data[147]!>=128 || data[195]!>=128 || data[243]!>=128 ||
         data[291]!>=128 || data[339]!>=128 || data[387]!>=128 ||
-        data[435]!>=128 || data[483]!>=128 || data[531]!>=128)) return 'padded';
+        data[435]!>=128 || data[483]!>=128 || data[531]!>=128)) {return 'padded';}
   // oxfmt-ignore
   if (!(data[47]!>=128  || data[95]!>=128  || data[143]!>=128 ||
         data[191]!>=128 || data[239]!>=128 || data[287]!>=128 ||
         data[335]!>=128 || data[383]!>=128 || data[431]!>=128 ||
-        data[479]!>=128 || data[527]!>=128 || data[575]!>=128)) return 'padded';
+        data[479]!>=128 || data[527]!>=128 || data[575]!>=128)) {return 'padded';}
   // oxfmt-ignore
   if (!(data[3]!>=128  || data[7]!>=128  || data[11]!>=128 ||
         data[15]!>=128 || data[19]!>=128 || data[23]!>=128 ||
         data[27]!>=128 || data[31]!>=128 || data[35]!>=128 ||
-        data[39]!>=128 || data[43]!>=128 || data[47]!>=128)) return 'padded';
+        data[39]!>=128 || data[43]!>=128 || data[47]!>=128)) {return 'padded';}
   // oxfmt-ignore
   if (!(data[531]!>=128 || data[535]!>=128 || data[539]!>=128 ||
         data[543]!>=128 || data[547]!>=128 || data[551]!>=128 ||
         data[555]!>=128 || data[559]!>=128 || data[563]!>=128 ||
-        data[567]!>=128 || data[571]!>=128 || data[575]!>=128)) return 'padded';
-  if (data[3]! < 128 || data[47]! < 128 || data[531]! < 128 || data[575]! < 128)
+        data[567]!>=128 || data[571]!>=128 || data[575]!>=128)) {return 'padded';}
+  if (data[3]! < 128 || data[47]! < 128 || data[531]! < 128 || data[575]! < 128) {
     return 'padded';
+  }
 
   return 'fill';
 }
@@ -171,7 +172,9 @@ function readPixels(img: HTMLImageElement): Uint8ClampedArray | null {
     canvas.width = SAMPLE_SIZE;
     canvas.height = SAMPLE_SIZE;
     const ctx = canvas.getContext('2d');
-    if (!ctx) return null;
+    if (!ctx) {
+      return null;
+    }
 
     // Draw the image on a 12x12 canvas to make the sampling more efficient
     const naturalW = img.naturalWidth || img.width;
@@ -199,7 +202,9 @@ function sampleAvatarColor(
   img: HTMLImageElement
 ): {hex: string | null; style: 'fill' | 'padded'} | null {
   const data = readPixels(img);
-  if (!data) return null;
+  if (!data) {
+    return null;
+  }
 
   const style = shouldPadImage(data);
 
@@ -215,7 +220,9 @@ function sampleAvatarColor(
 
   for (let i = 0; i < data.length; i += 4) {
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    if (data[i + 3]! < 128) continue;
+    if (data[i + 3]! < 128) {
+      continue;
+    }
 
     const r = data[i]!,
       g = data[i + 1]!,
@@ -238,7 +245,9 @@ function sampleAvatarColor(
   }
 
   const [r, g, b, count] = ccount > 0 ? [cr, cg, cb, ccount] : [ar, ag, ab, acount];
-  if (count === 0) return {hex: null, style};
+  if (count === 0) {
+    return {hex: null, style};
+  }
 
   const toHex = (v: number) =>
     Math.round(v / count)
@@ -265,7 +274,9 @@ async function resolveImageAvatarColors(
 ): Promise<{chonk: string | undefined; style: 'fill' | 'padded'} | null> {
   const sampled = await fetchAvatarColor(url);
 
-  if (!sampled?.hex) return null;
+  if (!sampled?.hex) {
+    return null;
+  }
 
   const chonk = color(sampled.hex)
     .darken(theme === 'dark' ? 0.85 : 0.45)

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -429,7 +429,9 @@ export function Control({
     const values = Array.isArray(value) ? value : [value];
     const options = items
       .flatMap(item => {
-        if ('options' in item) return item.options;
+        if ('options' in item) {
+          return item.options;
+        }
         return item;
       })
       .filter(item => values.includes(item.value));
@@ -461,8 +463,12 @@ export function Control({
   });
 
   const hasSelection = useMemo(() => {
-    if (value === undefined) return false;
-    if (Array.isArray(value)) return value.length > 0;
+    if (value === undefined) {
+      return false;
+    }
+    if (Array.isArray(value)) {
+      return value.length > 0;
+    }
     return true;
   }, [value]);
 

--- a/static/app/components/core/compactSelect/gridList/index.tsx
+++ b/static/app/components/core/compactSelect/gridList/index.tsx
@@ -144,7 +144,9 @@ function GridList({
             >
               {virtualizer.items.map(row => {
                 const item = listItems[row.index];
-                if (!item) return null;
+                if (!item) {
+                  return null;
+                }
                 if (item.type === 'section') {
                   return (
                     <GridListSection

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -252,7 +252,9 @@ export function ListBox<T extends ObjectLike>({
             {overlayIsOpen &&
               virtualizer.items.map(row => {
                 const item = listItems[row.index];
-                if (!item) return null;
+                if (!item) {
+                  return null;
+                }
                 if (item.type === 'section') {
                   return (
                     <ListBoxSection

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -31,8 +31,12 @@ import type {
 export function getSearchConfig<Value extends SelectKey>(
   search: boolean | SearchConfig<Value> | undefined
 ): SearchConfig<Value> | undefined {
-  if (!search) return undefined;
-  if (search === true) return {};
+  if (!search) {
+    return undefined;
+  }
+  if (search === true) {
+    return {};
+  }
   return search;
 }
 
@@ -471,7 +475,9 @@ export function getDuplicateOptionKeysInfo<Value extends SelectKey>(
 
       optionCount += 1;
       const key = String(item.key);
-      if (duplicates.has(key)) continue;
+      if (duplicates.has(key)) {
+        continue;
+      }
 
       if (seen.has(key)) {
         duplicates.add(key);

--- a/static/app/components/core/form/field/baseField.tsx
+++ b/static/app/components/core/form/field/baseField.tsx
@@ -150,9 +150,13 @@ export function BaseField<T extends HTMLElement>(
 }
 
 function animateRowHighlight(node: HTMLElement | null) {
-  if (!node) return;
+  if (!node) {
+    return;
+  }
   const name = node.getAttribute('name');
-  if (!name) return;
+  if (!name) {
+    return;
+  }
   const fieldRow = node.closest<HTMLElement>(`#${CSS.escape(name)}`);
   if (fieldRow) {
     fieldRow.dataset.highlight = '';

--- a/static/app/components/core/inspector.tsx
+++ b/static/app/components/core/inspector.tsx
@@ -725,12 +725,16 @@ function isTraceElement(el: unknown): el is TraceElement {
 }
 
 function getComponentName(el: unknown): string {
-  if (!isTraceElement(el)) return 'unknown';
+  if (!isTraceElement(el)) {
+    return 'unknown';
+  }
   return el.dataset.sentryComponent || el.dataset.sentryElement || 'unknown';
 }
 
 function getSourcePath(el: unknown): string {
-  if (!isTraceElement(el)) return 'unknown path';
+  if (!isTraceElement(el)) {
+    return 'unknown path';
+  }
   return el.dataset.sentrySourcePath?.split(/static\//)[1] || 'unknown path';
 }
 
@@ -746,7 +750,9 @@ function getComponentStorybookFile(
   stories: Record<string, string>
 ): string | null {
   const sourcePath = getSourcePath(el);
-  if (!sourcePath) return null;
+  if (!sourcePath) {
+    return null;
+  }
 
   const mdxSourcePath = sourcePath.replace(/\.tsx$/, '.mdx');
 
@@ -763,7 +769,9 @@ function getComponentStorybookFile(
 }
 
 function getSourcePathFromMouseEvent(event: MouseEvent): TraceElement[] | null {
-  if (!event.target || !isTraceElement(event.target)) return null;
+  if (!event.target || !isTraceElement(event.target)) {
+    return null;
+  }
 
   const target = event.target;
 
@@ -771,7 +779,9 @@ function getSourcePathFromMouseEvent(event: MouseEvent): TraceElement[] | null {
     ? target
     : target.closest('[data-sentry-source-path]');
 
-  if (!head) return null;
+  if (!head) {
+    return null;
+  }
 
   const trace: TraceElement[] = [head as TraceElement];
 
@@ -781,7 +791,9 @@ function getSourcePathFromMouseEvent(event: MouseEvent): TraceElement[] | null {
     const next = head.parentElement?.closest(
       '[data-sentry-source-path]'
     ) as TraceElement | null;
-    if (!next || next === head) break;
+    if (!next || next === head) {
+      break;
+    }
     trace.push(next);
     head = next;
   }
@@ -790,12 +802,16 @@ function getSourcePathFromMouseEvent(event: MouseEvent): TraceElement[] | null {
 }
 
 function isCoreComponent(el: unknown): boolean {
-  if (!isTraceElement(el)) return false;
+  if (!isTraceElement(el)) {
+    return false;
+  }
   return el.dataset.sentrySourcePath?.includes('app/components/core') ?? false;
 }
 
 function isViewComponent(el: unknown): boolean {
-  if (!isTraceElement(el)) return false;
+  if (!isTraceElement(el)) {
+    return false;
+  }
   return el.dataset.sentrySourcePath?.includes('app/views') ?? false;
 }
 

--- a/static/app/components/events/autofix/insights/autofixInsightCard.tsx
+++ b/static/app/components/events/autofix/insights/autofixInsightCard.tsx
@@ -131,7 +131,9 @@ export function AutofixInsightCard({
     // Remove markdown formatting and whitespace for the check
     const plainText = (hasFullJustification ? insight.justification : '').trim();
     // If there is a diff or markdown_snippets, allow expansion
-    if (insight.change_diff || insight.markdown_snippets) return true;
+    if (insight.change_diff || insight.markdown_snippets) {
+      return true;
+    }
     // If the justification is empty or just 'No details here.', not expandable
     return !!plainText && plainText.toLowerCase() !== t('No details here.').toLowerCase();
   }, [

--- a/static/app/components/events/autofix/insights/insightSourcesFooter.tsx
+++ b/static/app/components/events/autofix/insights/insightSourcesFooter.tsx
@@ -106,7 +106,9 @@ export function InsightSourcesFooter({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!newInsightText.trim()) return;
+    if (!newInsightText.trim()) {
+      return;
+    }
 
     updateInsight({
       message: newInsightText,

--- a/static/app/components/events/autofix/useTypingAnimation.ts
+++ b/static/app/components/events/autofix/useTypingAnimation.ts
@@ -60,7 +60,9 @@ export function useTypingAnimation({
     const interval = 1000 / speed; // ms per character
 
     const animate = (timestamp: number) => {
-      if (!enabled) return; // Check enabled status
+      if (!enabled) {
+        return;
+      } // Check enabled status
 
       const elapsed = timestamp - lastUpdateTimeRef.current;
       const charsToAdd = Math.floor(elapsed / interval);

--- a/static/app/components/events/autofix/utils/insightUtils.tsx
+++ b/static/app/components/events/autofix/utils/insightUtils.tsx
@@ -101,7 +101,9 @@ function mergeCodeUrls(urls: string[]): Map<string, string> {
       urlMapping.set(item.url, item.url);
     });
 
-    if (withRanges.length === 0) return;
+    if (withRanges.length === 0) {
+      return;
+    }
 
     // Sort by range size (largest first) to prioritize wider ranges
     withRanges.sort((a, b) => {
@@ -113,7 +115,9 @@ function mergeCodeUrls(urls: string[]): Map<string, string> {
     const processed = new Set<string>();
 
     withRanges.forEach(item => {
-      if (processed.has(item.url)) return;
+      if (processed.has(item.url)) {
+        return;
+      }
 
       const currentRange = {
         startLine: item.parsed.startLine!,
@@ -175,7 +179,9 @@ function deduplicateSources(insights: AutofixInsight[]): InsightSources {
   const allDiffUrls: string[] = [];
 
   insights.forEach(insight => {
-    if (!insight?.sources) return;
+    if (!insight?.sources) {
+      return;
+    }
 
     const sources = insight.sources;
 
@@ -256,7 +262,9 @@ function updateInsightsWithMergedUrls(insights: AutofixInsight[]): AutofixInsigh
   const allDiffUrls: string[] = [];
 
   insights.forEach(insight => {
-    if (!insight?.sources) return;
+    if (!insight?.sources) {
+      return;
+    }
     const sources = insight.sources;
 
     sources.code_used_urls?.forEach(url => allCodeUrls.push(url));
@@ -269,7 +277,9 @@ function updateInsightsWithMergedUrls(insights: AutofixInsight[]): AutofixInsigh
 
   // Update each insight with merged URLs
   return insights.map(insight => {
-    if (!insight?.sources) return insight;
+    if (!insight?.sources) {
+      return insight;
+    }
 
     const updatedSources: InsightSources = {
       ...insight.sources,

--- a/static/app/components/events/autofix/v1/body.tsx
+++ b/static/app/components/events/autofix/v1/body.tsx
@@ -44,10 +44,15 @@ function useScrollToSection({aiAutofix}: {aiAutofix: ReturnType<typeof useAiAuto
       }
 
       const step = autofixDataRef.current.steps?.find(s => {
-        if (sectionType === 'root_cause')
+        if (sectionType === 'root_cause') {
           return s.type === AutofixStepType.ROOT_CAUSE_ANALYSIS;
-        if (sectionType === 'solution') return s.type === AutofixStepType.SOLUTION;
-        if (sectionType === 'code_changes') return s.type === AutofixStepType.CHANGES;
+        }
+        if (sectionType === 'solution') {
+          return s.type === AutofixStepType.SOLUTION;
+        }
+        if (sectionType === 'code_changes') {
+          return s.type === AutofixStepType.CHANGES;
+        }
         return false;
       });
 

--- a/static/app/components/events/interfaces/frame/frameRegisters/utils.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/utils.tsx
@@ -59,8 +59,12 @@ export function getSortedRegisters(
       }
 
       // Mapped registers come before unmapped ones
-      if (indexA !== -1) return -1;
-      if (indexB !== -1) return 1;
+      if (indexA !== -1) {
+        return -1;
+      }
+      if (indexB !== -1) {
+        return 1;
+      }
     }
 
     // Fallback: natural sort (handles numeric suffixes correctly)

--- a/static/app/components/replays/canvasReplayerPlugin.spec.ts
+++ b/static/app/components/replays/canvasReplayerPlugin.spec.ts
@@ -22,16 +22,22 @@ jest.mock('lodash/debounce', () =>
   jest.fn().mockImplementation((callback, timeout) => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     const debounced = jest.fn((...args) => {
-      if (timeoutId) clearTimeout(timeoutId);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
       timeoutId = setTimeout(() => callback(...args), timeout);
     });
 
     const cancel = jest.fn(() => {
-      if (timeoutId) clearTimeout(timeoutId);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     });
 
     const flush = jest.fn(() => {
-      if (timeoutId) clearTimeout(timeoutId);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
       callback();
     });
 
@@ -197,8 +203,12 @@ describe('canvasReplayerPlugin', () => {
     const canvas2 = createCanvasNode();
 
     const replayer = createReplayer(requestedId => {
-      if (requestedId === id1) return canvas1;
-      if (requestedId === id2) return canvas2;
+      if (requestedId === id1) {
+        return canvas1;
+      }
+      if (requestedId === id2) {
+        return canvas2;
+      }
       return null;
     });
 

--- a/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
@@ -41,7 +41,9 @@ export function AskSeerOption<T>({state}: {state: ComboBoxState<T>}) {
   );
 
   const handleClick = () => {
-    if (optionDisableOverride) return;
+    if (optionDisableOverride) {
+      return;
+    }
     trackAnalytics('ai_query.interface', {
       organization,
       area: analyticsArea,

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -195,7 +195,9 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
     onInputChange: setSearchQuery,
     defaultFilter: () => true,
     onSelectionChange(key) {
-      if (typeof key !== 'string') return;
+      if (typeof key !== 'string') {
+        return;
+      }
 
       if (key === 'none-of-these') {
         trackAnalytics('ai_query.rejected', {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -228,7 +228,9 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
     onInputChange: setSearchQuery,
     defaultFilter: () => true,
     onSelectionChange(key) {
-      if (typeof key !== 'string') return;
+      if (typeof key !== 'string') {
+        return;
+      }
 
       if (key === 'none-of-these') {
         trackAnalytics('ai_query.rejected', {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchPopover.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchPopover.tsx
@@ -25,10 +25,14 @@ export function AskSeerSearchPopover(props: PopoverProps) {
       <ListBoxOverlay
         ref={element => {
           popoverRef.current = element;
-          if (!element || !props.containerRef.current) return;
+          if (!element || !props.containerRef.current) {
+            return;
+          }
 
           const resizeObserver = new ResizeObserver(entries => {
-            if (!props.containerRef.current) return;
+            if (!props.containerRef.current) {
+              return;
+            }
             element.style.width = `${entries[0]?.target.clientWidth}px`;
           });
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -85,12 +85,16 @@ function formatToken(token: string): string {
 }
 
 export function formatQueryToNaturalLanguage(query: string): string {
-  if (!query.trim()) return '';
+  if (!query.trim()) {
+    return '';
+  }
   const tokens = query.match(/(?:[^\s"]|"[^"]*")+/g) || [];
   const formattedTokens = tokens.map(formatToken);
 
   const formattedQuery = formattedTokens.reduce((result, token, index) => {
-    if (index === 0) return token;
+    if (index === 0) {
+      return token;
+    }
 
     const currentOriginalToken = tokens[index] || '';
     const prevOriginalToken = tokens[index - 1] || '';

--- a/static/app/components/searchQueryBuilder/hooks/useSelectOnDrag.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useSelectOnDrag.tsx
@@ -88,7 +88,9 @@ function getItemIndexAtPosition(
 ) {
   for (const [i, key] of keys.entries()) {
     const coords = coordinates[key];
-    if (!coords) continue;
+    if (!coords) {
+      continue;
+    }
 
     // If we are above this item, we must be in between this and the
     // previous item on the row above it.

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -477,7 +477,9 @@ export function SearchQueryBuilderCombobox<
           /^\w$/.test(e.key) ||
           e.key === ','
         ) {
-          if (isOpen || isCtrlKeyPressed(e)) return;
+          if (isOpen || isCtrlKeyPressed(e)) {
+            return;
+          }
           state.open();
           return;
         }

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -267,7 +267,9 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
             onlyOperator={onlyOperator}
             {...mergeProps(triggerProps, filterButtonProps, focusWithinProps)}
             ref={r => {
-              if (!r || !triggerProps.ref) return;
+              if (!r || !triggerProps.ref) {
+                return;
+              }
 
               if (typeof triggerProps.ref === 'function') {
                 triggerProps.ref(r);

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -25,13 +25,17 @@ function constrainAndAlignListBox({
   referenceRef,
   refsToSync,
 }: ConstrainAndAlignListBoxArgs) {
-  if (!referenceRef.current || !popoverRef.current) return;
+  if (!referenceRef.current || !popoverRef.current) {
+    return;
+  }
 
   const referenceRect = referenceRef.current.getBoundingClientRect();
   const popoverRect = popoverRef.current.getBoundingClientRect();
 
   refsToSync.forEach(ref => {
-    if (!ref.current) return;
+    if (!ref.current) {
+      return;
+    }
     ref.current.style.maxWidth = `${referenceRect.width}px`;
   });
 
@@ -129,7 +133,9 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
     (element: HTMLUListElement | null) => {
       listBoxRef.current = element;
 
-      if (!element) return;
+      if (!element) {
+        return;
+      }
 
       const refsToSync = [listBoxRef, popoverRef];
 

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -631,8 +631,12 @@ function SearchQueryBuilderInputInternal({
 
           if (
             parsedText?.some(textToken => {
-              if (textToken.type !== Token.FILTER) return false;
-              if (textToken.negated) return `!${textToken.key.text}` === filterValue;
+              if (textToken.type !== Token.FILTER) {
+                return false;
+              }
+              if (textToken.negated) {
+                return `!${textToken.key.text}` === filterValue;
+              }
               return textToken.key.text === filterValue;
             })
           ) {

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -195,7 +195,9 @@ export function useSortedFilterKeyItems({
 
   const flatKeys = useMemo(() => {
     const keys = Object.values(filterKeys);
-    if (!asyncKeys?.length) return keys;
+    if (!asyncKeys?.length) {
+      return keys;
+    }
 
     return [...keys, ...asyncKeys.filter(k => !staticKeyValues.has(k.key))];
   }, [filterKeys, asyncKeys, staticKeyValues]);
@@ -212,7 +214,9 @@ export function useSortedFilterKeyItems({
   // Merged lookup of static + async keys, used for validating search results.
   // Without this, async-only keys would be filtered out by the `filterKeys` check.
   const allKeysLookup = useMemo(() => {
-    if (!asyncKeys?.length) return filterKeys;
+    if (!asyncKeys?.length) {
+      return filterKeys;
+    }
 
     const merged = {...filterKeys};
     for (const tag of asyncKeys) {

--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -1829,7 +1829,9 @@ function Section(props: CategorySectionProps) {
     const iconFilter = createIconFilter(props.searchTerm);
     filteredIcons = filteredIcons.filter(iconFilter);
   }
-  if (filteredIcons.length === 0) return null;
+  if (filteredIcons.length === 0) {
+    return null;
+  }
 
   return (
     <Flex as="section" direction="column" gap="xl">

--- a/static/app/stories/moduleExports.tsx
+++ b/static/app/stories/moduleExports.tsx
@@ -5,7 +5,9 @@ import {Heading} from '@sentry/scraps/text';
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 
 export function ModuleExports(props: {exports: TypeLoader.TypeLoaderResult['exports']}) {
-  if (!props.exports?.exports || !props.exports.module) return null;
+  if (!props.exports?.exports || !props.exports.module) {
+    return null;
+  }
 
   const lines = [];
   // canonical source: @sentry/scraps/<component> (no deep imports)
@@ -65,7 +67,9 @@ export function ModuleExports(props: {exports: TypeLoader.TypeLoaderResult['expo
     }
   }
 
-  if (!lines.length) return null;
+  if (!lines.length) {
+    return null;
+  }
 
   return (
     <Stack gap="md" paddingTop="xl">

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -71,7 +71,9 @@ function StoryDetail() {
 
     while (queue.length > 0) {
       const node = queue.pop();
-      if (!node) break;
+      if (!node) {
+        break;
+      }
 
       if (node.filesystemPath === location.query.name) {
         storyNode = node;
@@ -176,7 +178,9 @@ function getStoryFromParams(
 
   while (queue.length > 0) {
     const node = queue.pop();
-    if (!node) break;
+    if (!node) {
+      break;
+    }
 
     if (node.category === context.category && node.slug === context.slug) {
       return node;

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -141,8 +141,12 @@ function MDXStoryTitle(props: {story: MDXStoryDescriptor}) {
 function StoryTabList() {
   const {story} = useStory();
 
-  if (!isMDXStory(story)) return null;
-  if (story.exports.frontmatter?.layout === 'document') return null;
+  if (!isMDXStory(story)) {
+    return null;
+  }
+  if (story.exports.frontmatter?.layout === 'document') {
+    return null;
+  }
 
   return (
     <TabList>
@@ -296,7 +300,9 @@ function StoryGrid(props: React.ComponentProps<typeof Grid>) {
 function StoryModuleExports(props: {
   exports: TypeLoader.TypeLoaderResult['exports'] | undefined;
 }) {
-  if (!props.exports) return null;
+  if (!props.exports) {
+    return null;
+  }
   return <Storybook.ModuleExports exports={props.exports} />;
 }
 

--- a/static/app/stories/view/storyTableOfContents.tsx
+++ b/static/app/stories/view/storyTableOfContents.tsx
@@ -87,7 +87,9 @@ function useActiveSection(entries: Entry[]): [string, (id: string) => void] {
   const [activeId, setActiveId] = useState('');
 
   useLayoutEffect(() => {
-    if (entries.length === 0) return void 0;
+    if (entries.length === 0) {
+      return void 0;
+    }
 
     const observer = new IntersectionObserver(
       intersectionEntries => {
@@ -175,7 +177,9 @@ export function StoryTableOfContents() {
   const nestedEntries = useMemo(() => nestContentEntries(entries), [entries]);
   const [activeId, setActiveId] = useActiveSection(entries);
 
-  if (nestedEntries.length === 0) return null;
+  if (nestedEntries.length === 0) {
+    return null;
+  }
 
   return (
     <StoryIndexContainer>

--- a/static/app/utils/array/segmentSequentialBy.tsx
+++ b/static/app/utils/array/segmentSequentialBy.tsx
@@ -16,7 +16,9 @@ export function segmentSequentialBy<T>(
   data: T[],
   predicate: Predicate<T>
 ): Array<Partition<T>> {
-  if (!data.length) return [];
+  if (!data.length) {
+    return [];
+  }
 
   const firstDatum: T = data.at(0)!;
   let previousPredicateValue = predicate(firstDatum);

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1095,7 +1095,9 @@ const getContextIcon = (value: string) => {
  */
 const dropVersion = (value: string) => {
   const valueArray = value.split(' ');
-  if (valueArray.length > 1) valueArray.pop();
+  if (valueArray.length > 1) {
+    valueArray.pop();
+  }
   return valueArray.join(' ');
 };
 

--- a/static/app/utils/string/ellipsize.tsx
+++ b/static/app/utils/string/ellipsize.tsx
@@ -10,16 +10,21 @@ import {ELLIPSIS} from 'sentry/utils/string/unicode';
  * ellipsize('short', 10) // returns 'short'
  */
 export function ellipsize(str: string, length: number): string {
-  if (length < 0 || isNaN(length))
+  if (length < 0 || isNaN(length)) {
     throw new TypeError(
       `Invalid string length argument value of ${length} provided to ellipsize`
     );
+  }
 
-  if (str.length <= length) return str;
+  if (str.length <= length) {
+    return str;
+  }
 
   // If the string is only whitespace, skip `trimRight` since trimming will completely erase the string. If the string was a long sequence of whitespace characters, that would return a loose ellipsis
   const trimmed = str.trim();
-  if (trimmed.length === 0) return `${str.slice(0, length)}${ELLIPSIS}`;
+  if (trimmed.length === 0) {
+    return `${str.slice(0, length)}${ELLIPSIS}`;
+  }
 
   // Otherwise, trim normally
   return `${str.slice(0, length).trimEnd()}${ELLIPSIS}`;

--- a/static/app/utils/string/looksLikeAJSONArray.tsx
+++ b/static/app/utils/string/looksLikeAJSONArray.tsx
@@ -11,6 +11,8 @@ export function looksLikeAJSONArray(value: string) {
   const trimmedValue = value.trim();
 
   // The string '[Filtered]' looks array-like, but it's actually a Relay special string
-  if (trimmedValue === '[Filtered]') return false;
+  if (trimmedValue === '[Filtered]') {
+    return false;
+  }
   return trimmedValue.startsWith('[') && trimmedValue.endsWith(']');
 }

--- a/static/app/utils/url/testUtils.tsx
+++ b/static/app/utils/url/testUtils.tsx
@@ -5,16 +5,22 @@ export function testableDebounce(callback: () => void, delay?: number) {
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
   const debounced = () => {
-    if (timeoutId) clearTimeout(timeoutId);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
     timeoutId = setTimeout(() => callback(), delay);
   };
 
   const cancel = () => {
-    if (timeoutId) clearTimeout(timeoutId);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   };
 
   const flush = () => {
-    if (timeoutId) clearTimeout(timeoutId);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
     callback();
   };
 

--- a/static/app/utils/url/useQueryParamState.tsx
+++ b/static/app/utils/url/useQueryParamState.tsx
@@ -83,7 +83,9 @@ export function useQueryParamState<T = string>({
 
   // Sync local state when URL query params change (e.g., browser back/forward navigation)
   useEffect(() => {
-    if (!syncStateWithUrl) return;
+    if (!syncStateWithUrl) {
+      return;
+    }
 
     setLocalState(deserializeValue());
   }, [deserializeValue, syncStateWithUrl]);

--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -106,7 +106,9 @@ export const useResizable = ({
 
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
-      if (!isDraggingRef.current) return;
+      if (!isDraggingRef.current) {
+        return;
+      }
 
       const deltaX = e.clientX - startXRef.current;
       const newWidth = Math.max(

--- a/static/app/views/alerts/rules/uptime/assertions/utils.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/utils.tsx
@@ -370,7 +370,9 @@ export const isLeafOp = (op: UptimeOp) =>
   op.op === UptimeOpType.HEADER_CHECK;
 
 export function leafOpsMatchByValue(a: UptimeOp, b: UptimeOp): boolean {
-  if (a.op !== b.op) return false;
+  if (a.op !== b.op) {
+    return false;
+  }
 
   if (
     a.op === UptimeOpType.STATUS_CODE_CHECK &&

--- a/static/app/views/alerts/rules/uptime/formErrors.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/formErrors.spec.tsx
@@ -194,10 +194,12 @@ describe('AssertionFormError', () => {
     function Setter() {
       const previewCheckResult = usePreviewCheckResult();
       useEffect(() => {
-        if ('data' in initial)
+        if ('data' in initial) {
           previewCheckResult?.setPreviewCheckData(initial.data ?? null);
-        if ('error' in initial)
+        }
+        if ('error' in initial) {
           previewCheckResult?.setPreviewCheckError(initial.error ?? null);
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
       return null;

--- a/static/app/views/alerts/rules/uptime/formErrors.tsx
+++ b/static/app/views/alerts/rules/uptime/formErrors.tsx
@@ -24,7 +24,9 @@ import {usePreviewCheckResult} from './previewCheckContext';
 export function mapPreviewCheckErrorToMessage(
   error: PreviewCheckError | null
 ): string | null {
-  if (!error) return null;
+  if (!error) {
+    return null;
+  }
 
   return error.assertion.error === PreviewCheckErrorKind.COMPILATION_ERROR
     ? t('Assertion Compilation Error')
@@ -112,7 +114,9 @@ export function mapPreviewCheckResultToMessage(
   response: PreviewCheckResult
 ): string | null {
   const result = response.check_result;
-  if (!result) return null;
+  if (!result) {
+    return null;
+  }
 
   if (result.assertion_failure_data) {
     return t('Assertion Failure');
@@ -137,14 +141,18 @@ function matchAssertionFailureDataLeafOp(
     (assertionOp.op === UptimeOpType.AND || assertionOp.op === UptimeOpType.OR)
   ) {
     const [failingChild] = failureDataOp.children;
-    if (!failingChild) return null;
+    if (!failingChild) {
+      return null;
+    }
     // For leaves, also match by value to distinguish siblings of the same op type.
     const match = assertionOp.children.find(
       c =>
         c.op === failingChild.op &&
         (isLeafOp(failingChild) ? leafOpsMatchByValue(failingChild, c) : true)
     );
-    if (!match) return null;
+    if (!match) {
+      return null;
+    }
     return matchAssertionFailureDataLeafOp(failingChild, match);
   }
 
@@ -174,12 +182,16 @@ function resolveErroredOpFromAssertPath(
 
   for (const segment of assertPath.slice(1)) {
     const index = Number.parseInt(segment, 10);
-    if (isNaN(index)) return null;
+    if (isNaN(index)) {
+      return null;
+    }
 
     if (current.op === UptimeOpType.AND || current.op === UptimeOpType.OR) {
       // eslint-disable-next-line @sentry/no-unnecessary-type-annotation
       const next: UptimeOp | undefined = current.children[index];
-      if (!next) return null;
+      if (!next) {
+        return null;
+      }
       current = next;
     } else if (current.op === UptimeOpType.NOT) {
       current = current.operand;
@@ -200,12 +212,16 @@ export function resolveErroredAssertionOp(
   previewCheckResult: ReturnType<typeof usePreviewCheckResult>,
   rootOp: UptimeAndOp
 ): UptimeOp | null {
-  if (!previewCheckResult) return null;
+  if (!previewCheckResult) {
+    return null;
+  }
   const {data, error} = previewCheckResult;
 
   if (data) {
     const result = data.check_result;
-    if (!result) return null;
+    if (!result) {
+      return null;
+    }
 
     if (result.assertion_failure_data) {
       return resolveErroredOpFromAssertionFailureData(
@@ -246,12 +262,16 @@ const ASSERTION_ERROR_TYPE_LABELS: Partial<Record<string, string>> = {
 function getFormAssertionErrorMessage(
   previewCheckResult: ReturnType<typeof usePreviewCheckResult>
 ): string | null {
-  if (!previewCheckResult) return null;
+  if (!previewCheckResult) {
+    return null;
+  }
   const {data, error} = previewCheckResult;
 
   if (data) {
     const result = data.check_result;
-    if (!result) return null;
+    if (!result) {
+      return null;
+    }
 
     if (result.assertion_failure_data) {
       return t('Assertion Failed');

--- a/static/app/views/automations/components/actions/ticketActionSettingsButton.tsx
+++ b/static/app/views/automations/components/actions/ticketActionSettingsButton.tsx
@@ -51,11 +51,15 @@ export function TicketActionSettingsButton() {
 
   // Find saved action data from the API response
   const savedActionData = useMemo(() => {
-    if (!automation) return;
+    if (!automation) {
+      return;
+    }
 
     for (const af of automation.actionFilters) {
       const found = af.actions?.find(a => a.id === action.id);
-      if (found) return found.data;
+      if (found) {
+        return found.data;
+      }
     }
 
     return;

--- a/static/app/views/dashboards/dashboardRevisionsDiff.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.ts
@@ -13,7 +13,9 @@ type FieldChange = {after: string; before: string; field: string};
 type FilterChange = {after: string; before: string; label: string};
 
 function formatTime(d: DashboardDetails): string | null {
-  if (d.period) return getRelativeSummary(d.period);
+  if (d.period) {
+    return getRelativeSummary(d.period);
+  }
   if (d.start && d.end) {
     const fmt = (s: string) => getFormattedDate(s, 'MMM D, YYYY', {local: !d.utc});
     return `${fmt(d.start)} – ${fmt(d.end)}`;
@@ -30,8 +32,12 @@ export function formatProjectIds(
   ids: number[] | undefined,
   resolveId: (id: number) => string | undefined
 ): string {
-  if (!ids?.length) return t('My Projects');
-  if (ids.includes(ALL_ACCESS_PROJECTS)) return t('All Projects');
+  if (!ids?.length) {
+    return t('My Projects');
+  }
+  if (ids.includes(ALL_ACCESS_PROJECTS)) {
+    return t('All Projects');
+  }
   return ids.map(id => resolveId(id) ?? String(id)).join(', ');
 }
 
@@ -90,8 +96,12 @@ export function diffFilters(
 }
 
 function truncateDescription(value: string): string {
-  if (!value) return t('(empty)');
-  if (value.length <= DESCRIPTION_PREVIEW_MAX_LENGTH) return value;
+  if (!value) {
+    return t('(empty)');
+  }
+  if (value.length <= DESCRIPTION_PREVIEW_MAX_LENGTH) {
+    return value;
+  }
   return value.slice(0, DESCRIPTION_PREVIEW_MAX_LENGTH) + '…';
 }
 
@@ -177,7 +187,9 @@ export function diffWidgets(
   const titleCounts = new Map<string, number>();
   const fingerprintCounts = new Map<string, number>();
   for (const w of base.widgets) {
-    if (w.id) baseById.set(w.id, w);
+    if (w.id) {
+      baseById.set(w.id, w);
+    }
     titleCounts.set(w.title, (titleCounts.get(w.title) ?? 0) + 1);
     const fp = makeWidgetFingerprint(w);
     fingerprintCounts.set(fp, (fingerprintCounts.get(fp) ?? 0) + 1);

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -160,7 +160,9 @@ export function AddFilter({
                   <MenuComponents.ApplyButton
                     disabled={!selectedFilterKey}
                     onClick={() => {
-                      if (!selectedFilterKey || !selectedDataset) return;
+                      if (!selectedFilterKey || !selectedDataset) {
+                        return;
+                      }
 
                       let defaultFilterValue = '';
                       const fieldDefinition =

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -124,7 +124,9 @@ function useNativeOperatorFilter(
     isValidNumericFilterValue(stagedFilterValue, globalFilterToken, globalFilter);
 
   const buildFilterQuery = () => {
-    if (!globalFilterToken) return '';
+    if (!globalFilterToken) {
+      return '';
+    }
 
     return newNumericFilterQuery(
       stagedFilterValue,

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -140,7 +140,9 @@ export function newNumericFilterQuery(
     valueType,
     token: filterToken,
   });
-  if (!cleanedValue) return '';
+  if (!cleanedValue) {
+    return '';
+  }
   const newFilterValue = modifyFilterValue(filterToken.text, filterToken, cleanedValue);
 
   const newFilterTokens = parseFilterValue(newFilterValue, globalFilter);

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -36,8 +36,12 @@ interface RevisionListItemProps {
 }
 
 function formatRevisionSource(source: DashboardRevision['source']): string {
-  if (source === 'pre-restore') return t('Revert Dashboard');
-  if (source === 'edit-with-agent') return t('Edit with Seer');
+  if (source === 'pre-restore') {
+    return t('Revert Dashboard');
+  }
+  if (source === 'edit-with-agent') {
+    return t('Edit with Seer');
+  }
   return t('Edit');
 }
 
@@ -155,7 +159,9 @@ export function RevisionDiffBody({
   isLoading: boolean;
   snapshot: DashboardDetails | undefined;
 }) {
-  if (isLoading) return <LoadingIndicator />;
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
   if (isError) {
     return (
       <Text size="sm" variant="muted">
@@ -163,7 +169,9 @@ export function RevisionDiffBody({
       </Text>
     );
   }
-  if (!snapshot) return null;
+  if (!snapshot) {
+    return null;
+  }
   if (baseRevisionId === null) {
     return (
       <Text size="sm" variant="muted">

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -113,7 +113,9 @@ export function SortableWidget(props: Props) {
     const newOrderBy = `${sort.kind === 'desc' ? '-' : ''}${sort.field}`;
     // Override the widget queries to pass the temporary sort to the widget and expanded modal
     const widgetQueries = cloneDeep(widget.queries);
-    if (widgetQueries[0]) widgetQueries[0].orderby = newOrderBy;
+    if (widgetQueries[0]) {
+      widgetQueries[0].orderby = newOrderBy;
+    }
     setQueries(widgetQueries);
   };
 

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -386,7 +386,9 @@ function makeContextCapture() {
   return {
     ContextCapture,
     getSnapshot: () => {
-      if (!ref.current) throw new Error('ContextCapture not mounted');
+      if (!ref.current) {
+        throw new Error('ContextCapture not mounted');
+      }
       return ref.current();
     },
   };

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -94,7 +94,9 @@ export function WidgetBuilderV2({
   const navigationElementRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (navigationElementRef.current) return;
+    if (navigationElementRef.current) {
+      return;
+    }
 
     const navigationElement = document.querySelector(
       'nav[aria-label="Primary Navigation"]'

--- a/static/app/views/dashboards/widgetBuilder/utils/trackEngagementAnalytics.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/trackEngagementAnalytics.tsx
@@ -9,7 +9,9 @@ export function trackEngagementAnalytics(
   globalFilterCount: number
 ) {
   // Handle edge-case of dashboard with no widgets.
-  if (!widgets.length) return;
+  if (!widgets.length) {
+    return;
+  }
 
   // For attributing engagement metrics initially track the ratio
   // of widgets reading from Transactions, Spans, Errors, and Issues, and Logs.

--- a/static/app/views/dashboards/widgetBuilder/utils/transformPerformanceScoreBreakdownSeries.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/transformPerformanceScoreBreakdownSeries.tsx
@@ -16,7 +16,9 @@ export function transformPerformanceScoreBreakdownSeries(
       : `performance_score(measurements.score.${webVital})`;
     const series = multiSeries[key];
 
-    if (!series?.data) return false;
+    if (!series?.data) {
+      return false;
+    }
 
     return series.data.some(([_timestamp, values]) =>
       values.some(v => (v.count || 0) > 0)

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -584,7 +584,9 @@ function useConflictingFilterWarning({
   widget: TWidget;
 }) {
   const conflictingFilterKeys = useMemo(() => {
-    if (!dashboardFilters) return [];
+    if (!dashboardFilters) {
+      return [];
+    }
 
     const widgetFilterKeys = widget.queries.flatMap(query => {
       const parseResult = parseQueryBuilderValue(query.conditions, getFieldDefinition);

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -126,8 +126,12 @@ ${JSON.stringify(aliases)}
           const bField = b?.[newSort.field] ?? 0;
           const value = newSort.kind === 'asc' ? 1 : -1;
 
-          if (aField < bField) return -value;
-          if (aField > bField) return value;
+          if (aField < bField) {
+            return -value;
+          }
+          if (aField > bField) {
+            return value;
+          }
           return 0;
         })
         .map(result => result[1]);
@@ -362,7 +366,9 @@ function onChangeSort(newSort: Sort) {
           onTriggerCellAction={(actions: Actions, value: string | number) => {
             switch (actions) {
               case Actions.ADD:
-                if (!filter.includes(value)) setFilter([...filter, value]);
+                if (!filter.includes(value)) {
+                  setFilter([...filter, value]);
+                }
                 break;
               case Actions.EXCLUDE:
                 setFilter(filter.filter(_value => _value !== value));

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -260,7 +260,9 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
               canSort={column.sortable ?? false}
               title={<StyledTooltip title={tooltipTitle}>{name}</StyledTooltip>}
               onClick={e => {
-                if (!onChangeSort) return;
+                if (!onChangeSort) {
+                  return;
+                }
                 e.preventDefault();
                 const nextDirection = direction === 'desc' ? 'asc' : 'desc';
                 onChangeSort({
@@ -383,7 +385,9 @@ TableWidgetVisualization.LoadingPlaceholder = function ({
       resizable={false}
       grid={{
         renderHeadCell: (_tableColumn, columnIndex) => {
-          if (!columns) return null;
+          if (!columns) {
+            return null;
+          }
           const column = columns[columnIndex]!;
           const isStarredColumn = column.key === SpanFields.IS_STARRED_TRANSACTION;
           const hasAlias = !!aliases?.[column.key];

--- a/static/app/views/detectors/hooks/useFilteredAnomalyThresholdSeries.tsx
+++ b/static/app/views/detectors/hooks/useFilteredAnomalyThresholdSeries.tsx
@@ -62,9 +62,15 @@ export function useFilteredAnomalyThresholdSeries({
     const [upperThreshold, lowerThreshold, seerValue] = anomalyThresholdSeries;
 
     const filtered = [];
-    if (thresholdType !== AlertRuleThresholdType.BELOW) filtered.push(upperThreshold);
-    if (thresholdType !== AlertRuleThresholdType.ABOVE) filtered.push(lowerThreshold);
-    if (seerValue) filtered.push(seerValue);
+    if (thresholdType !== AlertRuleThresholdType.BELOW) {
+      filtered.push(upperThreshold);
+    }
+    if (thresholdType !== AlertRuleThresholdType.ABOVE) {
+      filtered.push(lowerThreshold);
+    }
+    if (seerValue) {
+      filtered.push(seerValue);
+    }
 
     return filtered.filter((s): s is NonNullable<typeof s> => !!s);
   }, [anomalyThresholdSeries, detector, isAnomalyDetection, directThresholdType]);

--- a/static/app/views/discover/eventDetails.tsx
+++ b/static/app/views/discover/eventDetails.tsx
@@ -48,7 +48,9 @@ export default function EventDetails() {
   );
 
   useEffect(() => {
-    if (!event) return;
+    if (!event) {
+      return;
+    }
 
     if (event.groupID && event.eventID) {
       navigate({

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -180,7 +180,9 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
 
   const applySeerSearchQuery = useCallback(
     (result: AskSeerSearchQuery, runId?: number) => {
-      if (!result) return;
+      if (!result) {
+        return;
+      }
       const {
         query: queryToUse,
         sort,

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -156,7 +156,9 @@ export function excludeFromFilter(
  */
 export function copyToClipboard(value: string | number | string[]) {
   function stringifyValue(val: string | number | string[]): string {
-    if (!val) return '';
+    if (!val) {
+      return '';
+    }
     if (typeof val !== 'object') {
       return val.toString();
     }
@@ -252,7 +254,9 @@ function makeCellActions({
     addMenuItem(Actions.OPEN_ROW_IN_EXPLORE, t('View span samples'));
   }
 
-  if (value) addMenuItem(Actions.COPY_TO_CLIPBOARD, t('Copy to clipboard'));
+  if (value) {
+    addMenuItem(Actions.COPY_TO_CLIPBOARD, t('Copy to clipboard'));
+  }
 
   if (allowActions) {
     addMenuItem(Actions.COPY_LINK, t('Copy link'));

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
@@ -69,7 +69,9 @@ export function Chart({
   useLayoutEffect(() => {
     const chartInstance = chartRef.current?.getEchartsInstance();
 
-    if (!chartInstance) return;
+    if (!chartInstance) {
+      return;
+    }
 
     const width = chartInstance.getDom().offsetWidth;
 

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -130,7 +130,9 @@ export function AttributeDistribution() {
   const parsedLinks = parseLinkHeader(attributeBreakdownsPageLinks);
 
   const uniqueAttributeDistribution = useMemo(() => {
-    if (!attributeBreakdownsData) return [];
+    if (!attributeBreakdownsData) {
+      return [];
+    }
 
     const seen = new Set<string>();
     const filtered = Object.entries(

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
@@ -103,7 +103,9 @@ export function Chart({
   useLayoutEffect(() => {
     const chartInstance = chartRef.current?.getEchartsInstance();
 
-    if (!chartInstance) return;
+    if (!chartInstance) {
+      return;
+    }
 
     const width = chartInstance.getDom().offsetWidth;
 

--- a/static/app/views/explore/components/attributeBreakdowns/floatingTrigger.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/floatingTrigger.tsx
@@ -22,7 +22,9 @@ export function FloatingTrigger({chartIndex, params}: Props) {
   const {selectionState, setSelectionState, clearSelection} = params;
 
   const handleZoomIn = useCallback(() => {
-    if (!selectionState) return;
+    if (!selectionState) {
+      return;
+    }
 
     trackAnalytics('explore.floating_trigger.zoom_in', {organization});
 
@@ -55,7 +57,9 @@ export function FloatingTrigger({chartIndex, params}: Props) {
   }, [clearSelection, selectionState, location, navigate, organization]);
 
   const handleFindAttributeBreakdowns = useCallback(() => {
-    if (!selectionState) return;
+    if (!selectionState) {
+      return;
+    }
 
     trackAnalytics('explore.floating_trigger.compare_attribute_breakdowns', {
       organization,

--- a/static/app/views/explore/components/attributeBreakdowns/utils.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/utils.tsx
@@ -13,7 +13,9 @@ export function calculateAttributePopulationPercentage(
   }>,
   cohortTotal: number
 ): number {
-  if (cohortTotal === 0) return 0;
+  if (cohortTotal === 0) {
+    return 0;
+  }
 
   const populatedCount = values.reduce((acc, curr) => acc + curr.value, 0);
   return (populatedCount / cohortTotal) * 100;
@@ -53,7 +55,9 @@ export function formatChartXAxisLabel(
   const maxChars = Math.floor(pixelsPerLabel / pixelsPerCharacter);
 
   // If value fits, return it as-is
-  if (value.length <= maxChars) return value;
+  if (value.length <= maxChars) {
+    return value;
+  }
 
   // Otherwise, truncate and append '…'
   const truncatedLength = Math.max(1, maxChars - 2); // leaving space for (ellipsis)
@@ -86,7 +90,9 @@ export function tooltipActionsHtmlRenderer(
   attributeName: string,
   theme: Theme
 ): string {
-  if (!value) return '';
+  if (!value) {
+    return '';
+  }
 
   const escapedAttributeName = escape(attributeName);
   const escapedValue = escape(value);

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -91,7 +91,9 @@ export function useAttributeBreakdownsTooltip({
   // - Sets up the listener for clicks anywhere on the chart to toggle the frozen tooltip state.
   useEffect(() => {
     const chartInstance = chartRef.current?.getEchartsInstance();
-    if (!chartInstance) return;
+    if (!chartInstance) {
+      return;
+    }
 
     if (frozenPosition) {
       chartInstance.dispatchAction({
@@ -146,7 +148,9 @@ export function useAttributeBreakdownsTooltip({
   // This effect sets up the on click listeners for the tooltip actions.
   // e-charts tooltips do not support actions out of the box, so we need to handle them manually.
   useEffect(() => {
-    if (!frozenPosition) return;
+    if (!frozenPosition) {
+      return;
+    }
 
     const handleClickActions = (event: MouseEvent) => {
       event.preventDefault();

--- a/static/app/views/explore/hooks/useFilteredRankedAttributes.ts
+++ b/static/app/views/explore/hooks/useFilteredRankedAttributes.ts
@@ -31,9 +31,15 @@ export function useFilteredRankedAttributes({
     return [...filtered].sort((a, b) => {
       const aOrder = a.order.rrr;
       const bOrder = b.order.rrr;
-      if (aOrder === null && bOrder === null) return 0;
-      if (aOrder === null) return 1;
-      if (bOrder === null) return -1;
+      if (aOrder === null && bOrder === null) {
+        return 0;
+      }
+      if (aOrder === null) {
+        return 1;
+      }
+      if (bOrder === null) {
+        return -1;
+      }
       return aOrder - bOrder;
     });
   }, [rankedAttributes, searchQuery]);

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -43,7 +43,9 @@ export function useGroupByFields({
       extraColumnKind: FieldKind.TAG,
     })
       .filter(option => {
-        if (seen.has(option.value)) return false;
+        if (seen.has(option.value)) {
+          return false;
+        }
         seen.add(option.value);
         return true;
       })

--- a/static/app/views/explore/hooks/useTraceExploreAiQuerySetup.tsx
+++ b/static/app/views/explore/hooks/useTraceExploreAiQuerySetup.tsx
@@ -24,7 +24,9 @@ export function useTraceExploreAiQuerySetup({
   const memberProjects = projects.filter(p => p.isMember);
 
   useEffect(() => {
-    if (!enableAISearch) return;
+    if (!enableAISearch) {
+      return;
+    }
 
     const selectedProjects =
       pageFilters.selection.projects &&
@@ -40,7 +42,9 @@ export function useTraceExploreAiQuerySetup({
       const projectsChanged =
         prevSet.size !== currentSet.size || ![...prevSet].every(id => currentSet.has(id));
 
-      if (!projectsChanged) return;
+      if (!projectsChanged) {
+        return;
+      }
     }
 
     previousProjects.current = selectedProjects.map(Number);

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -64,7 +64,9 @@ export function useVisualizeFields({
       .filter(option => {
         // Filtering by value here, so it's based off of explicit tags i.e. `key`
         // or `tags[<key>, <boolean | number | string>]
-        if (seen.has(option.value)) return false;
+        if (seen.has(option.value)) {
+          return false;
+        }
         seen.add(option.value);
         return true;
       })

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -137,7 +137,9 @@ export function LogsTabSeerComboBox() {
 
   const applySeerSearchQuery = useCallback(
     (result: AskSeerSearchQuery, runId?: number) => {
-      if (!result) return;
+      if (!result) {
+        return;
+      }
       const {
         query: queryToUse,
         groupBys,

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -274,7 +274,9 @@ function VisualizeDropdown({
           .filter(option => {
             // Filtering by value here, so it's based off of explicit tags i.e. `key`
             // or `tags[<key>, <boolean | number | string>]
-            if (seen.has(option.value)) return false;
+            if (seen.has(option.value)) {
+              return false;
+            }
             seen.add(option.value);
             return true;
           })

--- a/static/app/views/explore/metrics/hooks/useSortableMetricQueries.tsx
+++ b/static/app/views/explore/metrics/hooks/useSortableMetricQueries.tsx
@@ -53,7 +53,9 @@ export function useSortableMetricQueries({
         const oldIndex = sortableItems.find(({id}) => id === active.id)?.index;
         const newIndex = sortableItems.find(({id}) => id === over?.id)?.index;
 
-        if (oldIndex === undefined || newIndex === undefined) return;
+        if (oldIndex === undefined || newIndex === undefined) {
+          return;
+        }
 
         reorderMetricQueries(
           arrayMove([...metricQueries], oldIndex, newIndex),

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -171,7 +171,9 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
   const applySeerSearchQuery = useCallback(
     (result: AskSeerSearchQuery, runId?: number) => {
-      if (!result) return;
+      if (!result) {
+        return;
+      }
       const {
         query: queryToUse,
         groupBys,

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -281,7 +281,9 @@ function Chart({
                   }
                 },
                 onInsideSelectionClick: params => {
-                  if (!params.selectionState) return;
+                  if (!params.selectionState) {
+                    return;
+                  }
 
                   params.setSelectionState({
                     ...params.selectionState,
@@ -289,7 +291,9 @@ function Chart({
                   });
                 },
                 onOutsideSelectionClick: params => {
-                  if (!params.selectionState?.isActionMenuVisible) return;
+                  if (!params.selectionState?.isActionMenuVisible) {
+                    return;
+                  }
 
                   params.setSelectionState({
                     ...params.selectionState,

--- a/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
@@ -64,10 +64,14 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
 
     const onMetricChange = useCallback(
       (newMetric: TraceMetric) => {
-        if (!crossEvents) return;
+        if (!crossEvents) {
+          return;
+        }
         setCrossEvents?.(
           crossEvents.map((c, i) => {
-            if (i === index) return {type: 'metrics', query, metric: newMetric};
+            if (i === index) {
+              return {type: 'metrics', query, metric: newMetric};
+            }
             return c;
           })
         );
@@ -81,10 +85,14 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
       () => ({
         initialQuery: query,
         onSearch: (newQuery: string) => {
-          if (!crossEvents) return;
+          if (!crossEvents) {
+            return;
+          }
           setCrossEvents?.(
             crossEvents.map((c, i) => {
-              if (i === index) return {type: 'metrics', query: newQuery, metric};
+              if (i === index) {
+                return {type: 'metrics', query: newQuery, metric};
+              }
               return c;
             })
           );

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
@@ -50,11 +50,15 @@ export const SpansTabCrossEventSearchBar = memo(
       () => ({
         initialQuery: query,
         onSearch: (newQuery: string) => {
-          if (!crossEvents) return;
+          if (!crossEvents) {
+            return;
+          }
 
           setCrossEvents?.(
             crossEvents.map((c, i) => {
-              if (i === index) return {query: newQuery, type};
+              if (i === index) {
+                return {query: newQuery, type};
+              }
               return c;
             })
           );

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBars.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBars.tsx
@@ -96,7 +96,9 @@ export function SpansTabCrossEventSearchBars() {
               )}
               options={getCrossEventDatasetOptions(crossEventDatasetAvailability)}
               onChange={({value: newValue}) => {
-                if (!isCrossEventType(newValue)) return;
+                if (!isCrossEventType(newValue)) {
+                  return;
+                }
 
                 trackAnalytics('trace.explorer.cross_event_changed', {
                   organization,
@@ -106,7 +108,9 @@ export function SpansTabCrossEventSearchBars() {
 
                 setCrossEvents(
                   crossEvents.map((c, i) => {
-                    if (i === index) return makeCrossEvent(newValue);
+                    if (i === index) {
+                      return makeCrossEvent(newValue);
+                    }
                     return c;
                   })
                 );

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -191,7 +191,9 @@ export function SpansTabSeerComboBox() {
 
   const applySeerSearchQuery = useCallback(
     (result: AskSeerSearchQuery, runId?: number) => {
-      if (!result) return;
+      if (!result) {
+        return;
+      }
       const {
         query: queryToUse,
         visualizations,

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -340,10 +340,14 @@ function GroupBySelector({
   // synchronously while the user types. Merge in any server-only matches once
   // the debounced search returns.
   const options = useMemo(() => {
-    if (!hasSearch || searchedOptions.length === 0) return baseOptions;
+    if (!hasSearch || searchedOptions.length === 0) {
+      return baseOptions;
+    }
     const baseValues = new Set(baseOptions.map(o => o.value));
     const additions = searchedOptions.filter(o => !baseValues.has(o.value));
-    if (additions.length === 0) return baseOptions;
+    if (additions.length === 0) {
+      return baseOptions;
+    }
     return [...baseOptions, ...additions];
   }, [hasSearch, baseOptions, searchedOptions]);
 
@@ -583,10 +587,14 @@ function AttributeArgumentSelect({
   // synchronously while the user types. Merge in any server-only matches once
   // the debounced search returns.
   const options = useMemo(() => {
-    if (!hasSearch || searchedOptions.length === 0) return baseOptions;
+    if (!hasSearch || searchedOptions.length === 0) {
+      return baseOptions;
+    }
     const baseValues = new Set(baseOptions.map(o => o.value));
     const additions = searchedOptions.filter(o => !baseValues.has(o.value));
-    if (additions.length === 0) return baseOptions;
+    if (additions.length === 0) {
+      return baseOptions;
+    }
     return [...baseOptions, ...additions];
   }, [hasSearch, baseOptions, searchedOptions]);
 
@@ -644,12 +652,19 @@ type AttributeKind = 'string' | 'number' | 'boolean';
 function getSupportedAttributeKinds(
   functionName: string | undefined
 ): readonly AttributeKind[] {
-  if (!functionName) return ['number'];
+  if (!functionName) {
+    return ['number'];
+  }
   // COUNT renders a fixed SPAN_DURATION option and ignores tag collections.
-  if (functionName === AggregationKey.COUNT) return [];
-  if (NO_ARGUMENT_SPAN_AGGREGATES.includes(functionName as AggregationKey)) return [];
-  if (functionName === AggregationKey.COUNT_UNIQUE)
+  if (functionName === AggregationKey.COUNT) {
+    return [];
+  }
+  if (NO_ARGUMENT_SPAN_AGGREGATES.includes(functionName as AggregationKey)) {
+    return [];
+  }
+  if (functionName === AggregationKey.COUNT_UNIQUE) {
     return ['string', 'number', 'boolean'];
+  }
   return ['number'];
 }
 

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -230,7 +230,9 @@ function ColumnEditorRow({
   // returns, merge in any attributes baseOptions doesn't already cover so the
   // user can still pick keys that weren't in the initial fetch.
   const options = useMemo(() => {
-    if (!hasSearch) return baseOptions;
+    if (!hasSearch) {
+      return baseOptions;
+    }
     const searched = buildColumnOptions({
       columns: [],
       stringTags: searchedStringTags,
@@ -239,10 +241,14 @@ function ColumnEditorRow({
       hiddenKeys,
       traceItemType,
     });
-    if (searched.length === 0) return baseOptions;
+    if (searched.length === 0) {
+      return baseOptions;
+    }
     const baseValues = new Set(baseOptions.map(o => o.value));
     const additions = searched.filter(o => !baseValues.has(o.value));
-    if (additions.length === 0) return baseOptions;
+    if (additions.length === 0) {
+      return baseOptions;
+    }
     return [...baseOptions, ...additions];
   }, [
     hasSearch,
@@ -365,8 +371,12 @@ function buildColumnOptions({
   })
     .filter(option => {
       const hidden = hiddenKeys ?? [];
-      if (hidden.includes(option.value)) return false;
-      if (typeof option.label === 'string' && hidden.includes(option.label)) return false;
+      if (hidden.includes(option.value)) {
+        return false;
+      }
+      if (typeof option.label === 'string' && hidden.includes(option.label)) {
+        return false;
+      }
       return true;
     })
     .toSorted((a, b) => sortKnownAttributes(a, b, traceItemType));

--- a/static/app/views/explore/utils/sortSearchedAttributes.tsx
+++ b/static/app/views/explore/utils/sortSearchedAttributes.tsx
@@ -93,7 +93,9 @@ export function sortKnownAttributes<Value extends SelectOption<string>>(
     getFieldDefinition(a.value, getFieldDefinitionType(traceItemType)) !== null;
   const bKnown =
     getFieldDefinition(b.value, getFieldDefinitionType(traceItemType)) !== null;
-  if (aKnown !== bKnown) return aKnown ? -1 : 1;
+  if (aKnown !== bKnown) {
+    return aKnown ? -1 : 1;
+  }
   const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
   const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');
   return aLabel.localeCompare(bLabel);

--- a/static/app/views/insights/pages/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanList.tsx
@@ -48,14 +48,17 @@ function getNodeTimeBounds(node: AITraceSpanNode | AITraceSpanNode[]) {
     startTime = totalStartAndEndTime.startTime;
     endTime = totalStartAndEndTime.endTime;
   } else {
-    if (!node.startTimestamp || !node.endTimestamp)
+    if (!node.startTimestamp || !node.endTimestamp) {
       return {startTime: 0, endTime: 0, duration: 0};
+    }
 
     startTime = node.startTimestamp;
     endTime = node.endTimestamp;
   }
 
-  if (endTime === 0) return {startTime: 0, endTime: 0, duration: 0};
+  if (endTime === 0) {
+    return {startTime: 0, endTime: 0, duration: 0};
+  }
 
   return {
     startTime,
@@ -379,7 +382,9 @@ function calculateRelativeTiming(
   traceBounds: TraceBounds,
   compressedStartByNodeId?: Map<string, number>
 ): {leftPercent: number; widthPercent: number} {
-  if (!node.value) return {leftPercent: 0, widthPercent: 0};
+  if (!node.value) {
+    return {leftPercent: 0, widthPercent: 0};
+  }
 
   let startTime: number, endTime: number;
 
@@ -390,7 +395,9 @@ function calculateRelativeTiming(
     return {leftPercent: 0, widthPercent: 0};
   }
 
-  if (traceBounds.duration === 0) return {leftPercent: 0, widthPercent: 0};
+  if (traceBounds.duration === 0) {
+    return {leftPercent: 0, widthPercent: 0};
+  }
 
   // Look up the pre-computed compressed start time for this node.
   // The span duration stays the same - only gaps between spans are compressed.

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -449,12 +449,16 @@ function AgentTags({agents}: {agents: string[]}) {
   const handleShowAll = () => {
     setShowAll(!showAll);
 
-    if (!containerRef.current) return;
+    if (!containerRef.current) {
+      return;
+    }
     // While the all tags are visible, observe the container to see if it displays more than one line (22px)
     // so we can reset the show all state accordingly
     const observer = new ResizeObserver(entries => {
       const containerElement = entries[0]?.target;
-      if (!containerElement || containerElement.clientHeight > 22) return;
+      if (!containerElement || containerElement.clientHeight > 22) {
+        return;
+      }
       setShowToggle(false);
       setShowAll(false);
       resizeObserverRef.current?.disconnect();

--- a/static/app/views/issueList/issueListCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListCommandPaletteActions.tsx
@@ -65,8 +65,12 @@ interface IssueListCommandPaletteActionsProps {
  * child items under header groups).
  */
 function getTagValueStrings(tag: Tag): string[] {
-  if (!tag.values?.length) return [];
-  if (typeof tag.values[0] === 'string') return tag.values as string[];
+  if (!tag.values?.length) {
+    return [];
+  }
+  if (typeof tag.values[0] === 'string') {
+    return tag.values as string[];
+  }
 
   const groups = tag.values as SearchGroup[];
   return groups.flatMap(group => {

--- a/static/app/views/navigation/mobileNavigation.tsx
+++ b/static/app/views/navigation/mobileNavigation.tsx
@@ -228,7 +228,9 @@ export function MobilePageFrameNavigation() {
   }, [isOpen, view]);
 
   const handleClickOutside = useCallback((e: MouseEvent | TouchEvent) => {
-    if (toggleButtonRef.current?.contains(e.target as Node)) return;
+    if (toggleButtonRef.current?.contains(e.target as Node)) {
+      return;
+    }
     setIsOpen(false);
   }, []);
 
@@ -244,7 +246,9 @@ export function MobilePageFrameNavigation() {
           <Button
             ref={toggleButtonRef}
             onClick={() => {
-              if (!isOpen) setView('expanded');
+              if (!isOpen) {
+                setView('expanded');
+              }
               setIsOpen(v => !v);
             }}
             icon={<IconMenu aria-hidden="true" />}

--- a/static/app/views/navigation/primary/whatsNew.tsx
+++ b/static/app/views/navigation/primary/whatsNew.tsx
@@ -215,7 +215,9 @@ export function PrimaryNavigationWhatsNew() {
   const uniqueBroadcasts = useMemo(() => {
     const seenTitles = new Set<string>();
     return allBroadcasts.filter(item => {
-      if (seenTitles.has(item.title)) return false;
+      if (seenTitles.has(item.title)) {
+        return false;
+      }
       seenTitles.add(item.title);
       return true;
     });

--- a/static/app/views/navigation/useCollapsedNavigation.tsx
+++ b/static/app/views/navigation/useCollapsedNavigation.tsx
@@ -45,7 +45,9 @@ export function useCollapsedNavigation() {
   const navigationParentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (navigationParentRef.current) return;
+    if (navigationParentRef.current) {
+      return;
+    }
     const navigationParentEl = document.querySelector(
       'nav[aria-label="Primary Navigation"]'
     )?.parentElement;

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -107,7 +107,9 @@ const scmOnboardingSteps: StepDescriptor[] = [
 function WelcomeVariable(props: StepProps) {
   const hasNewWelcomeUI = useHasNewWelcomeUI();
 
-  if (hasNewWelcomeUI) return <NewWelcomeUI {...props} />;
+  if (hasNewWelcomeUI) {
+    return <NewWelcomeUI {...props} />;
+  }
 
   return <TargetedOnboardingWelcome {...props} />;
 }

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -92,7 +92,9 @@ function shouldSuggestFramework(platformKey: PlatformKey): boolean {
 }
 
 function getPlatformName(platformKey: PlatformKey | undefined) {
-  if (!platformKey) return;
+  if (!platformKey) {
+    return;
+  }
   return getPlatformInfo(platformKey)?.name;
 }
 

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -378,7 +378,9 @@ export function useTrace(options: UseTraceOptions): TraceQueryResult {
     }
   );
 
-  if (isDemoMode) return demoTrace;
+  if (isDemoMode) {
+    return demoTrace;
+  }
   if (isEAPEnabled) {
     return isInitialEAPTraceEmpty && canRetryWithWiderPeriod
       ? eapTraceFallbackQuery

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -71,37 +71,51 @@ type MetaArg = TraceMeta | EAPTraceMeta | null | undefined;
 type ResponseMetaArg = ResponseTraceMeta | ResponseEAPTraceMeta | null | undefined;
 
 function isEAPTraceMeta(meta: MetaArg): meta is EAPTraceMeta {
-  if (!meta) return false;
+  if (!meta) {
+    return false;
+  }
   return 'uptimeCount' in meta && !('transactions' in meta);
 }
 
 function isResponseEAPTraceMeta(meta: ResponseMetaArg): meta is ResponseEAPTraceMeta {
-  if (!meta) return false;
+  if (!meta) {
+    return false;
+  }
   return 'spansCount' in meta;
 }
 
 export function getTraceMetaErrorCount(meta: MetaArg) {
-  if (!meta) return;
+  if (!meta) {
+    return;
+  }
   return isEAPTraceMeta(meta) ? meta.errorsCount : meta.errors;
 }
 
 export function getTraceMetaPerformanceIssueCount(meta: MetaArg) {
-  if (!meta) return;
+  if (!meta) {
+    return;
+  }
   return isEAPTraceMeta(meta) ? meta.performanceIssuesCount : meta.performance_issues;
 }
 
 export function getTraceMetaSpanCount(meta: MetaArg) {
-  if (!meta) return;
+  if (!meta) {
+    return;
+  }
   return isEAPTraceMeta(meta) ? meta.spansCount : meta.span_count;
 }
 
 export function getTraceMetaLogsCount(meta: MetaArg) {
-  if (!meta) return;
+  if (!meta) {
+    return;
+  }
   return isEAPTraceMeta(meta) ? meta.logsCount : undefined;
 }
 
 export function getTraceMetaTransactionChildCountMap(meta: MetaArg) {
-  if (!meta) return;
+  if (!meta) {
+    return;
+  }
   return isEAPTraceMeta(meta)
     ? meta.transactionChildCountMap
     : meta.transaction_child_count_map;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -187,10 +187,15 @@ export function Attributes({
   // a JSON-encoded array. NOTE: This happens a lot because EAP doesn't support
   // array values, so SDKs often store array values as JSON-encoded strings.
   sortedAndFilteredAttributes.forEach(attribute => {
-    if (Object.hasOwn(customRenderers, attribute.name)) return;
-    if (attribute.type !== 'str') return;
-    if (!looksLikeAJSONArray(attribute.value) && !looksLikeAJSONObject(attribute.value))
+    if (Object.hasOwn(customRenderers, attribute.name)) {
       return;
+    }
+    if (attribute.type !== 'str') {
+      return;
+    }
+    if (!looksLikeAJSONArray(attribute.value) && !looksLikeAJSONObject(attribute.value)) {
+      return;
+    }
 
     customRenderers[attribute.name] = jsonRenderer;
   });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.spec.tsx
@@ -1010,7 +1010,9 @@ describe('BaseNode', () => {
 
         const visitedIds: string[] = [];
         parent.forEachChild(node => {
-          if (node.id) visitedIds.push(node.id);
+          if (node.id) {
+            visitedIds.push(node.id);
+          }
         });
 
         expect(visitedIds).toHaveLength(2);
@@ -1030,7 +1032,9 @@ describe('BaseNode', () => {
 
         const visitedIds: string[] = [];
         root.forEachChild(node => {
-          if (node.id) visitedIds.push(node.id);
+          if (node.id) {
+            visitedIds.push(node.id);
+          }
         });
 
         expect(visitedIds).toEqual(['sibling', 'level1', 'level2']);
@@ -1074,7 +1078,9 @@ describe('BaseNode', () => {
 
         const visitedIds: string[] = [];
         nodeA.forEachChild(node => {
-          if (node.id) visitedIds.push(node.id);
+          if (node.id) {
+            visitedIds.push(node.id);
+          }
         });
 
         // Should visit B but not A (A is the starting node, marked visited first)
@@ -1096,7 +1102,9 @@ describe('BaseNode', () => {
 
         const visitedIds: string[] = [];
         nodeA.forEachChild(node => {
-          if (node.id) visitedIds.push(node.id);
+          if (node.id) {
+            visitedIds.push(node.id);
+          }
         });
 
         // Should visit B and C but not A (A is the starting node, marked visited first)

--- a/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
@@ -81,8 +81,12 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
         throw new Error(`Invalid field: ${field}`);
     }
 
-    if (aValue < bValue) return kind === 'asc' ? -1 : 1;
-    if (aValue > bValue) return kind === 'asc' ? 1 : -1;
+    if (aValue < bValue) {
+      return kind === 'asc' ? -1 : 1;
+    }
+    if (aValue > bValue) {
+      return kind === 'asc' ? 1 : -1;
+    }
     return 0;
   });
 

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
@@ -84,8 +84,12 @@ export function GroupInsightItemDiffTable({
         throw new Error(`Invalid field: ${field}`);
     }
 
-    if (aValue < bValue) return kind === 'asc' ? -1 : 1;
-    if (aValue > bValue) return kind === 'asc' ? 1 : -1;
+    if (aValue < bValue) {
+      return kind === 'asc' ? -1 : 1;
+    }
+    if (aValue > bValue) {
+      return kind === 'asc' ? 1 : -1;
+    }
     return 0;
   });
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -105,8 +105,12 @@ export function SizeCompareItemDiffTable({
         throw new Error(`Invalid field: ${field}`);
     }
 
-    if (aValue < bValue) return kind === 'asc' ? -1 : 1;
-    if (aValue > bValue) return kind === 'asc' ? 1 : -1;
+    if (aValue < bValue) {
+      return kind === 'asc' ? -1 : 1;
+    }
+    if (aValue > bValue) {
+      return kind === 'asc' ? 1 : -1;
+    }
     return 0;
   });
 

--- a/static/app/views/preprod/components/visualizations/appSizeLegend.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeLegend.tsx
@@ -100,7 +100,9 @@ export function AppSizeLegend({
 
     const resizeObserver = new ResizeObserver(entries => {
       const entry = entries[0];
-      if (!entry) return;
+      if (!entry) {
+        return;
+      }
 
       const currentWidth = entry.contentRect.width;
 
@@ -169,7 +171,9 @@ export function AppSizeLegend({
     }
   ) => {
     const categoryInfo = getCategoryInfo(categoryType);
-    if (!categoryInfo) return null;
+    if (!categoryInfo) {
+      return null;
+    }
 
     return (
       <LegendItem

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -815,9 +815,15 @@ const DragHandle = styled('div')`
 
 function imageSearchKey(image: SnapshotImage): string {
   const parts: string[] = [];
-  if (image.display_name) parts.push(image.display_name);
-  if (image.image_file_name) parts.push(image.image_file_name);
-  if (image.group) parts.push(image.group);
+  if (image.display_name) {
+    parts.push(image.display_name);
+  }
+  if (image.image_file_name) {
+    parts.push(image.image_file_name);
+  }
+  if (image.group) {
+    parts.push(image.group);
+  }
   return parts.join('\n').toLowerCase();
 }
 
@@ -852,8 +858,12 @@ function narrowItemBySearch(
         allMatched = false;
       }
     }
-    if (kept.length === 0) return null;
-    if (allMatched) return item;
+    if (kept.length === 0) {
+      return null;
+    }
+    if (allMatched) {
+      return item;
+    }
     return {...item, pairs: kept};
   }
   const kept: SnapshotImage[] = [];
@@ -865,7 +875,11 @@ function narrowItemBySearch(
       allMatched = false;
     }
   }
-  if (kept.length === 0) return null;
-  if (allMatched) return item;
+  if (kept.length === 0) {
+    return null;
+  }
+  if (allMatched) {
+    return item;
+  }
   return {...item, images: kept};
 }

--- a/static/app/views/preprod/utils/treemapFiltering.ts
+++ b/static/app/views/preprod/utils/treemapFiltering.ts
@@ -22,7 +22,9 @@ export function filterTreemapElement(
   const hasSearchFilter = !!ctx.term;
   const hasCategoryFilter = selectedCategories && selectedCategories.size > 0;
 
-  if (!hasSearchFilter && !hasCategoryFilter) return element;
+  if (!hasSearchFilter && !hasCategoryFilter) {
+    return element;
+  }
 
   // Root is a special case, only keep if children match.
   if (parentPath === '') {
@@ -56,7 +58,9 @@ function makeSearchCtx(searchQuery: string): SearchCtx {
 }
 
 function advancePathIdx(nodeNameLC: string, parts: string[], idx: number): number {
-  if (idx >= parts.length) return idx;
+  if (idx >= parts.length) {
+    return idx;
+  }
   return nodeNameLC.includes(parts[idx] ?? '') ? idx + 1 : idx;
 }
 
@@ -69,10 +73,16 @@ function currentNodeMatches(
   ctx: SearchCtx,
   pathIdx: number
 ): boolean {
-  if (!ctx.term) return true;
-  if (!ctx.hasPath) return nodeNameLC.includes(ctx.lcTerm);
+  if (!ctx.term) {
+    return true;
+  }
+  if (!ctx.hasPath) {
+    return nodeNameLC.includes(ctx.lcTerm);
+  }
 
-  if (pathIdx >= ctx.parts.length) return true; // already satisfied the whole path
+  if (pathIdx >= ctx.parts.length) {
+    return true;
+  } // already satisfied the whole path
   const needed = ctx.parts[pathIdx];
   return needed ? nodeNameLC.includes(needed) : false; // must advance to count as a match
 }
@@ -81,7 +91,9 @@ function categoryMatches(
   element: TreemapElement,
   selectedCategories?: Set<TreemapType>
 ): boolean {
-  if (!selectedCategories || selectedCategories.size === 0) return true;
+  if (!selectedCategories || selectedCategories.size === 0) {
+    return true;
+  }
   return selectedCategories.has(element.type);
 }
 
@@ -147,11 +159,15 @@ function filterChildren(
   pathIdx: number,
   selectedCategories?: Set<TreemapType>
 ): TreemapElement[] {
-  if (!children || children.length === 0) return [];
+  if (!children || children.length === 0) {
+    return [];
+  }
   const out: TreemapElement[] = [];
   for (const child of children) {
     const filtered = filterNode(child, ctx, pathIdx, selectedCategories);
-    if (filtered) out.push(filtered);
+    if (filtered) {
+      out.push(filtered);
+    }
   }
   return out;
 }

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -107,7 +107,9 @@ export function ExplorerDrawerContent({
   const latestTodoBlockIndex = useMemo(() => {
     for (let i = blocks.length - 1; i >= 0; i--) {
       const block = blocks[i];
-      if (block && Array.isArray(block.todos) && block.todos.length > 0) return i;
+      if (block && Array.isArray(block.todos) && block.todos.length > 0) {
+        return i;
+      }
     }
     return -1;
   }, [blocks]);
@@ -152,7 +154,9 @@ export function ExplorerDrawerContent({
   });
 
   const handleCopyLink = useCallback(async () => {
-    if (runId === null) return;
+    if (runId === null) {
+      return;
+    }
     try {
       const url = getExplorerUrl(runId);
       await navigator.clipboard.writeText(url);

--- a/static/app/views/seerExplorer/components/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/components/explorerMenu.tsx
@@ -149,7 +149,9 @@ export function useExplorerMenu({
   // Handle keyboard navigation with higher priority
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (!isVisible) return;
+      if (!isVisible) {
+        return;
+      }
 
       const isPrintableChar = e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey;
 

--- a/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
@@ -26,7 +26,9 @@ function makeContextCapture() {
   }
 
   function getSnapshot(componentOnly?: boolean): LLMContextSnapshot {
-    if (!ref.current) throw new Error('ContextCapture not mounted');
+    if (!ref.current) {
+      throw new Error('ContextCapture not mounted');
+    }
     return ref.current(componentOnly);
   }
 
@@ -420,7 +422,9 @@ describe('getLLMContext — full tree vs componentOnly', () => {
     // componentOnly snapshot should contain only the dashboard + its inner widget,
     // not the sibling dashboard
     await waitFor(() => {
-      if (!innerRef.current) throw new Error('not mounted');
+      if (!innerRef.current) {
+        throw new Error('not mounted');
+      }
       const snapshot = innerRef.current(true); // componentOnly
       expect(snapshot.nodes).toHaveLength(1);
       expect(snapshot.nodes[0]?.nodeType).toBe('dashboard');

--- a/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
+++ b/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
@@ -51,13 +51,21 @@ export function createGridHelpers(rows: number, cols: number): GridHelpers {
   const grid = Array.from({length: rows}, () => Array.from({length: cols}, () => ' '));
 
   const setCell = (r: number, c: number, ch: string) => {
-    if (r < 0 || r >= grid.length) return;
+    if (r < 0 || r >= grid.length) {
+      return;
+    }
     const row = grid[r];
-    if (!row) return;
-    if (c < 0) return;
+    if (!row) {
+      return;
+    }
+    if (c < 0) {
+      return;
+    }
     if (c >= row.length) {
       const toAdd = c - row.length + 1;
-      for (let i = 0; i < toAdd; i++) row.push(' ');
+      for (let i = 0; i < toAdd; i++) {
+        row.push(' ');
+      }
     }
     if (row[c] === ' ') {
       row[c] = ch;
@@ -65,13 +73,21 @@ export function createGridHelpers(rows: number, cols: number): GridHelpers {
   };
 
   const writeOverlay = (r: number, c: number, text: string) => {
-    if (r < 0 || r >= grid.length) return;
+    if (r < 0 || r >= grid.length) {
+      return;
+    }
     const row = grid[r];
-    if (!row) return;
-    if (c < 0) return;
+    if (!row) {
+      return;
+    }
+    if (c < 0) {
+      return;
+    }
     if (c + text.length >= row.length) {
       const toAdd = c + text.length - row.length + 1;
-      for (let i = 0; i < toAdd; i++) row.push(' ');
+      for (let i = 0; i < toAdd; i++) {
+        row.push(' ');
+      }
     }
     for (let i = 0; i < text.length; i++) {
       row[c + i] = text.charAt(i);
@@ -79,11 +95,15 @@ export function createGridHelpers(rows: number, cols: number): GridHelpers {
   };
 
   const putText = (text: string, l: number, r: number, t: number, b: number) => {
-    if (t > b || l > r) return;
+    if (t > b || l > r) {
+      return;
+    }
     const targetRow = Math.min(Math.max(Math.floor((t + b) / 2), 0), rows - 1);
     const clean = text.replace(/\s+/g, ' ').trim();
     const row = grid[targetRow];
-    if (!row) return;
+    if (!row) {
+      return;
+    }
     const startCol = Math.max(0, l);
     for (let i = 0; i < clean.length; i++) {
       setCell(targetRow, startCol + i, clean.charAt(i));
@@ -106,7 +126,9 @@ function computeLeftShiftPx(viewportWidth: number): number {
       const rect = n.getBoundingClientRect();
       const intersects = !(rect.right <= 0 || rect.left >= viewportWidth);
       if (intersects && rect.width > 0 && rect.height > 0) {
-        if (rect.right > shift) shift = rect.right;
+        if (rect.right > shift) {
+          shift = rect.right;
+        }
       }
     }
     return Math.max(0, Math.floor(shift));
@@ -427,11 +449,15 @@ function processCharts(
 
     const instanceByDom = new Map<Element, any>();
     for (const el of candidates) {
-      if (context.isExcluded(el) || !context.isVisible(el)) continue;
+      if (context.isExcluded(el) || !context.isVisible(el)) {
+        continue;
+      }
 
       let container: Element | null = el;
       const nearest = el.closest('[data-ec], .echarts-for-react, .echarts');
-      if (nearest) container = nearest;
+      if (nearest) {
+        container = nearest;
+      }
 
       let inst: any = null;
       if (container) {
@@ -453,7 +479,9 @@ function processCharts(
     let timeseriesChartCount = 0;
     for (const [, inst] of instanceByDom) {
       const dom: Element = inst.getDom();
-      if (context.isExcluded(dom) || !context.isVisible(dom)) continue;
+      if (context.isExcluded(dom) || !context.isVisible(dom)) {
+        continue;
+      }
 
       const rect = dom.getBoundingClientRect();
       if (
@@ -467,11 +495,15 @@ function processCharts(
 
       const option = inst.getOption?.() || {};
       const series: any[] = Array.isArray(option.series) ? option.series : [];
-      if (!series.length) continue;
+      if (!series.length) {
+        continue;
+      }
 
       let hasTimeseriesData = false;
       for (const s of series) {
-        if (s?.show === false) continue;
+        if (s?.show === false) {
+          continue;
+        }
         const type = String(s?.type || '').toLowerCase();
         if (TIMESERIES_TYPES.has(type)) {
           const data: any[] = Array.isArray(s?.data) ? s.data : [];
@@ -491,7 +523,9 @@ function processCharts(
     let chartIndex = 0;
     for (const [, inst] of instanceByDom) {
       const dom: Element = inst.getDom();
-      if (context.isExcluded(dom) || !context.isVisible(dom)) continue;
+      if (context.isExcluded(dom) || !context.isVisible(dom)) {
+        continue;
+      }
 
       const rect = dom.getBoundingClientRect();
       if (
@@ -505,12 +539,16 @@ function processCharts(
 
       const option = inst.getOption?.() || {};
       const series: any[] = Array.isArray(option.series) ? option.series : [];
-      if (!series.length) continue;
+      if (!series.length) {
+        continue;
+      }
 
       const timeseriesData: SeriesData[] = [];
 
       for (const s of series) {
-        if (s?.show === false) continue;
+        if (s?.show === false) {
+          continue;
+        }
 
         const type = String(s?.type || '').toLowerCase();
         if (!TIMESERIES_TYPES.has(type)) {
@@ -536,7 +574,9 @@ function processCharts(
         }
 
         const data: any[] = Array.isArray(s?.data) ? s.data : [];
-        if (!data.length) continue;
+        if (!data.length) {
+          continue;
+        }
 
         const rawSeriesName =
           s?.name || s?.seriesName || `Series${timeseriesData.length + 1}`;
@@ -558,10 +598,14 @@ function processCharts(
         }
       }
 
-      if (timeseriesData.length === 0) continue;
+      if (timeseriesData.length === 0) {
+        continue;
+      }
 
       const nonEmptySeries = timeseriesData.filter(s => s.data.size > 0);
-      if (nonEmptySeries.length === 0) continue;
+      if (nonEmptySeries.length === 0) {
+        continue;
+      }
 
       const seenNames = new Set<string>();
       const uniqueSeries = nonEmptySeries.filter(s => {
@@ -572,7 +616,9 @@ function processCharts(
         return true;
       });
 
-      if (uniqueSeries.length === 0) continue;
+      if (uniqueSeries.length === 0) {
+        continue;
+      }
 
       chartIndex++;
       const chartNumber = chartIndex;
@@ -762,7 +808,9 @@ function renderTextNodes(
 
             const effLeftPx = Math.max(rect.left, clipRect.left);
             const effRightPx = Math.min(rect.right, clipRect.right);
-            if (effRightPx <= effLeftPx) return remaining;
+            if (effRightPx <= effLeftPx) {
+              return remaining;
+            }
 
             const left = Math.max(0, Math.floor((effLeftPx - leftShiftPx) / cellWidthPx));
             const right = Math.floor((effRightPx - leftShiftPx - 1) / cellWidthPx);
@@ -772,7 +820,9 @@ function renderTextNodes(
               Math.floor((rect.bottom - 1) / cellHeightPx)
             );
 
-            if (right <= left || bottom < top) return remaining;
+            if (right <= left || bottom < top) {
+              return remaining;
+            }
 
             const capacity = Math.max(1, right - left + 1);
             let segment = remaining.slice(0, capacity);
@@ -805,20 +855,26 @@ function renderTextNodes(
           if (singleLineEllipsize) {
             for (const rect of rects) {
               const remaining = renderRect(rect, raw, true);
-              if (!remaining || remaining === raw) break;
+              if (!remaining || remaining === raw) {
+                break;
+              }
             }
           } else if (lineClampActive) {
             let remaining = raw;
             for (let idx = 0; idx < rects.length; idx++) {
               const isLast = idx === rects.length - 1;
               remaining = renderRect(rects[idx]!, remaining, isLast);
-              if (!remaining) break;
+              if (!remaining) {
+                break;
+              }
             }
           } else {
             let remaining = raw;
             for (const rect of rects) {
               remaining = renderRect(rect, remaining, false);
-              if (!remaining) break;
+              if (!remaining) {
+                break;
+              }
             }
           }
         }

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -1152,7 +1152,9 @@ export function useSeerExplorerDeepLink({
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled) {
+      return;
+    }
 
     const paramValue = location.query?.[RUN_ID_QUERY_PARAM];
     if (!paramValue || typeof paramValue !== 'string') {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -171,9 +171,13 @@ function mapScopeErrors(scopeErrors: unknown): ScopeErrors {
     return result;
   }
   for (const message of scopeErrors) {
-    if (typeof message !== 'string') continue;
+    if (typeof message !== 'string') {
+      continue;
+    }
     const match = message.match(/Requested permission of (\w+:\w+)/);
-    if (!match) continue;
+    if (!match) {
+      continue;
+    }
     const scope = match[1]!;
     if (scope === CONTINUOUS_INTEGRATION_SENTRY_APP_PERMISSION.scope) {
       result.continuousIntegration ??= message;

--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.tsx
@@ -120,8 +120,12 @@ function cloneSchemaFields(
       // would otherwise render unbounded. Honor schema-provided values when
       // present.
       if (nextField.type === 'textarea') {
-        if (nextField.maxRows === undefined) nextField.maxRows = 10;
-        if (nextField.autosize === undefined) nextField.autosize = true;
+        if (nextField.maxRows === undefined) {
+          nextField.maxRows = 10;
+        }
+        if (nextField.autosize === undefined) {
+          nextField.autosize = true;
+        }
       }
 
       if (nextField.default && getFieldDefault) {
@@ -496,13 +500,17 @@ export function SentryAppExternalFormNew({
 
       while (triggerQueue.length > 0) {
         const trigger = triggerQueue.shift()!;
-        if (processedTriggers.has(trigger)) continue;
+        if (processedTriggers.has(trigger)) {
+          continue;
+        }
         processedTriggers.add(trigger);
 
         const dependentFields = getAllSchemaFields(workingFieldGroups).filter(
           field => field.depends_on?.includes(trigger) && !fetchedFields.has(field.name)
         );
-        if (!dependentFields.length) continue;
+        if (!dependentFields.length) {
+          continue;
+        }
 
         for (const field of dependentFields) {
           fetchedFields.add(field.name);
@@ -528,21 +536,27 @@ export function SentryAppExternalFormNew({
           }))
         );
 
-        if (requestVersion !== dependentFetchVersionRef.current) return null;
+        if (requestVersion !== dependentFetchVersionRef.current) {
+          return null;
+        }
 
         const folded = foldChoiceResults(workingFieldGroups, workingDefaults, results);
         workingFieldGroups = folded.updatedFieldGroups;
         workingDefaults = folded.nextDefaultValues;
 
         for (const result of results) {
-          if (result.defaultValue === undefined) continue;
+          if (result.defaultValue === undefined) {
+            continue;
+          }
           // Preserve saved/user values: only apply a fetched defaultValue if
           // the field doesn't already have an effective value. Without this
           // check, the mount-time cascade clobbers a saved selection (e.g.
           // alert-rule-action settings round-tripping from the DB) with the
           // schema's default, and the next BFS iteration fetches its
           // dependents with the wrong parent value.
-          if (hasValue(workingValues[result.fieldName])) continue;
+          if (hasValue(workingValues[result.fieldName])) {
+            continue;
+          }
           workingValues = {...workingValues, [result.fieldName]: result.defaultValue};
           triggerQueue.push(result.fieldName);
         }
@@ -624,7 +638,9 @@ export function SentryAppExternalFormNew({
       }
     }
     const seedTriggers = Object.keys(initialFieldValues);
-    if (!seedTriggers.length) return;
+    if (!seedTriggers.length) {
+      return;
+    }
 
     const requestVersion = dependentFetchVersionRef.current + 1;
     dependentFetchVersionRef.current = requestVersion;
@@ -894,7 +910,9 @@ export function SentryAppExternalFormNew({
         directlyImpactedNames
       );
       const nextDefaultValues = {...externalDefaultValues};
-      for (const name of directlyImpactedNames) delete nextDefaultValues[name];
+      for (const name of directlyImpactedNames) {
+        delete nextDefaultValues[name];
+      }
 
       currentFormValuesRef.current = nextCurrentValues;
       setIsFetchingDependentFields(true);
@@ -908,7 +926,9 @@ export function SentryAppExternalFormNew({
           initialValues: nextCurrentValues,
           requestVersion,
         });
-        if (!cascadeResult) return;
+        if (!cascadeResult) {
+          return;
+        }
         allImpactedNames = cascadeResult.impactedNames;
 
         // Only apply newly-resolved defaults for the impacted fields.

--- a/static/app/views/settings/organizationRepositories/components/scmRepositoryTable.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/components/scmRepositoryTable.stories.tsx
@@ -90,7 +90,9 @@ const REPO_NAMES = [
  * "many projects (with +N collapse)" rows without reshuffling on every render.
  */
 function pickSlugsForRepo(allSlugs: string[], repoIndex: number): string[] {
-  if (allSlugs.length === 0) return [];
+  if (allSlugs.length === 0) {
+    return [];
+  }
   const counts = [0, 1, 1, 3, 0, 5];
   const count = Math.min(counts[repoIndex % counts.length]!, allSlugs.length);
   const start = (repoIndex * 3) % allSlugs.length;

--- a/static/app/views/settings/organizationRepositories/hooks/useSyncRepositories.tsx
+++ b/static/app/views/settings/organizationRepositories/hooks/useSyncRepositories.tsx
@@ -61,7 +61,9 @@ function usePhaseTimer(
   const scheduleRef = useRef<(idx: number) => void>(() => {});
   scheduleRef.current = (idx: number) => {
     const phase = configRef.current[idx];
-    if (!phase) return;
+    if (!phase) {
+      return;
+    }
 
     timerRef.current = window.setTimeout(() => {
       const nextIdx = idx + 1;
@@ -80,13 +82,17 @@ function usePhaseTimer(
   };
 
   function start() {
-    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
     setPhaseIndex(0);
     scheduleRef.current(0);
   }
 
   function cancel() {
-    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
     timerRef.current = null;
     setPhaseIndex(null);
   }
@@ -94,7 +100,9 @@ function usePhaseTimer(
   useEffect(() => {
     const timer = timerRef;
     return () => {
-      if (timer.current !== null) clearTimeout(timer.current);
+      if (timer.current !== null) {
+        clearTimeout(timer.current);
+      }
     };
   }, []);
 
@@ -206,7 +214,9 @@ export function useSyncRepositories(
 
   // Detect sync completion by comparing last_sync on each poll result.
   useEffect(() => {
-    if (!isSyncing || !query.data) return;
+    if (!isSyncing || !query.data) {
+      return;
+    }
 
     const currentLastSync = query.data.configData?.last_sync as string | undefined;
     if (currentLastSync !== lastSyncBefore) {

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -321,7 +321,9 @@ export function ProjectGeneralSettings({project, onChangeSlug}: Props) {
     ...fields.platform,
     options: fields.platform.options.filter(({value}) => {
       // Always include the current project's platform to display its icon and label
-      if (project.platform === value) return true;
+      if (project.platform === value) {
+        return true;
+      }
       return isPlatformAllowed({isSelfHosted, organization, platform: value});
     }),
     isOptionDisabled: (option: SelectOptionWithKey<string>) => {

--- a/static/app/views/settings/settingsCommandPaletteActions.tsx
+++ b/static/app/views/settings/settingsCommandPaletteActions.tsx
@@ -37,7 +37,9 @@ function titleFromRoute(route: string): string {
     .replace(/^account\//, '')
     .split('/')[0];
 
-  if (!segment) return 'Settings';
+  if (!segment) {
+    return 'Settings';
+  }
 
   return segment
     .split('-')
@@ -46,10 +48,18 @@ function titleFromRoute(route: string): string {
 }
 
 function isSettingsRoute(route: string): boolean {
-  if (!route.startsWith('/settings/')) return false;
-  if (route.includes(':projectId')) return false;
-  if (route.includes(':teamId')) return false;
-  if (route.includes(':appId')) return false;
+  if (!route.startsWith('/settings/')) {
+    return false;
+  }
+  if (route.includes(':projectId')) {
+    return false;
+  }
+  if (route.includes(':teamId')) {
+    return false;
+  }
+  if (route.includes(':appId')) {
+    return false;
+  }
   return true;
 }
 
@@ -79,8 +89,12 @@ function getSettingsFieldSections(orgSlug: string): SettingsFieldSection[] {
 
   const groups = new Map<string, Map<string, FormSearchField>>();
   for (const field of allFields) {
-    if (!isSettingsRoute(field.route)) continue;
-    if (typeof field.title !== 'string' || !field.title) continue;
+    if (!isSettingsRoute(field.route)) {
+      continue;
+    }
+    if (typeof field.title !== 'string' || !field.title) {
+      continue;
+    }
 
     const normalizedRoute = normalizeRouteForLookup(field.route);
     let routeFields = groups.get(normalizedRoute);

--- a/static/eslint/eslintPluginScraps/src/rules/no-core-import.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/no-core-import.ts
@@ -23,7 +23,9 @@ export const noCoreImport = ESLintUtils.RuleCreator.withoutDocs({
   create(context) {
     return {
       ImportDeclaration(node) {
-        if (node?.source.type !== 'Literal') return;
+        if (node?.source.type !== 'Literal') {
+          return;
+        }
 
         const importPath = node.source.value;
 

--- a/static/eslint/eslintPluginScraps/src/rules/no-token-import.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/no-token-import.ts
@@ -16,7 +16,9 @@ const EXCEPT_DIR_NAME = 'static/app/utils/theme';
  * @returns {boolean}
  */
 function isForbiddenImportPath(importPath: string) {
-  if (typeof importPath !== 'string') return false;
+  if (typeof importPath !== 'string') {
+    return false;
+  }
 
   return importPath.includes(TOKEN_PATH);
 }
@@ -37,8 +39,12 @@ export const noTokenImport = ESLintUtils.RuleCreator.withoutDocs({
 
     return {
       ImportDeclaration(node) {
-        if (node?.source.type !== 'Literal') return;
-        if (importerIsInAllowedDir) return;
+        if (node?.source.type !== 'Literal') {
+          return;
+        }
+        if (importerIsInAllowedDir) {
+          return;
+        }
 
         const value = node.source.value;
 

--- a/static/eslint/eslintPluginScraps/src/rules/restrict-jsx-slot-children.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/restrict-jsx-slot-children.ts
@@ -276,7 +276,9 @@ export const restrictJsxSlotChildren = ESLintUtils.RuleCreator.withoutDocs<
       propName: string,
       state: State
     ) {
-      if (!expr) return;
+      if (!expr) {
+        return;
+      }
 
       if (expr.type === 'JSXElement') {
         checkSlotTree(expr, propName, state);
@@ -326,7 +328,9 @@ export const restrictJsxSlotChildren = ESLintUtils.RuleCreator.withoutDocs<
      */
     let allowedNamesResolved = false;
     function resolveAllowedNames() {
-      if (allowedNamesResolved) return;
+      if (allowedNamesResolved) {
+        return;
+      }
       allowedNamesResolved = true;
 
       for (const [, state] of slotState) {
@@ -359,10 +363,14 @@ export const restrictJsxSlotChildren = ESLintUtils.RuleCreator.withoutDocs<
         // any JSXAttribute nodes, so importTracker has all imports recorded.
         resolveAllowedNames();
         const propName = node.name.type === 'JSXIdentifier' ? node.name.name : null;
-        if (!propName) return;
+        if (!propName) {
+          return;
+        }
 
         const state = slotState.get(propName);
-        if (!state) return;
+        if (!state) {
+          return;
+        }
 
         if (state.componentNames.size > 0) {
           const nameNode = node.parent.name; // JSXAttribute → JSXOpeningElement

--- a/static/eslint/eslintPluginSentry/no-static-translations.ts
+++ b/static/eslint/eslintPluginSentry/no-static-translations.ts
@@ -18,12 +18,20 @@ export const noStaticTranslations = ESLintUtils.RuleCreator.withoutDocs({
     return {
       CallExpression(node) {
         const callee = node.callee;
-        if (callee?.type !== 'Identifier') return;
-        if (!DYNAMIC_TRANSLATION_FNS.includes(callee.name)) return;
-        if (node.arguments.length === 0) return;
+        if (callee?.type !== 'Identifier') {
+          return;
+        }
+        if (!DYNAMIC_TRANSLATION_FNS.includes(callee.name)) {
+          return;
+        }
+        if (node.arguments.length === 0) {
+          return;
+        }
 
         const translationArg = node.arguments?.[0];
-        if (!translationArg) return;
+        if (!translationArg) {
+          return;
+        }
 
         // Check if it's ATTRIBUTE_METADATA[...].brief
         if (translationArg.type === 'MemberExpression') {

--- a/static/gsApp/views/seerAutomation/components/seerAutomationProjectList.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerAutomationProjectList.tsx
@@ -229,7 +229,9 @@ export function SeerAutomationProjectList() {
         await Promise.all(
           batch.map(projectId => {
             const project = projects.find(p => p.id === projectId);
-            if (!project) return Promise.resolve();
+            if (!project) {
+              return Promise.resolve();
+            }
 
             const updateData: any = {autofixAutomationTuning: value};
             if (value !== 'off') {
@@ -249,7 +251,9 @@ export function SeerAutomationProjectList() {
     } finally {
       Array.from(selected).forEach(projectId => {
         const project = projects.find(p => p.id === projectId);
-        if (!project) return;
+        if (!project) {
+          return;
+        }
         queryClient.invalidateQueries({
           queryKey: makeDetailedProjectQueryKey({
             orgSlug: organization.slug,
@@ -271,7 +275,9 @@ export function SeerAutomationProjectList() {
         await Promise.all(
           batch.map(projectId => {
             const project = projects.find(p => p.id === projectId);
-            if (!project) return Promise.resolve();
+            if (!project) {
+              return Promise.resolve();
+            }
             return api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
               method: 'PUT',
               data: {seerScannerAutomation: value},
@@ -285,7 +291,9 @@ export function SeerAutomationProjectList() {
     } finally {
       Array.from(selected).forEach(projectId => {
         const project = projects.find(p => p.id === projectId);
-        if (!project) return;
+        if (!project) {
+          return;
+        }
         queryClient.invalidateQueries({
           queryKey: makeDetailedProjectQueryKey({
             orgSlug: organization.slug,

--- a/static/gsApp/views/seerAutomation/onboarding/onboardingLegacy.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/onboardingLegacy.tsx
@@ -128,7 +128,9 @@ function ProjectRowWithUpdate({
   const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
 
   const handleProjectClick = useCallback(() => {
-    if (!repositories) return;
+    if (!repositories) {
+      return;
+    }
 
     const currentPreference = projectStates[project.id]?.preference;
     const currentRepoIds =
@@ -300,13 +302,19 @@ function ProjectsWithoutRepos({
   }, [projects, projectStates]);
 
   const projectsWithoutRepos = useMemo(() => {
-    if (isLoading) return [];
+    if (isLoading) {
+      return [];
+    }
 
     const filtered = projects.filter(project => {
-      if (successfullyConnectedProjects.has(project.id)) return false;
+      if (successfullyConnectedProjects.has(project.id)) {
+        return false;
+      }
 
       const state = projectStates[project.id];
-      if (!state || state.isPending) return false;
+      if (!state || state.isPending) {
+        return false;
+      }
 
       let repoCount = state.preference?.repositories?.length || 0;
       if (repoCount === 0 && state.codeMappingRepos) {
@@ -316,7 +324,9 @@ function ProjectsWithoutRepos({
     });
 
     // Apply search filter
-    if (!searchQuery.trim()) return filtered;
+    if (!searchQuery.trim()) {
+      return filtered;
+    }
 
     const query = searchQuery.toLowerCase();
     return filtered.filter(
@@ -611,7 +621,9 @@ export function SeerAutomationOnboarding() {
   const projectsWithoutRepos = useMemo(() => {
     return filteredProjects.filter(project => {
       // Exclude projects that have been successfully connected this session
-      if (successfullyConnectedProjects.has(project.id)) return false;
+      if (successfullyConnectedProjects.has(project.id)) {
+        return false;
+      }
 
       // Exclude projects that already have repositories
       const state = projectStates[project.id];


### PR DESCRIPTION
## Summary

- Enables the ESLint [`curly`](https://eslint.org/docs/latest/rules/curly) rule at error level, requiring curly braces around all control flow statements (`if`, `else`, `for`, `while`, `do`)
- The rule is added in the `plugin/prettier` config block so it overrides `eslint-config-prettier`'s disabling of the rule (it's a "special rule" that's safe to use alongside formatters)
- Auto-fixed all 124 files with existing violations and reformatted with `oxfmt`

## Test plan

- [x] Verified zero remaining `curly` violations via `eslint` across `static/app/`, `static/gsApp/`, `static/gsAdmin/`, `tests/js/`, and `static/eslint/`
- [x] All pre-commit hooks pass (eslint, stylelint, format)
- [ ] CI passes