### PR TITLE
fix(escalating): register issue_velocity referrer in Referrer enum

### DIFF
--- a/src/sentry/issues/escalating/issue_velocity.py
+++ b/src/sentry/issues/escalating/issue_velocity.py
@@ -25,6 +25,7 @@ from snuba_sdk import (
 )
 
 from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.snuba.referrer import Referrer
 from sentry.tasks.post_process import locks
 from sentry.utils import metrics
 from sentry.utils.locking import UnableToAcquireLock
@@ -37,7 +38,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # for snuba operations
-REFERRER = "sentry.issues.escalating.issue_velocity"
 THRESHOLD_QUANTILE = {"name": "p95", "function": "quantile(0.95)"}
 WEEK_IN_HOURS = 7 * 24
 
@@ -128,13 +128,18 @@ def calculate_threshold(project: Project) -> float | None:
 
     request = Request(
         dataset=Dataset.Events.value,
-        app_id=REFERRER,
+        app_id=Referrer.ISSUES_ESCALATING_ISSUE_VELOCITY.value,
         query=query,
-        tenant_ids={"referrer": REFERRER, "organization_id": project.organization.id},
+        tenant_ids={
+            "referrer": Referrer.ISSUES_ESCALATING_ISSUE_VELOCITY.value,
+            "organization_id": project.organization.id,
+        },
     )
 
     try:
-        result = raw_snql_query(request, referrer=REFERRER)["data"]
+        result = raw_snql_query(request, referrer=Referrer.ISSUES_ESCALATING_ISSUE_VELOCITY.value)[
+            "data"
+        ]
     except Exception:
         logger.exception(
             "sentry.issues.escalating.issue_velocity.calculate_threshold.error",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -670,6 +670,7 @@ class Referrer(StrEnum):
     IS_ESCALATING_GROUP = "sentry.issues.escalating.is_escalating"
     ISSUE_DETAILS_STREAMLINE_GRAPH = "issue_details.streamline_graph"
     ISSUE_DETAILS_STREAMLINE_LIST = "issue_details.streamline_list"
+    ISSUES_ESCALATING_ISSUE_VELOCITY = "sentry.issues.escalating.issue_velocity"
     ISSUES_SUSPECT_FLAGS_QUERY_BASELINE_SET = "issues.suspect_flags.query_baseline_set"
     ISSUES_SUSPECT_FLAGS_QUERY_SELECTION_SET = "issues.suspect_flags.query_selection_set"
     ISSUES_SUSPECT_FLAGS_QUERY_ERROR_COUNTS = "issues.suspect_flags.query_error_counts"


### PR DESCRIPTION
Add missing referrer to the referrer enum. As an aside, we seem to have a decent number of other missing referrers for later investigation ([query](https://sentry.sentry.io/explore/logs/?aggregateField=%7B%22groupBy%22%3A%22message%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28message%29%22%5D%2C%22visible%22%3Afalse%7D&logsFields=timestamp&logsFields=message&logsQuery=message%3A%EF%80%8DContains%EF%80%8Dreferrer&logsSortBys=-timestamp&mode=aggregate&statsPeriod=7d)).

Fixes https://github.com/getsentry/sentry/issues/115774