### PR TITLE
feat(seer): Scope /conversations slash command lookup with start/end/project

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -251,6 +251,9 @@ export const SENTRY_APP_PERMISSIONS: PermissionObj[] = [
 export const DEFAULT_TOAST_DURATION = 6000;
 export const DEFAULT_DEBOUNCE_DURATION = 300;
 
+// sentry.io project ID for seer-agents.
+export const SEER_AGENTS_PROJECT_ID = 6178942;
+
 export const ALL_ENVIRONMENTS_KEY = '__all_environments__';
 
 export const MENU_CLOSE_DELAY = 200;

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -9,6 +9,7 @@ import {useDismissable} from 'sentry/components/banner';
 import {LoadingContainer} from 'sentry/components/loading/loadingContainer';
 import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {SEER_AGENTS_PROJECT_ID} from 'sentry/constants';
 import {IconClose} from 'sentry/icons';
 import {tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -107,7 +108,7 @@ export function PrebuiltDashboardRenderer({
   const showSeerDataBanner =
     isSentryEmployee &&
     !dismissed &&
-    pageFilters.selection.projects.includes(6178942) &&
+    pageFilters.selection.projects.includes(SEER_AGENTS_PROJECT_ID) &&
     isAiAgentsOverview;
   const showDashboardMigrationAlert = Boolean(dashboardId);
   const hasPageAlerts = showDashboardMigrationAlert || showSeerDataBanner;

--- a/static/app/views/explore/conversations/utils/urlParams.tsx
+++ b/static/app/views/explore/conversations/utils/urlParams.tsx
@@ -1,5 +1,11 @@
 import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
 
+interface ConversationsUrlOptions {
+  end?: string;
+  project?: number | string;
+  start?: string;
+}
+
 /**
  * Returns a conversation URL for external use, e.g. telemetry tagging.
  * Uses an org redirect to the production sentry.io URL.
@@ -7,7 +13,20 @@ import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations
  */
 export function getConversationsUrlForExternalUse(
   organizationSlug: string,
-  conversationId: number | string
+  conversationId: number | string,
+  options?: ConversationsUrlOptions
 ): string {
-  return `https://sentry.io/organizations/${organizationSlug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${encodeURIComponent(conversationId)}/`;
+  const base = `https://sentry.io/organizations/${organizationSlug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${encodeURIComponent(conversationId)}/`;
+  const params = new URLSearchParams();
+  if (options?.start) {
+    params.set('start', options.start);
+  }
+  if (options?.end) {
+    params.set('end', options.end);
+  }
+  if (options?.project !== undefined) {
+    params.set('project', String(options.project));
+  }
+  const qs = params.toString();
+  return qs ? `${base}?${qs}` : base;
 }

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -164,9 +164,32 @@ export function ExplorerDrawerContent({
   }, [runId, organization]);
 
   const langfuseUrl = runId ? getLangfuseUrl(runId) : undefined;
-  const conversationsUrl = runId
-    ? getConversationsUrlForExternalUse('sentry', runId)
-    : undefined;
+  const conversationsUrl = useMemo(() => {
+    if (runId === null) {
+      return;
+    }
+    let minTs = Infinity;
+    let maxTs = -Infinity;
+    for (const block of blocks) {
+      const ts = Date.parse(block.timestamp);
+      if (Number.isNaN(ts)) {
+        continue;
+      }
+      if (ts < minTs) {
+        minTs = ts;
+      }
+      if (ts > maxTs) {
+        maxTs = ts;
+      }
+    }
+    return getConversationsUrlForExternalUse('sentry', runId, {
+      start: minTs === Infinity ? undefined : new Date(minTs).toISOString(),
+      end: maxTs === -Infinity ? undefined : new Date(maxTs).toISOString(),
+      // sentry.io seer-agents project — scopes the conversation lookup
+      // to the project that hosts the Seer Explorer's tracing data.
+      project: 6178942,
+    });
+  }, [runId, blocks]);
 
   const handleOpenLangfuse = useCallback(() => {
     // Command handler. Disabled in slash command menu for non-employees

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -5,6 +5,7 @@ import {useDrawer} from '@sentry/scraps/drawer';
 import {Stack} from '@sentry/scraps/layout';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {SEER_AGENTS_PROJECT_ID} from 'sentry/constants';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -185,9 +186,7 @@ export function ExplorerDrawerContent({
     return getConversationsUrlForExternalUse('sentry', runId, {
       start: minTs === Infinity ? undefined : new Date(minTs).toISOString(),
       end: maxTs === -Infinity ? undefined : new Date(maxTs).toISOString(),
-      // sentry.io seer-agents project — scopes the conversation lookup
-      // to the project that hosts the Seer Explorer's tracing data.
-      project: 6178942,
+      project: SEER_AGENTS_PROJECT_ID,
     });
   }, [runId, blocks]);
 


### PR DESCRIPTION
The Seer Explorer's `/conversations` slash command opened the AI conversation view with only the conversation ID, leaving the page filter at its 30d default. The detail page then scanned a 30-day window to locate spans for the conversation.

- `getConversationsUrlForExternalUse` now accepts optional `start`, `end`, and `project` query params. The other two callers (`blockComponents.tsx`, `seerExplorer/utils.tsx`) are unaffected.
- The `/conversations` handler in `explorerDrawerContent.tsx` derives `start`/`end` from the min/max of the session blocks' timestamps and passes `project=SEER_AGENTS_PROJECT_ID`.
- Pulled the hardcoded sentry.io seer-agents project ID (`6178942`) out of `prebuiltDashboardRenderer.tsx` and the new drawer code into a shared `SEER_AGENTS_PROJECT_ID` constant in `sentry/constants`.