### PR TITLE
feat(webhooks): Wire new service with feature-flagged routing

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -3,6 +3,7 @@ from typing import override
 from sentry import features
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.sentry_apps.services.legacy_webhook.service import send_legacy_webhooks_for_invocation
+from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, ActionInvocation, ConfigTransformer
@@ -38,6 +39,9 @@ class WebhookActionHandler(ActionHandler):
     @staticmethod
     @override
     def execute(invocation: ActionInvocation) -> None:
+        if not isinstance(invocation.event_data.event, GroupEvent):
+            return
+
         organization = invocation.detector.project.organization
         new_path = features.has("organizations:legacy-webhook-new-path", organization)
         disable_old = features.has("organizations:legacy-webhook-disable-old-path", organization)

--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -1,6 +1,8 @@
 from typing import override
 
+from sentry import features
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
+from sentry.sentry_apps.services.legacy_webhook.service import send_legacy_webhooks_for_invocation
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, ActionInvocation, ConfigTransformer
@@ -36,4 +38,12 @@ class WebhookActionHandler(ActionHandler):
     @staticmethod
     @override
     def execute(invocation: ActionInvocation) -> None:
-        execute_via_group_type_registry(invocation)
+        organization = invocation.detector.project.organization
+        new_path = features.has("organizations:legacy-webhook-new-path", organization)
+        disable_old = features.has("organizations:legacy-webhook-disable-old-path", organization)
+
+        if new_path:
+            send_legacy_webhooks_for_invocation(invocation)
+
+        if not disable_old:
+            execute_via_group_type_registry(invocation)

--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -39,14 +39,11 @@ class WebhookActionHandler(ActionHandler):
     @staticmethod
     @override
     def execute(invocation: ActionInvocation) -> None:
-        if not isinstance(invocation.event_data.event, GroupEvent):
-            return
-
         organization = invocation.detector.project.organization
         new_path = features.has("organizations:legacy-webhook-new-path", organization)
         disable_old = features.has("organizations:legacy-webhook-disable-old-path", organization)
 
-        if new_path:
+        if new_path and isinstance(invocation.event_data.event, GroupEvent):
             send_legacy_webhooks_for_invocation(invocation)
 
         if not disable_old:

--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -1,3 +1,4 @@
+import logging
 from typing import override
 
 from sentry import features
@@ -7,6 +8,8 @@ from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, ActionInvocation, ConfigTransformer
+
+logger = logging.getLogger(__name__)
 
 
 @action_handler_registry.register(Action.Type.WEBHOOK)
@@ -43,8 +46,14 @@ class WebhookActionHandler(ActionHandler):
         new_path = features.has("organizations:legacy-webhook-new-path", organization)
         disable_old = features.has("organizations:legacy-webhook-disable-old-path", organization)
 
+        if not disable_old:
+            try:
+                execute_via_group_type_registry(invocation)
+            except Exception:
+                logger.exception(
+                    "webhook_action_handler.old_path_error",
+                    extra={"invocation": invocation},
+                )
+
         if new_path and isinstance(invocation.event_data.event, GroupEvent):
             send_legacy_webhooks_for_invocation(invocation)
-
-        if not disable_old:
-            execute_via_group_type_registry(invocation)

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/webhook_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/webhook_issue_alert_handler.py
@@ -1,11 +1,8 @@
 from typing import Any
 
-from sentry import features
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
-from sentry.sentry_apps.services.legacy_webhook.service import send_legacy_webhooks_for_invocation
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import ActionInvocation
 from sentry.workflow_engine.typings.notification_action import ActionFieldMapping
 
 
@@ -24,15 +21,3 @@ class WebhookIssueAlertHandler(BaseIssueAlertHandler):
         cls, organization_id: int, blob: dict[str, Any], integration_cache: Any = None
     ) -> str:
         return "Send a notification via webhooks"
-
-    @classmethod
-    def invoke_legacy_registry(cls, invocation: ActionInvocation) -> None:
-        organization = invocation.detector.project.organization
-        new_path = features.has("organizations:legacy-webhook-new-path", organization)
-        disable_old = features.has("organizations:legacy-webhook-disable-old-path", organization)
-
-        if new_path:
-            send_legacy_webhooks_for_invocation(invocation)
-
-        if not disable_old:
-            super().invoke_legacy_registry(invocation)

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/webhook_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/webhook_issue_alert_handler.py
@@ -1,8 +1,11 @@
 from typing import Any
 
+from sentry import features
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
+from sentry.sentry_apps.services.legacy_webhook.service import send_legacy_webhooks_for_project
 from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionInvocation
 from sentry.workflow_engine.typings.notification_action import ActionFieldMapping
 
 
@@ -21,3 +24,24 @@ class WebhookIssueAlertHandler(BaseIssueAlertHandler):
         cls, organization_id: int, blob: dict[str, Any], integration_cache: Any = None
     ) -> str:
         return "Send a notification via webhooks"
+
+    @classmethod
+    def invoke_legacy_registry(cls, invocation: ActionInvocation) -> None:
+        organization = invocation.detector.project.organization
+        new_path = features.has("organizations:legacy-webhook-new-path", organization)
+        disable_old = features.has("organizations:legacy-webhook-disable-old-path", organization)
+
+        if new_path:
+            project = invocation.detector.project
+            group = invocation.event_data.group
+            event = invocation.event_data.event
+            rule = cls.create_rule_instance_from_action(
+                invocation.action,
+                invocation.detector,
+                invocation.event_data,
+                invocation.workflow_id,
+            )
+            send_legacy_webhooks_for_project(project, group, event, [rule.label])
+
+        if not (new_path and disable_old):
+            super().invoke_legacy_registry(invocation)

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/webhook_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/webhook_issue_alert_handler.py
@@ -3,7 +3,7 @@ from typing import Any
 from sentry import features
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
-from sentry.sentry_apps.services.legacy_webhook.service import send_legacy_webhooks_for_project
+from sentry.sentry_apps.services.legacy_webhook.service import send_legacy_webhooks_for_invocation
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import ActionInvocation
 from sentry.workflow_engine.typings.notification_action import ActionFieldMapping
@@ -32,16 +32,7 @@ class WebhookIssueAlertHandler(BaseIssueAlertHandler):
         disable_old = features.has("organizations:legacy-webhook-disable-old-path", organization)
 
         if new_path:
-            project = invocation.detector.project
-            group = invocation.event_data.group
-            event = invocation.event_data.event
-            rule = cls.create_rule_instance_from_action(
-                invocation.action,
-                invocation.detector,
-                invocation.event_data,
-                invocation.workflow_id,
-            )
-            send_legacy_webhooks_for_project(project, group, event, [rule.label])
+            send_legacy_webhooks_for_invocation(invocation)
 
-        if not (new_path and disable_old):
+        if not disable_old:
             super().invoke_legacy_registry(invocation)

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -5,7 +5,8 @@ from typing import Any, TypedDict
 
 from sentry.eventstore.models import GroupEvent
 from sentry.models.options.project_option import ProjectOption
-from sentry.workflow_engine.models import Workflow
+from sentry.models.rule import Rule
+from sentry.workflow_engine.models import AlertRuleWorkflow, Workflow
 from sentry.workflow_engine.types import ActionInvocation
 
 logger = logging.getLogger("sentry.legacy_webhook")
@@ -34,9 +35,24 @@ def split_urls(value: str) -> list[str]:
 def _get_triggering_rule_name(invocation: ActionInvocation) -> str:
     try:
         workflow = Workflow.objects.get(id=invocation.workflow_id)
-        return workflow.name
+        label = workflow.name
     except Workflow.DoesNotExist:
         return invocation.detector.name
+
+    alert_rule_workflow = AlertRuleWorkflow.objects.filter(
+        workflow_id=workflow.id,
+        rule_id__isnull=False,
+    ).first()
+    if alert_rule_workflow:
+        try:
+            label = Rule.objects.get(id=alert_rule_workflow.rule_id).label
+        except Rule.DoesNotExist:
+            logger.exception(
+                "Rule not found when querying for AlertRuleWorkflow",
+                extra={"rule_id": alert_rule_workflow.rule_id},
+            )
+
+    return label
 
 
 def build_legacy_webhook_payload(invocation: ActionInvocation) -> LegacyWebhookPayload:

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, TypedDict
 
+from sentry.eventstore.models import GroupEvent
 from sentry.models.options.project_option import ProjectOption
 from sentry.workflow_engine.models import Workflow
 from sentry.workflow_engine.types import ActionInvocation
@@ -41,6 +42,8 @@ def _get_triggering_rule_name(invocation: ActionInvocation) -> str:
 def build_legacy_webhook_payload(invocation: ActionInvocation) -> LegacyWebhookPayload:
     group = invocation.event_data.group
     event = invocation.event_data.event
+    if not isinstance(event, GroupEvent):
+        raise TypeError(f"Legacy webhook payload requires a GroupEvent, got {type(event).__name__}")
     triggering_rules = [_get_triggering_rule_name(invocation)]
     event_data = dict(event.data or {})
     data: LegacyWebhookPayload = {

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import logging
 from typing import Any, TypedDict
 
-from sentry.models.group import Group
 from sentry.models.options.project_option import ProjectOption
-from sentry.models.project import Project
-from sentry.services.eventstore.models import Event, GroupEvent
+from sentry.workflow_engine.models import Workflow
+from sentry.workflow_engine.types import ActionInvocation
 
 logger = logging.getLogger("sentry.legacy_webhook")
 
@@ -31,9 +30,18 @@ def split_urls(value: str) -> list[str]:
     return list(filter(bool, (url.strip() for url in value.splitlines())))
 
 
-def build_legacy_webhook_payload(
-    group: Group, event: GroupEvent | Event, triggering_rules: list[str]
-) -> LegacyWebhookPayload:
+def _get_triggering_rule_name(invocation: ActionInvocation) -> str:
+    try:
+        workflow = Workflow.objects.get(id=invocation.workflow_id)
+        return workflow.name
+    except Workflow.DoesNotExist:
+        return invocation.detector.name
+
+
+def build_legacy_webhook_payload(invocation: ActionInvocation) -> LegacyWebhookPayload:
+    group = invocation.event_data.group
+    event = invocation.event_data.event
+    triggering_rules = [_get_triggering_rule_name(invocation)]
     event_data = dict(event.data or {})
     data: LegacyWebhookPayload = {
         "id": str(group.id),
@@ -45,7 +53,7 @@ def build_legacy_webhook_payload(
         "culprit": group.culprit,
         "message": event.message,
         "url": group.get_absolute_url(params={"referrer": "webhooks_plugin"}),
-        "triggering_rules": list(triggering_rules),
+        "triggering_rules": triggering_rules,
         "event": {
             **event_data,
             "tags": event.tags,
@@ -56,20 +64,16 @@ def build_legacy_webhook_payload(
     return data
 
 
-def send_legacy_webhooks_for_project(
-    project: Project,
-    group: Group,
-    event: GroupEvent | Event,
-    triggering_rules: list[str],
-) -> None:
+def send_legacy_webhooks_for_invocation(invocation: ActionInvocation) -> None:
     # Delayed import to avoid circular dependency (tasks imports LegacyWebhookPayload from here)
     from sentry.sentry_apps.services.legacy_webhook.tasks import send_legacy_webhook_task
 
+    project = invocation.detector.project
     urls_raw = ProjectOption.objects.get_value(project, "webhooks:urls", default="")
     urls = split_urls(urls_raw)
     if not urls:
         return
 
-    payload = build_legacy_webhook_payload(group, event, triggering_rules)
+    payload = build_legacy_webhook_payload(invocation)
     for url in urls:
         send_legacy_webhook_task.delay(url=url, payload=payload)

--- a/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
+++ b/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
@@ -1,0 +1,106 @@
+import uuid
+from unittest import mock
+
+import responses
+
+from sentry.models.options.project_option import ProjectOption
+from sentry.notifications.notification_action.action_handler_registry.webhook_handler import (
+    WebhookActionHandler,
+)
+from sentry.plugins.base import plugins
+from sentry.utils import json
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+
+class TestWebhookActionHandlerExecute(BaseWorkflowTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.detector = self.create_detector(project=self.project)
+        self.workflow = self.create_workflow(environment=self.environment)
+        self.action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={"target_identifier": "webhooks"},
+        )
+        self.group, self.event, self.group_event = self.create_group_event()
+        self.event_data = WorkflowEventData(
+            event=self.group_event, workflow_env=self.environment, group=self.group
+        )
+        self.invocation = ActionInvocation(
+            event_data=self.event_data,
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
+        )
+        ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://example.com/hook")
+        webhook_plugin = plugins.get("webhooks")
+        webhook_plugin.set_option("enabled", True, self.project)
+
+    @responses.activate
+    def test_default_no_flags_fires_old_path_only(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        with self.tasks():
+            WebhookActionHandler.execute(self.invocation)
+
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_new_path_fires_both_paths(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        with self.tasks(), self.feature("organizations:legacy-webhook-new-path"):
+            WebhookActionHandler.execute(self.invocation)
+
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_new_path_disable_old_fires_new_only(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        with (
+            self.tasks(),
+            self.feature(
+                {
+                    "organizations:legacy-webhook-new-path": True,
+                    "organizations:legacy-webhook-disable-old-path": True,
+                }
+            ),
+        ):
+            WebhookActionHandler.execute(self.invocation)
+
+        assert len(responses.calls) == 1
+        body = json.loads(responses.calls[0].request.body)
+        assert body["id"] == str(self.group.id)
+
+    @responses.activate
+    @mock.patch("sentry.sentry_apps.services.legacy_webhook.tasks.logger")
+    def test_new_path_dry_run_logs_instead_of_sending(self, mock_logger: mock.MagicMock) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        with (
+            self.tasks(),
+            self.feature(
+                {
+                    "organizations:legacy-webhook-new-path": True,
+                    "organizations:legacy-webhook-disable-old-path": True,
+                    "organizations:legacy-webhook-dry-run": True,
+                }
+            ),
+        ):
+            WebhookActionHandler.execute(self.invocation)
+
+        assert len(responses.calls) == 0
+        mock_logger.info.assert_called_once()
+        assert mock_logger.info.call_args[0][0] == "legacy_webhook.dry_run"
+
+    @responses.activate
+    def test_disable_old_without_new_path_fires_nothing(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        with self.tasks(), self.feature("organizations:legacy-webhook-disable-old-path"):
+            WebhookActionHandler.execute(self.invocation)
+
+        assert len(responses.calls) == 0

--- a/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
+++ b/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
@@ -107,14 +107,13 @@ class TestWebhookActionHandlerExecute(BaseWorkflowTest):
 
         assert len(responses.calls) == 0
 
-    @responses.activate
     @mock.patch(
         "sentry.notifications.notification_action.action_handler_registry.webhook_handler.send_legacy_webhooks_for_invocation"
     )
     @mock.patch(
         "sentry.notifications.notification_action.action_handler_registry.webhook_handler.execute_via_group_type_registry"
     )
-    def test_non_group_event_skips_both_paths(
+    def test_non_group_event_skips_new_path_but_old_path_still_runs(
         self, mock_old_path: mock.MagicMock, mock_new_path: mock.MagicMock
     ) -> None:
         activity = Activity.objects.create(
@@ -136,4 +135,4 @@ class TestWebhookActionHandlerExecute(BaseWorkflowTest):
             WebhookActionHandler.execute(invocation)
 
         mock_new_path.assert_not_called()
-        mock_old_path.assert_not_called()
+        mock_old_path.assert_called_once_with(invocation)

--- a/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
+++ b/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
@@ -136,3 +136,21 @@ class TestWebhookActionHandlerExecute(BaseWorkflowTest):
 
         mock_new_path.assert_not_called()
         mock_old_path.assert_called_once_with(invocation)
+
+    @responses.activate
+    @mock.patch(
+        "sentry.notifications.notification_action.action_handler_registry.webhook_handler.execute_via_group_type_registry",
+        side_effect=Exception("legacy path error"),
+    )
+    def test_old_path_exception_does_not_block_new_path(
+        self, mock_old_path: mock.MagicMock
+    ) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        with self.tasks(), self.feature("organizations:legacy-webhook-new-path"):
+            WebhookActionHandler.execute(self.invocation)
+
+        mock_old_path.assert_called_once()
+        assert len(responses.calls) == 1
+        body = json.loads(responses.calls[0].request.body)
+        assert body["id"] == str(self.group.id)

--- a/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
+++ b/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
@@ -3,11 +3,13 @@ from unittest import mock
 
 import responses
 
+from sentry.models.activity import Activity
 from sentry.models.options.project_option import ProjectOption
 from sentry.notifications.notification_action.action_handler_registry.webhook_handler import (
     WebhookActionHandler,
 )
 from sentry.plugins.base import plugins
+from sentry.types.activity import ActivityType
 from sentry.utils import json
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
@@ -104,3 +106,34 @@ class TestWebhookActionHandlerExecute(BaseWorkflowTest):
             WebhookActionHandler.execute(self.invocation)
 
         assert len(responses.calls) == 0
+
+    @responses.activate
+    @mock.patch(
+        "sentry.notifications.notification_action.action_handler_registry.webhook_handler.send_legacy_webhooks_for_invocation"
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.action_handler_registry.webhook_handler.execute_via_group_type_registry"
+    )
+    def test_non_group_event_skips_both_paths(
+        self, mock_old_path: mock.MagicMock, mock_new_path: mock.MagicMock
+    ) -> None:
+        activity = Activity.objects.create(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+        )
+        invocation = ActionInvocation(
+            event_data=WorkflowEventData(
+                event=activity, workflow_env=self.environment, group=self.group
+            ),
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
+        )
+
+        with self.feature("organizations:legacy-webhook-new-path"):
+            WebhookActionHandler.execute(invocation)
+
+        mock_new_path.assert_not_called()
+        mock_old_path.assert_not_called()

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -667,6 +667,79 @@ class TestWebhookIssueAlertHandler(BaseWorkflowTest):
             assert blob == expected
 
 
+class TestWebhookIssueAlertHandlerInvokeLegacyRegistry(BaseWorkflowTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.handler = WebhookIssueAlertHandler()
+        self.detector = self.create_detector(project=self.project)
+        self.workflow = self.create_workflow(environment=self.environment)
+        self.action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={"target_identifier": "http://example.com/hook"},
+        )
+        self.group, self.event, self.group_event = self.create_group_event()
+        self.event_data = WorkflowEventData(
+            event=self.group_event, workflow_env=self.environment, group=self.group
+        )
+        self.invocation = ActionInvocation(
+            event_data=self.event_data,
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
+        )
+
+    @mock.patch(
+        "sentry.notifications.notification_action.issue_alert_registry.handlers.webhook_issue_alert_handler.send_legacy_webhooks_for_project"
+    )
+    def test_default_no_flags_fires_old_path_only(self, mock_send: mock.MagicMock) -> None:
+        with mock.patch.object(BaseIssueAlertHandler, "invoke_legacy_registry") as mock_old_path:
+            self.handler.invoke_legacy_registry(self.invocation)
+            mock_old_path.assert_called_once_with(self.invocation)
+        mock_send.assert_not_called()
+
+    @mock.patch(
+        "sentry.notifications.notification_action.issue_alert_registry.handlers.webhook_issue_alert_handler.send_legacy_webhooks_for_project"
+    )
+    def test_new_path_fires_both_paths(self, mock_send: mock.MagicMock) -> None:
+        with (
+            self.feature("organizations:legacy-webhook-new-path"),
+            mock.patch.object(BaseIssueAlertHandler, "invoke_legacy_registry") as mock_old_path,
+        ):
+            self.handler.invoke_legacy_registry(self.invocation)
+            mock_old_path.assert_called_once_with(self.invocation)
+        mock_send.assert_called_once()
+
+    @mock.patch(
+        "sentry.notifications.notification_action.issue_alert_registry.handlers.webhook_issue_alert_handler.send_legacy_webhooks_for_project"
+    )
+    def test_new_path_disable_old_fires_new_only(self, mock_send: mock.MagicMock) -> None:
+        with (
+            self.feature(
+                {
+                    "organizations:legacy-webhook-new-path": True,
+                    "organizations:legacy-webhook-disable-old-path": True,
+                }
+            ),
+            mock.patch.object(BaseIssueAlertHandler, "invoke_legacy_registry") as mock_old_path,
+        ):
+            self.handler.invoke_legacy_registry(self.invocation)
+            mock_old_path.assert_not_called()
+        mock_send.assert_called_once()
+
+    @mock.patch(
+        "sentry.notifications.notification_action.issue_alert_registry.handlers.webhook_issue_alert_handler.send_legacy_webhooks_for_project"
+    )
+    def test_guard_disable_old_without_new_path_fires_old(self, mock_send: mock.MagicMock) -> None:
+        with (
+            self.feature("organizations:legacy-webhook-disable-old-path"),
+            mock.patch.object(BaseIssueAlertHandler, "invoke_legacy_registry") as mock_old_path,
+        ):
+            self.handler.invoke_legacy_registry(self.invocation)
+            mock_old_path.assert_called_once_with(self.invocation)
+        mock_send.assert_not_called()
+
+
 class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -2,10 +2,15 @@ import uuid
 from unittest import mock
 
 import pytest
+import responses
 
 from sentry.constants import ObjectStatus
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.rule import Rule, RuleSource
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.notifications.notification_action.group_type_notification_registry.handlers.issue_alert_registry_handler import (
+    IssueAlertRegistryHandler,
+)
 from sentry.notifications.notification_action.issue_alert_registry import (
     AzureDevopsIssueAlertHandler,
     DiscordIssueAlertHandler,
@@ -26,6 +31,7 @@ from sentry.notifications.notification_action.types import (
     TicketingIssueAlertHandler,
 )
 from sentry.notifications.types import TEST_NOTIFICATION_ID, ActionTargetType, FallthroughChoiceType
+from sentry.plugins.base import plugins
 from sentry.testutils.helpers.data_blobs import (
     AZURE_DEVOPS_ACTION_DATA_BLOBS,
     EMAIL_ACTION_DATA_BLOBS,
@@ -34,6 +40,7 @@ from sentry.testutils.helpers.data_blobs import (
     JIRA_SERVER_ACTION_DATA_BLOBS,
     WEBHOOK_ACTION_DATA_BLOBS,
 )
+from sentry.utils import json
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
 from sentry.workflow_engine.typings.notification_action import (
@@ -670,12 +677,11 @@ class TestWebhookIssueAlertHandler(BaseWorkflowTest):
 class TestWebhookIssueAlertHandlerInvokeLegacyRegistry(BaseWorkflowTest):
     def setUp(self) -> None:
         super().setUp()
-        self.handler = WebhookIssueAlertHandler()
         self.detector = self.create_detector(project=self.project)
         self.workflow = self.create_workflow(environment=self.environment)
         self.action = self.create_action(
             type=Action.Type.WEBHOOK,
-            config={"target_identifier": "http://example.com/hook"},
+            config={"target_identifier": "webhooks"},
         )
         self.group, self.event, self.group_event = self.create_group_event()
         self.event_data = WorkflowEventData(
@@ -688,56 +694,76 @@ class TestWebhookIssueAlertHandlerInvokeLegacyRegistry(BaseWorkflowTest):
             notification_uuid=str(uuid.uuid4()),
             workflow_id=self.workflow.id,
         )
+        ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://example.com/hook")
+        webhook_plugin = plugins.get("webhooks")
+        webhook_plugin.set_option("enabled", True, self.project)
 
-    @mock.patch(
-        "sentry.notifications.notification_action.issue_alert_registry.handlers.webhook_issue_alert_handler.send_legacy_webhooks_for_project"
-    )
-    def test_default_no_flags_fires_old_path_only(self, mock_send: mock.MagicMock) -> None:
-        with mock.patch.object(BaseIssueAlertHandler, "invoke_legacy_registry") as mock_old_path:
-            self.handler.invoke_legacy_registry(self.invocation)
-            mock_old_path.assert_called_once_with(self.invocation)
-        mock_send.assert_not_called()
+    @responses.activate
+    def test_default_no_flags_fires_old_path_only(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
 
-    @mock.patch(
-        "sentry.notifications.notification_action.issue_alert_registry.handlers.webhook_issue_alert_handler.send_legacy_webhooks_for_project"
-    )
-    def test_new_path_fires_both_paths(self, mock_send: mock.MagicMock) -> None:
+        with self.tasks():
+            IssueAlertRegistryHandler.handle_workflow_action(self.invocation)
+
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_new_path_fires_both_paths(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        with self.tasks(), self.feature("organizations:legacy-webhook-new-path"):
+            IssueAlertRegistryHandler.handle_workflow_action(self.invocation)
+
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_new_path_disable_old_fires_new_only(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
         with (
-            self.feature("organizations:legacy-webhook-new-path"),
-            mock.patch.object(BaseIssueAlertHandler, "invoke_legacy_registry") as mock_old_path,
-        ):
-            self.handler.invoke_legacy_registry(self.invocation)
-            mock_old_path.assert_called_once_with(self.invocation)
-        mock_send.assert_called_once()
-
-    @mock.patch(
-        "sentry.notifications.notification_action.issue_alert_registry.handlers.webhook_issue_alert_handler.send_legacy_webhooks_for_project"
-    )
-    def test_new_path_disable_old_fires_new_only(self, mock_send: mock.MagicMock) -> None:
-        with (
+            self.tasks(),
             self.feature(
                 {
                     "organizations:legacy-webhook-new-path": True,
                     "organizations:legacy-webhook-disable-old-path": True,
                 }
             ),
-            mock.patch.object(BaseIssueAlertHandler, "invoke_legacy_registry") as mock_old_path,
         ):
-            self.handler.invoke_legacy_registry(self.invocation)
-            mock_old_path.assert_not_called()
-        mock_send.assert_called_once()
+            IssueAlertRegistryHandler.handle_workflow_action(self.invocation)
 
-    @mock.patch(
-        "sentry.notifications.notification_action.issue_alert_registry.handlers.webhook_issue_alert_handler.send_legacy_webhooks_for_project"
-    )
-    def test_guard_disable_old_without_new_path_fires_old(self, mock_send: mock.MagicMock) -> None:
+        assert len(responses.calls) == 1
+        body = json.loads(responses.calls[0].request.body)
+        assert body["id"] == str(self.group.id)
+
+    @responses.activate
+    @mock.patch("sentry.sentry_apps.services.legacy_webhook.tasks.logger")
+    def test_new_path_dry_run_logs_instead_of_sending(self, mock_logger: mock.MagicMock) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
         with (
-            self.feature("organizations:legacy-webhook-disable-old-path"),
-            mock.patch.object(BaseIssueAlertHandler, "invoke_legacy_registry") as mock_old_path,
+            self.tasks(),
+            self.feature(
+                {
+                    "organizations:legacy-webhook-new-path": True,
+                    "organizations:legacy-webhook-disable-old-path": True,
+                    "organizations:legacy-webhook-dry-run": True,
+                }
+            ),
         ):
-            self.handler.invoke_legacy_registry(self.invocation)
-            mock_old_path.assert_called_once_with(self.invocation)
-        mock_send.assert_not_called()
+            IssueAlertRegistryHandler.handle_workflow_action(self.invocation)
+
+        assert len(responses.calls) == 0
+        mock_logger.info.assert_called_once()
+        assert mock_logger.info.call_args[0][0] == "legacy_webhook.dry_run"
+
+    @responses.activate
+    def test_disable_old_without_new_path_fires_nothing(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+
+        with self.tasks(), self.feature("organizations:legacy-webhook-disable-old-path"):
+            IssueAlertRegistryHandler.handle_workflow_action(self.invocation)
+
+        assert len(responses.calls) == 0
 
 
 class TestSentryAppIssueAlertHandler(BaseWorkflowTest):

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -2,15 +2,10 @@ import uuid
 from unittest import mock
 
 import pytest
-import responses
 
 from sentry.constants import ObjectStatus
-from sentry.models.options.project_option import ProjectOption
 from sentry.models.rule import Rule, RuleSource
 from sentry.notifications.models.notificationaction import ActionTarget
-from sentry.notifications.notification_action.group_type_notification_registry.handlers.issue_alert_registry_handler import (
-    IssueAlertRegistryHandler,
-)
 from sentry.notifications.notification_action.issue_alert_registry import (
     AzureDevopsIssueAlertHandler,
     DiscordIssueAlertHandler,
@@ -31,7 +26,6 @@ from sentry.notifications.notification_action.types import (
     TicketingIssueAlertHandler,
 )
 from sentry.notifications.types import TEST_NOTIFICATION_ID, ActionTargetType, FallthroughChoiceType
-from sentry.plugins.base import plugins
 from sentry.testutils.helpers.data_blobs import (
     AZURE_DEVOPS_ACTION_DATA_BLOBS,
     EMAIL_ACTION_DATA_BLOBS,
@@ -40,7 +34,6 @@ from sentry.testutils.helpers.data_blobs import (
     JIRA_SERVER_ACTION_DATA_BLOBS,
     WEBHOOK_ACTION_DATA_BLOBS,
 )
-from sentry.utils import json
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
 from sentry.workflow_engine.typings.notification_action import (
@@ -672,98 +665,6 @@ class TestWebhookIssueAlertHandler(BaseWorkflowTest):
             blob = self.handler.build_rule_action_blob(action, self.organization.id)
 
             assert blob == expected
-
-
-class TestWebhookIssueAlertHandlerInvokeLegacyRegistry(BaseWorkflowTest):
-    def setUp(self) -> None:
-        super().setUp()
-        self.detector = self.create_detector(project=self.project)
-        self.workflow = self.create_workflow(environment=self.environment)
-        self.action = self.create_action(
-            type=Action.Type.WEBHOOK,
-            config={"target_identifier": "webhooks"},
-        )
-        self.group, self.event, self.group_event = self.create_group_event()
-        self.event_data = WorkflowEventData(
-            event=self.group_event, workflow_env=self.environment, group=self.group
-        )
-        self.invocation = ActionInvocation(
-            event_data=self.event_data,
-            action=self.action,
-            detector=self.detector,
-            notification_uuid=str(uuid.uuid4()),
-            workflow_id=self.workflow.id,
-        )
-        ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://example.com/hook")
-        webhook_plugin = plugins.get("webhooks")
-        webhook_plugin.set_option("enabled", True, self.project)
-
-    @responses.activate
-    def test_default_no_flags_fires_old_path_only(self) -> None:
-        responses.add(responses.POST, "http://example.com/hook")
-
-        with self.tasks():
-            IssueAlertRegistryHandler.handle_workflow_action(self.invocation)
-
-        assert len(responses.calls) == 1
-
-    @responses.activate
-    def test_new_path_fires_both_paths(self) -> None:
-        responses.add(responses.POST, "http://example.com/hook")
-
-        with self.tasks(), self.feature("organizations:legacy-webhook-new-path"):
-            IssueAlertRegistryHandler.handle_workflow_action(self.invocation)
-
-        assert len(responses.calls) == 2
-
-    @responses.activate
-    def test_new_path_disable_old_fires_new_only(self) -> None:
-        responses.add(responses.POST, "http://example.com/hook")
-
-        with (
-            self.tasks(),
-            self.feature(
-                {
-                    "organizations:legacy-webhook-new-path": True,
-                    "organizations:legacy-webhook-disable-old-path": True,
-                }
-            ),
-        ):
-            IssueAlertRegistryHandler.handle_workflow_action(self.invocation)
-
-        assert len(responses.calls) == 1
-        body = json.loads(responses.calls[0].request.body)
-        assert body["id"] == str(self.group.id)
-
-    @responses.activate
-    @mock.patch("sentry.sentry_apps.services.legacy_webhook.tasks.logger")
-    def test_new_path_dry_run_logs_instead_of_sending(self, mock_logger: mock.MagicMock) -> None:
-        responses.add(responses.POST, "http://example.com/hook")
-
-        with (
-            self.tasks(),
-            self.feature(
-                {
-                    "organizations:legacy-webhook-new-path": True,
-                    "organizations:legacy-webhook-disable-old-path": True,
-                    "organizations:legacy-webhook-dry-run": True,
-                }
-            ),
-        ):
-            IssueAlertRegistryHandler.handle_workflow_action(self.invocation)
-
-        assert len(responses.calls) == 0
-        mock_logger.info.assert_called_once()
-        assert mock_logger.info.call_args[0][0] == "legacy_webhook.dry_run"
-
-    @responses.activate
-    def test_disable_old_without_new_path_fires_nothing(self) -> None:
-        responses.add(responses.POST, "http://example.com/hook")
-
-        with self.tasks(), self.feature("organizations:legacy-webhook-disable-old-path"):
-            IssueAlertRegistryHandler.handle_workflow_action(self.invocation)
-
-        assert len(responses.calls) == 0
 
 
 class TestSentryAppIssueAlertHandler(BaseWorkflowTest):

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_client.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_client.py
@@ -1,20 +1,42 @@
+import uuid
+
 import responses
 
 from sentry.sentry_apps.services.legacy_webhook.client import LegacyWebhookClient
 from sentry.sentry_apps.services.legacy_webhook.service import build_legacy_webhook_payload
-from sentry.testutils.cases import TestCase
 from sentry.utils import json
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
-class TestLegacyWebhookClient(TestCase):
+class TestLegacyWebhookClient(BaseWorkflowTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.detector = self.create_detector(project=self.project)
+        self.workflow = self.create_workflow(environment=self.environment)
+        self.action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={"target_identifier": "webhooks"},
+        )
+        self.group, self.event, self.group_event = self.create_group_event()
+        self.event_data = WorkflowEventData(
+            event=self.group_event, workflow_env=self.environment, group=self.group
+        )
+        self.invocation = ActionInvocation(
+            event_data=self.event_data,
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
+        )
+        self.payload = build_legacy_webhook_payload(self.invocation)
+
     @responses.activate
     def test_posts_json_payload(self) -> None:
         responses.add(responses.POST, "http://example.com/hook")
 
-        payload = build_legacy_webhook_payload(
-            group=self.group, event=self.event, triggering_rules=["test-rule"]
-        )
-        client = LegacyWebhookClient(payload)
+        client = LegacyWebhookClient(self.payload)
         client.request("http://example.com/hook")
 
         assert len(responses.calls) == 1
@@ -22,16 +44,13 @@ class TestLegacyWebhookClient(TestCase):
         assert request.method == "POST"
         body = json.loads(request.body)
         assert body["id"] == str(self.group.id)
-        assert body["message"] == self.event.message
+        assert body["message"] == self.group_event.message
 
     @responses.activate
     def test_no_redirects(self) -> None:
         responses.add(responses.POST, "http://example.com/hook", status=301)
 
-        payload = build_legacy_webhook_payload(
-            group=self.group, event=self.event, triggering_rules=["test-rule"]
-        )
-        client = LegacyWebhookClient(payload)
+        client = LegacyWebhookClient(self.payload)
         client.request("http://example.com/hook")
 
         assert len(responses.calls) == 1
@@ -45,10 +64,7 @@ class TestLegacyWebhookClient(TestCase):
             body=ConnectionError("connection refused"),
         )
 
-        payload = build_legacy_webhook_payload(
-            group=self.group, event=self.event, triggering_rules=["test-rule"]
-        )
-        client = LegacyWebhookClient(payload)
+        client = LegacyWebhookClient(self.payload)
         try:
             client.request("http://example.com/hook")
         except Exception:

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
@@ -117,3 +117,19 @@ class TestSendLegacyWebhooksForInvocation(BaseWorkflowTest):
 
         payload = mock_task.delay.call_args.kwargs["payload"]
         assert payload["triggering_rules"] == [self.workflow.name]
+
+    @mock.patch(
+        "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
+    )
+    def test_triggering_rules_prefers_legacy_rule_label(self, mock_task: mock.MagicMock) -> None:
+        rule = self.create_project_rule(project=self.project)
+        rule.label = "My Custom Rule Name"
+        rule.save()
+        self.create_alert_rule_workflow(rule_id=rule.id, workflow=self.workflow)
+
+        ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://a.com")
+
+        send_legacy_webhooks_for_invocation(self.invocation)
+
+        payload = mock_task.delay.call_args.kwargs["payload"]
+        assert payload["triggering_rules"] == ["My Custom Rule Name"]

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
@@ -1,13 +1,17 @@
+import uuid
 from unittest import mock
 
 from sentry.models.options.project_option import ProjectOption
 from sentry.sentry_apps.services.legacy_webhook.service import (
     build_legacy_webhook_payload,
-    send_legacy_webhooks_for_project,
+    send_legacy_webhooks_for_invocation,
     split_urls,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 pytestmark = [requires_snuba]
 
@@ -29,42 +33,67 @@ class TestSplitUrls(TestCase):
         assert split_urls("http://a.com\n\nhttp://b.com\n") == ["http://a.com", "http://b.com"]
 
 
-class TestBuildLegacyWebhookPayload(TestCase):
+class TestBuildLegacyWebhookPayload(BaseWorkflowTest):
     def test_build_payload_matches_legacy_plugin(self) -> None:
-        event = self.store_event(
-            data={"message": "Hello world", "level": "warning"}, project_id=self.project.id
+        detector = self.create_detector(project=self.project)
+        workflow = self.create_workflow(environment=self.environment)
+        action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={"target_identifier": "webhooks"},
         )
-        group = event.group
-        assert group is not None
+        group, event, group_event = self.create_group_event()
+        event_data = WorkflowEventData(
+            event=group_event, workflow_env=self.environment, group=group
+        )
+        invocation = ActionInvocation(
+            event_data=event_data,
+            action=action,
+            detector=detector,
+            notification_uuid=str(uuid.uuid4()),
+            workflow_id=workflow.id,
+        )
 
-        payload = build_legacy_webhook_payload(group, event, ["my rule"])
+        payload = build_legacy_webhook_payload(invocation)
 
         assert payload["id"] == str(group.id)
         assert payload["project"] == self.project.slug
         assert payload["project_name"] == self.project.name
         assert payload["project_slug"] == self.project.slug
-        assert payload["level"] == "warning"
-        assert payload["message"] == "Hello world"
-        assert payload["triggering_rules"] == ["my rule"]
-        assert payload["event"]["event_id"] == event.event_id
-        assert payload["event"]["id"] == event.event_id
+        assert payload["message"] == group_event.message
+        assert payload["triggering_rules"] == [workflow.name]
+        assert payload["event"]["event_id"] == group_event.event_id
+        assert payload["event"]["id"] == group_event.event_id
         assert "tags" in payload["event"]
 
 
-class TestSendLegacyWebhooksForProject(TestCase):
+class TestSendLegacyWebhooksForInvocation(BaseWorkflowTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.detector = self.create_detector(project=self.project)
+        self.workflow = self.create_workflow(environment=self.environment)
+        self.action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={"target_identifier": "webhooks"},
+        )
+        self.group, self.event, self.group_event = self.create_group_event()
+        self.event_data = WorkflowEventData(
+            event=self.group_event, workflow_env=self.environment, group=self.group
+        )
+        self.invocation = ActionInvocation(
+            event_data=self.event_data,
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
+        )
+
     @mock.patch(
         "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
     )
     def test_dispatches_task_per_url(self, mock_task: mock.MagicMock) -> None:
-        event = self.store_event(
-            data={"message": "test", "level": "error"}, project_id=self.project.id
-        )
-        group = event.group
-        assert group is not None
-
         ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://a.com\nhttp://b.com")
 
-        send_legacy_webhooks_for_project(self.project, group, event, ["rule1"])
+        send_legacy_webhooks_for_invocation(self.invocation)
 
         assert mock_task.delay.call_count == 2
         urls_called = {call.kwargs["url"] for call in mock_task.delay.call_args_list}
@@ -74,12 +103,17 @@ class TestSendLegacyWebhooksForProject(TestCase):
         "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
     )
     def test_no_urls_configured_is_noop(self, mock_task: mock.MagicMock) -> None:
-        event = self.store_event(
-            data={"message": "test", "level": "error"}, project_id=self.project.id
-        )
-        group = event.group
-        assert group is not None
-
-        send_legacy_webhooks_for_project(self.project, group, event, ["rule1"])
+        send_legacy_webhooks_for_invocation(self.invocation)
 
         assert mock_task.delay.call_count == 0
+
+    @mock.patch(
+        "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
+    )
+    def test_triggering_rules_uses_workflow_name(self, mock_task: mock.MagicMock) -> None:
+        ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://a.com")
+
+        send_legacy_webhooks_for_invocation(self.invocation)
+
+        payload = mock_task.delay.call_args.kwargs["payload"]
+        assert payload["triggering_rules"] == [self.workflow.name]

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
@@ -1,28 +1,49 @@
+import uuid
 from unittest import mock
 
 import responses
 
 from sentry.sentry_apps.services.legacy_webhook.service import build_legacy_webhook_payload
 from sentry.sentry_apps.services.legacy_webhook.tasks import send_legacy_webhook_task
-from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
-class TestSendLegacyWebhookTask(TestCase):
+class TestSendLegacyWebhookTask(BaseWorkflowTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.detector = self.create_detector(project=self.project)
+        self.workflow = self.create_workflow(environment=self.environment)
+        self.action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={"target_identifier": "webhooks"},
+        )
+        self.group, self.event, self.group_event = self.create_group_event()
+        self.event_data = WorkflowEventData(
+            event=self.group_event, workflow_env=self.environment, group=self.group
+        )
+        self.invocation = ActionInvocation(
+            event_data=self.event_data,
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
+        )
+
     @responses.activate
     def test_task_sends_webhook(self) -> None:
         responses.add(responses.POST, "http://example.com/hook")
 
-        payload = build_legacy_webhook_payload(
-            group=self.group, event=self.event, triggering_rules=["test-rule"]
-        )
+        payload = build_legacy_webhook_payload(self.invocation)
         send_legacy_webhook_task(url="http://example.com/hook", payload=payload)
 
         assert len(responses.calls) == 1
         body = json.loads(responses.calls[0].request.body)
         assert body["id"] == str(self.group.id)
-        assert body["message"] == self.event.message
+        assert body["message"] == self.group_event.message
 
     @responses.activate
     @mock.patch("sentry.sentry_apps.services.legacy_webhook.tasks.logger")
@@ -30,9 +51,7 @@ class TestSendLegacyWebhookTask(TestCase):
     def test_task_dry_run_logs_instead_of_sending(self, mock_logger: mock.MagicMock) -> None:
         responses.add(responses.POST, "http://example.com/hook")
 
-        payload = build_legacy_webhook_payload(
-            group=self.group, event=self.event, triggering_rules=["test-rule"]
-        )
+        payload = build_legacy_webhook_payload(self.invocation)
         send_legacy_webhook_task(url="http://example.com/hook", payload=payload)
 
         assert len(responses.calls) == 0


### PR DESCRIPTION
Connects the dual write flags and new service together. See table below for what the NOA will do based on the flag setup.

| new-path | disable-old | dry-run | New path sends | Old path sends | Net result |
|---|---|---|---|---|---|
| OFF | OFF | N/A | no | yes | Old path only (default) |
| ON | OFF | OFF | yes | yes | Dual-write |
| ON | OFF | ON | logs only | yes | Old path sends + new path logs |
| ON | ON | OFF | yes | no | New path only (cutover) |
| ON | ON | ON | logs only | no | Dry-run only (nothing sends) |
| OFF | ON | N/A | no | no | Nothing fires |

## Context
PR 3 of the legacy webhook plugin migration. Depends on PR 2 (#115688).