### PR TITLE
fix(web): Redirect /scraps to stories

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -523,6 +523,11 @@ urlpatterns += [
         name="sentry-api-docs-redirect",
     ),
     re_path(
+        r"^scraps/?$",
+        RedirectView.as_view(pattern_name="stories", permanent=False),
+        name="sentry-scraps-redirect",
+    ),
+    re_path(
         r"^api/$",
         RedirectView.as_view(pattern_name="sentry-api", permanent=False),
         name="sentry-api-redirect",

--- a/tests/sentry/web/test_urls.py
+++ b/tests/sentry/web/test_urls.py
@@ -17,3 +17,11 @@ class ApiDocsRedirectTest(TestCase):
         resp = self.client.get(path)
         assert resp["Location"] == "https://docs.sentry.io/api/"
         assert resp.status_code == 302, resp.status_code
+
+
+class ScrapsRedirectTest(TestCase):
+    def test_response(self) -> None:
+        path = reverse("sentry-scraps-redirect")
+        resp = self.client.get(path)
+        assert resp["Location"] == reverse("stories")
+        assert resp.status_code == 302, resp.status_code


### PR DESCRIPTION
Add a top-level redirect for /scraps to the existing stories route.

This makes typing https://sentry.io/scraps into the browser land on the design system stories page instead of falling through to unrelated routing.

The change follows the existing pattern in `src/sentry/web/urls.py` for short convenience and legacy redirects, and adds a URL test to cover the new route.