### PR TITLE
feat(options): Add timing metric to options.get()

### DIFF
--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -296,7 +296,7 @@ class OptionsManager:
 
         with metrics.timer(
             "options.store.get",
-            tags={"region": settings.SENTRY_OPTIONS.get("system.region", "unknown")},
+            tags={"key": key, "region": settings.SENTRY_OPTIONS.get("system.region", "unknown")},
             sample_rate=0.01,
         ) as tags:
             opt = self.lookup_key(key)

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from collections.abc import Iterable, Sequence
 from enum import Enum
@@ -9,6 +10,7 @@ from typing import Any as TAny
 
 from django.conf import settings
 
+from sentry.silo.base import SiloMode
 from sentry.utils.flag import record_option
 from sentry.utils.hashlib import md5_text
 from sentry.utils.types import Any, Type, type_from_value
@@ -294,9 +296,13 @@ class OptionsManager:
         # values change. This case is unlikely, but good to cover our bases.
         from sentry.utils import metrics
 
+        sentry_env = os.environ.get("CUSTOMER_ID", settings.SENTRY_LOCAL_CELL) or "unknown"
+        if SiloMode.get_current_mode() == SiloMode.CONTROL:
+            sentry_env = SiloMode.CONTROL.name
+
         with metrics.timer(
             "options.store.get",
-            tags={"key": key, "region": settings.SENTRY_OPTIONS.get("system.region", "unknown")},
+            tags={"key": key, "region": sentry_env},
             sample_rate=0.01,
         ) as tags:
             opt = self.lookup_key(key)

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -292,45 +292,55 @@ class OptionsManager:
         """
         # TODO(mattrobenolt): Perform validation on key returned for type Justin Case
         # values change. This case is unlikely, but good to cover our bases.
-        opt = self.lookup_key(key)
+        from sentry.utils import metrics
 
-        # First check if the option should exist on disk, and if it actually
-        # has a value set, let's use that one instead without even attempting
-        # to fetch from network storage.
-        if opt.has_any_flag({FLAG_PRIORITIZE_DISK}):
-            try:
-                result = settings.SENTRY_OPTIONS[key]
-            except KeyError:
-                pass
-            else:
+        with metrics.timer(
+            "options.store.get",
+            tags={"region": settings.SENTRY_OPTIONS.get("system.region", "unknown")},
+            sample_rate=0.01,
+        ) as tags:
+            opt = self.lookup_key(key)
+
+            # First check if the option should exist on disk, and if it actually
+            # has a value set, let's use that one instead without even attempting
+            # to fetch from network storage.
+            if opt.has_any_flag({FLAG_PRIORITIZE_DISK}):
+                try:
+                    result = settings.SENTRY_OPTIONS[key]
+                except KeyError:
+                    pass
+                else:
+                    if result is not None:
+                        tags["source"] = "disk"
+                        record_option(key, result)
+                        return result
+
+            if not (opt.flags & FLAG_NOSTORE):
+                result = self.store.get(opt, silent=silent)
                 if result is not None:
+                    tags["source"] = "store"
                     record_option(key, result)
                     return result
 
-        if not (opt.flags & FLAG_NOSTORE):
-            result = self.store.get(opt, silent=silent)
-            if result is not None:
-                record_option(key, result)
-                return result
-
-        # Some values we don't want to allow them to be configured through
-        # config files and should only exist in the datastore
-        if opt.has_any_flag({FLAG_STOREONLY}):
-            optval = opt.default()
-        else:
-            try:
-                # default to the hardcoded local configuration for this key
-                optval = settings.SENTRY_OPTIONS[key]
-            except KeyError:
+            # Some values we don't want to allow them to be configured through
+            # config files and should only exist in the datastore
+            if opt.has_any_flag({FLAG_STOREONLY}):
+                optval = opt.default()
+            else:
                 try:
-                    optval = settings.SENTRY_DEFAULT_OPTIONS[key]
+                    # default to the hardcoded local configuration for this key
+                    optval = settings.SENTRY_OPTIONS[key]
                 except KeyError:
-                    optval = opt.default()
-        # options already present in store are cached by store
-        # caching here to avoid database queries
-        self.store.set_cache(opt, optval)
-        record_option(key, optval)
-        return optval
+                    try:
+                        optval = settings.SENTRY_DEFAULT_OPTIONS[key]
+                    except KeyError:
+                        optval = opt.default()
+            # options already present in store are cached by store
+            # caching here to avoid database queries
+            self.store.set_cache(opt, optval)
+            tags["source"] = "default"
+            record_option(key, optval)
+            return optval
 
     def delete(self, key: str):
         """

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_telemetry.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_telemetry.py
@@ -41,11 +41,12 @@ def test_records_duration_and_reraises_with_failed_status_on_exception() -> None
     timer, timer_tags = _capture_timer_tags()
 
     with (
-        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer),
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics") as mock_metrics,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
         pytest.raises(ValueError),
     ):
+        mock_metrics.timer.side_effect = timer
         boom()
 
     assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
@@ -64,11 +65,12 @@ def test_reraises_snuba_timeout_and_emits_timeout_status() -> None:
     timer, timer_tags = _capture_timer_tags()
 
     with (
-        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer),
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics") as mock_metrics,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
         pytest.raises(SnubaRPCTimeout),
     ):
+        mock_metrics.timer.side_effect = timer
         boom()
 
     assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
@@ -89,11 +91,12 @@ def test_reraises_snuba_error_and_emits_snuba_error_status() -> None:
     timer, timer_tags = _capture_timer_tags()
 
     with (
-        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer),
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics") as mock_metrics,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
         pytest.raises(SnubaRPCError),
     ):
+        mock_metrics.timer.side_effect = timer
         boom()
 
     assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
@@ -109,15 +112,14 @@ def test_passes_result_through_and_emits_completed_on_success() -> None:
 
     timer, timer_tags = _capture_timer_tags()
     with (
-        patch(
-            "sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer
-        ) as timer_mock,
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics") as mock_metrics,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
     ):
+        mock_metrics.timer.side_effect = timer
         assert add(2, 3) == 5
 
-    timer_mock.assert_called_once_with("dynamic_sampling.add.duration", sample_rate=1.0)
+    mock_metrics.timer.assert_called_once_with("dynamic_sampling.add.duration", sample_rate=1.0)
     assert timer_tags["status"] == DynamicSamplingStatus.COMPLETED.value
     emit.assert_called_once_with("dynamic_sampling.add.status", DynamicSamplingStatus.COMPLETED)
     sdk.capture_exception.assert_not_called()
@@ -131,15 +133,14 @@ def test_emits_returned_terminal_status_without_completed_status() -> None:
 
     timer, timer_tags = _capture_timer_tags()
     with (
-        patch(
-            "sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer
-        ) as timer_mock,
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics") as mock_metrics,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
     ):
+        mock_metrics.timer.side_effect = timer
         assert skipped() == DynamicSamplingStatus.NOT_IN_ROLLOUT
 
-    timer_mock.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
+    mock_metrics.timer.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
     assert timer_tags["status"] == DynamicSamplingStatus.NOT_IN_ROLLOUT.value
     emit.assert_called_once_with(
         "dynamic_sampling.skipped.status", DynamicSamplingStatus.NOT_IN_ROLLOUT
@@ -155,15 +156,14 @@ def test_emits_terminal_status_exception_without_failed_status() -> None:
 
     timer, timer_tags = _capture_timer_tags()
     with (
-        patch(
-            "sentry.dynamic_sampling.per_org.tasks.telemetry.metrics.timer", side_effect=timer
-        ) as timer_mock,
+        patch("sentry.dynamic_sampling.per_org.tasks.telemetry.metrics") as mock_metrics,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.emit_status") as emit,
         patch("sentry.dynamic_sampling.per_org.tasks.telemetry.sentry_sdk") as sdk,
     ):
+        mock_metrics.timer.side_effect = timer
         assert skipped() == DynamicSamplingStatus.NO_SUBSCRIPTION
 
-    timer_mock.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
+    mock_metrics.timer.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
     assert timer_tags["status"] == DynamicSamplingStatus.NO_SUBSCRIPTION.value
     emit.assert_called_once_with(
         "dynamic_sampling.skipped.status", DynamicSamplingStatus.NO_SUBSCRIPTION

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -401,3 +401,35 @@ class OptionsManagerTest(TestCase):
         assert opt.has_any_flag({FLAG_NOSTORE})
         assert opt.has_any_flag({FLAG_NOSTORE, FLAG_REQUIRED})
         assert not opt.has_any_flag({FLAG_REQUIRED})
+
+    @patch("sentry.utils.metrics.timer")
+    def test_get_metric_source_store(self, mock_timer) -> None:
+        self.manager.set("foo", "bar")
+        self.store.flush_local_cache()
+        self.manager.get("foo")
+
+        mock_timer.assert_called()
+        call_args = mock_timer.call_args
+        assert call_args[0][0] == "options.store.get"
+        assert "region" in call_args[1]["tags"]
+
+        ctx = mock_timer.return_value.__enter__.return_value
+        ctx.__setitem__.assert_any_call("source", "store")
+
+    @patch("sentry.utils.metrics.timer")
+    def test_get_metric_source_disk(self, mock_timer) -> None:
+        self.manager.register("disk_opt", flags=FLAG_PRIORITIZE_DISK)
+        with self.settings(SENTRY_OPTIONS={"disk_opt": "val"}):
+            self.manager.get("disk_opt")
+
+        ctx = mock_timer.return_value.__enter__.return_value
+        ctx.__setitem__.assert_any_call("source", "disk")
+
+    @patch("sentry.utils.metrics.timer")
+    def test_get_metric_source_default(self, mock_timer) -> None:
+        self.manager.delete("foo")
+        self.store.flush_local_cache()
+        self.manager.get("foo")
+
+        ctx = mock_timer.return_value.__enter__.return_value
+        ctx.__setitem__.assert_any_call("source", "default")


### PR DESCRIPTION
> **make sure to remove whitespace from the diff to view the real changes (minimal)**

Wraps the `OptionsManager.get()` to establish baseline performance of the current sentry options system. We will compare this to the new sentry options system to ensure we don't regress. Also includes some tests to ensure the metrics function is being called.

This matches the pattern already used with `features.has()` (see `src/sentry/features/manager.py` line 280)

Assuming our metrics library is written well, there should be minimal overhead. We set the sample rate low (1%) to reduce metrics volume. 
