### PR TITLE
fix(dashboards): prevent sticky navbar misalignment on scroll

### DIFF
--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -481,7 +481,7 @@ const AddWidgetWrapper = styled('div')`
 
 // eslint-disable-next-line @sentry/no-calling-components-as-functions
 const GridLayout = styled(WidthProvider(Responsive))`
-  margin: -${p => p.theme.space.xl};
+  margin: -${p => p.theme.space.lg} -${p => p.theme.space.xl};
 
   .react-grid-item.react-grid-placeholder {
     background: ${p => p.theme.tokens.background.transparent.accent.muted};


### PR DESCRIPTION
**Before**

<img width="775" height="152" alt="image" src="https://github.com/user-attachments/assets/eeb541b5-ecac-4c18-b66a-48be0d029ab0" />


**After**

<img width="794" height="468" alt="image" src="https://github.com/user-attachments/assets/9eb2e2c0-2be8-44fb-b752-e789540ad8d5" />
