### PR TITLE
fix(crons): De-flake "prefills with an existing monitor" test

### DIFF
--- a/static/app/views/insights/crons/components/monitorForm.spec.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.spec.tsx
@@ -181,7 +181,7 @@ describe('MonitorForm', () => {
     expect(mockHandleSubmitSuccess).toHaveBeenCalled();
   });
 
-  it.isKnownFlake('prefills with an existing monitor', async () => {
+  it('prefills with an existing monitor', async () => {
     const monitor = MonitorFixture({project});
 
     const apiEndpont = `/projects/${organization.slug}/${monitor.project.slug}/monitors/${monitor.slug}/`;
@@ -215,7 +215,7 @@ describe('MonitorForm', () => {
     await selectEvent.openMenu(screen.getByRole('textbox', {name: 'Schedule Type'}));
     const crontabOption = screen.getByRole('menuitemradio', {name: 'Crontab'});
     expect(crontabOption).toBeChecked();
-    await userEvent.click(crontabOption);
+    await userEvent.keyboard('{Escape}');
 
     // Schedule value
     expect(screen.getByRole('textbox', {name: 'Crontab Schedule'})).toHaveValue(
@@ -226,7 +226,7 @@ describe('MonitorForm', () => {
     await selectEvent.openMenu(screen.getByRole('textbox', {name: 'Timezone'}));
     const losAngelesOption = screen.getByRole('menuitemradio', {name: 'Los Angeles'});
     expect(losAngelesOption).toBeChecked();
-    await userEvent.click(losAngelesOption);
+    await userEvent.keyboard('{Escape}');
 
     // Margins
     expect(screen.getByRole('spinbutton', {name: 'Grace Period'})).toHaveValue(5);


### PR DESCRIPTION
De-flake the `prefills with an existing monitor` test in `monitorForm.spec.tsx`.

After asserting `toBeChecked()` on the Crontab and Los Angeles `menuitemradio` options, the test re-clicked them. Each click dispatched a same-value `setValue` into the FormModel, which still ran `validateField` and `updateShowSaveState` and scheduled a re-render. That extra state churn was the source of the rare race where the Grace Period spinbutton briefly read `55` instead of `5` before the next assertion ran (JEST-22P6 in Sentry).

Close the menus with `{Escape}` instead — the same pattern this test already uses for Owner and Notify a few lines below — and remove the `it.isKnownFlake` wrapper now that the source of the race is gone.

Verified locally: 25/25 consecutive isolated runs of this test pass, and the full spec file passes (5/5).

Fixes JEST-22P6