### PR TITLE
feat(cells): Add cell-routing mode to devservices

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -102,6 +102,13 @@ x-sentry-service-config:
         branch: main
         repo_link: https://github.com/getsentry/objectstore.git
         mode: containerized
+    synapse:
+      description: Cell routing services (proxy + ingest-router)
+      remote:
+        repo_name: synapse
+        branch: main
+        repo_link: https://github.com/getsentry/synapse.git
+        mode: default
     #########################################################
     # Supervisor Programs
     #########################################################
@@ -281,6 +288,7 @@ x-sentry-service-config:
         post-process-forwarder-errors,
       ]
     minimal: [postgres, snuba]
+    cell-routing: [postgres, snuba, relay, spotlight, objectstore, synapse]
     # The minimal set of services Symbolicator needs to run
     # Sentry integration tests.
     symbolicator-tests: [postgres, snuba, objectstore]

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3321,3 +3321,6 @@ CONDUIT_PUBLISH_JWT_AUDIENCE: str = os.getenv("CONDUIT_PUBLISH_JWT_AUDIENCE", "c
 SYNAPSE_HMAC_SECRET: list[str] | None = None
 if (val := os.environ.get("SYNAPSE_HMAC_SECRET")) is not None:
     SYNAPSE_HMAC_SECRET = [val]
+
+if SILO_DEVSERVER or IS_DEV:
+    SYNAPSE_HMAC_SECRET = ["synapse-dev-secret"]


### PR DESCRIPTION
Adds a new `cell-routing` devservices mode that brings up the synapse proxy + ingest-router alongside the usual local stack, so cell routing can be exercised end-to-end locally.

Also sets a dev default for `SYNAPSE_HMAC_SECRET` so the sentry devserver and synapse share the same secret out of the box without each developer having to export anything. Matching default lives on the synapse side.

Note: Relay integration is not properly configured yet, wiring the advertised upstream path will be a follow-up.
