### PR TITLE
docs(replays): Fix OpenAPI schema/example for replay details response

### DIFF
--- a/src/sentry/apidocs/examples/replay_examples.py
+++ b/src/sentry/apidocs/examples/replay_examples.py
@@ -63,7 +63,7 @@ class ReplayExamples:
     GET_REPLAY_DETAILS = [
         OpenApiExample(
             "Get single replay details",
-            value=replay_example,
+            value={"data": replay_example},
             status_codes=["200"],
             response_only=True,
         ),

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime, timezone
+from typing import TypedDict
 
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
@@ -32,6 +33,10 @@ from sentry.replays.lib.eap.snuba_transpiler import RequestMeta, Settings
 from sentry.replays.post_process import ReplayDetailsResponse, process_raw_response
 from sentry.replays.query import query_replay_instance
 from sentry.replays.validators import ReplayValidator
+
+
+class GetReplayResponse(TypedDict):
+    data: ReplayDetailsResponse
 
 
 def _query_replay_urls_eap(
@@ -231,7 +236,7 @@ class OrganizationReplayDetailsEndpoint(OrganizationReplayEndpoint):
         operation_id="Retrieve a Replay Instance",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, ReplayParams.REPLAY_ID, ReplayValidator],
         responses={
-            200: inline_sentry_response_serializer("GetReplay", ReplayDetailsResponse),
+            200: inline_sentry_response_serializer("GetReplay", GetReplayResponse),
             400: RESPONSE_BAD_REQUEST,
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,


### PR DESCRIPTION
## Summary

The organization replay details endpoint returns `{"data": <replay>}`, but:
- The schema declared `200: inline_sentry_response_serializer("GetReplay", ReplayDetailsResponse)` — a bare object with no `data` wrapper.
- `ReplayExamples.GET_REPLAY_DETAILS` showed `value=replay_example` — also bare.

Generated clients would have the wrong type. Other endpoints in the same example file (e.g. `GET_REPLAY_CLICKS`, `GET_REPLAY_DELETION_JOB`, `GET_REPLAY_VIEWED_BY`) already wrap in `data`, so this looks like an oversight specific to details.

Fix:
- Add `GetReplayResponse` TypedDict with `data: ReplayDetailsResponse`, same pattern used in `project_replay_jobs_delete.py` for the deletion-job endpoints.
- Wrap the example in `{"data": ...}`.

## Note on typing

There is no static check today that ties an endpoint's `200:` schema to the actual `Response(...)` body — endpoint methods are annotated as returning `rest_framework.response.Response` (no body type parameter), and `inline_sentry_response_serializer` just stashes the type for schema generation at build time. That's how this drifted. Worth a separate discussion whether it's worth pursuing something stronger.

## Test plan
- [x] mypy passes on changed files
- [x] prek passes on changed files
- [x] `tests/sentry/replays/endpoints/test_organization_replay_details.py` — the 2 pre-existing failures (snuba 404s) reproduce on master and are unrelated
- [ ] Verify the regenerated OpenAPI spec includes the `data` wrapper


Agent transcript: https://claudescope.sentry.dev/share/Xr_Rwv4QVRzGEEIbXZh2d6zbnvEyrhfRKrjff8qEAxs