### PR TITLE
feat(preprod): Add install_groups as a filterable key in artifact search

### DIFF
--- a/src/sentry/preprod/artifact_search.py
+++ b/src/sentry/preprod/artifact_search.py
@@ -85,6 +85,7 @@ search_config = SearchConfig.create_from(
         "images_renamed",
         "images_skipped",
         "images_unchanged",
+        "install_groups",
         "install_size",
         "installable",
         "is",
@@ -329,6 +330,17 @@ def apply_filters(
         if name == "distribution_error_code":
             values = token.value.value if token.is_in_filter else [token.value.value]
             q = Q(**{f"{db_field}__in": [_translate_distribution_error_code(v) for v in values]})
+            if token.is_negation:
+                queryset = queryset.exclude(q)
+            else:
+                queryset = queryset.filter(q)
+            continue
+
+        if name == "install_groups":
+            values = token.value.value if token.is_in_filter else [token.value.value]
+            q = Q()
+            for group in values:
+                q |= Q(extras__install_groups__contains=[group])
             if token.is_negation:
                 queryset = queryset.exclude(q)
             else:

--- a/src/sentry/preprod/artifact_search.py
+++ b/src/sentry/preprod/artifact_search.py
@@ -17,6 +17,7 @@ from sentry.api.event_search import (
 from sentry.db.models.fields.bounded import I64_MAX
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
+from sentry.preprod.build_distribution_utils import build_install_groups_q
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactQuerySet,
@@ -337,10 +338,13 @@ def apply_filters(
             continue
 
         if name == "install_groups":
-            values = token.value.value if token.is_in_filter else [token.value.value]
-            q = Q()
-            for group in values:
-                q |= Q(extras__install_groups__contains=[group])
+            if token.value.value == "":
+                raise InvalidSearchQuery("has:install_groups is not supported")
+            elif token.is_in_filter:
+                q = build_install_groups_q(token.value.value)
+            else:
+                q = build_install_groups_q([token.value.value])
+
             if token.is_negation:
                 queryset = queryset.exclude(q)
             else:

--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -207,6 +207,8 @@ def produce_preprod_build_distribution_to_eap(
         attributes["has_missing_dsym_binaries"] = artifact.extras.get("has_missing_dsym_binaries")
         # Android-specific fields
         attributes["has_proguard_mapping"] = artifact.extras.get("has_proguard_mapping")
+        # Distribution install groups (stored as JSON array, written as EAP array)
+        attributes["install_groups"] = artifact.extras.get("install_groups")
 
     attributes["has_installable_file"] = artifact.installable_app_file_id is not None
 

--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -207,7 +207,7 @@ def produce_preprod_build_distribution_to_eap(
         attributes["has_missing_dsym_binaries"] = artifact.extras.get("has_missing_dsym_binaries")
         # Android-specific fields
         attributes["has_proguard_mapping"] = artifact.extras.get("has_proguard_mapping")
-        # Distribution install groups (stored as JSON array, written as EAP array)
+
         attributes["install_groups"] = artifact.extras.get("install_groups")
 
     attributes["has_installable_file"] = artifact.installable_app_file_id is not None

--- a/tests/sentry/preprod/test_artifact_search.py
+++ b/tests/sentry/preprod/test_artifact_search.py
@@ -565,3 +565,72 @@ class ArtifactMatchesQuerySnapshotStatusFilterTest(TestCase):
         assert not artifact_matches_query(
             success, "snapshot_status:[pending, failed]", self.organization
         )
+
+
+class ArtifactMatchesQueryInstallGroupsFilterTest(TestCase):
+    def _create_artifact_with_install_groups(
+        self, groups: list[str] | None = None, extras: dict | None = None
+    ) -> PreprodArtifact:
+        if extras is None and groups is not None:
+            extras = {"install_groups": groups}
+        return self.create_preprod_artifact(project=self.project, extras=extras)
+
+    def test_single_value_match(self) -> None:
+        artifact = self._create_artifact_with_install_groups(["beta", "internal"])
+
+        assert artifact_matches_query(artifact, "install_groups:beta", self.organization)
+        assert artifact_matches_query(artifact, "install_groups:internal", self.organization)
+        assert not artifact_matches_query(artifact, "install_groups:production", self.organization)
+
+    def test_in_filter(self) -> None:
+        beta = self._create_artifact_with_install_groups(["beta"])
+        production = self._create_artifact_with_install_groups(["production"])
+
+        assert artifact_matches_query(beta, "install_groups:[beta, internal]", self.organization)
+        assert not artifact_matches_query(
+            production, "install_groups:[beta, internal]", self.organization
+        )
+
+    def test_negation_single(self) -> None:
+        artifact = self._create_artifact_with_install_groups(["beta"])
+
+        assert not artifact_matches_query(artifact, "!install_groups:beta", self.organization)
+        assert artifact_matches_query(artifact, "!install_groups:production", self.organization)
+
+    def test_negation_in_filter(self) -> None:
+        beta = self._create_artifact_with_install_groups(["beta"])
+        production = self._create_artifact_with_install_groups(["production"])
+
+        assert not artifact_matches_query(
+            beta, "!install_groups:[beta, internal]", self.organization
+        )
+        assert artifact_matches_query(
+            production, "!install_groups:[beta, internal]", self.organization
+        )
+
+    def test_null_extras(self) -> None:
+        artifact = self._create_artifact_with_install_groups(extras=None)
+
+        assert not artifact_matches_query(artifact, "install_groups:beta", self.organization)
+        assert artifact_matches_query(artifact, "!install_groups:beta", self.organization)
+
+    def test_missing_key_in_extras(self) -> None:
+        artifact = self._create_artifact_with_install_groups(extras={"other_field": "value"})
+
+        assert not artifact_matches_query(artifact, "install_groups:beta", self.organization)
+
+    def test_empty_array(self) -> None:
+        artifact = self._create_artifact_with_install_groups([])
+
+        assert not artifact_matches_query(artifact, "install_groups:beta", self.organization)
+
+    def test_multiple_groups_on_artifact(self) -> None:
+        artifact = self._create_artifact_with_install_groups(["beta", "internal", "qa"])
+
+        assert artifact_matches_query(artifact, "install_groups:internal", self.organization)
+        assert artifact_matches_query(
+            artifact, "install_groups:[qa, production]", self.organization
+        )
+        assert not artifact_matches_query(
+            artifact, "!install_groups:[beta, internal]", self.organization
+        )

--- a/tests/sentry/preprod/test_artifact_search.py
+++ b/tests/sentry/preprod/test_artifact_search.py
@@ -624,6 +624,16 @@ class ArtifactMatchesQueryInstallGroupsFilterTest(TestCase):
 
         assert not artifact_matches_query(artifact, "install_groups:beta", self.organization)
 
+    def test_has_filter_rejected(self) -> None:
+        import pytest
+
+        from sentry.exceptions import InvalidSearchQuery
+
+        artifact = self._create_artifact_with_install_groups(["beta"])
+
+        with pytest.raises(InvalidSearchQuery):
+            artifact_matches_query(artifact, "has:install_groups", self.organization)
+
     def test_multiple_groups_on_artifact(self) -> None:
         artifact = self._create_artifact_with_install_groups(["beta", "internal", "qa"])
 


### PR DESCRIPTION
Support filtering artifacts by `install_groups` in `artifact_search.py` so that all search consumers (builds list, sequential base resolution, quota matching, and the upcoming latest-build route) can narrow results by install group.

`install_groups` is stored as a JSON array in `PreprodArtifact.extras`, so it gets a special-case handler in `apply_filters()` that builds an OR of JSON containment queries — matching the same semantics as the existing `build_install_groups_q()` helper. Supports single value (`install_groups:beta`), IN filter (`install_groups:[beta, internal]`), and negation (`!install_groups:beta`).

**Special-case handler**

Unlike flat-column filters that fall through to the generic handler, `install_groups` needs `extras__install_groups__contains` containment lookups, so it's handled explicitly alongside `size_state`, `distribution_error_code`, and `snapshot_status`.

Refs EME-1160