### PR TITLE
feat(preprod): Display snapshot image tags in card headers

### DIFF
--- a/static/app/views/preprod/snapshots/main/collapsibleBadgeRow.tsx
+++ b/static/app/views/preprod/snapshots/main/collapsibleBadgeRow.tsx
@@ -10,10 +10,9 @@ const ONE_ROW_HEIGHT = 20;
 
 export function CollapsibleBadgeRow({tags}: {tags: Record<string, string>}) {
   const [expanded, setExpanded] = useState(false);
-  const [hiddenKeys, setHiddenKeys] = useState(new Set<string>());
+  const [overflowCount, setOverflowCount] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
-  const badgeRefs = useRef(new Map<string, HTMLElement>());
-  const toggleButtonRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -21,37 +20,37 @@ export function CollapsibleBadgeRow({tags}: {tags: Record<string, string>}) {
       return;
     }
 
-    const calculateHidden = () => {
-      const buttonWidth = toggleButtonRef.current?.offsetWidth ?? 0;
+    const calculate = () => {
+      const buttonEl = toggleRef.current;
+      const buttonWidth = buttonEl?.offsetWidth ?? 0;
       const containerWidth = container.offsetWidth;
 
-      const nextHidden = new Set<string>();
-      badgeRefs.current.forEach((el, key) => {
-        if (el.offsetTop >= ONE_ROW_HEIGHT) {
-          nextHidden.add(key);
-        } else if (
-          buttonWidth > 0 &&
-          el.offsetLeft + el.offsetWidth > containerWidth - buttonWidth
-        ) {
-          nextHidden.add(key);
+      let count = 0;
+      for (const child of container.children) {
+        if (child === buttonEl) {
+          continue;
         }
-      });
-      setHiddenKeys(prev =>
-        prev.size === nextHidden.size && [...prev].every(k => nextHidden.has(k))
-          ? prev
-          : nextHidden
-      );
+        const el = child as HTMLElement;
+        if (
+          el.offsetTop >= ONE_ROW_HEIGHT ||
+          (buttonWidth > 0 &&
+            el.offsetLeft + el.offsetWidth > containerWidth - buttonWidth)
+        ) {
+          count++;
+        }
+      }
+      setOverflowCount(prev => (prev === count ? prev : count));
     };
 
-    const rafId = requestAnimationFrame(calculateHidden);
-    const observer = new ResizeObserver(() => requestAnimationFrame(calculateHidden));
+    const rafId = requestAnimationFrame(calculate);
+    const observer = new ResizeObserver(() => requestAnimationFrame(calculate));
     observer.observe(container);
 
     return () => {
       cancelAnimationFrame(rafId);
       observer.disconnect();
     };
-  }, [tags, expanded, hiddenKeys.size]);
+  }, [tags, expanded, overflowCount]);
 
   const entries = Object.entries(tags);
 
@@ -66,26 +65,13 @@ export function CollapsibleBadgeRow({tags}: {tags: Record<string, string>}) {
       maxHeight={expanded ? undefined : `${ONE_ROW_HEIGHT}px`}
     >
       {entries.map(([key, value]) => (
-        <Badge
-          key={key}
-          ref={(el: HTMLElement | null) => {
-            if (el) {
-              badgeRefs.current.set(key, el);
-            } else {
-              badgeRefs.current.delete(key);
-            }
-          }}
-          variant="muted"
-          style={
-            !expanded && hiddenKeys.has(key) ? {visibility: 'hidden' as const} : undefined
-          }
-        >
+        <Badge key={key} variant="muted">
           {key}={value}
         </Badge>
       ))}
-      {hiddenKeys.size > 0 && !expanded && (
+      {overflowCount > 0 && !expanded && (
         <Flex
-          ref={toggleButtonRef}
+          ref={toggleRef}
           align="center"
           position="absolute"
           right="0"
@@ -102,7 +88,7 @@ export function CollapsibleBadgeRow({tags}: {tags: Record<string, string>}) {
               setExpanded(true);
             }}
           >
-            {t('+%s more tags', hiddenKeys.size)}
+            {t('+%s more tags', overflowCount)}
           </Button>
         </Flex>
       )}

--- a/static/app/views/preprod/snapshots/main/collapsibleBadgeRow.tsx
+++ b/static/app/views/preprod/snapshots/main/collapsibleBadgeRow.tsx
@@ -10,7 +10,7 @@ const ONE_ROW_HEIGHT = 20;
 
 export function CollapsibleBadgeRow({tags}: {tags: Record<string, string>}) {
   const [expanded, setExpanded] = useState(false);
-  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(new Set());
+  const [hiddenKeys, setHiddenKeys] = useState(new Set<string>());
   const containerRef = useRef<HTMLDivElement>(null);
   const badgeRefs = useRef(new Map<string, HTMLElement>());
   const toggleButtonRef = useRef<HTMLDivElement>(null);

--- a/static/app/views/preprod/snapshots/main/collapsibleBadgeRow.tsx
+++ b/static/app/views/preprod/snapshots/main/collapsibleBadgeRow.tsx
@@ -1,0 +1,104 @@
+import {useEffect, useRef, useState} from 'react';
+
+import {Badge} from '@sentry/scraps/badge';
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
+import {t} from 'sentry/locale';
+
+const ONE_ROW_HEIGHT = 20;
+
+export function CollapsibleBadgeRow({tags}: {tags: Record<string, string>}) {
+  const [expanded, setExpanded] = useState(false);
+  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(new Set());
+  const containerRef = useRef<HTMLDivElement>(null);
+  const badgeRefs = useRef(new Map<string, HTMLElement>());
+  const toggleButtonRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (expanded || !container) {
+      return;
+    }
+
+    const calculateHidden = () => {
+      const buttonWidth = toggleButtonRef.current?.offsetWidth ?? 0;
+      const containerWidth = container.offsetWidth;
+
+      const nextHidden = new Set<string>();
+      badgeRefs.current.forEach((el, key) => {
+        if (el.offsetTop >= ONE_ROW_HEIGHT) {
+          nextHidden.add(key);
+        } else if (
+          buttonWidth > 0 &&
+          el.offsetLeft + el.offsetWidth > containerWidth - buttonWidth
+        ) {
+          nextHidden.add(key);
+        }
+      });
+      setHiddenKeys(prev =>
+        prev.size === nextHidden.size && [...prev].every(k => nextHidden.has(k))
+          ? prev
+          : nextHidden
+      );
+    };
+
+    const rafId = requestAnimationFrame(calculateHidden);
+    const observer = new ResizeObserver(() => requestAnimationFrame(calculateHidden));
+    observer.observe(container);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      observer.disconnect();
+    };
+  }, [tags, expanded, hiddenKeys.size]);
+
+  const entries = Object.entries(tags);
+
+  return (
+    <Flex
+      ref={containerRef}
+      align="center"
+      gap="xs"
+      wrap="wrap"
+      overflow="hidden"
+      position="relative"
+      maxHeight={expanded ? undefined : `${ONE_ROW_HEIGHT}px`}
+    >
+      {entries.map(([key, value]) => (
+        <Badge
+          key={key}
+          ref={(el: HTMLElement | null) => {
+            if (el) {
+              badgeRefs.current.set(key, el);
+            } else {
+              badgeRefs.current.delete(key);
+            }
+          }}
+          variant="muted"
+          style={
+            !expanded && hiddenKeys.has(key) ? {visibility: 'hidden' as const} : undefined
+          }
+        >
+          {key}={value}
+        </Badge>
+      ))}
+      {hiddenKeys.size > 0 && !expanded && (
+        <Flex
+          ref={toggleButtonRef}
+          align="center"
+          position="absolute"
+          right="0"
+          bottom="0"
+          height={`${ONE_ROW_HEIGHT}px`}
+          background="primary"
+          paddingLeft="sm"
+        >
+          <Button variant="link" size="xs" onClick={() => setExpanded(true)}>
+            {t('+%s more tags', hiddenKeys.size)}
+          </Button>
+        </Flex>
+      )}
+    </Flex>
+  );
+}

--- a/static/app/views/preprod/snapshots/main/collapsibleBadgeRow.tsx
+++ b/static/app/views/preprod/snapshots/main/collapsibleBadgeRow.tsx
@@ -94,7 +94,14 @@ export function CollapsibleBadgeRow({tags}: {tags: Record<string, string>}) {
           background="primary"
           paddingLeft="sm"
         >
-          <Button variant="link" size="xs" onClick={() => setExpanded(true)}>
+          <Button
+            variant="link"
+            size="xs"
+            onClick={e => {
+              e.stopPropagation();
+              setExpanded(true);
+            }}
+          >
             {t('+%s more tags', hiddenKeys.size)}
           </Button>
         </Flex>

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
@@ -74,6 +74,7 @@ function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
     height: 180,
     image_file_name: 'button.light.png',
     key: 'head-button-light',
+    tags: null,
     width: 320,
     ...overrides,
   };

--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -120,6 +120,7 @@ function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
     height: 180,
     image_file_name: 'button.light.png',
     key: 'head-button-light',
+    tags: {lang: 'en', dir: 'ltr', theme: 'light'},
     width: 320,
     ...overrides,
   };
@@ -172,6 +173,7 @@ describe('SnapshotCards', () => {
       fileName: 'button.light.png',
       isDark: false,
       onToggleDark: noop,
+      tags: {lang: 'en', dir: 'ltr', theme: 'light'} as Record<string, string>,
     };
 
     it.snapshot(

--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -10,6 +10,11 @@ import {DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {CardHeader, ImageCard, PairCard} from './snapshotCards';
 
+jest.mock('@sentry/scraps/badge', () => ({
+  ...jest.requireActual('sentry/components/core/badge/badge'),
+  ...jest.requireActual('sentry/components/core/badge/tag'),
+}));
+
 jest.mock('@sentry/scraps/layout', () => {
   const actual = jest.requireActual('@sentry/scraps/layout');
   return {

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -2,13 +2,14 @@ import {Fragment, memo, useState} from 'react';
 import {ThemeProvider} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Badge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {IconInfo, IconLightning, IconLink, IconMoon} from 'sentry/icons';
+import {IconFile, IconInfo, IconLightning, IconLink, IconMoon} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
@@ -136,6 +137,7 @@ export const PairCard = memo(function PairCard({
         <CardHeader
           displayName={image.display_name}
           fileName={image.image_file_name}
+          tags={image.tags}
           status={DiffStatus.CHANGED}
           diffPercent={pair.diff}
           isDark={isDark}
@@ -220,6 +222,7 @@ export const ImageCard = memo(function ImageCard({
         <CardHeader
           displayName={image.display_name}
           fileName={image.image_file_name}
+          tags={image.tags}
           status={status}
           isDark={isDark}
           onToggleDark={() => setIsDark(v => !v)}
@@ -241,6 +244,7 @@ export const ImageCard = memo(function ImageCard({
 export const CardHeader = memo(function CardHeader({
   displayName,
   fileName,
+  tags,
   status,
   diffPercent,
   isDark,
@@ -264,45 +268,56 @@ export const CardHeader = memo(function CardHeader({
   onDoubleClick?: () => void;
   showBottomBorder?: boolean;
   status?: DiffStatus | null;
+  tags?: Record<string, string> | null;
 }) {
   const {copy} = useCopyToClipboard();
+  // TODO: remove fake tags once backend sends real data
+  const displayTags = tags ?? {lang: 'en', dir: 'ltr', theme: 'light'};
   return (
     <CardHeaderRow onDoubleClick={onDoubleClick} $showBottomBorder={showBottomBorder}>
-      <Stack gap="xs" minWidth="0" flex="1">
-        {displayName ? (
-          <Fragment>
+      <Flex align="center" justify="space-between" gap="md">
+        {displayName && (
+          <Flex align="center" width="fit-content" maxWidth="100%" minWidth="0">
             <Text size="md" bold ellipsis>
               {displayName}
             </Text>
-            <Text size="xs" variant="muted" monospace ellipsis>
-              {fileName}
-            </Text>
-          </Fragment>
-        ) : (
-          <Text size="md" bold monospace ellipsis>
-            {fileName}
-          </Text>
+            <IconButton
+              aria-label={t('Copy file name')}
+              tooltip={fileName}
+              icon={<IconFile size="xs" />}
+              onClick={() => copy(fileName, {successMessage: t('Copied file name')})}
+            />
+          </Flex>
         )}
-      </Stack>
-      <Flex align="center" gap="sm" onClick={e => e.stopPropagation()}>
-        {status && <StatusBadge status={status} diffPercent={diffPercent} />}
-        <IconButton
-          aria-label={isDark ? t('Light preview') : t('Dark preview')}
-          tooltip={isDark ? t('Light preview') : t('Dark preview')}
-          icon={isDark ? <IconLightning size="sm" /> : <IconMoon size="sm" />}
-          onClick={onToggleDark}
-        />
-        <IconButton
-          aria-label={t('Copy link to this snapshot')}
-          tooltip={t('Copy link')}
-          icon={<IconLink size="sm" />}
-          onClick={() => {
-            copy(copyUrl, {successMessage: t('Copied link to this snapshot')});
-            onCopyLink?.();
-          }}
-        />
-        <MetadataInfoButton copyData={copyData} onCopy={onCopyMetadata} />
+        <Flex align="center" gap="sm" shrink="0" onClick={e => e.stopPropagation()}>
+          {status && <StatusBadge status={status} diffPercent={diffPercent} />}
+          <IconButton
+            aria-label={isDark ? t('Light preview') : t('Dark preview')}
+            tooltip={isDark ? t('Light preview') : t('Dark preview')}
+            icon={isDark ? <IconLightning size="sm" /> : <IconMoon size="sm" />}
+            onClick={onToggleDark}
+          />
+          <IconButton
+            aria-label={t('Copy link to this snapshot')}
+            tooltip={t('Copy link')}
+            icon={<IconLink size="sm" />}
+            onClick={() => {
+              copy(copyUrl, {successMessage: t('Copied link to this snapshot')});
+              onCopyLink?.();
+            }}
+          />
+          <MetadataInfoButton copyData={copyData} onCopy={onCopyMetadata} />
+        </Flex>
       </Flex>
+      {Object.keys(displayTags).length > 0 && (
+        <Flex gap="xs" wrap="wrap">
+          {Object.entries(displayTags).map(([key, value]) => (
+            <Badge key={key} variant="muted">
+              {key}={value}
+            </Badge>
+          ))}
+        </Flex>
+      )}
     </CardHeaderRow>
   );
 });
@@ -431,9 +446,8 @@ const CardHeaderRow = styled('div')<{
   $showBottomBorder?: boolean;
 }>`
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: ${p => p.theme.space.md};
+  flex-direction: column;
+  gap: ${p => p.theme.space.xxs};
   padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
   border-bottom: ${p =>
     p.$showBottomBorder ? `1px solid ${p.theme.tokens.border.secondary}` : 0};

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -413,7 +413,7 @@ function IconButton({
 }: {
   'aria-label': string;
   icon: React.ReactNode;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent) => void;
   tooltip?: string;
 }) {
   const button = (

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -2,7 +2,6 @@ import {Fragment, memo, useState} from 'react';
 import {ThemeProvider} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Badge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
@@ -24,6 +23,7 @@ import type {
 import {DiffStatus, getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
+import {CollapsibleBadgeRow} from './collapsibleBadgeRow';
 import {
   ImageColumn,
   OnionCardBody,
@@ -271,24 +271,22 @@ export const CardHeader = memo(function CardHeader({
   tags?: Record<string, string> | null;
 }) {
   const {copy} = useCopyToClipboard();
-  // TODO: remove fake tags once backend sends real data
-  const displayTags = tags ?? {lang: 'en', dir: 'ltr', theme: 'light'};
   return (
     <CardHeaderRow onDoubleClick={onDoubleClick} $showBottomBorder={showBottomBorder}>
       <Flex align="center" justify="between" gap="md">
-        {displayName && (
-          <Flex align="center" width="fit-content" maxWidth="100%" minWidth="0">
-            <Text size="md" bold ellipsis>
-              {displayName}
-            </Text>
+        <Flex align="center" width="fit-content" maxWidth="100%" minWidth="0">
+          <Text size="md" bold ellipsis>
+            {displayName ?? fileName}
+          </Text>
+          {displayName && (
             <IconButton
               aria-label={t('Copy file name')}
               tooltip={fileName}
               icon={<IconFile size="xs" />}
               onClick={() => copy(fileName, {successMessage: t('Copied file name')})}
             />
-          </Flex>
-        )}
+          )}
+        </Flex>
         <Flex align="center" gap="sm" flex="0 0 auto" onClick={e => e.stopPropagation()}>
           {status && <StatusBadge status={status} diffPercent={diffPercent} />}
           <IconButton
@@ -309,15 +307,7 @@ export const CardHeader = memo(function CardHeader({
           <MetadataInfoButton copyData={copyData} onCopy={onCopyMetadata} />
         </Flex>
       </Flex>
-      {Object.keys(displayTags).length > 0 && (
-        <Flex gap="xs" wrap="wrap">
-          {Object.entries(displayTags).map(([key, value]) => (
-            <Badge key={key} variant="muted">
-              {key}={value}
-            </Badge>
-          ))}
-        </Flex>
-      )}
+      {tags && Object.keys(tags).length > 0 && <CollapsibleBadgeRow tags={tags} />}
     </CardHeaderRow>
   );
 });

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -283,7 +283,10 @@ export const CardHeader = memo(function CardHeader({
               aria-label={t('Copy file name')}
               tooltip={fileName}
               icon={<IconFile size="xs" />}
-              onClick={() => copy(fileName, {successMessage: t('Copied file name')})}
+              onClick={e => {
+                e.stopPropagation();
+                copy(fileName, {successMessage: t('Copied file name')});
+              }}
             />
           )}
         </Flex>

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -275,7 +275,7 @@ export const CardHeader = memo(function CardHeader({
   const displayTags = tags ?? {lang: 'en', dir: 'ltr', theme: 'light'};
   return (
     <CardHeaderRow onDoubleClick={onDoubleClick} $showBottomBorder={showBottomBorder}>
-      <Flex align="center" justify="space-between" gap="md">
+      <Flex align="center" justify="between" gap="md">
         {displayName && (
           <Flex align="center" width="fit-content" maxWidth="100%" minWidth="0">
             <Text size="md" bold ellipsis>
@@ -289,7 +289,7 @@ export const CardHeader = memo(function CardHeader({
             />
           </Flex>
         )}
-        <Flex align="center" gap="sm" shrink="0" onClick={e => e.stopPropagation()}>
+        <Flex align="center" gap="sm" flex="0 0 auto" onClick={e => e.stopPropagation()}>
           {status && <StatusBadge status={status} diffPercent={diffPercent} />}
           <IconButton
             aria-label={isDark ? t('Light preview') : t('Dark preview')}
@@ -447,7 +447,7 @@ const CardHeaderRow = styled('div')<{
 }>`
   display: flex;
   flex-direction: column;
-  gap: ${p => p.theme.space.xxs};
+  gap: ${p => p.theme.space['2xs']};
   padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
   border-bottom: ${p =>
     p.$showBottomBorder ? `1px solid ${p.theme.tokens.border.secondary}` : 0};

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -65,6 +65,7 @@ function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
     height: 180,
     image_file_name: 'button.light.png',
     key: 'head-button-light',
+    tags: null,
     width: 320,
     ...overrides,
   };

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -263,6 +263,7 @@ export function SnapshotMainContent({
         headerProps={{
           displayName: image.display_name,
           fileName: image.image_file_name,
+          tags: image.tags,
           status: DiffStatus.CHANGED,
           diffPercent: currentPair.diff,
           copyData: currentPair,
@@ -316,6 +317,7 @@ export function SnapshotMainContent({
         headerProps={{
           displayName: image.display_name,
           fileName: image.image_file_name,
+          tags: image.tags,
           status: DiffStatus.RENAMED,
           copyData: currentPair,
           copyUrl: buildSnapshotLink(image.image_file_name),
@@ -375,6 +377,7 @@ export function SnapshotMainContent({
       headerProps={{
         displayName: currentImage.display_name,
         fileName: currentImage.image_file_name,
+        tags: currentImage.tags,
         status,
         copyData: currentImage,
         copyUrl: buildSnapshotLink(currentImage.image_file_name),

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -11,6 +11,7 @@ export interface SnapshotImage {
   group?: string | null;
   height: number;
   key: string;
+  tags: Record<string, string> | null;
   width: number;
 }
 


### PR DESCRIPTION
Add a `tags` field to `SnapshotImage` and render tags as muted badges in snapshot card headers. Each tag appears as a `key=value` pill below the image name, giving reviewers quick visibility into the variant dimensions (language, direction, theme) of each snapshot.

**Card header layout rework**

The header switches from a single row with a subtitle file name to a two-row layout: the top row holds the display name, action icons, and status text; the bottom row holds the tag badges. The file name moves from inline text to a small icon button that copies the name on click.

Depends on #115659

<img width="1706" height="552" alt="CleanShot 2026-05-26 at 18 06 40@2x" src="https://github.com/user-attachments/assets/5d6ce626-92e6-4b24-a627-fb003d47a241" />

<img width="1628" height="456" alt="CleanShot 2026-05-26 at 18 05 54@2x" src="https://github.com/user-attachments/assets/d485516c-c023-485e-8ca6-9c73ef064629" />
