### PR TITLE
o11y(assisted-query): Track error outcomes and reasons for AI query analytics

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -6,7 +6,21 @@ import type {
   NoneOfTheseItem,
   QueryTokensProps,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+
+function extractErrorReason(err: Error): string {
+  if (err instanceof RequestError) {
+    const detail = err.responseJSON?.detail;
+    if (typeof detail === 'string') {
+      return detail;
+    }
+    if (detail?.message) {
+      return detail.message;
+    }
+  }
+  return err.message;
+}
 
 export function trackAiQueryOutcome({
   dataset,
@@ -23,14 +37,19 @@ export function trackAiQueryOutcome({
   referrer: string;
   resultCount: number;
   runId: number;
-  error?: string | boolean;
+  error?: string | boolean | Error;
 }) {
   const outcome = error
     ? 'error_on_load'
     : resultCount > 0
       ? 'has_results'
       : 'empty_results';
-  const errorReason = typeof error === 'string' ? error : undefined;
+  const errorReason =
+    typeof error === 'string'
+      ? error
+      : error instanceof Error
+        ? extractErrorReason(error)
+        : undefined;
   const attributes = {
     dataset,
     mode: mode.toString(),

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -15,6 +15,7 @@ export function trackAiQueryOutcome({
   referrer,
   resultCount,
   runId,
+  error = false,
 }: {
   dataset: 'spans' | 'errors' | 'logs' | 'tracemetrics' | 'issues';
   mode: Mode | 'samples' | 'aggregate';
@@ -22,15 +23,24 @@ export function trackAiQueryOutcome({
   referrer: string;
   resultCount: number;
   runId: number;
+  error?: string | boolean;
 }) {
+  const outcome = error
+    ? 'error_on_load'
+    : resultCount > 0
+      ? 'has_results'
+      : 'empty_results';
+  const errorReason = typeof error === 'string' ? error : undefined;
   const attributes = {
     dataset,
     mode: mode.toString(),
     org_slug: orgSlug,
     referrer,
     run_id: runId,
-    outcome: resultCount > 0 ? 'has_results' : 'empty_results',
+    outcome,
+    error_reason: errorReason,
   };
+
   Sentry.logger.info('assisted_query.outcome', {
     ...attributes,
     result_count: resultCount,

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -371,6 +371,9 @@ export class Results extends Component<Props, State> {
       return;
     }
 
+    const aiQueryRunId = getAiQueryRunId?.() ?? null;
+    const mode = eventView.hasAggregateField() ? 'aggregate' : 'samples';
+
     try {
       const totals = await fetchTotalCount(
         api,
@@ -379,11 +382,10 @@ export class Results extends Component<Props, State> {
       );
       this.setState({totalValues: totals});
 
-      const aiQueryRunId = getAiQueryRunId?.() ?? null;
       if (aiQueryRunId !== null) {
         trackAiQueryOutcome({
           dataset: 'errors',
-          mode: eventView.hasAggregateField() ? 'aggregate' : 'samples',
+          mode,
           referrer: 'errors',
           resultCount: totals,
           orgSlug: organization.slug,
@@ -392,6 +394,17 @@ export class Results extends Component<Props, State> {
       }
     } catch (err) {
       Sentry.captureException(err);
+      if (aiQueryRunId !== null) {
+        trackAiQueryOutcome({
+          dataset: 'errors',
+          mode,
+          referrer: 'errors',
+          resultCount: 0,
+          orgSlug: organization.slug,
+          runId: aiQueryRunId,
+          error: err instanceof Error ? err : true,
+        });
+      }
     }
   }
 

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -664,7 +664,8 @@ export function useLogAnalytics({
   const fields = useQueryParamsFields();
   const page_source = source;
 
-  const tableError = logsTableResult.error;
+  const tableError =
+    mode === Mode.AGGREGATE ? logsAggregatesTableResult.error : logsTableResult.error;
   const query_status = tableError?.message ? 'error' : 'success';
   const tableErrorBox = useBox(tableError);
   const autorefreshEnabled = useLogsAutoRefreshEnabled();

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -109,6 +109,7 @@ function useTrackAnalytics({
         : (spansTableResult.result.error?.message ?? '');
   const chartError = timeseriesResult.error?.message ?? '';
   const query_status = tableError || chartError ? 'error' : 'success';
+  const tableErrorBox = useBox(tableError);
 
   const {isLoading: isLoadingSeerSetup} = useOrganizationSeerSetup({
     enabled: !organization.hideAiFeatures,
@@ -172,6 +173,7 @@ function useTrackAnalytics({
         referrer: 'spans',
         resultCount: aggregatesTableResult.result.data?.length ?? 0,
         runId: aiQueryRunId,
+        error: tableErrorBox.current || false,
       });
     }
 
@@ -219,6 +221,7 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
+    tableErrorBox,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,
@@ -304,6 +307,7 @@ function useTrackAnalytics({
         referrer: 'spans',
         resultCount: spansTableResult.result.data?.length ?? 0,
         runId: aiQueryRunId,
+        error: tableErrorBox.current || false,
       });
     }
   }, [
@@ -327,6 +331,7 @@ function useTrackAnalytics({
     spansTableResult.result.data?.length,
     spansTableResult.result.isPending,
     spansTableResult.result.meta?.dataScanned,
+    tableErrorBox,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,
@@ -495,6 +500,7 @@ function useTrackAnalytics({
         referrer: 'traces',
         resultCount: tracesTableResult.result.data?.json?.data?.length ?? 0,
         runId: aiQueryRunId,
+        error: tableErrorBox.current || false,
       });
     }
   }, [
@@ -513,6 +519,7 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
+    tableErrorBox,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,
@@ -659,6 +666,7 @@ export function useLogAnalytics({
 
   const tableError = logsTableResult.error?.message ?? '';
   const query_status = tableError ? 'error' : 'success';
+  const tableErrorBox = useBox(tableError);
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const autorefreshBox = useBox(autorefreshEnabled); // Boxed to avoid useEffect firing analytics on changes.
   const aggregatesResultLengthBox = useBox(
@@ -756,6 +764,7 @@ export function useLogAnalytics({
         referrer: 'logs',
         resultCount: resultLengthBox.current,
         runId: aiQueryRunId,
+        error: tableErrorBox.current || false,
       });
     }
   }, [
@@ -778,6 +787,7 @@ export function useLogAnalytics({
     mode,
     resultLengthBox,
     sortBysBox,
+    tableErrorBox,
     yAxesBox,
     getRunIdForAnalytics,
   ]);
@@ -846,6 +856,7 @@ export function useLogAnalytics({
         referrer: 'logs',
         resultCount: aggregatesResultLengthBox.current,
         runId: aiQueryRunId,
+        error: tableErrorBox.current || false,
       });
     }
   }, [
@@ -868,6 +879,7 @@ export function useLogAnalytics({
     query,
     query_status,
     search,
+    tableErrorBox,
     yAxes,
     getRunIdForAnalytics,
   ]);
@@ -951,6 +963,7 @@ export function useMetricsPanelAnalytics({
       ? (metricAggregatesTableResult.result.error?.message ?? '')
       : (metricSamplesTableResult.error?.message ?? '');
   const query_status = tableError ? 'error' : 'success';
+  const tableErrorBox = useBox(tableError);
 
   const aggregatesResultLengthBox = useBox(
     metricAggregatesTableResult.result.data?.length || 0
@@ -1031,6 +1044,7 @@ export function useMetricsPanelAnalytics({
         referrer: 'tracemetrics',
         resultCount: resultLengthBox.current,
         runId: aiQueryRunId,
+        error: tableErrorBox.current || false,
       });
     }
   }, [
@@ -1055,6 +1069,7 @@ export function useMetricsPanelAnalytics({
     aggregateFunctionBox,
     groupBysBox,
     metricTypeBox,
+    tableErrorBox,
     getRunIdForAnalytics,
   ]);
 
@@ -1086,6 +1101,7 @@ export function useMetricsPanelAnalytics({
         referrer: 'tracemetrics',
         resultCount: aggregatesResultLengthBox.current,
         runId: aiQueryRunId,
+        error: tableErrorBox.current || false,
       });
     }
   }, [
@@ -1107,6 +1123,7 @@ export function useMetricsPanelAnalytics({
     metricNameBox,
     query,
     query_status,
+    tableErrorBox,
     getRunIdForAnalytics,
   ]);
 }

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -103,12 +103,12 @@ function useTrackAnalytics({
 
   const tableError =
     queryType === 'aggregate'
-      ? (aggregatesTableResult.result.error?.message ?? '')
+      ? aggregatesTableResult.result.error
       : queryType === 'traces'
-        ? (tracesTableResult?.error?.message ?? '')
-        : (spansTableResult.result.error?.message ?? '');
-  const chartError = timeseriesResult.error?.message ?? '';
-  const query_status = tableError || chartError ? 'error' : 'success';
+        ? tracesTableResult?.error
+        : spansTableResult.result.error;
+  const chartError = timeseriesResult.error;
+  const query_status = tableError?.message || chartError?.message ? 'error' : 'success';
   const tableErrorBox = useBox(tableError);
 
   const {isLoading: isLoadingSeerSetup} = useOrganizationSeerSetup({
@@ -664,8 +664,8 @@ export function useLogAnalytics({
   const fields = useQueryParamsFields();
   const page_source = source;
 
-  const tableError = logsTableResult.error?.message ?? '';
-  const query_status = tableError ? 'error' : 'success';
+  const tableError = logsTableResult.error;
+  const query_status = tableError?.message ? 'error' : 'success';
   const tableErrorBox = useBox(tableError);
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const autorefreshBox = useBox(autorefreshEnabled); // Boxed to avoid useEffect firing analytics on changes.
@@ -960,9 +960,9 @@ export function useMetricsPanelAnalytics({
 
   const tableError =
     mode === Mode.AGGREGATE
-      ? (metricAggregatesTableResult.result.error?.message ?? '')
-      : (metricSamplesTableResult.error?.message ?? '');
-  const query_status = tableError ? 'error' : 'success';
+      ? metricAggregatesTableResult.result.error
+      : metricSamplesTableResult.error;
+  const query_status = tableError?.message ? 'error' : 'success';
   const tableErrorBox = useBox(tableError);
 
   const aggregatesResultLengthBox = useBox(


### PR DESCRIPTION
## Summary

Extends `trackAiQueryOutcome` to emit a new `error_on_load` outcome (alongside the existing `has_results` / `empty_results`) and capture an `error_reason` attribute when an AI-assisted query's table load fails. Previously, errored queries were silently bucketed as `empty_results`, conflating empty data with failures.

### `trackAiQueryOutcome` util
- `error` param now accepts `string | boolean | Error` (was `string | boolean`).
- New `extractErrorReason(err)` centralizes reason extraction: for `RequestError` it pulls `responseJSON.detail` (handling both `string` and `{message}` shapes); for any other `Error` it falls back to `err.message`.
- Emits `outcome: 'error_on_load'` plus `error_reason` in the log/metric attributes whenever `error` is truthy.

### Discover errors (`views/discover/results.tsx`)
- `fetchTotalCount`'s `catch` block now calls `trackAiQueryOutcome` with `error: err` so failed total-count requests are tracked instead of silently swallowed.
- `aiQueryRunId` and `mode` hoisted above the `try` so both branches share them.

### Explore (`views/explore/hooks/useAnalytics.tsx`)
Spans, traces, logs, and metrics analytics hooks now pass the raw `Error` object (instead of a pre-extracted `error?.message` string) through to `trackAiQueryOutcome`. The error is boxed with `useBox` to avoid spurious effect re-fires on error-message identity changes; effect deps include the box ref.

## Test plan
- [ ] Trigger a failing query in Explore (spans/logs/metrics) and verify the `assisted_query.outcome` log/metric records `outcome: 'error_on_load'` with a populated `error_reason`.
- [ ] Trigger a 4xx/5xx from `events-meta/` in Discover (errors dataset) and verify the same.
- [ ] Confirm successful queries still emit `has_results` / `empty_results` correctly.