### PR TITLE
fix(preprod): Accept non-string tag values in snapshot image metadata

### DIFF
--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -21,7 +21,7 @@ class ImageMetadata(BaseModel):
         if v is None:
             return None
         if isinstance(v, dict):
-            return v
+            return {str(k): str(v_) for k, v_ in v.items()}
         if isinstance(v, list):
             return {str(tag): str(tag) for tag in v}
         return None
@@ -35,7 +35,7 @@ class ImageMetadata(BaseModel):
             if tags:
                 schema["properties"]["tags"] = {
                     "anyOf": [
-                        {"type": "object", "additionalProperties": {"type": "string"}},
+                        {"type": "object"},
                         {"type": "array", "items": {"type": "string"}},
                         {"type": "null"},
                     ]

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -151,6 +151,25 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert response.status_code == 400
         assert "detail" in response.data
 
+    def test_snapshot_boolean_tag_values_accepted(self) -> None:
+        url = self._get_create_url()
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "screen.png": {
+                    "content_hash": "abc123",
+                    "width": 375,
+                    "height": 812,
+                    "tags": {"show_background": True, "count": 42},
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code != 400
+
     def test_snapshot_invalid_image_schema(self) -> None:
         url = self._get_create_url()
         data = {

--- a/tests/sentry/preprod/snapshots/test_manifest.py
+++ b/tests/sentry/preprod/snapshots/test_manifest.py
@@ -59,6 +59,14 @@ class TestImageMetadataTagsCoercion:
         )
         assert manifest.images["screen.png"].tags == {"dark": "dark", "mobile": "mobile"}
 
+    def test_tags_boolean_values_coerced_to_strings(self) -> None:
+        meta = ImageMetadata(**_meta(tags={"dark_mode": True, "rtl": False}))
+        assert meta.tags == {"dark_mode": "True", "rtl": "False"}
+
+    def test_tags_numeric_values_coerced_to_strings(self) -> None:
+        meta = ImageMetadata(**_meta(tags={"count": 42, "ratio": 1.5}))
+        assert meta.tags == {"count": "42", "ratio": "1.5"}
+
 
 class TestImageMetadataJsonSchema:
     def test_schema_accepts_dict_tags(self) -> None:
@@ -76,3 +84,11 @@ class TestImageMetadataJsonSchema:
     def test_schema_accepts_no_tags(self) -> None:
         schema = ImageMetadata.schema()
         jsonschema.validate(_meta(), schema)
+
+    def test_schema_accepts_boolean_tag_values(self) -> None:
+        schema = ImageMetadata.schema()
+        jsonschema.validate(_meta(tags={"dark_mode": True}), schema)
+
+    def test_schema_accepts_numeric_tag_values(self) -> None:
+        schema = ImageMetadata.schema()
+        jsonschema.validate(_meta(tags={"count": 42}), schema)


### PR DESCRIPTION
## Summary
- Relaxes the `tags` JSON Schema in `ImageMetadata` to accept any value type (not just strings), so sidecar JSON files with boolean/numeric tag values no longer cause a 400 error
- Coerces all tag values to strings in the Pydantic `coerce_tags` validator, so downstream code always sees `dict[str, str]`

Fixes EME-1156