### PR TITLE
feat(repositories): Add project repo-link endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_repo_link.py
+++ b/src/sentry/api/endpoints/project_repo_link.py
@@ -1,0 +1,79 @@
+from typing import Any
+
+from rest_framework import serializers, status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
+from sentry.constants import ObjectStatus
+from sentry.models.project import Project
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
+from sentry.models.repository import Repository
+
+
+class ProjectRepoLinkSerializer(serializers.Serializer[ProjectRepository]):
+    repositoryId = serializers.IntegerField(required=True)
+
+    def __init__(self, *args: Any, project: Project, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.project = project
+        self.repository: Repository | None = None
+
+    def validate_repositoryId(self, value: int) -> int:
+        try:
+            self.repository = Repository.objects.get(
+                id=value,
+                organization_id=self.project.organization_id,
+                status=ObjectStatus.ACTIVE,
+            )
+        except Repository.DoesNotExist:
+            raise serializers.ValidationError("Repository not found.")
+        return value
+
+    def create(self, validated_data: dict[str, Any]) -> ProjectRepository:
+        assert self.repository is not None
+        project_repo, created = ProjectRepository.objects.get_or_create(
+            project=self.project,
+            repository=self.repository,
+            defaults={"source": ProjectRepositorySource.SCM_ONBOARDING},
+        )
+        self._created = created
+        return project_repo
+
+
+@cell_silo_endpoint
+class ProjectRepoLinkEndpoint(ProjectEndpoint):
+    owner = ApiOwner.ISSUES
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    permission_classes = (ProjectPermission,)
+
+    def post(self, request: Request, project: Project) -> Response:
+        serializer = ProjectRepoLinkSerializer(data=request.data, project=project)
+        if not serializer.is_valid():
+            errors = serializer.errors
+            repo_errors = errors.get("repositoryId", [])
+            if any("not found" in str(e).lower() for e in repo_errors):
+                return Response(
+                    {"detail": repo_errors[0]},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            return Response(errors, status=status.HTTP_400_BAD_REQUEST)
+
+        project_repo = serializer.save()
+        created = serializer._created
+
+        return Response(
+            {
+                "id": str(project_repo.id),
+                "projectId": str(project.id),
+                "repositoryId": str(project_repo.repository_id),
+                "source": project_repo.get_source_display(),
+                "created": created,
+            },
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -829,6 +829,7 @@ from .endpoints.project_profiling_profile import (
     ProjectProfilingRawChunkEndpoint,
     ProjectProfilingRawProfileEndpoint,
 )
+from .endpoints.project_repo_link import ProjectRepoLinkEndpoint
 from .endpoints.project_repo_path_parsing import ProjectRepoPathParsingEndpoint
 from .endpoints.project_reprocessing import ProjectReprocessingEndpoint
 from .endpoints.project_rule_actions import ProjectRuleActionsEndpoint
@@ -3276,6 +3277,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/stacktrace-source-context/$",
         ProjectStacktraceSourceContextEndpoint.as_view(),
         name="sentry-api-0-project-stacktrace-source-context",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/repo-link/$",
+        ProjectRepoLinkEndpoint.as_view(),
+        name="sentry-api-0-project-repo-link",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/repo-path-parsing/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -714,6 +714,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/replays/$replayId/viewed-by/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/replays/jobs/delete/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/replays/jobs/delete/$jobId/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/repo-link/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/repo-path-parsing/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/reprocessing/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/rule-actions/'

--- a/tests/sentry/api/endpoints/test_project_repo_link.py
+++ b/tests/sentry/api/endpoints/test_project_repo_link.py
@@ -1,0 +1,95 @@
+from sentry.constants import ObjectStatus
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
+from sentry.models.repository import Repository
+from sentry.testutils.cases import APITestCase
+
+
+class ProjectRepoLinkTest(APITestCase):
+    endpoint = "sentry-api-0-project-repo-link"
+    method = "post"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
+        )
+
+    def test_creates_link(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            repositoryId=self.repo.id,
+            status_code=201,
+        )
+        assert response.data["repositoryId"] == str(self.repo.id)
+        assert response.data["projectId"] == str(self.project.id)
+        assert response.data["created"] is True
+
+        pr = ProjectRepository.objects.get(project=self.project, repository=self.repo)
+        assert pr.source == ProjectRepositorySource.SCM_ONBOARDING
+
+    def test_idempotent(self) -> None:
+        ProjectRepository.objects.create(
+            project=self.project,
+            repository=self.repo,
+            source=ProjectRepositorySource.MANUAL,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            repositoryId=self.repo.id,
+            status_code=200,
+        )
+        assert response.data["created"] is False
+        assert response.data["source"] == "manual"
+        assert (
+            ProjectRepository.objects.filter(project=self.project, repository=self.repo).count()
+            == 1
+        )
+
+    def test_repo_not_found(self) -> None:
+        self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            repositoryId=999999,
+            status_code=404,
+        )
+
+    def test_repo_from_other_org(self) -> None:
+        other_org = self.create_organization()
+        other_repo = Repository.objects.create(
+            organization_id=other_org.id,
+            name="other/repo",
+            provider="integrations:github",
+            external_id="456",
+        )
+
+        self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            repositoryId=other_repo.id,
+            status_code=404,
+        )
+
+    def test_inactive_repo(self) -> None:
+        self.repo.status = ObjectStatus.HIDDEN
+        self.repo.save()
+
+        self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            repositoryId=self.repo.id,
+            status_code=404,
+        )
+
+    def test_missing_repository_id(self) -> None:
+        self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            status_code=400,
+        )


### PR DESCRIPTION
## Summary
Adds `POST /api/0/projects/{org}/{project}/repo-link/` to create a `ProjectRepository` link between a project and an existing repository.

Used by the SCM onboarding flow to persist the user's repo selection after project creation. The frontend PR to call this endpoint will follow.

- Accepts `{"repositoryId": <int>}` 
- Creates `ProjectRepository` with `source=SCM_ONBOARDING`
- Idempotent: returns 200 if the link already exists, 201 if created
- Scopes the repo lookup to the project's organization (IDOR prevention)

## Test plan
- [x] `test_creates_link` — creates ProjectRepository with correct source
- [x] `test_idempotent` — returns 200 without duplicating
- [x] `test_repo_not_found` — 404 for nonexistent repo
- [x] `test_repo_from_other_org` — 404 for repo in different org
- [x] `test_inactive_repo` — 404 for hidden/disabled repo
- [x] `test_missing_repository_id` — 400 for missing field