### PR TITLE
org-scoped URL for page export

### DIFF
--- a/static/app/views/issueDetails/groupDistributions/tagExportDropdown.spec.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagExportDropdown.spec.tsx
@@ -32,6 +32,32 @@ describe('TagExportDropdown', () => {
     ).toBeInTheDocument();
   });
 
+  it('uses org-prefixed URL for page export', async () => {
+    const organization = OrganizationFixture({features: ['discover-query']});
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(
+      <TagExportDropdown
+        tagKey="user"
+        group={group}
+        organization={organization}
+        project={project}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Export options'}));
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {name: 'Export Page to CSV'})
+    );
+
+    expect(openSpy).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/projects/${project.slug}/issues/${group.id}/tags/user/export/`,
+      '_blank'
+    );
+
+    openSpy.mockRestore();
+  });
+
   it('disables Export All option when organization does not have discover-query feature', async () => {
     const organization = OrganizationFixture({features: []});
 

--- a/static/app/views/issueDetails/groupDistributions/tagExportDropdown.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagExportDropdown.tsx
@@ -41,7 +41,7 @@ export function TagExportDropdown({tagKey, group, organization, project}: Props)
           // TODO(issues): Dropdown menu doesn't support hrefs yet
           onAction: () => {
             window.open(
-              `/${organization.slug}/${project.slug}/issues/${group.id}/tags/${tagKey}/export/`,
+              `/organizations/${organization.slug}/projects/${project.slug}/issues/${group.id}/tags/${tagKey}/export/`,
               '_blank'
             );
           },


### PR DESCRIPTION
Blocked on https://github.com/getsentry/sentry/pull/115841

These are just the accompanying FE changes to follow those ^ BE changes
