### PR TITLE
feat(source-map-config-issues): Updating processing errors metric

### DIFF
--- a/src/sentry/processing_errors/detection.py
+++ b/src/sentry/processing_errors/detection.py
@@ -19,6 +19,7 @@ from sentry.processing_errors.grouptype import (
 from sentry.processing_errors.provisioning import ensure_detector
 from sentry.tasks.post_process import PostProcessJob
 from sentry.utils import metrics
+from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
 from sentry.workflow_engine.models import DataPacket, DetectorState
 from sentry.workflow_engine.processors.detector import process_detectors
 
@@ -156,9 +157,11 @@ def _detect_for_config(
         1,
         attributes={
             "org_slug": event.project.organization.slug,
-            "project_id": str(event.project.id),
-            "project_slug": event.project.slug,
-            "platform": event.project.platform or "unknown",
+            "event_project_id": str(event.project.id),
+            "event_project_slug": event.project.slug,
+            "project_platform": event.project.platform or "unknown",
+            "event_platform": event.data.get("platform") or "unknown",
+            "event_sdk": normalized_sdk_tag_from_event(event.data),
             "error_type": ",".join(matching_error_types),
             "project_age_bucket": _project_age_bucket(event.project),
         },


### PR DESCRIPTION
Updates:
- Renamed `project_id` → `event_project_id` to avoid collision with EAP's reserved sentry.project_id alias. This silently stopped the attr from being propagated. 
- Added `sdk` and `event_platform` attrs