### PR TITLE
fix(preprod): Include image key and field path in snapshot validation errors

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -145,13 +145,42 @@ def validate_preprod_snapshot_post_schema(
         jsonschema.validate(data, SNAPSHOT_POST_REQUEST_SCHEMA)
         return data, None
     except jsonschema.ValidationError as e:
-        error_message = e.message
-        if e.path:
-            if field := e.path[0]:
-                error_message = SNAPSHOT_POST_REQUEST_ERROR_MESSAGES.get(str(field), error_message)
-        return {}, error_message
+        return {}, _format_validation_error(e)
     except (orjson.JSONDecodeError, TypeError):
         return {}, "Invalid json body"
+
+
+def _format_validation_error(e: jsonschema.ValidationError) -> str:
+    path = list(e.absolute_path)
+
+    if len(path) >= 2 and path[0] == "images":
+        image_key = path[1]
+        if rest := path[2:]:
+            field_path = ".".join(str(p) for p in rest)
+            return f'Validation error in image "{image_key}", field "{field_path}": {e.message}'
+        return f'Validation error in image "{image_key}": {e.message}'
+
+    if path:
+        field = str(path[0])
+        if friendly := SNAPSHOT_POST_REQUEST_ERROR_MESSAGES.get(field):
+            return friendly
+
+    return e.message
+
+
+def _format_pydantic_error(e: pydantic.ValidationError) -> str:
+    err = e.errors()[0]
+    loc = err.get("loc", ())
+    msg = err["msg"]
+
+    if len(loc) >= 2 and loc[0] == "images":
+        image_key = loc[1]
+        if rest := loc[2:]:
+            field_path = ".".join(str(p) for p in rest)
+            return f'Validation error in image "{image_key}", field "{field_path}": {msg}'
+        return f'Validation error in image "{image_key}": {msg}'
+
+    return f"Invalid image metadata: {msg}"
 
 
 @cell_silo_endpoint
@@ -582,7 +611,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             )
         except pydantic.ValidationError as e:
             return Response(
-                {"detail": f"Invalid image metadata: {e.errors()[0]['msg']}"},
+                {"detail": _format_pydantic_error(e)},
                 status=400,
             )
 

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -186,7 +186,46 @@ class ProjectPreprodSnapshotTest(APITestCase):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
-        assert "detail" in response.data
+        assert 'Validation error in image "hash1"' in response.data["detail"]
+
+    def test_snapshot_missing_content_hash_error_message(self) -> None:
+        url = self._get_create_url()
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "screen.png": {
+                    "width": 375,
+                    "height": 812,
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 400
+        assert 'Validation error in image "screen.png"' in response.data["detail"]
+        assert "content_hash" in response.data["detail"]
+
+    def test_snapshot_negative_width_error_message(self) -> None:
+        url = self._get_create_url()
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "login.png": {
+                    "content_hash": "abc123",
+                    "width": -100,
+                    "height": 812,
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 400
+        assert 'Validation error in image "login.png"' in response.data["detail"]
+        assert "width" in response.data["detail"]
 
     def test_snapshot_negative_dimensions(self) -> None:
         url = self._get_create_url()


### PR DESCRIPTION
Snapshot validation errors for image metadata returned raw messages like
`True is not of type 'string'` with no indication of which image or field
caused the error. This was especially unhelpful when uploading hundreds of
images via sentry-cli.

This improves error formatting for both validation layers:

- **jsonschema errors** (top-level schema): uses `absolute_path` instead of
  `path` to get full context even when `best_match` selects a nested error
- **Pydantic errors** (image metadata): extracts the image key and field from
  the `loc` tuple to produce actionable messages

Example: `Validation error in image "screen.png", field "content_hash": field required`

The original PR #115709 was reverted because its tests sent payloads that
Pydantic silently coerces (boolean tag values, boolean display_name) rather
than rejects — so the tests expected 400 but got 200. This version replaces
those tests with ones that trigger actual validation failures (missing
`content_hash`, negative `width`).

Fixes EME-1156