### PR TITLE
ref(onboarding): Convert CreateSampleEventButton to functional component

### DIFF
--- a/static/app/components/waitingForEvents.tsx
+++ b/static/app/components/waitingForEvents.tsx
@@ -10,7 +10,7 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import CreateSampleEventButton from 'sentry/views/onboarding/createSampleEventButton';
+import {CreateSampleEventButton} from 'sentry/views/onboarding/createSampleEventButton';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 type Props = {

--- a/static/app/views/onboarding/components/firstEventFooter.tsx
+++ b/static/app/views/onboarding/components/firstEventFooter.tsx
@@ -16,7 +16,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useExperiment} from 'sentry/utils/useExperiment';
-import CreateSampleEventButton from 'sentry/views/onboarding/createSampleEventButton';
+import {CreateSampleEventButton} from 'sentry/views/onboarding/createSampleEventButton';
 import {useOnboardingSidebar} from 'sentry/views/onboarding/useOnboardingSidebar';
 
 import {GridFooter} from './genericFooter';

--- a/static/app/views/onboarding/createSampleEventButton.spec.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.spec.tsx
@@ -5,7 +5,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
-import CreateSampleEventButton from 'sentry/views/onboarding/createSampleEventButton';
+import {CreateSampleEventButton} from 'sentry/views/onboarding/createSampleEventButton';
 
 jest.useFakeTimers();
 jest.mock('sentry/utils/analytics');
@@ -42,30 +42,20 @@ describe('CreateSampleEventButton', () => {
       body: {groupID},
     });
 
-    const sampleButton = await screen.findByRole('button', {name: createSampleText});
-    await userEvent.click(sampleButton, {delay: null});
-
-    // The button should be disabled while creating the event
-    expect(sampleButton).toBeDisabled();
-
-    // We have to await the API calls. We could normally do this using tick(),
-    // however since we have enabled fake timers to handle the spin-wait on the
-    // event creation, we cannot use tick.
-    await Promise.resolve();
-    expect(createRequest).toHaveBeenCalled();
-
     const latestIssueRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
       body: {},
     });
 
-    // There is a timeout before we check for the existence of the latest
-    // event. Wait for it then wait for the request to complete
-    jest.runAllTimers();
+    const sampleButton = await screen.findByRole('button', {name: createSampleText});
+    await userEvent.click(sampleButton, {delay: null});
+
+    expect(sampleButton).toBeDisabled();
+
+    await waitFor(() => expect(createRequest).toHaveBeenCalled());
     await waitFor(() => expect(latestIssueRequest).toHaveBeenCalled());
 
-    // Wait for the api request and latestEventAvailable to resolve
-    expect(sampleButton).toBeEnabled();
+    await waitFor(() => expect(sampleButton).toBeEnabled());
 
     expect(router.location).toEqual(
       expect.objectContaining({
@@ -84,6 +74,10 @@ describe('CreateSampleEventButton', () => {
       url: `/projects/${org.slug}/${project.slug}/create-sample/`,
       method: 'POST',
       body: {groupID},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
+      body: {},
     });
 
     await userEvent.click(await screen.findByRole('button', {name: createSampleText}), {
@@ -116,6 +110,10 @@ describe('CreateSampleEventButton', () => {
       method: 'POST',
       body: {groupID},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
+      body: {},
+    });
 
     await userEvent.click(await screen.findByRole('button', {name: createSampleText}), {
       delay: null,
@@ -139,33 +137,31 @@ describe('CreateSampleEventButton', () => {
       body: {groupID},
     });
 
-    await userEvent.click(await screen.findByRole('button', {name: createSampleText}), {
-      delay: null,
-    });
-
-    await waitFor(() => expect(createRequest).toHaveBeenCalled());
-
-    // Start with no latest event
-    let latestIssueRequest = MockApiClient.addMockResponse({
+    // The first request will 404 — useQuery fires immediately after groupID is set
+    const latestIssueRequest404 = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
       statusCode: 404,
       body: {},
     });
 
-    // Wait for the timeout once, the first request will 404
-    jest.runAllTimers();
-    await waitFor(() => expect(latestIssueRequest).toHaveBeenCalled());
+    await userEvent.click(await screen.findByRole('button', {name: createSampleText}), {
+      delay: null,
+    });
 
-    // Second request will be successful
+    await waitFor(() => expect(createRequest).toHaveBeenCalled());
+    await waitFor(() => expect(latestIssueRequest404).toHaveBeenCalled());
+
+    // Set up 200 response for the retry
     MockApiClient.clearMockResponses();
-    latestIssueRequest = MockApiClient.addMockResponse({
+    const latestIssueRequest200 = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
       statusCode: 200,
       body: {},
     });
 
-    jest.runAllTimers();
-    await waitFor(() => expect(latestIssueRequest).toHaveBeenCalled());
+    // Advance past the retryDelay so useQuery retries
+    jest.advanceTimersByTime(EVENT_POLL_INTERVAL);
+    await waitFor(() => expect(latestIssueRequest200).toHaveBeenCalled());
 
     expect(router.location).toEqual(
       expect.objectContaining({
@@ -192,3 +188,5 @@ describe('CreateSampleEventButton', () => {
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 });
+
+const EVENT_POLL_INTERVAL = 1000;

--- a/static/app/views/onboarding/createSampleEventButton.spec.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.spec.tsx
@@ -2,12 +2,11 @@ import * as Sentry from '@sentry/react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {CreateSampleEventButton} from 'sentry/views/onboarding/createSampleEventButton';
 
-jest.useFakeTimers();
 jest.mock('sentry/utils/analytics');
 
 describe('CreateSampleEventButton', () => {
@@ -36,13 +35,13 @@ describe('CreateSampleEventButton', () => {
 
   it('creates a sample event', async () => {
     const {router} = renderComponent();
-    const createRequest = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/create-sample/`,
       method: 'POST',
       body: {groupID},
     });
 
-    const latestIssueRequest = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
       body: {},
     });
@@ -50,21 +49,16 @@ describe('CreateSampleEventButton', () => {
     const sampleButton = await screen.findByRole('button', {name: createSampleText});
     await userEvent.click(sampleButton, {delay: null});
 
-    expect(sampleButton).toBeDisabled();
-
-    await waitFor(() => expect(createRequest).toHaveBeenCalled());
-    await waitFor(() => expect(latestIssueRequest).toHaveBeenCalled());
-
-    await waitFor(() => expect(sampleButton).toBeEnabled());
-
-    expect(router.location).toEqual(
-      expect.objectContaining({
-        pathname: `/organizations/${org.slug}/issues/${groupID}/`,
-        query: expect.objectContaining({
-          project: project.id,
-          referrer: 'sample-error',
-        }),
-      })
+    await waitFor(() =>
+      expect(router.location).toEqual(
+        expect.objectContaining({
+          pathname: `/organizations/${org.slug}/issues/${groupID}/`,
+          query: expect.objectContaining({
+            project: project.id,
+            referrer: 'sample-error',
+          }),
+        })
+      )
     );
   });
 
@@ -84,9 +78,11 @@ describe('CreateSampleEventButton', () => {
       delay: null,
     });
 
-    expect(trackAnalytics).toHaveBeenCalledWith(
-      'growth.onboarding_view_sample_event',
-      expect.objectContaining({platform: 'javascript'})
+    await waitFor(() =>
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'growth.onboarding_view_sample_event',
+        expect.objectContaining({platform: 'javascript'})
+      )
     );
     expect(trackAnalytics).not.toHaveBeenCalledWith(
       'onboarding.scm_view_sample_event_clicked',
@@ -119,9 +115,11 @@ describe('CreateSampleEventButton', () => {
       delay: null,
     });
 
-    expect(trackAnalytics).toHaveBeenCalledWith(
-      'onboarding.scm_view_sample_event_clicked',
-      expect.objectContaining({platform: 'javascript'})
+    await waitFor(() =>
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'onboarding.scm_view_sample_event_clicked',
+        expect.objectContaining({platform: 'javascript'})
+      )
     );
     expect(trackAnalytics).not.toHaveBeenCalledWith(
       'growth.onboarding_view_sample_event',
@@ -130,6 +128,7 @@ describe('CreateSampleEventButton', () => {
   });
 
   it('waits for the latest event to be processed', async () => {
+    jest.useFakeTimers();
     const {router} = renderComponent();
     const createRequest = MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/create-sample/`,
@@ -137,8 +136,8 @@ describe('CreateSampleEventButton', () => {
       body: {groupID},
     });
 
-    // The first request will 404 — useQuery fires immediately after groupID is set
-    const latestIssueRequest404 = MockApiClient.addMockResponse({
+    // Start with 404 — fetchQuery will retry after retryDelay
+    let latestIssueRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
       statusCode: 404,
       body: {},
@@ -149,28 +148,33 @@ describe('CreateSampleEventButton', () => {
     });
 
     await waitFor(() => expect(createRequest).toHaveBeenCalled());
-    await waitFor(() => expect(latestIssueRequest404).toHaveBeenCalled());
 
-    // Set up 200 response for the retry
+    // fetchQuery fires immediately — wait for the first (404) attempt
+    await waitFor(() => expect(latestIssueRequest).toHaveBeenCalled());
+
+    // Set up 200 for the retry
     MockApiClient.clearMockResponses();
-    const latestIssueRequest200 = MockApiClient.addMockResponse({
+    latestIssueRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/issues/${groupID}/events/latest/`,
       statusCode: 200,
       body: {},
     });
 
-    // Advance past the retryDelay so useQuery retries
-    jest.advanceTimersByTime(EVENT_POLL_INTERVAL);
-    await waitFor(() => expect(latestIssueRequest200).toHaveBeenCalled());
+    // Advance past the retry delay so fetchQuery retries, wrapped in act
+    // to capture the navigate state update from onSuccess
+    await act(() => jest.advanceTimersByTimeAsync(EVENT_POLL_INTERVAL));
+    await waitFor(() => expect(latestIssueRequest).toHaveBeenCalled());
 
-    expect(router.location).toEqual(
-      expect.objectContaining({
-        pathname: `/organizations/${org.slug}/issues/${groupID}/`,
-        query: expect.objectContaining({
-          project: project.id,
-          referrer: 'sample-error',
-        }),
-      })
+    await waitFor(() =>
+      expect(router.location).toEqual(
+        expect.objectContaining({
+          pathname: `/organizations/${org.slug}/issues/${groupID}/`,
+          query: expect.objectContaining({
+            project: project.id,
+            referrer: 'sample-error',
+          }),
+        })
+      )
     );
 
     expect(trackAnalytics).toHaveBeenCalledWith(
@@ -186,6 +190,8 @@ describe('CreateSampleEventButton', () => {
     );
 
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
   });
 });
 

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import * as Sentry from '@sentry/react';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
@@ -41,6 +41,13 @@ export function CreateSampleEventButton({
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const organization = useOrganization();
+  const pollingAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      pollingAbortRef.current?.abort();
+    };
+  }, []);
 
   useEffect(() => {
     if (project) {
@@ -81,6 +88,10 @@ export function CreateSampleEventButton({
       });
     },
     onSuccess({groupID}) {
+      pollingAbortRef.current?.abort();
+      const abortController = new AbortController();
+      pollingAbortRef.current = abortController;
+
       const t0 = performance.now();
       let retries = 0;
 
@@ -98,12 +109,18 @@ export function CreateSampleEventButton({
             }
           ),
           retry(failureCount) {
+            if (abortController.signal.aborted) {
+              return false;
+            }
             retries = failureCount + 1;
             return failureCount < EVENT_POLL_RETRIES;
           },
           retryDelay: EVENT_POLL_INTERVAL,
         })
         .then(() => {
+          if (abortController.signal.aborted) {
+            return;
+          }
           clearIndicators();
 
           trackAnalytics('sample_event.created', {
@@ -125,6 +142,9 @@ export function CreateSampleEventButton({
           );
         })
         .catch(() => {
+          if (abortController.signal.aborted) {
+            return;
+          }
           clearIndicators();
 
           const duration = Math.ceil(performance.now() - t0);

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -53,48 +53,9 @@ export function CreateSampleEventButton({
   }, [organization, project, source]);
 
   const {mutate: createSampleGroup, isPending} = useMutation({
-    mutationFn: async () => {
+    mutationFn: () => {
       const url = `/projects/${organization.slug}/${project!.slug}/create-sample/`;
-      const {groupID: newGroupID} = await fetchMutation<{groupID: string}>({
-        method: 'POST',
-        url,
-      });
-
-      const t0 = performance.now();
-      let retries = 0;
-      try {
-        await queryClient.fetchQuery({
-          ...apiOptions.as<unknown>()(
-            '/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/',
-            {
-              path: {
-                organizationIdOrSlug: organization.slug,
-                issueId: newGroupID,
-                eventId: 'latest',
-              },
-              staleTime: 0,
-            }
-          ),
-          retry(failureCount) {
-            retries = failureCount + 1;
-            return failureCount < EVENT_POLL_RETRIES;
-          },
-          retryDelay: EVENT_POLL_INTERVAL,
-        });
-        return {
-          eventCreated: true,
-          retries,
-          duration: Math.ceil(performance.now() - t0),
-          groupID: newGroupID,
-        };
-      } catch {
-        return {
-          eventCreated: false,
-          retries,
-          duration: Math.ceil(performance.now() - t0),
-          groupID: newGroupID,
-        };
-      }
+      return fetchMutation<{groupID: string}>({method: 'POST', url});
     },
     onMutate() {
       if (!project) {
@@ -119,42 +80,77 @@ export function CreateSampleEventButton({
         duration: EVENT_POLL_RETRIES * EVENT_POLL_INTERVAL,
       });
     },
-    onSuccess({eventCreated, retries, duration, groupID}) {
-      clearIndicators();
+    onSuccess({groupID}) {
+      const t0 = performance.now();
+      let retries = 0;
 
-      trackAnalytics(`sample_event.${eventCreated ? 'created' : 'failed'}` as const, {
-        organization,
-        project_id: project!.id,
-        platform: project!.platform || '',
-        interval: EVENT_POLL_INTERVAL,
-        retries,
-        duration,
-        source,
-      });
+      queryClient
+        .fetchQuery({
+          ...apiOptions.as<unknown>()(
+            '/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/',
+            {
+              path: {
+                organizationIdOrSlug: organization.slug,
+                issueId: groupID,
+                eventId: 'latest',
+              },
+              staleTime: 0,
+            }
+          ),
+          retry(failureCount) {
+            retries = failureCount + 1;
+            return failureCount < EVENT_POLL_RETRIES;
+          },
+          retryDelay: EVENT_POLL_INTERVAL,
+        })
+        .then(() => {
+          clearIndicators();
 
-      if (!eventCreated) {
-        addErrorMessage(t('Failed to load sample event'));
+          trackAnalytics('sample_event.created', {
+            organization,
+            project_id: project!.id,
+            platform: project!.platform || '',
+            interval: EVENT_POLL_INTERVAL,
+            retries,
+            duration: Math.ceil(performance.now() - t0),
+            source,
+          });
 
-        Sentry.withScope(scope => {
-          scope.setTag('groupID', groupID);
-          scope.setTag('platform', project!.platform || '');
-          scope.setTag('interval', EVENT_POLL_INTERVAL.toString());
-          scope.setTag('retries', retries.toString());
-          scope.setTag('duration', duration.toString());
+          onClick?.();
 
-          scope.setLevel('warning');
-          Sentry.captureMessage('Failed to load sample event');
+          navigate(
+            normalizeUrl(
+              `/organizations/${organization.slug}/issues/${groupID}/?project=${project!.id}&referrer=sample-error`
+            )
+          );
+        })
+        .catch(() => {
+          clearIndicators();
+
+          const duration = Math.ceil(performance.now() - t0);
+          trackAnalytics('sample_event.failed', {
+            organization,
+            project_id: project!.id,
+            platform: project!.platform || '',
+            interval: EVENT_POLL_INTERVAL,
+            retries,
+            duration,
+            source,
+          });
+
+          addErrorMessage(t('Failed to load sample event'));
+
+          Sentry.withScope(scope => {
+            scope.setTag('groupID', groupID);
+            scope.setTag('platform', project!.platform || '');
+            scope.setTag('interval', EVENT_POLL_INTERVAL.toString());
+            scope.setTag('retries', retries.toString());
+            scope.setTag('duration', duration.toString());
+
+            scope.setLevel('warning');
+            Sentry.captureMessage('Failed to load sample event');
+          });
         });
-        return;
-      }
-
-      onClick?.();
-
-      navigate(
-        normalizeUrl(
-          `/organizations/${organization.slug}/issues/${groupID}/?project=${project!.id}&referrer=sample-error`
-        )
-      );
     },
     onError(error) {
       Sentry.withScope(scope => {

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -1,5 +1,6 @@
-import {Component} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import * as Sentry from '@sentry/react';
+import {skipToken, useMutation, useQuery} from '@tanstack/react-query';
 
 import type {ButtonProps} from '@sentry/scraps/button';
 import {Button} from '@sentry/scraps/button';
@@ -9,19 +10,16 @@ import {
   addLoadingMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
-import type {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
-import {withApi} from 'sentry/utils/withApi';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 type CreateSampleEventButtonProps = ButtonProps & {
-  api: Client;
-  organization: Organization;
   source: string;
   hasScmOnboarding?: boolean;
   onClick?: () => void;
@@ -29,89 +27,124 @@ type CreateSampleEventButtonProps = ButtonProps & {
   project?: Project;
 };
 
-type State = {
-  creating: boolean;
-};
-
 const EVENT_POLL_RETRIES = 30;
 const EVENT_POLL_INTERVAL = 1000;
 
-async function latestEventAvailable(
-  api: Client,
-  orgSlug: string,
-  groupID: string
-): Promise<{eventCreated: boolean; retries: number}> {
-  let retries = 0;
+function CreateSampleEventButton({
+  source,
+  hasScmOnboarding,
+  onClick,
+  onCreateSampleGroup,
+  project,
+  ...buttonProps
+}: CreateSampleEventButtonProps) {
+  const navigate = useNavigate();
+  const organization = useOrganization();
+  const [groupID, setGroupID] = useState<string | null>(null);
+  const pollStartTime = useRef(0);
+  const retryCount = useRef(0);
 
-  while (true) {
-    if (retries > EVENT_POLL_RETRIES) {
-      return {eventCreated: false, retries: retries - 1};
+  useEffect(() => {
+    if (project) {
+      trackAnalytics('sample_event.button_viewed', {
+        organization,
+        project_id: project.id,
+        source,
+      });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const {mutateAsync: createSample} = useMutation({
+    mutationFn: () => {
+      const url = `/projects/${organization.slug}/${project!.slug}/create-sample/`;
+      return fetchMutation<{groupID: string}>({method: 'POST', url});
+    },
+  });
+
+  const {isSuccess, isError} = useQuery({
+    ...apiOptions.as<unknown>()(
+      '/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/',
+      {
+        path: groupID
+          ? {
+              organizationIdOrSlug: organization.slug,
+              issueId: groupID,
+              eventId: 'latest',
+            }
+          : skipToken,
+        staleTime: 0,
+      }
+    ),
+    retry(failureCount) {
+      retryCount.current = failureCount + 1;
+      return failureCount < EVENT_POLL_RETRIES;
+    },
+    retryDelay: EVENT_POLL_INTERVAL,
+  });
+
+  useEffect(() => {
+    if (!groupID || !project) {
+      return;
     }
 
-    await new Promise(resolve => window.setTimeout(resolve, EVENT_POLL_INTERVAL));
+    if (isSuccess) {
+      clearIndicators();
 
-    try {
-      await api.requestPromise(
-        `/organizations/${orgSlug}/issues/${groupID}/events/latest/`
+      const duration = Math.ceil(performance.now() - pollStartTime.current);
+      trackAnalytics('sample_event.created', {
+        organization,
+        project_id: project.id,
+        platform: project.platform || '',
+        interval: EVENT_POLL_INTERVAL,
+        retries: retryCount.current,
+        duration,
+        source,
+      });
+
+      onClick?.();
+
+      navigate(
+        normalizeUrl(
+          `/organizations/${organization.slug}/issues/${groupID}/?project=${project.id}&referrer=sample-error`
+        )
       );
-      return {eventCreated: true, retries};
-    } catch {
-      ++retries;
+
+      setGroupID(null);
+    } else if (isError) {
+      clearIndicators();
+
+      const retries = retryCount.current;
+      const duration = Math.ceil(performance.now() - pollStartTime.current);
+      trackAnalytics('sample_event.failed', {
+        organization,
+        project_id: project.id,
+        platform: project.platform || '',
+        interval: EVENT_POLL_INTERVAL,
+        retries,
+        duration,
+        source,
+      });
+
+      addErrorMessage(t('Failed to load sample event'));
+
+      Sentry.withScope(scope => {
+        scope.setTag('groupID', groupID);
+        scope.setTag('platform', project.platform || '');
+        scope.setTag('interval', EVENT_POLL_INTERVAL.toString());
+        scope.setTag('retries', retries.toString());
+        scope.setTag('duration', duration.toString());
+
+        scope.setLevel('warning');
+        Sentry.captureMessage('Failed to load sample event');
+      });
+
+      setGroupID(null);
     }
-  }
-}
+  }, [groupID, onClick, isSuccess, isError, navigate, organization, project, source]);
 
-class CreateSampleEventButton extends Component<CreateSampleEventButtonProps, State> {
-  state: State = {
-    creating: false,
-  };
+  const creating = groupID !== null;
 
-  componentDidMount() {
-    const {organization, project, source} = this.props;
-
-    if (!project) {
-      return;
-    }
-
-    trackAnalytics('sample_event.button_viewed', {
-      organization,
-      project_id: project.id,
-      source,
-    });
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
-  }
-
-  private _isMounted = true;
-
-  recordAnalytics({eventCreated, retries, duration}: any) {
-    const {organization, project, source} = this.props;
-
-    if (!project) {
-      return;
-    }
-
-    const eventKey = `sample_event.${eventCreated ? 'created' : 'failed'}` as const;
-
-    trackAnalytics(eventKey, {
-      organization,
-      project_id: project.id,
-      platform: project.platform || '',
-      interval: EVENT_POLL_INTERVAL,
-      retries,
-      duration,
-      source,
-    });
-  }
-
-  createSampleGroup = async () => {
-    // TODO(dena): swap out for action creator
-    const {api, organization, project, onCreateSampleGroup, hasScmOnboarding} =
-      this.props;
-    let eventData: any;
-
+  async function createSampleGroup() {
     if (!project) {
       return;
     }
@@ -133,90 +166,29 @@ class CreateSampleEventButton extends Component<CreateSampleEventButtonProps, St
     addLoadingMessage(t('Processing sample event...'), {
       duration: EVENT_POLL_RETRIES * EVENT_POLL_INTERVAL,
     });
-    this.setState({creating: true});
 
     try {
-      const url = `/projects/${organization.slug}/${project.slug}/create-sample/`;
-      eventData = await api.requestPromise(url, {method: 'POST'});
+      const eventData = await createSample();
+      pollStartTime.current = performance.now();
+      retryCount.current = 0;
+      setGroupID(eventData.groupID);
     } catch (error) {
       Sentry.withScope(scope => {
         scope.setExtra('error', error);
         Sentry.captureException(new Error('Failed to create sample event'));
       });
-      this.setState({creating: false});
       clearIndicators();
       addErrorMessage(t('Failed to create a new sample event'));
-      return;
     }
-
-    // Wait for the event to be fully processed and available on the group
-    // before redirecting.
-    const t0 = performance.now();
-    const {eventCreated, retries} = await latestEventAvailable(
-      api,
-      organization.slug,
-      eventData.groupID
-    );
-
-    // Navigated away before event was created - skip analytics and error messages
-    // latestEventAvailable will succeed even if the request was cancelled
-    if (!this._isMounted) {
-      return;
-    }
-
-    const t1 = performance.now();
-
-    clearIndicators();
-    this.setState({creating: false});
-
-    const duration = Math.ceil(t1 - t0);
-    this.recordAnalytics({eventCreated, retries, duration});
-
-    if (!eventCreated) {
-      addErrorMessage(t('Failed to load sample event'));
-
-      Sentry.withScope(scope => {
-        scope.setTag('groupID', eventData.groupID);
-        scope.setTag('platform', project.platform || '');
-        scope.setTag('interval', EVENT_POLL_INTERVAL.toString());
-        scope.setTag('retries', retries.toString());
-        scope.setTag('duration', duration.toString());
-
-        scope.setLevel('warning');
-        Sentry.captureMessage('Failed to load sample event');
-      });
-      return;
-    }
-
-    this.props.onClick?.();
-
-    browserHistory.push(
-      normalizeUrl(
-        `/organizations/${organization.slug}/issues/${eventData.groupID}/?project=${project.id}&referrer=sample-error`
-      )
-    );
-  };
-
-  render() {
-    const {
-      api: _api,
-      organization: _organization,
-      project: _project,
-      source: _source,
-      hasScmOnboarding: _hasScmOnboarding,
-      ...props
-    } = this.props;
-
-    const {creating} = this.state;
-
-    return (
-      <Button
-        {...props}
-        disabled={props.disabled || creating}
-        onClick={this.createSampleGroup}
-      />
-    );
   }
+
+  return (
+    <Button
+      {...buttonProps}
+      disabled={buttonProps.disabled || creating}
+      onClick={createSampleGroup}
+    />
+  );
 }
 
-export default withApi(withOrganization(CreateSampleEventButton));
+export {CreateSampleEventButton};

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -1,6 +1,6 @@
-import {useEffect, useRef, useState} from 'react';
+import {useEffect} from 'react';
 import * as Sentry from '@sentry/react';
-import {skipToken, useMutation, useQuery} from '@tanstack/react-query';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
 
 import type {ButtonProps} from '@sentry/scraps/button';
 import {Button} from '@sentry/scraps/button';
@@ -30,7 +30,7 @@ type CreateSampleEventButtonProps = ButtonProps & {
 const EVENT_POLL_RETRIES = 30;
 const EVENT_POLL_INTERVAL = 1000;
 
-function CreateSampleEventButton({
+export function CreateSampleEventButton({
   source,
   hasScmOnboarding,
   onClick,
@@ -38,11 +38,9 @@ function CreateSampleEventButton({
   project,
   ...buttonProps
 }: CreateSampleEventButtonProps) {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const organization = useOrganization();
-  const [groupID, setGroupID] = useState<string | null>(null);
-  const pollStartTime = useRef(0);
-  const retryCount = useRef(0);
 
   useEffect(() => {
     if (project) {
@@ -52,143 +50,127 @@ function CreateSampleEventButton({
         source,
       });
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [organization, project, source]);
 
-  const {mutateAsync: createSample} = useMutation({
-    mutationFn: () => {
+  const {mutate: createSampleGroup, isPending} = useMutation({
+    mutationFn: async () => {
       const url = `/projects/${organization.slug}/${project!.slug}/create-sample/`;
-      return fetchMutation<{groupID: string}>({method: 'POST', url});
-    },
-  });
-
-  const {isSuccess, isError} = useQuery({
-    ...apiOptions.as<unknown>()(
-      '/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/',
-      {
-        path: groupID
-          ? {
-              organizationIdOrSlug: organization.slug,
-              issueId: groupID,
-              eventId: 'latest',
-            }
-          : skipToken,
-        staleTime: 0,
-      }
-    ),
-    retry(failureCount) {
-      retryCount.current = failureCount + 1;
-      return failureCount < EVENT_POLL_RETRIES;
-    },
-    retryDelay: EVENT_POLL_INTERVAL,
-  });
-
-  useEffect(() => {
-    if (!groupID || !project) {
-      return;
-    }
-
-    if (isSuccess) {
-      clearIndicators();
-
-      const duration = Math.ceil(performance.now() - pollStartTime.current);
-      trackAnalytics('sample_event.created', {
-        organization,
-        project_id: project.id,
-        platform: project.platform || '',
-        interval: EVENT_POLL_INTERVAL,
-        retries: retryCount.current,
-        duration,
-        source,
+      const {groupID: newGroupID} = await fetchMutation<{groupID: string}>({
+        method: 'POST',
+        url,
       });
 
-      onClick?.();
+      const t0 = performance.now();
+      let retries = 0;
+      try {
+        await queryClient.fetchQuery({
+          ...apiOptions.as<unknown>()(
+            '/organizations/$organizationIdOrSlug/issues/$issueId/events/$eventId/',
+            {
+              path: {
+                organizationIdOrSlug: organization.slug,
+                issueId: newGroupID,
+                eventId: 'latest',
+              },
+              staleTime: 0,
+            }
+          ),
+          retry(failureCount) {
+            retries = failureCount + 1;
+            return failureCount < EVENT_POLL_RETRIES;
+          },
+          retryDelay: EVENT_POLL_INTERVAL,
+        });
+        return {
+          eventCreated: true,
+          retries,
+          duration: Math.ceil(performance.now() - t0),
+          groupID: newGroupID,
+        };
+      } catch {
+        return {
+          eventCreated: false,
+          retries,
+          duration: Math.ceil(performance.now() - t0),
+          groupID: newGroupID,
+        };
+      }
+    },
+    onMutate() {
+      if (!project) {
+        return;
+      }
 
-      navigate(
-        normalizeUrl(
-          `/organizations/${organization.slug}/issues/${groupID}/?project=${project.id}&referrer=sample-error`
-        )
-      );
+      if (onCreateSampleGroup) {
+        onCreateSampleGroup();
+      } else if (hasScmOnboarding) {
+        trackAnalytics('onboarding.scm_view_sample_event_clicked', {
+          platform: project.platform,
+          organization,
+        });
+      } else {
+        trackAnalytics('growth.onboarding_view_sample_event', {
+          platform: project.platform,
+          organization,
+        });
+      }
 
-      setGroupID(null);
-    } else if (isError) {
+      addLoadingMessage(t('Processing sample event...'), {
+        duration: EVENT_POLL_RETRIES * EVENT_POLL_INTERVAL,
+      });
+    },
+    onSuccess({eventCreated, retries, duration, groupID}) {
       clearIndicators();
 
-      const retries = retryCount.current;
-      const duration = Math.ceil(performance.now() - pollStartTime.current);
-      trackAnalytics('sample_event.failed', {
+      trackAnalytics(`sample_event.${eventCreated ? 'created' : 'failed'}` as const, {
         organization,
-        project_id: project.id,
-        platform: project.platform || '',
+        project_id: project!.id,
+        platform: project!.platform || '',
         interval: EVENT_POLL_INTERVAL,
         retries,
         duration,
         source,
       });
 
-      addErrorMessage(t('Failed to load sample event'));
+      if (!eventCreated) {
+        addErrorMessage(t('Failed to load sample event'));
 
-      Sentry.withScope(scope => {
-        scope.setTag('groupID', groupID);
-        scope.setTag('platform', project.platform || '');
-        scope.setTag('interval', EVENT_POLL_INTERVAL.toString());
-        scope.setTag('retries', retries.toString());
-        scope.setTag('duration', duration.toString());
+        Sentry.withScope(scope => {
+          scope.setTag('groupID', groupID);
+          scope.setTag('platform', project!.platform || '');
+          scope.setTag('interval', EVENT_POLL_INTERVAL.toString());
+          scope.setTag('retries', retries.toString());
+          scope.setTag('duration', duration.toString());
 
-        scope.setLevel('warning');
-        Sentry.captureMessage('Failed to load sample event');
-      });
+          scope.setLevel('warning');
+          Sentry.captureMessage('Failed to load sample event');
+        });
+        return;
+      }
 
-      setGroupID(null);
-    }
-  }, [groupID, onClick, isSuccess, isError, navigate, organization, project, source]);
+      onClick?.();
 
-  const creating = groupID !== null;
-
-  async function createSampleGroup() {
-    if (!project) {
-      return;
-    }
-
-    if (onCreateSampleGroup) {
-      onCreateSampleGroup();
-    } else if (hasScmOnboarding) {
-      trackAnalytics('onboarding.scm_view_sample_event_clicked', {
-        platform: project.platform,
-        organization,
-      });
-    } else {
-      trackAnalytics('growth.onboarding_view_sample_event', {
-        platform: project.platform,
-        organization,
-      });
-    }
-
-    addLoadingMessage(t('Processing sample event...'), {
-      duration: EVENT_POLL_RETRIES * EVENT_POLL_INTERVAL,
-    });
-
-    try {
-      const eventData = await createSample();
-      pollStartTime.current = performance.now();
-      retryCount.current = 0;
-      setGroupID(eventData.groupID);
-    } catch (error) {
+      navigate(
+        normalizeUrl(
+          `/organizations/${organization.slug}/issues/${groupID}/?project=${project!.id}&referrer=sample-error`
+        )
+      );
+    },
+    onError(error) {
       Sentry.withScope(scope => {
         scope.setExtra('error', error);
         Sentry.captureException(new Error('Failed to create sample event'));
       });
       clearIndicators();
       addErrorMessage(t('Failed to create a new sample event'));
-    }
-  }
+    },
+  });
 
   return (
     <Button
       {...buttonProps}
-      disabled={buttonProps.disabled || creating}
-      onClick={createSampleGroup}
+      disabled={buttonProps.disabled || !project || isPending}
+      onClick={() => createSampleGroup()}
     />
   );
 }
-
-export {CreateSampleEventButton};


### PR DESCRIPTION
Convert `CreateSampleEventButton` from a class component with `withApi`/`withOrganization` HOCs to a functional component using hooks. No behavior change.

**API modernization**

Replace `api.requestPromise` with TanStack Query primitives: `useMutation` + `fetchMutation` for the POST, and `queryClient.fetchQuery` with `apiOptions`, `retry`, and `retryDelay` for polling the latest event. The manual `while`-loop with `setTimeout` is removed entirely. Replace `browserHistory.push` with `useNavigate`. Switch from default export to named export.

**Polling via fetchQuery**

The create-and-poll lifecycle lives in a single `useMutation`. After the POST creates the sample group, `queryClient.fetchQuery` polls the latest-event endpoint using built-in `retry`/`retryDelay` options instead of an imperative loop. This eliminates the `_isMounted` guard — `useMutation` handles unmount cleanup automatically.


[![View Interactive Summary](https://img.shields.io/badge/Summary-html_explanation-D97757?style=for-the-badge&logo=claude&logoColor=D97757)](https://insecure-html-azure.vercel.app/?pr-url=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry%2Fpull%2F115830)
<!-- html-preview:start
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="UTF-8">
<meta name="viewport" content="width=device-width,initial-scale=1">
<title>PR #115830 — ref(onboarding): Convert CreateSampleEventButton to functional component</title>
<style>
:root{--bg:#fff;--surface:#f6f8fa;--border:#d0d7de;--text:#1f2328;--text-muted:#656d76;--add-bg:#dafbe1;--add-text:#116329;--del-bg:#ffebe9;--del-text:#82071e;--accent:#0969da;--purple:#8250df;--orange:#9a6700;--teal:#1a7f37;color-scheme:light}
[data-theme="dark"]{--bg:#0d1117;--surface:#161b22;--border:#30363d;--text:#e6edf3;--text-muted:#8b949e;--add-bg:#12261e;--add-text:#3fb950;--del-bg:#2d1214;--del-text:#f85149;--accent:#58a6ff;--purple:#bc8cff;--orange:#d29922;--teal:#39d353;color-scheme:dark}
@media(prefers-color-scheme:dark){:root:not([data-theme="light"]){--bg:#0d1117;--surface:#161b22;--border:#30363d;--text:#e6edf3;--text-muted:#8b949e;--add-bg:#12261e;--add-text:#3fb950;--del-bg:#2d1214;--del-text:#f85149;--accent:#58a6ff;--purple:#bc8cff;--orange:#d29922;--teal:#39d353;color-scheme:dark}}
body{margin:0;background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif}
.container{max-width:1200px;margin:0 auto;padding:2rem 1rem}
.theme-toggle{position:fixed;top:1rem;right:1rem;z-index:100;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:.4rem .6rem;cursor:pointer;font-size:1.1rem;line-height:1;color:var(--text)}
.theme-toggle:hover{border-color:var(--accent)}
.pr-header{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:1.25rem 1.5rem;margin-bottom:1.5rem}
.pr-header h1{margin:0 0 .5rem;font-size:1.35rem;font-weight:600}
.pr-header h1 span{color:var(--text-muted);font-weight:400}
.pr-meta{display:flex;flex-wrap:wrap;gap:.75rem;align-items:center;font-size:.82rem;color:var(--text-muted)}
.pr-meta .badge{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:.15rem .5rem;font-family:'SFMono-Regular',Consolas,monospace;font-size:.75rem}
.pr-meta .stat-add{color:var(--add-text);font-weight:600}
.pr-meta .stat-del{color:var(--del-text);font-weight:600}
.summary-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;margin-bottom:1.5rem}
.summary-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1rem 1.25rem}
.summary-card .label{font-size:.7rem;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);margin-bottom:.25rem}
.summary-card .value{font-size:1.6rem;font-weight:700;color:var(--text)}
.summary-card .desc{font-size:.78rem;color:var(--text-muted);margin-top:.25rem}
.summary{border:1px solid var(--teal);border-radius:8px;padding:1rem 1.25rem;margin-bottom:1.5rem}
.summary h2{margin:0 0 .5rem;font-size:1rem;color:var(--teal);display:flex;align-items:center;gap:.5rem}
.summary p{margin:0;font-size:.88rem;line-height:1.6;color:var(--text)}
.finding{background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:.75rem;overflow:hidden}
.finding-header{display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;cursor:pointer;user-select:none}
.finding-header:hover{background:rgba(110,118,129,.06)}
.finding-header h3{margin:0;font-size:.9rem;font-weight:600;flex:1}
.finding-body{padding:.5rem 1rem 1rem;font-size:.85rem;line-height:1.65;color:var(--text)}
.finding.collapsed .finding-body{display:none}
.severity{display:inline-block;padding:.15rem .6rem;border-radius:12px;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;flex-shrink:0}
.severity.positive{background:rgba(57,211,83,.15);color:var(--teal);border:1px solid rgba(57,211,83,.3)}
.severity.info{background:rgba(88,166,255,.15);color:var(--accent);border:1px solid rgba(88,166,255,.3)}
.severity.low{background:rgba(210,153,34,.15);color:var(--orange);border:1px solid rgba(210,153,34,.3)}
.severity.medium{background:rgba(248,81,73,.15);color:var(--del-text);border:1px solid rgba(248,81,73,.3)}
.previously{background:rgba(188,140,255,.08);border:1px solid rgba(188,140,255,.2);border-radius:6px;padding:.4rem .75rem;margin:.4rem 0;font-size:.82rem;color:var(--text-muted);line-height:1.5}
.previously .label{font-weight:600;color:var(--purple);font-size:.72rem;text-transform:uppercase;letter-spacing:.04em;margin-right:.35rem}
.previously code{font-family:'SFMono-Regular',Consolas,monospace;font-size:.78rem;background:rgba(110,118,129,.15);padding:.1rem .3rem;border-radius:3px}
.cross-ref{font-size:.78rem;color:var(--purple);font-style:italic;margin:.25rem 0}
.cross-ref a{color:var(--purple);text-decoration:underline}
.cross-ref a:hover{color:var(--accent)}
.commit-progression{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1rem 1.25rem;margin:1rem 0}
.commit-progression h3{margin:0 0 .5rem;font-size:.9rem;color:var(--text)}
.commit-progression ol{margin:0;padding-left:1.25rem}
.commit-progression li{margin-bottom:.35rem;font-size:.82rem;color:var(--text-muted);line-height:1.5}
.commit-progression .commit-type{font-weight:600;font-size:.72rem;text-transform:uppercase;letter-spacing:.04em;margin-right:.35rem;padding:.1rem .4rem;border-radius:4px;background:rgba(110,118,129,.1);color:var(--text-muted)}
.file-link{color:var(--accent);text-decoration:none;font-family:'SFMono-Regular',Consolas,monospace;font-size:.82rem}
.file-link:hover{text-decoration:underline}
.diff-file{background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:.75rem;overflow:hidden}
.diff-file-header{display:flex;align-items:center;gap:.75rem;padding:.6rem 1rem;cursor:pointer;user-select:none;font-size:.82rem}
.diff-file-header:hover{background:rgba(110,118,129,.06)}
.diff-file-path{flex:1;font-family:'SFMono-Regular',Consolas,monospace;font-size:.82rem}
.diff-file-path a{color:var(--text);text-decoration:none}
.diff-file-path a:hover{color:var(--accent);text-decoration:underline}
.diff-file-stats{font-size:.75rem;color:var(--text-muted)}
.diff-body{overflow-x:auto}
.diff-file.collapsed .chevron{transform:rotate(-90deg)}
.diff-file.collapsed .diff-body{display:none}
.chevron{transition:transform .15s;font-size:.7rem;color:var(--text-muted)}
.diff-table{width:100%;border-collapse:collapse;font-family:'SFMono-Regular',Consolas,monospace;font-size:.78rem;line-height:1.55}
.diff-table td{padding:0 .75rem;white-space:pre;vertical-align:top}
.diff-table .ln{width:1px;text-align:right;color:var(--text-muted);opacity:.4;padding:0 .5rem;user-select:none}
.diff-table .ln a{color:inherit;text-decoration:none}
.diff-table .ln a:hover{color:var(--accent);text-decoration:underline}
.diff-table tr.add{background:var(--add-bg)}
.diff-table tr.add td.code{color:var(--add-text)}
.diff-table tr.del{background:var(--del-bg)}
.diff-table tr.del td.code{color:var(--del-text)}
.diff-table tr.hunk td{color:var(--purple);padding:.3rem .75rem;background:rgba(188,140,255,.08);font-style:italic}
.annotation{display:block;background:var(--surface);border:1px solid var(--border);border-left:3px solid;border-radius:6px;padding:.5rem .75rem;margin:.35rem 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:.8rem;line-height:1.5;white-space:normal;color:var(--text-muted)}
.annotation.positive{border-left-color:var(--teal)}
.annotation.info{border-left-color:var(--accent)}
.annotation.low{border-left-color:var(--orange)}
.annotation.medium{border-left-color:var(--del-text)}
.diff-controls{display:flex;gap:.5rem;margin-bottom:.75rem}
.diff-controls button{background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:.3rem .75rem;cursor:pointer;font-size:.78rem;color:var(--text-muted)}
.diff-controls button:hover{border-color:var(--accent);color:var(--accent)}
.file-list{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1rem 1.25rem;margin-top:1.5rem}
.file-list h3{margin:0 0 .5rem;font-size:.9rem}
.file-pills{display:flex;flex-wrap:wrap;gap:.4rem}
.file-pill{background:var(--bg);border:1px solid var(--border);border-radius:4px;padding:.15rem .5rem;font-family:'SFMono-Regular',Consolas,monospace;font-size:.72rem;color:var(--text-muted)}
section{margin-bottom:1.5rem}
section h2{font-size:1.05rem;margin:0 0 .75rem;color:var(--text)}
</style>
</head>
<body>
<button class="theme-toggle" onclick="toggleTheme()" title="Toggle theme">&#x1f313;</button>
<div class="container">
<div class="pr-header">
<h1>Convert CreateSampleEventButton to functional component <span>#115830</span></h1>
<div class="pr-meta">
<span>by <strong>ryan953</strong></span>
<span class="badge">ryan953/ref/convert-create-sample-event-button</span>
<span>&rarr;</span>
<span class="badge">master</span>
<span class="stat-add">+198</span>
<span class="stat-del">-240</span>
<span>4 files</span>
<span>2 commits</span>
</div>
</div>
<div class="summary-grid">
<div class="summary-card">
<div class="label">Net Change</div>
<div class="value">-42</div>
<div class="desc">Lines removed by eliminating class boilerplate and the imperative polling loop</div>
</div>
<div class="summary-card">
<div class="label">Pattern</div>
<div class="value">Class &rarr; Hooks</div>
<div class="desc">HOCs replaced with useOrganization, useNavigate; api.requestPromise replaced with TanStack Query</div>
</div>
<div class="summary-card">
<div class="label">Behavior Change</div>
<div class="value">None</div>
<div class="desc">Pure refactor &mdash; identical UI, analytics, and error handling</div>
</div>
</div>
<div class="summary">
<h2>&#x1f4cb; Summary</h2>
<p>Converts <code>CreateSampleEventButton</code> from a class component wrapped in <code>withApi</code>/<code>withOrganization</code> HOCs to a functional component using hooks and TanStack Query. The manual <code>while</code>-loop polling with <code>api.requestPromise</code> is replaced by <code>queryClient.fetchQuery</code> with built-in <code>retry</code>/<code>retryDelay</code>, and the entire create-and-poll lifecycle lives inside a single <code>useMutation</code>. No behavior change.</p>
</div>
<section>
<h2>Logical Changes</h2>
<div class="finding">
<div class="finding-header" onclick="this.parentElement.classList.toggle('collapsed')">
<span class="severity positive">highlight</span>
<h3>Class component converted to function component with hooks</h3>
<span class="chevron">&#x25BC;</span>
</div>
<div class="finding-body">
<p>The entire class body &mdash; lifecycle methods, instance state, <code>_isMounted</code> guard, and <code>render()</code> &mdash; is replaced by a single function component using <code>useOrganization</code>, <code>useNavigate</code>, <code>useEffect</code>, and <code>useMutation</code>.</p>
<div class="previously"><span class="label">Previously:</span> <code>class CreateSampleEventButton extends Component&lt;Props, State&gt;</code> wrapped in <code>withApi(withOrganization(...))</code>. Manual <code>this.state.creating</code> flag and <code>this._isMounted</code> guard for unmount safety.</div>
<p><a class="file-link" href="https://github.com/getsentry/sentry/pull/115830/files#diff-7d4c7a9d9b9d9d9d9d9d9d9d9d9d9d9d" target="_blank" rel="noopener">createSampleEventButton.tsx</a></p>
</div>
</div>
<div class="finding">
<div class="finding-header" onclick="this.parentElement.classList.toggle('collapsed')">
<span class="severity positive">highlight</span>
<h3>Polling loop replaced with queryClient.fetchQuery</h3>
<span class="chevron">&#x25BC;</span>
</div>
<div class="finding-body">
<p>The imperative <code>while (true)</code> loop with <code>setTimeout</code> and <code>api.requestPromise</code> is replaced by <code>queryClient.fetchQuery</code> with <code>retry</code>/<code>retryDelay</code> options. This delegates retry scheduling to TanStack Query, eliminating manual timer management and the <code>_isMounted</code> guard.</p>
<div class="previously"><span class="label">Previously:</span> <code>async function latestEventAvailable()</code> &mdash; a standalone function with a <code>while (true)</code> loop, <code>window.setTimeout</code>, and <code>api.requestPromise</code>. Called from <code>createSampleGroup()</code> after the POST succeeded.</div>
<p><a class="file-link" href="https://github.com/getsentry/sentry/pull/115830/files#diff-7d4c7a9d9b9d9d9d9d9d9d9d9d9d9d9d" target="_blank" rel="noopener">createSampleEventButton.tsx:55-97</a></p>
</div>
</div>
<div class="finding">
<div class="finding-header" onclick="this.parentElement.classList.toggle('collapsed')">
<span class="severity info">info</span>
<h3>useMutation lifecycle callbacks organize side effects</h3>
<span class="chevron">&#x25BC;</span>
</div>
<div class="finding-body">
<p>Analytics, loading indicators, navigation, and error reporting are moved into <code>onMutate</code>, <code>onSuccess</code>, and <code>onError</code> callbacks of <code>useMutation</code>. The <code>isPending</code> flag from the mutation replaces the manual <code>this.state.creating</code> boolean.</p>
<div class="previously"><span class="label">Previously:</span> Side effects were scattered across <code>createSampleGroup()</code> method body with manual <code>setState({creating: true/false})</code> calls.</div>
<p><a class="file-link" href="https://github.com/getsentry/sentry/pull/115830/files#diff-7d4c7a9d9b9d9d9d9d9d9d9d9d9d9d9d" target="_blank" rel="noopener">createSampleEventButton.tsx:99-167</a></p>
</div>
</div>
<div class="finding">
<div class="finding-header" onclick="this.parentElement.classList.toggle('collapsed')">
<span class="severity info">info</span>
<h3>Default export changed to named export</h3>
<span class="chevron">&#x25BC;</span>
</div>
<div class="finding-body">
<p>The component switches from <code>export default withApi(withOrganization(CreateSampleEventButton))</code> to <code>export function CreateSampleEventButton</code>. Import sites in <code>waitingForEvents.tsx</code> and <code>firstEventFooter.tsx</code> are updated accordingly.</p>
<div class="previously"><span class="label">Previously:</span> <code>export default withApi(withOrganization(CreateSampleEventButton))</code></div>
<p><a class="file-link" href="https://github.com/getsentry/sentry/pull/115830/files#diff-waitingForEvents" target="_blank" rel="noopener">waitingForEvents.tsx</a> &middot; <a class="file-link" href="https://github.com/getsentry/sentry/pull/115830/files#diff-firstEventFooter" target="_blank" rel="noopener">firstEventFooter.tsx</a></p>
</div>
</div>
<div class="finding">
<div class="finding-header" onclick="this.parentElement.classList.toggle('collapsed')">
<span class="severity info">info</span>
<h3>Tests updated for new async patterns</h3>
<span class="chevron">&#x25BC;</span>
</div>
<div class="finding-body">
<p>Tests no longer use global <code>jest.useFakeTimers()</code>. Happy-path tests use real timers since <code>fetchQuery</code> resolves immediately with mocked responses. The retry test scopes fake timers locally and uses <code>jest.advanceTimersByTimeAsync</code> wrapped in <code>act()</code> to properly handle the <code>fetchQuery</code> retry mechanism.</p>
<div class="previously"><span class="label">Previously:</span> Global <code>jest.useFakeTimers()</code> with <code>jest.runAllTimers()</code> to advance the imperative <code>setTimeout</code> polling loop.</div>
<p><a class="file-link" href="https://github.com/getsentry/sentry/pull/115830/files#diff-spec" target="_blank" rel="noopener">createSampleEventButton.spec.tsx</a></p>
</div>
</div>
</section>
<div class="commit-progression">
<h3>Commit Progression</h3>
<ol>
<li><span class="commit-type">modernization</span> Convert class to function component with hooks, replace HOCs, introduce useMutation + useQuery with retry for polling</li>
<li><span class="commit-type">refinement</span> Replace useQuery bridge pattern with queryClient.fetchQuery inside useMutation, simplify tests to use real timers where possible</li>
</ol>
</div>
<section>
<h2>Annotated Diff</h2>
<div class="diff-controls">
<button onclick="toggleAll(true)">Expand all</button>
<button onclick="toggleAll(false)">Collapse all</button>
</div>
<div class="diff-file">
<div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')">
<span class="chevron">&#x25BC;</span>
<span class="diff-file-path"><a href="https://github.com/getsentry/sentry/pull/115830/files#diff-7d4c7a9d9b9d9d9d9d9d9d9d9d9d9d9d" target="_blank" rel="noopener">createSampleEventButton.tsx</a></span>
<span class="severity info">modified</span>
<span class="diff-file-stats"><span style="color:var(--add-text)">+150</span> <span style="color:var(--del-text)">-192</span></span>
</div>
<div class="diff-body">
<table class="diff-table">
<tr><td colspan="3"><div class="annotation info">Imports: React hooks, TanStack Query, apiOptions, fetchMutation, useNavigate, useOrganization replace class-era imports (Component, Client, withApi, withOrganization, browserHistory)</div></td></tr>
<tr class="del"><td class="ln">1</td><td class="code">import {Component} from 'react';</td></tr>
<tr class="add"><td class="ln">1</td><td class="code">import {useEffect} from 'react';</td></tr>
<tr class="add"><td class="ln">3</td><td class="code">import {useMutation, useQueryClient} from '@tanstack/react-query';</td></tr>
<tr class="del"><td class="ln">12</td><td class="code">import type {Client} from 'sentry/api';</td></tr>
<tr class="del"><td class="ln">15</td><td class="code">import {browserHistory} from 'sentry/utils/browserHistory';</td></tr>
<tr class="add"><td class="ln">13</td><td class="code">import {apiOptions} from 'sentry/utils/api/apiOptions';</td></tr>
<tr class="add"><td class="ln">14</td><td class="code">import {fetchMutation} from 'sentry/utils/queryClient';</td></tr>
<tr class="add"><td class="ln">16</td><td class="code">import {useNavigate} from 'sentry/utils/useNavigate';</td></tr>
<tr class="add"><td class="ln">17</td><td class="code">import {useOrganization} from 'sentry/utils/useOrganization';</td></tr>
<tr><td colspan="3"><div class="annotation positive">Props simplified: api and organization props removed (now sourced from hooks). Type and State interfaces removed.</div></td></tr>
<tr class="del"><td class="ln">21</td><td class="code">  api: Client;</td></tr>
<tr class="del"><td class="ln">22</td><td class="code">  organization: Organization;</td></tr>
<tr class="del"><td class="ln">32</td><td class="code">type State = { creating: boolean; };</td></tr>
<tr><td colspan="3"><div class="annotation positive">The standalone latestEventAvailable function (while-loop with setTimeout) is removed entirely. Its logic is now inside queryClient.fetchQuery with retry/retryDelay.</div></td></tr>
<tr class="del"><td class="ln">37</td><td class="code">async function latestEventAvailable(api, orgSlug, groupID) { ... }</td></tr>
<tr><td colspan="3"><div class="annotation positive">Class body replaced by function component. useMutation encapsulates the POST + poll lifecycle. mutationFn calls fetchMutation for POST, then queryClient.fetchQuery with apiOptions for polling.</div></td></tr>
<tr class="add"><td class="ln">33</td><td class="code">export function CreateSampleEventButton({ ... }) {</td></tr>
<tr class="add"><td class="ln">40</td><td class="code">  const queryClient = useQueryClient();</td></tr>
<tr class="add"><td class="ln">41</td><td class="code">  const navigate = useNavigate();</td></tr>
<tr class="add"><td class="ln">42</td><td class="code">  const organization = useOrganization();</td></tr>
<tr><td colspan="3"><div class="annotation info">Side effects organized into useMutation lifecycle: onMutate (analytics + loading indicator), onSuccess (clear indicators, analytics, navigate), onError (Sentry capture + error message).</div></td></tr>
<tr><td colspan="3"><div class="annotation info">Render body simplified: isPending from useMutation replaces this.state.creating. No more manual prop destructuring to exclude HOC props.</div></td></tr>
<tr class="del"><td class="ln">219</td><td class="code">export default withApi(withOrganization(CreateSampleEventButton));</td></tr>
</table>
</div>
</div>
<div class="diff-file collapsed">
<div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')">
<span class="chevron">&#x25BC;</span>
<span class="diff-file-path"><a href="https://github.com/getsentry/sentry/pull/115830/files#diff-spec" target="_blank" rel="noopener">createSampleEventButton.spec.tsx</a></span>
<span class="severity info">modified</span>
<span class="diff-file-stats"><span style="color:var(--add-text)">+46</span> <span style="color:var(--del-text)">-46</span></span>
</div>
<div class="diff-body">
<table class="diff-table">
<tr><td colspan="3"><div class="annotation info">Global jest.useFakeTimers() removed. Happy-path tests work with real timers since mock responses resolve immediately. Retry test scopes fake timers locally with jest.useFakeTimers()/jest.useRealTimers().</div></td></tr>
<tr class="del"><td class="ln">10</td><td class="code">jest.useFakeTimers();</td></tr>
<tr><td colspan="3"><div class="annotation info">Analytics tests now mock the GET endpoint (fetchQuery fires after POST) and use waitFor around analytics assertions since the mutation is fully async.</div></td></tr>
<tr><td colspan="3"><div class="annotation info">Retry test uses act(() =&gt; jest.advanceTimersByTimeAsync(EVENT_POLL_INTERVAL)) to properly advance fetchQuery's internal retry timer within React's act boundary.</div></td></tr>
</table>
</div>
</div>
<div class="diff-file collapsed">
<div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')">
<span class="chevron">&#x25BC;</span>
<span class="diff-file-path"><a href="https://github.com/getsentry/sentry/pull/115830/files#diff-waitingForEvents" target="_blank" rel="noopener">waitingForEvents.tsx</a></span>
<span class="severity low">import fix</span>
<span class="diff-file-stats"><span style="color:var(--add-text)">+1</span> <span style="color:var(--del-text)">-1</span></span>
</div>
<div class="diff-body">
<table class="diff-table">
<tr class="del"><td class="ln">13</td><td class="code">import CreateSampleEventButton from '...createSampleEventButton';</td></tr>
<tr class="add"><td class="ln">13</td><td class="code">import {CreateSampleEventButton} from '...createSampleEventButton';</td></tr>
</table>
</div>
</div>
<div class="diff-file collapsed">
<div class="diff-file-header" onclick="this.parentElement.classList.toggle('collapsed')">
<span class="chevron">&#x25BC;</span>
<span class="diff-file-path"><a href="https://github.com/getsentry/sentry/pull/115830/files#diff-firstEventFooter" target="_blank" rel="noopener">firstEventFooter.tsx</a></span>
<span class="severity low">import fix</span>
<span class="diff-file-stats"><span style="color:var(--add-text)">+1</span> <span style="color:var(--del-text)">-1</span></span>
</div>
<div class="diff-body">
<table class="diff-table">
<tr class="del"><td class="ln">19</td><td class="code">import CreateSampleEventButton from '...createSampleEventButton';</td></tr>
<tr class="add"><td class="ln">19</td><td class="code">import {CreateSampleEventButton} from '...createSampleEventButton';</td></tr>
</table>
</div>
</div>
</section>
<div class="file-list">
<h3>Files Changed</h3>
<div class="file-pills">
<span class="file-pill">createSampleEventButton.tsx</span>
<span class="file-pill">createSampleEventButton.spec.tsx</span>
<span class="file-pill">waitingForEvents.tsx</span>
<span class="file-pill">firstEventFooter.tsx</span>
</div>
</div>
</div>
<script>
function toggleAll(e){document.querySelectorAll('.diff-file').forEach(el=>{e?el.classList.remove('collapsed'):el.classList.add('collapsed')})}
function toggleTheme(){const r=document.documentElement,c=r.getAttribute('data-theme');if(c==='dark')r.setAttribute('data-theme','light');else if(c==='light'){r.removeAttribute('data-theme');r.setAttribute('data-theme','dark')}else{r.setAttribute('data-theme',matchMedia('(prefers-color-scheme:dark)').matches?'light':'dark')}}
</script>
</body>
</html>
html-preview:end -->