### PR TITLE
fix(members): Enforce allowed org roles on member detail page

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -351,7 +351,7 @@ function OrganizationMemberDetailContent({member}: {member: Member}) {
       )}
 
       <OrganizationRoleSelect
-        enforceAllowed={false}
+        enforceAllowed
         enforceRetired={hasTeamRoles}
         disabled={!canEdit || isPartnershipUser}
         roleList={organization.orgRoleList}


### PR DESCRIPTION
Enforce the `isAllowed` check on the organization role selector in the member detail page.

`OrganizationRoleSelect` was rendered with `enforceAllowed={false}`, which meant the `isAllowed` flag on each role was ignored. Roles that the current user lacks permission to assign (because the role's scopes exceed the viewer's own scopes) appeared as selectable radio buttons, even though the backend would reject the change. For example, a Manager could see Admin/Owner as selectable options.

Setting `enforceAllowed` to `true` makes the UI correctly disable roles above the viewer's scope level, matching the existing behavior on the invite flow and the backend's permission enforcement.

Ref: https://docs.sentry.io/organization/membership/#organization-level-roles