### PR TITLE
ref(aci): Minor cleanup to delayed workflow processing

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -921,7 +921,8 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
         project,
     )
 
-    fire_actions_for_groups(project.organization, groups_to_dcgs, group_to_groupevent)
+    if groups_to_dcgs and group_to_groupevent:
+        fire_actions_for_groups(project.organization, groups_to_dcgs, group_to_groupevent)
 
 
 @sentry_sdk.trace

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -716,7 +716,7 @@ def fire_actions_for_groups(
     serialized_groups = {
         group.id: group_event.event_id for group, (group_event, _) in group_to_groupevent.items()
     }
-    logger.info(
+    logger.debug(
         "workflow_engine.delayed_workflow.fire_actions_for_groups",
         extra={
             "groups_to_fire": groups_to_fire,


### PR DESCRIPTION
# Description
- Change an info log to debug to reduce the logs by ~5M per day
- Only invoke `fire_actions_for_groups` if there are actions to trigger; [approx 50%](https://sentry.sentry.io/explore/logs/?aggregateField={%22groupBy%22%3A%22group_to_groupevent%22}&aggregateField={%22yAxes%22%3A[%22count(message)%22]}&logsFields=timestamp&logsFields=message&logsFields=group_to_groupevent&logsQuery=message%3A%EF%80%8DContains%EF%80%8Ddelayed_workflow&logsSortBys=-timestamp&mode=aggregate&project=1&statsPeriod=24h) of the calls to this method there aren't groups_to_dcgs or group_to_group_event.