### PR TITLE
fix(issues): Enforce project access on event ID lookup endpoint

### DIFF
--- a/src/sentry/issues/endpoints/organization_eventid.py
+++ b/src/sentry/issues/endpoints/organization_eventid.py
@@ -18,7 +18,6 @@ from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.eap.occurrences.query_utils import build_event_id_in_filter
 from sentry.search.eap.rpc_utils import and_trace_item_filters
@@ -70,9 +69,13 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
         if event_id and not is_event_id(event_id):
             return Response({"detail": INVALID_ID_DETAILS.format("Event ID")}, status=400)
 
-        project_slugs_by_id = dict(
-            Project.objects.filter(organization=organization).values_list("id", "slug")
-        )
+        # Scope to projects the caller can access; the endpoint's org-level
+        # permission_classes only check org membership, not project access.
+        projects = self.get_projects(request, organization, include_all_accessible=True)
+        project_slugs_by_id = {project.id: project.slug for project in projects}
+
+        if not project_slugs_by_id:
+            raise ResourceDoesNotExist()
 
         try:
             snuba_filter = eventstore.Filter(

--- a/tests/snuba/api/endpoints/test_organization_eventid.py
+++ b/tests/snuba/api/endpoints/test_organization_eventid.py
@@ -61,6 +61,24 @@ class EventIdLookupEndpointTest(APITestCase, SnubaTestCase):
             resp = self.client.get(url, format="json")
             assert resp.status_code == 429
 
+    def test_access_non_member_project(self) -> None:
+        # Org member who is not on the project's owning team must not be able
+        # to resolve event IDs from that project, even with Open Membership off.
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+
+        user_no_team = self.create_user(is_superuser=False)
+        self.create_member(user=user_no_team, organization=self.org, role="member", teams=[])
+        self.login_as(user_no_team)
+
+        url = reverse(
+            "sentry-api-0-event-id-lookup",
+            kwargs={"organization_id_or_slug": self.org.slug, "event_id": self.event.event_id},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 404, response.content
+
     def test_invalid_event_id(self) -> None:
         with pytest.raises(NoReverseMatch):
             reverse(

--- a/tests/snuba/api/endpoints/test_organization_eventid.py
+++ b/tests/snuba/api/endpoints/test_organization_eventid.py
@@ -63,7 +63,7 @@ class EventIdLookupEndpointTest(APITestCase, SnubaTestCase):
 
     def test_access_non_member_project(self) -> None:
         # Org member who is not on the project's owning team must not be able
-        # to resolve event IDs from that project, even with Open Membership off.
+        # to resolve event IDs from that project when Open Membership is off.
         self.org.flags.allow_joinleave = False
         self.org.save()
 
@@ -78,6 +78,27 @@ class EventIdLookupEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 404, response.content
+
+    def test_open_membership_allows_non_team_member(self) -> None:
+        # With Open Membership on (the default), any org member has global
+        # project access, so a member not on the project's team can still
+        # resolve event IDs from it.
+        self.org.flags.allow_joinleave = True
+        self.org.save()
+
+        user_no_team = self.create_user(is_superuser=False)
+        self.create_member(user=user_no_team, organization=self.org, role="member", teams=[])
+        self.login_as(user_no_team)
+
+        url = reverse(
+            "sentry-api-0-event-id-lookup",
+            kwargs={"organization_id_or_slug": self.org.slug, "event_id": self.event.event_id},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["projectSlug"] == self.project.slug
+        assert response.data["eventId"] == str(self.event.event_id)
 
     def test_invalid_event_id(self) -> None:
         with pytest.raises(NoReverseMatch):


### PR DESCRIPTION
The `EventIdLookupEndpoint` (`GET /api/0/organizations/{org}/eventids/{event_id}/`) inherits from `OrganizationEndpoint`, whose permission class only checks organization membership. The handler then queried `Project.objects.filter(organization=organization)` directly — every project in the org — and used that as the search scope for the eventstore lookup. As a result, any org member could resolve an event ID from a project whose owning team they were not on, including the case of a team member whose access was revoked but who retained event IDs collected during prior legitimate access. The sibling `ShortIdLookupEndpoint` already enforces project-level access via `GroupPermission` → `ProjectPermission.has_object_permission`; the eventid endpoint did not.

This switches the project lookup to `self.get_projects(request, organization, include_all_accessible=True)`. `include_all_accessible` keeps the previous behaviour for org owners, managers, staff, and superusers (their global scope returns `True` from `has_project_access` for every org project) while applying `has_project_access` per project for everyone else. An early `ResourceDoesNotExist` is raised when the caller has access to no projects in the org, since the previous handler would otherwise pass an empty `project_ids` list to Snuba and surface as an `UnqualifiedQueryError` (500).

Adds a regression test mirroring `test_access_non_member_project` on the shortid endpoint: org member, `allow_joinleave=False`, no team memberships, expects 404 on event-id lookup.

Fixes VULN-52