### PR TITLE
fix(issues): Stop double-emitting issue activities for Seer PR created

### DIFF
--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -55,7 +55,6 @@ SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
     SentryAppEventType.SEER_SOLUTION_COMPLETED: ActivityType.SEER_SOLUTION_COMPLETED,
     SentryAppEventType.SEER_CODING_STARTED: ActivityType.SEER_CODING_STARTED,
     SentryAppEventType.SEER_CODING_COMPLETED: ActivityType.SEER_CODING_COMPLETED,
-    SentryAppEventType.SEER_PR_CREATED: ActivityType.SEER_PR_CREATED,
 }
 
 logger = logging.getLogger(__name__)
@@ -719,8 +718,6 @@ def _create_seer_activity(
         solution = event_payload.get("solution")
         if solution:
             activity_data["summary"] = solution.get("one_line_summary")
-    elif event_type == SentryAppEventType.SEER_PR_CREATED:
-        activity_data["pull_requests"] = event_payload.get("pull_requests")
 
     Activity.objects.create_group_activity(
         group,

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -57,6 +57,11 @@ SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
     SentryAppEventType.SEER_CODING_COMPLETED: ActivityType.SEER_CODING_COMPLETED,
 }
 
+SEER_OPERATOR_AUTOFIX_UPDATE_EVENTS: set[SentryAppEventType] = {
+    *SEER_EVENT_TO_ACTIVITY_TYPE.keys(),
+    SentryAppEventType.SEER_PR_CREATED,
+}
+
 logger = logging.getLogger(__name__)
 
 
@@ -761,7 +766,7 @@ def process_autofix_updates(
             lifecycle.record_failure(failure_reason="missing_identifiers")
             return
 
-        if event_type not in SEER_EVENT_TO_ACTIVITY_TYPE:
+        if event_type not in SEER_OPERATOR_AUTOFIX_UPDATE_EVENTS:
             lifecycle.record_halt(halt_reason="skipped")
             return
 

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -626,7 +626,6 @@ export const SEER_ACTIVITY_TYPES = new Set<GroupActivityType>([
   GroupActivityType.SEER_SOLUTION_COMPLETED,
   GroupActivityType.SEER_CODING_STARTED,
   GroupActivityType.SEER_CODING_COMPLETED,
-  GroupActivityType.SEER_PR_CREATED,
 ]);
 
 interface GroupActivityBase {

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -934,37 +934,6 @@ class SeerOperatorTest(TestCase):
         seer_type_values = [t.value for t in SEER_EVENT_TO_ACTIVITY_TYPE.values()]
         assert not Activity.objects.filter(group=self.group, type__in=seer_type_values).exists()
 
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_create_seer_activity_pr_created_with_pull_requests(self, _mock_has_access):
-        event_payload = {
-            "run_id": MOCK_RUN_ID,
-            "group_id": self.group.id,
-            "pull_requests": [
-                {
-                    "pull_request": {
-                        "pr_number": 42,
-                        "pr_url": "https://github.com/owner/repo/pull/42",
-                    },
-                    "repo_name": "owner/repo",
-                    "provider": "github",
-                }
-            ],
-        }
-
-        with self.feature("organizations:seer-activity-timeline"):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_PR_CREATED,
-                event_payload=event_payload,
-                organization_id=self.organization.id,
-            )
-
-        activity = Activity.objects.get(group=self.group, type=ActivityType.SEER_PR_CREATED.value)
-        assert activity.data["pull_requests"][0]["repo_name"] == "owner/repo"
-        assert (
-            activity.data["pull_requests"][0]["pull_request"]["pr_url"]
-            == "https://github.com/owner/repo/pull/42"
-        )
-
 
 class TestGetAutofixExplorerStatus(TestCase):
     @staticmethod


### PR DESCRIPTION
Resolves [ID-1534](https://linear.app/getsentry/issue/ID-1534/fix-double-emitting-of-seer-pr-created-activities).

We already have issue activity recording in place for Seer Autofix PRs created via our GitHub webhook, so we can remove the creation logic for this redundant activity type.

<img width="572" height="150" alt="image" src="https://github.com/user-attachments/assets/1abcc685-92f6-4a87-8100-35bdceed4829" />