### PR TITLE
feat(options): Add timing metric to options.get()

### DIFF
--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -292,45 +292,55 @@ class OptionsManager:
         """
         # TODO(mattrobenolt): Perform validation on key returned for type Justin Case
         # values change. This case is unlikely, but good to cover our bases.
-        opt = self.lookup_key(key)
+        from sentry.utils import metrics
 
-        # First check if the option should exist on disk, and if it actually
-        # has a value set, let's use that one instead without even attempting
-        # to fetch from network storage.
-        if opt.has_any_flag({FLAG_PRIORITIZE_DISK}):
-            try:
-                result = settings.SENTRY_OPTIONS[key]
-            except KeyError:
-                pass
-            else:
+        with metrics.timer(
+            "options.store.get",
+            tags={"region": settings.SENTRY_OPTIONS.get("system.region", "unknown")},
+            sample_rate=0.01,
+        ) as tags:
+            opt = self.lookup_key(key)
+
+            # First check if the option should exist on disk, and if it actually
+            # has a value set, let's use that one instead without even attempting
+            # to fetch from network storage.
+            if opt.has_any_flag({FLAG_PRIORITIZE_DISK}):
+                try:
+                    result = settings.SENTRY_OPTIONS[key]
+                except KeyError:
+                    pass
+                else:
+                    if result is not None:
+                        tags["source"] = "disk"
+                        record_option(key, result)
+                        return result
+
+            if not (opt.flags & FLAG_NOSTORE):
+                result = self.store.get(opt, silent=silent)
                 if result is not None:
+                    tags["source"] = "store"
                     record_option(key, result)
                     return result
 
-        if not (opt.flags & FLAG_NOSTORE):
-            result = self.store.get(opt, silent=silent)
-            if result is not None:
-                record_option(key, result)
-                return result
-
-        # Some values we don't want to allow them to be configured through
-        # config files and should only exist in the datastore
-        if opt.has_any_flag({FLAG_STOREONLY}):
-            optval = opt.default()
-        else:
-            try:
-                # default to the hardcoded local configuration for this key
-                optval = settings.SENTRY_OPTIONS[key]
-            except KeyError:
+            # Some values we don't want to allow them to be configured through
+            # config files and should only exist in the datastore
+            if opt.has_any_flag({FLAG_STOREONLY}):
+                optval = opt.default()
+            else:
                 try:
-                    optval = settings.SENTRY_DEFAULT_OPTIONS[key]
+                    # default to the hardcoded local configuration for this key
+                    optval = settings.SENTRY_OPTIONS[key]
                 except KeyError:
-                    optval = opt.default()
-        # options already present in store are cached by store
-        # caching here to avoid database queries
-        self.store.set_cache(opt, optval)
-        record_option(key, optval)
-        return optval
+                    try:
+                        optval = settings.SENTRY_DEFAULT_OPTIONS[key]
+                    except KeyError:
+                        optval = opt.default()
+            # options already present in store are cached by store
+            # caching here to avoid database queries
+            self.store.set_cache(opt, optval)
+            tags["source"] = "default"
+            record_option(key, optval)
+            return optval
 
     def delete(self, key: str):
         """

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -401,3 +401,35 @@ class OptionsManagerTest(TestCase):
         assert opt.has_any_flag({FLAG_NOSTORE})
         assert opt.has_any_flag({FLAG_NOSTORE, FLAG_REQUIRED})
         assert not opt.has_any_flag({FLAG_REQUIRED})
+
+    @patch("sentry.utils.metrics.timer")
+    def test_get_metric_source_store(self, mock_timer) -> None:
+        self.manager.set("foo", "bar")
+        self.store.flush_local_cache()
+        self.manager.get("foo")
+
+        mock_timer.assert_called()
+        call_args = mock_timer.call_args
+        assert call_args[0][0] == "options.store.get"
+        assert "region" in call_args[1]["tags"]
+
+        ctx = mock_timer.return_value.__enter__.return_value
+        ctx.__setitem__.assert_any_call("source", "store")
+
+    @patch("sentry.utils.metrics.timer")
+    def test_get_metric_source_disk(self, mock_timer) -> None:
+        self.manager.register("disk_opt", flags=FLAG_PRIORITIZE_DISK)
+        with self.settings(SENTRY_OPTIONS={"disk_opt": "val"}):
+            self.manager.get("disk_opt")
+
+        ctx = mock_timer.return_value.__enter__.return_value
+        ctx.__setitem__.assert_any_call("source", "disk")
+
+    @patch("sentry.utils.metrics.timer")
+    def test_get_metric_source_default(self, mock_timer) -> None:
+        self.manager.delete("foo")
+        self.store.flush_local_cache()
+        self.manager.get("foo")
+
+        ctx = mock_timer.return_value.__enter__.return_value
+        ctx.__setitem__.assert_any_call("source", "default")


### PR DESCRIPTION
## Summary
- Wraps `OptionsManager.get()` with `metrics.timer("options.store.get")` to measure option lookup latency
- Tags each call with `source` (disk/store/default) and `region` for filtering in Datadog
- Uses 1% sample rate, matching the existing `features.has()` pattern
- Establishes baseline latency data ahead of the sentry-options platform migration

## Context
Part of DI-1934 (Gather metrics). We need before/after latency data to prove the sentry-options migration doesn't regress performance and to demonstrate operational improvement.

## Test plan
- [x] All 72 existing options manager tests pass
- [x] 3 new tests verify correct `source` tag for each resolution path (store, disk, default)
- [x] All pre-commit hooks pass