### PR TITLE
ref(seer): Option to route severity to group-seer

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -114,6 +114,7 @@ from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.net.http import connection_from_url
+from sentry.options.rollout import in_random_rollout
 from sentry.plugins.base import plugins
 from sentry.quotas.base import index_data_category
 from sentry.receivers.features import record_event_processed
@@ -1961,6 +1962,12 @@ severity_connection_pool = connection_from_url(
     timeout=settings.SEER_SEVERITY_TIMEOUT,  # Defaults to 300 milliseconds
 )
 
+severity_connection_pool_group_seer = connection_from_url(
+    settings.SEER_SCORING_URL,
+    retries=settings.SEER_SEVERITY_RETRIES,
+    timeout=settings.SEER_SEVERITY_TIMEOUT,  # Defaults to 300 milliseconds
+)
+
 
 class SeverityScoreRequest(TypedDict):
     message: str
@@ -1983,8 +1990,11 @@ def make_severity_score_request(
         payload["trigger_timeout"] = True
     if options.get("processing.severity-backlog-test.error"):
         payload["trigger_error"] = True
+    default_connection_pool = severity_connection_pool
+    if in_random_rollout("issues.severity.group-seer-rollout-rate"):
+        default_connection_pool = severity_connection_pool_group_seer
     return make_signed_seer_api_request(
-        connection_pool or severity_connection_pool,
+        connection_pool or default_connection_pool,
         "/v0/issues/severity-score",
         body=orjson.dumps(payload),
         timeout=timeout,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1132,6 +1132,12 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "issues.severity.group-seer-rollout-rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Killswitch for issue priority
 register(

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -18,7 +18,9 @@ from sentry.event_manager import (
     SEER_ERROR_COUNT_KEY,
     EventManager,
     _get_severity_score,
+    make_severity_score_request,
     severity_connection_pool,
+    severity_connection_pool_group_seer,
 )
 from sentry.models.group import Group
 from sentry.testutils.cases import TestCase
@@ -328,6 +330,32 @@ class TestGetEventSeverity(TestCase):
         assert severity == 1.0
         assert reason == "microservice_error"
         assert cache.get(SEER_ERROR_COUNT_KEY) == 1
+
+    @patch("sentry.event_manager.make_signed_seer_api_request")
+    def test_group_seer_rollout_routes_to_scoring_pool(self, mock_request: MagicMock) -> None:
+        body = {
+            "message": "boom",
+            "has_stacktrace": 0,
+            "handled": True,
+            "org_id": 1,
+            "project_id": 1,
+        }
+        with override_options({"issues.severity.group-seer-rollout-rate": 1.0}):
+            make_severity_score_request(body)
+        assert mock_request.call_args[0][0] is severity_connection_pool_group_seer
+
+    @patch("sentry.event_manager.make_signed_seer_api_request")
+    def test_group_seer_rollout_disabled_uses_default_pool(self, mock_request: MagicMock) -> None:
+        body = {
+            "message": "boom",
+            "has_stacktrace": 0,
+            "handled": True,
+            "org_id": 1,
+            "project_id": 1,
+        }
+        with override_options({"issues.severity.group-seer-rollout-rate": 0.0}):
+            make_severity_score_request(body)
+        assert mock_request.call_args[0][0] is severity_connection_pool
 
 
 @with_feature("projects:first-event-severity-calculation")

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -17,6 +17,7 @@ from sentry.constants import PLACEHOLDER_EVENT_TITLES
 from sentry.event_manager import (
     SEER_ERROR_COUNT_KEY,
     EventManager,
+    SeverityScoreRequest,
     _get_severity_score,
     make_severity_score_request,
     severity_connection_pool,
@@ -332,30 +333,22 @@ class TestGetEventSeverity(TestCase):
         assert cache.get(SEER_ERROR_COUNT_KEY) == 1
 
     @patch("sentry.event_manager.make_signed_seer_api_request")
-    def test_group_seer_rollout_routes_to_scoring_pool(self, mock_request: MagicMock) -> None:
-        body = {
+    def test_group_seer_rollout_selects_pool(self, mock_request: MagicMock) -> None:
+        body: SeverityScoreRequest = {
             "message": "boom",
             "has_stacktrace": 0,
             "handled": True,
             "org_id": 1,
             "project_id": 1,
         }
-        with override_options({"issues.severity.group-seer-rollout-rate": 1.0}):
-            make_severity_score_request(body)
-        assert mock_request.call_args[0][0] is severity_connection_pool_group_seer
 
-    @patch("sentry.event_manager.make_signed_seer_api_request")
-    def test_group_seer_rollout_disabled_uses_default_pool(self, mock_request: MagicMock) -> None:
-        body = {
-            "message": "boom",
-            "has_stacktrace": 0,
-            "handled": True,
-            "org_id": 1,
-            "project_id": 1,
-        }
         with override_options({"issues.severity.group-seer-rollout-rate": 0.0}):
             make_severity_score_request(body)
         assert mock_request.call_args[0][0] is severity_connection_pool
+
+        with override_options({"issues.severity.group-seer-rollout-rate": 1.0}):
+            make_severity_score_request(body)
+        assert mock_request.call_args[0][0] is severity_connection_pool_group_seer
 
 
 @with_feature("projects:first-event-severity-calculation")


### PR DESCRIPTION
wait for https://github.com/getsentry/ops/pull/20670

we're getting stockouts on L4s for the first time in a while. 1/5th of seer-gpu deploys hit them last week. [GCP warned that L4s are legacy ](https://sentry.slack.com/archives/C0290U8F3DY/p1778016529667789?thread_ts=1778013664.795569&cid=C0290U8F3DY)and to expect stockouts

i wanna move the very lightweight severity model to a lighter weight group-seer deployment while i transition group-ingest to a different machine type, and eventually transition group-seer to T4 GPUs or CPUs