### PR TITLE
fix(repositories): Fix deletion ordering for ProjectRepository children

### DIFF
--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -46,7 +46,10 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
         from sentry.models.userreport import UserReport
         from sentry.monitors.models import Monitor
         from sentry.replays.models import ReplayRecordingSegment
-        from sentry.seer.models.project_repository import SeerProjectRepository
+        from sentry.seer.models.project_repository import (
+            SeerProjectRepository,
+            SeerProjectRepositoryBranchOverride,
+        )
         from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
         from sentry.snuba.models import QuerySubscription
         from sentry.workflow_engine.models import Detector
@@ -91,17 +94,26 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
             relations.append(ModelRelation(m1, {"project_id": instance.id}, BulkModelDeletionTask))
 
         # These models join through ProjectRepository rather than having a direct project FK.
-        # Order matters: RPPC and SPR must be deleted before ProjectRepository.
+        # Order matters: branch overrides → SPR → RPPC → ProjectRepository.
+        # BulkModelDeletionTask does raw SQL DELETE which bypasses Django
+        # CASCADE, so children must be deleted before parents.
         relations.append(
             ModelRelation(
-                RepositoryProjectPathConfig,
-                {"project_repository__project_id": instance.id},
+                SeerProjectRepositoryBranchOverride,
+                {"seer_project_repository__project_repository__project_id": instance.id},
                 BulkModelDeletionTask,
             )
         )
         relations.append(
             ModelRelation(
                 SeerProjectRepository,
+                {"project_repository__project_id": instance.id},
+                BulkModelDeletionTask,
+            )
+        )
+        relations.append(
+            ModelRelation(
+                RepositoryProjectPathConfig,
                 {"project_repository__project_id": instance.id},
                 BulkModelDeletionTask,
             )

--- a/src/sentry/deletions/defaults/projectrepository.py
+++ b/src/sentry/deletions/defaults/projectrepository.py
@@ -3,12 +3,19 @@ from sentry.integrations.models.repository_project_path_config import (
     RepositoryProjectPathConfig,
 )
 from sentry.models.projectrepository import ProjectRepository
-from sentry.seer.models.project_repository import SeerProjectRepository
+from sentry.seer.models.project_repository import (
+    SeerProjectRepository,
+    SeerProjectRepositoryBranchOverride,
+)
 
 
 class ProjectRepositoryDeletionTask(ModelDeletionTask[ProjectRepository]):
     def get_child_relations(self, instance: ProjectRepository) -> list[BaseRelation]:
         return [
-            ModelRelation(RepositoryProjectPathConfig, {"project_repository_id": instance.id}),
+            ModelRelation(
+                SeerProjectRepositoryBranchOverride,
+                {"seer_project_repository__project_repository_id": instance.id},
+            ),
             ModelRelation(SeerProjectRepository, {"project_repository_id": instance.id}),
+            ModelRelation(RepositoryProjectPathConfig, {"project_repository_id": instance.id}),
         ]

--- a/src/sentry/deletions/defaults/repository.py
+++ b/src/sentry/deletions/defaults/repository.py
@@ -33,7 +33,10 @@ class RepositoryDeletionTask(ModelDeletionTask[Repository]):
 
     def get_child_relations(self, instance: Repository) -> list[BaseRelation]:
         from sentry.models.projectrepository import ProjectRepository
-        from sentry.seer.models.project_repository import SeerProjectRepository
+        from sentry.seer.models.project_repository import (
+            SeerProjectRepository,
+            SeerProjectRepositoryBranchOverride,
+        )
 
         return _get_repository_child_relations(instance) + [
             # Only delete ProjectRepository and SeerProjectRepository when the
@@ -41,11 +44,19 @@ class RepositoryDeletionTask(ModelDeletionTask[Repository]):
             # (repository_cascade_delete_on_hide). Seer preferences and
             # project-repo links should survive a hide so they're restored
             # if the repo is re-enabled.
-            ModelRelation(ProjectRepository, {"repository_id": instance.id}),
+            #
+            # Order matters: branch overrides → SPR → ProjectRepository.
+            # BulkModelDeletionTask does raw SQL DELETE which bypasses Django
+            # CASCADE, so children must be deleted before parents.
+            ModelRelation(
+                SeerProjectRepositoryBranchOverride,
+                {"seer_project_repository__project_repository__repository_id": instance.id},
+            ),
             ModelRelation(
                 SeerProjectRepository,
                 {"project_repository__repository_id": instance.id},
             ),
+            ModelRelation(ProjectRepository, {"repository_id": instance.id}),
         ]
 
     def delete_instance(self, instance: Repository) -> None:


### PR DESCRIPTION
## Summary
- Add `SeerProjectRepositoryBranchOverride` to deletion child relations in project, repository, and project-repository deletion tasks
- Fix ordering so branch overrides are deleted before `SeerProjectRepository`, which is deleted before `ProjectRepository`
- `BulkModelDeletionTask` does raw SQL DELETE which bypasses Django CASCADE, so FK children must be explicitly deleted in the correct order

## Test plan
- [x] `tests/sentry/deletions/test_project.py` — all pass
- [x] `tests/sentry/deletions/test_repository.py` — all pass
- [x] `tests/sentry/tasks/test_repository.py` — all pass

Fixes SENTRY-5PSY