### PR TITLE
ref(cells): Remove the includeFeatureFlags query param from the org listing request

### DIFF
--- a/static/app/views/integrationOrganizationLink/index.spec.tsx
+++ b/static/app/views/integrationOrganizationLink/index.spec.tsx
@@ -58,7 +58,6 @@ describe('IntegrationOrganizationLink', () => {
     const org2Lite = pick(org2, ['slug', 'name', 'id']);
     getOrgsMock = MockApiClient.addMockResponse({
       url: '/organizations/',
-      match: [MockApiClient.matchQuery({include_feature_flags: 1})],
       body: [org1Lite, org2Lite],
     });
   });

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -90,10 +90,7 @@ export default function IntegrationOrganizationLink() {
     data: organizations = [],
     isPending: isPendingOrganizations,
     error: organizationsError,
-  } = useApiQuery<Organization[]>(
-    [getApiUrl('/organizations/'), {query: {include_feature_flags: 1}}],
-    {staleTime: Infinity}
-  );
+  } = useApiQuery<Organization[]>([getApiUrl('/organizations/')], {staleTime: Infinity});
 
   const hasSelectedOrg = !!selectedOrgSlug;
   const organizationQuery = useQuery(


### PR DESCRIPTION
This removes the includeFeatureFlags query param from being sent with the org listing request when linking an organization to integration.

This change is a no-op:
- the `features` property is never read anywhere in the UI code
- the org listing API won't be able to return features as it's moving to control
