### PR TITLE
ref(replays): use shared platform icon resolver

### DIFF
--- a/static/app/utils/replays/generatePlatformIconName.tsx
+++ b/static/app/utils/replays/generatePlatformIconName.tsx
@@ -1,24 +1,5 @@
+import {getLogoImage} from 'sentry/components/events/contexts/contextIcon';
 import {generateIconName} from 'sentry/components/events/contexts/utils';
-
-const PLATFORM_ALIASES = {
-  ios: 'apple',
-  mac: 'apple',
-  macos: 'apple',
-  'mac-os-x': 'apple',
-  darwin: 'apple',
-  tvos: 'apple-tv',
-  watchos: 'apple-watch',
-  iphone: 'apple-iphone',
-  ipad: 'apple-ipad',
-  'legacy-edge': 'edge-legacy',
-  'mobile-safari': 'safari',
-  'chrome-mobile-ios': 'chrome',
-  'google-chrome': 'chrome',
-  'chrome-os': 'chrome',
-  net: 'dotnet',
-  'net-core': 'dotnetcore',
-  'net-framework': 'dotnetframework',
-};
 
 /**
  * Generates names used for PlatformIcon. Translates ContextIcon names (https://sentry.sentry.io/stories/stories/shared/components/events/contexts/contexticon) to PlatformIcon (https://www.npmjs.com/package/platformicons) names
@@ -27,7 +8,5 @@ export function generatePlatformIconName(
   name: string,
   version: string | undefined
 ): string {
-  const contextName = generateIconName(name, version);
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-  return contextName in PLATFORM_ALIASES ? PLATFORM_ALIASES[contextName] : contextName;
+  return getLogoImage(generateIconName(name, version)) ?? 'default';
 }


### PR DESCRIPTION
Stacked on #115701.

`generatePlatformIconName` used to maintain its own `PLATFORM_ALIASES` table — a strict subset of `LOGO_MAPPING` in `contextIcon.tsx`, kept in sync by hand. With the migration to platformicons, the canonical mapping now lives in `getLogoImage`. This change drops the duplicate table and delegates to `getLogoImage`, also clearing the `@ts-expect-error` from the previous keyed access.