### PR TITLE
fix(preprod): Include image key and field path in snapshot validation errors

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -144,13 +144,30 @@ def validate_preprod_snapshot_post_schema(
         jsonschema.validate(data, SNAPSHOT_POST_REQUEST_SCHEMA)
         return data, None
     except jsonschema.ValidationError as e:
-        error_message = e.message
-        if e.path:
-            if field := e.path[0]:
-                error_message = SNAPSHOT_POST_REQUEST_ERROR_MESSAGES.get(str(field), error_message)
-        return {}, error_message
+        return {}, _format_validation_error(e)
     except (orjson.JSONDecodeError, TypeError):
         return {}, "Invalid json body"
+
+
+def _format_validation_error(e: jsonschema.ValidationError) -> str:
+    # absolute_path includes full context even when best_match selects a nested error
+    path = list(e.absolute_path)
+
+    if len(path) >= 3 and path[0] == "images":
+        image_key = path[1]
+        field_path = ".".join(str(p) for p in path[2:])
+        return f'Validation error in image "{image_key}", field "{field_path}": {e.message}'
+
+    if len(path) >= 2 and path[0] == "images":
+        image_key = path[1]
+        return f'Validation error in image "{image_key}": {e.message}'
+
+    if path:
+        field = str(path[0])
+        if friendly := SNAPSHOT_POST_REQUEST_ERROR_MESSAGES.get(field):
+            return friendly
+
+    return e.message
 
 
 @cell_silo_endpoint

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -150,7 +150,6 @@ def validate_preprod_snapshot_post_schema(
 
 
 def _format_validation_error(e: jsonschema.ValidationError) -> str:
-    # absolute_path includes full context even when best_match selects a nested error
     path = list(e.absolute_path)
 
     if len(path) >= 3 and path[0] == "images":

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -152,13 +152,11 @@ def validate_preprod_snapshot_post_schema(
 def _format_validation_error(e: jsonschema.ValidationError) -> str:
     path = list(e.absolute_path)
 
-    if len(path) >= 3 and path[0] == "images":
-        image_key = path[1]
-        field_path = ".".join(str(p) for p in path[2:])
-        return f'Validation error in image "{image_key}", field "{field_path}": {e.message}'
-
     if len(path) >= 2 and path[0] == "images":
         image_key = path[1]
+        if rest := path[2:]:
+            field_path = ".".join(str(p) for p in rest)
+            return f'Validation error in image "{image_key}", field "{field_path}": {e.message}'
         return f'Validation error in image "{image_key}": {e.message}'
 
     if path:

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -167,7 +167,49 @@ class ProjectPreprodSnapshotTest(APITestCase):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
-        assert "detail" in response.data
+        assert 'Validation error in image "hash1"' in response.data["detail"]
+
+    def test_snapshot_boolean_tag_value_error_message(self) -> None:
+        url = self._get_create_url()
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "screen.png": {
+                    "content_hash": "abc123",
+                    "width": 375,
+                    "height": 812,
+                    "tags": {"show_background": True},
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 400
+        assert 'Validation error in image "screen.png"' in response.data["detail"]
+        assert "tags" in response.data["detail"]
+
+    def test_snapshot_boolean_display_name_error_message(self) -> None:
+        url = self._get_create_url()
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "login.png": {
+                    "content_hash": "abc123",
+                    "width": 375,
+                    "height": 812,
+                    "display_name": True,
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 400
+        assert 'Validation error in image "login.png"' in response.data["detail"]
+        assert "display_name" in response.data["detail"]
 
     def test_snapshot_negative_dimensions(self) -> None:
         url = self._get_create_url()


### PR DESCRIPTION
## Summary
- Snapshot validation errors now include which image and which field caused the failure, instead of returning raw jsonschema messages like `True is not of type 'string'`
- Uses `absolute_path` instead of `path` on jsonschema errors to get full context even when `best_match` selects a nested error (e.g., inside `anyOf` for tags)
- Example: `Validation error in image "screen.png", field "tags.show_background": True is not of type 'string'`

Fixes EME-1156