### PR TITLE
ref(seer): rm severity conditional routing

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -114,7 +114,6 @@ from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.net.http import connection_from_url
-from sentry.options.rollout import in_random_rollout
 from sentry.plugins.base import plugins
 from sentry.quotas.base import index_data_category
 from sentry.receivers.features import record_event_processed
@@ -1957,12 +1956,6 @@ def _process_existing_aggregate(
 
 
 severity_connection_pool = connection_from_url(
-    settings.SEER_GROUPING_URL,
-    retries=settings.SEER_SEVERITY_RETRIES,
-    timeout=settings.SEER_SEVERITY_TIMEOUT,  # Defaults to 300 milliseconds
-)
-
-severity_connection_pool_group_seer = connection_from_url(
     settings.SEER_SCORING_URL,
     retries=settings.SEER_SEVERITY_RETRIES,
     timeout=settings.SEER_SEVERITY_TIMEOUT,  # Defaults to 300 milliseconds
@@ -1990,11 +1983,8 @@ def make_severity_score_request(
         payload["trigger_timeout"] = True
     if options.get("processing.severity-backlog-test.error"):
         payload["trigger_error"] = True
-    default_connection_pool = severity_connection_pool
-    if in_random_rollout("issues.severity.group-seer-rollout-rate"):
-        default_connection_pool = severity_connection_pool_group_seer
     return make_signed_seer_api_request(
-        connection_pool or default_connection_pool,
+        connection_pool or severity_connection_pool,
         "/v0/issues/severity-score",
         body=orjson.dumps(payload),
         timeout=timeout,

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -17,11 +17,8 @@ from sentry.constants import PLACEHOLDER_EVENT_TITLES
 from sentry.event_manager import (
     SEER_ERROR_COUNT_KEY,
     EventManager,
-    SeverityScoreRequest,
     _get_severity_score,
-    make_severity_score_request,
     severity_connection_pool,
-    severity_connection_pool_group_seer,
 )
 from sentry.models.group import Group
 from sentry.testutils.cases import TestCase
@@ -331,24 +328,6 @@ class TestGetEventSeverity(TestCase):
         assert severity == 1.0
         assert reason == "microservice_error"
         assert cache.get(SEER_ERROR_COUNT_KEY) == 1
-
-    @patch("sentry.event_manager.make_signed_seer_api_request")
-    def test_group_seer_rollout_selects_pool(self, mock_request: MagicMock) -> None:
-        body: SeverityScoreRequest = {
-            "message": "boom",
-            "has_stacktrace": 0,
-            "handled": True,
-            "org_id": 1,
-            "project_id": 1,
-        }
-
-        with override_options({"issues.severity.group-seer-rollout-rate": 0.0}):
-            make_severity_score_request(body)
-        assert mock_request.call_args[0][0] is severity_connection_pool
-
-        with override_options({"issues.severity.group-seer-rollout-rate": 1.0}):
-            make_severity_score_request(body)
-        assert mock_request.call_args[0][0] is severity_connection_pool_group_seer
 
 
 @with_feature("projects:first-event-severity-calculation")


### PR DESCRIPTION
1. [this](https://github.com/getsentry/sentry/pull/115765)
2. https://github.com/getsentry/sentry-options-automator/pull/7860
3. https://github.com/getsentry/sentry/pull/115768

[all traffic moved to group-seer](https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22server_name%22%7D&aggregateField=%7B%22groupBy%22%3A%22http.status_code%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&field=server_name&field=http.status_code&mode=aggregate&project=6178942&query=span.description%3A%2Fv0%2Fissues%2Fseverity-score&statsPeriod=5m)