### PR TITLE
feat(explore): Link to aggregates from dropdown

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
@@ -71,6 +71,7 @@ export function InvalidTokenTooltip({
       })}
       position="bottom"
       title={warning ?? tokenWarning ?? invalid?.reason ?? t('This token is invalid')}
+      isHoverable={hasWarning || hasTokenWarning || tooltipProps.isHoverable}
       {...tooltipProps}
     >
       {children}

--- a/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
@@ -3,7 +3,6 @@ import {memo, useCallback, useMemo} from 'react';
 import {Grid} from '@sentry/scraps/layout';
 
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
-import {t} from 'sentry/locale';
 import {
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
   type AggregationKey,
@@ -23,6 +22,7 @@ import {
   useQueryParamsMode,
   useSetQueryParamsCrossEvents,
 } from 'sentry/views/explore/queryParams/context';
+import {SamplesModeAggregateFilterWarning} from 'sentry/views/explore/spans/samplesModeAggregateFilterWarning';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface SpansTabCrossEventMetricsSearchBarProps {
@@ -96,9 +96,7 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
                 if (
                   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.includes(key as AggregationKey)
                 ) {
-                  return t(
-                    "This key won't affect the results because samples mode does not support aggregate functions"
-                  );
+                  return <SamplesModeAggregateFilterWarning />;
                 }
                 return;
               }

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
@@ -1,7 +1,6 @@
 import {memo, useMemo} from 'react';
 
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
-import {t} from 'sentry/locale';
 import {
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
   type AggregationKey,
@@ -18,6 +17,7 @@ import {
   useQueryParamsMode,
   useSetQueryParamsCrossEvents,
 } from 'sentry/views/explore/queryParams/context';
+import {SamplesModeAggregateFilterWarning} from 'sentry/views/explore/spans/samplesModeAggregateFilterWarning';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface SpansTabCrossEventSearchBarProps {
@@ -66,9 +66,7 @@ export const SpansTabCrossEventSearchBar = memo(
                 if (
                   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.includes(key as AggregationKey)
                 ) {
-                  return t(
-                    "This key won't affect the results because samples mode does not support aggregate functions"
-                  );
+                  return <SamplesModeAggregateFilterWarning />;
                 }
                 return;
               }

--- a/static/app/views/explore/spans/samplesModeAggregateFilterWarning.tsx
+++ b/static/app/views/explore/spans/samplesModeAggregateFilterWarning.tsx
@@ -1,0 +1,29 @@
+import {useMemo} from 'react';
+
+import {Link} from '@sentry/scraps/link';
+
+import {tct} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {getTargetWithReadableQueryParams} from 'sentry/views/explore/spans/spansQueryParams';
+
+const SPANS_TABLE_KEY = 'table';
+
+export function SamplesModeAggregateFilterWarning() {
+  const location = useLocation();
+
+  const target = useMemo(() => {
+    const nextLocation = getTargetWithReadableQueryParams(location, {
+      mode: Mode.AGGREGATE,
+    });
+    const {[SPANS_TABLE_KEY]: _table, ...query} = nextLocation.query;
+    return {...nextLocation, query};
+  }, [location]);
+
+  return tct(
+    "This key won't affect the results because samples mode does not support aggregate functions. [link:View aggregates]",
+    {
+      link: <Link to={target} />,
+    }
+  );
+}

--- a/static/app/views/explore/spans/samplesModeAggregateFilterWarning.tsx
+++ b/static/app/views/explore/spans/samplesModeAggregateFilterWarning.tsx
@@ -3,6 +3,7 @@ import {useMemo} from 'react';
 import {Link} from '@sentry/scraps/link';
 
 import {tct} from 'sentry/locale';
+import {updateNullableLocation} from 'sentry/utils/url/updateNullableLocation';
 import {useLocation} from 'sentry/utils/useLocation';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getTargetWithReadableQueryParams} from 'sentry/views/explore/spans/spansQueryParams';
@@ -16,8 +17,8 @@ export function SamplesModeAggregateFilterWarning() {
     const nextLocation = getTargetWithReadableQueryParams(location, {
       mode: Mode.AGGREGATE,
     });
-    const {[SPANS_TABLE_KEY]: _table, ...query} = nextLocation.query;
-    return {...nextLocation, query};
+    updateNullableLocation(nextLocation, SPANS_TABLE_KEY, null);
+    return nextLocation;
   }, [location]);
 
   return tct(

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -43,6 +43,7 @@ import {
 } from 'sentry/views/explore/queryParams/context';
 import {CrossEventQueryingDropdown} from 'sentry/views/explore/spans/crossEvents/crossEventQueryingDropdown';
 import {SpansTabCrossEventSearchBars} from 'sentry/views/explore/spans/crossEvents/crossEventSearchBars';
+import {SamplesModeAggregateFilterWarning} from 'sentry/views/explore/spans/samplesModeAggregateFilterWarning';
 import {SpansTabSeerComboBox} from 'sentry/views/explore/spans/spansTabSeerComboBox';
 import {ExploreSpansTour, ExploreSpansTourContext} from 'sentry/views/explore/spans/tour';
 import {findSuggestedColumns} from 'sentry/views/explore/utils';
@@ -114,9 +115,7 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
         mode === Mode.SAMPLES
           ? (key: string) => {
               if (ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.includes(key as AggregationKey)) {
-                return t(
-                  "This key won't affect the results because samples mode does not support aggregate functions"
-                );
+                return <SamplesModeAggregateFilterWarning />;
               }
               return;
             }


### PR DESCRIPTION
This PR adds in a link for aggregate functions in the search query builder when not on the aggregates tab, which provides a link for users to navigate to the aggregates table.