### PR TITLE
ref(preprod): Use TimeToIdle instead of TimeToLive for upload expiration

### DIFF
--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -8,6 +8,7 @@ from objectstore_client import (
     Client,
     MetricsBackend,
     Session,
+    TimeToIdle,
     TimeToLive,
     TokenGenerator,
     Usecase,
@@ -62,7 +63,7 @@ class SentryMetricsBackend(MetricsBackend):
 
 _OBJECTSTORE_CLIENT: Client | None = None
 _ATTACHMENTS_USECASE: Usecase | None = None
-_PREPROD_USECASE = Usecase("preprod", expiration_policy=TimeToLive(timedelta(days=30)))
+_PREPROD_USECASE = Usecase("preprod", expiration_policy=TimeToIdle(timedelta(days=30)))
 
 
 def create_client() -> Client:

--- a/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.urls import reverse
-from objectstore_client import TimeToLive
+from objectstore_client import TimeToIdle
 from objectstore_client.metadata import format_expiration
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -57,7 +57,7 @@ class ProjectPreprodUploadOptionsEndpoint(ProjectEndpoint):
             ],
             authToken=session.mint_token(expiry_seconds=60 * 60),  # 1H
             expirationPolicy=format_expiration(
-                TimeToLive(timedelta(days=30))
+                TimeToIdle(timedelta(days=30))
             ),  # Hardcoded for now, check with Objectstore before increasing
         )
 

--- a/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
@@ -56,9 +56,10 @@ class ProjectPreprodUploadOptionsEndpoint(ProjectEndpoint):
                 ("project", str(project.id)),
             ],
             authToken=session.mint_token(expiry_seconds=60 * 60),  # 1H
-            expirationPolicy=format_expiration(
-                TimeToIdle(timedelta(days=30))
-            ),  # Hardcoded for now, check with Objectstore before increasing
+            # TimeToIdle resets the 30-day countdown each time an object is
+            # fetched (e.g. loading images in the UI). This is intentional —
+            # actively viewed snapshots should not silently expire.
+            expirationPolicy=format_expiration(TimeToIdle(timedelta(days=30))),
         )
 
         return Response({"objectstore": options})

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
@@ -36,7 +36,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
 
         assert data["authToken"] == "fake-token"
 
-        assert data["expirationPolicy"] == "ttl:30 days"
+        assert data["expirationPolicy"] == "tti:30 days"
 
         mock_get_session.assert_called_once_with(org=self.org.id, project=self.project.id)
 


### PR DESCRIPTION
Switch the objectstore expiration policy from `TimeToLive` to `TimeToIdle`
so that preprod snapshots that are still being accessed are not expired
after a fixed 30-day window. With `TimeToIdle`, the expiration timer resets
on each access, keeping actively-used snapshots alive.