### PR TITLE
fix(agents): Use minVersion in SDK update alert for consistency

### DIFF
--- a/static/app/views/insights/pages/agents/components/sdkUpdateAlert.spec.tsx
+++ b/static/app/views/insights/pages/agents/components/sdkUpdateAlert.spec.tsx
@@ -120,7 +120,7 @@ describe('SdkUpdateAlert', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText(textWithMarkupMatcher('Update to 2.5.0 or later.'))
+      screen.getByText(textWithMarkupMatcher('Update to 2.0.0 or later.'))
     ).toBeInTheDocument();
   });
 
@@ -155,7 +155,7 @@ describe('SdkUpdateAlert', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText(textWithMarkupMatcher('Update to 8.5.0 or later.'))
+      screen.getByText(textWithMarkupMatcher('Update to 8.0.0 or later.'))
     ).toBeInTheDocument();
   });
 
@@ -190,7 +190,7 @@ describe('SdkUpdateAlert', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText(textWithMarkupMatcher('Update to 10.5.0 or later.'))
+      screen.getByText(textWithMarkupMatcher('Update to 10.0.0 or later.'))
     ).toBeInTheDocument();
   });
 
@@ -263,11 +263,11 @@ describe('SdkUpdateAlert', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText(textWithMarkupMatcher('Update to 2.5.0 or later.'))
+      screen.getByText(textWithMarkupMatcher('Update to 2.0.0 or later.'))
     ).toBeInTheDocument();
   });
 
-  it('renders alert without suggested version when suggestions are not available', async () => {
+  it('renders alert with minVersion when suggestions are not available', async () => {
     renderMockSdkUpdateRequest({
       organization,
       body: [
@@ -296,6 +296,8 @@ describe('SdkUpdateAlert', () => {
       )
     ).toBeInTheDocument();
 
-    expect(screen.getByText(/Update to the latest version\./)).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher('Update to 2.0.0 or later.'))
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/insights/pages/agents/components/sdkUpdateAlert.tsx
+++ b/static/app/views/insights/pages/agents/components/sdkUpdateAlert.tsx
@@ -1,6 +1,6 @@
 import {Alert} from '@sentry/scraps/alert';
 
-import {t, tct} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 import {useProjectSdkNeedsUpdate} from 'sentry/utils/useProjectSdkNeedsUpdate';
 import {semverCompare} from 'sentry/utils/versions/semverCompare';
 
@@ -59,10 +59,6 @@ export function SdkUpdateAlert({
     return null;
   }
 
-  const suggestedVersion = validSdkUpdate.suggestions?.find(
-    suggestion => suggestion.type === 'updateSdk'
-  )?.newSdkVersion;
-
   return (
     <Alert variant="warning">
       {tct(
@@ -71,11 +67,9 @@ export function SdkUpdateAlert({
           packageName: <code>{packageName}</code>,
         }
       )}{' '}
-      {suggestedVersion
-        ? tct('Update to [latestVersion] or later.', {
-            latestVersion: <code>{suggestedVersion}</code>,
-          })
-        : t('Update to the latest version.')}
+      {tct('Update to [minVersionCode] or later.', {
+        minVersionCode: <code>{minVersion}</code>,
+      })}
     </Alert>
   );
 }


### PR DESCRIPTION
The SDK update alert in the Conversations empty state showed a mismatched version compared to the install step. The alert displayed the `suggestedVersion` (latest available SDK) while the install instructions showed `minVersion` (minimum required). Now both consistently show `minVersion`.

Closes TET-2364

<img width="1120" height="1082" alt="CleanShot 2026-05-18 at 13 20 19@2x" src="https://github.com/user-attachments/assets/444ef1e4-e1f2-4de4-8821-29bbe1f1bb86" />
