### PR TITLE
feat(ourlogs): make downsampling alert dismissible

### DIFF
--- a/static/app/views/explore/logs/logsDownsamplingAlert.spec.tsx
+++ b/static/app/views/explore/logs/logsDownsamplingAlert.spec.tsx
@@ -1,0 +1,162 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
+import type {UseInfiniteLogsQueryResult} from 'sentry/views/explore/logs/useLogsQuery';
+import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
+
+import {LogsDownSamplingAlert} from './logsDownsamplingAlert';
+
+const organization = OrganizationFixture();
+
+function ProviderWrapper({children}: {children: React.ReactNode}) {
+  return (
+    <LogsQueryParamsProvider
+      analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+      source="location"
+    >
+      {children}
+    </LogsQueryParamsProvider>
+  );
+}
+
+function makeTimeSeries(
+  dataScanned: 'partial' | 'full',
+  sampleCount: number
+): TimeSeries {
+  return {
+    yAxis: 'count()',
+    meta: {
+      interval: 3600000,
+      valueType: 'integer',
+      valueUnit: null,
+      dataScanned,
+    },
+    values: [{timestamp: 0, value: 10, sampleCount}],
+  };
+}
+
+function makeTableResult(
+  dataScanned: 'full' | 'partial' | undefined,
+  rowCount: number
+): UseInfiniteLogsQueryResult {
+  return {
+    dataScanned,
+    data: Array.from({length: rowCount}, (_, i) => ({id: String(i)})),
+  } as unknown as UseInfiniteLogsQueryResult;
+}
+
+function makeTimeseriesResult(
+  series: TimeSeries[]
+): ReturnType<typeof useSortedTimeSeries> {
+  return {
+    data: series.length ? {key: series} : {},
+  } as unknown as ReturnType<typeof useSortedTimeSeries>;
+}
+
+const ALERT_TEXT = /volume of logs in this time range is too large/i;
+
+describe('LogsDownSamplingAlert', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders the alert when timeseries is partial, table is full, and timeseries has fewer samples', () => {
+    render(
+      <LogsDownSamplingAlert
+        tableResult={makeTableResult('full', 100)}
+        timeseriesResult={makeTimeseriesResult([makeTimeSeries('partial', 10)])}
+      />,
+      {organization, additionalWrapper: ProviderWrapper}
+    );
+
+    expect(screen.getByText(ALERT_TEXT)).toBeInTheDocument();
+  });
+
+  it('does not render when table data is also partial', () => {
+    render(
+      <LogsDownSamplingAlert
+        tableResult={makeTableResult('partial', 100)}
+        timeseriesResult={makeTimeseriesResult([makeTimeSeries('partial', 10)])}
+      />,
+      {organization, additionalWrapper: ProviderWrapper}
+    );
+
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('does not render when timeseries data is full', () => {
+    render(
+      <LogsDownSamplingAlert
+        tableResult={makeTableResult('full', 100)}
+        timeseriesResult={makeTimeseriesResult([makeTimeSeries('full', 10)])}
+      />,
+      {organization, additionalWrapper: ProviderWrapper}
+    );
+
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('does not render when timeseries sample count is not less than table row count', () => {
+    render(
+      <LogsDownSamplingAlert
+        tableResult={makeTableResult('full', 10)}
+        timeseriesResult={makeTimeseriesResult([makeTimeSeries('partial', 100)])}
+      />,
+      {organization, additionalWrapper: ProviderWrapper}
+    );
+
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('renders a dismiss button in the alert', () => {
+    render(
+      <LogsDownSamplingAlert
+        tableResult={makeTableResult('full', 100)}
+        timeseriesResult={makeTimeseriesResult([makeTimeSeries('partial', 10)])}
+      />,
+      {organization, additionalWrapper: ProviderWrapper}
+    );
+
+    expect(screen.getByRole('button', {name: 'Dismiss Alert'})).toBeInTheDocument();
+  });
+
+  it('hides the alert after the dismiss button is clicked', async () => {
+    render(
+      <LogsDownSamplingAlert
+        tableResult={makeTableResult('full', 100)}
+        timeseriesResult={makeTimeseriesResult([makeTimeSeries('partial', 10)])}
+      />,
+      {organization, additionalWrapper: ProviderWrapper}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Dismiss Alert'}));
+
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('stays hidden when remounted after dismissal', async () => {
+    const props = {
+      tableResult: makeTableResult('full', 100),
+      timeseriesResult: makeTimeseriesResult([makeTimeSeries('partial', 10)]),
+    };
+
+    const {unmount} = render(<LogsDownSamplingAlert {...props} />, {
+      organization,
+      additionalWrapper: ProviderWrapper,
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Dismiss Alert'}));
+    unmount();
+
+    render(<LogsDownSamplingAlert {...props} />, {
+      organization,
+      additionalWrapper: ProviderWrapper,
+    });
+
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/logs/logsDownsamplingAlert.tsx
+++ b/static/app/views/explore/logs/logsDownsamplingAlert.tsx
@@ -1,9 +1,13 @@
 import {useMemo} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
 
+import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {useDismissAlert} from 'sentry/utils/useDismissAlert';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import type {UseInfiniteLogsQueryResult} from 'sentry/views/explore/logs/useLogsQuery';
 import {useQueryParamsTopEventsLimit} from 'sentry/views/explore/queryParams/context';
@@ -18,6 +22,10 @@ export function LogsDownSamplingAlert({
   tableResult,
   timeseriesResult,
 }: LogsDownSamplingAlertProps) {
+  const organization = useOrganization();
+  const {isDismissed, dismiss} = useDismissAlert({
+    key: `${organization.slug}:logs-downsampling-alert`,
+  });
   const topEventsLimit = useQueryParamsTopEventsLimit();
   const isTopEvents = defined(topEventsLimit);
 
@@ -49,6 +57,7 @@ export function LogsDownSamplingAlert({
     // is here to educate the user that the results they're seeing may be a
     // little strange as there is more data in the table than the chart leads
     // one to believe.
+    !isDismissed &&
     timeseriesDataScanned === 'partial' &&
     tableDataScanned === 'full' &&
     // If the number of samples in the timeseries is greater than or equals to
@@ -58,7 +67,18 @@ export function LogsDownSamplingAlert({
   ) {
     return (
       <Alert.Container>
-        <Alert variant="warning">
+        <Alert
+          variant="warning"
+          trailingItems={
+            <Button
+              size="zero"
+              variant="link"
+              icon={<IconClose />}
+              onClick={dismiss}
+              aria-label={t('Dismiss Alert')}
+            />
+          }
+        >
           {t(
             'The volume of logs in this time range is too large for us to do a full scan for the chart. Try reducing the date range or number of projects to attempt scanning all logs.'
           )}


### PR DESCRIPTION
Adds the standard `useDismissAlert` hook to the `LogsDownSamplingAlert` component to give it a persistent dismiss button. I also added unit tests while I was in the area.

Closes LOGS-745.