### PR TITLE
feat(profiles): add backend redirect for `/explore/profiling`

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1188,6 +1188,15 @@ urlpatterns += [
                     DisabledMemberView.as_view(),
                     name="sentry-organization-disabled-member",
                 ),
+                re_path(
+                    r"^(?P<organization_slug>[^/]+)/explore/profiling/(?P<rest>.*)$",
+                    RedirectView.as_view(
+                        url="/organizations/%(organization_slug)s/explore/profiles/%(rest)s",
+                        permanent=False,
+                        query_string=True,
+                    ),
+                    name="sentry-organization-explore-profiling-redirect",
+                ),
                 # need to force these to React and ensure organization_slug is captured
                 re_path(
                     r"^(?P<organization_slug>[^/]+)/(?P<sub_page>[\w_-]+)/",

--- a/tests/sentry/web/test_urls.py
+++ b/tests/sentry/web/test_urls.py
@@ -17,3 +17,30 @@ class ApiDocsRedirectTest(TestCase):
         resp = self.client.get(path)
         assert resp["Location"] == "https://docs.sentry.io/api/"
         assert resp.status_code == 302, resp.status_code
+
+
+class ExploreProfilingRedirectTest(TestCase):
+    def test_redirects_to_profiles(self) -> None:
+        org = self.create_organization()
+        resp = self.client.get(f"/organizations/{org.slug}/explore/profiling/")
+        assert resp["Location"] == f"/organizations/{org.slug}/explore/profiles/"
+        assert resp.status_code == 302, resp.status_code
+
+    def test_preserves_subpath(self) -> None:
+        org = self.create_organization()
+        resp = self.client.get(
+            f"/organizations/{org.slug}/explore/profiling/profile/my-project/abc123/flamegraph/"
+        )
+        assert (
+            resp["Location"]
+            == f"/organizations/{org.slug}/explore/profiles/profile/my-project/abc123/flamegraph/"
+        )
+        assert resp.status_code == 302, resp.status_code
+
+    def test_preserves_query_string(self) -> None:
+        org = self.create_organization()
+        resp = self.client.get(f"/organizations/{org.slug}/explore/profiling/?referrer=performance")
+        assert (
+            resp["Location"] == f"/organizations/{org.slug}/explore/profiles/?referrer=performance"
+        )
+        assert resp.status_code == 302, resp.status_code


### PR DESCRIPTION
Stacks on #115627 by adding a backend redirect. After this we'll be able to remove the frontend redirects.

Continues EXP-955.