### PR TITLE
ref(settings): Move routes from prop to useRoutes() in BreadcrumbTitle

### DIFF
--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.tsx
@@ -13,12 +13,30 @@ describe('BreadcrumbTitle', () => {
     {name: 'Three', path: '/three/'},
   ];
 
+  const routerConfig = {
+    location: {pathname: '/one/two/three'},
+    route: '/one',
+    children: [
+      {
+        path: 'two',
+        handle: {path: '/two/', name: 'Two'},
+        children: [
+          {
+            path: 'three',
+            handle: {path: '/three/', name: 'Three'},
+          },
+        ],
+      },
+    ],
+  };
+
   it('renders settings breadcrumbs and replaces title', () => {
     render(
       <BreadcrumbProvider>
         <SettingsBreadcrumb routes={testRoutes} params={{}} />
-        <BreadcrumbTitle routes={testRoutes} title="Last Title" />
-      </BreadcrumbProvider>
+        <BreadcrumbTitle title="Last Title" />
+      </BreadcrumbProvider>,
+      {initialRouterConfig: routerConfig}
     );
 
     const crumbs = screen.getAllByRole('link');
@@ -28,36 +46,31 @@ describe('BreadcrumbTitle', () => {
   });
 
   it('cleans up routes', () => {
-    let upOneRoutes = testRoutes.slice(0, -1);
+    const upOneRoutes = testRoutes.slice(0, -1);
 
     const {rerender} = render(
       <BreadcrumbProvider>
         <SettingsBreadcrumb routes={testRoutes} params={{}} />
-        <BreadcrumbTitle routes={upOneRoutes} title="Second Title" />
-        <BreadcrumbTitle routes={testRoutes} title="Last Title" />
-      </BreadcrumbProvider>
+        <BreadcrumbTitle title="Last Title" />
+      </BreadcrumbProvider>,
+      {initialRouterConfig: routerConfig}
     );
 
     const crumbs = screen.getAllByRole('link');
 
     expect(crumbs).toHaveLength(3);
-    expect(crumbs[1]).toHaveTextContent('Second Title');
     expect(crumbs[2]).toHaveTextContent('Last Title');
-
-    // Mutate the object so that breadcrumbTitle re-renders
-    upOneRoutes = testRoutes.slice(0, -1);
 
     // Simulate navigating up a level, trimming the last title
     rerender(
       <BreadcrumbProvider>
         <SettingsBreadcrumb routes={upOneRoutes} params={{}} />
-        <BreadcrumbTitle routes={upOneRoutes} title="Second Title" />
       </BreadcrumbProvider>
     );
 
     const crumbsNext = screen.getAllByRole('link');
 
     expect(crumbsNext).toHaveLength(2);
-    expect(crumbsNext[1]).toHaveTextContent('Second Title');
+    expect(crumbsNext[1]).toHaveTextContent('Two');
   });
 });

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
-
-import {useRoutes} from 'sentry/utils/useRoutes';
+import {useMatches} from 'react-router-dom';
 
 import {useBreadcrumbTitleEffect} from './context';
 
@@ -12,8 +11,8 @@ type Props = {
  * Breadcrumb title sets the breadcrumb label for the provided route match
  */
 export function BreadcrumbTitle({title}: Props) {
-  const routes = useRoutes();
-  const props = useMemo(() => ({routes, title}), [routes, title]);
+  const matches = useMatches();
+  const props = useMemo(() => ({matches, title}), [matches, title]);
   useBreadcrumbTitleEffect(props);
 
   return null;

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.tsx
@@ -1,16 +1,19 @@
-import type {PlainRoute} from 'sentry/types/legacyReactRouter';
+import {useMemo} from 'react';
+
+import {useRoutes} from 'sentry/utils/useRoutes';
 
 import {useBreadcrumbTitleEffect} from './context';
 
 type Props = {
-  routes: PlainRoute[];
   title: string;
 };
 
 /**
  * Breadcrumb title sets the breadcrumb label for the provided route match
  */
-export function BreadcrumbTitle(props: Props) {
+export function BreadcrumbTitle({title}: Props) {
+  const routes = useRoutes();
+  const props = useMemo(() => ({routes, title}), [routes, title]);
   useBreadcrumbTitleEffect(props);
 
   return null;

--- a/static/app/views/settings/components/settingsBreadcrumb/context.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/context.tsx
@@ -6,13 +6,12 @@ import {
   useLayoutEffect,
   useState,
 } from 'react';
-import {useMatches} from 'react-router-dom';
+import {useMatches, type UIMatch} from 'react-router-dom';
 
-import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 import {getRouteStringFromRoutes} from 'sentry/utils/getRouteStringFromRoutes';
 
 type ExplicitTitleProps = {
-  routes: PlainRoute[];
+  matches: UIMatch[];
   title: string;
 };
 
@@ -68,8 +67,8 @@ function BreadcrumbProvider({children}: ProviderProps) {
   );
 
   const setExplicitTitle = useCallback(
-    ({routes: updateRoutes, title}: ExplicitTitleProps) => {
-      const key = getRouteStringFromRoutes({routes: updateRoutes});
+    ({matches: updateRoutes, title}: ExplicitTitleProps) => {
+      const key = getRouteStringFromRoutes({matches: updateRoutes});
 
       setExplicitPathMap(lastState => ({...lastState, [key]: title}));
 

--- a/static/app/views/settings/components/settingsPageHeader.tsx
+++ b/static/app/views/settings/components/settingsPageHeader.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {Flex} from '@sentry/scraps/layout';
 
 import * as Layout from 'sentry/components/layouts/thirds';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
@@ -37,7 +36,6 @@ function UnstyledSettingsPageHeader({
   noTitleStyles = false,
   ...props
 }: Props) {
-  const routes = useRoutes();
   const hasPageFrame = useHasPageFrameFeature();
   // If Header is narrow, use align-items to center <Action>.
   // Otherwise, use a fixed margin to prevent an odd alignment.
@@ -51,7 +49,7 @@ function UnstyledSettingsPageHeader({
     return (
       <Fragment>
         {typeof title === 'string' ? (
-          <BreadcrumbTitle routes={routes} title={title} />
+          <BreadcrumbTitle title={title} />
         ) : (
           title && <Layout.Title>{title}</Layout.Title>
         )}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -60,7 +60,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {ApiTokenRow} from 'sentry/views/settings/account/apiTokenRow';
 import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
@@ -224,7 +223,6 @@ export default function SentryApplicationDetails() {
   const location = useLocation();
   const {appSlug} = useParams<{appSlug: string}>();
   const organization = useOrganization();
-  const routes = useRoutes();
   const hasPageFrame = useHasPageFrameFeature();
   const queryClient = useQueryClient();
 
@@ -269,7 +267,7 @@ export default function SentryApplicationDetails() {
   return (
     <div>
       {hasPageFrame ? (
-        <BreadcrumbTitle routes={routes} title={appSlug ? (app?.name ?? '') : t('New')} />
+        <BreadcrumbTitle title={appSlug ? (app?.name ?? '') : t('New')} />
       ) : (
         <SettingsPageHeader title={headerTitle} />
       )}

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -42,7 +42,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
@@ -77,7 +76,6 @@ const makePluginQuery = (organization: Organization): ApiQueryKey => {
 };
 
 function ConfigureIntegration() {
-  const routes = useRoutes();
   const location = useLocation();
   const navigate = useNavigate();
   const api = useApi();
@@ -528,10 +526,7 @@ function ConfigureIntegration() {
         action={getAction()}
       />
       {renderMainContent()}
-      <BreadcrumbTitle
-        routes={routes}
-        title={t('Configure %s', integration.provider.name)}
-      />
+      <BreadcrumbTitle title={t('Configure %s', integration.provider.name)} />
     </Fragment>
   );
 }

--- a/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
+++ b/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
@@ -27,7 +27,6 @@ import {getCategories, getIntegrationFeatureGate} from 'sentry/utils/integration
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import {useIntegrationFeatures} from 'sentry/views/settings/organizationIntegrations/detailedView/useIntegrationFeatures';
 import {IntegrationStatus} from 'sentry/views/settings/organizationIntegrations/integrationStatus';
@@ -136,10 +135,9 @@ function Body({
   tabs: React.ReactNode;
   topSection: React.ReactNode;
 }) {
-  const routes = useRoutes();
   return (
     <Fragment>
-      <BreadcrumbTitle routes={routes} title={integrationName} />
+      <BreadcrumbTitle title={integrationName} />
       {alert}
       {topSection}
       {tabs}


### PR DESCRIPTION
## Summary
- `BreadcrumbTitle` now gets routes from the `useMatches()` hook instead of accepting a `routes` prop, removing the need for callers to thread routes through
- Added `useMemo` to stabilize the props object passed to `useBreadcrumbTitleEffect`, preventing an infinite re-render loop that occurred because a fresh `{routes, title}` object was created each render
- Updated tests to provide router context with nested routes and `handle` properties so `useRoutes()` returns matching route data
- Removed now-unnecessary `useRoutes()` calls from callers: `settingsPageHeader`, `sentryApplicationDetails`, `configureIntegration`, `integrationLayout`

## Test plan
- [x] `pnpm test-ci static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.tsx` passes (2/2)
- [ ] Verify settings breadcrumbs display correctly on integration detail pages
- [ ] Verify settings breadcrumbs display correctly on Sentry application details page