### PR TITLE
fix(workflow_engine): Normalize error.handled values to 0/1

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -240,8 +240,7 @@ class BaseEventFrequencyQueryHandler(ABC):
             # The stored value may be a string ("true"/"false"), bool, or int.
             # Normalize to 1/0 for the Snuba condition (UInt8 column).
             # We can get stricter here once we clean existing data and validate within the API.
-            raw = condition["value"]
-            comparable = raw.lower() if isinstance(raw, str) else raw
+            comparable = rhs.lower() if isinstance(rhs, str) else rhs
             if comparable in _HANDLED_TRUE_VALUES:
                 int_value = 1
             elif comparable in _HANDLED_FALSE_VALUES:
@@ -249,7 +248,7 @@ class BaseEventFrequencyQueryHandler(ABC):
             else:
                 logger.error(
                     "workflow_engine.unrecognized_handled_filter_value",
-                    extra={"attribute": attribute, "value": raw},
+                    extra={"attribute": attribute, "value": rhs},
                 )
                 return None
             if attribute == "error.unhandled":

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -233,16 +233,18 @@ class BaseEventFrequencyQueryHandler(ABC):
             if condition["match"] not in (MatchType.IS_SET, MatchType.NOT_SET)
             else None
         )
-        if attribute in ("error.handled", "error.unhandled"):
+        if attribute in ("error.handled", "error.unhandled") and condition["match"] not in (
+            MatchType.IS_SET,
+            MatchType.NOT_SET,
+        ):
             # The stored value may be a string ("true"/"false"), bool, or int.
             # Normalize to 1/0 for the Snuba condition (UInt8 column).
             # We can get stricter here once we clean existing data and validate within the API.
             raw = condition["value"]
-            if isinstance(raw, str):
-                raw = raw.lower()
-            if raw in _HANDLED_TRUE_VALUES:
+            comparable = raw.lower() if isinstance(raw, str) else raw
+            if comparable in _HANDLED_TRUE_VALUES:
                 int_value = 1
-            elif raw in _HANDLED_FALSE_VALUES:
+            elif comparable in _HANDLED_FALSE_VALUES:
                 int_value = 0
             else:
                 logger.error(

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -233,9 +233,9 @@ class BaseEventFrequencyQueryHandler(ABC):
             if condition["match"] not in (MatchType.IS_SET, MatchType.NOT_SET)
             else None
         )
-        if attribute in ("error.handled", "error.unhandled") and condition["match"] not in (
-            MatchType.IS_SET,
-            MatchType.NOT_SET,
+        if attribute in ("error.handled", "error.unhandled") and condition["match"] in (
+            MatchType.EQUAL,
+            MatchType.NOT_EQUAL,
         ):
             # The stored value may be a string ("true"/"false"), bool, or int.
             # Normalize to 1/0 for the Snuba condition (UInt8 column).

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -238,6 +238,8 @@ class BaseEventFrequencyQueryHandler(ABC):
             # Normalize to 1/0 for the Snuba condition (UInt8 column).
             # We can get stricter here once we clean existing data and validate within the API.
             raw = condition["value"]
+            if isinstance(raw, str):
+                raw = raw.lower()
             if raw in _HANDLED_TRUE_VALUES:
                 int_value = 1
             elif raw in _HANDLED_FALSE_VALUES:

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Mapping
@@ -28,6 +29,11 @@ from sentry.utils.iterators import chunked
 from sentry.utils.registry import Registry
 from sentry.utils.snuba import options_override
 from sentry.workflow_engine.models.data_condition import Condition
+
+logger = logging.getLogger(__name__)
+
+_HANDLED_TRUE_VALUES = (True, 1, "true", "1")
+_HANDLED_FALSE_VALUES = (False, 0, "false", "0")
 
 QueryFilter = dict[str, Any]
 QueryResult = dict[int, int | float]
@@ -227,9 +233,24 @@ class BaseEventFrequencyQueryHandler(ABC):
             if condition["match"] not in (MatchType.IS_SET, MatchType.NOT_SET)
             else None
         )
-        if attribute == "error.unhandled":
-            # flip values, since the queried column is "error.handled"
-            rhs = not condition["value"]
+        if attribute in ("error.handled", "error.unhandled"):
+            # The stored value may be a string ("true"/"false"), bool, or int.
+            # Normalize to 1/0 for the Snuba condition (UInt8 column).
+            raw = condition["value"]
+            if raw in _HANDLED_TRUE_VALUES:
+                int_value = 1
+            elif raw in _HANDLED_FALSE_VALUES:
+                int_value = 0
+            else:
+                logger.error(
+                    "workflow_engine.unrecognized_handled_filter_value",
+                    extra={"attribute": attribute, "value": raw},
+                )
+                return None
+            if attribute == "error.unhandled":
+                # flip, since the queried column is "error.handled"
+                int_value = 1 - int_value
+            rhs = int_value
 
         match condition["match"]:
             case MatchType.EQUAL:

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -32,8 +32,8 @@ from sentry.workflow_engine.models.data_condition import Condition
 
 logger = logging.getLogger(__name__)
 
-_HANDLED_TRUE_VALUES = (True, 1, "true", "1")
-_HANDLED_FALSE_VALUES = (False, 0, "false", "0")
+_HANDLED_TRUE_VALUES = (True, 1, "true", "1", "yes")
+_HANDLED_FALSE_VALUES = (False, 0, "false", "0", "no")
 
 QueryFilter = dict[str, Any]
 QueryResult = dict[int, int | float]
@@ -236,6 +236,7 @@ class BaseEventFrequencyQueryHandler(ABC):
         if attribute in ("error.handled", "error.unhandled"):
             # The stored value may be a string ("true"/"false"), bool, or int.
             # Normalize to 1/0 for the Snuba condition (UInt8 column).
+            # We can get stricter here once we clean existing data and validate within the API.
             raw = condition["value"]
             if raw in _HANDLED_TRUE_VALUES:
                 int_value = 1

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
@@ -26,13 +26,17 @@ pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
         (True, 1),
         (1, 1),
         ("true", 1),
+        ("True", 1),
         ("1", 1),
         ("yes", 1),
+        ("Yes", 1),
         (False, 0),
         (0, 0),
         ("false", 0),
+        ("False", 0),
         ("0", 0),
         ("no", 0),
+        ("No", 0),
     ],
 )
 def test_error_handled_normalizes_value(value: bool | int | str, expected_rhs: int) -> None:
@@ -51,14 +55,18 @@ def test_error_handled_normalizes_value(value: bool | int | str, expected_rhs: i
         (True, 0),
         (1, 0),
         ("true", 0),
+        ("True", 0),
         ("1", 0),
         ("yes", 0),
+        ("Yes", 0),
         # "unhandled = false" →  handled = 1
         (False, 1),
         (0, 1),
         ("false", 1),
+        ("False", 1),
         ("0", 1),
         ("no", 1),
+        ("No", 1),
     ],
 )
 def test_error_unhandled_normalizes_and_flips_value(

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
@@ -88,6 +88,24 @@ def test_error_handled_unrecognized_value_returns_none(attribute: str) -> None:
     assert cond is None
 
 
+@pytest.mark.parametrize(
+    ("attribute", "match"),
+    [
+        ("error.handled", "is"),
+        ("error.handled", "ns"),
+        ("error.unhandled", "is"),
+        ("error.unhandled", "ns"),
+    ],
+)
+def test_error_handled_is_set_not_set_skips_normalization(attribute: str, match: str) -> None:
+    # IS_SET / NOT_SET filters omit "value" from the condition dict; the normalization
+    # block must not run for these match types or it will KeyError.
+    cond = BaseEventFrequencyQueryHandler.convert_filter_to_snuba_condition(
+        {"attribute": attribute, "match": match}, TSDBModel.group
+    )
+    assert cond is not None
+
+
 class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
     handler = EventFrequencyQueryHandler
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
@@ -27,13 +27,15 @@ pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
         (1, 1),
         ("true", 1),
         ("1", 1),
+        ("yes", 1),
         (False, 0),
         (0, 0),
         ("false", 0),
         ("0", 0),
+        ("no", 0),
     ],
 )
-def test_error_handled_normalizes_value(value, expected_rhs):
+def test_error_handled_normalizes_value(value: bool | int | str, expected_rhs: int) -> None:
     cond = BaseEventFrequencyQueryHandler.convert_filter_to_snuba_condition(
         {"attribute": "error.handled", "match": "eq", "value": value}, TSDBModel.group
     )
@@ -50,14 +52,18 @@ def test_error_handled_normalizes_value(value, expected_rhs):
         (1, 0),
         ("true", 0),
         ("1", 0),
+        ("yes", 0),
         # "unhandled = false" →  handled = 1
         (False, 1),
         (0, 1),
         ("false", 1),
         ("0", 1),
+        ("no", 1),
     ],
 )
-def test_error_unhandled_normalizes_and_flips_value(value, expected_rhs):
+def test_error_unhandled_normalizes_and_flips_value(
+    value: bool | int | str, expected_rhs: int
+) -> None:
     cond = BaseEventFrequencyQueryHandler.convert_filter_to_snuba_condition(
         {"attribute": "error.unhandled", "match": "eq", "value": value}, TSDBModel.group
     )
@@ -67,7 +73,7 @@ def test_error_unhandled_normalizes_and_flips_value(value, expected_rhs):
 
 
 @pytest.mark.parametrize("attribute", ["error.handled", "error.unhandled"])
-def test_error_handled_unrecognized_value_returns_none(attribute):
+def test_error_handled_unrecognized_value_returns_none(attribute: str) -> None:
     cond = BaseEventFrequencyQueryHandler.convert_filter_to_snuba_condition(
         {"attribute": attribute, "match": "eq", "value": "garbage"}, TSDBModel.group
     )

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
@@ -7,7 +7,9 @@ from sentry.issues.grouptype import GroupCategory, PerformanceNPlusOneGroupType
 from sentry.models.group import Group
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
+from sentry.tsdb.base import TSDBModel
 from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers import (
+    BaseEventFrequencyQueryHandler,
     EventFrequencyQueryHandler,
     EventUniqueUserFrequencyQueryHandler,
     PercentSessionsQueryHandler,
@@ -16,6 +18,60 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import EventFrequ
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_rhs"),
+    [
+        (True, 1),
+        (1, 1),
+        ("true", 1),
+        ("1", 1),
+        (False, 0),
+        (0, 0),
+        ("false", 0),
+        ("0", 0),
+    ],
+)
+def test_error_handled_normalizes_value(value, expected_rhs):
+    cond = BaseEventFrequencyQueryHandler.convert_filter_to_snuba_condition(
+        {"attribute": "error.handled", "match": "eq", "value": value}, TSDBModel.group
+    )
+    assert cond is not None
+    _, _, rhs = cond
+    assert rhs == expected_rhs
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_rhs"),
+    [
+        # "unhandled = true"  →  handled = 0
+        (True, 0),
+        (1, 0),
+        ("true", 0),
+        ("1", 0),
+        # "unhandled = false" →  handled = 1
+        (False, 1),
+        (0, 1),
+        ("false", 1),
+        ("0", 1),
+    ],
+)
+def test_error_unhandled_normalizes_and_flips_value(value, expected_rhs):
+    cond = BaseEventFrequencyQueryHandler.convert_filter_to_snuba_condition(
+        {"attribute": "error.unhandled", "match": "eq", "value": value}, TSDBModel.group
+    )
+    assert cond is not None
+    _, _, rhs = cond
+    assert rhs == expected_rhs
+
+
+@pytest.mark.parametrize("attribute", ["error.handled", "error.unhandled"])
+def test_error_handled_unrecognized_value_returns_none(attribute):
+    cond = BaseEventFrequencyQueryHandler.convert_filter_to_snuba_condition(
+        {"attribute": attribute, "match": "eq", "value": "garbage"}, TSDBModel.group
+    )
+    assert cond is None
 
 
 class EventFrequencyQueryTest(EventFrequencyQueryTestBase):

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
@@ -20,64 +20,23 @@ from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequency
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
 
 
-@pytest.mark.parametrize(
-    ("value", "expected_rhs"),
-    [
-        (True, 1),
-        (1, 1),
-        ("true", 1),
-        ("True", 1),
-        ("1", 1),
-        ("yes", 1),
-        ("Yes", 1),
-        (False, 0),
-        (0, 0),
-        ("false", 0),
-        ("False", 0),
-        ("0", 0),
-        ("no", 0),
-        ("No", 0),
-    ],
-)
-def test_error_handled_normalizes_value(value: bool | int | str, expected_rhs: int) -> None:
+_TRUTHY_VALUES: list[bool | int | str] = [True, 1, "true", "True", "1", "yes", "Yes"]
+_FALSY_VALUES: list[bool | int | str] = [False, 0, "false", "False", "0", "no", "No"]
+
+
+@pytest.mark.parametrize("attribute", ["error.handled", "error.unhandled"])
+@pytest.mark.parametrize("value", _TRUTHY_VALUES + _FALSY_VALUES)
+def test_error_handled_normalizes_value(attribute: str, value: bool | int | str) -> None:
     cond = BaseEventFrequencyQueryHandler.convert_filter_to_snuba_condition(
-        {"attribute": "error.handled", "match": "eq", "value": value}, TSDBModel.group
+        {"attribute": attribute, "match": "eq", "value": value}, TSDBModel.group
     )
     assert cond is not None
     _, _, rhs = cond
-    assert rhs == expected_rhs
 
-
-@pytest.mark.parametrize(
-    ("value", "expected_rhs"),
-    [
-        # "unhandled = true"  →  handled = 0
-        (True, 0),
-        (1, 0),
-        ("true", 0),
-        ("True", 0),
-        ("1", 0),
-        ("yes", 0),
-        ("Yes", 0),
-        # "unhandled = false" →  handled = 1
-        (False, 1),
-        (0, 1),
-        ("false", 1),
-        ("False", 1),
-        ("0", 1),
-        ("no", 1),
-        ("No", 1),
-    ],
-)
-def test_error_unhandled_normalizes_and_flips_value(
-    value: bool | int | str, expected_rhs: int
-) -> None:
-    cond = BaseEventFrequencyQueryHandler.convert_filter_to_snuba_condition(
-        {"attribute": "error.unhandled", "match": "eq", "value": value}, TSDBModel.group
-    )
-    assert cond is not None
-    _, _, rhs = cond
-    assert rhs == expected_rhs
+    is_truthy = value in _TRUTHY_VALUES
+    if attribute == "error.unhandled":
+        is_truthy = not is_truthy
+    assert rhs == (1 if is_truthy else 0)
 
 
 @pytest.mark.parametrize("attribute", ["error.handled", "error.unhandled"])


### PR DESCRIPTION
This is essentially reproducing the logic at src/sentry/api/event_search.py#L1132-L1136 to coerce this type.
Ideally, we'd be able to reuse the parsing logic to handle our filters generally, but it isn't an easy match.

Query showing known cases https://redash.getsentry.net/queries/11226/source.