### PR TITLE
feat(seer): Add helper for bulk updating Seer project settings

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -805,7 +805,7 @@ def update_seer_project_settings(project: Project, data: SeerProjectSettingsUpda
 
     with transaction.atomic(using=router.db_for_write(ProjectOption)):
         # Lock project rows to serialize concurrent writes.
-        list(Project.objects.select_for_update().filter(id=project.id).first())
+        Project.objects.select_for_update().filter(id=project.id).first()
 
         for key in options_to_delete:
             project.delete_option(key)

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -763,39 +763,38 @@ def _get_seer_project_options_to_update(
             options_to_set["sentry:seer_automation_handoff_target"] = agent
             options_to_set["sentry:seer_automation_handoff_integration_id"] = integration_id
 
-    stopping_point: str | None = data.get("stoppingPoint")
-    if stopping_point is not None:
-        if stopping_point == "off":
-            # Disable automation and leave stopping point and handoff_auto_create_pr unchanged
-            # so that reenabling restores the prior state.
-            _set_or_clear(
-                "sentry:autofix_automation_tuning",
-                AutofixAutomationTuningSettings.OFF,
-                default=AUTOFIX_AUTOMATION_TUNING_DEFAULT,
-            )
-        else:
-            # Enable automation and set the stopping point.
-            _set_or_clear(
-                "sentry:autofix_automation_tuning",
-                AutofixAutomationTuningSettings.MEDIUM,
-                default=AUTOFIX_AUTOMATION_TUNING_DEFAULT,
-            )
-            _set_or_clear(
-                "sentry:seer_automated_run_stopping_point",
-                stopping_point,
-                default=SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
-            )
-
-            if stopping_point == AutofixStoppingPoint.OPEN_PR:
-                # Safe to set even if no external handoff is configured
-                # since we'll only read it if the other handoff options are all non-null.
-                options_to_set["sentry:seer_automation_handoff_auto_create_pr"] = True
-            else:
-                options_to_clear.append("sentry:seer_automation_handoff_auto_create_pr")
-
     if "scannerAutomation" in data:
         _set_or_clear("sentry:seer_scanner_automation", data["scannerAutomation"], default=True)
 
+    if "stoppingPoint" not in data:
+        return options_to_set, options_to_clear
+    elif data["stoppingPoint"] == "off":
+        # Disable automation and leave stopping point and handoff_auto_create_pr unchanged
+        # so that reenabling restores the prior state.
+        _set_or_clear(
+            "sentry:autofix_automation_tuning",
+            AutofixAutomationTuningSettings.OFF,
+            default=AUTOFIX_AUTOMATION_TUNING_DEFAULT,
+        )
+    else:
+        # Enable automation and set the stopping point.
+        _set_or_clear(
+            "sentry:autofix_automation_tuning",
+            AutofixAutomationTuningSettings.MEDIUM,
+            default=AUTOFIX_AUTOMATION_TUNING_DEFAULT,
+        )
+        _set_or_clear(
+            "sentry:seer_automated_run_stopping_point",
+            data["stoppingPoint"],
+            default=SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
+        )
+
+        if data["stoppingPoint"] == AutofixStoppingPoint.OPEN_PR:
+            # Safe to set even if no external handoff is configured
+            # since we'll only read it if the other handoff options are all non-null.
+            options_to_set["sentry:seer_automation_handoff_auto_create_pr"] = True
+        else:
+            options_to_clear.append("sentry:seer_automation_handoff_auto_create_pr")
     return options_to_set, options_to_clear
 
 
@@ -831,7 +830,8 @@ def bulk_update_seer_project_settings(
         list(Project.objects.select_for_update().filter(id__in=project_ids).order_by("id"))
 
         if options_to_delete:
-            # Use _raw_delete to skip ProjectOptionManager post_delete signals (each row triggers reload_cache).
+            # Use _raw_delete to skip per-row post_delete signals that each trigger reload_cache.
+            # For efficiency, we reload once per project after the transaction instead.
             ProjectOption.objects.filter(
                 project_id__in=project_ids, key__in=options_to_delete
             )._raw_delete(using=router.db_for_write(ProjectOption))

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, Literal, NotRequired, TypedDict
@@ -814,7 +814,7 @@ def update_seer_project_settings(project: Project, data: SeerProjectSettingsUpda
 
 
 def bulk_update_seer_project_settings(
-    projects: Sequence[Project], data: SeerProjectSettingsUpdate
+    projects: list[Project], data: SeerProjectSettingsUpdate
 ) -> None:
     """Apply high-level Seer settings to multiple projects in bulk."""
     if not projects:
@@ -828,9 +828,10 @@ def bulk_update_seer_project_settings(
         list(Project.objects.select_for_update().filter(id__in=project_ids))
 
         if options_to_delete:
+            # Use _raw_delete to skip ProjectOptionManager post_delete signals (each row triggers reload_cache).
             ProjectOption.objects.filter(
                 project_id__in=project_ids, key__in=options_to_delete
-            ).delete()
+            )._raw_delete(using=router.db_for_write(ProjectOption))
 
         if options_to_set:
             ProjectOption.objects.bulk_create(
@@ -844,8 +845,8 @@ def bulk_update_seer_project_settings(
                 update_fields=["value"],
             )
 
-    # For all projects, manually reload cache and invalidate Relay config
-    # since bulk ProjectOption operations bypass update_option/delete_option.
+    # Manually reload each project's cache, since _raw_delete and bulk_create
+    # bypass the cache reloading in update_option and delete_option.
     for project_id in project_ids:
         ProjectOption.objects.reload_cache(project_id, "projectoption.bulk_set_value")
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, Literal, NotRequired, TypedDict
@@ -733,72 +733,121 @@ class SeerProjectSettingsUpdate(TypedDict, total=False):
     scannerAutomation: bool
 
 
-def update_seer_project_settings(project: Project, data: SeerProjectSettingsUpdate) -> None:
-    """Apply high-level Seer settings to a project. Only update a setting if it's present in data."""
+def _get_seer_project_options_to_update(
+    data: SeerProjectSettingsUpdate,
+) -> tuple[dict[str, Any], list[str]]:
+    """Return (options_to_set, options_to_clear) for the given Seer project settings update.
+    Clear the option if it's the default; otherwise, set it."""
+    options_to_set: dict[str, Any] = {}
+    options_to_clear: list[str] = []
 
-    def _set_if_not_default(key: str, value: Any, default: Any) -> None:
-        """If we're trying to set a default, delete the option. Otherwise, set it."""
+    def _set_or_clear(key: str, value: Any, default: Any) -> None:
         if value == default:
-            project.delete_option(key)
+            options_to_clear.append(key)
         else:
-            project.update_option(key, value)
+            options_to_set[key] = value
+
+    if "agent" in data:
+        agent = data["agent"]
+        if agent == AutomationCodingAgent.SEER:
+            options_to_clear += [
+                "sentry:seer_automation_handoff_point",
+                "sentry:seer_automation_handoff_target",
+                "sentry:seer_automation_handoff_integration_id",
+            ]
+        else:
+            integration_id = data.get("integrationId")
+            if integration_id is None:
+                raise ValueError("integrationId is required for external coding agents")
+            options_to_set["sentry:seer_automation_handoff_point"] = AutofixHandoffPoint.ROOT_CAUSE
+            options_to_set["sentry:seer_automation_handoff_target"] = agent
+            options_to_set["sentry:seer_automation_handoff_integration_id"] = integration_id
+
+    stopping_point: str | None = data.get("stoppingPoint")
+    if stopping_point is not None:
+        if stopping_point == "off":
+            # Disable automation and leave stopping point and handoff_auto_create_pr unchanged
+            # so that reenabling restores the prior state.
+            _set_or_clear(
+                "sentry:autofix_automation_tuning",
+                AutofixAutomationTuningSettings.OFF,
+                default=AUTOFIX_AUTOMATION_TUNING_DEFAULT,
+            )
+        else:
+            # Enable automation and set the stopping point.
+            _set_or_clear(
+                "sentry:autofix_automation_tuning",
+                AutofixAutomationTuningSettings.MEDIUM,
+                default=AUTOFIX_AUTOMATION_TUNING_DEFAULT,
+            )
+            _set_or_clear(
+                "sentry:seer_automated_run_stopping_point",
+                stopping_point,
+                default=SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
+            )
+
+            if stopping_point == AutofixStoppingPoint.OPEN_PR:
+                # Safe to set even if no external handoff is configured
+                # since we'll only read it if the other handoff options are all non-null.
+                options_to_set["sentry:seer_automation_handoff_auto_create_pr"] = True
+            else:
+                options_to_clear.append("sentry:seer_automation_handoff_auto_create_pr")
+
+    if "scannerAutomation" in data:
+        _set_or_clear("sentry:seer_scanner_automation", data["scannerAutomation"], default=True)
+
+    return options_to_set, options_to_clear
+
+
+def update_seer_project_settings(project: Project, data: SeerProjectSettingsUpdate) -> None:
+    """Apply high-level Seer settings to a single project."""
+    options_to_set, options_to_delete = _get_seer_project_options_to_update(data)
 
     with transaction.atomic(using=router.db_for_write(ProjectOption)):
+        # Lock project rows to serialize concurrent writes.
         list(Project.objects.select_for_update().filter(id=project.id))
 
-        stopping_point: str | None = data.get("stoppingPoint")
+        for key in options_to_delete:
+            project.delete_option(key)
+        for key, value in options_to_set.items():
+            project.update_option(key, value)
 
-        if "agent" in data:
-            agent: str = data["agent"]
-            if agent == AutomationCodingAgent.SEER:
-                project.delete_option("sentry:seer_automation_handoff_point")
-                project.delete_option("sentry:seer_automation_handoff_target")
-                project.delete_option("sentry:seer_automation_handoff_integration_id")
-            else:
-                integration_id = data.get("integrationId")
-                if integration_id is None:
-                    raise ValueError("integrationId is required for external coding agents")
 
-                project.update_option(
-                    "sentry:seer_automation_handoff_point", AutofixHandoffPoint.ROOT_CAUSE
-                )
-                project.update_option("sentry:seer_automation_handoff_target", agent)
-                project.update_option(
-                    "sentry:seer_automation_handoff_integration_id", integration_id
-                )
+def bulk_update_seer_project_settings(
+    projects: Sequence[Project], data: SeerProjectSettingsUpdate
+) -> None:
+    """Apply high-level Seer settings to multiple projects in bulk."""
+    if not projects:
+        return
 
-        if stopping_point is not None:
-            if stopping_point == "off":
-                # Turn off tuning and leave stopping point and handoff_auto_create_pr unchanged
-                # so that reenabling restores the prior state.
-                _set_if_not_default(
-                    "sentry:autofix_automation_tuning",
-                    AutofixAutomationTuningSettings.OFF,
-                    default=AUTOFIX_AUTOMATION_TUNING_DEFAULT,
-                )
-            else:
-                _set_if_not_default(
-                    "sentry:autofix_automation_tuning",
-                    AutofixAutomationTuningSettings.MEDIUM,
-                    default=AUTOFIX_AUTOMATION_TUNING_DEFAULT,
-                )
-                _set_if_not_default(
-                    "sentry:seer_automated_run_stopping_point",
-                    stopping_point,
-                    default=SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
-                )
+    options_to_set, options_to_delete = _get_seer_project_options_to_update(data)
+    project_ids = [p.id for p in projects]
 
-                if stopping_point == AutofixStoppingPoint.OPEN_PR:
-                    # Safe to set even if no external handoff is configured
-                    # since we'll only read it if the other handoff options are all non-null.
-                    project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
-                else:
-                    project.delete_option("sentry:seer_automation_handoff_auto_create_pr")
+    with transaction.atomic(using=router.db_for_write(ProjectOption)):
+        # Lock project rows to serialize concurrent writes.
+        list(Project.objects.select_for_update().filter(id__in=project_ids))
 
-        if "scannerAutomation" in data:
-            _set_if_not_default(
-                "sentry:seer_scanner_automation", data["scannerAutomation"], default=True
+        if options_to_delete:
+            ProjectOption.objects.filter(
+                project_id__in=project_ids, key__in=options_to_delete
+            ).delete()
+
+        if options_to_set:
+            ProjectOption.objects.bulk_create(
+                [
+                    ProjectOption(project_id=pid, key=key, value=value)
+                    for pid in project_ids
+                    for key, value in options_to_set.items()
+                ],
+                update_conflicts=True,
+                unique_fields=["project_id", "key"],
+                update_fields=["value"],
             )
+
+    # For all projects, manually reload cache and invalidate Relay config
+    # since bulk ProjectOption operations bypass update_option/delete_option.
+    for project_id in project_ids:
+        ProjectOption.objects.reload_cache(project_id, "projectoption.bulk_set_value")
 
 
 def has_project_connected_repos(organization: Organization, project: Project) -> bool:

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -805,7 +805,7 @@ def update_seer_project_settings(project: Project, data: SeerProjectSettingsUpda
 
     with transaction.atomic(using=router.db_for_write(ProjectOption)):
         # Lock project rows to serialize concurrent writes.
-        list(Project.objects.select_for_update().filter(id=project.id))
+        list(Project.objects.select_for_update().filter(id=project.id).first())
 
         for key in options_to_delete:
             project.delete_option(key)
@@ -821,11 +821,14 @@ def bulk_update_seer_project_settings(
         return
 
     options_to_set, options_to_delete = _get_seer_project_options_to_update(data)
+    if not options_to_set and not options_to_delete:
+        return
+
     project_ids = [p.id for p in projects]
 
     with transaction.atomic(using=router.db_for_write(ProjectOption)):
         # Lock project rows to serialize concurrent writes.
-        list(Project.objects.select_for_update().filter(id__in=project_ids))
+        list(Project.objects.select_for_update().filter(id__in=project_ids).order_by("id"))
 
         if options_to_delete:
             # Use _raw_delete to skip ProjectOptionManager post_delete signals (each row triggers reload_cache).

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -24,6 +24,7 @@ from sentry.seer.autofix.utils import (
     CodingAgentProviderType,
     CodingAgentStatus,
     bulk_read_preferences_from_sentry_db,
+    bulk_update_seer_project_settings,
     bulk_write_preferences_to_sentry_db,
     clear_preference_automation_handoff,
     deduplicate_repositories,
@@ -1762,3 +1763,102 @@ class TestUpdateSeerProjectSettings(TestCase):
         assert not ProjectOption.objects.filter(
             project=self.project, key="sentry:seer_scanner_automation"
         ).exists()
+
+
+class TestBulkUpdateSeerProjectSettings(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project_a = self.create_project(organization=self.organization)
+        self.project_b = self.create_project(organization=self.organization)
+        self.projects = [self.project_a, self.project_b]
+
+    def test_empty_projects(self) -> None:
+        """Empty project list should be a no-op without errors."""
+        bulk_update_seer_project_settings([], {"scannerAutomation": False})
+
+    def test_sets_options(self) -> None:
+        """All provided settings fields should be applied to every project."""
+        bulk_update_seer_project_settings(
+            self.projects,
+            {
+                "agent": AutomationCodingAgent.CURSOR,
+                "integrationId": 99,
+                "stoppingPoint": AutofixStoppingPoint.OPEN_PR,
+                "scannerAutomation": False,
+            },
+        )
+
+        for project in self.projects:
+            assert (
+                project.get_option("sentry:seer_automation_handoff_target")
+                == AutomationCodingAgent.CURSOR
+            )
+            assert (
+                project.get_option("sentry:seer_automation_handoff_point")
+                == AutofixHandoffPoint.ROOT_CAUSE
+            )
+            assert project.get_option("sentry:seer_automation_handoff_integration_id") == 99
+            assert (
+                project.get_option("sentry:autofix_automation_tuning")
+                == AutofixAutomationTuningSettings.MEDIUM
+            )
+            assert (
+                project.get_option("sentry:seer_automated_run_stopping_point")
+                == AutofixStoppingPoint.OPEN_PR
+            )
+            assert project.get_option("sentry:seer_automation_handoff_auto_create_pr") is True
+            assert project.get_option("sentry:seer_scanner_automation") is False
+
+    def test_seer_agent_clears_handoff(self) -> None:
+        """Switching to seer agent should delete handoff options across all projects."""
+        for project in self.projects:
+            project.update_option(
+                "sentry:seer_automation_handoff_target",
+                CodingAgentProviderType.CURSOR_BACKGROUND_AGENT,
+            )
+            project.update_option(
+                "sentry:seer_automation_handoff_point", AutofixHandoffPoint.ROOT_CAUSE
+            )
+            project.update_option("sentry:seer_automation_handoff_integration_id", 42)
+
+        bulk_update_seer_project_settings(self.projects, {"agent": AutomationCodingAgent.SEER})
+
+        for project in self.projects:
+            assert project.get_option("sentry:seer_automation_handoff_target") is None
+            assert project.get_option("sentry:seer_automation_handoff_point") is None
+            assert project.get_option("sentry:seer_automation_handoff_integration_id") is None
+
+    def test_upserts_existing_options(self) -> None:
+        """Existing options should be overwritten, not duplicated."""
+        for project in self.projects:
+            project.update_option("sentry:seer_scanner_automation", True)
+
+        bulk_update_seer_project_settings(self.projects, {"scannerAutomation": False})
+
+        for project in self.projects:
+            assert project.get_option("sentry:seer_scanner_automation") is False
+            assert (
+                ProjectOption.objects.filter(
+                    project=project, key="sentry:seer_scanner_automation"
+                ).count()
+                == 1
+            )
+
+    def test_deletes_default_options(self) -> None:
+        """Setting a value equal to its registered default should delete the ProjectOption row."""
+        for project in self.projects:
+            project.update_option("sentry:seer_automated_run_stopping_point", "open_pr")
+
+        bulk_update_seer_project_settings(
+            self.projects,
+            {"stoppingPoint": AutofixStoppingPoint(SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT)},
+        )
+
+        for project in self.projects:
+            assert (
+                project.get_option("sentry:seer_automated_run_stopping_point")
+                == SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
+            )
+            assert not ProjectOption.objects.filter(
+                project=project, key="sentry:seer_automated_run_stopping_point"
+            ).exists()

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -1809,7 +1809,7 @@ class TestBulkUpdateSeerProjectSettings(TestCase):
             assert project.get_option("sentry:seer_automation_handoff_auto_create_pr") is True
             assert project.get_option("sentry:seer_scanner_automation") is False
 
-    def test_seer_agent_clears_handoff(self) -> None:
+    def test_agent_seer_clears_handoff_options(self) -> None:
         """Switching to seer agent should delete handoff options across all projects."""
         for project in self.projects:
             project.update_option(
@@ -1844,7 +1844,7 @@ class TestBulkUpdateSeerProjectSettings(TestCase):
                 == 1
             )
 
-    def test_deletes_default_options(self) -> None:
+    def test_clears_option_when_value_is_default(self) -> None:
         """Setting a value equal to its registered default should delete the ProjectOption row."""
         for project in self.projects:
             project.update_option("sentry:seer_automated_run_stopping_point", "open_pr")
@@ -1862,3 +1862,67 @@ class TestBulkUpdateSeerProjectSettings(TestCase):
             assert not ProjectOption.objects.filter(
                 project=project, key="sentry:seer_automated_run_stopping_point"
             ).exists()
+
+    def test_stopping_point_off_sets_tuning_off(self) -> None:
+        """stoppingPoint='off' should set tuning to OFF and preserve existing stopping point."""
+        for project in self.projects:
+            project.update_option(
+                "sentry:seer_automated_run_stopping_point", AutofixStoppingPoint.OPEN_PR
+            )
+            project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
+
+        bulk_update_seer_project_settings(self.projects, {"stoppingPoint": "off"})
+
+        for project in self.projects:
+            assert (
+                project.get_option("sentry:autofix_automation_tuning")
+                == AutofixAutomationTuningSettings.OFF
+            )
+
+    def test_mixed_sets_and_clears_options(self) -> None:
+        """Test that sets new options and deletes existing ones."""
+        for project in self.projects:
+            project.update_option(
+                "sentry:seer_automation_handoff_target",
+                CodingAgentProviderType.CURSOR_BACKGROUND_AGENT,
+            )
+            project.update_option(
+                "sentry:seer_automation_handoff_point", AutofixHandoffPoint.ROOT_CAUSE
+            )
+            project.update_option("sentry:seer_automation_handoff_integration_id", 42)
+
+        bulk_update_seer_project_settings(
+            self.projects,
+            {"agent": AutomationCodingAgent.SEER, "scannerAutomation": False},
+        )
+
+        for project in self.projects:
+            assert project.get_option("sentry:seer_automation_handoff_target") is None
+            assert project.get_option("sentry:seer_automation_handoff_point") is None
+            assert project.get_option("sentry:seer_automation_handoff_integration_id") is None
+            assert project.get_option("sentry:seer_scanner_automation") is False
+
+    def test_omitted_fields_preserve_existing_options(self) -> None:
+        """Updating one field should not clobber unrelated existing options."""
+        for project in self.projects:
+            project.update_option(
+                "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
+            )
+            project.update_option(
+                "sentry:seer_automated_run_stopping_point", AutofixStoppingPoint.OPEN_PR
+            )
+            project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
+
+        bulk_update_seer_project_settings(self.projects, {"scannerAutomation": False})
+
+        for project in self.projects:
+            assert (
+                project.get_option("sentry:autofix_automation_tuning")
+                == AutofixAutomationTuningSettings.MEDIUM
+            )
+            assert (
+                project.get_option("sentry:seer_automated_run_stopping_point")
+                == AutofixStoppingPoint.OPEN_PR
+            )
+            assert project.get_option("sentry:seer_automation_handoff_auto_create_pr") is True
+            assert project.get_option("sentry:seer_scanner_automation") is False


### PR DESCRIPTION
Relates to CW-1285

Support both single-project and bulk-project Seer settings updates via `update_seer_project_settings` and `bulk_update_seer_project_settings`.
- Refactor `update_seer_project_settings` so that the extracted option-mapping logic can be reused by both the single-project and [upcoming bulk-project](https://github.com/getsentry/sentry/pull/115234) code paths. 
- Add `bulk_update_seer_project_settings` helper that bulk creates and deletes project options, instead of using per-project loops. **We use `_raw_delete` to bypass per-row `post_delete` cache reloads**, and manually reload each project's cache at the end (`bulk_create` also bypasses `post_save` cache reloads).

---

### Why [`_raw_delete`](https://github.com/getsentry/sentry/pull/115756/changes#diff-204df1d50b6d80eb112a1bafcdc4bb853e274f0e56ae3e082897b201aa0de550R831-R834) + [manual `reload_cache`](https://github.com/getsentry/sentry/pull/115756/changes#diff-204df1d50b6d80eb112a1bafcdc4bb853e274f0e56ae3e082897b201aa0de550R848-R851)?

`ProjectOptionManager` auto-connects a `post_delete` signal handler that calls `reload_cache` on every `ProjectOption` row deletion. However, `bulk_create` does not trigger any `post_save` signal, so we have to reload each project's cache at the end of the transaction anyway. For a bulk update touching N projects × up to 7 option keys, that's up to 7N redundant `reload_cache` calls for row deletions.

We considered three approaches:

#### 1. Per-project loop (sequential)
Use `update_option`/`delete_option` per project inside a single transaction. Simplest, but extremely slow due to serialized DB round-trips.

#### 2. Per-project loop (thread pool, ~10 workers)
Parallelize the per-project loop with `ThreadPoolExecutor`. ~3x speedup over sequential, but still much slower than bulk due to per-project round-trips. Also adds complexity: `connections.close_all()` per thread, no shared transaction, choosing a worker count.

#### 3. Bulk ops with `_raw_delete` (chosen)
`_raw_delete` is a private Django `QuerySet` method that does not hit `post_delete`. We pair it with `bulk_create` for upserts and do a single `reload_cache` per project at the end. This gives us exactly N cache refreshes instead of up to 7N.

We chose `_raw_delete` over `post_delete.disconnect`/`connect` because signal disconnect is global — another request thread deleting a `ProjectOption` during our window would miss its signal. `_raw_delete` is scoped to the queryset, so no thread-safety concern.

`_raw_delete` is private API but stable and has been in Django since 1.5 (2013)--only 2 commits 58b27e0 and ddefc3f have ever touched it and both are cosmetic changes.

#### Local benchmarks (max_workers=10 for thread pool)

```
n=   5  bulk=0.060s  loop=0.376s  pool=0.148s  pool_vs_loop=2.5x  bulk_vs_loop=6.2x
n=  25  bulk=0.093s  loop=2.191s  pool=0.668s  pool_vs_loop=3.3x  bulk_vs_loop=23.5x
n= 100  bulk=0.277s  loop=12.858s  pool=4.473s  pool_vs_loop=2.9x  bulk_vs_loop=46.5x
n= 500  bulk=3.866s  loop=70.040s  pool=24.923s  pool_vs_loop=2.8x  bulk_vs_loop=18.1x
```

Bulk is **6-46x** faster than the sequential loop and **3-9x** faster than the thread pool. At N=100 [(99.9% of orgs)](https://redash.getsentry.net/queries/11145), bulk completes in <0.3s vs 13s for the loop.

The bulk approach is also the easiest to migrate away from if we move off `ProjectOption` in the future — the bulk query logic stays the same, we'd just swap the model. A thread pool approach would require ripping out concurrency machinery.
