### PR TITLE
perf(teams): Avoid organization N+1 in team projects

### DIFF
--- a/src/sentry/core/endpoints/team_projects.py
+++ b/src/sentry/core/endpoints/team_projects.py
@@ -162,9 +162,13 @@ class TeamProjectsEndpoint(TeamEndpoint):
         Return a list of projects bound to a team.
         """
         if request.auth and hasattr(request.auth, "project"):
-            queryset = Project.objects.filter(id=request.auth.project.id)
+            queryset = Project.objects.filter(id=request.auth.project.id).select_related(
+                "organization"
+            )
         else:
-            queryset = Project.objects.filter(teams=team, status=ObjectStatus.ACTIVE)
+            queryset = Project.objects.filter(
+                teams=team, status=ObjectStatus.ACTIVE
+            ).select_related("organization")
 
         stats_period = request.GET.get("statsPeriod")
         if stats_period not in (None, "", "24h", "14d", "30d"):


### PR DESCRIPTION
The N+1 happens in `ProjectSummarySerializer` while building access and feature data, after the team projects endpoint has fetched the projects.

Use the same pattern as the other project serialization callsites and load `organization` on the endpoint queryset instead of adding a broader serializer-side cache mutation.

fixes SENTRY-5MH7

[example trace](https://sentry.sentry.io/insights/summary/trace/29094cad5c3543528eac6cc8b7daa1ce/?fov=150683.390083313%2C7055.670627593994&node=span-9aa1f6ab35debbe8&project=1&query=&referrer=performance-transaction-summary&segmentSpansCursor=0%3A5%3A0&source=performance_transaction_summary&statsPeriod=14d&timestamp=1778616529&transaction=%2Fapi%2F0%2Fteams%2F%7Borganization_id_or_slug%7D%2F%7Bteam_id_or_slug%7D%2Fprojects%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29&unselectedSeries=Releases)