### PR TITLE
ref(spans): remove unused dropped_segments logic and zrem cleanup option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3297,19 +3297,6 @@ register(
     default=0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-
-# When True, done_flush_segments uses Lua scripts to conditionally clean up
-# segments only if their state hasn't changed since the flush started: Phase 1
-# ZREMs the queue entry only if the score is unchanged, and Phase 2 deletes the
-# per-segment data keys (hrs, ic, ibc) only if the ingested count is unchanged.
-# When False, both phases unconditionally remove queue entries and delete data
-# keys for every flushed segment.
-register(
-    "spans.buffer.done-flush-conditional-zrem",
-    default=True,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Compression level for spans buffer segments. Default -1 disables compression, 0-22 for zstd levels
 register(
     "spans.buffer.compression.level",

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -116,11 +116,7 @@ from sentry import options
 from sentry.constants import DataCategory
 from sentry.models.project import Project
 from sentry.processing.backpressure.memory import ServiceMemory, iter_cluster_memory_usage
-from sentry.spans.buffer_logger import (
-    BufferLogger,
-    EvalshaData,
-    emit_observability_metrics,
-)
+from sentry.spans.buffer_logger import BufferLogger, EvalshaData, emit_observability_metrics
 from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.spans.debug_trace_logger import DebugTraceLogger
 from sentry.spans.segment_key import (
@@ -742,8 +738,7 @@ class SpansBuffer:
         now: int,
     ) -> tuple[dict[SegmentKey, list[bytes]], dict[SegmentKey, list[PayloadKey]]]:
         """
-        Loads the segments from Redis, given a list of segment keys. Segments
-        exceeding a certain size are skipped, and an error is logged.
+        Loads the segments from Redis, given a list of segment keys.
 
         :param segment_keys: List of segment keys to load.
         :param segment_to_queue: Mapping of segment keys to their queue keys for TTL checking.
@@ -779,8 +774,6 @@ class SpansBuffer:
                 cursors[payload_key] = 0
             payload_keys_map[key] = segment_payload_keys
 
-        dropped_segments: set[SegmentKey] = set()
-
         def _add_spans(key: SegmentKey, raw_data: bytes):
             """
             Decompress and add spans to the segment.
@@ -799,10 +792,6 @@ class SpansBuffer:
 
             for key, (cursor, scan_values) in zip(current_keys, scan_results):
                 segment_key = scan_key_to_segment[key]
-                if segment_key in dropped_segments:
-                    cursors.pop(key, None)
-                    continue
-
                 for scan_value in scan_values:
                     if segment_key in payloads:
                         _add_spans(segment_key, scan_value)

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -32,7 +32,6 @@ DEFAULT_OPTIONS = {
     "spans.buffer.flusher.max-unhealthy-seconds": 60,
     "spans.buffer.flusher.use-stuck-detector": False,
     "spans.buffer.flusher.flush-lock-ttl": 0,
-    "spans.buffer.done-flush-conditional-zrem": True,
     "spans.buffer.compression.level": 0,
     "spans.buffer.pipeline-batch-size": 0,
     "spans.buffer.max-spans-per-evalsha": 0,


### PR DESCRIPTION
Refs STREAM-1000

`_load_segment_data` no longer carries the dead `dropped_segments` branch (we don't drop segments anymore), which was initialized but never populated. This also updates the stale docstring that still described skipped oversized segments.

also removes the unused `spans.buffer.done-flush-conditional-zrem` option.
