### PR TITLE
fix(preprod): Skip strict jsonschema for snapshot image metadata

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import jsonschema
 import orjson
+import pydantic
 from django.conf import settings
 from django.db import IntegrityError, router, transaction
 from django.utils import timezone
@@ -82,7 +83,7 @@ SNAPSHOT_POST_REQUEST_SCHEMA: dict[str, Any] = {
         "app_id": {"type": "string", "maxLength": 255},
         "images": {
             "type": "object",
-            "additionalProperties": ImageMetadata.schema(),
+            "additionalProperties": True,
             "maxProperties": 50000,
         },
         "diff_threshold": {"type": "number", "minimum": 0.0, "exclusiveMaximum": 1.0},
@@ -618,12 +619,18 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             # Write manifest inside the transaction so that a failed objectstore
             # write rolls back the DB records, ensuring both succeed or neither does.
             session = get_preprod_session(project.organization_id, project.id)
-            manifest = SnapshotManifest(
-                images=images,
-                diff_threshold=diff_threshold,
-                selective=selective,
-                all_image_file_names=all_image_file_names,
-            )
+            try:
+                manifest = SnapshotManifest(
+                    images=images,
+                    diff_threshold=diff_threshold,
+                    selective=selective,
+                    all_image_file_names=all_image_file_names,
+                )
+            except pydantic.ValidationError as e:
+                return Response(
+                    {"detail": f"Invalid image metadata: {e.errors()[0]['msg']}"},
+                    status=400,
+                )
             manifest_json = manifest.json(exclude_none=True)
             session.put(manifest_json.encode(), key=manifest_key)
 

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -571,6 +571,21 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                     status=400,
                 )
 
+        # Validate before entering the transaction so invalid data never creates
+        # orphaned DB records.
+        try:
+            manifest = SnapshotManifest(
+                images=images,
+                diff_threshold=diff_threshold,
+                selective=selective,
+                all_image_file_names=all_image_file_names,
+            )
+        except pydantic.ValidationError as e:
+            return Response(
+                {"detail": f"Invalid image metadata: {e.errors()[0]['msg']}"},
+                status=400,
+            )
+
         # has_vcs tag differentiates transactions that include a CommitComparison
         # lookup from those that skip it, so we can isolate their latency on dashboards.
         with (
@@ -619,18 +634,6 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             # Write manifest inside the transaction so that a failed objectstore
             # write rolls back the DB records, ensuring both succeed or neither does.
             session = get_preprod_session(project.organization_id, project.id)
-            try:
-                manifest = SnapshotManifest(
-                    images=images,
-                    diff_threshold=diff_threshold,
-                    selective=selective,
-                    all_image_file_names=all_image_file_names,
-                )
-            except pydantic.ValidationError as e:
-                return Response(
-                    {"detail": f"Invalid image metadata: {e.errors()[0]['msg']}"},
-                    status=400,
-                )
             manifest_json = manifest.json(exclude_none=True)
             session.put(manifest_json.encode(), key=manifest_key)
 

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -21,7 +21,7 @@ class ImageMetadata(BaseModel):
         if v is None:
             return None
         if isinstance(v, dict):
-            return v
+            return {str(k): str(v_) for k, v_ in v.items()}
         if isinstance(v, list):
             return {str(tag): str(tag) for tag in v}
         return None
@@ -35,7 +35,7 @@ class ImageMetadata(BaseModel):
             if tags:
                 schema["properties"]["tags"] = {
                     "anyOf": [
-                        {"type": "object", "additionalProperties": {"type": "string"}},
+                        {"type": "object"},
                         {"type": "array", "items": {"type": "string"}},
                         {"type": "null"},
                     ]

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -151,6 +151,25 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert response.status_code == 400
         assert "detail" in response.data
 
+    def test_snapshot_boolean_tag_values_accepted(self) -> None:
+        url = self._get_create_url()
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "screen.png": {
+                    "content_hash": "abc123",
+                    "width": 375,
+                    "height": 812,
+                    "tags": {"show_background": True, "count": 42},
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code != 400
+
     def test_snapshot_invalid_image_schema(self) -> None:
         url = self._get_create_url()
         data = {

--- a/tests/sentry/preprod/snapshots/test_manifest.py
+++ b/tests/sentry/preprod/snapshots/test_manifest.py
@@ -59,6 +59,14 @@ class TestImageMetadataTagsCoercion:
         )
         assert manifest.images["screen.png"].tags == {"dark": "dark", "mobile": "mobile"}
 
+    def test_tags_boolean_values_coerced_to_strings(self) -> None:
+        meta = ImageMetadata(**_meta(tags={"dark_mode": True, "rtl": False}))
+        assert meta.tags == {"dark_mode": "True", "rtl": "False"}
+
+    def test_tags_numeric_values_coerced_to_strings(self) -> None:
+        meta = ImageMetadata(**_meta(tags={"count": 42, "ratio": 1.5}))
+        assert meta.tags == {"count": "42", "ratio": "1.5"}
+
 
 class TestImageMetadataJsonSchema:
     def test_schema_accepts_dict_tags(self) -> None:
@@ -76,3 +84,11 @@ class TestImageMetadataJsonSchema:
     def test_schema_accepts_no_tags(self) -> None:
         schema = ImageMetadata.schema()
         jsonschema.validate(_meta(), schema)
+
+    def test_schema_accepts_boolean_tag_values(self) -> None:
+        schema = ImageMetadata.schema()
+        jsonschema.validate(_meta(tags={"dark_mode": True}), schema)
+
+    def test_schema_accepts_numeric_tag_values(self) -> None:
+        schema = ImageMetadata.schema()
+        jsonschema.validate(_meta(tags={"count": 42}), schema)


### PR DESCRIPTION
## Summary
- Removes strict `ImageMetadata.schema()` from the jsonschema validation for image entries — replaces with `additionalProperties: True`
- Top-level fields (app_id, VCS fields, selective, etc.) are still validated by jsonschema
- Image metadata validation is handled by Pydantic when constructing the `SnapshotManifest`, which already coerces types and allows extra fields
- Catches `pydantic.ValidationError` and returns a 400 with a useful message instead of letting it become a 500

Depends on #115710

Fixes EME-1156