### PR TITLE
feat(cells); Add org scoping to `GroupTagExportView`

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1105,6 +1105,11 @@ urlpatterns += [
                     name="sentry-organization-project-event-redirect",
                 ),
                 re_path(
+                    r"^(?P<organization_slug>[^/]+)/projects/(?P<project_id_or_slug>[^/]+)/issues/(?P<group_id>\d+)/tags/(?P<key>[^/]+)/export/$",
+                    GroupTagExportView.as_view(),
+                    name="sentry-organization-group-tag-export",
+                ),
+                re_path(
                     r"^(?P<organization_slug>[^/]+)/api-keys/$",
                     react_page_view,
                     name="sentry-organization-api-keys",

--- a/tests/sentry/web/frontend/test_group_tag_export.py
+++ b/tests/sentry/web/frontend/test_group_tag_export.py
@@ -72,6 +72,21 @@ class GroupTagExportTest(TestCase, SnubaTestCase):
         response = self.client.get(self.url)
         self.verify_test(response)
 
+    def test_simple_organization_prefix(self) -> None:
+        url = reverse(
+            "sentry-organization-group-tag-export",
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_id_or_slug": self.project.slug,
+                "group_id": self.group.id,
+                "key": self.key,
+            },
+        )
+        self.url = f"{url}?environment={self.environment.name}"
+
+        response = self.client.get(self.url)
+        self.verify_test(response)
+
     def test_simple_customer_domain(self) -> None:
         url = reverse(
             "sentry-customer-domain-sentry-group-tag-export",


### PR DESCRIPTION
Add the standardized org-scoped variant for `GroupTagExportView` — `sentry-organization-group-tag-export` — with the canonical `/{org}/projects/{project}/issues/{group}/tags/{key}/export/` path shape.

resolves three URLs:
- `sentry-group-tag-export`
- `sentry-customer-domain-sentry-group-tag-export`
- `sentry-api-0-issues-related-issues` (already deprecated via https://github.com/getsentry/sentry/pull/107180)

`sentry-project-event-redirect`was also already resolved via https://github.com/getsentry/sentry/pull/105880
