### PR TITLE
ref(settings): Convert OrganizationAccessRequests to function component with fetchMutation

### DIFF
--- a/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
+++ b/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import {useMutation} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Panel} from 'sentry/components/panels/panel';
@@ -78,8 +79,8 @@ export function OrganizationAccessRequests({
                       team: <strong>#{team.slug}</strong>,
                     })}
               </div>
-              <div>
-                <StyledButton
+              <Flex gap="md">
+                <Button
                   variant="primary"
                   size="sm"
                   onClick={e => {
@@ -89,7 +90,7 @@ export function OrganizationAccessRequests({
                   busy={isBusy}
                 >
                   {t('Approve')}
-                </StyledButton>
+                </Button>
                 <Button
                   busy={isBusy}
                   onClick={e => {
@@ -100,7 +101,7 @@ export function OrganizationAccessRequests({
                 >
                   {t('Deny')}
                 </Button>
-              </div>
+              </Flex>
             </StyledPanelItem>
           );
         })}
@@ -114,8 +115,4 @@ const StyledPanelItem = styled(PanelItem)`
   grid-template-columns: auto max-content;
   gap: ${p => p.theme.space.xl};
   align-items: center;
-`;
-
-const StyledButton = styled(Button)`
-  margin-right: ${p => p.theme.space.md};
 `;

--- a/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
+++ b/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
@@ -24,15 +24,48 @@ export function OrganizationAccessRequests({
   requestList,
   onRemoveAccessRequest,
 }: Props) {
-  const {mutate, isPending, variables} = useMutation({
-    mutationFn: ({id, isApproved}: {id: string; isApproved: boolean}) => {
+  if (!requestList?.length) {
+    return null;
+  }
+
+  return (
+    <Panel>
+      <PanelHeader>{t('Pending Team Requests')}</PanelHeader>
+
+      <PanelBody>
+        {requestList.map(accessRequest => (
+          <AccessRequestItem
+            key={accessRequest.id}
+            accessRequest={accessRequest}
+            orgSlug={orgSlug}
+            onRemoveAccessRequest={onRemoveAccessRequest}
+          />
+        ))}
+      </PanelBody>
+    </Panel>
+  );
+}
+
+function AccessRequestItem({
+  accessRequest,
+  orgSlug,
+  onRemoveAccessRequest,
+}: {
+  accessRequest: AccessRequest;
+  onRemoveAccessRequest: (id: string, isApproved: boolean) => void;
+  orgSlug: string;
+}) {
+  const {id, member, team, requester} = accessRequest;
+
+  const {mutate, isPending} = useMutation({
+    mutationFn: ({isApproved}: {isApproved: boolean}) => {
       return fetchMutation({
         method: 'PUT',
         url: `/organizations/${orgSlug}/access-requests/${id}/`,
         data: {isApproved},
       });
     },
-    onSuccess: (_data, {id, isApproved}) => {
+    onSuccess: (_data, {isApproved}) => {
       onRemoveAccessRequest(id, isApproved);
       addSuccessMessage(
         isApproved ? t('Team request approved') : t('Team request denied')
@@ -45,64 +78,49 @@ export function OrganizationAccessRequests({
     },
   });
 
-  if (!requestList?.length) {
-    return null;
-  }
+  const memberName =
+    member.user && (member.user.name || member.user.email || member.user.username);
+  const requesterName =
+    requester && (requester.name || requester.email || requester.username);
 
   return (
-    <Panel>
-      <PanelHeader>{t('Pending Team Requests')}</PanelHeader>
-
-      <PanelBody>
-        {requestList.map(({id, member, team, requester}) => {
-          const memberName =
-            member.user &&
-            (member.user.name || member.user.email || member.user.username);
-          const requesterName =
-            requester && (requester.name || requester.email || requester.username);
-          const isBusy = isPending && variables?.id === id;
-          return (
-            <StyledPanelItem key={id}>
-              <div data-test-id="request-message">
-                {requesterName
-                  ? tct('[requesterName] requests to add [name] to the [team] team.', {
-                      requesterName,
-                      name: <strong>{memberName}</strong>,
-                      team: <strong>#{team.slug}</strong>,
-                    })
-                  : tct('[name] requests access to the [team] team.', {
-                      name: <strong>{memberName}</strong>,
-                      team: <strong>#{team.slug}</strong>,
-                    })}
-              </div>
-              <Flex gap="md">
-                <Button
-                  variant="primary"
-                  size="sm"
-                  onClick={e => {
-                    e.stopPropagation();
-                    mutate({id, isApproved: true});
-                  }}
-                  busy={isBusy}
-                >
-                  {t('Approve')}
-                </Button>
-                <Button
-                  busy={isBusy}
-                  onClick={e => {
-                    e.stopPropagation();
-                    mutate({id, isApproved: false});
-                  }}
-                  size="sm"
-                >
-                  {t('Deny')}
-                </Button>
-              </Flex>
-            </StyledPanelItem>
-          );
-        })}
-      </PanelBody>
-    </Panel>
+    <StyledPanelItem>
+      <div data-test-id="request-message">
+        {requesterName
+          ? tct('[requesterName] requests to add [name] to the [team] team.', {
+              requesterName,
+              name: <strong>{memberName}</strong>,
+              team: <strong>#{team.slug}</strong>,
+            })
+          : tct('[name] requests access to the [team] team.', {
+              name: <strong>{memberName}</strong>,
+              team: <strong>#{team.slug}</strong>,
+            })}
+      </div>
+      <Flex gap="md">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={e => {
+            e.stopPropagation();
+            mutate({isApproved: true});
+          }}
+          busy={isPending}
+        >
+          {t('Approve')}
+        </Button>
+        <Button
+          busy={isPending}
+          onClick={e => {
+            e.stopPropagation();
+            mutate({isApproved: false});
+          }}
+          size="sm"
+        >
+          {t('Deny')}
+        </Button>
+      </Flex>
+    </StyledPanelItem>
   );
 }
 

--- a/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
+++ b/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
@@ -1,141 +1,112 @@
-import {Component} from 'react';
 import styled from '@emotion/styled';
+import {useMutation} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import type {Client} from 'sentry/api';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {PanelItem} from 'sentry/components/panels/panelItem';
 import {t, tct} from 'sentry/locale';
 import type {AccessRequest} from 'sentry/types/organization';
-import {withApi} from 'sentry/utils/withApi';
+import {fetchMutation} from 'sentry/utils/queryClient';
 
 type Props = {
-  api: Client;
   onRemoveAccessRequest: (id: string, isApproved: boolean) => void;
   orgSlug: string;
   requestList: AccessRequest[];
 };
 
-type State = {
-  accessRequestBusy: Record<string, boolean>;
-};
-
-type HandleOpts = {
-  errorMessage: string;
-  id: string;
-  isApproved: boolean;
-  successMessage: string;
-};
-
-class OrganizationAccessRequests extends Component<Props, State> {
-  state: State = {
-    accessRequestBusy: {},
-  };
-
-  async handleAction({id, isApproved, successMessage, errorMessage}: HandleOpts) {
-    const {api, orgSlug, onRemoveAccessRequest} = this.props;
-
-    this.setState(state => ({
-      accessRequestBusy: {...state.accessRequestBusy, [id]: true},
-    }));
-
-    try {
-      await api.requestPromise(`/organizations/${orgSlug}/access-requests/${id}/`, {
+export function OrganizationAccessRequests({
+  orgSlug,
+  requestList,
+  onRemoveAccessRequest,
+}: Props) {
+  const {
+    mutate: handleAction,
+    isPending,
+    variables,
+  } = useMutation({
+    mutationFn: ({id, isApproved}: {id: string; isApproved: boolean}) => {
+      return fetchMutation({
         method: 'PUT',
+        url: `/organizations/${orgSlug}/access-requests/${id}/`,
         data: {isApproved},
       });
+    },
+    onSuccess: (_data, {id, isApproved}) => {
       onRemoveAccessRequest(id, isApproved);
-      addSuccessMessage(successMessage);
-    } catch {
-      addErrorMessage(errorMessage);
-    }
+      addSuccessMessage(
+        isApproved ? t('Team request approved') : t('Team request denied')
+      );
+    },
+    onError: (_error, {isApproved}) => {
+      addErrorMessage(
+        isApproved ? t('Error approving team request') : t('Error denying team request')
+      );
+    },
+  });
 
-    this.setState(state => ({
-      accessRequestBusy: {...state.accessRequestBusy, [id]: false},
-    }));
+  if (!requestList?.length) {
+    return null;
   }
 
-  handleApprove = (id: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    this.handleAction({
-      id,
-      isApproved: true,
-      successMessage: t('Team request approved'),
-      errorMessage: t('Error approving team request'),
-    });
-  };
+  return (
+    <Panel>
+      <PanelHeader>{t('Pending Team Requests')}</PanelHeader>
 
-  handleDeny = (id: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    this.handleAction({
-      id,
-      isApproved: false,
-      successMessage: t('Team request denied'),
-      errorMessage: t('Error denying team request'),
-    });
-  };
-
-  render() {
-    const {requestList} = this.props;
-    const {accessRequestBusy} = this.state;
-
-    if (!requestList?.length) {
-      return null;
-    }
-
-    return (
-      <Panel>
-        <PanelHeader>{t('Pending Team Requests')}</PanelHeader>
-
-        <PanelBody>
-          {requestList.map(({id, member, team, requester}) => {
-            const memberName =
-              member.user &&
-              (member.user.name || member.user.email || member.user.username);
-            const requesterName =
-              requester && (requester.name || requester.email || requester.username);
-            return (
-              <StyledPanelItem key={id}>
-                <div data-test-id="request-message">
-                  {requesterName
-                    ? tct('[requesterName] requests to add [name] to the [team] team.', {
-                        requesterName,
-                        name: <strong>{memberName}</strong>,
-                        team: <strong>#{team.slug}</strong>,
-                      })
-                    : tct('[name] requests access to the [team] team.', {
-                        name: <strong>{memberName}</strong>,
-                        team: <strong>#{team.slug}</strong>,
-                      })}
-                </div>
-                <div>
-                  <StyledButton
-                    variant="primary"
-                    size="sm"
-                    onClick={e => this.handleApprove(id, e)}
-                    busy={accessRequestBusy[id]}
-                  >
-                    {t('Approve')}
-                  </StyledButton>
-                  <Button
-                    busy={accessRequestBusy[id]}
-                    onClick={e => this.handleDeny(id, e)}
-                    size="sm"
-                  >
-                    {t('Deny')}
-                  </Button>
-                </div>
-              </StyledPanelItem>
-            );
-          })}
-        </PanelBody>
-      </Panel>
-    );
-  }
+      <PanelBody>
+        {requestList.map(({id, member, team, requester}) => {
+          const memberName =
+            member.user &&
+            (member.user.name || member.user.email || member.user.username);
+          const requesterName =
+            requester && (requester.name || requester.email || requester.username);
+          const isBusy = isPending && variables?.id === id;
+          return (
+            <StyledPanelItem key={id}>
+              <div data-test-id="request-message">
+                {requesterName
+                  ? tct('[requesterName] requests to add [name] to the [team] team.', {
+                      requesterName,
+                      name: <strong>{memberName}</strong>,
+                      team: <strong>#{team.slug}</strong>,
+                    })
+                  : tct('[name] requests access to the [team] team.', {
+                      name: <strong>{memberName}</strong>,
+                      team: <strong>#{team.slug}</strong>,
+                    })}
+              </div>
+              <div>
+                <StyledButton
+                  variant="primary"
+                  size="sm"
+                  onClick={e => {
+                    e.stopPropagation();
+                    handleAction({id, isApproved: true});
+                  }}
+                  busy={isBusy}
+                >
+                  {t('Approve')}
+                </StyledButton>
+                <Button
+                  busy={isBusy}
+                  onClick={e => {
+                    e.stopPropagation();
+                    handleAction({id, isApproved: false});
+                  }}
+                  size="sm"
+                >
+                  {t('Deny')}
+                </Button>
+              </div>
+            </StyledPanelItem>
+          );
+        })}
+      </PanelBody>
+    </Panel>
+  );
 }
 
 const StyledPanelItem = styled(PanelItem)`
@@ -148,5 +119,3 @@ const StyledPanelItem = styled(PanelItem)`
 const StyledButton = styled(Button)`
   margin-right: ${p => p.theme.space.md};
 `;
-
-export default withApi(OrganizationAccessRequests);

--- a/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
+++ b/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
@@ -24,11 +24,7 @@ export function OrganizationAccessRequests({
   requestList,
   onRemoveAccessRequest,
 }: Props) {
-  const {
-    mutate: handleAction,
-    isPending,
-    variables,
-  } = useMutation({
+  const {mutate, isPending, variables} = useMutation({
     mutationFn: ({id, isApproved}: {id: string; isApproved: boolean}) => {
       return fetchMutation({
         method: 'PUT',
@@ -85,7 +81,7 @@ export function OrganizationAccessRequests({
                   size="sm"
                   onClick={e => {
                     e.stopPropagation();
-                    handleAction({id, isApproved: true});
+                    mutate({id, isApproved: true});
                   }}
                   busy={isBusy}
                 >
@@ -95,7 +91,7 @@ export function OrganizationAccessRequests({
                   busy={isBusy}
                   onClick={e => {
                     e.stopPropagation();
-                    handleAction({id, isApproved: false});
+                    mutate({id, isApproved: false});
                   }}
                   size="sm"
                 >

--- a/static/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -18,7 +18,7 @@ import {useTeams} from 'sentry/utils/useTeams';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
-import OrganizationAccessRequests from './organizationAccessRequests';
+import {OrganizationAccessRequests} from './organizationAccessRequests';
 import {OtherTeamsTable} from './otherTeamsTable';
 import {YourTeamsTable} from './yourTeamsTable';
 


### PR DESCRIPTION
## Summary

- Convert `OrganizationAccessRequests` from a class component to a function component
- Replace `withApi` HOC + `api.requestPromise` with `fetchMutation` from `queryClient`
- Use `useMutation` hook with `isPending`/`variables` for request state instead of manual `accessRequestBusy` state tracking
- Change from default export to named export

## Test plan

- [ ] Verify pending team requests render correctly on the organization teams settings page
- [ ] Approve a team request and confirm success toast + removal from list
- [ ] Deny a team request and confirm success toast + removal from list
- [ ] Verify button busy state shows on the correct row during a request

[![View Interactive Summary](https://img.shields.io/badge/Summary-html_explanation-D97757?style=for-the-badge&logo=claude&logoColor=D97757)](https://insecure-html-azure.vercel.app/?pr-url=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry%2Fpull%2F115813)
<!-- html-preview:start
<!DOCTYPE html> <html lang="en"> <head> <meta charset="UTF-8"> <meta name="viewport" content="width=device-width,initial-scale=1"> <title>PR #115813 — ref(settings): Convert OrganizationAccessRequests to function component with fetchMutation</title> <style> :root{--bg:#fff;--surface:#f6f8fa;--border:#d0d7de;--text:#1f2328;--text-muted:#656d76;--add-bg:#dafbe1;--add-text:#116329;--del-bg:#ffebe9;--del-text:#82071e;--accent:#0969da;--purple:#8250df;--orange:#9a6700;--teal:#1a7f37;color-scheme:light} [data-theme="dark"]{--bg:#0d1117;--surface:#161b22;--border:#30363d;--text:#e6edf3;--text-muted:#8b949e;--add-bg:#12261e;--add-text:#3fb950;--del-bg:#2d1214;--del-text:#f85149;--accent:#58a6ff;--purple:#bc8cff;--orange:#d29922;--teal:#39d353;color-scheme:dark} @media(prefers-color-scheme:dark){:root:not([data-theme="light"]){--bg:#0d1117;--surface:#161b22;--border:#30363d;--text:#e6edf3;--text-muted:#8b949e;--add-bg:#12261e;--add-text:#3fb950;--del-bg:#2d1214;--del-text:#f85149;--accent:#58a6ff;--purple:#bc8cff;--orange:#d29922;--teal:#39d353;color-scheme:dark}} body{margin:0;background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif} .container{max-width:1200px;margin:0 auto;padding:2rem 1rem} .theme-toggle{position:fixed;top:1rem;right:1rem;z-index:100;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:.4rem .6rem;cursor:pointer;font-size:1.1rem;line-height:1;color:var(--text)} .theme-toggle:hover{border-color:var(--accent)} .pr-header{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-bottom:1.5rem} .pr-header h1{margin:0 0 .5rem;font-size:1.4rem;line-height:1.3} .pr-header h1 .pr-num{color:var(--text-muted);font-weight:400} .pr-meta{display:flex;flex-wrap:wrap;gap:.75rem;align-items:center;font-size:.85rem;color:var(--text-muted)} .pr-meta .badge{display:inline-block;padding:.15rem .5rem;border-radius:6px;font-family:'SFMono-Regular',Consolas,monospace;font-size:.75rem;background:rgba(110,118,129,.1);border:1px solid var(--border)} .pr-meta .stat-add{color:var(--add-text);font-weight:600} .pr-meta .stat-del{color:var(--del-text);font-weight:600} .summary-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;margin-bottom:1.5rem} .summary-card{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem} .summary-card .card-label{text-transform:uppercase;font-size:.68rem;font-weight:600;letter-spacing:.06em;color:var(--text-muted);margin-bottom:.25rem} .summary-card .card-value{font-size:1.6rem;font-weight:700;color:var(--text);margin-bottom:.15rem} .summary-card .card-desc{font-size:.8rem;color:var(--text-muted)} .summary{border:1px solid var(--teal);border-radius:10px;padding:1rem 1.25rem;margin-bottom:1.5rem;background:rgba(57,211,83,.04)} .summary h2{margin:0 0 .5rem;font-size:1rem;display:flex;align-items:center;gap:.5rem} .summary p{margin:0;font-size:.9rem;line-height:1.6;color:var(--text-muted)} .findings-section{margin-bottom:1.5rem} .findings-section h2{font-size:1.1rem;margin:0 0 .75rem} .finding{background:var(--surface);border:1px solid var(--border);border-radius:10px;margin-bottom:.75rem;overflow:hidden} .finding-header{display:flex;align-items:center;gap:.6rem;padding:.75rem 1rem;cursor:pointer;user-select:none} .finding-header:hover{background:rgba(110,118,129,.06)} .finding-header .chevron{transition:transform .15s;font-size:.7rem;color:var(--text-muted)} .finding.collapsed .chevron{transform:rotate(-90deg)} .finding.collapsed .finding-body{display:none} .finding-header h3{margin:0;font-size:.9rem;font-weight:600;flex:1} .finding-body{padding:0 1rem 1rem;font-size:.85rem;line-height:1.65;color:var(--text-muted)} .finding-body .file-refs{margin-top:.5rem} .severity{display:inline-block;padding:.15rem .6rem;border-radius:12px;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;flex-shrink:0} .severity.positive{background:rgba(57,211,83,.15);color:var(--teal);border:1px solid rgba(57,211,83,.3)} .severity.info{background:rgba(88,166,255,.15);color:var(--accent);border:1px solid rgba(88,166,255,.3)} .severity.low{background:rgba(210,153,34,.15);color:var(--orange);border:1px solid rgba(210,153,34,.3)} .severity.medium{background:rgba(248,81,73,.15);color:var(--del-text);border:1px solid rgba(248,81,73,.3)} .previously{background:rgba(188,140,255,.08);border:1px solid rgba(188,140,255,.2);border-radius:6px;padding:.4rem .75rem;margin:.4rem 0;font-size:.82rem;color:var(--text-muted);line-height:1.5} .previously .label{font-weight:600;color:var(--purple);font-size:.72rem;text-transform:uppercase;letter-spacing:.04em;margin-right:.35rem} .previously code{font-family:'SFMono-Regular',Consolas,monospace;font-size:.78rem;background:rgba(110,118,129,.15);padding:.1rem .3rem;border-radius:3px} .cross-ref{font-size:.78rem;color:var(--purple);font-style:italic;margin:.25rem 0} .cross-ref a{color:var(--purple);text-decoration:underline} .cross-ref a:hover{color:var(--accent)} .file-link{color:var(--accent);text-decoration:none;font-family:'SFMono-Regular',Consolas,monospace;font-size:.82rem} .file-link:hover{text-decoration:underline} .diff-section{margin-bottom:1.5rem} .diff-section h2{font-size:1.1rem;margin:0 0 .5rem} .diff-controls{display:flex;gap:.5rem;margin-bottom:.75rem} .diff-controls button{background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:.3rem .7rem;font-size:.78rem;cursor:pointer;color:var(--text-muted)} .diff-controls button:hover{border-color:var(--accent);color:var(--accent)} .diff-file{background:var(--surface);border:1px solid var(--border);border-radius:10px;margin-bottom:.75rem;overflow:hidden} .diff-file-header{display:flex;align-items:center;gap:.5rem;padding:.6rem 1rem;cursor:pointer;user-select:none;font-size:.85rem} .diff-file-header:hover{background:rgba(110,118,129,.06)} .diff-file-header .chevron{transition:transform .15s;font-size:.7rem;color:var(--text-muted)} .diff-file.collapsed .chevron{transform:rotate(-90deg)} .diff-file.collapsed .diff-body{display:none} .diff-file-path{flex:1;font-family:'SFMono-Regular',Consolas,monospace;font-size:.82rem} .diff-file-path a{color:var(--text);text-decoration:none} .diff-file-path a:hover{color:var(--accent);text-decoration:underline} .diff-file-stats{font-size:.78rem;color:var(--text-muted)} .diff-file-stats .stat-add{color:var(--add-text)} .diff-file-stats .stat-del{color:var(--del-text)} .diff-badge{display:inline-block;padding:.1rem .4rem;border-radius:4px;font-size:.68rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em;background:rgba(110,118,129,.1);color:var(--text-muted)} .diff-body{overflow-x:auto} .diff-table{width:100%;border-collapse:collapse;font-family:'SFMono-Regular',Consolas,monospace;font-size:.78rem;line-height:1.55} .diff-table td{padding:0 .75rem;white-space:pre;vertical-align:top} .diff-table .ln{width:1px;text-align:right;color:var(--text-muted);opacity:.4;padding:0 .5rem;user-select:none} .diff-table .ln a{color:inherit;text-decoration:none} .diff-table .ln a:hover{color:var(--accent);text-decoration:underline} .diff-table tr.add{background:var(--add-bg)} .diff-table tr.add td.code{color:var(--add-text)} .diff-table tr.del{background:var(--del-bg)} .diff-table tr.del td.code{color:var(--del-text)} .diff-table tr.hunk td{color:var(--purple);padding:.3rem .75rem;background:rgba(188,140,255,.08);font-style:italic} .annotation{display:block;background:var(--surface);border:1px solid var(--border);border-left:3px solid;border-radius:6px;padding:.5rem .75rem;margin:.35rem 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:.8rem;line-height:1.5;white-space:normal;color:var(--text-muted)} .annotation.positive{border-left-color:var(--teal)} .annotation.info{border-left-color:var(--accent)} .file-list{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;margin-top:1.5rem} .file-list h3{margin:0 0 .5rem;font-size:.9rem} .file-pills{display:flex;flex-wrap:wrap;gap:.4rem} .file-pill{display:inline-block;padding:.2rem .6rem;border-radius:6px;font-size:.75rem;font-family:'SFMono-Regular',Consolas,monospace;background:rgba(110,118,129,.08);border:1px solid var(--border);color:var(--text-muted)} .testing-notes{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1rem 1.25rem;margin:1.5rem 0} .testing-notes h3{margin:0 0 .75rem;font-size:.95rem;color:var(--text);display:flex;align-items:center;gap:.5rem} .testing-notes ol{margin:0;padding-left:1.25rem;color:var(--text)} .testing-notes li{margin-bottom:1rem;line-height:1.6} .testing-notes .label{font-weight:600;font-size:.78rem;text-transform:uppercase;letter-spacing:.04em;margin-right:.4rem} .testing-notes .label.url{color:var(--accent)} .testing-notes .label.action{color:var(--purple)} .testing-notes .label.expected{color:var(--teal)} .testing-notes .label.previous{color:var(--orange)} </style> </head> <body> <button class="theme-toggle" onclick="toggleTheme()" title="Toggle theme">&#x1f313;</button> <div class="container"> <div class="pr-header"> <h1>ref(settings): Convert OrganizationAccessRequests to function component with fetchMutation <span class="pr-num">#115813</span></h1> <div class="pr-meta"> <span>by <strong>ryan953</strong></span> <span class="badge">ryan/refactor-org-access-requests-fetch-mutation</span> <span>&#x2192;</span> <span class="badge">master</span> <span class="stat-add">+86</span> <span class="stat-del">-117</span> <span>2 files</span> <span>1 commit</span> </div> </div> <div class="summary-grid"> <div class="summary-card"> <div class="card-label">Net Change</div> <div class="card-value">-31</div> <div class="card-desc">Lines removed after modernization</div> </div> <div class="summary-card"> <div class="card-label">Pattern</div> <div class="card-value">Class &#x2192; Hook</div> <div class="card-desc">Class component converted to function with useMutation</div> </div> <div class="summary-card"> <div class="card-label">API Migration</div> <div class="card-value">fetchMutation</div> <div class="card-desc">Replaces withApi HOC + api.requestPromise</div> </div> </div> <div class="summary"> <h2>&#x1f4cb; Summary</h2> <p>Modernizes the <code>OrganizationAccessRequests</code> component from a class component using <code>withApi</code> HOC and manual busy-state tracking to a function component using <code>useMutation</code> with <code>fetchMutation</code>. This eliminates boilerplate state management and aligns the component with the codebase's migration toward React Query for mutations.</p> </div> <div class="findings-section"> <h2>Logical Changes</h2> <div class="finding"> <div class="finding-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#x25BC;</span> <span class="severity positive">highlight</span> <h3>Class component converted to function component</h3> </div> <div class="finding-body"> <p>The entire <code>OrganizationAccessRequests</code> class (extending <code>Component&lt;Props, State&gt;</code>) is replaced with a plain function component. The <code>withApi</code> HOC wrapper and default export are replaced by a named export of the function, and the import in <code>organizationTeams.tsx</code> switches to a named import accordingly.</p> <div class="previously"> <span class="label">Previously:</span> <code>class OrganizationAccessRequests extends Component&lt;Props, State&gt;</code> wrapped with <code>withApi()</code> and exported as default. </div> <div class="file-refs"> <a class="file-link" href="https://github.com/getsentry/sentry/pull/115813/files#diff-a59c0cc3f74b5cca5e88c6faa2d6e3e7c63d54c3c10e6be97e9e0e7091e5c3d6R21" target="_blank" rel="noopener">organizationAccessRequests.tsx:21</a> &#x2014; <a class="file-link" href="https://github.com/getsentry/sentry/pull/115813/files#diff-42c76d6fde69e78d8a47e89b6df2f1d8e080f92de32dd2c6b67db5e2f4cc2b29R21" target="_blank" rel="noopener">organizationTeams.tsx:21</a> </div> </div> </div> <div class="finding"> <div class="finding-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#x25BC;</span> <span class="severity positive">highlight</span> <h3>api.requestPromise replaced with fetchMutation</h3> </div> <div class="finding-body"> <p>The mutation function now calls <code>fetchMutation({ method: 'PUT', url, data })</code> from <code>sentry/utils/queryClient</code> instead of using an injected <code>api</code> client instance. This removes the <code>useApi</code> / <code>withApi</code> dependency entirely and uses the shared query client API instance.</p> <div class="previously"> <span class="label">Previously:</span> <code>api.requestPromise(`/organizations/${orgSlug}/access-requests/${id}/`, { method: 'PUT', data: {isApproved} })</code> via the <code>withApi</code> HOC injecting <code>api: Client</code> as a prop. </div> <div class="file-refs"> <a class="file-link" href="https://github.com/getsentry/sentry/pull/115813/files#diff-a59c0cc3f74b5cca5e88c6faa2d6e3e7c63d54c3c10e6be97e9e0e7091e5c3d6R33" target="_blank" rel="noopener">organizationAccessRequests.tsx:33-38</a> </div> </div> </div> <div class="finding"> <div class="finding-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#x25BC;</span> <span class="severity info">info</span> <h3>Manual busy state replaced with useMutation's isPending + variables</h3> </div> <div class="finding-body"> <p>The old <code>accessRequestBusy: Record&lt;string, boolean&gt;</code> state with manual <code>setState</code> calls before/after the request is replaced by <code>useMutation</code>'s built-in <code>isPending</code> flag and <code>variables</code> object. The busy state for each row is now derived as <code>isPending &amp;&amp; variables?.id === id</code>.</p> <div class="previously"> <span class="label">Previously:</span> Manual state: <code>this.setState(state =&gt; ({ accessRequestBusy: {...state.accessRequestBusy, [id]: true} }))</code> before the request, then set back to <code>false</code> in a finally-style block. </div> <div class="file-refs"> <a class="file-link" href="https://github.com/getsentry/sentry/pull/115813/files#diff-a59c0cc3f74b5cca5e88c6faa2d6e3e7c63d54c3c10e6be97e9e0e7091e5c3d6R28" target="_blank" rel="noopener">organizationAccessRequests.tsx:28-30</a> &#x2014; <a class="file-link" href="https://github.com/getsentry/sentry/pull/115813/files#diff-a59c0cc3f74b5cca5e88c6faa2d6e3e7c63d54c3c10e6be97e9e0e7091e5c3d6R67" target="_blank" rel="noopener">organizationAccessRequests.tsx:67</a> </div> </div> </div> <div class="finding"> <div class="finding-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#x25BC;</span> <span class="severity info">info</span> <h3>Success/error messages inlined into mutation callbacks</h3> </div> <div class="finding-body"> <p>The old <code>handleApprove</code>/<code>handleDeny</code> methods passed <code>successMessage</code>/<code>errorMessage</code> strings into a generic <code>handleAction</code>. Now the <code>onSuccess</code> and <code>onError</code> callbacks directly derive the appropriate message from <code>isApproved</code>, eliminating the <code>HandleOpts</code> type and two separate handler methods.</p> <div class="previously"> <span class="label">Previously:</span> <code>HandleOpts</code> type with <code>{ id, isApproved, successMessage, errorMessage }</code> passed to a single <code>handleAction</code> method. Separate <code>handleApprove</code> and <code>handleDeny</code> class methods constructed the options. </div> <div class="file-refs"> <a class="file-link" href="https://github.com/getsentry/sentry/pull/115813/files#diff-a59c0cc3f74b5cca5e88c6faa2d6e3e7c63d54c3c10e6be97e9e0e7091e5c3d6R39" target="_blank" rel="noopener">organizationAccessRequests.tsx:39-49</a> </div> </div> </div> <div class="finding"> <div class="finding-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#x25BC;</span> <span class="severity info">info</span> <h3>Click handlers inlined in JSX</h3> </div> <div class="finding-body"> <p>The <code>e.stopPropagation()</code> calls that were in the separate <code>handleApprove</code>/<code>handleDeny</code> methods are now inline arrow functions in the <code>onClick</code> props. Each calls <code>e.stopPropagation()</code> then <code>handleAction({id, isApproved})</code> directly. Functionally identical.</p> <div class="file-refs"> <a class="file-link" href="https://github.com/getsentry/sentry/pull/115813/files#diff-a59c0cc3f74b5cca5e88c6faa2d6e3e7c63d54c3c10e6be97e9e0e7091e5c3d6R86" target="_blank" rel="noopener">organizationAccessRequests.tsx:86-89</a> &#x2014; <a class="file-link" href="https://github.com/getsentry/sentry/pull/115813/files#diff-a59c0cc3f74b5cca5e88c6faa2d6e3e7c63d54c3c10e6be97e9e0e7091e5c3d6R96" target="_blank" rel="noopener">organizationAccessRequests.tsx:96-99</a> </div> </div> </div> </div> <div class="testing-notes"> <h3>&#x1f9ea; Testing Notes</h3> <ol> <li><span class="label url">URL:</span> Settings &#x2192; Organization &#x2192; Teams (requires pending access requests)<br><span class="label action">Action:</span> Verify the pending team requests panel renders with request details<br><span class="label expected">Expected:</span> Request messages display requester name, member name, and team slug<br><span class="label previous">Previous:</span> Same rendering behavior</li> <li><span class="label action">Action:</span> Click "Approve" on a pending request<br><span class="label expected">Expected:</span> Button shows busy state, success toast "Team request approved", request removed from list<br><span class="label previous">Previous:</span> Same behavior but via api.requestPromise</li> <li><span class="label action">Action:</span> Click "Deny" on a pending request<br><span class="label expected">Expected:</span> Button shows busy state, success toast "Team request denied", request removed from list</li> <li><span class="label action">Action:</span> Simulate network error on approve/deny<br><span class="label expected">Expected:</span> Error toast appears ("Error approving/denying team request"), busy state clears automatically via useMutation</li> </ol> </div> <div class="diff-section"> <h2>Annotated Diff</h2> <div class="diff-controls"> <button onclick="toggleAll(true)">Expand all</button> <button onclick="toggleAll(false)">Collapse all</button> </div> <div class="diff-file"> <div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#x25BC;</span> <span class="diff-file-path"><a href="https://github.com/getsentry/sentry/pull/115813/files#diff-a59c0cc3f74b5cca5e88c6faa2d6e3e7c63d54c3c10e6be97e9e0e7091e5c3d6" target="_blank" rel="noopener">organizationAccessRequests.tsx</a></span> <span class="diff-badge">modified</span> <span class="diff-file-stats"><span class="stat-add">+84</span> <span class="stat-del">-115</span></span> </div> <div class="diff-body"> <table class="diff-table"> <tr class="hunk"><td colspan="3">@@ Imports @@</td></tr> <tr class="del"><td class="ln">1</td><td class="ln"></td><td class="code">-import {Component} from 'react';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">2</td><td class="code">+import {useMutation} from '@tanstack/react-query';</td></tr> <tr class="del"><td class="ln">7</td><td class="ln"></td><td class="code">-import type {Client} from 'sentry/api';</td></tr> <tr class="del"><td class="ln">13</td><td class="ln"></td><td class="code">-import {withApi} from 'sentry/utils/withApi';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">13</td><td class="code">+import {fetchMutation} from 'sentry/utils/queryClient';</td></tr> <tr><td colspan="3"><div class="annotation info">Imports switch from class Component + withApi HOC to useMutation + fetchMutation</div></td></tr> <tr class="hunk"><td colspan="3">@@ Props / Types @@</td></tr> <tr class="del"><td class="ln">16</td><td class="ln"></td><td class="code">-  api: Client;</td></tr> <tr class="del"><td class="ln">21</td><td class="ln"></td><td class="code">-type State = { accessRequestBusy: Record&lt;string, boolean&gt; };</td></tr> <tr class="del"><td class="ln">25</td><td class="ln"></td><td class="code">-type HandleOpts = { errorMessage, id, isApproved, successMessage };</td></tr> <tr><td colspan="3"><div class="annotation positive">api prop, State type, and HandleOpts type all removed &#x2014; no longer needed</div></td></tr> <tr class="hunk"><td colspan="3">@@ Component declaration + mutation @@</td></tr> <tr class="del"><td class="ln">31</td><td class="ln"></td><td class="code">-class OrganizationAccessRequests extends Component&lt;Props, State&gt; {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">21</td><td class="code">+export function OrganizationAccessRequests({ orgSlug, requestList, onRemoveAccessRequest }: Props) {</td></tr> <tr class="add"><td class="ln"></td><td class="ln">28</td><td class="code">+  const { mutate: handleAction, isPending, variables } = useMutation({</td></tr> <tr class="add"><td class="ln"></td><td class="ln">33</td><td class="code">+    mutationFn: ({id, isApproved}) =&gt; fetchMutation({</td></tr> <tr class="add"><td class="ln"></td><td class="ln">34</td><td class="code">+      method: 'PUT',</td></tr> <tr class="add"><td class="ln"></td><td class="ln">35</td><td class="code">+      url: `/organizations/${orgSlug}/access-requests/${id}/`,</td></tr> <tr class="add"><td class="ln"></td><td class="ln">36</td><td class="code">+      data: {isApproved},</td></tr> <tr class="add"><td class="ln"></td><td class="ln">37</td><td class="code">+    }),</td></tr> <tr><td colspan="3"><div class="annotation positive">Core change: fetchMutation replaces api.requestPromise, useMutation replaces manual state</div></td></tr> <tr class="hunk"><td colspan="3">@@ Busy state derivation @@</td></tr> <tr class="add"><td class="ln"></td><td class="ln">67</td><td class="code">+          const isBusy = isPending &amp;&amp; variables?.id === id;</td></tr> <tr><td colspan="3"><div class="annotation info">Busy state derived from useMutation instead of manual Record&lt;string, boolean&gt;</div></td></tr> <tr class="hunk"><td colspan="3">@@ Export @@</td></tr> <tr class="del"><td class="ln">141</td><td class="ln"></td><td class="code">-export default withApi(OrganizationAccessRequests);</td></tr> <tr><td colspan="3"><div class="annotation info">Default export removed &#x2014; function is now a named export at declaration</div></td></tr> </table> </div> </div> <div class="diff-file collapsed"> <div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')"> <span class="chevron">&#x25BC;</span> <span class="diff-file-path"><a href="https://github.com/getsentry/sentry/pull/115813/files#diff-42c76d6fde69e78d8a47e89b6df2f1d8e080f92de32dd2c6b67db5e2f4cc2b29" target="_blank" rel="noopener">organizationTeams.tsx</a></span> <span class="diff-badge">modified</span> <span class="diff-file-stats"><span class="stat-add">+1</span> <span class="stat-del">-1</span></span> </div> <div class="diff-body"> <table class="diff-table"> <tr class="hunk"><td colspan="3">@@ Import @@</td></tr> <tr class="del"><td class="ln">21</td><td class="ln"></td><td class="code">-import OrganizationAccessRequests from './organizationAccessRequests';</td></tr> <tr class="add"><td class="ln"></td><td class="ln">21</td><td class="code">+import {OrganizationAccessRequests} from './organizationAccessRequests';</td></tr> <tr><td colspan="3"><div class="annotation info">Import updated from default to named export</div></td></tr> </table> </div> </div> </div> <div class="file-list"> <h3>Files Changed</h3> <div class="file-pills"> <span class="file-pill">organizationAccessRequests.tsx</span> <span class="file-pill">organizationTeams.tsx</span> </div> </div> </div> <script> function toggleAll(e){document.querySelectorAll('.diff-file').forEach(function(el){e?el.classList.remove('collapsed'):el.classList.add('collapsed')})} function toggleTheme(){var r=document.documentElement,c=r.getAttribute('data-theme');if(c==='dark')r.setAttribute('data-theme','light');else if(c==='light'){r.removeAttribute('data-theme');r.setAttribute('data-theme','dark')}else{r.setAttribute('data-theme',matchMedia('(prefers-color-scheme:dark)').matches?'light':'dark')}} </script> </body> </html>
html-preview:end -->
