### PR TITLE
feat(cells): Remove cross-org feature gating from notification settings

### DIFF
--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -55,10 +55,3 @@ export const NOTIFICATION_SETTINGS_PATHNAMES: Record<NotificationSettingsType, s
   spikeProtection: 'spike-protection',
   brokenMonitors: 'broken-monitors',
 };
-
-export const NOTIFICATION_FEATURE_MAP: Partial<
-  Record<NotificationSettingsType, string | string[]>
-> = {
-  quota: ['spend-visibility-notifications', 'user-spend-notifications-settings'],
-  spikeProtection: 'spike-projections',
-};

--- a/static/app/views/settings/account/notifications/notificationSettings.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.spec.tsx
@@ -1,9 +1,5 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {NOTIFICATION_SETTING_FIELDS} from 'sentry/views/settings/account/notifications/fields';
 import {NotificationSettings} from 'sentry/views/settings/account/notifications/notificationSettings';
 
@@ -20,14 +16,10 @@ function renderMockRequests() {
 
 describe('NotificationSettings', () => {
   it('should render', async () => {
-    const {organization} = initializeOrg();
-    OrganizationsStore.load([organization]);
-
     renderMockRequests();
 
     render(<NotificationSettings />);
 
-    // There are 8 notification setting Selects/Toggles.
     for (const field of [
       'alerts',
       'workflow',
@@ -37,63 +29,13 @@ describe('NotificationSettings', () => {
       'email',
       'personalActivityNotifications',
       'selfAssignOnResolve',
-    ] as const) {
-      expect(
-        await screen.findByText(String(NOTIFICATION_SETTING_FIELDS[field].label))
-      ).toBeInTheDocument();
-    }
-    expect(screen.getByText('Issue Alerts')).toBeInTheDocument();
-  });
-
-  it('renders quota section with feature flag', async () => {
-    const {organization} = initializeOrg({
-      organization: {
-        features: ['user-spend-notifications-settings'],
-      },
-    });
-    OrganizationsStore.load([organization]);
-
-    renderMockRequests();
-
-    render(<NotificationSettings />);
-
-    // There are 9 notification setting Selects/Toggles.
-
-    for (const field of [
-      'alerts',
-      'workflow',
-      'deploy',
-      'approval',
-      'reports',
-      'email',
       'quota',
-      'personalActivityNotifications',
-      'selfAssignOnResolve',
+      'spikeProtection',
     ] as const) {
       expect(
         await screen.findByText(String(NOTIFICATION_SETTING_FIELDS[field].label))
       ).toBeInTheDocument();
     }
     expect(screen.getByText('Issue Alerts')).toBeInTheDocument();
-  });
-
-  it('renders spend section instead of quota section with feature flag', async () => {
-    const {organization} = initializeOrg({
-      organization: {
-        features: ['user-spend-notifications-settings', 'spend-visibility-notifications'],
-      },
-    });
-
-    const organizationNoFlag = OrganizationFixture();
-    organizationNoFlag.features.push('user-spend-notifications-settings');
-    OrganizationsStore.load([organization, organizationNoFlag]);
-
-    renderMockRequests();
-
-    render(<NotificationSettings />);
-
-    expect(await screen.findByText('Spend')).toBeInTheDocument();
-
-    expect(screen.queryByText('Quota')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/account/notifications/notificationSettings.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.spec.tsx
@@ -1,5 +1,6 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {ConfigStore} from 'sentry/stores/configStore';
 import {NOTIFICATION_SETTING_FIELDS} from 'sentry/views/settings/account/notifications/fields';
 import {NotificationSettings} from 'sentry/views/settings/account/notifications/notificationSettings';
 
@@ -37,5 +38,19 @@ describe('NotificationSettings', () => {
       ).toBeInTheDocument();
     }
     expect(screen.getByText('Issue Alerts')).toBeInTheDocument();
+  });
+
+  it('hides quota notifications on self-hosted', async () => {
+    ConfigStore.set('isSelfHosted', true);
+    renderMockRequests();
+
+    render(<NotificationSettings />);
+
+    expect(
+      await screen.findByText(String(NOTIFICATION_SETTING_FIELDS.alerts.label))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(String(NOTIFICATION_SETTING_FIELDS.quota.label))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -15,13 +15,10 @@ import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import {OrganizationsStore} from 'sentry/stores/organizationsStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation, setApiQueryData, useApiQuery} from 'sentry/utils/queryClient';
 import type {NotificationSettingsType} from 'sentry/views/settings/account/notifications/constants';
 import {
-  NOTIFICATION_FEATURE_MAP,
   NOTIFICATION_SETTINGS_PATHNAMES,
   NOTIFICATION_SETTINGS_TYPES,
 } from 'sentry/views/settings/account/notifications/constants';
@@ -40,28 +37,10 @@ const notificationSchema = z.object({
 type NotificationFields = z.infer<typeof notificationSchema>;
 
 export function NotificationSettings() {
-  const {organizations} = useLegacyStore(OrganizationsStore);
   const queryClient = useQueryClient();
-  const checkFeatureFlag = (flag: string) => {
-    return organizations.some(org => org.features?.includes(flag));
-  };
-  const notificationFields = NOTIFICATION_SETTINGS_TYPES.filter(type => {
-    const notificationFlag = NOTIFICATION_FEATURE_MAP[type];
-    if (Array.isArray(notificationFlag)) {
-      return notificationFlag.some(flag => checkFeatureFlag(flag));
-    }
-    if (notificationFlag) {
-      return checkFeatureFlag(notificationFlag);
-    }
-    return true;
-  });
 
   const renderOneSetting = (type: NotificationSettingsType) => {
     const field = NOTIFICATION_SETTING_FIELDS[type];
-    if (type === 'quota' && checkFeatureFlag('spend-visibility-notifications')) {
-      field.label = t('Spend');
-      field.help = t('Notifications that help avoid surprise invoices.');
-    }
     return (
       <FieldWrapper key={type}>
         <div>
@@ -125,7 +104,7 @@ export function NotificationSettings() {
         {isError && <LoadingError onRetry={refetch} />}
         <Panel>
           <PanelHeader>{t('Notification')}</PanelHeader>
-          <PanelBody>{notificationFields.map(renderOneSetting)}</PanelBody>
+          <PanelBody>{NOTIFICATION_SETTINGS_TYPES.map(renderOneSetting)}</PanelBody>
         </Panel>
         {isPending && <LoadingIndicator />}
         {initialData && (

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -15,6 +15,7 @@ import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
+import {ConfigStore} from 'sentry/stores/configStore';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation, setApiQueryData, useApiQuery} from 'sentry/utils/queryClient';
 import type {NotificationSettingsType} from 'sentry/views/settings/account/notifications/constants';
@@ -38,6 +39,11 @@ type NotificationFields = z.infer<typeof notificationSchema>;
 
 export function NotificationSettings() {
   const queryClient = useQueryClient();
+
+  const isSelfHosted = ConfigStore.get('isSelfHosted');
+  const notificationFields = NOTIFICATION_SETTINGS_TYPES.filter(
+    type => !(type === 'quota' && isSelfHosted)
+  );
 
   const renderOneSetting = (type: NotificationSettingsType) => {
     const field = NOTIFICATION_SETTING_FIELDS[type];
@@ -104,7 +110,7 @@ export function NotificationSettings() {
         {isError && <LoadingError onRetry={refetch} />}
         <Panel>
           <PanelHeader>{t('Notification')}</PanelHeader>
-          <PanelBody>{NOTIFICATION_SETTINGS_TYPES.map(renderOneSetting)}</PanelBody>
+          <PanelBody>{notificationFields.map(renderOneSetting)}</PanelBody>
         </Panel>
         {isPending && <LoadingIndicator />}
         {initialData && (


### PR DESCRIPTION
NotificationSettings is a per-user account page, but it was deciding which entries to show by reading feature flags off every org in OrganizationsStore — "does *any* of my orgs have feature X?" — to toggle the quota and spikeProtection entries and to relabel "Quota" as "Spend".

There are two main reasons to move away from this model:
- Features are org-scoped state, not user-scoped. Folding them across all of a user's orgs via .some() produces gates that don't reflect what any specific org can do. A single privileged membership flips the gate for all orgs the user belongs to.
- The store is fed from the /organizations/ listing, which is moving to the control silo as part of the cellularization work. The `features` list is not available through that endpoint without an expensive cross-cell fan-out so this data will not be available in control.

This change now shows the "quota" and "spike protection" options unconditionally in the UI regardless of org membership in saas deployments. They are not shown in self-hosted and dev.

