### PR TITLE
perf(bootstrap): Parallelize locale and moment chunk fetches

### DIFF
--- a/static/app/bootstrap/initializeLocale.tsx
+++ b/static/app/bootstrap/initializeLocale.tsx
@@ -66,12 +66,15 @@ export async function initializeLocale(config: Config) {
     queryStringLang || config.user?.options?.language || config.languageCode || 'en';
 
   try {
-    const translations = await getTranslations(languageCode);
-    setLocale(translations);
-
-    // No need to import english
-    if (languageCode !== 'en') {
-      await import(`moment/locale/${languageCode}`);
+    if (languageCode === 'en') {
+      const translations = await getTranslations(languageCode);
+      setLocale(translations);
+    } else {
+      const [translations] = await Promise.all([
+        getTranslations(languageCode),
+        import(`moment/locale/${languageCode}`),
+      ]);
+      setLocale(translations);
       moment.locale(languageCode);
     }
   } catch (err) {

--- a/static/app/bootstrap/initializeLocale.tsx
+++ b/static/app/bootstrap/initializeLocale.tsx
@@ -85,6 +85,5 @@ export async function initializeLocale(config: Config) {
     }
   } catch (err) {
     Sentry.captureException(err);
-    setLocale(DEFAULT_LOCALE_DATA);
   }
 }

--- a/static/app/bootstrap/initializeLocale.tsx
+++ b/static/app/bootstrap/initializeLocale.tsx
@@ -70,18 +70,17 @@ export async function initializeLocale(config: Config) {
       const translations = await getTranslations(languageCode);
       setLocale(translations);
     } else {
-      await Promise.all([
+      const [translations, momentLocaleLoaded] = await Promise.all([
         getTranslations(languageCode),
-        import(`moment/locale/${languageCode}`),
-      ])
-        .then(([translations]) => {
-          setLocale(translations);
-          moment.locale(languageCode);
-        })
-        .catch(err => {
-          Sentry.captureException(err);
-          setLocale(DEFAULT_LOCALE_DATA);
-        });
+        import(`moment/locale/${languageCode}`).then(
+          () => true,
+          () => false
+        ),
+      ]);
+      setLocale(translations);
+      if (momentLocaleLoaded) {
+        moment.locale(languageCode);
+      }
     }
   } catch (err) {
     Sentry.captureException(err);

--- a/static/app/bootstrap/initializeLocale.tsx
+++ b/static/app/bootstrap/initializeLocale.tsx
@@ -72,7 +72,7 @@ export async function initializeLocale(config: Config) {
     } else {
       const [translations] = await Promise.all([
         getTranslations(languageCode),
-        import(`moment/locale/${languageCode}`),
+        import(`moment/locale/${languageCode}`).catch(() => null),
       ]);
       setLocale(translations);
       moment.locale(languageCode);

--- a/static/app/bootstrap/initializeLocale.tsx
+++ b/static/app/bootstrap/initializeLocale.tsx
@@ -70,14 +70,21 @@ export async function initializeLocale(config: Config) {
       const translations = await getTranslations(languageCode);
       setLocale(translations);
     } else {
-      const [translations] = await Promise.all([
+      await Promise.all([
         getTranslations(languageCode),
-        import(`moment/locale/${languageCode}`).catch(() => null),
-      ]);
-      setLocale(translations);
-      moment.locale(languageCode);
+        import(`moment/locale/${languageCode}`),
+      ])
+        .then(([translations]) => {
+          setLocale(translations);
+          moment.locale(languageCode);
+        })
+        .catch(err => {
+          Sentry.captureException(err);
+          setLocale(DEFAULT_LOCALE_DATA);
+        });
     }
   } catch (err) {
     Sentry.captureException(err);
+    setLocale(DEFAULT_LOCALE_DATA);
   }
 }


### PR DESCRIPTION
Parallelize translation async resources for non english users (we don't need to fetch them sequentially)