### PR TITLE
ref(forms): Migrate early features settings

### DIFF
--- a/static/app/views/settings/earlyFeatures/settingsForm.spec.tsx
+++ b/static/app/views/settings/earlyFeatures/settingsForm.spec.tsx
@@ -29,17 +29,10 @@ describe('EarlyFeaturesSettingsForm', () => {
     expect(toggle).not.toBeChecked();
   });
 
-  it('updates a flag when toggled', async () => {
+  it('updates a flag when toggled and can toggle it back after a successful save', async () => {
     const putMock = MockApiClient.addMockResponse({
       url: '/internal/feature-flags/',
       method: 'PUT',
-      body: {
-        ...featureFlags,
-        'organizations:my-flag': {
-          ...featureFlags['organizations:my-flag'],
-          value: true,
-        },
-      },
     });
 
     render(<EarlyFeaturesSettingsForm access={new Set(organization.access)} />, {
@@ -50,11 +43,25 @@ describe('EarlyFeaturesSettingsForm', () => {
     await userEvent.click(toggle);
 
     await waitFor(() => {
-      expect(putMock).toHaveBeenCalledWith(
+      expect(putMock).toHaveBeenNthCalledWith(
+        1,
         '/internal/feature-flags/',
         expect.objectContaining({
           method: 'PUT',
           data: {'organizations:my-flag': true},
+        })
+      );
+    });
+
+    await userEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenNthCalledWith(
+        2,
+        '/internal/feature-flags/',
+        expect.objectContaining({
+          method: 'PUT',
+          data: {'organizations:my-flag': false},
         })
       );
     });

--- a/static/app/views/settings/earlyFeatures/settingsForm.spec.tsx
+++ b/static/app/views/settings/earlyFeatures/settingsForm.spec.tsx
@@ -1,0 +1,62 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {EarlyFeaturesSettingsForm} from 'sentry/views/settings/earlyFeatures/settingsForm';
+
+describe('EarlyFeaturesSettingsForm', () => {
+  const organization = OrganizationFixture({access: ['org:write']});
+  const featureFlags = {
+    'organizations:my-flag': {
+      description: 'My feature flag',
+      value: false,
+    },
+  };
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: '/internal/feature-flags/',
+      body: featureFlags,
+    });
+  });
+
+  it('renders flags with their current values', async () => {
+    render(<EarlyFeaturesSettingsForm access={new Set(organization.access)} />, {
+      organization,
+    });
+
+    const toggle = await screen.findByRole('checkbox', {name: 'My feature flag'});
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('updates a flag when toggled', async () => {
+    const putMock = MockApiClient.addMockResponse({
+      url: '/internal/feature-flags/',
+      method: 'PUT',
+      body: {
+        ...featureFlags,
+        'organizations:my-flag': {
+          ...featureFlags['organizations:my-flag'],
+          value: true,
+        },
+      },
+    });
+
+    render(<EarlyFeaturesSettingsForm access={new Set(organization.access)} />, {
+      organization,
+    });
+
+    const toggle = await screen.findByRole('checkbox', {name: 'My feature flag'});
+    await userEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith(
+        '/internal/feature-flags/',
+        expect.objectContaining({
+          method: 'PUT',
+          data: {'organizations:my-flag': true},
+        })
+      );
+    });
+  });
+});

--- a/static/app/views/settings/earlyFeatures/settingsForm.tsx
+++ b/static/app/views/settings/earlyFeatures/settingsForm.tsx
@@ -3,10 +3,10 @@ import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Scope} from 'sentry/types/core';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -64,14 +64,30 @@ export function EarlyFeaturesSettingsForm({access}: Props) {
         data,
       }),
     onSuccess: (_response, updatedFlags) => {
-      queryClient.setQueryData(featureFlagsQueryOptions.queryKey, previous => {
-        if (!previous) {
-          return previous;
+      const previous = queryClient.getQueryData(featureFlagsQueryOptions.queryKey);
+
+      for (const [flag, newValue] of Object.entries(updatedFlags)) {
+        const previousFlag = previous?.json[flag];
+        if (!previousFlag) {
+          continue;
+        }
+        addSuccessMessage(
+          tct('Changed [fieldName] from [oldValue] to [newValue]', {
+            fieldName: <strong>{previousFlag.description}</strong>,
+            oldValue: <em>{previousFlag.value ? t('enabled') : t('disabled')}</em>,
+            newValue: <em>{newValue ? t('enabled') : t('disabled')}</em>,
+          })
+        );
+      }
+
+      queryClient.setQueryData(featureFlagsQueryOptions.queryKey, prev => {
+        if (!prev) {
+          return prev;
         }
 
         return {
-          ...previous,
-          json: updateFeatureFlags(previous.json, updatedFlags),
+          ...prev,
+          json: updateFeatureFlags(prev.json, updatedFlags),
         };
       });
     },

--- a/static/app/views/settings/earlyFeatures/settingsForm.tsx
+++ b/static/app/views/settings/earlyFeatures/settingsForm.tsx
@@ -1,48 +1,86 @@
-import {mutationOptions} from '@tanstack/react-query';
+import {mutationOptions, useQuery, useQueryClient} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import type {Scope} from 'sentry/types/core';
-import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {fetchMutation} from 'sentry/utils/queryClient';
 
 interface Props {
   access: Set<Scope>;
 }
 
-type FeatureFlags = Record<string, {description: string; value: boolean}>;
+type FeatureFlag = {description: string; value: boolean};
+type FeatureFlags = Record<string, FeatureFlag>;
+
+const featureFlagsQueryOptions = apiOptions.as<FeatureFlags>()(
+  '/internal/feature-flags/',
+  {
+    staleTime: 0,
+  }
+);
 
 function getFeatureFlagSchema(flag: string) {
   return z.object({[flag]: z.boolean()});
 }
 
-export function EarlyFeaturesSettingsForm({access}: Props) {
-  const {data: featureFlags, isPending} = useApiQuery<FeatureFlags>(
-    ['/internal/feature-flags/'],
-    {staleTime: 0}
+function updateFeatureFlags(
+  featureFlags: FeatureFlags,
+  updatedFlags: Record<string, boolean>
+): FeatureFlags {
+  return Object.fromEntries(
+    Object.entries(featureFlags).map(([flag, featureFlag]) => [
+      flag,
+      Object.hasOwn(updatedFlags, flag)
+        ? {...featureFlag, value: updatedFlags[flag]!}
+        : featureFlag,
+    ])
   );
+}
 
-  if (isPending || !featureFlags) {
+export function EarlyFeaturesSettingsForm({access}: Props) {
+  const queryClient = useQueryClient();
+  const {data: featureFlags, isPending, isError} = useQuery(featureFlagsQueryOptions);
+
+  if (isPending) {
     return <LoadingIndicator />;
+  }
+
+  if (isError) {
+    return <LoadingError />;
   }
 
   const disabled = !access.has('org:write');
   const featureFlagMutationOptions = mutationOptions({
     mutationFn: (data: Record<string, boolean>) =>
-      fetchMutation<FeatureFlags>({
+      fetchMutation<void>({
         method: 'PUT',
         url: '/internal/feature-flags/',
         data,
       }),
+    onSuccess: (_response, updatedFlags) => {
+      queryClient.setQueryData(featureFlagsQueryOptions.queryKey, previous => {
+        if (!previous) {
+          return previous;
+        }
+
+        return {
+          ...previous,
+          json: updateFeatureFlags(previous.json, updatedFlags),
+        };
+      });
+    },
     onError: () => addErrorMessage(t('Unable to save change')),
   });
 
   return (
     <FieldGroup title={t('Early Adopter Features')}>
-      {Object.entries(featureFlags).map(([flag, {description, value}]) => (
+      {Object.entries(featureFlags ?? {}).map(([flag, {description, value}]) => (
         <AutoSaveForm
           key={flag}
           name={flag}

--- a/static/app/views/settings/earlyFeatures/settingsForm.tsx
+++ b/static/app/views/settings/earlyFeatures/settingsForm.tsx
@@ -36,7 +36,7 @@ function updateFeatureFlags(
   return Object.fromEntries(
     Object.entries(featureFlags).map(([flag, featureFlag]) => [
       flag,
-      updatedFlags[flag] ? {...featureFlag, value: updatedFlags[flag]} : featureFlag,
+      flag in updatedFlags ? {...featureFlag, value: updatedFlags[flag]!} : featureFlag,
     ])
   );
 }

--- a/static/app/views/settings/earlyFeatures/settingsForm.tsx
+++ b/static/app/views/settings/earlyFeatures/settingsForm.tsx
@@ -34,10 +34,13 @@ function updateFeatureFlags(
   updatedFlags: Record<string, boolean>
 ): FeatureFlags {
   return Object.fromEntries(
-    Object.entries(featureFlags).map(([flag, featureFlag]) => [
-      flag,
-      flag in updatedFlags ? {...featureFlag, value: updatedFlags[flag]!} : featureFlag,
-    ])
+    Object.entries(featureFlags).map(([flag, featureFlag]) => {
+      const newValue = updatedFlags[flag];
+      return [
+        flag,
+        newValue === undefined ? featureFlag : {...featureFlag, value: newValue},
+      ];
+    })
   );
 }
 

--- a/static/app/views/settings/earlyFeatures/settingsForm.tsx
+++ b/static/app/views/settings/earlyFeatures/settingsForm.tsx
@@ -1,17 +1,13 @@
-import {Fragment} from 'react';
+import {mutationOptions} from '@tanstack/react-query';
+import {z} from 'zod';
+
+import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {Form} from 'sentry/components/forms/form';
-import JsonForm from 'sentry/components/forms/jsonForm';
-import type {JsonFormObject} from 'sentry/components/forms/types';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import type {OrganizationAuthProvider} from 'sentry/types/auth';
 import type {Scope} from 'sentry/types/core';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useOrganization} from 'sentry/utils/useOrganization';
+import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
 
 interface Props {
   access: Set<Scope>;
@@ -19,66 +15,52 @@ interface Props {
 
 type FeatureFlags = Record<string, {description: string; value: boolean}>;
 
+function getFeatureFlagSchema(flag: string) {
+  return z.object({[flag]: z.boolean()});
+}
+
 export function EarlyFeaturesSettingsForm({access}: Props) {
-  const location = useLocation();
-  const organization = useOrganization();
+  const {data: featureFlags, isPending} = useApiQuery<FeatureFlags>(
+    ['/internal/feature-flags/'],
+    {staleTime: 0}
+  );
 
-  const {data: authProvider, isPending: authProviderIsLoading} =
-    useApiQuery<OrganizationAuthProvider>(
-      [
-        getApiUrl('/organizations/$organizationIdOrSlug/auth-provider/', {
-          path: {organizationIdOrSlug: organization.slug},
-        }),
-      ],
-      {staleTime: 0}
-    );
-
-  const {data: featureFlags, isPending: featureFlagsIsLoading} =
-    useApiQuery<FeatureFlags>([getApiUrl('/internal/feature-flags/')], {staleTime: 0});
-
-  if (authProviderIsLoading || featureFlagsIsLoading) {
+  if (isPending || !featureFlags) {
     return <LoadingIndicator />;
   }
 
-  const initialData: Record<string, boolean> = {};
-  for (const flag in featureFlags) {
-    if (Object.hasOwn(featureFlags, flag)) {
-      const obj = featureFlags[flag]!;
-      initialData[flag] = obj.value;
-    }
-  }
-
-  const jsonFormSettings = {
-    additionalFieldProps: {hasSsoEnabled: !!authProvider},
-    features: new Set(organization.features),
-    access,
-    location,
-    disabled: !access.has('org:write'),
-  };
-
-  const featuresForm: JsonFormObject = {
-    title: t('Early Adopter Features'),
-    fields: Object.entries(featureFlags || {}).map(([flag, obj]) => ({
-      label: obj.description,
-      name: flag,
-      type: 'boolean',
-    })),
-  };
+  const disabled = !access.has('org:write');
+  const featureFlagMutationOptions = mutationOptions({
+    mutationFn: (data: Record<string, boolean>) =>
+      fetchMutation<FeatureFlags>({
+        method: 'PUT',
+        url: '/internal/feature-flags/',
+        data,
+      }),
+    onError: () => addErrorMessage(t('Unable to save change')),
+  });
 
   return (
-    <Fragment>
-      <Form
-        data-test-id="organization-settings"
-        apiMethod="PUT"
-        apiEndpoint="/internal/feature-flags/"
-        saveOnBlur
-        allowUndo
-        initialData={initialData}
-        onSubmitError={() => addErrorMessage('Unable to save change')}
-        onSubmitSuccess={() => {}}
-      >
-        <JsonForm {...jsonFormSettings} forms={[featuresForm]} />
-      </Form>
-    </Fragment>
+    <FieldGroup title={t('Early Adopter Features')}>
+      {Object.entries(featureFlags).map(([flag, {description, value}]) => (
+        <AutoSaveForm
+          key={flag}
+          name={flag}
+          schema={getFeatureFlagSchema(flag)}
+          initialValue={value}
+          mutationOptions={featureFlagMutationOptions}
+        >
+          {field => (
+            <field.Layout.Row label={description}>
+              <field.Switch
+                checked={field.state.value}
+                onChange={field.handleChange}
+                disabled={disabled}
+              />
+            </field.Layout.Row>
+          )}
+        </AutoSaveForm>
+      ))}
+    </FieldGroup>
   );
 }

--- a/static/app/views/settings/earlyFeatures/settingsForm.tsx
+++ b/static/app/views/settings/earlyFeatures/settingsForm.tsx
@@ -36,9 +36,7 @@ function updateFeatureFlags(
   return Object.fromEntries(
     Object.entries(featureFlags).map(([flag, featureFlag]) => [
       flag,
-      Object.hasOwn(updatedFlags, flag)
-        ? {...featureFlag, value: updatedFlags[flag]!}
-        : featureFlag,
+      updatedFlags[flag] ? {...featureFlag, value: updatedFlags[flag]} : featureFlag,
     ])
   );
 }


### PR DESCRIPTION
Replace the legacy early-features JsonForm with individual AutoSaveForm switches.

This keeps the page behavior the same while removing the old form wrapper and
adding focused coverage for rendering and updates.

closes https://linear.app/getsentry/issue/DE-1248