### PR TITLE
perf(bootstrap): Preload initializeApp chunk during locale init

### DIFF
--- a/static/app/bootstrap/initializeMain.tsx
+++ b/static/app/bootstrap/initializeMain.tsx
@@ -3,14 +3,9 @@ import type {Config} from 'sentry/types/system';
 import {initializeLocale} from './initializeLocale';
 
 export async function initializeMain(config: Config) {
-  // This needs to be loaded as early as possible, or else the locale library can
-  // throw an exception and prevent the application from being loaded.
-  //
-  // e.g. `app/constants` uses `t()` and is imported quite early
-  await initializeLocale(config);
-
-  // This is dynamically imported because we need to make sure locale is configured
-  // before proceeding.
-  const {initializeApp} = await import('./initializeApp');
+  const [, {initializeApp}] = await Promise.all([
+    initializeLocale(config),
+    import('./initializeApp'),
+  ]);
   initializeApp(config);
 }


### PR DESCRIPTION
## Summary

- Fetch the `initializeApp` chunk in parallel with locale initialization using `Promise.all`, instead of sequentially waiting for locale to finish before starting the chunk fetch.
- The `initializeApp` code still only **executes** after locale completes, preserving the invariant that `t()` is available before any app code runs. Only the network fetch is overlapped.

## Test plan

- [ ] Verify app boots correctly with default locale (English)
- [ ] Verify app boots correctly with a non-English locale (e.g. `?lang=fr`)
- [ ] Verify no console errors during initialization