### PR TITLE
fix(seer): Pass issue short ID to coding agents

### DIFF
--- a/src/sentry/integrations/coding_agent/models.py
+++ b/src/sentry/integrations/coding_agent/models.py
@@ -8,3 +8,4 @@ class CodingAgentLaunchRequest(BaseModel):
     repository: SeerRepoDefinition
     branch_name: str
     auto_create_pr: bool = False
+    issue_short_id: str | None = None

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -770,6 +770,7 @@ class SeerAgentClient:
         auto_create_pr: bool = False,
         provider: str | None = None,
         user_id: int | None = None,
+        issue_short_id: str | None = None,
     ) -> dict[str, list]:
         """
         Launch coding agents for an agent run.
@@ -786,6 +787,7 @@ class SeerAgentClient:
             auto_create_pr: Whether to automatically create a PR when agent finishes
             provider: The coding agent provider (e.g., 'github_copilot') - alternative to integration_id
             user_id: The user ID (required for user-authenticated providers like GitHub Copilot)
+            issue_short_id: Optional Sentry issue short ID for coding agent session naming
 
         Returns:
             Dictionary with 'successes' and 'failures' lists
@@ -800,4 +802,5 @@ class SeerAgentClient:
             auto_create_pr=auto_create_pr,
             provider=provider,
             user_id=user_id,
+            issue_short_id=issue_short_id,
         )

--- a/src/sentry/seer/agent/coding_agent_handoff.py
+++ b/src/sentry/seer/agent/coding_agent_handoff.py
@@ -80,6 +80,7 @@ def launch_coding_agents(
     auto_create_pr: bool = False,
     provider: str | None = None,
     user_id: int | None = None,
+    issue_short_id: str | None = None,
 ) -> dict[str, list]:
     """
     Launch coding agents for an agent run.
@@ -94,6 +95,7 @@ def launch_coding_agents(
         auto_create_pr: Whether to automatically create a PR when agent finishes
         provider: The coding agent provider (e.g., 'github_copilot') - alternative to integration_id
         user_id: The user ID (required for user-authenticated providers like GitHub Copilot)
+        issue_short_id: Optional Sentry issue short ID for coding agent session naming
 
     Returns:
         Dictionary with 'successes' and 'failures' lists
@@ -118,6 +120,7 @@ def launch_coding_agents(
             repository=repo,
             branch_name=sanitize_branch_name(branch_name_base),
             auto_create_pr=auto_create_pr,
+            issue_short_id=issue_short_id,
         )
 
         try:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -573,6 +573,7 @@ def trigger_coding_agent_handoff(
         repos=[repo],
         branch_name_base=group.title or "seer",
         auto_create_pr=auto_create_pr,
+        issue_short_id=short_id,
     )
 
     coding_agent_name = _resolve_coding_agent_name(group.organization.id, integration_id, provider)

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -330,6 +330,7 @@ def _launch_agents_for_repos(
             repository=repo,
             branch_name=sanitize_branch_name(autofix_state.request.issue["title"]),
             auto_create_pr=auto_create_pr,
+            issue_short_id=short_id,
         )
 
         try:

--- a/tests/sentry/seer/agent/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/agent/test_coding_agent_handoff.py
@@ -46,12 +46,15 @@ class TestLaunchCodingAgents(TestCase):
             run_id=self.run_id,
             prompt="Fix the bug",
             repos=[_repo("owner", "repo")],
+            issue_short_id="AIML-2301",
         )
 
         assert len(result["successes"]) == 1
         assert len(result["failures"]) == 0
         assert result["successes"][0]["repo_name"] == "owner/repo"
         mock_installation.launch.assert_called_once()
+        launch_request = mock_installation.launch.call_args[0][0]
+        assert launch_request.issue_short_id == "AIML-2301"
         mock_store.assert_called_once_with(
             run_id=self.run_id,
             coding_agent_states=[mock_installation.launch.return_value],

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -609,6 +609,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert len(repos) == 1
         assert repos[0].owner == "owner"
         assert repos[0].name == "repo"
+        assert call_kwargs["issue_short_id"] == self.group.qualified_short_id
 
     @patch("sentry.seer.autofix.autofix_agent.analytics.record")
     @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -284,6 +284,8 @@ class TestLaunchAgentsForRepos(TestCase):
         mock_get_prompt.assert_called_once()
         call_args = mock_get_prompt.call_args
         assert call_args[0][3] == "AIML-2301"
+        launch_request = mock_installation.launch.call_args[0][0]
+        assert launch_request.issue_short_id == "AIML-2301"
         assert mock_store_states.call_args.kwargs["organization_id"] == self.organization.id
 
 


### PR DESCRIPTION
Thread the Sentry issue short ID through coding agent launch requests so Claude Agent sessions can use the session title support added in [getsentry/getsentry#19892](https://github.com/getsentry/getsentry/pull/19892).

Autofix and agent handoff now both include the short ID on `CodingAgentLaunchRequest`, while existing coding agents can continue to ignore the optional field.

**Regression Coverage**

Adds focused assertions for the classic Autofix launcher, the agent handoff launcher, and the `trigger_coding_agent_handoff` wrapper so the short ID is preserved where it used to be dropped.