### PR TITLE
feat(onboarding): Link selected repository to project after creation

### DIFF
--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -829,6 +829,68 @@ describe('ScmPlatformFeatures', () => {
       });
     });
 
+    it('links selected repository to project after creation', async () => {
+      const onComplete = jest.fn();
+      const createdProject = ProjectFixture({
+        slug: 'javascript-nextjs',
+        platform: 'javascript-nextjs',
+      });
+      MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: createdProject,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/${mockRepository.id}/platforms/`,
+        body: [],
+      });
+
+      const repoLinkRequest = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${createdProject.slug}/repo/`,
+        method: 'POST',
+        body: {
+          id: '1',
+          projectId: createdProject.id,
+          repositoryId: mockRepository.id,
+          source: 'scm_onboarding',
+          created: true,
+        },
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedPlatform: nextJsPlatform,
+            selectedRepository: mockRepository,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          }),
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalled();
+      });
+
+      expect(repoLinkRequest).toHaveBeenCalledWith(
+        `/projects/${organization.slug}/${createdProject.slug}/repo/`,
+        expect.objectContaining({
+          method: 'POST',
+          data: {repositoryId: mockRepository.id},
+        })
+      );
+    });
+
     it('reuses the existing project when the platform is unchanged', async () => {
       const onComplete = jest.fn();
       const existingProject = ProjectFixture({
@@ -943,6 +1005,11 @@ describe('ScmPlatformFeatures', () => {
         url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
         method: 'POST',
         body: createdProject,
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${createdProject.slug}/repo/`,
+        method: 'POST',
+        body: {},
       });
 
       render(

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -29,6 +29,7 @@ import type {Team} from 'sentry/types/organization';
 import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDisabledGamingPlatform} from 'sentry/utils/platform';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -433,6 +434,19 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
           firstTeamSlug: firstAdminTeam?.slug,
         });
         setCreatedProjectSlug(project.slug);
+
+        if (selectedRepository?.id) {
+          try {
+            await fetchMutation({
+              url: `/projects/${organization.slug}/${project.slug}/repo/`,
+              method: 'POST',
+              data: {repositoryId: selectedRepository.id},
+            });
+          } catch (error) {
+            Sentry.captureException(error);
+          }
+        }
+
         onComplete(platform, {product: currentFeatures});
       } catch (error) {
         addErrorMessage(t('Failed to create project'));

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -229,6 +229,73 @@ describe('ScmProjectDetails', () => {
     });
   });
 
+  it('links selected repository to project after creation', async () => {
+    const onComplete = jest.fn();
+    const createdProject = ProjectFixture({
+      slug: 'javascript-nextjs',
+      name: 'javascript-nextjs',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: createdProject,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [teamWithAccess],
+    });
+
+    const repoLinkRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${createdProject.slug}/repo/`,
+      method: 'POST',
+      body: {
+        id: '1',
+        projectId: createdProject.id,
+        repositoryId: mockRepository.id,
+        source: 'scm_onboarding',
+        created: true,
+      },
+    });
+
+    render(
+      <ScmProjectDetails
+        onComplete={onComplete}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+          selectedRepository: mockRepository,
+        }),
+      }
+    );
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    expect(repoLinkRequest).toHaveBeenCalledWith(
+      `/projects/${organization.slug}/${createdProject.slug}/repo/`,
+      expect.objectContaining({
+        method: 'POST',
+        data: {repositoryId: mockRepository.id},
+      })
+    );
+  });
+
   it('defaults team selector to first admin team', async () => {
     render(
       <ScmProjectDetails

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -14,6 +14,7 @@ import {IconGroup, IconProject, IconSiren} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Team} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {slugify} from 'sentry/utils/slugify';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -36,6 +37,7 @@ export function ScmProjectDetails({onComplete, genBackButton}: StepProps) {
   const {
     selectedPlatform,
     selectedFeatures,
+    selectedRepository,
     createdProjectSlug,
     setCreatedProjectSlug,
     projectDetailsForm,
@@ -159,6 +161,19 @@ export function ScmProjectDetails({onComplete, genBackButton}: StepProps) {
       // the project via useRecentCreatedProject without corrupting
       // selectedPlatform.key (which the platform features step needs).
       setCreatedProjectSlug(project.slug);
+
+      if (selectedRepository?.id) {
+        try {
+          await fetchMutation({
+            url: `/projects/${organization.slug}/${project.slug}/repo/`,
+            method: 'POST',
+            data: {repositoryId: selectedRepository.id},
+          });
+        } catch (error) {
+          Sentry.captureException(error);
+        }
+      }
+
       setProjectDetailsForm({
         projectName: projectNameResolved,
         teamSlug: teamSlugResolved,


### PR DESCRIPTION
After creating a project during SCM onboarding, call `POST /projects/{org}/{project}/repo/` to persist the user's repository selection as a `ProjectRepository` row with `source=SCM_ONBOARDING`.