### PR TITLE
Auto-create PRs for manual Seer handoff

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -500,6 +500,7 @@ def trigger_coding_agent_handoff(
     integration_id: int | None = None,
     provider: str | None = None,
     user_id: int | None = None,
+    auto_create_pr: bool | None = None,
 ) -> dict[str, list]:
     """
     Trigger a coding agent handoff for an existing agent-based autofix run.
@@ -513,6 +514,7 @@ def trigger_coding_agent_handoff(
         integration_id: The coding agent integration ID (e.g., Cursor)
         provider: The coding agent provider (e.g., 'github_copilot') - alternative to integration_id
         user_id: The user ID (required for user-authenticated providers like GitHub Copilot)
+        auto_create_pr: Optional override for whether the coding agent should create a PR
 
     Returns:
         Dictionary with 'successes' and 'failures' lists
@@ -522,11 +524,12 @@ def trigger_coding_agent_handoff(
     ):
         raise PermissionDenied("Code generation is disabled for this organization")
 
-    auto_create_pr = False
     preference = read_preference_from_sentry_db(group.project)
     repo_definitions: list[SeerRepoDefinition] = preference.repositories
-    if preference.automation_handoff:
-        auto_create_pr = preference.automation_handoff.auto_create_pr
+    if auto_create_pr is None:
+        auto_create_pr = False
+        if preference.automation_handoff:
+            auto_create_pr = preference.automation_handoff.auto_create_pr
 
     if not repo_definitions:
         return {

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -288,6 +288,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                     integration_id=integration_id,
                     provider=provider,
                     user_id=request.user.id if request.user else None,
+                    auto_create_pr=True,
                 )
             except SeerPermissionError as e:
                 if _is_unknown_run_id_error(e):

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -799,6 +799,34 @@ class TestTriggerCodingAgentHandoff(TestCase):
 
     @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_trigger_coding_agent_handoff_uses_auto_create_pr_override(
+        self, mock_client_class, mock_get_autofix_state
+    ):
+        """Test that manual handoff can force PR creation independent of automation settings."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = self._make_run_state()
+        mock_client.launch_coding_agents.return_value = {
+            "successes": [],
+            "failures": [],
+        }
+        self._make_repo_and_projectrepo()
+        self._make_handoff(auto_create_pr=False)
+        mock_get_autofix_state.return_value = None
+
+        trigger_coding_agent_handoff(
+            group=self.group,
+            run_id=123,
+            referrer=AutofixReferrer.UNKNOWN,
+            integration_id=456,
+            auto_create_pr=True,
+        )
+
+        call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
+        assert call_kwargs["auto_create_pr"] is True
+
+    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_trigger_coding_agent_handoff_filters_to_relevant_repo(
         self, mock_client_class, mock_get_autofix_state
     ):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -1099,6 +1099,34 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
                 mock_handoff.call_args.kwargs["referrer"] == AutofixReferrer.GROUP_AUTOFIX_ENDPOINT
             )
 
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_coding_agent_handoff")
+    def test_post_coding_agent_handoff_auto_creates_pr_by_default(self, mock_handoff):
+        mock_handoff.return_value = {"successes": [{"repo_name": "owner/repo"}], "failures": []}
+        group = self.create_group()
+
+        self.login_as(user=self.user)
+        with self.feature(EXPLORER_FLAGS[0]):
+            response = self.client.post(
+                self._get_url(group.id, mode="explorer"),
+                data={
+                    "step": "coding_agent_handoff",
+                    "run_id": 123,
+                    "integration_id": 456,
+                },
+                format="json",
+            )
+
+        assert response.status_code == 202, response.data
+        mock_handoff.assert_called_once_with(
+            group=group,
+            run_id=123,
+            referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
+            integration_id=456,
+            provider=None,
+            user_id=self.user.id,
+            auto_create_pr=True,
+        )
+
     @patch("sentry.seer.agent.client_utils.make_agent_state_request")
     @patch("sentry.seer.agent.client.make_agent_update_request")
     def test_open_pr(self, mock_explorer_update_request, mock_explorer_state_request):


### PR DESCRIPTION
## Summary
- default manual explorer coding-agent handoff to auto-create PRs
- preserve project preference behavior for automated handoffs
- add endpoint and handoff helper coverage

## Testing
- not run locally; this fresh worktree did not have .venv available
- git diff --check