### PR TITLE
feat(integrations): disable auth token creation button without perms

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -404,6 +404,14 @@ describe('Sentry Application Details', () => {
       });
     });
 
+    it('disables the new token button when user lacks org:write', async () => {
+      const organization = OrganizationFixture({access: ['org:read']});
+      render(<SentryApplicationDetails />, {initialRouterConfig, organization});
+
+      const button = await screen.findByRole('button', {name: 'New Token'});
+      expect(button).toBeDisabled();
+    });
+
     it('removing token from list', async () => {
       MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/api-tokens/${token.id}/`,

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -844,14 +844,22 @@ function SentryApplicationForm({
             t('Created On'),
             t('Scopes'),
             <AddTokenHeader key="token-add">
-              <Button
-                size="xs"
-                icon={<IconAdd />}
-                onClick={onAddToken}
-                data-test-id="token-add"
+              <Tooltip
+                disabled={hasTokenAccess()}
+                title={t(
+                  'You must be a Manager or Owner to create authentication tokens.'
+                )}
               >
-                {t('New Token')}
-              </Button>
+                <Button
+                  size="xs"
+                  icon={<IconAdd />}
+                  onClick={onAddToken}
+                  disabled={!hasTokenAccess()}
+                  data-test-id="token-add"
+                >
+                  {t('New Token')}
+                </Button>
+              </Tooltip>
             </AddTokenHeader>,
           ]}
           isEmpty={tokens.length === 0}


### PR DESCRIPTION
The backend requires org:write or org:admin to create internal integration auth tokens. Disable the New Token button in the frontend for users without that scope, with a tooltip explaining the requirement, so the constraint is visible before the request is attempted

Old:
<img width="1246" height="284" alt="Screenshot 2026-05-18 at 5 03 46 PM" src="https://github.com/user-attachments/assets/e3ba238b-73e1-4068-a4e0-688d019e58fc" />
New:
<img width="1223" height="273" alt="Screenshot 2026-05-18 at 5 03 29 PM" src="https://github.com/user-attachments/assets/4238cb2b-5c84-4853-b408-0e8a5993d7e8" />
