### PR TITLE
feat(conversations): swap badge from alpha to beta

### DIFF
--- a/static/app/views/explore/conversations/layout.tsx
+++ b/static/app/views/explore/conversations/layout.tsx
@@ -93,7 +93,7 @@ function ConversationsHeader() {
           />
         ) : (
           <Fragment>
-            {CONVERSATIONS_LANDING_TITLE} <FeatureBadge type="alpha" />
+            {CONVERSATIONS_LANDING_TITLE} <FeatureBadge type="beta" />
           </Fragment>
         )}
       </TopBar.Slot>

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -127,7 +127,7 @@ export function ExploreSecondaryNavigation() {
                 <SecondaryNavigation.Link
                   to={`${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`}
                   analyticsItemName="explore_conversations"
-                  trailingItems={<FeatureBadge type="alpha" />}
+                  trailingItems={<FeatureBadge type="beta" />}
                 >
                   {t('Conversations')}
                 </SecondaryNavigation.Link>


### PR DESCRIPTION
Update the Conversations feature badge from `alpha` to `beta` in:
- Explore secondary navigation sidebar
- Conversations page header

Refs TET-2363

<img width="882" height="996" alt="CleanShot 2026-05-18 at 12 32 58@2x" src="https://github.com/user-attachments/assets/fd91a179-e0e5-4cdf-bd70-c2443e5079de" />
