### PR TITLE
fix(search): Hide size limit prompt while filtering

### DIFF
--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -142,6 +142,7 @@ export function ListBox<T extends ObjectLike>({
   keyDownHandler = DEFAULT_KEY_DOWN_HANDLER,
   label,
   hiddenOptions = EMPTY_SET,
+  hasSearch,
   searchable,
   overlayIsOpen,
   showSectionHeaders = true,
@@ -281,7 +282,7 @@ export function ListBox<T extends ObjectLike>({
                 );
               })}
 
-            {!searchable && hiddenOptions.size > 0 && (
+            {!searchable && !hasSearch && hiddenOptions.size > 0 && (
               <SizeLimitMessage>
                 {sizeLimitMessage ?? t('Use search to find more options…')}
               </SizeLimitMessage>

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -182,6 +182,37 @@ describe('SearchQueryBuilder', () => {
   });
 
   describe('rendering search query builder', () => {
+    it('does not show the size-limit prompt after the user searches filter keys', async () => {
+      const manyMatchingFilterKeys = Object.fromEntries(
+        Array.from({length: 20}, (_, index) => [
+          `matching_key_${index}`,
+          {
+            key: `matching_key_${index}`,
+            name: `matching_key_${index}`,
+            kind: FieldKind.TAG,
+          },
+        ])
+      ) as TagCollection;
+
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          filterKeys={manyMatchingFilterKeys}
+          filterKeySections={[]}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('matching');
+
+      expect(
+        await screen.findByRole('option', {name: 'matching_key_0'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('Use search to find more options…')
+      ).not.toBeInTheDocument();
+    });
+
     describe('footer', () => {
       it('displays wildcard footer when canUseWildcard is true', async () => {
         render(


### PR DESCRIPTION
Compact select was not respecting this prop being passed, which resulted in it rendering the search message when it shouldn't be.