### PR TITLE
feat(night-shift): Enable code review for autofix runs

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -224,6 +224,7 @@ class SeerAgentClient:
         is_interactive: bool = False,
         enable_coding: bool = False,
         enable_code_mode_tools: str = "off",
+        code_review_enabled: bool = False,
         max_iterations: int | None = None,
     ):
         self.organization = organization
@@ -237,6 +238,7 @@ class SeerAgentClient:
         self.category_value = category_value
         self.is_interactive = is_interactive
         self.enable_code_mode_tools = enable_code_mode_tools
+        self.code_review_enabled = code_review_enabled
         self.max_iterations = max_iterations
 
         if enable_coding and not organization.get_option("sentry:enable_seer_coding", True):
@@ -311,6 +313,7 @@ class SeerAgentClient:
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
             enable_code_mode_tools=self.enable_code_mode_tools,
+            code_review_enabled=self.code_review_enabled,
             proxy_headers=get_proxy_headers() if self.enable_code_mode_tools != "off" else None,
         )
 

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -73,6 +73,7 @@ class AgentChatRequest(TypedDict):
     category_value: NotRequired[str]
     metadata: NotRequired[dict[str, Any]]
     is_context_engine_enabled: NotRequired[bool]
+    code_review_enabled: NotRequired[bool]
     max_iterations: NotRequired[int]
     proxy_headers: NotRequired[dict[str, str] | None]
     ui_tools: NotRequired[str | None]

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -133,7 +133,12 @@ STEP_CONFIGS: dict[AutofixStep, StepConfig] = {
 }
 
 
-def build_step_prompt(step: AutofixStep, group: Group, user_context: str | None = None) -> str:
+def build_step_prompt(
+    step: AutofixStep,
+    group: Group,
+    user_context: str | None = None,
+    code_review_enabled: bool = False,
+) -> str:
     """
     Build the prompt for a step using issue details.
 
@@ -153,6 +158,12 @@ def build_step_prompt(step: AutofixStep, group: Group, user_context: str | None 
     )
 
     parts = [prompt]
+
+    if code_review_enabled and step == AutofixStep.CODE_CHANGES:
+        parts.append(
+            "When your edits are complete, call review_code_changes to check for bugs. "
+            "If it reports issues, fix them and call it again until no issues remain."
+        )
 
     user_context = user_context or ""
     user_context = user_context.strip()
@@ -187,6 +198,7 @@ def get_autofix_agent_client(
     intelligence_level: Literal["low", "medium", "high"] = "medium",
     reasoning_effort: Literal["low", "medium", "high"] | None = None,
     enable_coding: bool = False,
+    code_review_enabled: bool = False,
 ) -> SeerAgentClient:
     from sentry.seer.autofix.on_completion_hook import (
         AutofixOnCompletionHook,  # nested to avoid circular import
@@ -202,6 +214,7 @@ def get_autofix_agent_client(
         reasoning_effort=reasoning_effort,
         on_completion_hook=AutofixOnCompletionHook,
         enable_coding=enable_coding,
+        code_review_enabled=code_review_enabled,
     )
 
 
@@ -231,6 +244,7 @@ def trigger_autofix_agent(
     reasoning_effort: Literal["low", "medium", "high"] | None = _UNSET,
     user_context: str | None = None,
     insert_index: int | None = None,
+    code_review_enabled: bool = False,
 ) -> int:
     """
     Start or continue an agent-based autofix run.
@@ -262,6 +276,7 @@ def trigger_autofix_agent(
             config.reasoning_effort if reasoning_effort is _UNSET else reasoning_effort
         ),
         enable_coding=config.enable_coding,
+        code_review_enabled=code_review_enabled,
     )
     if run_id is not None:
         _get_group_run_state(client, group, run_id)
@@ -276,7 +291,7 @@ def trigger_autofix_agent(
             )
         )
 
-    prompt = build_step_prompt(step, group, user_context)
+    prompt = build_step_prompt(step, group, user_context, code_review_enabled)
     prompt_metadata = {
         "step": step.value,
         "referrer": referrer.value,

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -537,6 +537,7 @@ def _run_autofix_for_candidates(
                 intelligence_level=options["intelligence_level"],
                 reasoning_effort=options["reasoning_effort"],
                 user_context=user_context,
+                code_review_enabled=True,
             )
         except Exception:
             logger.exception(


### PR DESCRIPTION
## Summary
- Add `code_review_enabled` flag to `SeerAgentClient` and pipe it through from Sentry to Seer
- Enable the `review_code_changes` tool for night shift autofix runs
- Add prompt instruction telling the agent to call the review tool after making edits

## Companion PR

[getsentry/seer#6008](https://github.com/getsentry/seer/pull/6008) — Seer-side changes that add the `code_review_enabled` flag and the `review_code_changes` tool.

## Test plan
- [ ] Verify night shift autofix runs now use the code review tool
- [ ] Verify non-night-shift autofix runs are unaffected (code_review_enabled defaults to false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)