### PR TITLE
fix(ourlogs): reset column sort to default on third click

### DIFF
--- a/static/app/views/explore/logs/tables/logsAggregateTable.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.tsx
@@ -127,13 +127,18 @@ export function LogsAggregateTable({
                 canSort
                 direction={direction}
                 generateSortLink={() => {
+                  const nextSort = (() => {
+                    switch (direction) {
+                      case 'asc':
+                        return {field: allFields[0]!, kind: 'desc' as const};
+                      case 'desc':
+                        return {field: column.key, kind: 'asc' as const};
+                      default:
+                        return {field: column.key, kind: 'desc' as const};
+                    }
+                  })();
                   return getTargetWithReadableQueryParams(location, {
-                    aggregateSortBys: [
-                      {
-                        field: column.key,
-                        kind: direction === 'desc' ? 'asc' : 'desc',
-                      },
-                    ],
+                    aggregateSortBys: [nextSort],
                   });
                 }}
                 title={title}

--- a/static/app/views/explore/logs/tables/logsAggregateTable.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.tsx
@@ -130,7 +130,10 @@ export function LogsAggregateTable({
                   const nextSort = (() => {
                     switch (direction) {
                       case 'asc':
-                        return {field: allFields[0]!, kind: 'desc' as const};
+                        return {
+                          field: visualizes[0]?.yAxis ?? allFields[0]!,
+                          kind: 'desc' as const,
+                        };
                       case 'desc':
                         return {field: column.key, kind: 'asc' as const};
                       default:

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -472,4 +472,51 @@ describe('LogsInfiniteTable', () => {
     await screen.findByText('abc123de');
     await screen.findByText('abc123ee');
   });
+
+  it('cycles column sort: unsorted → desc → asc → reset to default timestamp desc', async () => {
+    // Start with severity sorted ascending (second click has already happened)
+    mockUseLocation.mockReturnValue(
+      LocationFixture({
+        pathname: `/organizations/${organization.slug}/explore/logs/`,
+        query: {
+          [LOGS_FIELDS_KEY]: visibleColumnFields,
+          [LOGS_SORT_BYS_KEY]: 'severity',
+        },
+      })
+    );
+
+    const {router} = render(
+      <OrganizationContext.Provider value={organization}>
+        <LogsQueryParamsProvider
+          analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+          source="location"
+        >
+          <LogsPageDataProvider>
+            <LogsInfiniteTable
+              analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+            />
+          </LogsPageDataProvider>
+        </LogsQueryParamsProvider>
+      </OrganizationContext.Provider>,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/logs/`,
+            query: {
+              [LOGS_FIELDS_KEY]: visibleColumnFields,
+              [LOGS_SORT_BYS_KEY]: 'severity',
+            },
+          },
+        },
+        organization,
+      }
+    );
+
+    // Wait for table headers to be rendered (empty while pending)
+    const severityHeader = await screen.findByText('Severity');
+
+    // Third click (asc → reset): should navigate to default timestamp desc sort
+    await userEvent.click(severityHeader);
+    expect(router.location.query[LOGS_SORT_BYS_KEY]).toBe('-timestamp');
+  });
 });

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -11,6 +11,7 @@ import {
   userEvent,
   waitFor,
   within,
+  type RenderOptions,
 } from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
@@ -194,8 +195,8 @@ describe('LogsInfiniteTable', () => {
     });
   });
 
-  const renderWithProviders = (children: React.ReactNode) => {
-    return render(
+  function Wrapper({children}: {children: React.ReactNode}) {
+    return (
       <OrganizationContext.Provider value={organization}>
         <LogsQueryParamsProvider
           analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
@@ -205,6 +206,10 @@ describe('LogsInfiniteTable', () => {
         </LogsQueryParamsProvider>
       </OrganizationContext.Provider>
     );
+  }
+
+  const renderWithProviders = (children: React.ReactElement, options?: RenderOptions) => {
+    return render(children, {additionalWrapper: Wrapper, ...options});
   };
 
   it('should render the table component', async () => {
@@ -485,19 +490,8 @@ describe('LogsInfiniteTable', () => {
       })
     );
 
-    const {router} = render(
-      <OrganizationContext.Provider value={organization}>
-        <LogsQueryParamsProvider
-          analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-          source="location"
-        >
-          <LogsPageDataProvider>
-            <LogsInfiniteTable
-              analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-            />
-          </LogsPageDataProvider>
-        </LogsQueryParamsProvider>
-      </OrganizationContext.Provider>,
+    const {router} = renderWithProviders(
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
       {
         initialRouterConfig: {
           location: {

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -41,6 +41,7 @@ import {
 } from 'sentry/views/explore/components/table';
 import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
+import {logsTimestampDescendingSortBy} from 'sentry/views/explore/contexts/logs/sortBys';
 import {
   MINIMUM_INFINITE_SCROLL_FETCH_COOLDOWN_MS,
   QUANTIZE_MINUTES,
@@ -658,8 +659,16 @@ function LogsTableHeader({
                   isFrozen
                     ? undefined
                     : () => {
-                        const kind = direction === 'desc' ? 'asc' : 'desc';
-                        setSortBys([{field, kind}]);
+                        switch (direction) {
+                          case 'asc':
+                            setSortBys([logsTimestampDescendingSortBy]);
+                            break;
+                          case 'desc':
+                            setSortBys([{field, kind: 'asc'}]);
+                            break;
+                          default:
+                            setSortBys([{field, kind: 'desc'}]);
+                        }
                       }
                 }
                 isFrozen={isFrozen}

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -91,7 +91,7 @@ export interface RouterConfig {
   routes?: string[];
 }
 
-interface RenderOptions extends rtl.RenderOptions, ProviderOptions {
+export interface RenderOptions extends rtl.RenderOptions, ProviderOptions {
   initialRouterConfig?: RouterConfig;
   outletContext?: Record<string, unknown>;
 }


### PR DESCRIPTION
Column sort previously had no way to return to the default state: clicking a column header only toggled between `desc` and `asc`. This adds a third state to reset back to default.

- **Infinite table**: `undefined → desc → asc → timestamp desc` (the default sort)
- **Aggregate table**: `undefined → desc → asc → first-field desc` (the aggregate default)

Closes LOGS-808.