### PR TITLE
ref(hookStore): Change HookStore to single-value semantics

### DIFF
--- a/static/app/components/acl/feature.spec.tsx
+++ b/static/app/components/acl/feature.spec.tsx
@@ -284,11 +284,11 @@ describe('Feature', () => {
 
     beforeEach(() => {
       hookFn = jest.fn(() => null);
-      HookStore.add('feature-disabled:sso-basic', hookFn);
+      HookStore.set('feature-disabled:sso-basic', hookFn);
     });
 
     afterEach(() => {
-      HookStore.remove('feature-disabled:sso-basic', hookFn);
+      HookStore.remove('feature-disabled:sso-basic');
     });
 
     it('uses hookName if provided', () => {

--- a/static/app/components/acl/feature.tsx
+++ b/static/app/components/acl/feature.tsx
@@ -174,10 +174,10 @@ function Feature({
   // Override the renderDisabled function with a hook store function if there
   // is one registered for the feature.
   if (hookName) {
-    const hooks = HookStore.get(hookName);
+    const hook = HookStore.get(hookName);
 
-    if (hooks.length > 0) {
-      customDisabledRender = hooks[0]!;
+    if (hook) {
+      customDisabledRender = hook;
     }
   }
   const renderProps = {

--- a/static/app/components/hook.spec.tsx
+++ b/static/app/components/hook.spec.tsx
@@ -20,7 +20,7 @@ describe('Hook', () => {
   });
 
   it('renders component from a hook', () => {
-    HookStore.add('sidebar:help-menu', ({organization}) => (
+    HookStore.set('sidebar:help-menu', ({organization}) => (
       <HookWrapper key={0} organization={organization}>
         {organization.slug}
       </HookWrapper>
@@ -32,13 +32,13 @@ describe('Hook', () => {
       </div>
     );
 
-    expect(HookStore.get('sidebar:help-menu')).toHaveLength(1);
+    expect(HookStore.get('sidebar:help-menu')).toBeDefined();
     expect(screen.getByTestId('hook-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('hook-wrapper')).toHaveTextContent('org-slug');
   });
 
-  it('can re-render when hooks get after initial render', () => {
-    HookStore.add('sidebar:help-menu', ({organization}) => (
+  it('re-renders when hook is replaced after initial render', () => {
+    HookStore.set('sidebar:help-menu', ({organization}) => (
       <HookWrapper key={0} organization={organization}>
         Old Hook
       </HookWrapper>
@@ -51,7 +51,7 @@ describe('Hook', () => {
     expect(screen.getByTestId('hook-wrapper')).toBeInTheDocument();
 
     act(() =>
-      HookStore.add('sidebar:help-menu', () => (
+      HookStore.set('sidebar:help-menu', () => (
         <HookWrapper key="new" organization={null}>
           New Hook
         </HookWrapper>
@@ -60,19 +60,19 @@ describe('Hook', () => {
 
     rerender(<Hook name="sidebar:help-menu" organization={OrganizationFixture()} />);
 
-    expect(screen.getAllByTestId('hook-wrapper')).toHaveLength(2);
+    expect(screen.getAllByTestId('hook-wrapper')).toHaveLength(1);
     expect(screen.getByText(/New Hook/)).toBeInTheDocument();
-    expect(screen.getByText(/Old Hook/)).toBeInTheDocument();
+    expect(screen.queryByText(/Old Hook/)).not.toBeInTheDocument();
   });
 
   it('re-fetches hooks when name prop changes', () => {
-    HookStore.add('sidebar:help-menu', ({organization}) => (
+    HookStore.set('sidebar:help-menu', ({organization}) => (
       <HookWrapper key="help" organization={organization}>
         Help Hook
       </HookWrapper>
     ));
 
-    HookStore.add('sidebar:organization-dropdown-menu', () => (
+    HookStore.set('sidebar:organization-dropdown-menu', () => (
       <HookWrapper key="bottom">Bottom Hook</HookWrapper>
     ));
 
@@ -95,21 +95,14 @@ describe('Hook', () => {
   });
 
   it('can use children as a render prop', () => {
-    let idx = 0;
     render(
       <Hook name="sidebar:help-menu" organization={OrganizationFixture()}>
-        {({hooks}) =>
-          hooks.map((hook, i) => (
-            <HookWrapper key={i}>
-              {hook} {`hook: ${++idx}`}
-            </HookWrapper>
-          ))
-        }
+        {({rendered}) => <HookWrapper>{rendered} hook: 1</HookWrapper>}
       </Hook>
     );
 
     act(() =>
-      HookStore.add('sidebar:help-menu', () => (
+      HookStore.set('sidebar:help-menu', () => (
         <HookWrapper key="new" organization={null}>
           First Hook
         </HookWrapper>
@@ -117,18 +110,18 @@ describe('Hook', () => {
     );
 
     act(() =>
-      HookStore.add('sidebar:help-menu', () => (
+      HookStore.set('sidebar:help-menu', () => (
         <HookWrapper key="new" organization={null}>
           Second Hook
         </HookWrapper>
       ))
     );
 
-    for (let i = 0; i < idx; i++) {
-      expect(screen.getByText(`hook: ${idx}`)).toBeInTheDocument();
-    }
+    expect(screen.getByText(/hook: 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Second Hook/)).toBeInTheDocument();
+    expect(screen.queryByText(/First Hook/)).not.toBeInTheDocument();
 
-    // Has 2 Wrappers from store, and each is wrapped by another Wrapper
-    expect(screen.getAllByTestId('hook-wrapper')).toHaveLength(4);
+    // 2 HookWrappers: the render prop's outer wrapper + the registered hook's inner wrapper
+    expect(screen.getAllByTestId('hook-wrapper')).toHaveLength(2);
   });
 });

--- a/static/app/components/hook.tsx
+++ b/static/app/components/hook.tsx
@@ -14,52 +14,54 @@ type Props<H extends ComponentHookName> = {
    */
   name: H;
   /**
-   * If children are provided as a function to the Hook, the hooks will be
-   * passed down as a render prop.
+   * If children are provided as a function to the Hook, the rendered hook
+   * will be passed down as a render prop.
    */
-  children?: (opts: {hooks: Array<Hooks[H]>}) => React.ReactNode;
+  children?: (opts: {rendered: React.ReactNode}) => React.ReactNode;
 } & Omit<Parameters<Hooks[H]>[0], 'name'>;
 
 /**
  * Instead of accessing the HookStore directly, use this.
  *
- * If the hook slot needs to perform anything w/ the hooks, you can pass a
- * function as a child and you will receive an object with a `hooks` key
+ * If the hook slot needs to perform anything w/ the hook, you can pass a
+ * function as a child and you will receive an object with a `hook` key.
  *
  * Example:
  *
  *   <Hook name="my-hook">
- *     {({hooks}) => hooks.map(hook => (
- *       <Wrapper>{hook}</Wrapper>
- *     ))}
+ *     {({rendered}) => <Wrapper>{rendered}</Wrapper>}
  *   </Hook>
  */
 function Hook<H extends ComponentHookName>({name, children, ...props}: Props<H>) {
-  const [hookCallbacks, setHookCallbacks] = useState<Array<Hooks[H]>>(() =>
+  // Wrap in a thunk: useState(fn) calls fn() as a lazy initializer, so storing
+  // a function as state requires the () => fn pattern throughout.
+  const [hookCallback, setHookCallback] = useState<Hooks[H] | undefined>(() =>
     HookStore.get(name)
   );
 
   useEffect(() => {
-    setHookCallbacks([...HookStore.get(name)]);
+    setHookCallback(() => HookStore.get(name));
 
-    const unsubscribe = HookStore.listen((hookName: HookName, hooks: Array<Hooks[H]>) => {
-      if (hookName === name) {
-        setHookCallbacks([...hooks]);
-      }
-    }, undefined);
+    const unsubscribe = HookStore.listen(
+      (hookName: HookName, hook: Hooks[H] | undefined) => {
+        if (hookName === name) {
+          setHookCallback(() => hook);
+        }
+      },
+      undefined
+    );
     return () => unsubscribe();
   }, [name]);
 
-  if (!hookCallbacks?.length) {
+  if (!hookCallback) {
     return null;
   }
 
-  const rendered = hookCallbacks.map((HookComp, index) => (
-    <HookComp key={index} {...props} />
-  ));
+  const HookComp = hookCallback as React.ComponentType<any>;
+  const rendered = <HookComp {...props} />;
 
   if (typeof children === 'function') {
-    return children({hooks: rendered});
+    return children({rendered});
   }
 
   return rendered;

--- a/static/app/components/hookOrDefault.spec.tsx
+++ b/static/app/components/hookOrDefault.spec.tsx
@@ -25,7 +25,7 @@ describe('HookOrDefault', () => {
   });
 
   it('should render from HookStore', () => {
-    HookStore.add(
+    HookStore.set(
       'component:replay-onboarding-cta',
       () =>
         function ({organization}) {

--- a/static/app/components/hookOrDefault.tsx
+++ b/static/app/components/hookOrDefault.tsx
@@ -25,9 +25,7 @@ interface Params<H extends HookName> {
  * Use this instead of the usual ternery operator when using getsentry hooks.
  * So in lieu of:
  *
- *  HookStore.get('component:org-auth-view').length
- *   ? HookStore.get('component:org-auth-view')[0]()
- *   : OrganizationAuth
+ *  HookStore.get('component:org-auth-view')?.() ?? OrganizationAuth
  *
  * do this instead:
  *
@@ -70,25 +68,27 @@ export function HookOrDefault<H extends HookName>({
   }
 
   function HookOrDefaultComponent(props: Props) {
-    const [hooks, setHooks] = useState(HookStore.get(hookName));
+    // Wrap in a thunk: useState(fn) calls fn() as a lazy initializer, so storing
+    // a function as state requires the () => fn pattern throughout.
+    const [hook, setHook] = useState(() => HookStore.get(hookName));
 
     useEffect(() => {
-      const unsubscribe = HookStore.listen((name: string, newHooks: Array<Hooks[H]>) => {
-        if (name === hookName) {
-          setHooks(newHooks);
-        }
-      }, undefined);
+      const unsubscribe = HookStore.listen(
+        (name: string, newHook: Hooks[H] | undefined) => {
+          if (name === hookName) {
+            setHook(() => newHook);
+          }
+        },
+        undefined
+      );
 
       return () => {
         unsubscribe();
       };
     }, []);
 
-    const hookExists = hooks?.length;
-    const componentFromHook = hooks[0]?.();
     // Defining the props here is unnecessary and slow for typescript
-    const HookComponent: React.ComponentType<any> =
-      hookExists && componentFromHook ? componentFromHook : getDefaultComponent();
+    const HookComponent: React.ComponentType<any> = hook?.() ?? getDefaultComponent();
 
     if (!HookComponent) {
       return null;

--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -70,8 +70,7 @@ function InviteMembersModal({
   }
 
   const defaultOrgRoles =
-    HookStore.get('member-invite-modal:organization-roles')[0]?.(organization) ??
-    ORG_ROLES;
+    HookStore.get('member-invite-modal:organization-roles')?.(organization) ?? ORG_ROLES;
 
   return (
     <ErrorBoundary>

--- a/static/app/components/search/sources/routeSource.spec.tsx
+++ b/static/app/components/search/sources/routeSource.spec.tsx
@@ -35,7 +35,7 @@ describe('RouteSource', () => {
 
   it('can load links via hooks', async () => {
     const mock = jest.fn().mockReturnValue(null);
-    HookStore.add('settings:organization-navigation-config', () => {
+    HookStore.set('settings:organization-navigation-config', () => {
       return {
         id: 'settings-usage-billing',
         name: 'Usage & Billing',

--- a/static/app/components/search/sources/routeSource.tsx
+++ b/static/app/components/search/sources/routeSource.tsx
@@ -74,9 +74,7 @@ export function RouteSource({searchOptions, query, children}: Props) {
     const navConfigHook = organization
       ? HookStore.get('settings:organization-navigation-config')
       : undefined;
-    const navigationFromHook: NavigationSection[] = navConfigHook
-      ? [navConfigHook(organization!)]
-      : [];
+    const navigationFromHook = navConfigHook ? [navConfigHook(organization)] : [];
 
     const searchMap = [
       mapFunc(getUserOrgNavigationConfiguration, context),

--- a/static/app/components/search/sources/routeSource.tsx
+++ b/static/app/components/search/sources/routeSource.tsx
@@ -71,10 +71,11 @@ export function RouteSource({searchOptions, query, children}: Props) {
       features: new Set(project?.features),
     } as Context;
 
-    const navigationFromHook = organization
-      ? HookStore.get('settings:organization-navigation-config').map(cb =>
-          cb(organization)
-        )
+    const navConfigHook = organization
+      ? HookStore.get('settings:organization-navigation-config')
+      : undefined;
+    const navigationFromHook: NavigationSection[] = navConfigHook
+      ? [navConfigHook(organization!)]
       : [];
 
     const searchMap = [

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -46,7 +46,7 @@ import {SettingsWrapper} from 'sentry/views/settings/components/settingsWrapper'
 import {type SentryRouteObject} from './types';
 
 const routeHook = (name: HookName): SentryRouteObject => {
-  return HookStore.get(name)?.[0]?.() ?? {};
+  return HookStore.get(name)?.() ?? {};
 };
 
 function buildRoutes(): RouteObject[] {

--- a/static/app/scrapsProviders/tracking.tsx
+++ b/static/app/scrapsProviders/tracking.tsx
@@ -5,7 +5,7 @@ import {TrackingContextProvider} from '@sentry/scraps/trackingContext';
 import {HookStore} from 'sentry/stores/hookStore';
 
 export function SentryTrackingProvider({children}: {children: React.ReactNode}) {
-  const useButtonTracking = HookStore.get('react-hook:use-button-tracking')[0];
+  const useButtonTracking = HookStore.get('react-hook:use-button-tracking');
   const trackingContextValue = useMemo(() => ({useButtonTracking}), [useButtonTracking]);
 
   return (

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -298,7 +298,7 @@ const storeConfig: GuideStoreDefinition = {
     this.state = {...this.state, currentGuide: nextGuide, currentStep};
 
     this.trigger(this.state);
-    HookStore.get('callback:on-guide-update').map(cb => cb(nextGuide, {dismissed}));
+    HookStore.get('callback:on-guide-update')?.(nextGuide, {dismissed});
   },
 };
 

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -13,12 +13,12 @@ interface Internals {
 type HookCallback = (...args: any[]) => void;
 
 interface HookStoreDefinition extends StoreDefinition, Internals {
-  add<H extends HookName>(hookName: H, callback: Hooks[H]): void;
-  get<H extends HookName>(hookName: H): Array<Hooks[H]>;
+  get<H extends HookName>(hookName: H): Hooks[H] | undefined;
   getCallback(hookName: HookName, key: string): HookCallback | undefined;
   init(): void;
   persistCallback(hookName: HookName, key: string, value: HookCallback): void;
-  remove<H extends HookName>(hookName: H, callback: Hooks[H]): void;
+  remove(hookName: HookName): void;
+  set<H extends HookName>(hookName: H, callback: Hooks[H]): void;
 }
 
 const storeConfig: HookStoreDefinition = {
@@ -33,25 +33,18 @@ const storeConfig: HookStoreDefinition = {
     this.hookCallbacks = {}; // For persisting hook pure functions / useX react hooks remotely.
   },
 
-  add(hookName, callback) {
-    if (this.hooks[hookName] === undefined) {
-      this.hooks[hookName] = [];
-    }
-
-    this.hooks[hookName].push(callback);
-    this.trigger(hookName, this.hooks[hookName]);
+  set(hookName, callback) {
+    this.hooks[hookName] = callback;
+    this.trigger(hookName, callback);
   },
 
-  remove(hookName, callback) {
-    if (this.hooks[hookName] === undefined) {
-      return;
-    }
-    this.hooks[hookName] = this.hooks[hookName]!.filter((cb: any) => cb !== callback);
-    this.trigger(hookName, this.hooks[hookName]);
+  remove(hookName) {
+    delete this.hooks[hookName];
+    this.trigger(hookName, undefined);
   },
 
   get(hookName) {
-    return this.hooks[hookName]! || [];
+    return this.hooks[hookName];
   },
 
   persistCallback(hookName, key, value) {

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -289,7 +289,7 @@ const metricDataStore = new Map<string, Record<PropertyKey, unknown>>();
  * Record metrics.
  */
 export const metric: RecordMetric = (name, value, tags) =>
-  HookStore.get('metrics:event').forEach(cb => cb(name, value, tags));
+  HookStore.get('metrics:event')?.(name, value, tags);
 
 // JSDOM implements window.performance but not window.performance.mark
 export const CAN_MARK =

--- a/static/app/utils/analytics/makeAnalyticsFunction.tsx
+++ b/static/app/utils/analytics/makeAnalyticsFunction.tsx
@@ -11,7 +11,7 @@ import type {Organization} from 'sentry/types/organization';
  * rawTrackAnalyticsEvent.
  */
 const rawTrackAnalyticsEvent: Hooks['analytics:raw-track-event'] = (data, options) =>
-  HookStore.get('analytics:raw-track-event').forEach(cb => cb(data, options));
+  HookStore.get('analytics:raw-track-event')?.(data, options);
 
 const hasAnalyticsDebug = () => window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
 

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -70,7 +70,7 @@ const defaultFeatureGateComponents: ReturnType<Hooks['integrations:feature-gates
 
 export const getIntegrationFeatureGate = () => {
   const defaultHook = () => defaultFeatureGateComponents;
-  const featureHook = HookStore.get('integrations:feature-gates')[0] || defaultHook;
+  const featureHook = HookStore.get('integrations:feature-gates') || defaultHook;
   return featureHook();
 };
 

--- a/static/app/utils/replays/useReplayForCriticalFlow.spec.tsx
+++ b/static/app/utils/replays/useReplayForCriticalFlow.spec.tsx
@@ -10,7 +10,7 @@ describe('useReplayForCriticalFlow', () => {
 
   it('delegates to the registered hook implementation', () => {
     const impl = jest.fn();
-    HookStore.add('react-hook:use-replay-for-critical-flow', impl);
+    HookStore.set('react-hook:use-replay-for-critical-flow', impl);
 
     renderHookWithProviders(() =>
       useReplayForCriticalFlow({flowName: 'scm_onboarding', sampleRate: 0.5})

--- a/static/app/utils/replays/useReplayForCriticalFlow.tsx
+++ b/static/app/utils/replays/useReplayForCriticalFlow.tsx
@@ -30,6 +30,6 @@ const noop = (_: UseReplayForCriticalFlowOptions) => {};
  * through to a noop.
  */
 export function useReplayForCriticalFlow(options: UseReplayForCriticalFlowOptions) {
-  const useImpl = HookStore.get('react-hook:use-replay-for-critical-flow')[0] ?? noop;
+  const useImpl = HookStore.get('react-hook:use-replay-for-critical-flow') ?? noop;
   useImpl(options);
 }

--- a/static/app/utils/useExperiment.tsx
+++ b/static/app/utils/useExperiment.tsx
@@ -88,6 +88,6 @@ function useNoopExperiment(options: UseExperimentOptions): UseExperimentResult {
  */
 export function useExperiment(options: UseExperimentOptions): UseExperimentResult {
   const useExperimentHook =
-    HookStore.get('react-hook:use-experiment')[0] ?? useNoopExperiment;
+    HookStore.get('react-hook:use-experiment') ?? useNoopExperiment;
   return useExperimentHook(options);
 }

--- a/static/app/utils/useMaxPickableDays.tsx
+++ b/static/app/utils/useMaxPickableDays.tsx
@@ -16,7 +16,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
  */
 export function useDefaultMaxPickableDays(): number {
   const useDefaultMaxPickableDaysHook =
-    HookStore.get('react-hook:use-default-max-pickable-days')[0] ??
+    HookStore.get('react-hook:use-default-max-pickable-days') ??
     useDefaultMaxPickableDaysImpl;
   return useDefaultMaxPickableDaysHook();
 }
@@ -46,7 +46,7 @@ export function useMaxPickableDays({
   dataCategories,
 }: UseMaxPickableDaysProps): MaxPickableDaysOptions {
   const useMaxPickableDaysHook =
-    HookStore.get('react-hook:use-max-pickable-days')[0] ?? useMaxPickableDaysImpl;
+    HookStore.get('react-hook:use-max-pickable-days') ?? useMaxPickableDaysImpl;
   return useMaxPickableDaysHook({dataCategories});
 }
 

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
@@ -116,7 +116,7 @@ describe('SetupAlertIntegrationButton', () => {
       })
     );
 
-    HookStore.add('integrations:feature-gates', () => {
+    HookStore.set('integrations:feature-gates', () => {
       return {
         IntegrationFeatures: p =>
           p.children({

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -48,7 +48,7 @@ export default function AlertWizard() {
   const {project} = useAlertBuilderOutlet();
 
   const useMetricDetectorLimit =
-    HookStore.get('react-hook:use-metric-detector-limit')[0] ?? (() => null);
+    HookStore.get('react-hook:use-metric-detector-limit') ?? (() => null);
   const quota = useMetricDetectorLimit();
   const canCreateMetricAlert = !quota?.hasReachedLimit;
 

--- a/static/app/views/app/index.spec.tsx
+++ b/static/app/views/app/index.spec.tsx
@@ -136,17 +136,17 @@ describe('App', () => {
       partnerDisplayName: 'Foo',
       agreements: ['standard', 'partner_presence'],
     });
-    HookStore.add('component:partnership-agreement', () => <HookWrapper key={0} />);
+    HookStore.set('component:partnership-agreement', () => <HookWrapper key={0} />);
     render(<App />, {initialRouterConfig: defaultRouterConfig});
 
     await waitFor(() => OrganizationsStore.getAll().length === 1);
-    expect(HookStore.get('component:partnership-agreement')).toHaveLength(1);
+    expect(HookStore.get('component:partnership-agreement')).toBeDefined();
     expect(screen.getByTestId('hook-wrapper')).toBeInTheDocument();
   });
 
   it('does not render PartnerAgreement for non-partnered orgs', async () => {
     ConfigStore.set('partnershipAgreementPrompt', null);
-    HookStore.add('component:partnership-agreement', () => <HookWrapper key={0} />);
+    HookStore.set('component:partnership-agreement', () => <HookWrapper key={0} />);
     render(<App />, {initialRouterConfig: defaultRouterConfig});
 
     await waitFor(() => OrganizationsStore.getAll().length === 1);

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -136,7 +136,7 @@ export function App() {
 
     // Set the user for analytics
     if (user) {
-      HookStore.get('analytics:init-user').map(cb => cb(user));
+      HookStore.get('analytics:init-user')?.(user);
     }
 
     initApiClientErrorHandling();

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -540,7 +540,7 @@ function useTimeRangeWarning({widget}: {widget: TWidget}) {
     selection: {datetime},
   } = usePageFilters();
   const useRetentionLimit =
-    HookStore.get('react-hook:use-dashboard-dataset-retention-limit')[0] ?? (() => null);
+    HookStore.get('react-hook:use-dashboard-dataset-retention-limit') ?? (() => null);
   const retentionLimitDays = useRetentionLimit({
     dataset: widget.widgetType ?? WidgetType.ERRORS,
   });

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -77,7 +77,7 @@ function MonitorTypeField() {
   const [selectedDetectorType, setDetectorType] = useDetectorTypeQueryState();
 
   const useMetricDetectorLimit =
-    HookStore.get('react-hook:use-metric-detector-limit')[0] ?? (() => null);
+    HookStore.get('react-hook:use-metric-detector-limit') ?? (() => null);
   const quota = useMetricDetectorLimit();
   const canCreateMetricDetector = !quota?.hasReachedLimit;
 

--- a/static/app/views/insights/crons/components/monitorCreateForm.tsx
+++ b/static/app/views/insights/crons/components/monitorCreateForm.tsx
@@ -49,7 +49,7 @@ export function MonitorCreateForm() {
   const organization = useOrganization();
   const {projects} = useProjects();
   const {selection} = usePageFilters();
-  const monitorCreationCallbacks = HookStore.get('callback:on-monitor-created');
+  const onMonitorCreated = HookStore.get('callback:on-monitor-created');
 
   const form = useRef(
     new FormModel({
@@ -79,7 +79,7 @@ export function MonitorCreateForm() {
         query: endpointOptions.query,
       })
     );
-    monitorCreationCallbacks.map(cb => cb(organization));
+    onMonitorCreated?.(organization);
   }
 
   function changeScheduleType(type: ScheduleType) {

--- a/static/app/views/insights/crons/components/statusToggleButton.tsx
+++ b/static/app/views/insights/crons/components/statusToggleButton.tsx
@@ -21,7 +21,7 @@ export function StatusToggleButton({
   const organization = useOrganization();
   const {status} = monitor;
   const isDisabled = status === 'disabled';
-  const monitorCreationCallbacks = HookStore.get('callback:on-monitor-created');
+  const onMonitorCreated = HookStore.get('callback:on-monitor-created');
 
   const Icon = isDisabled ? IconPlay : IconPause;
 
@@ -38,7 +38,7 @@ export function StatusToggleButton({
         await onToggleStatus(isDisabled ? 'active' : 'disabled');
         // TODO(epurkhiser): This hook is probably too specialized and could
         // maybe do to be a component hook instead
-        monitorCreationCallbacks.map(cb => cb(organization));
+        onMonitorCreated?.(organization);
       }}
       {...props}
     />

--- a/static/app/views/issueDetails/streamline/eventMissingBanner.tsx
+++ b/static/app/views/issueDetails/streamline/eventMissingBanner.tsx
@@ -24,8 +24,8 @@ export function EventMissingBanner() {
   }>();
   const eventId = eventIdParam ?? defaultEventId;
 
-  const retentionHook = HookStore.get('react-hook:use-get-max-retention-days')[0];
-  const useGetMaxRetentionDays = retentionHook ?? (() => MAX_PICKABLE_DAYS);
+  const useGetMaxRetentionDays =
+    HookStore.get('react-hook:use-get-max-retention-days') ?? (() => MAX_PICKABLE_DAYS);
   const maxRetentionDays = useGetMaxRetentionDays();
   const statsPeriod = maxRetentionDays ? `${maxRetentionDays}d` : '30d';
 

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -64,8 +64,7 @@ export function StreamlinedGroupHeader({event, group, project}: GroupHeaderProps
   const {sort: _sort, ...query} = location.query;
   const {count: eventCount, userCount} = group;
   const useGetMaxRetentionDays =
-    HookStore.get('react-hook:use-get-max-retention-days')[0] ??
-    (() => MAX_PICKABLE_DAYS);
+    HookStore.get('react-hook:use-get-max-retention-days') ?? (() => MAX_PICKABLE_DAYS);
   const maxRetentionDays = useGetMaxRetentionDays();
   const userCountPeriod = maxRetentionDays ? `(${maxRetentionDays}d)` : '(30d)';
   const {title: primaryTitle, subtitle} = getTitle(group);

--- a/static/app/views/issueDetails/useGroupDefaultStatsPeriod.tsx
+++ b/static/app/views/issueDetails/useGroupDefaultStatsPeriod.tsx
@@ -38,8 +38,7 @@ export function useGroupDefaultStatsPeriod(
   project: Project
 ): UseGroupDefaultStatsPeriodResult {
   const useGetMaxRetentionDays =
-    HookStore.get('react-hook:use-get-max-retention-days')[0] ??
-    (() => MAX_PICKABLE_DAYS);
+    HookStore.get('react-hook:use-get-max-retention-days') ?? (() => MAX_PICKABLE_DAYS);
   const maxRetentionDays = useGetMaxRetentionDays();
   let isMaxRetention = false;
 

--- a/static/app/views/navigation/mobileNavigation.tsx
+++ b/static/app/views/navigation/mobileNavigation.tsx
@@ -77,7 +77,7 @@ export function MobileNavigation() {
   const showSuperuserWarning =
     isActiveSuperuser() &&
     !ConfigStore.get('isSelfHosted') &&
-    !HookStore.get('component:superuser-warning-excluded')[0]?.(organization);
+    !HookStore.get('component:superuser-warning-excluded')?.(organization);
 
   return (
     <MobileNavigationHeader>

--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -83,7 +83,7 @@ function PrimaryNavigationSidebarHeader(props: PrimaryNavigationSidebarHeaderPro
   const showSuperuserWarning =
     isActiveSuperuser() &&
     !ConfigStore.get('isSelfHosted') &&
-    !HookStore.get('component:superuser-warning-excluded')[0]?.(organization);
+    !HookStore.get('component:superuser-warning-excluded')?.(organization);
 
   const hasPageFrame = useHasPageFrameFeature();
 

--- a/static/app/views/navigation/useTopOffset.tsx
+++ b/static/app/views/navigation/useTopOffset.tsx
@@ -29,7 +29,7 @@ export function useTopOffset(): TopOffset {
     hasPageFrame &&
     isActiveSuperuser() &&
     !ConfigStore.get('isSelfHosted') &&
-    !HookStore.get('component:superuser-warning-excluded')[0]?.(organization);
+    !HookStore.get('component:superuser-warning-excluded')?.(organization);
 
   if (!hasPageFrame) {
     return {

--- a/static/app/views/onboarding/components/useScmFeatureMeta.tsx
+++ b/static/app/views/onboarding/components/useScmFeatureMeta.tsx
@@ -103,6 +103,6 @@ function useFallbackScmFeatureMeta(): UseScmFeatureMetaResult {
  */
 export function useScmFeatureMeta(): UseScmFeatureMetaResult {
   const hook =
-    HookStore.get('react-hook:use-scm-feature-meta')[0] ?? useFallbackScmFeatureMeta;
+    HookStore.get('react-hook:use-scm-feature-meta') ?? useFallbackScmFeatureMeta;
   return hook();
 }

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -46,7 +46,7 @@ function OrganizationCreate() {
   const client = useApi();
 
   const hasDataConsent =
-    HookStore.get('component:data-consent-org-creation-checkbox').length !== 0;
+    HookStore.get('component:data-consent-org-creation-checkbox') !== undefined;
 
   // This is a trimmed down version of the logic in ApiForm. It validates the
   // form data prior to submitting the request, and overrides the request host

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -88,7 +88,7 @@ function AppLayout({organization}: LayoutProps) {
   const showSuperuserWarning =
     isActiveSuperuser() &&
     !ConfigStore.get('isSelfHosted') &&
-    !HookStore.get('component:superuser-warning-excluded')[0]?.(organization);
+    !HookStore.get('component:superuser-warning-excluded')?.(organization);
 
   return (
     <PrimaryNavigationContextProvider>

--- a/static/app/views/routeAnalyticsContextProvider.tsx
+++ b/static/app/views/routeAnalyticsContextProvider.tsx
@@ -39,7 +39,7 @@ interface Props {
 }
 
 export function RouteAnalyticsContextProvider({children}: Props) {
-  const useRouteActivatedHook = HookStore.get('react-hook:route-activated')[0];
+  const useRouteActivatedHook = HookStore.get('react-hook:route-activated');
 
   const context: RouteContextInterface = {
     params: useParams(),

--- a/static/app/views/settings/organization/organizationSettingsNavigation.tsx
+++ b/static/app/views/settings/organization/organizationSettingsNavigation.tsx
@@ -40,9 +40,9 @@ class OrganizationSettingsNavigation extends Component<Props, State> {
   unsubscribe = HookStore.listen(
     (
       hookName: HookName,
-      hooks: Array<Hooks['settings:organization-navigation-config']>
+      hook: Hooks['settings:organization-navigation-config'] | undefined
     ) => {
-      this.handleHooks(hookName, hooks);
+      this.handleHooks(hookName, hook);
     },
     undefined
   );
@@ -51,25 +51,24 @@ class OrganizationSettingsNavigation extends Component<Props, State> {
     // Allow injection via getsentry et all
     const {organization} = this.props as Props;
 
+    const navConfig = HookStore.get('settings:organization-navigation-config');
+    const navHook = HookStore.get('settings:organization-navigation');
+
     return {
-      hookConfigs: HookStore.get('settings:organization-navigation-config').map(cb =>
-        cb(organization)
-      ),
-      hooks: HookStore.get('settings:organization-navigation').map(cb =>
-        cb(organization)
-      ),
+      hookConfigs: navConfig ? [navConfig(organization)] : [],
+      hooks: navHook ? [navHook(organization)] : [],
     };
   }
 
   handleHooks(
     name: HookName,
-    hooks: Array<Hooks['settings:organization-navigation-config']>
+    hook: Hooks['settings:organization-navigation-config'] | undefined
   ) {
     const org = this.props.organization;
     if (name !== 'settings:organization-navigation-config') {
       return;
     }
-    this.setState({hookConfigs: hooks.map(cb => cb(org))});
+    this.setState({hookConfigs: hook ? [hook(org)] : []});
   }
 
   render() {

--- a/static/gsApp/components/gsBillingNavigationConfig.tsx
+++ b/static/gsApp/components/gsBillingNavigationConfig.tsx
@@ -24,13 +24,11 @@ type NavProps = NavigationProps & {
 
 class GSBillingNavigationConfig extends Component<Props> {
   componentDidMount() {
-    // Clear store before adding since this can be called multiple times
-    HookStore.remove('settings:organization-navigation-config', this.getConfig);
-    HookStore.add('settings:organization-navigation-config', this.getConfig);
+    HookStore.set('settings:organization-navigation-config', this.getConfig);
   }
 
   componentWillUnmount() {
-    HookStore.remove('settings:organization-navigation-config', this.getConfig);
+    HookStore.remove('settings:organization-navigation-config');
   }
 
   getConfig = (organization: Organization): NavigationSection => {

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -401,4 +401,4 @@ const entries = Object.entries as <T>(
 ) => Array<[Extract<keyof T, string>, T[keyof T]]>;
 
 export const registerHooks = () =>
-  entries(GETSENTRY_HOOKS).forEach(entry => HookStore.add(...entry));
+  entries(GETSENTRY_HOOKS).forEach(entry => HookStore.set(...entry));


### PR DESCRIPTION
HookStore.get() previously returned an array of registered callbacks,
but in practice only a single callback was ever registered per hook
name. The registration pattern (object literal keys in GETSENTRY_HOOKS,
and the remove-then-add pattern in GSBillingNavigationConfig) already
guaranteed at most one callback per slot.

Tighten the types to reflect reality:
- get() returns Hooks[H] | undefined instead of Array<Hooks[H]>
- add() is renamed to set() and overwrites instead of pushing
- remove() no longer takes a callback argument — it just clears the slot

All consumers updated: [0] indexing gone, .forEach/.map loops replaced
with single optional calls.