### PR TITLE
perf(static): Cache content-hashed dist assets forever

### DIFF
--- a/src/sentry/web/constants.py
+++ b/src/sentry/web/constants.py
@@ -1,5 +1,11 @@
 FOREVER_CACHE = "max-age=315360000"
 
+# For content-hashed build assets (chunks/, assets/) whose URLs change when
+# content changes. Long max-age avoids revalidation on every page load;
+# stale-while-revalidate lets the browser serve instantly from cache while
+# refreshing in the background, so a misclassified file self-corrects.
+IMMUTABLE_CACHE = "max-age=604800, stale-while-revalidate=300"
+
 # See
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#requiring_revalidation
 # This means that clients *CAN* cache the resource, but they must revalidate

--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -1,5 +1,6 @@
 import os
 import posixpath
+import re
 from urllib.parse import unquote
 
 from django.conf import settings
@@ -7,7 +8,7 @@ from django.contrib.staticfiles import finders
 from django.http import Http404, HttpResponseNotFound
 from django.views import static
 
-from sentry.web.constants import FOREVER_CACHE, NEVER_CACHE, NO_CACHE
+from sentry.web.constants import FOREVER_CACHE, IMMUTABLE_CACHE, NEVER_CACHE, NO_CACHE
 from sentry.web.frontend.base import all_silo_view
 
 
@@ -33,13 +34,18 @@ def resolve(path):
     return os.path.split(absolute_path)
 
 
+_CONTENT_HASHED_ASSET_RE = re.compile(r"\.[0-9a-f]{16,}\.\w+(?:\.gz)?$")
+_CACHEABLE_DIST_DIRS = ("chunks/", "assets/")
+
+
 @all_silo_view
 def frontend_app_static_media(request, **kwargs):
     """
-    Serve static files that should not have any versioned paths/filenames.
-    These assets will have cache headers to say that it can be cached by a
-    client, but it *must* be validated against the origin server before the
-    cached asset can be used.
+    Serve static files from the frontend build output (/_static/dist/).
+
+    Files in chunks/ and assets/ whose filenames contain a content hash
+    are immutable and cached forever. Everything else (entrypoints like
+    app.js, sentry.css) must be revalidated on each request.
     """
 
     path = kwargs.get("path", "")
@@ -48,9 +54,18 @@ def frontend_app_static_media(request, **kwargs):
     response = static_media(request, **kwargs)
 
     if not settings.DEBUG:
-        response["Cache-Control"] = NO_CACHE
+        if _is_content_hashed_asset(path):
+            response["Cache-Control"] = IMMUTABLE_CACHE
+        else:
+            response["Cache-Control"] = NO_CACHE
 
     return response
+
+
+def _is_content_hashed_asset(path: str) -> bool:
+    return path.startswith(_CACHEABLE_DIST_DIRS) and bool(
+        _CONTENT_HASHED_ASSET_RE.search(os.path.basename(path))
+    )
 
 
 @all_silo_view

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -5,7 +5,7 @@ from django.test.utils import override_settings
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.utils.assets import get_frontend_app_asset_url
-from sentry.web.constants import FOREVER_CACHE, NEVER_CACHE, NO_CACHE
+from sentry.web.constants import FOREVER_CACHE, IMMUTABLE_CACHE, NEVER_CACHE, NO_CACHE
 
 
 class StaticMediaTest(TestCase):
@@ -85,6 +85,80 @@ class StaticMediaTest(TestCase):
                 os.unlink(os.path.join(dist_path, "test.js"))
             except Exception:
                 pass
+
+    @override_settings(DEBUG=False)
+    def test_frontend_app_content_hashed_assets_cached_forever(self) -> None:
+        """
+        Content-hashed files in chunks/ and assets/ under /_static/dist/
+        are immutable and should be cached forever.
+        """
+        dist_path = os.path.join("src", "sentry", "static", "sentry", "dist")
+        cases = [
+            ("assets", "rubik-regular.fad64911e39b541f.woff2"),
+            ("chunks", "1016.d44eb37649c6e092.js"),
+            ("chunks/locale", "zh-cn.4ddebd56c0630d59.js"),
+        ]
+
+        created: list[str] = []
+        try:
+            for subdir, filename in cases:
+                dirpath = os.path.join(dist_path, subdir)
+                os.makedirs(dirpath, exist_ok=True)
+                filepath = os.path.join(dirpath, filename)
+                with open(filepath, "a"):
+                    pass
+                created.append(filepath)
+
+                url = f"/_static/dist/sentry/{subdir}/{filename}"
+                response = self.client.get(url)
+                close_streaming_response(response)
+                assert response.status_code == 200, f"{url} returned {response.status_code}"
+                assert response["Cache-Control"] == IMMUTABLE_CACHE, (
+                    f"{url} got {response['Cache-Control']}, expected FOREVER_CACHE"
+                )
+        finally:
+            for fp in created:
+                try:
+                    os.unlink(fp)
+                except Exception:
+                    pass
+
+    @override_settings(DEBUG=False)
+    def test_frontend_app_unhashed_assets_not_cached_forever(self) -> None:
+        """
+        Files without a content hash or in entrypoints/ should NOT get
+        FOREVER_CACHE, even if they happen to be in chunks/ or assets/.
+        """
+        dist_path = os.path.join("src", "sentry", "static", "sentry", "dist")
+        cases = [
+            ("entrypoints", "app.js"),
+            ("assets", "no-hash.svg"),
+            ("chunks", "no-hash.js"),
+        ]
+
+        created: list[str] = []
+        try:
+            for subdir, filename in cases:
+                dirpath = os.path.join(dist_path, subdir)
+                os.makedirs(dirpath, exist_ok=True)
+                filepath = os.path.join(dirpath, filename)
+                with open(filepath, "a"):
+                    pass
+                created.append(filepath)
+
+                url = f"/_static/dist/sentry/{subdir}/{filename}"
+                response = self.client.get(url)
+                close_streaming_response(response)
+                assert response.status_code == 200, f"{url} returned {response.status_code}"
+                assert response["Cache-Control"] == NO_CACHE, (
+                    f"{url} got {response['Cache-Control']}, expected NO_CACHE"
+                )
+        finally:
+            for fp in created:
+                try:
+                    os.unlink(fp)
+                except Exception:
+                    pass
 
     @override_settings(DEBUG=False)
     def test_no_cors(self) -> None:


### PR DESCRIPTION
Content-hashed files under `/_static/dist/` (fonts in `assets/`, JS in `chunks/`) have immutable filenames like `rubik-regular.fad64911e39b541f.woff2`, but `frontend_app_static_media` applied `NO_CACHE` (`max-age=0, must-revalidate`) to everything under that path. This forced browsers to revalidate these files on every page load despite the content never changing at a given URL.

Now files that are both in `chunks/` or `assets/` **and** have a content hash pattern in the filename get a new `IMMUTABLE_CACHE` header (`max-age=604800, stale-while-revalidate=300`). The browser serves from cache for up to 7 days without a network request, and after expiry serves stale for up to 5 minutes while revalidating in the background. Unhashed entrypoints (`app.js`, `sentry.css`) continue to get `NO_CACHE`.

Both conditions (correct directory + hash pattern in filename) are required to prevent accidental long-term caching of mutable files. Using `stale-while-revalidate` instead of `FOREVER_CACHE` adds a safety net: even if a file is misclassified, it self-corrects within a week.

This affects fonts (Rubik, Roboto Mono), all code-split JS chunks, and image/SVG assets — roughly the majority of static files served on each page load.