### PR TITLE
chore(issues): add multiple select support to sentry app form

### DIFF
--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.spec.tsx
@@ -110,4 +110,49 @@ describe('SentryAppExternalFormNew', () => {
     expect(screen.getByText('board R')).toBeInTheDocument();
     expect(screen.getByText('Bug')).toBeInTheDocument();
   });
+
+  it('renders multi-select field and allows selecting multiple options', async () => {
+    const config: ComponentProps<typeof SentryAppExternalFormNew>['config'] = {
+      uri: '/integrations/sentry/issues/create',
+      required_fields: [
+        {
+          type: 'text',
+          name: 'title',
+          label: 'Title',
+          default: 'issue.title',
+        },
+      ],
+      optional_fields: [
+        {
+          type: 'select',
+          name: 'labelId',
+          label: 'Labels',
+          multiple: true,
+          choices: [
+            ['bug', 'Bug'],
+            ['feature', 'Feature'],
+            ['improvement', 'Improvement'],
+          ],
+        },
+      ],
+    };
+
+    render(
+      <SentryAppExternalFormNew
+        sentryAppInstallationUuid={sentryAppInstallation.uuid}
+        appName={sentryApp.name}
+        config={config}
+        action="create"
+        element="issue-link"
+        onSubmitSuccess={jest.fn()}
+      />
+    );
+
+    const labelsField = screen.getByRole('textbox', {name: 'Labels'});
+    await selectEvent.select(labelsField, 'Bug');
+    await selectEvent.select(labelsField, 'Feature');
+
+    const removeButtons = screen.getAllByRole('img', {name: 'Remove item'});
+    expect(removeButtons).toHaveLength(2);
+  });
 });

--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
@@ -24,6 +24,7 @@ export type FieldFromSchema = Omit<Field, 'choices' | 'type'> & {
   choices?: Array<[any, string]>;
   default?: 'issue.title' | 'issue.description';
   depends_on?: string[];
+  multiple?: boolean;
   skip_load_on_open?: boolean;
   uri?: string;
 };
@@ -376,6 +377,7 @@ class SentryAppExternalForm extends Component<Props, State> {
         filterOption: createFilter({}),
         allowClear: !required,
         placeholder: 'Type to search',
+        multiple: field.multiple,
       } as Field;
       if (field.depends_on) {
         // check if this is dependent on other fields which haven't been set yet


### PR DESCRIPTION
Addresses frontend part of [ISWF-1518](https://linear.app/getsentry/issue/ISWF-1518/specify-1-label-when-creating-linear-issue-via-sentry).

Added multiple select support for sentry app form. This allows users to select multiple labels when creating a Linear issue. 

Backend found in [this PR](https://github.com/getsentry/sentry/pull/115814).