### PR TITLE
chore(ci): split MDX typechecking into its own gated job

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -30,6 +30,14 @@ typecheckable_rules_changed: &typecheckable_rules_changed
   - added|deleted|modified: 'static/**/*.{ts,tsx,js,jsx,mjs}'
   - added|deleted|modified: 'static/**/*.mdx'
 
+# Trigger whether to run MDX typechecking
+mdx_typecheckable: &mdx_typecheckable
+  - *sentry_frontend_workflow_file
+  - added|modified: '.github/file-filters.yml'
+  - added|deleted|modified: '**/tsconfig*.json'
+  - added|deleted|modified: 'static/**/*.mdx'
+  - added|deleted|modified: 'static/app/components/core/**/*.{ts,tsx}'
+
 # Trigger to apply the 'Scope: Frontend' label to PRs
 frontend_all: &frontend_all
   - *sentry_frontend_workflow_file

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -37,6 +37,7 @@ mdx_typecheckable: &mdx_typecheckable
   - added|deleted|modified: '**/tsconfig*.json'
   - added|deleted|modified: 'static/**/*.mdx'
   - added|deleted|modified: 'static/app/components/core/**/*.{ts,tsx}'
+  - added|deleted|modified: 'static/**/__stories__/**/*.{ts,tsx}'
 
 # Trigger to apply the 'Scope: Frontend' label to PRs
 frontend_all: &frontend_all

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -27,6 +27,7 @@ jobs:
       testable_modified: ${{ steps.changes.outputs.testable_modified }}
       testable_rules_changed: ${{ steps.changes.outputs.testable_rules_changed }}
       typecheckable_rules_changed: ${{ steps.changes.outputs.typecheckable_rules_changed }}
+      mdx_typecheckable: ${{ steps.changes.outputs.mdx_typecheckable }}
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -58,6 +59,21 @@ jobs:
       - name: tsc
         id: tsc
         run: pnpm run typecheck
+
+  typescript-mdx:
+    if: needs.files-changed.outputs.mdx_typecheckable == 'true'
+    needs: files-changed
+    name: typescript (mdx)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: setup matchers
+        run: |
+          echo "::remove-matcher owner=masters::"
+          echo "::add-matcher::.github/tsc.json"
 
       - name: tsc (mdx)
         id: tsc-mdx
@@ -205,7 +221,15 @@ jobs:
   # This check is the only required Github check
   frontend-required-check:
     needs:
-      [files-changed, frontend-jest-tests, typescript, eslint, knip, form-field-registry]
+      [
+        files-changed,
+        frontend-jest-tests,
+        typescript,
+        typescript-mdx,
+        eslint,
+        knip,
+        form-field-registry,
+      ]
     name: Frontend
     # This is necessary since a failed/skipped dependent job would cause this job to be skipped
     if: always()


### PR DESCRIPTION
Follow-up to #115504. Now that the main `typescript` job uses `tsgo`, MDX typechecking (Volar + `tsc`) is the bottleneck. This splits it into a separate `typescript-mdx` job gated to `*.mdx` and `static/app/components/core/**` changes, so most PRs skip it entirely.