### PR TITLE
chore(dynamic-ampling): add a metric counter to see if we sometimes have implicit-factor < 1

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -219,8 +219,12 @@ def boost_low_volume_transactions_of_project(project_transactions: ProjectTransa
 
     # Only after checking the nullability of rebalanced_transactions, we want to unpack the tuple.
     named_rates, implicit_rate = rebalanced_transactions
-    if implicit_rate < sample_rate:
-        metrics.incr("dynamic_sampling.boost_low_volume_transactions.implicit_factor_below_one")
+    implicit_factor = implicit_rate / sample_rate
+    comparison = "below" if implicit_factor < 1.0 else "above" if implicit_factor > 1.0 else "equal"
+    metrics.incr(
+        "dynamic_sampling.boost_low_volume_transactions.implicit_factor",
+        tags={"comparison": comparison},
+    )
     set_transactions_resampling_rates(
         org_id=org_id,
         proj_id=project_id,

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -219,12 +219,15 @@ def boost_low_volume_transactions_of_project(project_transactions: ProjectTransa
 
     # Only after checking the nullability of rebalanced_transactions, we want to unpack the tuple.
     named_rates, implicit_rate = rebalanced_transactions
-    implicit_factor = implicit_rate / sample_rate
-    comparison = "below" if implicit_factor < 1.0 else "above" if implicit_factor > 1.0 else "equal"
-    metrics.incr(
-        "dynamic_sampling.boost_low_volume_transactions.implicit_factor",
-        tags={"comparison": comparison},
-    )
+    if sample_rate > 0:
+        implicit_factor = implicit_rate / sample_rate
+        comparison = (
+            "below" if implicit_factor < 1.0 else "above" if implicit_factor > 1.0 else "equal"
+        )
+        metrics.incr(
+            "dynamic_sampling.boost_low_volume_transactions.implicit_factor",
+            tags={"comparison": comparison},
+        )
     set_transactions_resampling_rates(
         org_id=org_id,
         proj_id=project_id,

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -219,6 +219,8 @@ def boost_low_volume_transactions_of_project(project_transactions: ProjectTransa
 
     # Only after checking the nullability of rebalanced_transactions, we want to unpack the tuple.
     named_rates, implicit_rate = rebalanced_transactions
+    if implicit_rate < sample_rate:
+        metrics.incr("dynamic_sampling.boost_low_volume_transactions.implicit_factor_below_one")
     set_transactions_resampling_rates(
         org_id=org_id,
         proj_id=project_id,


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-2310/verify-transaction-data-on-eap-is-equivalent-to-transaction-data-on