### PR TITLE
feat(markdown): Expose default components via `Default` prop

### DIFF
--- a/static/app/components/core/markdown/defaultComponents.tsx
+++ b/static/app/components/core/markdown/defaultComponents.tsx
@@ -187,7 +187,7 @@ export const DefaultTableRow = styled('tr')`
   }
 `;
 
-export const DefaultTableHeaderCell = styled('th')<{align?: string | null}>`
+const StyledTableHeaderCell = styled('th')<{align?: string | null}>`
   padding-inline: ${p => p.theme.space.xl};
   padding-block: ${p => p.theme.space.sm};
   text-align: ${p => p.align ?? 'left'};
@@ -200,8 +200,28 @@ export const DefaultTableHeaderCell = styled('th')<{align?: string | null}>`
   }
 `;
 
-export const DefaultTableCell = styled('td')<{align?: string | null}>`
+export function DefaultTableHeaderCell({
+  children,
+  align,
+}: {
+  children: ReactNode;
+  align?: string | null;
+}) {
+  return <StyledTableHeaderCell align={align}>{children}</StyledTableHeaderCell>;
+}
+
+const StyledTableCell = styled('td')<{align?: string | null}>`
   padding-inline: ${p => p.theme.space.xl};
   padding-block: ${p => p.theme.space.lg};
   text-align: ${p => p.align ?? 'left'};
 `;
+
+export function DefaultTableCell({
+  children,
+  align,
+}: {
+  children: ReactNode;
+  align?: string | null;
+}) {
+  return <StyledTableCell align={align}>{children}</StyledTableCell>;
+}

--- a/static/app/components/core/markdown/defaultComponents.tsx
+++ b/static/app/components/core/markdown/defaultComponents.tsx
@@ -187,7 +187,8 @@ export const DefaultTableRow = styled('tr')`
   }
 `;
 
-const StyledTableHeaderCell = styled('th')<{align?: string | null}>`
+type Align = 'left' | 'center' | 'right';
+export const DefaultTableHeaderCell = styled('th')<{align?: Align}>`
   padding-inline: ${p => p.theme.space.xl};
   padding-block: ${p => p.theme.space.sm};
   text-align: ${p => p.align ?? 'left'};
@@ -200,28 +201,8 @@ const StyledTableHeaderCell = styled('th')<{align?: string | null}>`
   }
 `;
 
-export function DefaultTableHeaderCell({
-  children,
-  align,
-}: {
-  children: ReactNode;
-  align?: string | null;
-}) {
-  return <StyledTableHeaderCell align={align}>{children}</StyledTableHeaderCell>;
-}
-
-const StyledTableCell = styled('td')<{align?: string | null}>`
+export const DefaultTableCell = styled('td')<{align?: Align}>`
   padding-inline: ${p => p.theme.space.xl};
   padding-block: ${p => p.theme.space.lg};
   text-align: ${p => p.align ?? 'left'};
 `;
-
-export function DefaultTableCell({
-  children,
-  align,
-}: {
-  children: ReactNode;
-  align?: string | null;
-}) {
-  return <StyledTableCell align={align}>{children}</StyledTableCell>;
-}

--- a/static/app/components/core/markdown/defaultComponents.tsx
+++ b/static/app/components/core/markdown/defaultComponents.tsx
@@ -1,4 +1,4 @@
-import {type ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {CodeBlock, InlineCode} from '@sentry/scraps/code';
@@ -148,6 +148,10 @@ export function DefaultTaskListItem({
 
 export function DefaultHorizontalRule() {
   return <Separator orientation="horizontal" />;
+}
+
+export function DefaultText({children}: {children: string}) {
+  return <React.Fragment>{children}</React.Fragment>;
 }
 
 export function DefaultLineBreak() {

--- a/static/app/components/core/markdown/markdown.mdx
+++ b/static/app/components/core/markdown/markdown.mdx
@@ -90,6 +90,24 @@ New line here.
 
 The `components` prop lets you replace any rendered element with a custom React component. Keys are named after design system primitives: `Heading`, `Paragraph`, `Link`, `InlineCode`, `CodeBlock`, `Text`, etc.
 
+Every override receives a `Default` prop — a reference to the built-in component for that element. This lets you conditionally customize rendering without importing internal defaults.
+
+### Falling Back to the Default
+
+Use the `Default` prop to apply custom behavior for specific cases and fall through to the built-in rendering for everything else.
+
+```jsx
+<Markdown
+  raw={content}
+  components={{
+    Heading: ({children, level, Default}) => {
+      if (level > 3) return <strong>{children}</strong>;
+      return <Default level={level}>{children}</Default>;
+    },
+  }}
+/>
+```
+
 ### Custom Links and Text Transforms
 
 Use `components.Link` to control how links render (e.g., client-side navigation). Use `components.Text` to intercept plain text and inject patterns like issue linkification.
@@ -172,6 +190,8 @@ The component applies the same security model as the existing `MarkedText`:
 - **React escaping** handles all other content — no `dangerouslySetInnerHTML` for markdown tokens.
 
 ## Available Component Keys
+
+Every override receives a `Default` prop in addition to the props listed below (except `Image`, which has no built-in default).
 
 | Key              | Default                        | Props                        |
 | ---------------- | ------------------------------ | ---------------------------- |

--- a/static/app/components/core/markdown/markdown.tsx
+++ b/static/app/components/core/markdown/markdown.tsx
@@ -34,10 +34,12 @@ export type MarkdownComponents = Partial<{
   Strong: ComponentType<WithDefault<{children: ReactNode}>>;
   Table: ComponentType<WithDefault<{children: ReactNode}>>;
   TableBody: ComponentType<WithDefault<{children: ReactNode}>>;
-  TableCell: ComponentType<WithDefault<{children: ReactNode; align?: string | null}>>;
+  TableCell: ComponentType<
+    WithDefault<{children: ReactNode; align?: 'left' | 'right' | 'center'}>
+  >;
   TableHead: ComponentType<WithDefault<{children: ReactNode}>>;
   TableHeaderCell: ComponentType<
-    WithDefault<{children: ReactNode; align?: string | null}>
+    WithDefault<{children: ReactNode; align?: 'left' | 'right' | 'center'}>
   >;
   TableRow: ComponentType<WithDefault<{children: ReactNode}>>;
   TaskList: ComponentType<WithDefault<{children: ReactNode}>>;

--- a/static/app/components/core/markdown/markdown.tsx
+++ b/static/app/components/core/markdown/markdown.tsx
@@ -10,32 +10,40 @@ import {MarkedLexer} from 'sentry/utils/marked/marked';
 import {Token} from './token';
 import {streamingAnimationStyles, useStreamingAnimation} from './useStreamingAnimation';
 
+type WithDefault<Props> = Props & {Default: ComponentType<Props>};
+
 export type MarkdownComponents = Partial<{
-  Blockquote: ComponentType<{children: ReactNode}>;
-  CodeBlock: ComponentType<{children: string; lang?: string}>;
-  Emphasis: ComponentType<{children: ReactNode}>;
-  Heading: ComponentType<{children: ReactNode; level: 1 | 2 | 3 | 4 | 5 | 6}>;
-  HorizontalRule: ComponentType<Record<PropertyKey, unknown>>;
-  Html: ComponentType<{html: string}>;
+  Blockquote: ComponentType<WithDefault<{children: ReactNode}>>;
+  CodeBlock: ComponentType<WithDefault<{children: string; lang?: string}>>;
+  Emphasis: ComponentType<WithDefault<{children: ReactNode}>>;
+  Heading: ComponentType<
+    WithDefault<{children: ReactNode; level: 1 | 2 | 3 | 4 | 5 | 6}>
+  >;
+  HorizontalRule: ComponentType<WithDefault<Record<PropertyKey, unknown>>>;
+  Html: ComponentType<WithDefault<{html: string}>>;
   Image: ComponentType<{src: string; alt?: string; title?: string | null}>;
-  InlineCode: ComponentType<{children: string}>;
-  LineBreak: ComponentType<Record<PropertyKey, unknown>>;
-  Link: ComponentType<{children: ReactNode; href: string; title?: string | null}>;
-  ListItem: ComponentType<{children: ReactNode; checked?: boolean}>;
-  OrderedList: ComponentType<{children: ReactNode}>;
-  Paragraph: ComponentType<{children: ReactNode}>;
-  Strikethrough: ComponentType<{children: ReactNode}>;
-  Strong: ComponentType<{children: ReactNode}>;
-  Table: ComponentType<{children: ReactNode}>;
-  TableBody: ComponentType<{children: ReactNode}>;
-  TableCell: ComponentType<{children: ReactNode; align?: string | null}>;
-  TableHead: ComponentType<{children: ReactNode}>;
-  TableHeaderCell: ComponentType<{children: ReactNode; align?: string | null}>;
-  TableRow: ComponentType<{children: ReactNode}>;
-  TaskList: ComponentType<{children: ReactNode}>;
-  TaskListItem: ComponentType<{checked: boolean; children: ReactNode}>;
-  Text: ComponentType<{children: string}>;
-  UnorderedList: ComponentType<{children: ReactNode}>;
+  InlineCode: ComponentType<WithDefault<{children: string}>>;
+  LineBreak: ComponentType<WithDefault<Record<PropertyKey, unknown>>>;
+  Link: ComponentType<
+    WithDefault<{children: ReactNode; href: string; title?: string | null}>
+  >;
+  ListItem: ComponentType<WithDefault<{children: ReactNode; checked?: boolean}>>;
+  OrderedList: ComponentType<WithDefault<{children: ReactNode}>>;
+  Paragraph: ComponentType<WithDefault<{children: ReactNode}>>;
+  Strikethrough: ComponentType<WithDefault<{children: ReactNode}>>;
+  Strong: ComponentType<WithDefault<{children: ReactNode}>>;
+  Table: ComponentType<WithDefault<{children: ReactNode}>>;
+  TableBody: ComponentType<WithDefault<{children: ReactNode}>>;
+  TableCell: ComponentType<WithDefault<{children: ReactNode; align?: string | null}>>;
+  TableHead: ComponentType<WithDefault<{children: ReactNode}>>;
+  TableHeaderCell: ComponentType<
+    WithDefault<{children: ReactNode; align?: string | null}>
+  >;
+  TableRow: ComponentType<WithDefault<{children: ReactNode}>>;
+  TaskList: ComponentType<WithDefault<{children: ReactNode}>>;
+  TaskListItem: ComponentType<WithDefault<{checked: boolean; children: ReactNode}>>;
+  Text: ComponentType<WithDefault<{children: string}>>;
+  UnorderedList: ComponentType<WithDefault<{children: ReactNode}>>;
 }>;
 
 interface MarkdownProps {

--- a/static/app/components/core/markdown/token.tsx
+++ b/static/app/components/core/markdown/token.tsx
@@ -1,4 +1,4 @@
-import type {ComponentType, ReactNode} from 'react';
+import type {ReactNode} from 'react';
 
 import {Checkbox} from '@sentry/scraps/checkbox';
 
@@ -170,12 +170,7 @@ export function Token({
               {token.header.map((cell, i) => (
                 <Th
                   key={i}
-                  Default={
-                    DefaultTableHeaderCell as ComponentType<{
-                      children: ReactNode;
-                      align?: string | null;
-                    }>
-                  }
+                  Default={DefaultTableHeaderCell}
                   align={token.align[i] ?? undefined}
                 >
                   {renderInline(cell.tokens, components)}
@@ -189,12 +184,7 @@ export function Token({
                 {row.map((cell, cellIndex) => (
                   <Td
                     key={cellIndex}
-                    Default={
-                      DefaultTableCell as ComponentType<{
-                        children: ReactNode;
-                        align?: string | null;
-                      }>
-                    }
+                    Default={DefaultTableCell}
                     align={token.align[cellIndex] ?? undefined}
                   >
                     {renderInline(cell.tokens, components)}

--- a/static/app/components/core/markdown/token.tsx
+++ b/static/app/components/core/markdown/token.tsx
@@ -1,4 +1,4 @@
-import type {ElementType, ReactNode} from 'react';
+import type {ComponentType, ReactNode} from 'react';
 
 import {Checkbox} from '@sentry/scraps/checkbox';
 
@@ -29,6 +29,7 @@ import {
   DefaultTableRow,
   DefaultTaskList,
   DefaultTaskListItem,
+  DefaultText,
   DefaultUnorderedList,
 } from './defaultComponents';
 import type {MarkdownComponents} from './markdown';
@@ -71,13 +72,13 @@ export function Token({
 
     case 'paragraph': {
       const P = components.Paragraph ?? DefaultParagraph;
-      return <P>{renderInline(token.tokens, components)}</P>;
+      return <P Default={DefaultParagraph}>{renderInline(token.tokens, components)}</P>;
     }
 
     case 'heading': {
       const H = components.Heading ?? DefaultHeading;
       return (
-        <H level={token.depth as 1 | 2 | 3 | 4 | 5 | 6}>
+        <H Default={DefaultHeading} level={token.depth as 1 | 2 | 3 | 4 | 5 | 6}>
           {renderInline(token.tokens, components)}
         </H>
       );
@@ -85,28 +86,52 @@ export function Token({
 
     case 'code': {
       const Code = components.CodeBlock ?? DefaultCodeBlock;
-      return <Code lang={token.lang ?? undefined}>{token.text}</Code>;
+      return (
+        <Code Default={DefaultCodeBlock} lang={token.lang ?? undefined}>
+          {token.text}
+        </Code>
+      );
     }
 
     case 'codespan': {
       const Code = components.InlineCode ?? DefaultInlineCode;
-      return <Code>{token.text}</Code>;
+      return <Code Default={DefaultInlineCode}>{token.text}</Code>;
     }
 
     case 'blockquote': {
       const Blockquote = components.Blockquote ?? DefaultBlockquote;
-      return <Blockquote>{renderInline(token.tokens, components)}</Blockquote>;
+      return (
+        <Blockquote Default={DefaultBlockquote}>
+          {renderInline(token.tokens, components)}
+        </Blockquote>
+      );
     }
 
     case 'list': {
       const isTaskList = token.items.some(item => item.task);
-      const List: ElementType = isTaskList
-        ? (components.TaskList ?? DefaultTaskList)
-        : token.ordered
-          ? (components.OrderedList ?? DefaultOrderedList)
-          : (components.UnorderedList ?? DefaultUnorderedList);
+      if (isTaskList) {
+        const List = components.TaskList ?? DefaultTaskList;
+        return (
+          <List Default={DefaultTaskList}>
+            {token.items.map((item, i) => (
+              <Token key={i} token={item} components={components} />
+            ))}
+          </List>
+        );
+      }
+      if (token.ordered) {
+        const List = components.OrderedList ?? DefaultOrderedList;
+        return (
+          <List Default={DefaultOrderedList}>
+            {token.items.map((item, i) => (
+              <Token key={i} token={item} components={components} />
+            ))}
+          </List>
+        );
+      }
+      const List = components.UnorderedList ?? DefaultUnorderedList;
       return (
-        <List>
+        <List Default={DefaultUnorderedList}>
           {token.items.map((item, i) => (
             <Token key={i} token={item} components={components} />
           ))}
@@ -118,13 +143,13 @@ export function Token({
       if (token.task) {
         const TaskLi = components.TaskListItem ?? DefaultTaskListItem;
         return (
-          <TaskLi checked={token.checked ?? false}>
+          <TaskLi Default={DefaultTaskListItem} checked={token.checked ?? false}>
             {renderInline(token.tokens, components)}
           </TaskLi>
         );
       }
       const Li = components.ListItem ?? DefaultListItem;
-      return <Li>{renderInline(token.tokens, components)}</Li>;
+      return <Li Default={DefaultListItem}>{renderInline(token.tokens, components)}</Li>;
     }
 
     case 'checkbox':
@@ -139,21 +164,39 @@ export function Token({
       const Td = components.TableCell ?? DefaultTableCell;
 
       return (
-        <TableComp>
-          <Thead>
-            <Tr>
+        <TableComp Default={DefaultTable}>
+          <Thead Default={DefaultTableHead}>
+            <Tr Default={DefaultTableRow}>
               {token.header.map((cell, i) => (
-                <Th key={i} align={token.align[i] ?? undefined}>
+                <Th
+                  key={i}
+                  Default={
+                    DefaultTableHeaderCell as ComponentType<{
+                      children: ReactNode;
+                      align?: string | null;
+                    }>
+                  }
+                  align={token.align[i] ?? undefined}
+                >
                   {renderInline(cell.tokens, components)}
                 </Th>
               ))}
             </Tr>
           </Thead>
-          <Tbody>
+          <Tbody Default={DefaultTableBody}>
             {token.rows.map((row, rowIndex) => (
-              <Tr key={rowIndex}>
+              <Tr key={rowIndex} Default={DefaultTableRow}>
                 {row.map((cell, cellIndex) => (
-                  <Td key={cellIndex} align={token.align[cellIndex] ?? undefined}>
+                  <Td
+                    key={cellIndex}
+                    Default={
+                      DefaultTableCell as ComponentType<{
+                        children: ReactNode;
+                        align?: string | null;
+                      }>
+                    }
+                    align={token.align[cellIndex] ?? undefined}
+                  >
                     {renderInline(cell.tokens, components)}
                   </Td>
                 ))}
@@ -166,27 +209,31 @@ export function Token({
 
     case 'hr': {
       const Hr = components.HorizontalRule ?? DefaultHorizontalRule;
-      return <Hr />;
+      return <Hr Default={DefaultHorizontalRule} />;
     }
 
     case 'html': {
       const Html = components.Html ?? DefaultHtmlBlock;
-      return <Html html={sanitizeHtml(token.text)} />;
+      return <Html Default={DefaultHtmlBlock} html={sanitizeHtml(token.text)} />;
     }
 
     case 'strong': {
       const Strong = components.Strong ?? DefaultStrong;
-      return <Strong>{renderInline(token.tokens, components)}</Strong>;
+      return (
+        <Strong Default={DefaultStrong}>{renderInline(token.tokens, components)}</Strong>
+      );
     }
 
     case 'em': {
       const Em = components.Emphasis ?? DefaultEmphasis;
-      return <Em>{renderInline(token.tokens, components)}</Em>;
+      return <Em Default={DefaultEmphasis}>{renderInline(token.tokens, components)}</Em>;
     }
 
     case 'del': {
       const Del = components.Strikethrough ?? DefaultStrikethrough;
-      return <Del>{renderInline(token.tokens, components)}</Del>;
+      return (
+        <Del Default={DefaultStrikethrough}>{renderInline(token.tokens, components)}</Del>
+      );
     }
 
     case 'link': {
@@ -195,7 +242,7 @@ export function Token({
       }
       const A = components.Link ?? DefaultLink;
       return (
-        <A href={token.href} title={token.title}>
+        <A Default={DefaultLink} href={token.href} title={token.title}>
           {renderInline(token.tokens, components)}
         </A>
       );
@@ -217,7 +264,7 @@ export function Token({
       }
       const TextComponent = components.Text;
       if (TextComponent) {
-        return <TextComponent>{token.text}</TextComponent>;
+        return <TextComponent Default={DefaultText}>{token.text}</TextComponent>;
       }
       return token.text;
     }
@@ -227,7 +274,7 @@ export function Token({
 
     case 'br': {
       const Br = components.LineBreak ?? DefaultLineBreak;
-      return <Br />;
+      return <Br Default={DefaultLineBreak} />;
     }
 
     case 'def':


### PR DESCRIPTION
Each `MarkdownComponents` override now receives a `Default` prop — a reference to the built-in component for that element. Consumers can conditionally customize rendering and fall through to the default without importing the internal `defaultComponents` module.

```tsx
<Markdown
  raw={content}
  components={{
    Heading: ({children, level, Default}) => {
      if (level > 3) return <strong>{children}</strong>;
      return <Default level={level}>{children}</Default>;
    },
  }}
/>
```

`Image` is excluded since it has no built-in default. Two styled table cell components (`DefaultTableHeaderCell`, `DefaultTableCell`) need a cast due to native HTML `align` attribute narrowing.