### PR TITLE
ref(routeAnalytics): Replace HookStore persistCallback with a plain module cell

### DIFF
--- a/static/app/stores/organizationStore.tsx
+++ b/static/app/stores/organizationStore.tsx
@@ -3,8 +3,8 @@ import {createStore} from 'reflux';
 import {ORGANIZATION_FETCH_ERROR_TYPES} from 'sentry/constants';
 import type {Organization} from 'sentry/types/organization';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {callSetOrganizationCallback} from 'sentry/utils/routeAnalytics/setOrganizationCallback';
 
-import {HookStore} from './hookStore';
 import type {StrictStoreDefinition} from './types';
 
 type State = {
@@ -63,10 +63,7 @@ const storeConfig: OrganizationStoreDefinition = {
     };
     this.trigger(this.get());
 
-    HookStore.getCallback(
-      'react-hook:route-activated',
-      'setOrganization'
-    )?.(organization);
+    callSetOrganizationCallback(organization);
   },
 
   onFetchOrgError(err) {

--- a/static/app/utils/routeAnalytics/setOrganizationCallback.tsx
+++ b/static/app/utils/routeAnalytics/setOrganizationCallback.tsx
@@ -1,0 +1,17 @@
+import type {Organization} from 'sentry/types/organization';
+
+/**
+ * A module-level cell that bridges RouteAnalyticsContext (React) and
+ * organizationStore (Reflux). organizationStore cannot access React context
+ * directly, so useRouteAnalyticsHookSetup registers the setOrganization
+ * state setter here and organizationStore calls it when org data loads.
+ */
+let callback: ((org: Organization) => void) | undefined;
+
+export function registerSetOrganizationCallback(fn: (org: Organization) => void): void {
+  callback = fn;
+}
+
+export function callSetOrganizationCallback(org: Organization): void {
+  callback?.(org);
+}

--- a/static/app/utils/routeAnalytics/useRouteAnalyticsHookSetup.spec.tsx
+++ b/static/app/utils/routeAnalytics/useRouteAnalyticsHookSetup.spec.tsx
@@ -1,7 +1,7 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
 
-import {HookStore} from 'sentry/stores/hookStore';
+import {callSetOrganizationCallback} from 'sentry/utils/routeAnalytics/setOrganizationCallback';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 
@@ -31,8 +31,7 @@ describe('useRouteAnalyticsHookSetup', () => {
         </OrganizationContext>
       </RouteAnalyticsContext>
     );
-    expect(
-      HookStore.getCallback('react-hook:route-activated', 'setOrganization')
-    ).toEqual(setOrganization);
+    callSetOrganizationCallback(organization);
+    expect(setOrganization).toHaveBeenCalledWith(organization);
   });
 });

--- a/static/app/utils/routeAnalytics/useRouteAnalyticsHookSetup.tsx
+++ b/static/app/utils/routeAnalytics/useRouteAnalyticsHookSetup.tsx
@@ -1,6 +1,6 @@
 import {useContext} from 'react';
 
-import {HookStore} from 'sentry/stores/hookStore';
+import {registerSetOrganizationCallback} from 'sentry/utils/routeAnalytics/setOrganizationCallback';
 import {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 
 /**
@@ -10,9 +10,5 @@ import {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider'
  */
 export function useRouteAnalyticsHookSetup() {
   const {setOrganization} = useContext(RouteAnalyticsContext);
-  HookStore.persistCallback(
-    'react-hook:route-activated',
-    'setOrganization',
-    setOrganization
-  );
+  registerSetOrganizationCallback(setOrganization);
 }


### PR DESCRIPTION
`HookStore.persistCallback`/`getCallback` was used as a shared mutable cell to bridge the `setOrganization` React state setter from `RouteAnalyticsContext` into `organizationStore`, which has no access to React context.

Replace with a plain module-level variable in `setOrganizationCallback.tsx`. `useRouteAnalyticsHookSetup` writes into it; `organizationStore` reads from it. Same semantics, no Reflux machinery involved.