### PR TITLE
ref(tests): replace `as jest.Mock` casts with `jest.mocked()`

### DIFF
--- a/static/app/actionCreators/navigation.spec.tsx
+++ b/static/app/actionCreators/navigation.spec.tsx
@@ -1,3 +1,4 @@
+import {isValidElement} from 'react';
 import type {Location} from 'history';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -120,12 +121,15 @@ describe('navigation ActionCreator', () => {
     navigateTo('/settings/:orgId/teams/:teamId/settings/', navigate, location);
     expect(openModal).toHaveBeenCalled();
 
-    const modalFactory = (openModal as jest.Mock).mock.calls[0]?.[0];
+    const modalFactory = jest.mocked(openModal).mock.calls[0]?.[0];
     if (!modalFactory) {
       throw new Error('Expected openModal to be called with a renderer');
     }
 
     const modal = modalFactory({closeModal: jest.fn()} as any);
+    if (!isValidElement<{needOrg: boolean; needTeam: boolean}>(modal)) {
+      throw new Error('Expected modalFactory to return a React element');
+    }
     expect(modal.props.needOrg).toBe(true);
     expect(modal.props.needTeam).toBe(true);
   });

--- a/static/app/components/acl/demoModeDisabled.spec.tsx
+++ b/static/app/components/acl/demoModeDisabled.spec.tsx
@@ -10,7 +10,7 @@ jest.mock('sentry/utils/demoMode', () => ({
 
 describe('DisableInDemoMode', () => {
   it('renders children when demo mode is disabled', () => {
-    (isDemoModeActive as jest.Mock).mockReturnValue(false);
+    jest.mocked(isDemoModeActive).mockReturnValue(false);
 
     render(
       <DisableInDemoMode>
@@ -23,7 +23,7 @@ describe('DisableInDemoMode', () => {
   });
 
   it('renders a tooltip when demo mode is enabled', () => {
-    (isDemoModeActive as jest.Mock).mockReturnValue(true);
+    jest.mocked(isDemoModeActive).mockReturnValue(true);
 
     render(
       <DisableInDemoMode>

--- a/static/app/components/charts/eventsRequest.spec.tsx
+++ b/static/app/components/charts/eventsRequest.spec.tsx
@@ -5,6 +5,7 @@ import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {EventsRequestProps} from 'sentry/components/charts/eventsRequest';
 import {EventsRequest} from 'sentry/components/charts/eventsRequest';
+import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organization';
 
 const COUNT_OBJ = {
   count: 123,
@@ -34,10 +35,10 @@ describe('EventsRequest', () => {
 
   describe('with props changes', () => {
     beforeAll(() => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
-          data: [[new Date(), [COUNT_OBJ]]],
-        })
+          data: [[0, [COUNT_OBJ]]],
+        } as EventsStats)
       );
     });
 
@@ -75,7 +76,7 @@ describe('EventsRequest', () => {
 
     it('makes a new request if projects prop changes', async () => {
       const {rerender} = render(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
-      (doEventsRequest as jest.Mock).mockClear();
+      jest.mocked(doEventsRequest).mockClear();
 
       rerender(
         <EventsRequest {...DEFAULTS} project={[123]}>
@@ -93,7 +94,7 @@ describe('EventsRequest', () => {
 
     it('makes a new request if environments prop changes', async () => {
       const {rerender} = render(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
-      (doEventsRequest as jest.Mock).mockClear();
+      jest.mocked(doEventsRequest).mockClear();
 
       rerender(
         <EventsRequest {...DEFAULTS} environment={['dev']}>
@@ -111,7 +112,7 @@ describe('EventsRequest', () => {
 
     it('makes a new request if period prop changes', async () => {
       const {rerender} = render(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
-      (doEventsRequest as jest.Mock).mockClear();
+      jest.mocked(doEventsRequest).mockClear();
 
       rerender(
         <EventsRequest {...DEFAULTS} period="7d">
@@ -131,23 +132,23 @@ describe('EventsRequest', () => {
 
   describe('transforms', () => {
     beforeEach(() => {
-      (doEventsRequest as jest.Mock).mockClear();
+      jest.mocked(doEventsRequest).mockClear();
     });
 
     it('expands period in query if `includePrevious`', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
           data: [
             [
-              new Date(),
+              0,
               [
                 {...COUNT_OBJ, count: 321},
                 {...COUNT_OBJ, count: 79},
               ],
             ],
-            [new Date(), [COUNT_OBJ]],
+            [0, [COUNT_OBJ]],
           ],
-        })
+        } as EventsStats)
       );
       render(
         <EventsRequest {...DEFAULTS} includePrevious>
@@ -219,33 +220,33 @@ describe('EventsRequest', () => {
     });
 
     it('expands multiple periods in query if `includePrevious`', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
           'count()': {
             data: [
               [
-                new Date(),
+                0,
                 [
                   {...COUNT_OBJ, count: 321},
                   {...COUNT_OBJ, count: 79},
                 ],
               ],
-              [new Date(), [COUNT_OBJ]],
+              [0, [COUNT_OBJ]],
             ],
           },
           'failure_count()': {
             data: [
               [
-                new Date(),
+                0,
                 [
                   {...COUNT_OBJ, count: 421},
                   {...COUNT_OBJ, count: 79},
                 ],
               ],
-              [new Date(), [COUNT_OBJ]],
+              [0, [COUNT_OBJ]],
             ],
           },
-        })
+        } as MultiSeriesEventsStats)
       );
       const multiYOptions = {
         yAxis: ['count()', 'failure_count()'],
@@ -299,10 +300,10 @@ describe('EventsRequest', () => {
     });
 
     it('aggregates counts per timestamp only when `includeTimeAggregation` prop is true', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
-          data: [[new Date(), [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
-        })
+          data: [[0, [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
+        } as EventsStats)
       );
 
       const {rerender} = render(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
@@ -338,10 +339,10 @@ describe('EventsRequest', () => {
     });
 
     it('aggregates all counts per timestamp when category name identical', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
-          data: [[new Date(), [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
-        })
+          data: [[0, [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
+        } as EventsStats)
       );
 
       const {rerender} = render(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
@@ -379,23 +380,23 @@ describe('EventsRequest', () => {
 
   describe('yAxis', () => {
     beforeEach(() => {
-      (doEventsRequest as jest.Mock).mockClear();
+      jest.mocked(doEventsRequest).mockClear();
     });
 
     it('supports yAxis', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
           data: [
             [
-              new Date(),
+              0,
               [
                 {...COUNT_OBJ, count: 321},
                 {...COUNT_OBJ, count: 79},
               ],
             ],
-            [new Date(), [COUNT_OBJ]],
+            [0, [COUNT_OBJ]],
           ],
-        })
+        } as EventsStats)
       );
 
       render(
@@ -460,33 +461,33 @@ describe('EventsRequest', () => {
     });
 
     it('supports multiple yAxis', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
           'epm()': {
             data: [
               [
-                new Date(),
+                0,
                 [
                   {...COUNT_OBJ, count: 321},
                   {...COUNT_OBJ, count: 79},
                 ],
               ],
-              [new Date(), [COUNT_OBJ]],
+              [0, [COUNT_OBJ]],
             ],
           },
           'apdex()': {
             data: [
               [
-                new Date(),
+                0,
                 [
                   {...COUNT_OBJ, count: 321},
                   {...COUNT_OBJ, count: 79},
                 ],
               ],
-              [new Date(), [COUNT_OBJ]],
+              [0, [COUNT_OBJ]],
             ],
           },
-        })
+        } as MultiSeriesEventsStats)
       );
 
       render(
@@ -519,37 +520,37 @@ describe('EventsRequest', () => {
 
   describe('topEvents', () => {
     beforeEach(() => {
-      (doEventsRequest as jest.Mock).mockClear();
+      jest.mocked(doEventsRequest).mockClear();
     });
 
     it('supports topEvents parameter', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
           'project1,error': {
             data: [
               [
-                new Date(),
+                0,
                 [
                   {...COUNT_OBJ, count: 321},
                   {...COUNT_OBJ, count: 79},
                 ],
               ],
-              [new Date(), [COUNT_OBJ]],
+              [0, [COUNT_OBJ]],
             ],
           },
           'project1,warning': {
             data: [
               [
-                new Date(),
+                0,
                 [
                   {...COUNT_OBJ, count: 321},
                   {...COUNT_OBJ, count: 79},
                 ],
               ],
-              [new Date(), [COUNT_OBJ]],
+              [0, [COUNT_OBJ]],
             ],
           },
-        })
+        } as MultiSeriesEventsStats)
       );
 
       render(
@@ -585,7 +586,7 @@ describe('EventsRequest', () => {
 
   describe('out of retention', () => {
     beforeEach(() => {
-      (doEventsRequest as jest.Mock).mockClear();
+      jest.mocked(doEventsRequest).mockClear();
     });
 
     it('does not make request', () => {
@@ -614,18 +615,18 @@ describe('EventsRequest', () => {
 
   describe('timeframe', () => {
     beforeEach(() => {
-      (doEventsRequest as jest.Mock).mockClear();
+      jest.mocked(doEventsRequest).mockClear();
     });
 
     it('passes query timeframe start and end to the child if supplied by timeseriesData', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
           p95: {
-            data: [[new Date(), [COUNT_OBJ]]],
+            data: [[0, [COUNT_OBJ]]],
             start: 1627402280,
             end: 1627402398,
           },
-        })
+        } as MultiSeriesEventsStats)
       );
       render(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
 
@@ -644,13 +645,13 @@ describe('EventsRequest', () => {
 
   describe('custom performance metrics', () => {
     beforeEach(() => {
-      (doEventsRequest as jest.Mock).mockClear();
+      jest.mocked(doEventsRequest).mockClear();
     });
 
     it('passes timeseriesResultTypes to child', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
-          data: [[new Date(), [COUNT_OBJ]]],
+          data: [[0, [COUNT_OBJ]]],
           start: 1627402280,
           end: 1627402398,
           meta: {
@@ -661,7 +662,7 @@ describe('EventsRequest', () => {
               p95_measurements_custom: 'kibibyte',
             },
           },
-        })
+        } as unknown as EventsStats)
       );
       render(
         <EventsRequest {...DEFAULTS} yAxis="p95(measurements.custom)">
@@ -679,9 +680,9 @@ describe('EventsRequest', () => {
     });
 
     it('passes timeseriesResultsUnits to child for single yAxis', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
-          data: [[new Date(), [COUNT_OBJ]]],
+          data: [[0, [COUNT_OBJ]]],
           start: 1627402280,
           end: 1627402398,
           meta: {
@@ -692,7 +693,7 @@ describe('EventsRequest', () => {
               p95_measurements_custom: 'kibibyte',
             },
           },
-        })
+        } as unknown as EventsStats)
       );
       render(
         <EventsRequest {...DEFAULTS} yAxis="p95(measurements.custom)">
@@ -711,10 +712,10 @@ describe('EventsRequest', () => {
     });
 
     it('passes timeseriesResultsUnits to child for multiple yAxis', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
           'p95(measurements.custom)': {
-            data: [[new Date(), [COUNT_OBJ]]],
+            data: [[0, [COUNT_OBJ]]],
             start: 1627402280,
             end: 1627402398,
             meta: {
@@ -727,7 +728,7 @@ describe('EventsRequest', () => {
             },
           },
           'p50(measurements.lcp)': {
-            data: [[new Date(), [COUNT_OBJ]]],
+            data: [[0, [COUNT_OBJ]]],
             start: 1627402280,
             end: 1627402398,
             meta: {
@@ -739,7 +740,7 @@ describe('EventsRequest', () => {
               },
             },
           },
-        })
+        } as unknown as MultiSeriesEventsStats)
       );
       render(
         <EventsRequest
@@ -767,9 +768,9 @@ describe('EventsRequest', () => {
     });
 
     it('does not include timeseriesResultsUnits when meta has no units', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
-          data: [[new Date(), [COUNT_OBJ]]],
+          data: [[0, [COUNT_OBJ]]],
           start: 1627402280,
           end: 1627402398,
           meta: {
@@ -777,7 +778,7 @@ describe('EventsRequest', () => {
               'count()': 'integer',
             },
           },
-        })
+        } as unknown as EventsStats)
       );
       render(
         <EventsRequest {...DEFAULTS} yAxis="count()">
@@ -796,9 +797,9 @@ describe('EventsRequest', () => {
     });
 
     it('scales timeseries values according to unit meta', async () => {
-      (doEventsRequest as jest.Mock).mockImplementation(() =>
+      jest.mocked(doEventsRequest).mockImplementation(() =>
         Promise.resolve({
-          data: [[new Date(), [COUNT_OBJ]]],
+          data: [[1508208080000, [COUNT_OBJ]]],
           start: 1627402280,
           end: 1627402398,
           meta: {
@@ -809,7 +810,7 @@ describe('EventsRequest', () => {
               p95_measurements_custom: 'mebibyte',
             },
           },
-        })
+        } as unknown as EventsStats)
       );
       render(
         <EventsRequest

--- a/static/app/components/events/autofix/autofixDiff.spec.tsx
+++ b/static/app/components/events/autofix/autofixDiff.spec.tsx
@@ -24,7 +24,7 @@ describe('AutofixDiff', () => {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-    (addErrorMessage as jest.Mock).mockClear();
+    jest.mocked(addErrorMessage).mockClear();
   });
 
   it('displays a modified file diff correctly', () => {

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -18,8 +18,8 @@ const sampleInsights: AutofixInsight[] = [
 ];
 
 beforeEach(() => {
-  (addLoadingMessage as jest.Mock).mockClear();
-  (addErrorMessage as jest.Mock).mockClear();
+  jest.mocked(addLoadingMessage).mockClear();
+  jest.mocked(addErrorMessage).mockClear();
   MockApiClient.clearMockResponses();
 });
 

--- a/static/app/components/events/autofix/autofixOutputStream.spec.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.spec.tsx
@@ -13,8 +13,8 @@ describe('AutofixOutputStream', () => {
 
   beforeEach(() => {
     mockApi.requestPromise.mockReset();
-    (addSuccessMessage as jest.Mock).mockClear();
-    (addErrorMessage as jest.Mock).mockClear();
+    jest.mocked(addSuccessMessage).mockClear();
+    jest.mocked(addErrorMessage).mockClear();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/123/autofix/update/',
       method: 'POST',

--- a/static/app/components/modals/dataWidgetViewerModal.spec.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.spec.tsx
@@ -226,7 +226,7 @@ describe('Modals -> DataWidgetViewerModal', () => {
           queries: [mockQuery, additionalMockQuery],
           widgetType: WidgetType.DISCOVER,
         };
-        (ReactEchartsCore as jest.Mock).mockClear();
+        jest.mocked(ReactEchartsCore).mockClear();
         MockApiClient.addMockResponse({
           url: '/organizations/org-slug/events-stats/',
           body: {
@@ -322,7 +322,7 @@ describe('Modals -> DataWidgetViewerModal', () => {
         const {router} = await renderModal({initialData, widget: mockWidget});
         act(() => {
           // Simulate dataZoom event on chart
-          (ReactEchartsCore as jest.Mock).mock.calls[0][0].onEvents.datazoom(undefined, {
+          jest.mocked(ReactEchartsCore).mock.calls[0]![0].onEvents!.datazoom!(undefined, {
             getModel: () => {
               return {
                 _payload: {

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.spec.tsx
@@ -50,7 +50,7 @@ describe('OnboardingCopyMarkdownButton', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Copy instructions'}));
 
-    const copiedText = (navigator.clipboard.writeText as jest.Mock).mock.calls[0][0];
+    const copiedText = jest.mocked(navigator.clipboard.writeText).mock.calls[0]![0];
     expect(copiedText).toContain('## Install');
     expect(copiedText).toContain(`\n\n---\n\n${postamble}`);
   });

--- a/static/app/components/replays/canvasReplayerPlugin.spec.ts
+++ b/static/app/components/replays/canvasReplayerPlugin.spec.ts
@@ -96,7 +96,7 @@ function createReplayer(getNodeImpl: (id: number) => Node | null) {
 describe('canvasReplayerPlugin', () => {
   beforeEach(() => {
     jest.clearAllTimers();
-    (canvasMutation as jest.Mock).mockClear();
+    jest.mocked(canvasMutation).mockClear();
   });
 
   it('does not clear current canvas snapshot when flushing queued sync events before processing a canvas event', async () => {
@@ -143,7 +143,7 @@ describe('canvasReplayerPlugin', () => {
     await Promise.resolve();
 
     // We should have processed the queued latest sync event and the realtime event
-    expect((canvasMutation as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(jest.mocked(canvasMutation).mock.calls.length).toBeGreaterThanOrEqual(2);
 
     // Critically, the current canvas snapshot should not be cleared
     expect(img.src).toContain('data:image/png;base64');

--- a/static/app/utils/demoMode/demoTours.spec.tsx
+++ b/static/app/utils/demoMode/demoTours.spec.tsx
@@ -31,7 +31,7 @@ interface MockToursState {
   [DemoTour.PERFORMANCE]: TourState<DemoTourStep>;
 }
 
-const mockUseLocalStorageState = useLocalStorageState as jest.Mock;
+const mockUseLocalStorageState = jest.mocked(useLocalStorageState);
 
 function createWrapper() {
   return function ({children}: {children?: React.ReactNode}) {

--- a/static/app/views/alerts/rules/uptime/assertionSuggestionsButton.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertionSuggestionsButton.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('@sentry/scraps/drawer', () => {
   };
 });
 
-const mockedUseDrawer = useDrawer as unknown as jest.Mock;
+const mockedUseDrawer = jest.mocked(useDrawer);
 
 describe('AssertionSuggestionsButton', () => {
   const organization = OrganizationFixture();

--- a/static/app/views/explore/logs/usePersistentLogsPageParameters.spec.tsx
+++ b/static/app/views/explore/logs/usePersistentLogsPageParameters.spec.tsx
@@ -1,3 +1,5 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
@@ -30,20 +32,20 @@ describe('usePersistentLogsPageParameters', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useNavigate as jest.Mock).mockReturnValue(navigateMock);
+    jest.mocked(useNavigate).mockReturnValue(navigateMock);
   });
 
   it('navigates with persisted fields and sortBys if missing in URL', () => {
-    (useLocation as jest.Mock).mockReturnValue({
-      pathname: '/logs/',
-      query: {},
-    });
+    jest
+      .mocked(useLocation)
+      .mockReturnValue(LocationFixture({pathname: '/logs/', query: {}}));
 
-    (usePersistedLogsPageParams as jest.Mock).mockReturnValue([
+    jest.mocked(usePersistedLogsPageParams).mockReturnValue([
       {
         fields: ['message', 'sentry.message.parameters.0'],
-        sortBys: [{field: 'sentry.message.parameters.0', order: 'desc'}],
+        sortBys: [{field: 'sentry.message.parameters.0', kind: 'asc' as const}],
       },
+      jest.fn(),
     ]);
 
     function Main() {
@@ -65,19 +67,22 @@ describe('usePersistentLogsPageParameters', () => {
   });
 
   it('does not navigate if fields and sortBys are already set', () => {
-    (useLocation as jest.Mock).mockReturnValue({
-      pathname: '/logs/',
-      query: {
-        [LOGS_FIELDS_KEY]: ['level', 'timestamp'],
-        [LOGS_SORT_BYS_KEY]: [{field: 'timestamp', order: 'asc'}],
-      },
-    });
+    jest.mocked(useLocation).mockReturnValue(
+      LocationFixture({
+        pathname: '/logs/',
+        query: {
+          [LOGS_FIELDS_KEY]: ['level', 'timestamp'],
+          [LOGS_SORT_BYS_KEY]: ['timestamp'],
+        },
+      })
+    );
 
-    (usePersistedLogsPageParams as jest.Mock).mockReturnValue([
+    jest.mocked(usePersistedLogsPageParams).mockReturnValue([
       {
         fields: ['timestamp', 'message'],
-        sortBys: [{field: 'timestamp', order: 'desc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc' as const}],
       },
+      jest.fn(),
     ]);
 
     function Main() {
@@ -91,16 +96,16 @@ describe('usePersistentLogsPageParameters', () => {
   });
 
   it('uses replace to navigate only on the first render', () => {
-    (useLocation as jest.Mock).mockReturnValue({
-      pathname: '/logs/',
-      query: {},
-    });
+    jest
+      .mocked(useLocation)
+      .mockReturnValue(LocationFixture({pathname: '/logs/', query: {}}));
 
-    (usePersistedLogsPageParams as jest.Mock).mockReturnValue([
+    jest.mocked(usePersistedLogsPageParams).mockReturnValue([
       {
         fields: ['message'],
-        sortBys: [{field: 'message', order: 'desc'}],
+        sortBys: [{field: 'message', kind: 'asc' as const}],
       },
+      jest.fn(),
     ]);
 
     function Main() {
@@ -112,11 +117,12 @@ describe('usePersistentLogsPageParameters', () => {
     expect(navigateMock).toHaveBeenCalledWith(expect.anything(), {replace: true});
 
     // Change the fields and sort by props to retrigger navigation
-    (usePersistedLogsPageParams as jest.Mock).mockReturnValue([
+    jest.mocked(usePersistedLogsPageParams).mockReturnValue([
       {
         fields: ['test'],
-        sortBys: [{field: 'test', order: 'desc'}],
+        sortBys: [{field: 'test', kind: 'asc' as const}],
       },
+      jest.fn(),
     ]);
 
     rerender(<Main />);

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -154,7 +154,7 @@ describe('SpansTabContent', () => {
       expect.objectContaining({result_mode: 'span samples'})
     );
 
-    (trackAnalytics as jest.Mock).mockClear();
+    jest.mocked(trackAnalytics).mockClear();
     await userEvent.click(await screen.findByText('Trace Samples'));
 
     await screen.findByText(/No trace results found/);
@@ -164,7 +164,7 @@ describe('SpansTabContent', () => {
       expect.objectContaining({result_mode: 'trace samples'})
     );
 
-    (trackAnalytics as jest.Mock).mockClear();
+    jest.mocked(trackAnalytics).mockClear();
     await userEvent.click(await screen.findByRole('tab', {name: 'Aggregates'}));
 
     await screen.findByText(/No spans found/);

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.spec.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.spec.tsx
@@ -75,7 +75,7 @@ function SelectionInitializer() {
 describe('IssueListBulkCommandPaletteActions', () => {
   beforeEach(() => {
     GroupStore.reset();
-    (addLoadingMessage as jest.Mock).mockClear();
+    jest.mocked(addLoadingMessage).mockClear();
     ConfigStore.loadInitialData({
       user: UserFixture({id: '1', name: 'Test User'}),
     } as any);

--- a/static/app/views/onboarding/useConfigureSdk.spec.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.spec.tsx
@@ -40,7 +40,7 @@ function mockCreateProjectHook() {
   };
 }
 
-const mockUseCreateProject = useCreateProject as jest.Mock;
+const mockUseCreateProject = jest.mocked(useCreateProject);
 
 describe('useConfigureSdk', () => {
   const onComplete = jest.fn();
@@ -70,7 +70,9 @@ describe('useConfigureSdk', () => {
     ProjectsStore.loadInitialData([ProjectFixture()]);
 
     createProjectInstance = mockCreateProjectHook();
-    mockUseCreateProject.mockReturnValue(createProjectInstance);
+    mockUseCreateProject.mockReturnValue(
+      createProjectInstance as unknown as ReturnType<typeof useCreateProject>
+    );
     jest.mocked(useModal).mockReturnValue({
       openModal: mockOpenModal,
       closeModal: jest.fn(),

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/index.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/index.spec.tsx
@@ -41,7 +41,7 @@ describe('AccountSecuritySessionHistory', () => {
   });
 
   it('renders empty in demo mode even if ips exist', () => {
-    (isDemoModeActive as jest.Mock).mockReturnValue(true);
+    jest.mocked(isDemoModeActive).mockReturnValue(true);
 
     render(<SessionHistory />);
 
@@ -49,6 +49,6 @@ describe('AccountSecuritySessionHistory', () => {
     expect(screen.queryByText('192.168.0.1')).not.toBeInTheDocument();
     expect(screen.queryByText('US (CA)')).not.toBeInTheDocument();
 
-    (isDemoModeActive as jest.Mock).mockReset();
+    jest.mocked(isDemoModeActive).mockReset();
   });
 });

--- a/static/app/views/settings/account/apiApplications/index.spec.tsx
+++ b/static/app/views/settings/account/apiApplications/index.spec.tsx
@@ -71,7 +71,7 @@ describe('ApiApplications', () => {
   });
 
   it('renders empty in demo mode even if there are applications', async () => {
-    (isDemoModeActive as jest.Mock).mockReturnValue(true);
+    jest.mocked(isDemoModeActive).mockReturnValue(true);
 
     MockApiClient.addMockResponse({
       url: '/api-applications/',
@@ -84,7 +84,7 @@ describe('ApiApplications', () => {
       await screen.findByText("You haven't created any applications yet.")
     ).toBeInTheDocument();
 
-    (isDemoModeActive as jest.Mock).mockReset();
+    jest.mocked(isDemoModeActive).mockReset();
   });
 
   it('creates confidential application via modal', async () => {

--- a/static/app/views/settings/account/apiTokens.spec.tsx
+++ b/static/app/views/settings/account/apiTokens.spec.tsx
@@ -46,7 +46,7 @@ describe('ApiTokens', () => {
   });
 
   it('renders empty in demo mode even if there are tokens', async () => {
-    (isDemoModeActive as jest.Mock).mockReturnValue(true);
+    jest.mocked(isDemoModeActive).mockReturnValue(true);
 
     MockApiClient.addMockResponse({
       url: '/api-tokens/',
@@ -59,7 +59,7 @@ describe('ApiTokens', () => {
       await screen.findByText("You haven't created any authentication tokens yet.")
     ).toBeInTheDocument();
 
-    (isDemoModeActive as jest.Mock).mockReset();
+    jest.mocked(isDemoModeActive).mockReset();
   });
 
   it('can delete token', async () => {

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -686,7 +686,7 @@ describe('OrganizationMembersList', () => {
     });
 
     it('renders only current user in demo mode', async () => {
-      (isDemoModeActive as jest.Mock).mockReturnValue(true);
+      jest.mocked(isDemoModeActive).mockReturnValue(true);
 
       render(<OrganizationMembersList />, {
         organization,
@@ -697,7 +697,7 @@ describe('OrganizationMembersList', () => {
       expect(await screen.findByText(currentUser.name)).toBeInTheDocument();
       expect(screen.queryByText(member.name)).not.toBeInTheDocument();
 
-      (isDemoModeActive as jest.Mock).mockReset();
+      jest.mocked(isDemoModeActive).mockReset();
     });
 
     it('allows you to leave as a member after searching', async () => {

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -1,3 +1,4 @@
+import {isValidElement} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {DetailedProjectFixture} from 'sentry-fixture/project';
 
@@ -264,7 +265,11 @@ describe('projectGeneralSettings', () => {
     expect(addErrorMessage).toHaveBeenCalled();
 
     // Check the error message
-    const {container} = render((addErrorMessage as jest.Mock).mock.calls[0][0]);
+    const errorMessage = jest.mocked(addErrorMessage).mock.calls[0]![0];
+    if (!isValidElement(errorMessage)) {
+      throw new Error('Expected addErrorMessage to be called with a React element');
+    }
+    const {container} = render(errorMessage);
     expect(container).toHaveTextContent(
       'Error transferring project-slug. An organization owner could not be found'
     );

--- a/static/gsApp/overrides/analyticsInitUser.spec.tsx
+++ b/static/gsApp/overrides/analyticsInitUser.spec.tsx
@@ -24,10 +24,10 @@ describe('analyticsInitUser', () => {
   });
   afterEach(() => {
     sessionStorageWrapper.removeItem('marketing_event_recorded');
-    (trackMarketingEvent as jest.Mock).mockClear();
-    (Amplitude.setUserId as jest.Mock).mockClear();
-    (Amplitude.track as jest.Mock).mockClear();
-    (Amplitude.Identify as jest.Mock).mockClear();
+    jest.mocked(trackMarketingEvent).mockClear();
+    jest.mocked(Amplitude.setUserId).mockClear();
+    jest.mocked(Amplitude.track).mockClear();
+    jest.mocked(Amplitude.Identify).mockClear();
   });
   it('calls getInstance and initializes with user and user properties', () => {
     analyticsInitUser(user);

--- a/static/gsApp/overrides/useButtonTracking.spec.tsx
+++ b/static/gsApp/overrides/useButtonTracking.spec.tsx
@@ -55,7 +55,7 @@ describe('buttonTracking', () => {
   );
 
   afterEach(() => {
-    (rawTrackAnalyticsEvent as jest.Mock).mockClear();
+    jest.mocked(rawTrackAnalyticsEvent).mockClear();
   });
 
   it('calls rawTrackAnalyticsEvent with default values', () => {

--- a/static/gsApp/overrides/useReplayForCriticalFlow.spec.tsx
+++ b/static/gsApp/overrides/useReplayForCriticalFlow.spec.tsx
@@ -9,8 +9,8 @@ jest.mock('getsentry/utils/useReplayInit');
 
 describe('useReplayForCriticalFlow (gsApp)', () => {
   const flush = jest.fn();
-  const setTag = Sentry.setTag as jest.Mock;
-  const getReplay = Sentry.getReplay as jest.Mock;
+  const setTag = jest.mocked(Sentry.setTag);
+  const getReplay = jest.mocked(Sentry.getReplay);
   const mockedUseReplayReady = jest.mocked(useReplayReady);
 
   beforeEach(() => {
@@ -26,7 +26,7 @@ describe('useReplayForCriticalFlow (gsApp)', () => {
   // without mocking Math.random.
 
   it('tags and flushes at the default sampleRate of 1', () => {
-    getReplay.mockReturnValue({flush});
+    getReplay.mockReturnValue({flush} as unknown as ReturnType<typeof Sentry.getReplay>);
 
     const {unmount} = renderHookWithProviders(() =>
       useReplayForCriticalFlow({flowName: 'scm_onboarding'})
@@ -42,7 +42,7 @@ describe('useReplayForCriticalFlow (gsApp)', () => {
   });
 
   it('does nothing when sampleRate is 0', () => {
-    getReplay.mockReturnValue({flush});
+    getReplay.mockReturnValue({flush} as unknown as ReturnType<typeof Sentry.getReplay>);
 
     renderHookWithProviders(() =>
       useReplayForCriticalFlow({flowName: 'scm_onboarding', sampleRate: 0})
@@ -54,7 +54,7 @@ describe('useReplayForCriticalFlow (gsApp)', () => {
   });
 
   it('does nothing when disabled', () => {
-    getReplay.mockReturnValue({flush});
+    getReplay.mockReturnValue({flush} as unknown as ReturnType<typeof Sentry.getReplay>);
 
     renderHookWithProviders(() =>
       useReplayForCriticalFlow({flowName: 'scm_onboarding', enabled: false})
@@ -66,7 +66,7 @@ describe('useReplayForCriticalFlow (gsApp)', () => {
   });
 
   it('waits for replay to be ready before tagging or flushing', () => {
-    getReplay.mockReturnValue({flush});
+    getReplay.mockReturnValue({flush} as unknown as ReturnType<typeof Sentry.getReplay>);
     mockedUseReplayReady.mockReturnValue(false);
 
     renderHookWithProviders(() => useReplayForCriticalFlow({flowName: 'scm_onboarding'}));

--- a/static/gsApp/overrides/useRouteActivatedHook.spec.tsx
+++ b/static/gsApp/overrides/useRouteActivatedHook.spec.tsx
@@ -52,7 +52,7 @@ describe('useRouteActivatedHook', () => {
   });
 
   afterEach(() => {
-    (rawTrackAnalyticsEvent as jest.Mock).mockClear();
+    jest.mocked(rawTrackAnalyticsEvent).mockClear();
   });
 
   it('calls rawTrackAnalyticsEvent after one seconds if org is set', () => {

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx
@@ -29,10 +29,10 @@ describe('rawTrackAnalyticsEvent', () => {
   });
 
   afterEach(() => {
-    (trackReloadEvent as jest.Mock).mockClear();
-    (trackAmplitudeEvent as jest.Mock).mockClear();
-    (trackMarketingEvent as jest.Mock).mockClear();
-    (uniqueId as jest.Mock).mockClear();
+    jest.mocked(trackReloadEvent).mockClear();
+    jest.mocked(trackAmplitudeEvent).mockClear();
+    jest.mocked(trackMarketingEvent).mockClear();
+    jest.mocked(uniqueId).mockClear();
   });
 
   it('tracks in reload but not amplitude with undefined organization', () => {

--- a/static/gsApp/utils/trackAmplitudeEvent.spec.tsx
+++ b/static/gsApp/utils/trackAmplitudeEvent.spec.tsx
@@ -22,9 +22,9 @@ describe('trackAmplitudeEvent', () => {
     );
   });
   afterEach(() => {
-    (Amplitude.setUserId as jest.Mock).mockClear();
-    (Amplitude.track as jest.Mock).mockClear();
-    (Amplitude.setGroup as jest.Mock).mockClear();
+    jest.mocked(Amplitude.setUserId).mockClear();
+    jest.mocked(Amplitude.track).mockClear();
+    jest.mocked(Amplitude.setGroup).mockClear();
   });
 
   it('organization id is a number calls track', () => {


### PR DESCRIPTION
Replaces 75 occurrences of `as jest.Mock` type assertions with the `jest.mocked()` helper across 26 test files. `jest.mocked()` is the idiomatic approach — it preserves the original type while narrowing to the mock interface, whereas `as jest.Mock` is an unsafe cast.

This is a pure mechanical change with no behavioral differences.