### PR TITLE
fix(explore): pymark fail on test for arrays in detail endpoint

### DIFF
--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -167,6 +167,12 @@ class ProjectTraceItemDetailsEndpointTest(
             + "Z",
         }
 
+    @pytest.mark.xfail(
+        reason=(
+            "On snuba, attributes_array JSON column is no longer read on the trace-item-details hot path "
+            "and stack.* array attributes are not returned"
+        ),
+    )
     def test_details_exposes_arrays(self) -> None:
         event_id = uuid.uuid4().hex
         group = self.create_group(project=self.project)


### PR DESCRIPTION
Disable array related test  for TraceItemDetails endpoint, as arrays in EAP are going behind FF.