### PR TITLE
perf(preprod): Virtualize snapshot sidebar for 40k image builds

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -325,6 +325,8 @@ function LazyImage({
         ref={refCallback}
         src={src}
         alt={alt}
+        loading="lazy"
+        decoding="async"
         width={width || undefined}
         height={height || undefined}
         onLoad={onLoad}

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.spec.tsx
@@ -6,6 +6,20 @@ import {SnapshotSidebarContent, type SidebarSection} from './snapshotSidebarCont
 
 const noop = () => {};
 
+beforeEach(() => {
+  jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: 350,
+    height: 600,
+    top: 0,
+    left: 0,
+    bottom: 600,
+    right: 350,
+    x: 0,
+    y: 0,
+    toJSON: jest.fn(),
+  });
+});
+
 const statusCounts: Record<DiffStatus, number> = {
   [DiffStatus.CHANGED]: 1,
   [DiffStatus.ADDED]: 0,
@@ -29,7 +43,7 @@ function renderSidebar(sections: SidebarSection[]) {
 }
 
 describe('SnapshotSidebarContent', () => {
-  it('renders displayName in the sidebar, not the key', () => {
+  it('renders displayName in the sidebar, not the key', async () => {
     renderSidebar([
       {
         type: DiffStatus.CHANGED,
@@ -43,11 +57,11 @@ describe('SnapshotSidebarContent', () => {
       },
     ]);
 
-    expect(screen.getByText('MyPreview')).toBeInTheDocument();
+    expect(await screen.findByText('MyPreview')).toBeInTheDocument();
     expect(screen.queryByText('com.example.MyClass.MyPreview')).not.toBeInTheDocument();
   });
 
-  it('shows group name as displayName when group is set', () => {
+  it('shows group name as displayName when group is set', async () => {
     renderSidebar([
       {
         type: DiffStatus.UNCHANGED,
@@ -61,6 +75,6 @@ describe('SnapshotSidebarContent', () => {
       },
     ]);
 
-    expect(screen.getByText('components')).toBeInTheDocument();
+    expect(await screen.findByText('components')).toBeInTheDocument();
   });
 });

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -58,7 +58,7 @@ type VirtualRow =
   | {group: SidebarGroup; indented: boolean; type: 'item'};
 
 const ITEM_HEIGHT = 36;
-const SECTION_HEADER_HEIGHT = 36;
+const SECTION_HEADER_HEIGHT = 28;
 
 interface SnapshotSidebarContentProps {
   activeStatuses: Set<DiffStatus>;
@@ -424,12 +424,15 @@ const VirtualRowPositioner = styled('div')`
 const SectionHeaderButton = styled('button')`
   display: flex;
   align-items: center;
-  gap: ${p => p.theme.space.sm};
+  gap: ${p => p.theme.space.xs};
   width: 100%;
-  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
+  height: ${p => p.theme.form.xs.height};
+  padding: ${p => p.theme.form.xs.paddingTop}px ${p => p.theme.form.xs.paddingRight}px
+    ${p => p.theme.form.xs.paddingBottom}px ${p => p.theme.space.xs};
   background: transparent;
   border: none;
   cursor: pointer;
+  font-size: ${p => p.theme.form.xs.fontSize};
 
   &:hover {
     background: ${p => p.theme.tokens.background.secondary};

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -138,7 +138,7 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
     initialRect: {width: 0, height: 500},
   });
 
-  const prevActiveItemKeyRef = useRef(activeItemKey);
+  const prevActiveItemKeyRef = useRef<string | null | undefined>(undefined);
   useEffect(() => {
     if (!activeItemKey || activeItemKey === prevActiveItemKeyRef.current) {
       prevActiveItemKeyRef.current = activeItemKey;

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -2,11 +2,12 @@ import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
+import {Disclosure} from '@sentry/scraps/disclosure';
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {IconChevron, IconSearch} from 'sentry/icons';
+import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
 
@@ -196,7 +197,7 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
           </Flex>
         )}
       </Stack>
-      <VirtualScrollContainer ref={scrollRef}>
+      <Stack ref={scrollRef} overflow="auto" flex="1" paddingRight="0">
         {hasGroups ? (
           <div
             style={{
@@ -239,7 +240,7 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
             </Text>
           </Flex>
         )}
-      </VirtualScrollContainer>
+      </Stack>
     </Stack>
   );
 });
@@ -254,17 +255,20 @@ const SectionHeaderRow = memo(function SectionHeaderRow({
   row: Extract<VirtualRow, {type: 'header'}>;
 }) {
   return (
-    <SectionHeaderButton
-      type="button"
-      aria-expanded={expanded}
-      onClick={() => onToggle(row.sectionType)}
+    <SectionDisclosure
+      size="xs"
+      expanded={expanded}
+      onExpandedChange={() => onToggle(row.sectionType)}
     >
-      <IconChevron size="xs" direction={expanded ? 'down' : 'right'} />
-      <Dot pillColor={row.meta.color} active />
-      <Text size="sm" bold>
-        {row.meta.label}
-      </Text>
-    </SectionHeaderButton>
+      <Disclosure.Title>
+        <Flex align="center" gap="sm">
+          <Dot pillColor={row.meta.color} active />
+          <Text size="sm" bold>
+            {row.meta.label}
+          </Text>
+        </Flex>
+      </Disclosure.Title>
+    </SectionDisclosure>
   );
 });
 
@@ -407,11 +411,18 @@ const SidebarItemRow = styled('div')<{indented: boolean; isSelected: boolean}>`
   }
 `;
 
-const VirtualScrollContainer = styled('div')`
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
+const SectionDisclosure = styled(Disclosure)`
+  width: 100%;
+  align-items: stretch;
+
+  > :first-child {
+    padding-right: 0;
+    border-radius: 0;
+
+    > button {
+      border-radius: 0;
+    }
+  }
 `;
 
 const VirtualRowPositioner = styled('div')`
@@ -419,22 +430,4 @@ const VirtualRowPositioner = styled('div')`
   top: 0;
   left: 0;
   width: 100%;
-`;
-
-const SectionHeaderButton = styled('button')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  width: 100%;
-  height: ${p => p.theme.form.xs.height};
-  padding: ${p => p.theme.form.xs.paddingTop}px ${p => p.theme.form.xs.paddingRight}px
-    ${p => p.theme.form.xs.paddingBottom}px ${p => p.theme.space.xs};
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  font-size: ${p => p.theme.form.xs.fontSize};
-
-  &:hover {
-    background: ${p => p.theme.tokens.background.secondary};
-  }
 `;

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -135,6 +135,7 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
     estimateSize: i =>
       virtualRows[i]!.type === 'header' ? SECTION_HEADER_HEIGHT : ITEM_HEIGHT,
     overscan: 25,
+    initialRect: {width: 0, height: 500},
   });
 
   const prevActiveItemKeyRef = useRef(activeItemKey);

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -1,12 +1,12 @@
-import {memo, useEffect, useRef, useState} from 'react';
+import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import {useVirtualizer} from '@tanstack/react-virtual';
 
-import {Disclosure} from '@sentry/scraps/disclosure';
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {IconSearch} from 'sentry/icons';
+import {IconChevron, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
 
@@ -53,6 +53,13 @@ const STATUS_META: Record<DiffStatus, {color: PillColor; label: string}> = {
   [DiffStatus.UNCHANGED]: {color: 'muted', label: t('Unchanged')},
 };
 
+type VirtualRow =
+  | {meta: {color: PillColor; label: string}; sectionType: DiffStatus; type: 'header'}
+  | {group: SidebarGroup; indented: boolean; type: 'item'};
+
+const ITEM_HEIGHT = 36;
+const SECTION_HEADER_HEIGHT = 36;
+
 interface SnapshotSidebarContentProps {
   activeStatuses: Set<DiffStatus>;
   onSearchChange: (query: string) => void;
@@ -77,42 +84,76 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
   const hasActiveFilter = activeStatuses.size > 0;
   const isStatusActive = (status: DiffStatus) =>
     !hasActiveFilter || activeStatuses.has(status);
-  const listRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const container = listRef.current;
-    if (!container || !activeItemKey) {
-      return;
-    }
-    const el = container.querySelector<HTMLElement>(
-      `[data-item-key="${CSS.escape(activeItemKey)}"]`
-    );
-    if (!el) {
-      return;
-    }
-    const cRect = container.getBoundingClientRect();
-    const eRect = el.getBoundingClientRect();
-    if (eRect.top < cRect.top) {
-      container.scrollTop -= cRect.top - eRect.top;
-    } else if (eRect.bottom > cRect.bottom) {
-      container.scrollTop += eRect.bottom - cRect.bottom;
-    }
-  }, [activeItemKey]);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   const [collapsed, setCollapsed] = useState<Set<DiffStatus>>(() => new Set());
-  const toggleSection = (type: DiffStatus, expanded: boolean) => {
+  const toggleSection = useCallback((type: DiffStatus) => {
     setCollapsed(prev => {
       const next = new Set(prev);
-      if (expanded) {
+      if (next.has(type)) {
         next.delete(type);
       } else {
         next.add(type);
       }
       return next;
     });
-  };
+  }, []);
+
+  const showSectionHeaders = useMemo(
+    () => sections.filter(s => s.groups.length > 0).length > 1,
+    [sections]
+  );
+
+  const virtualRows = useMemo(() => {
+    const rows: VirtualRow[] = [];
+    for (const section of sections) {
+      if (section.groups.length === 0) {
+        continue;
+      }
+      const sectionType = section.type;
+      const meta = sectionType ? STATUS_META[sectionType] : null;
+      const showHeader = !!sectionType && !!meta && showSectionHeaders;
+      if (showHeader) {
+        rows.push({type: 'header', sectionType, meta});
+        if (!collapsed.has(sectionType)) {
+          for (const group of section.groups) {
+            rows.push({type: 'item', group, indented: true});
+          }
+        }
+      } else {
+        for (const group of section.groups) {
+          rows.push({type: 'item', group, indented: false});
+        }
+      }
+    }
+    return rows;
+  }, [sections, collapsed, showSectionHeaders]);
+
+  const virtualizer = useVirtualizer({
+    count: virtualRows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: i =>
+      virtualRows[i]!.type === 'header' ? SECTION_HEADER_HEIGHT : ITEM_HEIGHT,
+    overscan: 25,
+  });
+
+  const prevActiveItemKeyRef = useRef(activeItemKey);
+  useEffect(() => {
+    if (!activeItemKey || activeItemKey === prevActiveItemKeyRef.current) {
+      prevActiveItemKeyRef.current = activeItemKey;
+      return;
+    }
+    prevActiveItemKeyRef.current = activeItemKey;
+    const idx = virtualRows.findIndex(
+      r => r.type === 'item' && r.group.key === activeItemKey
+    );
+    if (idx !== -1) {
+      virtualizer.scrollToIndex(idx, {align: 'auto'});
+    }
+  }, [activeItemKey, virtualRows, virtualizer]);
 
   const hasGroups = sections.some(s => s.groups.length > 0);
+  const virtualItems = virtualizer.getVirtualItems();
 
   return (
     <Stack height="100%" width="100%">
@@ -154,78 +195,116 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
           </Flex>
         )}
       </Stack>
-      <Stack ref={listRef} overflow="auto" flex="1" paddingRight="0">
-        {sections.map(section => {
-          if (section.groups.length === 0) {
-            return null;
-          }
-          const sectionType = section.type;
-          const meta = sectionType ? STATUS_META[sectionType] : null;
-          const isCollapsed = !!sectionType && collapsed.has(sectionType);
-          const showHeader = !!meta && !!sectionType && sections.length > 1;
-          const items = section.groups.map(group => {
-            const isActive = group.key === activeItemKey;
-            return (
-              <SidebarItemRow
-                key={group.key}
-                data-item-key={group.key}
-                isSelected={isActive}
-                indented={showHeader}
-                onClick={e => {
-                  e.stopPropagation();
-                  onSelectItem(group.key);
-                }}
-              >
-                <Flex align="center" gap="sm" flex="1" minWidth="0">
-                  <Text
-                    size="md"
-                    variant={isActive ? 'accent' : 'muted'}
-                    bold={isActive}
-                    ellipsis
-                    onPointerEnter={setTitleOnOverflow}
-                  >
-                    {group.displayName}
-                  </Text>
-                </Flex>
-                <CountBadge>
-                  <Text variant="muted" size="xs">
-                    {group.count}
-                  </Text>
-                </CountBadge>
-              </SidebarItemRow>
-            );
-          });
-          if (!showHeader) {
-            return <Stack key={sectionType ?? 'solo'}>{items}</Stack>;
-          }
-          return (
-            <SectionDisclosure
-              key={sectionType}
-              size="xs"
-              expanded={!isCollapsed}
-              onExpandedChange={expanded => toggleSection(sectionType, expanded)}
-            >
-              <Disclosure.Title>
-                <Flex align="center" gap="sm">
-                  <Dot pillColor={meta.color} active />
-                  <Text size="sm" bold>
-                    {meta.label}
-                  </Text>
-                </Flex>
-              </Disclosure.Title>
-              {!isCollapsed && items}
-            </SectionDisclosure>
-          );
-        })}
-        {!hasGroups && (
+      <VirtualScrollContainer ref={scrollRef}>
+        {hasGroups ? (
+          <div
+            style={{
+              height: virtualizer.getTotalSize(),
+              position: 'relative',
+              width: '100%',
+            }}
+          >
+            {virtualItems.map(vi => {
+              const row = virtualRows[vi.index]!;
+              return (
+                <VirtualRowPositioner
+                  key={vi.key}
+                  ref={virtualizer.measureElement}
+                  data-index={vi.index}
+                  style={{transform: `translateY(${vi.start}px)`}}
+                >
+                  {row.type === 'header' ? (
+                    <SectionHeaderRow
+                      row={row}
+                      expanded={!collapsed.has(row.sectionType)}
+                      onToggle={toggleSection}
+                    />
+                  ) : (
+                    <SidebarItem
+                      group={row.group}
+                      indented={row.indented}
+                      isActive={row.group.key === activeItemKey}
+                      onSelect={onSelectItem}
+                    />
+                  )}
+                </VirtualRowPositioner>
+              );
+            })}
+          </div>
+        ) : (
           <Flex align="center" justify="center" padding="lg">
             <Text variant="muted" size="sm">
               {t('No components found.')}
             </Text>
           </Flex>
         )}
-      </Stack>
+      </VirtualScrollContainer>
     </Stack>
+  );
+});
+
+const SectionHeaderRow = memo(function SectionHeaderRow({
+  row,
+  expanded,
+  onToggle,
+}: {
+  expanded: boolean;
+  onToggle: (type: DiffStatus) => void;
+  row: Extract<VirtualRow, {type: 'header'}>;
+}) {
+  return (
+    <SectionHeaderButton
+      type="button"
+      aria-expanded={expanded}
+      onClick={() => onToggle(row.sectionType)}
+    >
+      <IconChevron size="xs" direction={expanded ? 'down' : 'right'} />
+      <Dot pillColor={row.meta.color} active />
+      <Text size="sm" bold>
+        {row.meta.label}
+      </Text>
+    </SectionHeaderButton>
+  );
+});
+
+const SidebarItem = memo(function SidebarItem({
+  group,
+  indented,
+  isActive,
+  onSelect,
+}: {
+  group: SidebarGroup;
+  indented: boolean;
+  isActive: boolean;
+  onSelect: (key: string) => void;
+}) {
+  return (
+    <SidebarItemRow
+      data-item-key={group.key}
+      isSelected={isActive}
+      indented={indented}
+      onClick={e => {
+        e.stopPropagation();
+        onSelect(group.key);
+      }}
+    >
+      <Flex align="center" gap="sm" flex="1" minWidth="0">
+        <Text
+          size="md"
+          variant={isActive ? 'accent' : 'muted'}
+          bold={isActive}
+          ellipsis
+          onPointerEnter={setTitleOnOverflow}
+        >
+          {group.displayName}
+        </Text>
+      </Flex>
+      <CountBadge>
+        <Text variant="muted" size="xs">
+          {group.count}
+        </Text>
+      </CountBadge>
+    </SidebarItemRow>
   );
 });
 
@@ -307,20 +386,6 @@ const CountBadge = styled('div')`
   background: ${p => p.theme.tokens.background.secondary};
 `;
 
-const SectionDisclosure = styled(Disclosure)`
-  width: 100%;
-  align-items: stretch;
-
-  > :first-child {
-    padding-right: 0;
-    border-radius: 0;
-
-    > button {
-      border-radius: 0;
-    }
-  }
-`;
-
 const SidebarItemRow = styled('div')<{indented: boolean; isSelected: boolean}>`
   display: flex;
   align-items: center;
@@ -335,6 +400,35 @@ const SidebarItemRow = styled('div')<{indented: boolean; isSelected: boolean}>`
     ${p => (p.isSelected ? p.theme.tokens.border.accent.vibrant : 'transparent')};
   background: ${p =>
     p.isSelected ? p.theme.tokens.background.transparent.accent.muted : 'transparent'};
+
+  &:hover {
+    background: ${p => p.theme.tokens.background.secondary};
+  }
+`;
+
+const VirtualScrollContainer = styled('div')`
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+`;
+
+const VirtualRowPositioner = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+`;
+
+const SectionHeaderButton = styled('button')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.sm};
+  width: 100%;
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
+  background: transparent;
+  border: none;
+  cursor: pointer;
 
   &:hover {
     background: ${p => p.theme.tokens.background.secondary};


### PR DESCRIPTION
The snapshot sidebar rendered every item as a real DOM node. When viewing
a build with 40,000 images, this meant 40k+ DOM elements in the sidebar
alone, causing severe page lag — scrolling, typing in search, and
navigating were all sluggish.

This replaces the flat rendering with `@tanstack/react-virtual` (the
same library already used by the main list view). Only ~50 sidebar nodes
exist in the DOM at any time (visible items + 25 overscan). The section
header collapse/expand, search filtering, active-item highlighting, and
scroll-to-active behaviors are all preserved.

Additional changes:
- Added `loading="lazy"` and `decoding="async"` to the `LazyImage`
  component's `<img>` as a belt-and-suspenders measure alongside the
  existing virtualizer
- Replaced `<Disclosure>` section headers with a standalone button
  (Disclosure wraps children, which is incompatible with virtualization),
  preserving `aria-expanded` for accessibility
- Memoized `SidebarItem` and `SectionHeaderRow` sub-components
- Fixed scroll-to-active to only fire on actual `activeItemKey` changes,
  not on collapse/expand which also mutates `virtualRows`