### PR TITLE
ref(releases): Convert ReleaseIssues to functional component

### DIFF
--- a/static/app/views/explore/releases/detail/overview/index.tsx
+++ b/static/app/views/explore/releases/detail/overview/index.tsx
@@ -59,7 +59,7 @@ import {ReleaseStats} from './sidebar/releaseStats';
 import {TotalCrashFreeUsers} from './sidebar/totalCrashFreeUsers';
 import {ReleaseArchivedNotice} from './releaseArchivedNotice';
 import {ReleaseComparisonChart} from './releaseComparisonChart';
-import ReleaseIssues from './releaseIssues';
+import {ReleaseIssues} from './releaseIssues';
 
 const RELEASE_PERIOD_KEY = 'release';
 
@@ -385,9 +385,7 @@ function ReleaseOverview() {
             </DemoTourElement>
           )}
           <ReleaseIssues
-            organization={organization}
             version={version}
-            location={location}
             releaseBounds={releaseBounds}
             queryFilterDescription={t('In this release')}
             withChart

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.spec.tsx
@@ -27,6 +27,33 @@ describe('ReleaseIssues', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues-count/`,
       body: {},
+      match: [
+        MockApiClient.matchQuery({
+          start: '2020-03-23T01:02:00Z',
+          end: '2020-03-24T02:04:59Z',
+          query: [
+            'first-release:"1.0.0" is:unresolved',
+            'release:"1.0.0" is:unresolved',
+            'error.handled:0 release:"1.0.0" is:unresolved',
+            'regressed_in_release:"1.0.0"',
+          ],
+        }),
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues-count/`,
+      body: {},
+      match: [
+        MockApiClient.matchQuery({
+          statsPeriod: '24h',
+          query: [
+            'first-release:"1.0.0" is:unresolved',
+            'release:"1.0.0" is:unresolved',
+            'error.handled:0 release:"1.0.0" is:unresolved',
+            'regressed_in_release:"1.0.0"',
+          ],
+        }),
+      ],
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/1.0.0/resolved/`,

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.spec.tsx
@@ -25,10 +25,8 @@ describe('ReleaseIssues', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues-count/?end=2020-03-24T02%3A04%3A59Z&query=first-release%3A%221.0.0%22%20is%3Aunresolved&query=release%3A%221.0.0%22%20is%3Aunresolved&query=error.handled%3A0%20release%3A%221.0.0%22%20is%3Aunresolved&query=regressed_in_release%3A%221.0.0%22&start=2020-03-23T01%3A02%3A00Z`,
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues-count/?query=first-release%3A%221.0.0%22%20is%3Aunresolved&query=release%3A%221.0.0%22%20is%3Aunresolved&query=error.handled%3A0%20release%3A%221.0.0%22%20is%3Aunresolved&query=regressed_in_release%3A%221.0.0%22&statsPeriod=24h`,
+      url: `/organizations/${organization.slug}/issues-count/`,
+      body: {},
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/1.0.0/resolved/`,

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.spec.tsx
@@ -1,77 +1,72 @@
 import {GroupFixture} from 'sentry-fixture/group';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ReleaseFixture} from 'sentry-fixture/release';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import ReleaseIssues from 'sentry/views/explore/releases/detail/overview/releaseIssues';
+import {ReleaseIssues} from 'sentry/views/explore/releases/detail/overview/releaseIssues';
 import {getReleaseBounds} from 'sentry/views/explore/releases/utils';
 
 describe('ReleaseIssues', () => {
   let issuesEndpoint: jest.Mock;
   let resolvedIssuesEndpoint: jest.Mock;
 
-  const props = {
-    orgId: 'org',
-    organization: OrganizationFixture(),
-    version: '1.0.0',
-    location: LocationFixture({query: {}}),
-    releaseBounds: getReleaseBounds(ReleaseFixture({version: '1.0.0'})),
-  };
+  const organization = OrganizationFixture();
+  const version = '1.0.0';
+  const releaseBounds = getReleaseBounds(ReleaseFixture({version: '1.0.0'}));
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/users/`,
+      url: `/organizations/${organization.slug}/users/`,
       body: [],
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues-count/?end=2020-03-24T02%3A04%3A59Z&query=first-release%3A%221.0.0%22%20is%3Aunresolved&query=release%3A%221.0.0%22%20is%3Aunresolved&query=error.handled%3A0%20release%3A%221.0.0%22%20is%3Aunresolved&query=regressed_in_release%3A%221.0.0%22&start=2020-03-23T01%3A02%3A00Z`,
+      url: `/organizations/${organization.slug}/issues-count/?end=2020-03-24T02%3A04%3A59Z&query=first-release%3A%221.0.0%22%20is%3Aunresolved&query=release%3A%221.0.0%22%20is%3Aunresolved&query=error.handled%3A0%20release%3A%221.0.0%22%20is%3Aunresolved&query=regressed_in_release%3A%221.0.0%22&start=2020-03-23T01%3A02%3A00Z`,
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues-count/?query=first-release%3A%221.0.0%22%20is%3Aunresolved&query=release%3A%221.0.0%22%20is%3Aunresolved&query=error.handled%3A0%20release%3A%221.0.0%22%20is%3Aunresolved&query=regressed_in_release%3A%221.0.0%22&statsPeriod=24h`,
+      url: `/organizations/${organization.slug}/issues-count/?query=first-release%3A%221.0.0%22%20is%3Aunresolved&query=release%3A%221.0.0%22%20is%3Aunresolved&query=error.handled%3A0%20release%3A%221.0.0%22%20is%3Aunresolved&query=regressed_in_release%3A%221.0.0%22&statsPeriod=24h`,
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/releases/1.0.0/resolved/`,
+      url: `/organizations/${organization.slug}/releases/1.0.0/resolved/`,
     });
 
     issuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues/`,
+      url: `/organizations/${organization.slug}/issues/`,
       body: [],
     });
     resolvedIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/releases/1.0.0/resolved/`,
+      url: `/organizations/${organization.slug}/releases/1.0.0/resolved/`,
       body: [],
     });
   });
 
   it('shows an empty state', async () => {
-    const {rerender} = render(<ReleaseIssues {...props} />);
+    render(<ReleaseIssues version={version} releaseBounds={releaseBounds} />, {
+      organization,
+    });
 
     expect(await screen.findByText('No new issues in this release.')).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('radio', {name: 'Resolved 0'}));
-    // Simulate query change
-    rerender(
-      <ReleaseIssues
-        {...props}
-        location={LocationFixture({query: {issuesType: 'resolved'}})}
-      />
-    );
     expect(
       await screen.findByText('No resolved issues in this release.')
     ).toBeInTheDocument();
   });
 
   it('shows an empty sttate with stats period', async () => {
-    const query = {pageStatsPeriod: '24h'};
-    const {rerender} = render(
-      <ReleaseIssues {...props} location={LocationFixture({query})} />
-    );
+    render(<ReleaseIssues version={version} releaseBounds={releaseBounds} />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {pageStatsPeriod: '24h'},
+        },
+      },
+    });
 
     expect(
       await screen.findByText(
@@ -80,13 +75,6 @@ describe('ReleaseIssues', () => {
     ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('radio', {name: 'Unhandled 0'}));
-    // Simulate query change
-    rerender(
-      <ReleaseIssues
-        {...props}
-        location={LocationFixture({query: {...query, issuesType: 'unhandled'}})}
-      />
-    );
     expect(
       await screen.findByText(
         textWithMarkupMatcher('No unhandled issues for the last 24 hours.')
@@ -95,7 +83,9 @@ describe('ReleaseIssues', () => {
   });
 
   it('can switch issue filters', async () => {
-    const {rerender} = render(<ReleaseIssues {...props} />);
+    render(<ReleaseIssues version={version} releaseBounds={releaseBounds} />, {
+      organization,
+    });
 
     // New
     expect(await screen.findByRole('radio', {name: 'New Issues 0'})).toBeChecked();
@@ -121,13 +111,6 @@ describe('ReleaseIssues', () => {
 
     // Resolved
     await userEvent.click(screen.getByRole('radio', {name: 'Resolved 0'}));
-    // Simulate query change
-    rerender(
-      <ReleaseIssues
-        {...props}
-        location={LocationFixture({query: {issuesType: 'resolved'}})}
-      />
-    );
     expect(screen.getByRole('button', {name: 'Open in Issues'})).toHaveAttribute(
       'href',
       '/organizations/org-slug/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&query=release%3A1.0.0&sort=freq&start=2020-03-23T01%3A02%3A00Z'
@@ -150,12 +133,6 @@ describe('ReleaseIssues', () => {
 
     // Unhandled
     await userEvent.click(screen.getByRole('radio', {name: 'Unhandled 0'}));
-    rerender(
-      <ReleaseIssues
-        {...props}
-        location={LocationFixture({query: {issuesType: 'unhandled'}})}
-      />
-    );
     expect(screen.getByRole('button', {name: 'Open in Issues'})).toHaveAttribute(
       'href',
       '/organizations/org-slug/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&query=release%3A1.0.0%20error.handled%3A0&sort=freq&start=2020-03-23T01%3A02%3A00Z'
@@ -178,12 +155,6 @@ describe('ReleaseIssues', () => {
 
     // All
     await userEvent.click(screen.getByRole('radio', {name: 'All Issues 0'}));
-    rerender(
-      <ReleaseIssues
-        {...props}
-        location={LocationFixture({query: {issuesType: 'all'}})}
-      />
-    );
     expect(await screen.findByRole('button', {name: 'Open in Issues'})).toHaveAttribute(
       'href',
       '/organizations/org-slug/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&query=release%3A1.0.0&sort=freq&start=2020-03-23T01%3A02%3A00Z'
@@ -207,11 +178,13 @@ describe('ReleaseIssues', () => {
 
   it('includes release context when linking to issue', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues/`,
+      url: `/organizations/${organization.slug}/issues/`,
       body: [GroupFixture({id: '123'})],
     });
 
-    render(<ReleaseIssues {...props} />);
+    render(<ReleaseIssues version={version} releaseBounds={releaseBounds} />, {
+      organization,
+    });
 
     await userEvent.click(screen.getByRole('radio', {name: /New Issues/}));
 

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.spec.tsx
@@ -55,10 +55,6 @@ describe('ReleaseIssues', () => {
         }),
       ],
     });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/releases/1.0.0/resolved/`,
-    });
-
     issuesEndpoint = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/`,
       body: [],

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
@@ -144,6 +144,44 @@ function getIssuesEndpoint(
   }
 }
 
+function getIssuesUrl(
+  version: string,
+  location: ReturnType<typeof useLocation>,
+  releaseBounds: ReleaseBounds,
+  issuesType: IssuesType,
+  organizationSlug: string
+) {
+  const {queryParams} = getIssuesEndpoint(version, location, releaseBounds, issuesType);
+  const query = new MutableSearch([]);
+
+  switch (issuesType) {
+    case IssuesType.NEW:
+      query.setFilterValues('firstRelease', [version]);
+      break;
+    case IssuesType.UNHANDLED:
+      query.setFilterValues('release', [version]);
+      query.setFilterValues('error.handled', ['0']);
+      break;
+    case IssuesType.REGRESSED:
+      query.setFilterValues('regressed_in_release', [version]);
+      break;
+    case IssuesType.RESOLVED:
+    case IssuesType.ALL:
+    default:
+      query.setFilterValues('release', [version]);
+  }
+
+  return {
+    pathname: `/organizations/${organizationSlug}/issues/`,
+    query: {
+      ...queryParams,
+      limit: undefined,
+      cursor: undefined,
+      query: query.formatString(),
+    },
+  };
+}
+
 export function ReleaseIssues({
   releaseBounds,
   version,
@@ -251,43 +289,6 @@ export function ReleaseIssues({
     setOnCursor(() => cursorFn);
   }, []);
 
-  const getIssuesUrl = useCallback(() => {
-    const {queryParams: qp} = getIssuesEndpoint(
-      version,
-      location,
-      releaseBounds,
-      issuesType
-    );
-    const query = new MutableSearch([]);
-
-    switch (issuesType) {
-      case IssuesType.NEW:
-        query.setFilterValues('firstRelease', [version]);
-        break;
-      case IssuesType.UNHANDLED:
-        query.setFilterValues('release', [version]);
-        query.setFilterValues('error.handled', ['0']);
-        break;
-      case IssuesType.REGRESSED:
-        query.setFilterValues('regressed_in_release', [version]);
-        break;
-      case IssuesType.RESOLVED:
-      case IssuesType.ALL:
-      default:
-        query.setFilterValues('release', [version]);
-    }
-
-    return {
-      pathname: `/organizations/${organization.slug}/issues/`,
-      query: {
-        ...qp,
-        limit: undefined,
-        cursor: undefined,
-        query: query.formatString(),
-      },
-    };
-  }, [version, location, releaseBounds, issuesType, organization.slug]);
-
   const renderEmptyMessage = useCallback(() => {
     const isEntireReleasePeriod =
       !location.query.pageStatsPeriod && !location.query.pageStart;
@@ -394,7 +395,16 @@ export function ReleaseIssues({
         </DemoTourElement>
 
         <OpenInButtonBar>
-          <LinkButton to={getIssuesUrl()} size="xs">
+          <LinkButton
+            to={getIssuesUrl(
+              version,
+              location,
+              releaseBounds,
+              issuesType,
+              organization.slug
+            )}
+            size="xs"
+          >
             {t('Open in Issues')}
           </LinkButton>
 

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
@@ -1,7 +1,6 @@
-import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import isEqual from 'lodash/isEqual';
-import * as qs from 'query-string';
+import {useQuery} from '@tanstack/react-query';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Grid, type GridProps} from '@sentry/scraps/layout';
@@ -13,9 +12,9 @@ import {QueryCount} from 'sentry/components/queryCount';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import {escapeDoubleQuotes} from 'sentry/utils';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {DemoTourElement, DemoTourStep} from 'sentry/utils/demoMode/demoTours';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -188,24 +187,10 @@ export function ReleaseIssues({
   queryFilterDescription,
   withChart = false,
 }: Props) {
-  const api = useApi();
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
 
-  const [count, setCount] = useState<{
-    all: number | null;
-    new: number | null;
-    regressed: number | null;
-    resolved: number | null;
-    unhandled: number | null;
-  }>({
-    new: null,
-    all: null,
-    resolved: null,
-    unhandled: null,
-    regressed: null,
-  });
   const [pageLinks, setPageLinks] = useState<string | undefined>();
   const [onCursor, setOnCursor] = useState<(() => void) | undefined>();
 
@@ -221,55 +206,49 @@ export function ReleaseIssues({
     () => getReleaseParams({location, releaseBounds}),
     [location, releaseBounds]
   );
-  const prevReleaseParamsRef = useRef(releaseParams);
 
-  useEffect(() => {
-    if (isEqual(releaseParams, prevReleaseParamsRef.current)) {
-      return;
-    }
-    prevReleaseParamsRef.current = releaseParams;
-  }, [releaseParams]);
+  const {data: issueCountData} = useQuery(
+    apiOptions.as<Record<string, number>>()(
+      '/organizations/$organizationIdOrSlug/issues-count/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        query: {
+          ...releaseParams,
+          query: [
+            `${issuesQuery.new}:"${version}" is:unresolved`,
+            `${issuesQuery.all}:"${version}" is:unresolved`,
+            `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`,
+            `${issuesQuery.regressed}:"${version}"`,
+          ],
+        },
+        staleTime: 0,
+      }
+    )
+  );
 
-  const fetchIssuesCount = useCallback(async () => {
-    const issuesCountPath = `/organizations/${organization.slug}/issues-count/`;
-    const params = [
-      `${issuesQuery.new}:"${version}" is:unresolved`,
-      `${issuesQuery.all}:"${version}" is:unresolved`,
-      `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`,
-      `${issuesQuery.regressed}:"${version}"`,
-    ];
-    const queryParameters = {
-      ...getReleaseParams({location, releaseBounds}),
-      query: params,
-    };
-    const issueCountEndpoint = `${issuesCountPath}?${qs.stringify(queryParameters)}`;
-    const resolvedEndpoint = `/organizations/${
-      organization.slug
-    }/releases/${encodeURIComponent(version)}/resolved/`;
+  const {data: resolvedData} = useQuery(
+    apiOptions.as<unknown[]>()(
+      '/organizations/$organizationIdOrSlug/releases/$version/resolved/',
+      {
+        path: {organizationIdOrSlug: organization.slug, version},
+        staleTime: 0,
+      }
+    )
+  );
 
-    try {
-      const [issueResponse, resolvedResponse] = await Promise.all([
-        api.requestPromise(issueCountEndpoint),
-        api.requestPromise(resolvedEndpoint),
-      ]);
-      setCount({
-        all: issueResponse[`${issuesQuery.all}:"${version}" is:unresolved`] || 0,
-        new: issueResponse[`${issuesQuery.new}:"${version}" is:unresolved`] || 0,
-        resolved: resolvedResponse.length,
-        unhandled:
-          issueResponse[
-            `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`
-          ] || 0,
-        regressed: issueResponse[`${issuesQuery.regressed}:"${version}"`] || 0,
-      });
-    } catch {
-      // do nothing
-    }
-  }, [api, organization.slug, version, location, releaseBounds]);
-
-  useEffect(() => {
-    fetchIssuesCount();
-  }, [fetchIssuesCount]);
+  const count = useMemo(
+    () => ({
+      new: issueCountData?.[`${issuesQuery.new}:"${version}" is:unresolved`] ?? null,
+      all: issueCountData?.[`${issuesQuery.all}:"${version}" is:unresolved`] ?? null,
+      resolved: resolvedData?.length ?? null,
+      unhandled:
+        issueCountData?.[
+          `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`
+        ] ?? null,
+      regressed: issueCountData?.[`${issuesQuery.regressed}:"${version}"`] ?? null,
+    }),
+    [issueCountData, resolvedData, version]
+  );
 
   function handleIssuesTypeSelection(newIssuesType: IssuesType) {
     navigate(

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
@@ -1,6 +1,6 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
-import {useQuery} from '@tanstack/react-query';
+import {useQueries} from '@tanstack/react-query';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Grid, type GridProps} from '@sentry/scraps/layout';
@@ -202,53 +202,50 @@ export function ReleaseIssues({
     issuesType
   );
 
-  const releaseParams = useMemo(
-    () => getReleaseParams({location, releaseBounds}),
-    [location, releaseBounds]
-  );
-
-  const {data: issueCountData} = useQuery(
-    apiOptions.as<Record<string, number>>()(
-      '/organizations/$organizationIdOrSlug/issues-count/',
-      {
-        path: {organizationIdOrSlug: organization.slug},
-        query: {
-          ...releaseParams,
-          query: [
-            `${issuesQuery.new}:"${version}" is:unresolved`,
-            `${issuesQuery.all}:"${version}" is:unresolved`,
-            `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`,
-            `${issuesQuery.regressed}:"${version}"`,
-          ],
-        },
-        staleTime: 0,
-      }
-    )
-  );
-
-  const {data: resolvedData} = useQuery(
-    apiOptions.as<unknown[]>()(
-      '/organizations/$organizationIdOrSlug/releases/$version/resolved/',
-      {
-        path: {organizationIdOrSlug: organization.slug, version},
-        staleTime: 0,
-      }
-    )
-  );
-
-  const count = useMemo(
-    () => ({
-      new: issueCountData?.[`${issuesQuery.new}:"${version}" is:unresolved`] ?? null,
-      all: issueCountData?.[`${issuesQuery.all}:"${version}" is:unresolved`] ?? null,
-      resolved: resolvedData?.length ?? null,
-      unhandled:
-        issueCountData?.[
-          `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`
-        ] ?? null,
-      regressed: issueCountData?.[`${issuesQuery.regressed}:"${version}"`] ?? null,
+  const {data: count} = useQueries({
+    queries: [
+      apiOptions.as<Record<string, number>>()(
+        '/organizations/$organizationIdOrSlug/issues-count/',
+        {
+          path: {organizationIdOrSlug: organization.slug},
+          query: {
+            ...getReleaseParams({location, releaseBounds}),
+            query: [
+              `${issuesQuery.new}:"${version}" is:unresolved`,
+              `${issuesQuery.all}:"${version}" is:unresolved`,
+              `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`,
+              `${issuesQuery.regressed}:"${version}"`,
+            ],
+          },
+          staleTime: 0,
+        }
+      ),
+      apiOptions.as<unknown[]>()(
+        '/organizations/$organizationIdOrSlug/releases/$version/resolved/',
+        {
+          path: {organizationIdOrSlug: organization.slug, version},
+          staleTime: 0,
+        }
+      ),
+    ],
+    combine: ([issueCountResult, resolvedResult]) => ({
+      data: {
+        new:
+          issueCountResult.data?.[`${issuesQuery.new}:"${version}" is:unresolved`] ??
+          null,
+        all:
+          issueCountResult.data?.[`${issuesQuery.all}:"${version}" is:unresolved`] ??
+          null,
+        resolved: resolvedResult.data?.length ?? null,
+        unhandled:
+          issueCountResult.data?.[
+            `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`
+          ] ?? null,
+        regressed:
+          issueCountResult.data?.[`${issuesQuery.regressed}:"${version}"`] ?? null,
+      },
     }),
-    [issueCountData, resolvedData, version]
-  );
+  });
 
   function handleIssuesTypeSelection(newIssuesType: IssuesType) {
     navigate(

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
@@ -187,7 +187,7 @@ export function ReleaseIssues({
   const location = useLocation();
   const organization = useOrganization();
 
-  const [pageLinks, setPageLinks] = useState<string | undefined>();
+  const [pageLinks, setPageLinks] = useState<string | null>(null);
   const [onCursor, setOnCursor] = useState<(() => void) | undefined>();
 
   const [issuesType, setIssuesType] = useQueryState(
@@ -246,10 +246,11 @@ export function ReleaseIssues({
     }),
   });
 
-  const handleFetchSuccess = useCallback((groupListState: any, cursorFn: any) => {
-    setPageLinks(groupListState.pageLinks);
-    setOnCursor(() => cursorFn);
-  }, []);
+  const handleFetchSuccess: React.ComponentProps<typeof GroupList>['onFetchSuccess'] =
+    useCallback((groupListState, cursorFn) => {
+      setPageLinks(groupListState.pageLinks);
+      setOnCursor(() => cursorFn);
+    }, []);
 
   const renderEmptyMessage = useCallback(() => {
     const isEntireReleasePeriod =

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
@@ -1,6 +1,5 @@
-import {Component, Fragment} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 import * as qs from 'query-string';
 
@@ -9,18 +8,17 @@ import {Grid, type GridProps} from '@sentry/scraps/layout';
 import {Pagination} from '@sentry/scraps/pagination';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 
-import type {Client} from 'sentry/api';
 import {GroupList} from 'sentry/components/issues/groupList';
 import {QueryCount} from 'sentry/components/queryCount';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import {escapeDoubleQuotes} from 'sentry/utils';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {DemoTourElement, DemoTourStep} from 'sentry/utils/demoMode/demoTours';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {withApi} from 'sentry/utils/withApi';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useApi} from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {EmptyState} from 'sentry/views/explore/releases/detail/commitsAndFiles/emptyState';
 import type {ReleaseBounds} from 'sentry/views/explore/releases/utils';
 import {getReleaseParams} from 'sentry/views/explore/releases/utils';
@@ -48,79 +46,218 @@ type IssuesQueryParams = {
   sort: string;
 };
 
-const defaultProps = {
-  withChart: false,
-};
-
-type Props = {
-  api: Client;
-  location: Location;
-  organization: Organization;
+interface Props {
   releaseBounds: ReleaseBounds;
   version: string;
   queryFilterDescription?: string;
-} & Partial<typeof defaultProps>;
+  withChart?: boolean;
+}
 
-type State = {
-  count: {
+function getActiveIssuesType(location: ReturnType<typeof useLocation>): IssuesType {
+  const query = (location.query?.issuesType as string) ?? '';
+  return Object.values<string>(IssuesType).includes(query)
+    ? (query as IssuesType)
+    : IssuesType.NEW;
+}
+
+function getIssuesEndpoint(
+  version: string,
+  location: ReturnType<typeof useLocation>,
+  releaseBounds: ReleaseBounds,
+  issuesType: IssuesType
+): {
+  endpoint: React.ComponentProps<typeof GroupList>['endpoint'];
+  queryParams: IssuesQueryParams;
+} {
+  const queryParams = {
+    ...getReleaseParams({
+      location,
+      releaseBounds,
+    }),
+    limit: 10,
+    sort: IssueSortOptions.FREQ,
+    groupStatsPeriod: 'auto',
+  };
+
+  switch (issuesType) {
+    case IssuesType.ALL:
+      return {
+        endpoint: {
+          path: '/organizations/$organizationIdOrSlug/issues/',
+        },
+        queryParams: {
+          ...queryParams,
+          query: new MutableSearch([
+            `${issuesQuery.all}:${version}`,
+            'is:unresolved',
+          ]).formatString(),
+        },
+      };
+    case IssuesType.RESOLVED:
+      return {
+        endpoint: {
+          path: '/organizations/$organizationIdOrSlug/releases/$version/resolved/',
+          version,
+        },
+        queryParams: {...queryParams, query: ''},
+      };
+    case IssuesType.UNHANDLED:
+      return {
+        endpoint: {
+          path: '/organizations/$organizationIdOrSlug/issues/',
+        },
+        queryParams: {
+          ...queryParams,
+          query: new MutableSearch([
+            `${issuesQuery.all}:${version}`,
+            issuesQuery.unhandled,
+            'is:unresolved',
+          ]).formatString(),
+        },
+      };
+    case IssuesType.REGRESSED:
+      return {
+        endpoint: {
+          path: '/organizations/$organizationIdOrSlug/issues/',
+        },
+        queryParams: {
+          ...queryParams,
+          query: new MutableSearch([
+            `${issuesQuery.regressed}:${version}`,
+          ]).formatString(),
+        },
+      };
+    case IssuesType.NEW:
+    default:
+      return {
+        endpoint: {
+          path: '/organizations/$organizationIdOrSlug/issues/',
+        },
+        queryParams: {
+          ...queryParams,
+          query: new MutableSearch([
+            `${issuesQuery.new}:${version}`,
+            'is:unresolved',
+          ]).formatString(),
+        },
+      };
+  }
+}
+
+function ReleaseIssues({
+  releaseBounds,
+  version,
+  queryFilterDescription,
+  withChart = false,
+}: Props) {
+  const api = useApi();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const organization = useOrganization();
+
+  const [count, setCount] = useState<{
     all: number | null;
     new: number | null;
     regressed: number | null;
     resolved: number | null;
     unhandled: number | null;
-  };
-  onCursor?: () => void;
-  pageLinks?: string;
-};
+  }>({
+    new: null,
+    all: null,
+    resolved: null,
+    unhandled: null,
+    regressed: null,
+  });
+  const [pageLinks, setPageLinks] = useState<string | undefined>();
+  const [onCursor, setOnCursor] = useState<(() => void) | undefined>();
 
-class ReleaseIssues extends Component<Props, State> {
-  static defaultProps = defaultProps;
-  state: State = this.getInitialState();
+  const issuesType = getActiveIssuesType(location);
+  const {endpoint, queryParams} = getIssuesEndpoint(
+    version,
+    location,
+    releaseBounds,
+    issuesType
+  );
 
-  getInitialState() {
-    return {
-      count: {
-        new: null,
-        all: null,
-        resolved: null,
-        unhandled: null,
-        regressed: null,
-      },
-    };
-  }
+  const releaseParams = useMemo(
+    () => getReleaseParams({location, releaseBounds}),
+    [location, releaseBounds]
+  );
+  const prevReleaseParamsRef = useRef(releaseParams);
 
-  componentDidMount() {
-    this.fetchIssuesCount();
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (
-      !isEqual(
-        getReleaseParams({
-          location: this.props.location,
-          releaseBounds: this.props.releaseBounds,
-        }),
-        getReleaseParams({
-          location: prevProps.location,
-          releaseBounds: prevProps.releaseBounds,
-        })
-      )
-    ) {
-      this.fetchIssuesCount();
+  useEffect(() => {
+    if (isEqual(releaseParams, prevReleaseParamsRef.current)) {
+      return;
     }
+    prevReleaseParamsRef.current = releaseParams;
+  }, [releaseParams]);
+
+  const fetchIssuesCount = useCallback(async () => {
+    const issuesCountPath = `/organizations/${organization.slug}/issues-count/`;
+    const params = [
+      `${issuesQuery.new}:"${version}" is:unresolved`,
+      `${issuesQuery.all}:"${version}" is:unresolved`,
+      `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`,
+      `${issuesQuery.regressed}:"${version}"`,
+    ];
+    const queryParameters = {
+      ...getReleaseParams({location, releaseBounds}),
+      query: params,
+    };
+    const issueCountEndpoint = `${issuesCountPath}?${qs.stringify(queryParameters)}`;
+    const resolvedEndpoint = `/organizations/${
+      organization.slug
+    }/releases/${encodeURIComponent(version)}/resolved/`;
+
+    try {
+      const [issueResponse, resolvedResponse] = await Promise.all([
+        api.requestPromise(issueCountEndpoint),
+        api.requestPromise(resolvedEndpoint),
+      ]);
+      setCount({
+        all: issueResponse[`${issuesQuery.all}:"${version}" is:unresolved`] || 0,
+        new: issueResponse[`${issuesQuery.new}:"${version}" is:unresolved`] || 0,
+        resolved: resolvedResponse.length,
+        unhandled:
+          issueResponse[
+            `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`
+          ] || 0,
+        regressed: issueResponse[`${issuesQuery.regressed}:"${version}"`] || 0,
+      });
+    } catch {
+      // do nothing
+    }
+  }, [api, organization.slug, version, location, releaseBounds]);
+
+  useEffect(() => {
+    fetchIssuesCount();
+  }, [fetchIssuesCount]);
+
+  function handleIssuesTypeSelection(newIssuesType: IssuesType) {
+    navigate(
+      {
+        ...location,
+        query: {
+          ...location.query,
+          issuesType: newIssuesType,
+        },
+      },
+      {replace: true}
+    );
   }
 
-  getActiveIssuesType(): IssuesType {
-    const query = (this.props.location.query?.issuesType as string) ?? '';
-    return Object.values<string>(IssuesType).includes(query)
-      ? (query as IssuesType)
-      : IssuesType.NEW;
-  }
+  const handleFetchSuccess = useCallback((groupListState: any, cursorFn: any) => {
+    setPageLinks(groupListState.pageLinks);
+    setOnCursor(() => cursorFn);
+  }, []);
 
-  getIssuesUrl() {
-    const {version, organization} = this.props;
-    const issuesType = this.getActiveIssuesType();
-    const {queryParams} = this.getIssuesEndpoint();
+  const getIssuesUrl = useCallback(() => {
+    const {queryParams: qp} = getIssuesEndpoint(
+      version,
+      location,
+      releaseBounds,
+      issuesType
+    );
     const query = new MutableSearch([]);
 
     switch (issuesType) {
@@ -143,167 +280,15 @@ class ReleaseIssues extends Component<Props, State> {
     return {
       pathname: `/organizations/${organization.slug}/issues/`,
       query: {
-        ...queryParams,
+        ...qp,
         limit: undefined,
         cursor: undefined,
         query: query.formatString(),
       },
     };
-  }
+  }, [version, location, releaseBounds, issuesType, organization.slug]);
 
-  getIssuesEndpoint(): {
-    endpoint: React.ComponentProps<typeof GroupList>['endpoint'];
-    queryParams: IssuesQueryParams;
-  } {
-    const {version, location, releaseBounds} = this.props;
-    const issuesType = this.getActiveIssuesType();
-
-    const queryParams = {
-      ...getReleaseParams({
-        location,
-        releaseBounds,
-      }),
-      limit: 10,
-      sort: IssueSortOptions.FREQ,
-      groupStatsPeriod: 'auto',
-    };
-
-    switch (issuesType) {
-      case IssuesType.ALL:
-        return {
-          endpoint: {
-            path: '/organizations/$organizationIdOrSlug/issues/',
-          },
-          queryParams: {
-            ...queryParams,
-            query: new MutableSearch([
-              `${issuesQuery.all}:${version}`,
-              'is:unresolved',
-            ]).formatString(),
-          },
-        };
-      case IssuesType.RESOLVED:
-        return {
-          endpoint: {
-            path: '/organizations/$organizationIdOrSlug/releases/$version/resolved/',
-            version,
-          },
-          queryParams: {...queryParams, query: ''},
-        };
-      case IssuesType.UNHANDLED:
-        return {
-          endpoint: {
-            path: '/organizations/$organizationIdOrSlug/issues/',
-          },
-          queryParams: {
-            ...queryParams,
-            query: new MutableSearch([
-              `${issuesQuery.all}:${version}`,
-              issuesQuery.unhandled,
-              'is:unresolved',
-            ]).formatString(),
-          },
-        };
-      case IssuesType.REGRESSED:
-        return {
-          endpoint: {
-            path: '/organizations/$organizationIdOrSlug/issues/',
-          },
-          queryParams: {
-            ...queryParams,
-            query: new MutableSearch([
-              `${issuesQuery.regressed}:${version}`,
-            ]).formatString(),
-          },
-        };
-      case IssuesType.NEW:
-      default:
-        return {
-          endpoint: {
-            path: '/organizations/$organizationIdOrSlug/issues/',
-          },
-          queryParams: {
-            ...queryParams,
-            query: new MutableSearch([
-              `${issuesQuery.new}:${version}`,
-              'is:unresolved',
-            ]).formatString(),
-          },
-        };
-    }
-  }
-
-  async fetchIssuesCount() {
-    const {api, organization, version} = this.props;
-    const issueCountEndpoint = this.getIssueCountEndpoint();
-    const resolvedEndpoint = `/organizations/${
-      organization.slug
-    }/releases/${encodeURIComponent(version)}/resolved/`;
-
-    try {
-      await Promise.all([
-        api.requestPromise(issueCountEndpoint),
-        api.requestPromise(resolvedEndpoint),
-      ]).then(([issueResponse, resolvedResponse]) => {
-        this.setState({
-          count: {
-            all: issueResponse[`${issuesQuery.all}:"${version}" is:unresolved`] || 0,
-            new: issueResponse[`${issuesQuery.new}:"${version}" is:unresolved`] || 0,
-            resolved: resolvedResponse.length,
-            unhandled:
-              issueResponse[
-                `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`
-              ] || 0,
-            regressed: issueResponse[`${issuesQuery.regressed}:"${version}"`] || 0,
-          },
-        });
-      });
-    } catch {
-      // do nothing
-    }
-  }
-
-  getIssueCountEndpoint() {
-    const {organization, version, location, releaseBounds} = this.props;
-    const issuesCountPath = `/organizations/${organization.slug}/issues-count/`;
-
-    const params = [
-      `${issuesQuery.new}:"${version}" is:unresolved`,
-      `${issuesQuery.all}:"${version}" is:unresolved`,
-      `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`,
-      `${issuesQuery.regressed}:"${version}"`,
-    ];
-    const queryParams = params.map(param => param);
-    const queryParameters = {
-      ...getReleaseParams({
-        location,
-        releaseBounds,
-      }),
-      query: queryParams,
-    };
-
-    return `${issuesCountPath}?${qs.stringify(queryParameters)}`;
-  }
-
-  handleIssuesTypeSelection = (issuesType: IssuesType) => {
-    const {location} = this.props;
-
-    browserHistory.replace({
-      ...location,
-      query: {
-        ...location.query,
-        issuesType,
-      },
-    });
-  };
-
-  handleFetchSuccess = (groupListState: any, onCursor: any) => {
-    this.setState({pageLinks: groupListState.pageLinks, onCursor});
-  };
-
-  renderEmptyMessage = () => {
-    const {location, releaseBounds} = this.props;
-    const issuesType = this.getActiveIssuesType();
+  const renderEmptyMessage = useCallback(() => {
     const isEntireReleasePeriod =
       !location.query.pageStatsPeriod && !location.query.pageStart;
 
@@ -351,94 +336,88 @@ class ReleaseIssues extends Component<Props, State> {
           : null}
       </EmptyState>
     );
-  };
+  }, [issuesType, location, releaseBounds]);
 
-  render() {
-    const {count, pageLinks, onCursor} = this.state;
-    const issuesType = this.getActiveIssuesType();
-    const {queryFilterDescription, withChart, version} = this.props;
-    const {endpoint, queryParams} = this.getIssuesEndpoint();
-    const issuesTypes = [
-      {value: IssuesType.ALL, label: t('All Issues'), issueCount: count.all},
-      {value: IssuesType.NEW, label: t('New Issues'), issueCount: count.new},
-      {
-        value: IssuesType.UNHANDLED,
-        label: t('Unhandled'),
-        issueCount: count.unhandled,
-      },
-      {
-        value: IssuesType.REGRESSED,
-        label: t('Regressed'),
-        issueCount: count.regressed,
-      },
-      {
-        value: IssuesType.RESOLVED,
-        label: t('Resolved'),
-        issueCount: count.resolved,
-      },
-    ];
+  const issuesTypes = [
+    {value: IssuesType.ALL, label: t('All Issues'), issueCount: count.all},
+    {value: IssuesType.NEW, label: t('New Issues'), issueCount: count.new},
+    {
+      value: IssuesType.UNHANDLED,
+      label: t('Unhandled'),
+      issueCount: count.unhandled,
+    },
+    {
+      value: IssuesType.REGRESSED,
+      label: t('Regressed'),
+      issueCount: count.regressed,
+    },
+    {
+      value: IssuesType.RESOLVED,
+      label: t('Resolved'),
+      issueCount: count.resolved,
+    },
+  ];
 
-    return (
-      <Fragment>
-        <ControlsWrapper>
-          <DemoTourElement
-            id={DemoTourStep.RELEASES_ISSUES}
-            title={t('New and regressed issues')}
-            description={t(
-              'Along with reviewing how your release is trending over time compared to previous releases, you can view new and regressed issues here.'
-            )}
-            position="top-start"
-          >
-            {tourProps => (
-              <div {...tourProps}>
-                <SegmentedControl
-                  aria-label={t('Issue type')}
-                  size="xs"
-                  value={issuesType}
-                  onChange={key => this.handleIssuesTypeSelection(key)}
-                >
-                  {issuesTypes.map(({value, label, issueCount}) => (
-                    <SegmentedControl.Item key={value} textValue={label}>
-                      {label}&nbsp;
-                      <QueryCount
-                        count={issueCount}
-                        max={99}
-                        hideParens
-                        hideIfEmpty={false}
-                      />
-                    </SegmentedControl.Item>
-                  ))}
-                </SegmentedControl>
-              </div>
-            )}
-          </DemoTourElement>
+  return (
+    <Fragment>
+      <ControlsWrapper>
+        <DemoTourElement
+          id={DemoTourStep.RELEASES_ISSUES}
+          title={t('New and regressed issues')}
+          description={t(
+            'Along with reviewing how your release is trending over time compared to previous releases, you can view new and regressed issues here.'
+          )}
+          position="top-start"
+        >
+          {tourProps => (
+            <div {...tourProps}>
+              <SegmentedControl
+                aria-label={t('Issue type')}
+                size="xs"
+                value={issuesType}
+                onChange={key => handleIssuesTypeSelection(key)}
+              >
+                {issuesTypes.map(({value, label, issueCount}) => (
+                  <SegmentedControl.Item key={value} textValue={label}>
+                    {label}&nbsp;
+                    <QueryCount
+                      count={issueCount}
+                      max={99}
+                      hideParens
+                      hideIfEmpty={false}
+                    />
+                  </SegmentedControl.Item>
+                ))}
+              </SegmentedControl>
+            </div>
+          )}
+        </DemoTourElement>
 
-          <OpenInButtonBar>
-            <LinkButton to={this.getIssuesUrl()} size="xs">
-              {t('Open in Issues')}
-            </LinkButton>
+        <OpenInButtonBar>
+          <LinkButton to={getIssuesUrl()} size="xs">
+            {t('Open in Issues')}
+          </LinkButton>
 
-            <StyledPagination pageLinks={pageLinks} onCursor={onCursor} size="xs" />
-          </OpenInButtonBar>
-        </ControlsWrapper>
-        <div data-test-id="release-wrapper">
-          <GroupList
-            endpoint={endpoint}
-            queryParams={queryParams}
-            query={`release:"${escapeDoubleQuotes(version)}"`}
-            canSelectGroups={false}
-            queryFilterDescription={queryFilterDescription}
-            withChart={withChart}
-            renderEmptyMessage={this.renderEmptyMessage}
-            withPagination={false}
-            onFetchSuccess={this.handleFetchSuccess}
-            source="release"
-            numPlaceholderRows={queryParams.limit}
-          />
-        </div>
-      </Fragment>
-    );
-  }
+          <StyledPagination pageLinks={pageLinks} onCursor={onCursor} size="xs" />
+        </OpenInButtonBar>
+      </ControlsWrapper>
+      <div data-test-id="release-wrapper">
+        <GroupList
+          endpoint={endpoint}
+          queryParams={queryParams}
+          query={`release:"${escapeDoubleQuotes(version)}"`}
+          canSelectGroups={false}
+          queryFilterDescription={queryFilterDescription}
+          withChart={withChart}
+          renderEmptyMessage={renderEmptyMessage}
+          withPagination={false}
+          onFetchSuccess={handleFetchSuccess}
+          source="release"
+          numPlaceholderRows={queryParams.limit}
+        />
+      </div>
+    </Fragment>
+  );
 }
 
 const ControlsWrapper = styled('div')`
@@ -461,4 +440,4 @@ const StyledPagination = styled(Pagination)`
   margin: 0;
 `;
 
-export default withApi(withOrganization(ReleaseIssues));
+export {ReleaseIssues};

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
@@ -230,18 +230,15 @@ export function ReleaseIssues({
     combine: ([issueCountResult, resolvedResult]) => ({
       data: {
         new:
-          issueCountResult.data?.[`${issuesQuery.new}:"${version}" is:unresolved`] ??
-          null,
+          issueCountResult.data?.[`${issuesQuery.new}:"${version}" is:unresolved`] || 0,
         all:
-          issueCountResult.data?.[`${issuesQuery.all}:"${version}" is:unresolved`] ??
-          null,
-        resolved: resolvedResult.data?.length ?? null,
+          issueCountResult.data?.[`${issuesQuery.all}:"${version}" is:unresolved`] || 0,
+        resolved: resolvedResult.data?.length ?? 0,
         unhandled:
           issueCountResult.data?.[
             `${issuesQuery.unhandled} ${issuesQuery.all}:"${version}" is:unresolved`
-          ] ?? null,
-        regressed:
-          issueCountResult.data?.[`${issuesQuery.regressed}:"${version}"`] ?? null,
+          ] || 0,
+        regressed: issueCountResult.data?.[`${issuesQuery.regressed}:"${version}"`] || 0,
       },
     }),
   });

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import {useQueries} from '@tanstack/react-query';
+import {parseAsStringEnum, useQueryState} from 'nuqs';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Grid, type GridProps} from '@sentry/scraps/layout';
@@ -16,7 +17,6 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {DemoTourElement, DemoTourStep} from 'sentry/utils/demoMode/demoTours';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {EmptyState} from 'sentry/views/explore/releases/detail/commitsAndFiles/emptyState';
 import type {ReleaseBounds} from 'sentry/views/explore/releases/utils';
@@ -52,12 +52,9 @@ interface Props {
   withChart?: boolean;
 }
 
-function getActiveIssuesType(location: ReturnType<typeof useLocation>): IssuesType {
-  const query = (location.query?.issuesType as string) ?? '';
-  return Object.values<string>(IssuesType).includes(query)
-    ? (query as IssuesType)
-    : IssuesType.NEW;
-}
+const parseAsIssuesType = parseAsStringEnum(Object.values(IssuesType)).withDefault(
+  IssuesType.NEW
+);
 
 function getIssuesEndpoint(
   version: string,
@@ -188,13 +185,15 @@ export function ReleaseIssues({
   withChart = false,
 }: Props) {
   const location = useLocation();
-  const navigate = useNavigate();
   const organization = useOrganization();
 
   const [pageLinks, setPageLinks] = useState<string | undefined>();
   const [onCursor, setOnCursor] = useState<(() => void) | undefined>();
 
-  const issuesType = getActiveIssuesType(location);
+  const [issuesType, setIssuesType] = useQueryState(
+    'issuesType',
+    parseAsIssuesType.withOptions({history: 'replace'})
+  );
   const {endpoint, queryParams} = getIssuesEndpoint(
     version,
     location,
@@ -246,19 +245,6 @@ export function ReleaseIssues({
       },
     }),
   });
-
-  function handleIssuesTypeSelection(newIssuesType: IssuesType) {
-    navigate(
-      {
-        ...location,
-        query: {
-          ...location.query,
-          issuesType: newIssuesType,
-        },
-      },
-      {replace: true}
-    );
-  }
 
   const handleFetchSuccess = useCallback((groupListState: any, cursorFn: any) => {
     setPageLinks(groupListState.pageLinks);
@@ -352,7 +338,7 @@ export function ReleaseIssues({
                 aria-label={t('Issue type')}
                 size="xs"
                 value={issuesType}
-                onChange={key => handleIssuesTypeSelection(key)}
+                onChange={setIssuesType}
               >
                 {issuesTypes.map(({value, label, issueCount}) => (
                   <SegmentedControl.Item key={value} textValue={label}>

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
@@ -144,7 +144,7 @@ function getIssuesEndpoint(
   }
 }
 
-function ReleaseIssues({
+export function ReleaseIssues({
   releaseBounds,
   version,
   queryFilterDescription,
@@ -439,5 +439,3 @@ const OpenInButtonBar = styled((props: GridProps) => (
 const StyledPagination = styled(Pagination)`
   margin: 0;
 `;
-
-export {ReleaseIssues};


### PR DESCRIPTION
Convert the `ReleaseIssues` class component to a functional component, removing the `browserHistory` shim import.

**Hooks replace HOCs and shim**

`withApi`, `withOrganization`, and `browserHistory` are replaced with `useApi`, `useOrganization`, and `useNavigate` hooks respectively. `useLocation` replaces the `location` prop. The component's public API shrinks to just `version`, `releaseBounds`, `queryFilterDescription`, and `withChart`.

**Test updates**

Tests now use `initialRouterConfig` and `organization` render options instead of passing `location` and `organization` as props. Manual `rerender` calls for location changes are replaced by relying on the component's own `navigate()` call triggered by user interaction.

(https://img.shields.io/badge/Review-html_summary-D97757?style=for-the-badge&logo=claude&logoColor=D97757)](https://insecure-html-azure.vercel.app/?pr-url=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry%2Fpull%2F115698)

[![View Interactive Review](https://img.shields.io/badge/Review-html_summary-D97757?style=for-the-badge&logo=claude&logoColor=D97757)](https://insecure-html-azure.vercel.app/?pr-url=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry%2Fpull%2F115698)
<!-- html-preview:start
<!DOCTYPE html> <html lang="en"> <head> <meta charset="UTF-8"> <meta name="viewport" content="width=device-width, initial-scale=1.0"> <title>PR #115698 Review — ref(releases): Convert ReleaseIssues to functional component</title> <style> :root { --bg: #0d1117; --surface: #161b22; --border: #30363d; --text: #e6edf3; --text-muted: #8b949e; --add-bg: #12261e; --add-text: #3fb950; --del-bg: #2d1214; --del-text: #f85149; --accent: #58a6ff; --purple: #bc8cff; --orange: #d29922; --teal: #39d353; } * { margin: 0; padding: 0; box-sizing: border-box; } body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; line-height: 1.6; } .container { max-width: 1200px; margin: 0 auto; padding: 2rem 1.5rem; } .pr-header { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.5rem; margin-bottom: 1.5rem; } .pr-header h1 { font-size: 1.4rem; font-weight: 600; margin-bottom: 0.5rem; } .pr-header h1 span { color: var(--text-muted); font-weight: 400; } .meta { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; font-size: 0.85rem; color: var(--text-muted); } .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 6px; font-size: 0.75rem; font-family: 'SFMono-Regular', Consolas, monospace; background: rgba(110, 118, 129, 0.15); border: 1px solid var(--border); } .stat-add { color: var(--add-text); } .stat-del { color: var(--del-text); } .summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; } .summary-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.25rem; } .summary-card .label { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted); margin-bottom: 0.25rem; } .summary-card .value { font-size: 1.6rem; font-weight: 700; } .summary-card .desc { font-size: 0.8rem; color: var(--text-muted); margin-top: 0.15rem; } .verdict { display: flex; align-items: flex-start; gap: 0.75rem; background: var(--surface); border: 1px solid var(--teal); border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 1.5rem; } .verdict .icon { font-size: 1.4rem; flex-shrink: 0; } .verdict h3 { font-size: 1rem; margin-bottom: 0.2rem; } .verdict p { font-size: 0.85rem; color: var(--text-muted); } .findings { margin-bottom: 1.5rem; } .findings h2 { font-size: 1.1rem; margin-bottom: 0.75rem; } .finding { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; margin-bottom: 0.5rem; overflow: hidden; } .finding-header { display: flex; align-items: center; gap: 0.6rem; padding: 0.65rem 1rem; cursor: pointer; user-select: none; } .finding-header:hover { background: rgba(110, 118, 129, 0.08); } .finding-header .title { font-weight: 600; font-size: 0.88rem; } .finding-header .file-ref { font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.75rem; color: var(--text-muted); margin-left: auto; } .finding-body { padding: 0.5rem 1rem 0.85rem; font-size: 0.85rem; color: var(--text-muted); line-height: 1.6; border-top: 1px solid var(--border); } .finding-body code { font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.8rem; background: rgba(110, 118, 129, 0.15); padding: 0.1rem 0.35rem; border-radius: 4px; } .finding.collapsed .finding-body { display: none; } .severity { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 12px; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; flex-shrink: 0; } .severity.positive { background: rgba(57, 211, 83, 0.15); color: var(--teal); border: 1px solid rgba(57, 211, 83, 0.3); } .severity.info { background: rgba(88, 166, 255, 0.15); color: var(--accent); border: 1px solid rgba(88, 166, 255, 0.3); } .severity.low { background: rgba(210, 153, 34, 0.15); color: var(--orange); border: 1px solid rgba(210, 153, 34, 0.3); } .severity.medium { background: rgba(248, 81, 73, 0.15); color: var(--del-text); border: 1px solid rgba(248, 81, 73, 0.3); } .diff-section { margin-bottom: 1.5rem; } .diff-section h2 { font-size: 1.1rem; margin-bottom: 0.5rem; } .diff-controls { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; } .diff-controls button { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; color: var(--text-muted); padding: 0.3rem 0.75rem; font-size: 0.78rem; cursor: pointer; } .diff-controls button:hover { border-color: var(--accent); color: var(--text); } .diff-file { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; margin-bottom: 0.75rem; overflow: hidden; } .diff-file-header { display: flex; align-items: center; gap: 0.5rem; padding: 0.6rem 1rem; cursor: pointer; user-select: none; font-size: 0.85rem; } .diff-file-header:hover { background: rgba(110, 118, 129, 0.08); } .diff-file-header .chevron { transition: transform 0.2s; font-size: 0.7rem; color: var(--text-muted); } .diff-file-header .filepath { font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.8rem; } .diff-file-header .change-badge { font-size: 0.7rem; padding: 0.1rem 0.45rem; border-radius: 4px; text-transform: uppercase; font-weight: 600; background: rgba(88, 166, 255, 0.15); color: var(--accent); } .diff-file-header .stats { margin-left: auto; font-size: 0.78rem; } .diff-file.collapsed .chevron { transform: rotate(-90deg); } .diff-file.collapsed .diff-body { display: none; } .diff-body { overflow-x: auto; } .diff-table { width: 100%; border-collapse: collapse; font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.78rem; line-height: 1.55; } .diff-table td { padding: 0 0.75rem; white-space: pre; vertical-align: top; } .diff-table .ln { width: 1px; text-align: right; color: var(--text-muted); opacity: 0.4; padding: 0 0.5rem; user-select: none; } .diff-table tr.add { background: var(--add-bg); } .diff-table tr.add td.code { color: var(--add-text); } .diff-table tr.del { background: var(--del-bg); } .diff-table tr.del td.code { color: var(--del-text); } .diff-table tr.hunk td { color: var(--purple); padding: 0.3rem 0.75rem; background: rgba(188, 140, 255, 0.08); font-style: italic; } .annotation { display: block; background: var(--surface); border: 1px solid var(--border); border-left: 3px solid; border-radius: 6px; padding: 0.5rem 0.75rem; margin: 0.35rem 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 0.8rem; line-height: 1.5; white-space: normal; color: var(--text-muted); } .annotation.positive { border-left-color: var(--teal); } .annotation.info { border-left-color: var(--accent); } .annotation.low { border-left-color: var(--orange); } .annotation.medium { border-left-color: var(--del-text); } .ann-label { font-weight: 700; text-transform: uppercase; font-size: 0.72rem; letter-spacing: 0.04em; margin-right: 0.4rem; } .ann-label.positive { color: var(--teal); } .ann-label.info { color: var(--accent); } .ann-label.low { color: var(--orange); } .ann-label.medium { color: var(--del-text); } .file-list { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.25rem; } .file-list h3 { font-size: 0.9rem; margin-bottom: 0.5rem; } .file-pills { display: flex; flex-wrap: wrap; gap: 0.4rem; } .file-pill { font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.72rem; padding: 0.2rem 0.5rem; border-radius: 4px; background: rgba(110, 118, 129, 0.1); border: 1px solid var(--border); color: var(--text-muted); } </style> </head> <body> <div class="container"> <div class="pr-header"> <h1>Convert ReleaseIssues to functional component <span>#115698</span></h1> <div class="meta"> <span>by ryan953</span> <span class="badge">ryan953/ref/remove-browser-history-release-issues</span> <span>&#8594;</span> <span class="badge">master</span> <span class="stat-add">+342</span> <span class="stat-del">-400</span> <span>3 files</span> <span>10 commits</span> </div> </div> <div class="summary-grid"> <div class="summary-card"> <div class="label">Migration Type</div> <div class="value" style="color: var(--accent);">Class &#8594; FC</div> <div class="desc">Class component converted to functional component with hooks</div> </div> <div class="summary-card"> <div class="label">Legacy Shims Removed</div> <div class="value" style="color: var(--teal);">4</div> <div class="desc">browserHistory, withApi, withOrganization, qs.stringify</div> </div> <div class="summary-card"> <div class="label">Net Lines</div> <div class="value" style="color: var(--add-text);">-58</div> <div class="desc">Smaller API surface, fewer indirections</div> </div> <div class="summary-card"> <div class="label">Modern Replacements</div> <div class="value" style="color: var(--purple);">5</div> <div class="desc">useLocation, useOrganization, useQueryState, useQueries, apiOptions</div> </div> </div> <div class="verdict"> <div class="icon">&#9989;</div> <div> <h3>Approve</h3> <p>Clean class-to-function conversion. All legacy shims replaced with modern hooks and React Query patterns. Tests updated to use render options and <code>MockApiClient.matchQuery</code> instead of prop injection and URL-embedded query params. No behavioral changes to the UI.</p> </div> </div> <div class="findings"> <h2>Findings</h2> <div class="finding" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity positive">positive</span> <span class="title">Clean removal of HOC wrappers and browserHistory shim</span> <span class="file-ref">releaseIssues.tsx</span> </div> <div class="finding-body"> Replacing <code>withApi(withOrganization(...))</code> and <code>browserHistory.replace</code> with <code>useOrganization</code>, <code>useLocation</code>, and <code>useQueryState</code> from nuqs eliminates two HOC wrappers and the browserHistory shim. The component&#39;s public API shrinks from 6 props (including injected ones) to 4 explicit props. </div> </div> <div class="finding" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity positive">positive</span> <span class="title">useQueries with combine replaces manual fetchIssuesCount</span> <span class="file-ref">releaseIssues.tsx:204-247</span> </div> <div class="finding-body"> The old <code>componentDidMount</code>/<code>componentDidUpdate</code> + <code>api.requestPromise</code> + <code>setState</code> pattern is replaced by a single <code>useQueries</code> call with <code>apiOptions</code> and <code>combine</code>. This removes ~50 lines of lifecycle management, the manual <code>qs.stringify</code> URL construction, and the silent <code>catch {}</code> error swallowing. React Query handles caching, refetching, and error states automatically. </div> </div> <div class="finding" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity positive">positive</span> <span class="title">Tests no longer rely on manual rerender for navigation</span> <span class="file-ref">releaseIssues.spec.tsx</span> </div> <div class="finding-body"> Tests previously called <code>rerender</code> with a new <code>LocationFixture</code> to simulate URL changes after clicking filter radios. Now clicking the radio buttons triggers <code>useQueryState</code> internally, so tests verify the full interaction path. This removed 5 separate <code>rerender</code> blocks across 3 tests. </div> </div> <div class="finding" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity positive">positive</span> <span class="title">Test mocks use matchQuery for stricter matching</span> <span class="file-ref">releaseIssues.spec.tsx:27-57</span> </div> <div class="finding-body"> The old mocks baked query params into the URL string, which was fragile and hard to read. The new mocks use <code>MockApiClient.matchQuery</code> to match on structured query params, distinguishing the release-bounds case (<code>start</code>/<code>end</code>) from the stats-period case (<code>statsPeriod: &#39;24h&#39;</code>). A duplicate resolved endpoint mock was also removed. </div> </div> <div class="finding collapsed" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity info">info</span> <span class="title">Named export replaces default export</span> <span class="file-ref">releaseIssues.tsx</span> </div> <div class="finding-body"> Changed from <code>export default withApi(withOrganization(ReleaseIssues))</code> to <code>export function ReleaseIssues</code>. Both import sites updated. Aligns with the <code>@sentry/no-default-exports</code> lint rule. </div> </div> <div class="finding collapsed" onclick="this.classList.toggle('collapsed')"> <div class="finding-header"> <span class="severity low">low</span> <span class="title">cursorFn parameter typed as any</span> <span class="file-ref">releaseIssues.tsx:250</span> </div> <div class="finding-body"> The type coverage bot flagged <code>cursorFn</code> in the <code>handleFetchSuccess</code> callback as <code>any</code>-typed. The type is inferred from <code>React.ComponentProps&lt;typeof GroupList&gt;[&#39;onFetchSuccess&#39;]</code>, so this is likely an upstream type gap in the <code>GroupList</code> component props. Informational only &#8212; the bot confirms it doesn&#39;t block the PR. </div> </div> </div> <div class="diff-section"> <h2>Annotated Diff</h2> <div class="diff-controls"> <button onclick="toggleAll(true)">Expand All</button> <button onclick="toggleAll(false)">Collapse All</button> </div> <div class="diff-file"> <div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#9660;</span> <span class="filepath">static/.../overview/releaseIssues.tsx</span> <span class="change-badge">modified</span> <span class="stats"><span class="stat-add">+288</span> <span class="stat-del">-338</span></span> </div> <div class="diff-body"> <table class="diff-table"> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ Imports @@</td></tr> <tr class="del"><td class="ln">1</td><td class="ln"></td><td class="code">-import {Component, Fragment} from 'react';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">1</td><td class="code">+import {Fragment, useCallback, useState} from 'react';</td></tr> <tr class="del"><td class="ln">3</td><td class="ln"></td><td class="code">-import type {Location} from 'history';</td></tr> <tr class="del"><td class="ln">4</td><td class="ln"></td><td class="code">-import isEqual from 'lodash/isEqual';</td></tr> <tr class="del"><td class="ln">5</td><td class="ln"></td><td class="code">-import * as qs from 'query-string';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">3</td><td class="code">+import {useQueries} from '@tanstack/react-query';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">4</td><td class="code">+import {parseAsStringEnum, useQueryState} from 'nuqs';</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> Removed 5 legacy imports (Component, Location, isEqual, qs, browserHistory). Replaced with modern React Query and nuqs hooks.</div></td></tr> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ HOC imports @@</td></tr> <tr class="del"><td class="ln">12</td><td class="ln"></td><td class="code">-import type {Client} from 'sentry/api';</td></tr> <tr class="del"><td class="ln">17</td><td class="ln"></td><td class="code">-import type {Organization} from 'sentry/types/organization';</td></tr> <tr class="del"><td class="ln">19</td><td class="ln"></td><td class="code">-import {browserHistory} from 'sentry/utils/browserHistory';</td></tr> <tr class="del"><td class="ln">22</td><td class="ln"></td><td class="code">-import {withApi} from 'sentry/utils/withApi';</td></tr> <tr class="del"><td class="ln">23</td><td class="ln"></td><td class="code">-import {withOrganization} from 'sentry/utils/withOrganization';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">16</td><td class="code">+import {apiOptions} from 'sentry/utils/api/apiOptions';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">19</td><td class="code">+import {useLocation} from 'sentry/utils/useLocation';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">20</td><td class="code">+import {useOrganization} from 'sentry/utils/useOrganization';</td></tr> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ Props @@</td></tr> <tr class="del"><td class="ln">55</td><td class="ln"></td><td class="code">-type Props = {</td></tr> <tr class="del"><td class="ln">56</td><td class="ln"></td><td class="code">- api: Client;</td></tr> <tr class="del"><td class="ln">57</td><td class="ln"></td><td class="code">- location: Location;</td></tr> <tr class="del"><td class="ln">58</td><td class="ln"></td><td class="code">- organization: Organization;</td></tr> <tr class="add"><td class="ln"></td><td class="ln">49</td><td class="code">+interface Props {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">50</td><td class="code">+ releaseBounds: ReleaseBounds;</td></tr> <tr class="add"><td class="ln"></td><td class="ln">51</td><td class="code">+ version: string;</td></tr> <tr class="add"><td class="ln"></td><td class="ln">52</td><td class="code">+ withChart?: boolean;</td></tr> <tr><td colspan="3"><div class="annotation info"><span class="ann-label info">info</span> Props narrowed from 6 (including HOC-injected api, location, organization) to 4 caller-controlled values.</div></td></tr> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ Data fetching @@</td></tr> <tr class="del"><td class="ln">170</td><td class="ln"></td><td class="code">- async fetchIssuesCount() {</td></tr> <tr class="del"><td class="ln">171</td><td class="ln"></td><td class="code">- const {api, organization, version} = this.props;</td></tr> <tr class="del"><td class="ln">172</td><td class="ln"></td><td class="code">- const issueCountEndpoint = this.getIssueCountEndpoint();</td></tr> <tr class="del"><td class="ln">184</td><td class="ln"></td><td class="code">- } catch { /* do nothing */ }</td></tr> <tr class="add"><td class="ln"></td><td class="ln">204</td><td class="code">+ const {data: count} = useQueries({</td></tr> <tr class="add"><td class="ln"></td><td class="ln">205</td><td class="code">+ queries: [</td></tr> <tr class="add"><td class="ln"></td><td class="ln">206</td><td class="code">+ apiOptions.as&lt;Record&lt;string, number&gt;&gt;()(</td></tr> <tr class="add"><td class="ln"></td><td class="ln">207</td><td class="code">+ '/organizations/$organizationIdOrSlug/issues-count/',</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> ~50 lines of manual lifecycle + <code>api.requestPromise</code> + <code>qs.stringify</code> replaced by a single <code>useQueries</code> call with <code>combine</code>. The silent <code>catch {}</code> is gone &#8212; React Query handles errors properly.</div></td></tr> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ Navigation handler @@</td></tr> <tr class="del"><td class="ln">250</td><td class="ln"></td><td class="code">- handleIssuesTypeSelection = (issuesType: IssuesType) =&gt; {</td></tr> <tr class="del"><td class="ln">253</td><td class="ln"></td><td class="code">- browserHistory.replace({</td></tr> <tr class="add"><td class="ln"></td><td class="ln">193</td><td class="code">+ const [issuesType, setIssuesType] = useQueryState(</td></tr> <tr class="add"><td class="ln"></td><td class="ln">194</td><td class="code">+ 'issuesType',</td></tr> <tr class="add"><td class="ln"></td><td class="ln">195</td><td class="code">+ parseAsIssuesType.withOptions({history: 'replace'})</td></tr> <tr class="add"><td class="ln"></td><td class="ln">196</td><td class="code">+ );</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> <code>browserHistory.replace</code> + manual <code>getActiveIssuesType</code> parser replaced by <code>useQueryState</code> from nuqs with <code>parseAsStringEnum</code>. URL sync and type validation in one line.</div></td></tr> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ Export @@</td></tr> <tr class="del"><td class="ln">464</td><td class="ln"></td><td class="code">-export default withApi(withOrganization(ReleaseIssues));</td></tr> </table> </div> </div> <div class="diff-file"> <div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#9660;</span> <span class="filepath">static/.../overview/releaseIssues.spec.tsx</span> <span class="change-badge">modified</span> <span class="stats"><span class="stat-add">+53</span> <span class="stat-del">-59</span></span> </div> <div class="diff-body"> <table class="diff-table"> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ Test setup @@</td></tr> <tr class="del"><td class="ln">1</td><td class="ln"></td><td class="code">-import {LocationFixture} from 'sentry-fixture/locationFixture';</td></tr> <tr class="del"><td class="ln">7</td><td class="ln"></td><td class="code">-import ReleaseIssues from '...';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">8</td><td class="code">+import {ReleaseIssues} from '...';</td></tr> <tr><td colspan="3"><div class="annotation info"><span class="ann-label info">info</span> <code>LocationFixture</code> import removed &#8212; no longer needed since tests use <code>initialRouterConfig</code> instead of prop injection.</div></td></tr> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ Mock setup @@</td></tr> <tr class="del"><td class="ln">28</td><td class="ln"></td><td class="code">- url: `.../issues-count/?end=...&amp;query=...&amp;start=...`,</td></tr> <tr class="add"><td class="ln"></td><td class="ln">27</td><td class="code">+ url: `.../issues-count/`,</td></tr> <tr class="add"><td class="ln"></td><td class="ln">28</td><td class="code">+ body: {},</td></tr> <tr class="add"><td class="ln"></td><td class="ln">29</td><td class="code">+ match: [MockApiClient.matchQuery({</td></tr> <tr class="add"><td class="ln"></td><td class="ln">30</td><td class="code">+ start: '2020-03-23T01:02:00Z',</td></tr> <tr class="add"><td class="ln"></td><td class="ln">31</td><td class="code">+ end: '2020-03-24T02:04:59Z',</td></tr> <tr class="add"><td class="ln"></td><td class="ln">32</td><td class="code">+ query: [...],</td></tr> <tr class="add"><td class="ln"></td><td class="ln">33</td><td class="code">+ })],</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> Mock URLs no longer embed query params. Using <code>MockApiClient.matchQuery</code> is more readable and resilient to param ordering changes. Two distinct mocks now match on <code>start/end</code> vs <code>statsPeriod</code>.</div></td></tr> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ Render calls @@</td></tr> <tr class="del"><td class="ln">91</td><td class="ln"></td><td class="code">- const {rerender} = render(&lt;ReleaseIssues {...props} /&gt;);</td></tr> <tr class="add"><td class="ln"></td><td class="ln">84</td><td class="code">+ render(&lt;ReleaseIssues version={version} releaseBounds={releaseBounds} /&gt;, {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">85</td><td class="code">+ organization,</td></tr> <tr class="add"><td class="ln"></td><td class="ln">86</td><td class="code">+ });</td></tr> <tr class="del"><td class="ln">121</td><td class="ln"></td><td class="code">- rerender(&lt;ReleaseIssues {...props} location={LocationFixture({...})} /&gt;);</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> Five <code>rerender</code> blocks removed across 3 tests. Clicking radio buttons now triggers <code>useQueryState</code> internally &#8212; tests verify the full user interaction.</div></td></tr> </table> </div> </div> <div class="diff-file collapsed"> <div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#9660;</span> <span class="filepath">static/.../overview/index.tsx</span> <span class="change-badge">modified</span> <span class="stats"><span class="stat-add">+1</span> <span class="stat-del">-3</span></span> </div> <div class="diff-body"> <table class="diff-table"> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ Import @@</td></tr> <tr class="del"><td class="ln">62</td><td class="ln"></td><td class="code">-import ReleaseIssues from './releaseIssues';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">62</td><td class="code">+import {ReleaseIssues} from './releaseIssues';</td></tr> <tr class="hunk"><td class="ln"></td><td class="ln"></td><td>@@ Usage @@</td></tr> <tr class="del"><td class="ln">388</td><td class="ln"></td><td class="code">- organization={organization}</td></tr> <tr class="del"><td class="ln">390</td><td class="ln"></td><td class="code">- location={location}</td></tr> <tr><td colspan="3"><div class="annotation positive"><span class="ann-label positive">positive</span> Caller simplified &#8212; two fewer props to thread through.</div></td></tr> </table> </div> </div> </div> <div class="file-list"> <h3>Changed Files</h3> <div class="file-pills"> <span class="file-pill">static/app/views/explore/releases/detail/overview/index.tsx</span> <span class="file-pill">static/app/views/explore/releases/detail/overview/releaseIssues.tsx</span> <span class="file-pill">static/app/views/explore/releases/detail/overview/releaseIssues.spec.tsx</span> </div> </div> </div> <script> function toggleAll(expand) { document.querySelectorAll('.diff-file').forEach(function(el) { if (expand) { el.classList.remove('collapsed'); } else { el.classList.add('collapsed'); } }); } </script> </body> </html>
html-preview:end -->