### PR TITLE
feat(issues): Consolidate activity comment input

### DIFF
--- a/static/app/components/activity/note/index.tsx
+++ b/static/app/components/activity/note/index.tsx
@@ -1,5 +1,6 @@
 import {useState} from 'react';
-import styled from '@emotion/styled';
+
+import {Container} from '@sentry/scraps/layout';
 
 import type {ActivityAuthorType} from 'sentry/components/activity/item';
 import {ActivityItem} from 'sentry/components/activity/item';
@@ -21,7 +22,9 @@ type Props = {
   authorName: string;
   dateCreated: Date | string;
   /**
-   * min-height for NoteInput textarea
+   * Minimum height for the comment editor, in pixels.
+   *
+   * Passed through to NoteInput.
    */
   minHeight: number;
   /**
@@ -51,7 +54,6 @@ type Props = {
    * this component's props.
    */
   activity?: ActivityType;
-  editBodyPadding?: boolean;
   /**
    * pass through to ActivityItem. Hides the date/timestamp in header
    */
@@ -68,7 +70,6 @@ function Note(props: Props) {
     dateCreated,
     text,
     authorName,
-    editBodyPadding,
     hideDate,
     minHeight,
     showTime,
@@ -90,21 +91,19 @@ function Note(props: Props) {
   };
 
   if (editing) {
-    const noteInput = (
-      <NoteInput
-        {...{noteId, minHeight, text, projectSlugs}}
-        onCancel={() => setEditing(false)}
-        onUpdate={note => {
-          onUpdate(note, props);
-          setEditing(false);
-        }}
-        onCreate={note => onCreate?.(note)}
-      />
-    );
-
     return (
       <ActivityItem noPadding {...activityItemProps}>
-        {editBodyPadding ? <EditBody>{noteInput}</EditBody> : noteInput}
+        <Container padding="lg">
+          <NoteInput
+            {...{noteId, minHeight, text, projectSlugs}}
+            onCancel={() => setEditing(false)}
+            onUpdate={note => {
+              onUpdate(note, props);
+              setEditing(false);
+            }}
+            onCreate={note => onCreate?.(note)}
+          />
+        </Container>
       </ActivityItem>
     );
   }
@@ -124,9 +123,5 @@ function Note(props: Props) {
     </ActivityItem>
   );
 }
-
-const EditBody = styled('div')`
-  padding: ${p => p.theme.space.lg};
-`;
 
 export {Note};

--- a/static/app/components/activity/note/index.tsx
+++ b/static/app/components/activity/note/index.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import styled from '@emotion/styled';
 
 import type {ActivityAuthorType} from 'sentry/components/activity/item';
 import {ActivityItem} from 'sentry/components/activity/item';
@@ -50,6 +51,7 @@ type Props = {
    * this component's props.
    */
   activity?: ActivityType;
+  editBodyPadding?: boolean;
   /**
    * pass through to ActivityItem. Hides the date/timestamp in header
    */
@@ -66,6 +68,7 @@ function Note(props: Props) {
     dateCreated,
     text,
     authorName,
+    editBodyPadding,
     hideDate,
     minHeight,
     showTime,
@@ -87,17 +90,21 @@ function Note(props: Props) {
   };
 
   if (editing) {
+    const noteInput = (
+      <NoteInput
+        {...{noteId, minHeight, text, projectSlugs}}
+        onCancel={() => setEditing(false)}
+        onUpdate={note => {
+          onUpdate(note, props);
+          setEditing(false);
+        }}
+        onCreate={note => onCreate?.(note)}
+      />
+    );
+
     return (
       <ActivityItem noPadding {...activityItemProps}>
-        <NoteInput
-          {...{noteId, minHeight, text, projectSlugs}}
-          onCancel={() => setEditing(false)}
-          onUpdate={note => {
-            onUpdate(note, props);
-            setEditing(false);
-          }}
-          onCreate={note => onCreate?.(note)}
-        />
+        {editBodyPadding ? <EditBody>{noteInput}</EditBody> : noteInput}
       </ActivityItem>
     );
   }
@@ -117,5 +124,9 @@ function Note(props: Props) {
     </ActivityItem>
   );
 }
+
+const EditBody = styled('div')`
+  padding: ${p => p.theme.space.lg};
+`;
 
 export {Note};

--- a/static/app/components/activity/note/index.tsx
+++ b/static/app/components/activity/note/index.tsx
@@ -91,7 +91,7 @@ function Note(props: Props) {
       <ActivityItem noPadding {...activityItemProps}>
         <NoteInput
           {...{noteId, minHeight, text, projectSlugs}}
-          onEditFinish={() => setEditing(false)}
+          onCancel={() => setEditing(false)}
           onUpdate={note => {
             onUpdate(note, props);
             setEditing(false);

--- a/static/app/components/activity/note/input.spec.tsx
+++ b/static/app/components/activity/note/input.spec.tsx
@@ -51,7 +51,7 @@ describe('NoteInput', () => {
 
     it('handles errors', async () => {
       const errorJSON = {detail: {message: 'Note is bad', code: 401, extra: ''}};
-      render(<NoteInput error={!!errorJSON} errorJSON={errorJSON} />);
+      render(<NoteInput errorJSON={errorJSON} />);
 
       await userEvent.type(screen.getByRole('textbox'), 'something{Control>}{enter}');
       expect(screen.getByText('Note is bad')).toBeInTheDocument();
@@ -60,7 +60,9 @@ describe('NoteInput', () => {
     it('has a disabled submit button when no text is entered', async () => {
       render(<NoteInput />);
 
-      expect(screen.getByRole('button', {name: 'Post Comment'})).toBeDisabled();
+      expect(screen.queryByRole('button', {name: 'Comment'})).not.toBeInTheDocument();
+      await userEvent.click(screen.getByRole('textbox'));
+      expect(screen.getByRole('button', {name: 'Comment'})).toBeDisabled();
       await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     });
 
@@ -68,7 +70,7 @@ describe('NoteInput', () => {
       render(<NoteInput />);
       await userEvent.type(screen.getByRole('textbox'), 'something');
 
-      expect(screen.getByRole('button', {name: 'Post Comment'})).toBeEnabled();
+      expect(screen.getByRole('button', {name: 'Comment'})).toBeEnabled();
     });
 
     it('can mention a team', async () => {
@@ -78,7 +80,7 @@ describe('NoteInput', () => {
       await userEvent.type(screen.getByRole('textbox'), '#team');
       await userEvent.click(screen.getByRole('option', {name: '# team -slug'}));
       expect(screen.getByRole('textbox')).toHaveTextContent('#team-slug');
-      await userEvent.click(screen.getByRole('button', {name: 'Post Comment'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Comment'}));
       expect(onCreate).toHaveBeenCalledWith({
         text: '**#team-slug** ',
         mentions: ['team:1'],
@@ -91,7 +93,7 @@ describe('NoteInput', () => {
       await userEvent.type(screen.getByRole('textbox'), '@foo');
       await userEvent.click(screen.getByRole('option', {name: 'Foo Bar'}));
       expect(screen.getByRole('textbox')).toHaveTextContent('@Foo Bar');
-      await userEvent.click(screen.getByRole('button', {name: 'Post Comment'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Comment'}));
       expect(onCreate).toHaveBeenCalledWith({
         text: '**@Foo Bar** ',
         mentions: ['user:1'],
@@ -110,12 +112,12 @@ describe('NoteInput', () => {
       render(<NoteInput {...props} onUpdate={onUpdate} />);
 
       // Switch to preview
-      await userEvent.click(screen.getByRole('tab', {name: 'Preview'}));
+      await userEvent.click(screen.getByRole('radio', {name: 'Preview'}));
 
       expect(screen.getByText('an existing item')).toBeInTheDocument();
 
       // Switch to edit
-      await userEvent.click(screen.getByRole('tab', {name: 'Edit'}));
+      await userEvent.click(screen.getByRole('radio', {name: 'Edit'}));
 
       expect(screen.getByRole('textbox')).toHaveTextContent('an existing item');
 
@@ -129,13 +131,13 @@ describe('NoteInput', () => {
     });
 
     it('canels editing and moves to preview mode', async () => {
-      const onEditFinish = jest.fn();
-      render(<NoteInput {...props} onEditFinish={onEditFinish} />);
+      const onCancel = jest.fn();
+      render(<NoteInput {...props} onCancel={onCancel} />);
 
       await userEvent.type(screen.getByRole('textbox'), ' new content');
 
       await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
-      expect(onEditFinish).toHaveBeenCalled();
+      expect(onCancel).toHaveBeenCalled();
     });
   });
 });

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -29,7 +29,9 @@ type Props = {
   busy?: boolean;
   errorJSON?: CreateError | null;
   /**
-   * Minimum height of the edit area
+   * Minimum height for the editor textarea and preview, in pixels.
+   *
+   * Defaults to 140.
    */
   minHeight?: number;
   /**

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -1,12 +1,15 @@
 import {useCallback, useId, useState} from 'react';
-import type {MentionsInputProps} from 'react-mentions';
 import {Mention, MentionsInput} from 'react-mentions';
 import type {Theme} from '@emotion/react';
-import {css, useTheme} from '@emotion/react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {AnimatePresence, motion, useReducedMotion} from 'framer-motion';
+import {z} from 'zod';
 
 import {Button} from '@sentry/scraps/button';
-import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+import {Flex} from '@sentry/scraps/layout';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 
 import {IconMarkdown} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -24,10 +27,6 @@ type Props = {
    * Is the note saving?
    */
   busy?: boolean;
-  /**
-   * Display an error message
-   */
-  error?: boolean;
   errorJSON?: CreateError | null;
   /**
    * Minimum height of the edit area
@@ -38,9 +37,9 @@ type Props = {
    * you are editing an existing item
    */
   noteId?: string;
+  onCancel?: () => void;
   onChange?: (e: MentionChangeEvent, extra: {updating?: boolean}) => void;
   onCreate?: (data: NoteType) => void;
-  onEditFinish?: () => void;
   onUpdate?: (data: NoteType) => void;
   placeholder?: string;
   /**
@@ -49,12 +48,18 @@ type Props = {
   text?: string;
 };
 
+type EditorMode = 'write' | 'preview';
+
+const noteInputSchema = z.object({
+  text: z.string(),
+});
+
 function NoteInput({
   text,
   onCreate,
   onChange,
   onUpdate,
-  onEditFinish,
+  onCancel,
   noteId,
   errorJSON,
   busy = false,
@@ -62,6 +67,7 @@ function NoteInput({
   minHeight = 140,
 }: Props) {
   const theme = useTheme();
+  const prefersReducedMotion = useReducedMotion();
 
   const {getMemberSuggestions} = useMemberMentionData();
   const {teams} = useTeams();
@@ -71,47 +77,44 @@ function NoteInput({
     display: `#${team.slug}`,
   }));
 
-  const [value, setValue] = useState(text ?? '');
-
   const [memberMentions, setMemberMentions] = useState<Mentioned[]>([]);
   const [teamMentions, setTeamMentions] = useState<Mentioned[]>([]);
-
-  const canSubmit = value.trim() !== '';
-
-  const cleanMarkdown = value
-    .replace(/\[sentry\.strip:member\]/g, '@')
-    .replace(/\[sentry\.strip:team\]/g, '');
+  const [editorMode, setEditorMode] = useState<EditorMode>('write');
 
   const existingItem = !!noteId;
+  const [areControlsVisible, setAreControlsVisible] = useState(existingItem);
 
-  // each mention looks like [id, display]
-  const finalizedMentions = [...memberMentions, ...teamMentions]
-    .filter(mention => value.includes(mention[1]))
-    .map(mention => mention[0]);
+  const getCleanMarkdown = (comment: string) =>
+    comment
+      .replace(/\[sentry\.strip:member\]/g, '@')
+      .replace(/\[sentry\.strip:team\]/g, '');
 
-  const submitForm = useCallback(
-    () =>
-      existingItem
+  const submitNote = useCallback(
+    (comment: string) => {
+      const cleanMarkdown = getCleanMarkdown(comment);
+      // each mention looks like [id, display]
+      const finalizedMentions = [...memberMentions, ...teamMentions]
+        .filter(mention => comment.includes(mention[1]))
+        .map(mention => mention[0]);
+
+      return existingItem
         ? onUpdate?.({text: cleanMarkdown, mentions: finalizedMentions})
-        : onCreate?.({text: cleanMarkdown, mentions: finalizedMentions}),
-    [existingItem, onUpdate, cleanMarkdown, finalizedMentions, onCreate]
+        : onCreate?.({text: cleanMarkdown, mentions: finalizedMentions});
+    },
+    [existingItem, memberMentions, onCreate, onUpdate, teamMentions]
   );
 
-  const handleCancel = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      onEditFinish?.();
-    },
-    [onEditFinish]
-  );
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {text: text ?? ''},
+    validators: {onDynamic: noteInputSchema},
+    onSubmit: ({value}) => submitNote(value.text),
+  });
 
-  const handleSubmit = useCallback(
-    (e: React.MouseEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      submitForm();
-    },
-    [submitForm]
-  );
+  const handleCancel = (e: React.MouseEvent) => {
+    e.preventDefault();
+    onCancel?.();
+  };
 
   const handleAddMember = useCallback(
     (id: string | number, display: string) =>
@@ -125,24 +128,6 @@ function NoteInput({
     []
   );
 
-  const handleChange: MentionsInputProps['onChange'] = useCallback(
-    (e: MentionChangeEvent) => {
-      setValue(e.target.value);
-      onChange?.(e, {updating: existingItem});
-    },
-    [existingItem, onChange]
-  );
-
-  const handleKeyDown: MentionsInputProps['onKeyDown'] = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      // Auto submit the form on [meta,ctrl] + Enter
-      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && canSubmit) {
-        submitForm();
-      }
-    },
-    [canSubmit, submitForm]
-  );
-
   const errorId = useId();
   const errorMessage =
     (errorJSON &&
@@ -150,75 +135,136 @@ function NoteInput({
         ? errorJSON.detail
         : errorJSON.detail?.message || t('Unable to post comment'))) ||
     null;
+  const controlsAnimation = prefersReducedMotion
+    ? {
+        initial: false,
+        animate: {opacity: 1, height: 'auto'},
+        exit: {opacity: 0, height: 0},
+        transition: {duration: 0},
+      }
+    : {
+        initial: {opacity: 0, y: -4, height: 0},
+        animate: {opacity: 1, y: 0, height: 'auto'},
+        exit: {opacity: 0, y: -4, height: 0},
+        transition: theme.motion.framer.enter.fast,
+      };
 
   return (
-    <NoteInputForm data-test-id="note-input-form" noValidate onSubmit={handleSubmit}>
-      <Tabs>
-        <TabList variant="floating">
-          <TabList.Item key="edit">{existingItem ? t('Edit') : t('Write')}</TabList.Item>
-          <TabList.Item key="preview">{t('Preview')}</TabList.Item>
-        </TabList>
-        <NoteInputPanel>
-          <TabPanels.Item key="edit">
-            <MentionsInput
-              aria-errormessage={errorMessage ? errorId : undefined}
-              style={mentionStyle({theme, minHeight})}
-              placeholder={placeholder}
-              onChange={handleChange}
-              onKeyDown={handleKeyDown}
-              value={value}
-              required
-              autoFocus
-            >
-              <Mention
-                trigger="@"
-                data={getMemberSuggestions}
-                onAdd={handleAddMember}
-                displayTransform={(_id, display) => `@${display}`}
-                markup="**[sentry.strip:member]__display__**"
-                appendSpaceOnAdd
-              />
-              <Mention
-                trigger="#"
-                data={suggestTeams}
-                onAdd={handleAddTeam}
-                markup="**[sentry.strip:team]__display__**"
-                displayTransform={(_id, display) => display}
-                appendSpaceOnAdd
-              />
-            </MentionsInput>
-          </TabPanels.Item>
-          <TabPanels.Item key="preview">
-            <NotePreview minHeight={minHeight} text={cleanMarkdown} />
-          </TabPanels.Item>
-        </NoteInputPanel>
-      </Tabs>
-      <Footer>
-        {errorMessage ? (
-          <div id={errorId}>
-            {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
-          </div>
-        ) : (
-          <MarkdownIndicator>
-            <IconMarkdown /> {t('Markdown supported')}
-          </MarkdownIndicator>
-        )}
-        <div>
-          {existingItem && (
-            <FooterButton variant="danger" onClick={handleCancel}>
-              {t('Cancel')}
-            </FooterButton>
+    <form.AppForm form={form}>
+      <EditorSurface>
+        <form.AppField name="text">
+          {field => (
+            <NoteInputPanel>
+              {editorMode === 'write' ? (
+                <field.Base<HTMLTextAreaElement>>
+                  {({ref, ...fieldProps}) => (
+                    <MentionsEditor>
+                      <MentionsInput
+                        {...fieldProps}
+                        aria-label={existingItem ? t('Edit comment') : t('Add a comment')}
+                        aria-errormessage={errorMessage ? errorId : undefined}
+                        inputRef={ref}
+                        style={mentionStyle({theme, minHeight})}
+                        placeholder={placeholder}
+                        onChange={(e: MentionChangeEvent) => {
+                          setAreControlsVisible(true);
+                          field.handleChange(e.target.value);
+                          onChange?.(e, {updating: existingItem});
+                        }}
+                        onFocus={() => setAreControlsVisible(true)}
+                        onKeyDown={e => {
+                          if (
+                            e.key === 'Enter' &&
+                            (e.metaKey || e.ctrlKey) &&
+                            field.state.value.trim() !== ''
+                          ) {
+                            e.preventDefault();
+                            form.handleSubmit();
+                          }
+                        }}
+                        value={field.state.value}
+                        required
+                        autoFocus={existingItem}
+                      >
+                        <Mention
+                          trigger="@"
+                          data={getMemberSuggestions}
+                          onAdd={handleAddMember}
+                          displayTransform={(_id, display) => `@${display}`}
+                          markup="**[sentry.strip:member]__display__**"
+                          appendSpaceOnAdd
+                        />
+                        <Mention
+                          trigger="#"
+                          data={suggestTeams}
+                          onAdd={handleAddTeam}
+                          markup="**[sentry.strip:team]__display__**"
+                          displayTransform={(_id, display) => display}
+                          appendSpaceOnAdd
+                        />
+                      </MentionsInput>
+                    </MentionsEditor>
+                  )}
+                </field.Base>
+              ) : (
+                <NotePreview
+                  minHeight={minHeight}
+                  text={getCleanMarkdown(field.state.value)}
+                />
+              )}
+            </NoteInputPanel>
           )}
-          <FooterButton
-            error={!!errorMessage}
-            type="submit"
-            disabled={busy || !canSubmit}
-          >
-            {existingItem ? t('Save Comment') : t('Post Comment')}
-          </FooterButton>
-        </div>
-      </Footer>
-    </NoteInputForm>
+        </form.AppField>
+      </EditorSurface>
+      <AnimatePresence initial={false}>
+        {areControlsVisible && (
+          <MotionControls key="composer-controls" {...controlsAnimation}>
+            <Flex align="center" justify="between" gap="md" paddingTop="sm">
+              <Flex align="center" gap="md">
+                <SegmentedControl<EditorMode>
+                  aria-label={t('Comment editor mode')}
+                  size="xs"
+                  value={editorMode}
+                  onChange={setEditorMode}
+                >
+                  <SegmentedControl.Item key="write">
+                    {existingItem ? t('Edit') : t('Write')}
+                  </SegmentedControl.Item>
+                  <SegmentedControl.Item key="preview">
+                    {t('Preview')}
+                  </SegmentedControl.Item>
+                </SegmentedControl>
+                <MarkdownIndicator>
+                  <IconMarkdown size="sm" />
+                  {t('Markdown supported')}
+                </MarkdownIndicator>
+              </Flex>
+              <Flex align="center" gap="sm">
+                {errorMessage && (
+                  <div id={errorId}>
+                    <ErrorMessage>{errorMessage}</ErrorMessage>
+                  </div>
+                )}
+                <Flex gap="sm">
+                  {existingItem && (
+                    <Button size="xs" onClick={handleCancel}>
+                      {t('Cancel')}
+                    </Button>
+                  )}
+                  <form.Subscribe selector={state => state.values.text.trim() === ''}>
+                    {isEmpty => (
+                      <form.SubmitButton size="xs" disabled={busy || isEmpty}>
+                        {existingItem ? t('Save') : t('Comment')}
+                      </form.SubmitButton>
+                    )}
+                  </form.Subscribe>
+                </Flex>
+              </Flex>
+            </Flex>
+          </MotionControls>
+        )}
+      </AnimatePresence>
+    </form.AppForm>
   );
 }
 
@@ -243,79 +289,23 @@ const getNotePreviewCss = (p: NotePreviewProps) => {
 `;
 };
 
-const getNoteInputErrorStyles = (p: {theme: Theme; error?: string}) => {
-  if (!p.error) {
-    return '';
-  }
-
-  return `
-  color: ${p.theme.tokens.content.danger};
-  margin: -1px;
-  border: 1px solid ${p.theme.tokens.content.danger};
-  border-radius: ${p.theme.radius.md};
-
-    &:before {
-      display: block;
-      content: '';
-      width: 0;
-      height: 0;
-      border-top: 7px solid transparent;
-      border-bottom: 7px solid transparent;
-      border-right: 7px solid ${p.theme.colors.red400};
-      position: absolute;
-      left: -7px;
-      top: 12px;
-    }
-
-    &:after {
-      display: block;
-      content: '';
-      width: 0;
-      height: 0;
-      border-top: 6px solid transparent;
-      border-bottom: 6px solid transparent;
-      border-right: 6px solid #fff;
-      position: absolute;
-      left: -5px;
-      top: 12px;
-    }
-  `;
-};
-
-const NoteInputForm = styled('form')<{error?: string}>`
-  transition: padding 0.2s ease-in-out;
-
-  ${p => getNoteInputErrorStyles(p)};
+const EditorSurface = styled('div')`
+  background: ${p => p.theme.tokens.background.primary};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
 `;
 
-const NoteInputPanel = styled(TabPanels)`
+const NoteInputPanel = styled('div')`
   ${textStyles}
-  border-top: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: 0 0 ${p => p.theme.radius.md} ${p => p.theme.radius.md};
 `;
 
-const Footer = styled('div')`
-  display: flex;
-  border-top: 1px solid ${p => p.theme.tokens.border.primary};
-  justify-content: space-between;
-  padding-left: ${p => p.theme.space.lg};
+const MentionsEditor = styled('div')`
+  flex: 1;
+  min-width: 0;
 `;
 
-const FooterButton = styled(Button)<{error?: boolean}>`
-  margin: -1px -1px -1px;
-  border-radius: 0 0 ${p => p.theme.radius.md};
-
-  ${p =>
-    p.error &&
-    css`
-      &,
-      &:active,
-      &:focus,
-      &:hover {
-        border-bottom-color: ${p.theme.tokens.border.danger};
-        border-right-color: ${p.theme.tokens.border.danger};
-      }
-    `}
+const MotionControls = styled(motion.div)`
+  overflow: hidden;
 `;
 
 const ErrorMessage = styled('span')`
@@ -326,11 +316,12 @@ const ErrorMessage = styled('span')`
   font-size: 0.9em;
 `;
 
-const MarkdownIndicator = styled('div')`
+const MarkdownIndicator = styled('span')`
   display: flex;
   align-items: center;
-  gap: ${p => p.theme.space.md};
+  gap: ${p => p.theme.space.xs};
   color: ${p => p.theme.tokens.content.secondary};
+  font-size: ${p => p.theme.font.size.sm};
 `;
 
 const NotePreview = styled(MarkedText, {

--- a/static/app/components/activity/note/inputWithStorage.tsx
+++ b/static/app/components/activity/note/inputWithStorage.tsx
@@ -13,11 +13,10 @@ type InputProps = React.ComponentProps<typeof NoteInput>;
 type Props = {
   itemKey: string;
   storageKey: string;
-  onCancel?: () => void;
   onLoad?: (data: string) => string;
   onSave?: (data: string) => string;
-  source?: string;
   text?: string;
+  variant?: 'compact' | 'full';
 } & InputProps;
 
 function fetchFromStorage(storageKey: string) {
@@ -57,7 +56,7 @@ function NoteInputWithStorage({
   onLoad,
   onSave,
   text,
-  source,
+  variant,
   ...props
 }: Props) {
   const value = useMemo(() => {
@@ -134,8 +133,7 @@ function NoteInputWithStorage({
     [itemKey, onCreate, storageKey]
   );
 
-  // Make sure `this.props` does not override `onChange` and `onCreate`
-  if (source === 'issue-details') {
+  if (variant === 'compact') {
     return (
       <StreamlinedNoteInput
         text={value}

--- a/static/app/components/activity/note/mentionStyle.tsx
+++ b/static/app/components/activity/note/mentionStyle.tsx
@@ -13,7 +13,7 @@ type Options = {
 export function mentionStyle({theme, minHeight, streamlined}: Options) {
   const inputProps = {
     fontSize: theme.font.size.md,
-    padding: `${theme.space.lg} ${theme.space.xl}`,
+    padding: `${theme.space.lg} ${theme.space.lg}`,
     outline: 0,
     border: 0,
     minHeight,
@@ -32,7 +32,7 @@ export function mentionStyle({theme, minHeight, streamlined}: Options) {
 
   return {
     control: {
-      backgroundColor: theme.tokens.background.primary,
+      backgroundColor: 'transparent',
       fontSize: 15,
       fontWeight: 'normal',
     },

--- a/static/app/views/issueDetails/activitySection.tsx
+++ b/static/app/views/issueDetails/activitySection.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useState} from 'react';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Container} from '@sentry/scraps/layout';
 
 import {ActivityAuthor} from 'sentry/components/activity/author';
 import {ActivityItem} from 'sentry/components/activity/item';
@@ -46,7 +46,7 @@ export function ActivitySection(props: Props) {
 
   return (
     <Fragment>
-      <Flex marginBottom="xl">
+      <Container marginBottom="xl">
         <NoteInputWithStorage
           key={inputId}
           storageKey="groupinput:latest"
@@ -62,7 +62,7 @@ export function ActivitySection(props: Props) {
           }}
           {...noteProps}
         />
-      </Flex>
+      </Container>
 
       {visibleActivities.map(item => {
         const authorName = item.user ? item.user.name : 'Sentry';

--- a/static/app/views/issueDetails/activitySection.tsx
+++ b/static/app/views/issueDetails/activitySection.tsx
@@ -1,5 +1,7 @@
 import {Fragment, useState} from 'react';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import {ActivityAuthor} from 'sentry/components/activity/author';
 import {ActivityItem} from 'sentry/components/activity/item';
 import {Note} from 'sentry/components/activity/note';
@@ -36,7 +38,7 @@ export function ActivitySection(props: Props) {
   const me = useUser();
   const projectSlugs = group?.project ? [group.project.slug] : [];
   const noteProps = {
-    minHeight: 140,
+    minHeight: 112,
     group,
     projectSlugs,
     placeholder: placeholderText,
@@ -44,21 +46,23 @@ export function ActivitySection(props: Props) {
 
   return (
     <Fragment>
-      <NoteInputWithStorage
-        key={inputId}
-        storageKey="groupinput:latest"
-        itemKey={group.id}
-        onCreate={n => {
-          onCreate(n, me);
-          trackAnalytics('issue_details.comment_created', {
-            organization,
-            org_streamline_only: organization.streamlineOnly ?? undefined,
-            streamline: false,
-          });
-          setInputId(uniqueId());
-        }}
-        {...noteProps}
-      />
+      <Flex marginBottom="xl">
+        <NoteInputWithStorage
+          key={inputId}
+          storageKey="groupinput:latest"
+          itemKey={group.id}
+          onCreate={n => {
+            onCreate(n, me);
+            trackAnalytics('issue_details.comment_created', {
+              organization,
+              org_streamline_only: organization.streamlineOnly ?? undefined,
+              streamline: false,
+            });
+            setInputId(uniqueId());
+          }}
+          {...noteProps}
+        />
+      </Flex>
 
       {visibleActivities.map(item => {
         const authorName = item.user ? item.user.name : 'Sentry';
@@ -67,6 +71,7 @@ export function ActivitySection(props: Props) {
           return (
             <ErrorBoundary mini key={`note-${item.id}`}>
               <Note
+                editBodyPadding
                 showTime={false}
                 text={item.data.text}
                 noteId={item.id}

--- a/static/app/views/issueDetails/activitySection.tsx
+++ b/static/app/views/issueDetails/activitySection.tsx
@@ -71,7 +71,6 @@ export function ActivitySection(props: Props) {
           return (
             <ErrorBoundary mini key={`note-${item.id}`}>
               <Note
-                editBodyPadding
                 showTime={false}
                 text={item.data.text}
                 noteId={item.id}

--- a/static/app/views/issueDetails/activitySection.tsx
+++ b/static/app/views/issueDetails/activitySection.tsx
@@ -44,24 +44,21 @@ export function ActivitySection(props: Props) {
 
   return (
     <Fragment>
-      <ActivityItem noPadding author={{type: 'user', user: me}}>
-        <NoteInputWithStorage
-          key={inputId}
-          storageKey="groupinput:latest"
-          itemKey={group.id}
-          onCreate={n => {
-            onCreate(n, me);
-            trackAnalytics('issue_details.comment_created', {
-              organization,
-              org_streamline_only: organization.streamlineOnly ?? undefined,
-              streamline: false,
-            });
-            setInputId(uniqueId());
-          }}
-          source="activity"
-          {...noteProps}
-        />
-      </ActivityItem>
+      <NoteInputWithStorage
+        key={inputId}
+        storageKey="groupinput:latest"
+        itemKey={group.id}
+        onCreate={n => {
+          onCreate(n, me);
+          trackAnalytics('issue_details.comment_created', {
+            organization,
+            org_streamline_only: organization.streamlineOnly ?? undefined,
+            streamline: false,
+          });
+          setInputId(uniqueId());
+        }}
+        {...noteProps}
+      />
 
       {visibleActivities.map(item => {
         const authorName = item.user ? item.user.name : 'Sentry';

--- a/static/app/views/issueDetails/streamline/sidebar/activityDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activityDrawer.tsx
@@ -49,41 +49,41 @@ export function ActivityDrawer({group, project}: ActivityDrawerProps) {
       </EventDrawerHeader>
       <EventNavigator>
         <Header>{t('Activity')}</Header>
+        <SegmentedControl
+          size="xs"
+          aria-label={t('Filter activity')}
+          value={filter}
+          onChange={value => {
+            trackAnalytics('issue_details.activity_drawer.filter_changed', {
+              organization,
+              filter: value,
+            });
+            setSearchParams(
+              params => {
+                if (value === 'comments') {
+                  params.set('filter', 'comments');
+                } else {
+                  params.delete('filter');
+                }
+                return params;
+              },
+              {replace: true}
+            );
+          }}
+        >
+          <SegmentedControl.Item key="comments">
+            {t('Comments Only')}
+          </SegmentedControl.Item>
+          <SegmentedControl.Item key="all">{t('All Activity')}</SegmentedControl.Item>
+        </SegmentedControl>
       </EventNavigator>
       <EventDrawerBody>
-        <div>
-          <SegmentedControl
-            size="xs"
-            aria-label={t('Filter activity')}
-            value={filter}
-            onChange={value => {
-              trackAnalytics('issue_details.activity_drawer.filter_changed', {
-                organization,
-                filter: value,
-              });
-              setSearchParams(
-                params => {
-                  if (value === 'comments') {
-                    params.set('filter', 'comments');
-                  } else {
-                    params.delete('filter');
-                  }
-                  return params;
-                },
-                {replace: true}
-              );
-            }}
-          >
-            <SegmentedControl.Item key="comments">
-              {t('Comments Only')}
-            </SegmentedControl.Item>
-            <SegmentedControl.Item key="all">{t('All Activity')}</SegmentedControl.Item>
-          </SegmentedControl>
-        </div>
         <StreamlinedActivitySection
           group={group}
-          isDrawer
+          variant="drawer"
           filterComments={filter === 'comments'}
+          minHeight={72}
+          placeholder={t('Add a comment. Tag users with @, or teams with #')}
         />
       </EventDrawerBody>
     </EventDrawerContainer>

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
@@ -71,16 +71,16 @@ describe('StreamlinedActivitySection', () => {
 
     render(<StreamlinedActivitySection group={group} />);
 
-    const commentInput = screen.getByRole('textbox', {name: 'Add a comment'});
+    const commentInput = screen.getByPlaceholderText('Add a comment…');
     expect(commentInput).toBeInTheDocument();
+
     expect(
       screen.queryByRole('button', {name: 'Submit comment'})
     ).not.toBeInTheDocument();
 
     await userEvent.click(commentInput);
 
-    // Button appears after input is focused
-    const submitButton = await screen.findByRole('button', {name: 'Submit comment'});
+    const submitButton = screen.getByRole('button', {name: 'Submit comment'});
     expect(submitButton).toBeInTheDocument();
 
     expect(submitButton).toBeDisabled();
@@ -107,7 +107,7 @@ describe('StreamlinedActivitySection', () => {
 
     render(<StreamlinedActivitySection group={group} />);
 
-    const commentInput = screen.getByRole('textbox', {name: 'Add a comment'});
+    const commentInput = screen.getByPlaceholderText('Add a comment…');
     await userEvent.type(commentInput, comment);
     await userEvent.keyboard('{Meta>}{Enter}{/Meta}');
     expect(postMock).toHaveBeenCalled();
@@ -131,11 +131,11 @@ describe('StreamlinedActivitySection', () => {
       },
     });
 
-    render(<StreamlinedActivitySection group={group} isDrawer />);
+    render(<StreamlinedActivitySection group={group} variant="drawer" />);
 
-    await userEvent.type(screen.getByRole('textbox', {name: 'Add a comment'}), '@jane');
+    await userEvent.type(screen.getByPlaceholderText('Add a comment…'), '@jane');
     await userEvent.click(await screen.findByRole('option', {name: 'Jane Doe'}));
-    await userEvent.click(screen.getByRole('button', {name: 'Submit comment'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Comment'}));
 
     expect(postMock).toHaveBeenCalledWith(
       '/organizations/org-slug/issues/1337/comments/',
@@ -205,7 +205,7 @@ describe('StreamlinedActivitySection', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Comment Actions'}));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Edit'}));
 
-    await userEvent.type(screen.getByRole('textbox', {name: 'Edit comment'}), ' Updated');
+    await userEvent.type(screen.getByDisplayValue('Group Test'), ' Updated');
     await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
 
     expect(editMock).not.toHaveBeenCalled();
@@ -215,7 +215,7 @@ describe('StreamlinedActivitySection', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Comment Actions'}));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Edit'}));
 
-    await userEvent.type(screen.getByRole('textbox', {name: 'Edit comment'}), ' Updated');
+    await userEvent.type(screen.getByDisplayValue('Group Test'), ' Updated');
     await userEvent.click(screen.getByRole('button', {name: 'Save comment'}));
 
     expect(editMock).toHaveBeenCalledTimes(1);
@@ -321,7 +321,7 @@ describe('StreamlinedActivitySection', () => {
       project,
     });
 
-    render(<StreamlinedActivitySection group={updatedActivityGroup} isDrawer />);
+    render(<StreamlinedActivitySection group={updatedActivityGroup} variant="drawer" />);
 
     for (const activity of activities) {
       expect(
@@ -329,7 +329,7 @@ describe('StreamlinedActivitySection', () => {
       ).toBeInTheDocument();
     }
 
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByText('View 4 more')).not.toBeInTheDocument();
   });
 
   it('filters comments correctly', async () => {
@@ -357,7 +357,11 @@ describe('StreamlinedActivitySection', () => {
     });
 
     render(
-      <StreamlinedActivitySection group={updatedActivityGroup} isDrawer filterComments />
+      <StreamlinedActivitySection
+        group={updatedActivityGroup}
+        variant="drawer"
+        filterComments
+      />
     );
 
     for (const activity of activities) {

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Grid} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -53,10 +53,12 @@ function TimelineItem({
   group,
   teams,
   isDrawer,
+  inputVariant,
 }: {
   group: Group;
   handleDelete: (item: GroupActivity) => void;
   handleUpdate: (item: GroupActivity, n: NoteType) => void;
+  inputVariant: 'compact' | 'full';
   item: GroupActivity;
   teams: Team[];
   isDrawer?: boolean;
@@ -109,10 +111,11 @@ function TimelineItem({
       }
     >
       {item.type === GroupActivityType.NOTE && editing ? (
-        <NoteInputWithStorage
+        <ActivityNoteInput
           itemKey={item.id}
           storageKey={`groupinput:${item.id}`}
-          source="issue-details"
+          minHeight={96}
+          variant={inputVariant}
           text={item.data.text}
           noteId={item.id}
           onUpdate={n => {
@@ -132,23 +135,45 @@ function TimelineItem({
   );
 }
 
+function ActivityNoteInput(props: React.ComponentProps<typeof NoteInputWithStorage>) {
+  return (
+    <ActivityInputFrame data-test-id="activity-input-frame">
+      <NoteInputWithStorage {...props} />
+    </ActivityInputFrame>
+  );
+}
+
 interface StreamlinedActivitySectionProps {
   group: Group;
   /**
    * Whether to filter the activity to only show comments.
    */
   filterComments?: boolean;
+  minHeight?: number;
+  onCreate?: (n: NoteType, me: User) => void;
+  onDelete?: (item: GroupActivity) => void;
+  onUpdate?: (item: GroupActivity, n: NoteType) => void;
+  placeholder?: string;
   /**
-   * Whether the activity section is being rendered in the activity drawer.
-   * Disables collapse feature, and hides headers
+   * Controls layout and input style.
+   * - `sidebar` (default): fold section, compact input, collapses at 5 items
+   * - `drawer`: full input, no collapse, larger text
+   * - `inline`: full input, no collapse
+   * TODO: Revisit whether `drawer` and `inline` should be one variant with
+   * an explicit density/text-size option after the feedback activity split.
    */
-  isDrawer?: boolean;
+  variant?: 'sidebar' | 'drawer' | 'inline';
 }
 
 export function StreamlinedActivitySection({
   group,
-  isDrawer,
   filterComments,
+  onCreate: onCreateProp,
+  onDelete: onDeleteProp,
+  onUpdate: onUpdateProp,
+  variant = 'sidebar',
+  minHeight = 96,
+  placeholder = t('Add a comment\u2026'),
 }: StreamlinedActivitySectionProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -160,10 +185,10 @@ export function StreamlinedActivitySection({
   const activeUser = useUser();
   const projectSlugs = group?.project ? [group.project.slug] : [];
   const noteProps = {
-    minHeight: 140,
+    minHeight,
     group,
     projectSlugs,
-    placeholder: t('Add a comment\u2026'),
+    placeholder,
   };
 
   const mutators = useMutateActivity({
@@ -173,6 +198,11 @@ export function StreamlinedActivitySection({
 
   const handleDelete = useCallback(
     (item: GroupActivity) => {
+      if (onDeleteProp) {
+        onDeleteProp(item);
+        return;
+      }
+
       const restore = group.activity.find(activity => activity.id === item.id);
       const index = GroupStore.removeActivity(group.id, item.id);
 
@@ -198,11 +228,16 @@ export function StreamlinedActivitySection({
         }
       );
     },
-    [group.activity, mutators, group.id, organization]
+    [onDeleteProp, group.activity, mutators, group.id, organization]
   );
 
   const handleUpdate = useCallback(
     (item: GroupActivity, n: NoteType) => {
+      if (onUpdateProp) {
+        onUpdateProp(item, n);
+        return;
+      }
+
       mutators.handleUpdate(n, item.id, group.activity, {
         onError: () => {
           addErrorMessage(t('Unable to update comment'));
@@ -219,10 +254,15 @@ export function StreamlinedActivitySection({
         },
       });
     },
-    [group.activity, mutators, group.id, organization]
+    [onUpdateProp, group.activity, mutators, group.id, organization]
   );
 
-  const handleCreate = (n: NoteType, _me: User) => {
+  const handleCreate = (n: NoteType, me: User) => {
+    if (onCreateProp) {
+      onCreateProp(n, me);
+      return;
+    }
+
     mutators.handleCreate(n, group.activity, {
       onError: err => {
         const errMessage = err.responseJSON?.detail
@@ -255,36 +295,55 @@ export function StreamlinedActivitySection({
     ? group.activity
     : group.activity.filter(item => !SEER_ACTIVITY_TYPES.has(item.type));
 
-  return isDrawer ? (
-    <Timeline.Container>
-      <NoteInputWithStorage
-        key={inputId}
-        storageKey="groupinput:latest"
-        itemKey={group.id}
-        onCreate={n => {
-          handleCreate(n, activeUser);
-          setInputId(uniqueId());
-        }}
-        source="issue-details"
-        {...noteProps}
-      />
-      {visibleActivities
-        .filter(item => !filterComments || item.type === GroupActivityType.NOTE)
-        .map(item => {
-          return (
-            <TimelineItem
-              item={item}
-              handleDelete={handleDelete}
-              handleUpdate={handleUpdate}
-              group={group}
-              teams={teams}
-              key={item.id}
-              isDrawer={isDrawer}
-            />
-          );
-        })}
+  const filteredActivities = visibleActivities.filter(
+    item => !filterComments || item.type === GroupActivityType.NOTE
+  );
+  const isDrawer = variant === 'drawer';
+  const inputVariant = variant === 'sidebar' ? 'compact' : 'full';
+
+  const renderActivityItem = (item: GroupActivity) => (
+    <TimelineItem
+      item={item}
+      handleDelete={handleDelete}
+      handleUpdate={handleUpdate}
+      group={group}
+      teams={teams}
+      key={item.id}
+      isDrawer={isDrawer}
+      inputVariant={inputVariant}
+    />
+  );
+
+  const noteInput = (
+    <ActivityNoteInput
+      key={inputId}
+      storageKey="groupinput:latest"
+      itemKey={group.id}
+      onCreate={n => {
+        handleCreate(n, activeUser);
+        setInputId(uniqueId());
+      }}
+      variant={inputVariant}
+      {...noteProps}
+    />
+  );
+
+  const timeline = (
+    <Timeline.Container data-test-id="activity-timeline">
+      {filteredActivities.map(renderActivityItem)}
     </Timeline.Container>
-  ) : (
+  );
+
+  if (variant !== 'sidebar') {
+    return (
+      <Grid gap="xl">
+        {noteInput}
+        {timeline}
+      </Grid>
+    );
+  }
+
+  return (
     <SidebarFoldSection
       title={
         <SidebarSectionTitle style={{gap: theme.space.sm, margin: 0}}>
@@ -293,71 +352,37 @@ export function StreamlinedActivitySection({
       }
       sectionKey={SectionKey.ACTIVITY}
     >
-      <Timeline.Container>
-        <NoteInputWithStorage
-          key={inputId}
-          storageKey="groupinput:latest"
-          itemKey={group.id}
-          onCreate={n => {
-            handleCreate(n, activeUser);
-            setInputId(uniqueId());
-          }}
-          source="issue-details"
-          {...noteProps}
-        />
-        {visibleActivities.length < 5 ? (
-          visibleActivities
-            .filter(item => !filterComments || item.type === GroupActivityType.NOTE)
-            .map(item => {
-              return (
-                <TimelineItem
-                  item={item}
-                  handleDelete={handleDelete}
-                  handleUpdate={handleUpdate}
-                  group={group}
-                  teams={teams}
-                  key={item.id}
-                  isDrawer={isDrawer}
-                />
-              );
-            })
-        ) : (
-          <Fragment>
-            {visibleActivities.slice(0, 3).map(item => {
-              return (
-                <TimelineItem
-                  item={item}
-                  handleDelete={handleDelete}
-                  handleUpdate={handleUpdate}
-                  group={group}
-                  teams={teams}
-                  key={item.id}
-                  isDrawer={isDrawer}
-                />
-              );
-            })}
-            <ActivityTimelineItem
-              title={
-                <LinkButton
-                  aria-label={t('View all activity')}
-                  to={activityLink}
-                  size="xs"
-                  replace
-                  preventScrollReset
-                  analyticsEventKey="issue_details.activity_expanded"
-                  analyticsEventName="Issue Details: Activity Expanded"
-                  analyticsParams={{
-                    num_activities_hidden: visibleActivities.length - 3,
-                  }}
-                >
-                  {t('View %s more', visibleActivities.length - 3)}
-                </LinkButton>
-              }
-              icon={<RotatedEllipsisIcon direction="up" />}
-            />
-          </Fragment>
-        )}
-      </Timeline.Container>
+      <Grid gap="lg">
+        {noteInput}
+        <Timeline.Container data-test-id="activity-timeline">
+          {filteredActivities.length < 5 ? (
+            filteredActivities.map(renderActivityItem)
+          ) : (
+            <Fragment>
+              {filteredActivities.slice(0, 3).map(renderActivityItem)}
+              <ActivityTimelineItem
+                title={
+                  <LinkButton
+                    aria-label={t('View all activity')}
+                    to={activityLink}
+                    size="xs"
+                    replace
+                    preventScrollReset
+                    analyticsEventKey="issue_details.activity_expanded"
+                    analyticsEventName="Issue Details: Activity Expanded"
+                    analyticsParams={{
+                      num_activities_hidden: filteredActivities.length - 3,
+                    }}
+                  >
+                    {t('View %s more', filteredActivities.length - 3)}
+                  </LinkButton>
+                }
+                icon={<RotatedEllipsisIcon direction="up" />}
+              />
+            </Fragment>
+          )}
+        </Timeline.Container>
+      </Grid>
     </SidebarFoldSection>
   );
 }
@@ -394,4 +419,8 @@ const NoteWrapper = styled('div')<{isDrawer?: boolean}>`
 
 const MessageWrapper = styled('div')<{isDrawer?: boolean}>`
   font-size: ${p => (p.isDrawer ? p.theme.font.size.md : p.theme.font.size.sm)};
+`;
+
+const ActivityInputFrame = styled('div')`
+  color: ${p => p.theme.tokens.content.primary};
 `;


### PR DESCRIPTION
smaller pr than #115616 consolidates the activity inputs, uses our new Form components. 

- Controls appear after focusing the input like we currently do in the activity drawer
- brings back the "preview" and markdown supported indicators

activity drawer before

<img width="1250" height="313" alt="image" src="https://github.com/user-attachments/assets/2fb8ba74-7125-4f74-95d7-c025b2874484" />

activity drawer after

<img width="1132" height="371" alt="image" src="https://github.com/user-attachments/assets/96df63fe-fade-4559-95ba-bc748f62cff1" />

feedback before

<img width="786" height="293" alt="image" src="https://github.com/user-attachments/assets/219098cc-b13f-4614-9955-5c3f0eab285c" />

feedback after

<img width="802" height="242" alt="image" src="https://github.com/user-attachments/assets/1b2e9ff4-7af9-4f40-83c4-62e0a8363c98" />

