### PR TITLE
feat(preprod): Expose is_selective flag in snapshot details API response

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -497,6 +497,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             state=artifact.state,
             vcs_info=vcs_info,
             app_id=artifact.app_id,
+            is_selective=snapshot_metrics.is_selective,
             images=image_list,
             image_count=snapshot_metrics.image_count,
             changed=categorized.changed,

--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -91,6 +91,7 @@ class SnapshotDetailsApiResponse(BaseModel):
     state: PreprodArtifact.ArtifactState
     vcs_info: BuildDetailsVcsInfo
     app_id: str | None = None
+    is_selective: bool = False
 
     # Solo fields (comparison_type == SOLO)
     images: list[SnapshotImageResponse] = []


### PR DESCRIPTION
Adds the `is_selective` field to the snapshot details GET API response so
users can identify which builds were selective uploads when querying later.

The `is_selective` flag was already persisted in the database
(`PreprodSnapshotMetrics.is_selective`) and used internally for comparison
logic, but was never surfaced in the API response. This exposes it via
`SnapshotDetailsApiResponse` so the frontend and API consumers can
distinguish selective builds from full uploads.