### PR TITLE
fix(dashboards): reset table fields when switching from details widget

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -504,16 +504,14 @@ export function useWidgetBuilderState(): {
                     ? [
                         {
                           kind: 'desc',
-                          field: generateFieldAsString(
-                            validReleaseSortOptions[0] as QueryFieldValue
-                          ),
+                          field: generateFieldAsString(validReleaseSortOptions[0]!),
                         },
                       ]
                     : []
                   : [
                       {
                         kind: 'desc',
-                        field: generateFieldAsString(newFields[0] as QueryFieldValue),
+                        field: generateFieldAsString(newFields[0]!),
                       },
                     ],
                 options

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -466,11 +466,22 @@ export function useWidgetBuilderState(): {
             setLimit(undefined, options);
             setYAxis([], options);
             setLegendAlias([], options);
-            const newFields = [
-              ...columnsWithoutAlias,
-              ...aggregatesWithoutAlias,
-              ...(yAxisWithoutAlias ?? []),
-            ];
+            // When coming from DETAILS, its hardcoded display columns are not
+            // user-chosen, so reset to the dataset's default table fields
+            // instead of carrying them over.
+            let newFields: Column[];
+            if (displayType === DisplayType.DETAILS) {
+              newFields =
+                currentDatasetConfig.defaultWidgetQuery.fields?.map(field =>
+                  explodeField({field})
+                ) ?? [];
+            } else {
+              newFields = [
+                ...columnsWithoutAlias,
+                ...aggregatesWithoutAlias,
+                ...(yAxisWithoutAlias ?? []),
+              ];
+            }
             setFields(newFields, options);
 
             // Keep the sort if it's already contained in the new fields


### PR DESCRIPTION
## Summary
- When switching the widget builder display type from **Details** to **Table**, the 5 hardcoded detail columns (`id`, `span.op`, `span.group`, `span.description`, `span.category`) were carried over as the table's selected fields instead of falling back to the dataset's default table fields.
- The details widget doesn't let users select fields, so it doesn't make sense for the selection to carry over.