### PR TITLE
fix(members): Scope invite-request role updates to caller's allowed roles

### DIFF
--- a/src/sentry/core/endpoints/organization_member_requests_invite_details.py
+++ b/src/sentry/core/endpoints/organization_member_requests_invite_details.py
@@ -6,7 +6,6 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import roles
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationMemberEndpoint
@@ -109,7 +108,10 @@ class OrganizationInviteRequestDetailsEndpoint(OrganizationMemberEndpoint):
 
         serializer = OrganizationMemberRequestSerializer(
             data=request.data,
-            context={"organization": organization, "allowed_roles": roles.get_all()},
+            context={
+                "organization": organization,
+                "allowed_roles": get_allowed_org_roles(request, organization),
+            },
             partial=True,
         )
 

--- a/src/sentry/core/endpoints/organization_member_requests_invite_details.py
+++ b/src/sentry/core/endpoints/organization_member_requests_invite_details.py
@@ -20,6 +20,7 @@ from sentry.core.endpoints.organization_member_utils import (
 from sentry.exceptions import UnableToAcceptMemberInvitationException
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
+from sentry.roles import organization_roles
 from sentry.users.models.user import User
 from sentry.utils.audit import get_api_key_for_audit_log
 
@@ -106,11 +107,20 @@ class OrganizationInviteRequestDetailsEndpoint(OrganizationMemberEndpoint):
         :auth: required
         """
 
+        allowed_roles = get_allowed_org_roles(request, organization, creating_org_invite=True)
+
+        # Integration tokens are not associated with an OrganizationMember, so
+        # get_allowed_org_roles cannot resolve their invitable roles. Mirror the
+        # POST handler in OrganizationMemberIndexEndpoint and restrict them to
+        # the member role.
+        if not allowed_roles and request.access.is_integration_token:
+            allowed_roles = [organization_roles.get("member")]
+
         serializer = OrganizationMemberRequestSerializer(
             data=request.data,
             context={
                 "organization": organization,
-                "allowed_roles": get_allowed_org_roles(request, organization),
+                "allowed_roles": allowed_roles,
             },
             partial=True,
         )

--- a/tests/sentry/api/endpoints/test_organization_invite_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_details.py
@@ -187,6 +187,42 @@ class OrganizationInviteRequestUpdateTest(InviteRequestBase, HybridCloudTestMixi
         assert resp.status_code == 400
         assert OrganizationMember.objects.filter(id=self.request_to_join.id, role="member").exists()
 
+    def test_integration_token_with_member_write_can_update_to_member_role(self) -> None:
+        internal_integration = self.create_internal_integration(
+            name="Internal App", organization=self.org, scopes=["member:write"]
+        )
+        token = self.create_internal_integration_token(
+            user=self.user, internal_integration=internal_integration
+        )
+
+        resp = self.client.put(
+            f"/api/0/organizations/{self.org.slug}/invite-requests/{self.request_to_join.id}/",
+            data={"role": "member"},
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert resp.status_code == 200
+        assert OrganizationMember.objects.filter(id=self.request_to_join.id, role="member").exists()
+
+    def test_integration_token_with_member_write_cannot_escalate_to_owner(self) -> None:
+        internal_integration = self.create_internal_integration(
+            name="Internal App", organization=self.org, scopes=["member:write"]
+        )
+        token = self.create_internal_integration_token(
+            user=self.user, internal_integration=internal_integration
+        )
+
+        resp = self.client.put(
+            f"/api/0/organizations/{self.org.slug}/invite-requests/{self.request_to_join.id}/",
+            data={"role": "owner"},
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert resp.status_code == 400
+        assert OrganizationMember.objects.filter(id=self.request_to_join.id, role="member").exists()
+
 
 class OrganizationInviteRequestApproveTest(InviteRequestBase, HybridCloudTestMixin):
     method = "put"

--- a/tests/sentry/api/endpoints/test_organization_invite_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_details.py
@@ -173,6 +173,20 @@ class OrganizationInviteRequestUpdateTest(InviteRequestBase, HybridCloudTestMixi
         resp = self.get_response(self.org.slug, self.request_to_join.id, role="manager")
         assert resp.status_code == 403
 
+    def test_manager_cannot_escalate_invite_role_to_owner(self) -> None:
+        self.login_as(user=self.manager)
+        resp = self.get_response(self.org.slug, self.request_to_join.id, role="owner")
+
+        assert resp.status_code == 400
+        assert OrganizationMember.objects.filter(id=self.request_to_join.id, role="member").exists()
+
+    def test_manager_cannot_escalate_invite_orgrole_to_owner(self) -> None:
+        self.login_as(user=self.manager)
+        resp = self.get_response(self.org.slug, self.request_to_join.id, orgRole="owner")
+
+        assert resp.status_code == 400
+        assert OrganizationMember.objects.filter(id=self.request_to_join.id, role="member").exists()
+
 
 class OrganizationInviteRequestApproveTest(InviteRequestBase, HybridCloudTestMixin):
     method = "put"


### PR DESCRIPTION
Align the PUT handler on `OrganizationInviteRequestDetailsEndpoint` with the approve path on the same endpoint and with the equivalent PUT on `organization_member_details`.

Previously, the role-update path constructed `OrganizationMemberRequestSerializer` with `allowed_roles=roles.get_all()`, so any caller who passed the `member:write`/`member:admin` scope check on the endpoint could set the invite's role to anything in the role table — including roles they themselves could not assign. The approve branch one block down already used `get_allowed_org_roles(request, organization)`, so a Manager could not directly approve an owner invite, but they could rewrite a pending non-owner invite to owner and leave it for an Owner to approve from the request queue. The escalated role is persisted by the immediate `member.save()`, so the gap is observable in isolation as well as via the approve chain.

The fix is the one-line swap to `get_allowed_org_roles(request, organization)` in the update-path serializer context. The approve-side `validate_invitation` check is left as-is; it remains a correct second-stage gate on the approver's allowed roles.

Tests: `test_manager_cannot_escalate_invite_role_to_owner` and `test_manager_cannot_escalate_invite_orgrole_to_owner` exercise both the deprecated `role` and current `orgRole` shapes. They fail against `master` (200 + persisted owner role) and pass with the fix (400 + role unchanged).

Fixes CORE-167