### PR TITLE
ref(dynamic-sampling): Use already queried data when computing boosted release platform

### DIFF
--- a/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
@@ -19,7 +19,7 @@ class BoostLatestReleasesBias(Bias):
 
     def generate_rules(self, project: Project, base_sample_rate: float) -> list[PolymorphicRule]:
         factor = apply_dynamic_factor(base_sample_rate, LATEST_RELEASES_BOOST_FACTOR)
-        boosted_releases = ProjectBoostedReleases(project.id).get_extended_boosted_releases()
+        boosted_releases = ProjectBoostedReleases(project).get_extended_boosted_releases()
 
         return cast(
             list[PolymorphicRule],

--- a/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
@@ -137,7 +137,7 @@ class ProjectBoostedReleases:
     def __init__(self, project: Project):
         self.redis_client = get_redis_client_for_ds()
         self.project_id = project.id
-        self.project_platform = project.platform
+        self.project_platform = Platform(project.platform)
 
     @property
     def has_boosted_releases(self) -> bool:

--- a/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
@@ -134,10 +134,10 @@ class ProjectBoostedReleases:
     # Limit of boosted releases per project.
     BOOSTED_RELEASES_HASH_EXPIRATION = 60 * 60 * 1000
 
-    def __init__(self, project_id: int):
+    def __init__(self, project: Project):
         self.redis_client = get_redis_client_for_ds()
-        self.project_id = project_id
-        self.project_platform = _get_project_platform(self.project_id)
+        self.project_id = project.id
+        self.project_platform = project.platform
 
     @property
     def has_boosted_releases(self) -> bool:
@@ -296,9 +296,7 @@ class LatestReleaseBias:
     def __init__(self, latest_release_params: LatestReleaseParams):
         self.redis_client = get_redis_client_for_ds()
         self.latest_release_params = latest_release_params
-        self.project_boosted_releases = ProjectBoostedReleases(
-            self.latest_release_params.project.id
-        )
+        self.project_boosted_releases = ProjectBoostedReleases(self.latest_release_params.project)
 
     @sentry_sdk.tracing.trace
     def observe_release(self, on_boosted_release_added: Callable[[], None]) -> None:

--- a/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
@@ -23,15 +23,6 @@ def _get_environment_cache_key(environment: str | None) -> str:
     return f"{ENVIRONMENT_SEPARATOR}{environment}" if environment else ""
 
 
-def _get_project_platform(project_id: int) -> Platform:
-    try:
-        return Platform(Project.objects.get(id=project_id).platform)
-    except Project.DoesNotExist:
-        # If we don't find the project of this release we just default to having no platform name in the
-        # BoostedRelease.
-        return Platform()
-
-
 @dataclass(frozen=True)
 class BoostedRelease:
     """
@@ -44,14 +35,14 @@ class BoostedRelease:
     # We also store the cache key corresponding to this boosted release entry, in order to remove it efficiently.
     cache_key: str
 
-    def extend(self, release: Release, project_id: int) -> "ExtendedBoostedRelease":
+    def extend(self, release: Release, platform: Platform) -> "ExtendedBoostedRelease":
         return ExtendedBoostedRelease(
             id=self.id,
             timestamp=self.timestamp,
             environment=self.environment,
             cache_key=self.cache_key,
             version=release.version,
-            platform=_get_project_platform(project_id),
+            platform=platform,
         )
 
 
@@ -85,7 +76,7 @@ class BoostedReleases:
         )
 
     def to_extended_boosted_releases(
-        self, project_id: int
+        self, platform: Platform
     ) -> tuple[list[ExtendedBoostedRelease], list[str]]:
         # We get release models in order to have all the information to extend the releases we get from the cache.
         models = self._get_releases_models()
@@ -104,7 +95,7 @@ class BoostedReleases:
                 continue
 
             extended_boosted_release = boosted_release.extend(
-                release=release_model, project_id=project_id
+                release=release_model, platform=platform
             )
 
             if extended_boosted_release.is_active(current_timestamp):
@@ -171,7 +162,9 @@ class ProjectBoostedReleases:
         """
         # We read all boosted releases and we augment them in two separate loops in order to perform a single query
         # to fetch all the release models. This optimization avoids peforming a query for each release.
-        active, expired = self._get_boosted_releases().to_extended_boosted_releases(self.project_id)
+        active, expired = self._get_boosted_releases().to_extended_boosted_releases(
+            self.project_platform
+        )
         # We delete all the expired releases.
         if expired:
             self.redis_client.hdel(self._generate_cache_key_for_boosted_releases_hash(), *expired)

--- a/src/sentry/models/releases/release_project.py
+++ b/src/sentry/models/releases/release_project.py
@@ -24,7 +24,7 @@ class ReleaseProjectModelManager(BaseManager["ReleaseProject"]):
     def _on_post(project, trigger):
         from sentry.dynamic_sampling import ProjectBoostedReleases
 
-        project_boosted_releases = ProjectBoostedReleases(project.id)
+        project_boosted_releases = ProjectBoostedReleases(project)
         # We want to invalidate the project config only if dynamic sampling is enabled and there exists boosted releases
         # in the project.
         if (

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -3756,7 +3756,7 @@ class DSLatestReleaseBoostTest(TestCase):
             f"ds::r:{release_2.id}:e:prod": str(ts),
             f"ds::r:{release_3.id}:e:dev": str(ts),
         }
-        assert ProjectBoostedReleases(project_id=project.id).get_extended_boosted_releases() == [
+        assert ProjectBoostedReleases(project).get_extended_boosted_releases() == [
             ExtendedBoostedRelease(
                 id=release_1.id,
                 timestamp=ts,
@@ -3821,7 +3821,7 @@ class DSLatestReleaseBoostTest(TestCase):
         assert self.redis_client.hgetall(f"ds::p:{project.id}:boosted_releases") == {
             f"ds::r:{release_2.id}:e:{self.environment1.name}": str(ts),
         }
-        assert ProjectBoostedReleases(project_id=project.id).get_extended_boosted_releases() == [
+        assert ProjectBoostedReleases(project).get_extended_boosted_releases() == [
             ExtendedBoostedRelease(
                 id=release_2.id,
                 timestamp=ts,
@@ -3854,7 +3854,7 @@ class DSLatestReleaseBoostTest(TestCase):
         assert self.redis_client.hgetall(f"ds::p:{project.id}:boosted_releases") == {
             f"ds::r:{release.id}:e:{self.environment1.name}": str(ts_1)
         }
-        assert ProjectBoostedReleases(project_id=project.id).get_extended_boosted_releases() == [
+        assert ProjectBoostedReleases(project).get_extended_boosted_releases() == [
             ExtendedBoostedRelease(
                 id=release.id,
                 timestamp=ts_1,
@@ -3888,9 +3888,7 @@ class DSLatestReleaseBoostTest(TestCase):
                 f"ds::r:{release.id}:e:{self.environment1.name}": str(ts_1),
                 f"ds::r:{release.id}:e:{self.environment2.name}": str(ts_2),
             }
-            assert ProjectBoostedReleases(
-                project_id=project.id
-            ).get_extended_boosted_releases() == [
+            assert ProjectBoostedReleases(project).get_extended_boosted_releases() == [
                 ExtendedBoostedRelease(
                     id=release.id,
                     timestamp=ts_1,
@@ -3928,9 +3926,7 @@ class DSLatestReleaseBoostTest(TestCase):
                 f"ds::r:{release.id}:e:{self.environment2.name}": str(ts_2),
                 f"ds::r:{release.id}": str(ts_3),
             }
-            assert ProjectBoostedReleases(
-                project_id=project.id
-            ).get_extended_boosted_releases() == [
+            assert ProjectBoostedReleases(project).get_extended_boosted_releases() == [
                 ExtendedBoostedRelease(
                     id=release.id,
                     timestamp=ts_1,
@@ -3975,7 +3971,7 @@ class DSLatestReleaseBoostTest(TestCase):
             )
 
         assert self.redis_client.hgetall(f"ds::p:{project.id}:boosted_releases") == {}
-        assert ProjectBoostedReleases(project_id=project.id).get_extended_boosted_releases() == []
+        assert ProjectBoostedReleases(project).get_extended_boosted_releases() == []
 
     @freeze_time("2022-11-03 10:00:00")
     def test_release_not_boosted_with_deleted_release_after_event_received(self) -> None:
@@ -4016,7 +4012,7 @@ class DSLatestReleaseBoostTest(TestCase):
         }
         # We expect to not see the release 2 because it will not be in the database anymore, thus we mark it as
         # expired.
-        assert ProjectBoostedReleases(project_id=project.id).get_extended_boosted_releases() == [
+        assert ProjectBoostedReleases(project).get_extended_boosted_releases() == [
             ExtendedBoostedRelease(
                 id=release_1.id,
                 timestamp=ts,
@@ -4061,7 +4057,7 @@ class DSLatestReleaseBoostTest(TestCase):
             ts,
         )
 
-        assert ProjectBoostedReleases(project_id=project.id).get_extended_boosted_releases() == [
+        assert ProjectBoostedReleases(project).get_extended_boosted_releases() == [
             ExtendedBoostedRelease(
                 id=release_1.id,
                 timestamp=ts,
@@ -4149,9 +4145,7 @@ class DSLatestReleaseBoostTest(TestCase):
             assert self.redis_client.hgetall(f"ds::p:{project.id}:boosted_releases") == {
                 f"ds::r:{release_3.id}:e:{self.environment1.name}": str(ts)
             }
-            assert ProjectBoostedReleases(
-                project_id=project.id
-            ).get_extended_boosted_releases() == [
+            assert ProjectBoostedReleases(project).get_extended_boosted_releases() == [
                 ExtendedBoostedRelease(
                     id=release_3.id,
                     timestamp=ts,
@@ -4231,7 +4225,7 @@ class DSLatestReleaseBoostTest(TestCase):
             f"ds::r:{release_2.id}": str(ts - 1),
             f"ds::r:{release_3.id}:e:{self.environment1.name}": str(ts),
         }
-        assert ProjectBoostedReleases(project_id=project.id).get_extended_boosted_releases() == [
+        assert ProjectBoostedReleases(project).get_extended_boosted_releases() == [
             ExtendedBoostedRelease(
                 id=release_2.id,
                 timestamp=ts - 1,
@@ -4300,7 +4294,7 @@ class DSLatestReleaseBoostTest(TestCase):
             f"ds::r:{release_1.id}:e:{self.environment2.name}": str(ts),
             f"ds::r:{release_1.id}": str(ts),
         }
-        assert ProjectBoostedReleases(project_id=project.id).get_extended_boosted_releases() == [
+        assert ProjectBoostedReleases(project).get_extended_boosted_releases() == [
             ExtendedBoostedRelease(
                 id=release_1.id,
                 timestamp=ts,

--- a/tests/sentry/models/releases/test_release_project.py
+++ b/tests/sentry/models/releases/test_release_project.py
@@ -53,7 +53,7 @@ class ReleaseProjectManagerTestCase(TestCase):
         ):
             project = self.create_project(name="foo")
             release = Release.objects.create(organization_id=project.organization_id, version="42")
-            project_boosted_releases = ProjectBoostedReleases(project.id)
+            project_boosted_releases = ProjectBoostedReleases(project)
             # We store a boosted release for this project.
             project_boosted_releases.add_boosted_release(release.id, None)
             assert project_boosted_releases.has_boosted_releases


### PR DESCRIPTION
This is our [top query](https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22transaction%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&mode=aggregate&project=1&query=span.description%3A%22SELECT%20%5C%22sentry_project%5C%22.%5C%22id%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22slug%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22name%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22forced_color%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22organization_id%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22public%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22date_added%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22status%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22first_event%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22external_id%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22flags%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22platform%5C%22%20FROM%20%5C%22sentry_project%5C%22%20WHERE%20%5C%22sentry_project%5C%22.%5C%22id%5C%22%20%3D%20%25s%20LIMIT%2021%22&statsPeriod=24h) for a project row (10x second place). But the data already exists in memory at each call site! Let's re-use the already queried project model.

You can see that the [transaction](https://sentry.sentry.io/explore/traces/trace/48bd65d7d8054efa87ab06ceed977cd3/?aggregateField=%7B%22groupBy%22%3A%22transaction%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&mode=samples&node=span-8b45bf1b0c1e592b&project=1&query=span.description%3A%22SELECT%20%5C%22sentry_project%5C%22.%5C%22id%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22slug%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22name%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22forced_color%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22organization_id%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22public%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22date_added%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22status%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22first_event%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22external_id%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22flags%5C%22%2C%20%5C%22sentry_project%5C%22.%5C%22platform%5C%22%20FROM%20%5C%22sentry_project%5C%22%20WHERE%20%5C%22sentry_project%5C%22.%5C%22id%5C%22%20%3D%20%25s%20LIMIT%2021%22%20transaction%3Aspans.consumers.process_segments.process_segment&sort=-span.duration&source=traces&statsPeriod=24h&targetId=9a13383fb2e2c949&timestamp=1779161578) typically records a project cache hit as its first op and then queries the project anyway further down. I'm having some difficulty grouping correctly but if you look [here](https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22span.op%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&field=span.op&mode=aggregate&project=1&query=transaction%3Aspans.consumers.process_segments.process_segment&statsPeriod=24h) you can see that `event_manager.dynamic_sampling_observe_latest_release`'s volume is ~90% of the project-query volume linked above. Since we know it always queries once we can conclude a significant resource savings is possible by using the cached value.

Optionally, we could pass the `id` and `platform` as values (which would be best IMO) but since this is a drive-by PR its best to preserve things as much as possible.