### PR TITLE
lint: enable jest/prefer-jest-mocked

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -875,6 +875,7 @@ export default typescript.config([
         'error',
         {additionalTestBlockFunctions: ['it.isKnownFlake']},
       ],
+      'jest/prefer-jest-mocked': 'error',
 
       'jest/expect-expect': 'off', // Disabled as we have many tests which render as simple validations
       'jest/no-conditional-expect': 'off', // TODO(ryan953): Fix violations then delete this line

--- a/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
+++ b/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
@@ -32,7 +32,7 @@ jest.mock('@sentry/scraps/button', () => ({
 
 jest.mock('sentry/components/events/autofix/useAutofix');
 
-const mockButton = Button as jest.MockedFunction<typeof Button>;
+const mockButton = jest.mocked(Button);
 
 describe('AutofixChanges', () => {
   const defaultProps = {

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -130,9 +130,7 @@ describe('projectGeneralSettings', () => {
       })
     );
 
-    const addSuccessMessageMock = addSuccessMessage as jest.MockedFunction<
-      typeof addSuccessMessage
-    >;
+    const addSuccessMessageMock = jest.mocked(addSuccessMessage);
     const undo = addSuccessMessageMock.mock.calls[0]?.[1]?.undo;
 
     expect(undo).toBeInstanceOf(Function);

--- a/static/gsApp/components/productSelectionAvailability.spec.tsx
+++ b/static/gsApp/components/productSelectionAvailability.spec.tsx
@@ -333,9 +333,7 @@ describe('ProductSelectionAvailability', () => {
         },
       };
 
-      const MockUsePreviewData = usePreviewData as jest.MockedFunction<
-        typeof usePreviewData
-      >;
+      const MockUsePreviewData = jest.mocked(usePreviewData);
       const mockReservations: Reservations = {
         reservedErrors: 50000,
         reservedTransactions: 0,

--- a/static/gsApp/components/productUnavailableCTA.spec.tsx
+++ b/static/gsApp/components/productUnavailableCTA.spec.tsx
@@ -201,9 +201,7 @@ describe('ProductUnavailableCTA', () => {
         canSelfServe: true,
       });
 
-      const MockUsePreviewData = usePreviewData as jest.MockedFunction<
-        typeof usePreviewData
-      >;
+      const MockUsePreviewData = jest.mocked(usePreviewData);
       const mockReservations: Reservations = {
         reservedErrors: 50000,
         reservedTransactions: 0,

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx
@@ -25,7 +25,7 @@ describe('rawTrackAnalyticsEvent', () => {
   const org_id = Number(organization.id);
 
   beforeEach(() => {
-    (uniqueId as jest.MockedFunction<typeof uniqueId>).mockReturnValue('345');
+    jest.mocked(uniqueId).mockReturnValue('345');
   });
 
   afterEach(() => {


### PR DESCRIPTION
Enables [`jest/prefer-jest-mocked`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-jest-mocked.md) from `eslint-plugin-jest` (already a dep). It covers `jest.Mock`, `jest.MockedFunction`, `jest.MockedClass`, and `jest.MockedObject` assertions and autofixes to `jest.mocked()`. The five remaining offending files are fixed in this PR as well.