### PR TITLE
feat(preprod): Add install_groups filter to preprod search UI

### DIFF
--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -28,6 +28,11 @@ export const MOBILE_BUILDS_ALLOWED_KEYS = [
   'platform_name',
 ];
 
+export const MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS = [
+  ...MOBILE_BUILDS_ALLOWED_KEYS,
+  'install_groups',
+];
+
 export const SNAPSHOT_ALLOWED_KEYS = [
   'app_id',
   'git_base_ref',

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -34,6 +34,8 @@ interface PreprodSearchBarProps {
   searchSource?: string;
 }
 
+const FREEFORM_SEARCH_KEYS = new Set(['install_groups']);
+
 function filterToAllowedKeys(
   attributes: TagCollection,
   allowedKeys: string[]
@@ -44,6 +46,15 @@ function filterToAllowedKeys(
     if (allowedSet.has(key) && attributes[key]) {
       result[key] = attributes[key];
     }
+  }
+  return result;
+}
+
+function markFreeformKeys(attributes: TagCollection): TagCollection {
+  const result: TagCollection = {};
+  for (const key in attributes) {
+    const tag = attributes[key]!;
+    result[key] = FREEFORM_SEARCH_KEYS.has(key) ? {...tag, predefined: true} : tag;
   }
   return result;
 }
@@ -80,9 +91,11 @@ export function PreprodSearchBar({
 
   const stringAttributes = useMemo(
     () =>
-      allowedKeys
-        ? filterToAllowedKeys(rawStringAttributes, allowedKeys)
-        : rawStringAttributes,
+      markFreeformKeys(
+        allowedKeys
+          ? filterToAllowedKeys(rawStringAttributes, allowedKeys)
+          : rawStringAttributes
+      ),
     [allowedKeys, rawStringAttributes]
   );
 

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2700,6 +2700,12 @@ const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.INTEGER,
   },
+  install_groups: {
+    desc: t('The install groups this build belongs to'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
   snapshot_status: {
     desc: t('Status of the snapshot in the comparison pipeline'),
     kind: FieldKind.FIELD,

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -99,6 +99,7 @@ export const SENTRY_PREPROD_STRING_TAGS: string[] = [
   'build_version',
   'git_base_ref',
   'git_head_ref',
+  'install_groups',
   'platform_name',
   'snapshot_status',
 ];

--- a/static/app/views/explore/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/explore/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -6,6 +6,11 @@ import {Container} from '@sentry/scraps/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {
+  MOBILE_BUILDS_ALLOWED_KEYS,
+  MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS,
+  SNAPSHOT_ALLOWED_KEYS,
+} from 'sentry/components/preprod/constants';
+import {
   getPreprodBuildsDisplay,
   PreprodBuildsDisplay,
 } from 'sentry/components/preprod/preprodBuildsDisplay';
@@ -188,6 +193,13 @@ export default function PreprodBuilds() {
             initialQuery={localSearchQuery}
             display={activeDisplay}
             projects={[Number(projectId)]}
+            allowedKeys={
+              activeDisplay === PreprodBuildsDisplay.SNAPSHOT
+                ? SNAPSHOT_ALLOWED_KEYS
+                : activeDisplay === PreprodBuildsDisplay.DISTRIBUTION
+                  ? MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS
+                  : MOBILE_BUILDS_ALLOWED_KEYS
+            }
             onChange={handleSearch}
             onDisplayChange={handleDisplayChange}
           />

--- a/static/app/views/explore/releases/list/mobileBuilds.tsx
+++ b/static/app/views/explore/releases/list/mobileBuilds.tsx
@@ -10,6 +10,7 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {
   MOBILE_BUILDS_ALLOWED_KEYS,
+  MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS,
   SNAPSHOT_ALLOWED_KEYS,
 } from 'sentry/components/preprod/constants';
 import {
@@ -211,7 +212,9 @@ export function MobileBuilds({
         allowedKeys={
           activeDisplay === PreprodBuildsDisplay.SNAPSHOT
             ? SNAPSHOT_ALLOWED_KEYS
-            : MOBILE_BUILDS_ALLOWED_KEYS
+            : activeDisplay === PreprodBuildsDisplay.DISTRIBUTION
+              ? MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS
+              : MOBILE_BUILDS_ALLOWED_KEYS
         }
         hideDisplayToggle={hideDisplayToggle}
         onSearch={handleSearch}


### PR DESCRIPTION
Expose the `install_groups` key in the preprod search bar so users can filter builds by install group in both the mobile builds list and release detail views.

**Freeform search (no autocompletion)**

`install_groups` is marked as a freeform search key (`predefined: true` with no values), which suppresses the tag-values API call. Users type values directly instead of picking from a dropdown — install group names are user-defined and not enumerable server-side.

**Display-aware allowed keys**

The search bar now passes `allowedKeys` conditional on the active display in both the builds list and release detail pages. The distribution display includes `install_groups`; builds and snapshot displays do not.

Refs EME-1160