### PR TITLE
fix(settings): Fix Seer drawer stopping point not changing on mutate from "No Automation"

### DIFF
--- a/static/app/utils/seer/stoppingPoint.ts
+++ b/static/app/utils/seer/stoppingPoint.ts
@@ -11,6 +11,7 @@ import {t} from 'sentry/locale';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
 import type {DetailedProject, Project} from 'sentry/types/project';
+import {makeDetailedProjectQueryKey} from 'sentry/utils/project/useDetailedProject';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -283,6 +284,12 @@ export function getProjectStoppingPointMutationOptions({
       );
       queryClient.invalidateQueries({
         queryKey: bulkAutofixAutomationSettingsInfiniteOptions({organization}).queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeDetailedProjectQueryKey({
+          orgSlug: organization.slug,
+          projectSlug: project.slug,
+        }),
       });
     },
   });


### PR DESCRIPTION
fixes ENG-7631

Before: changing the stopping point from "No Automation" to "Stop after PR drafted" in the Seer drawer changes the table value but not the drawer value.


https://github.com/user-attachments/assets/3db60922-7d40-4e40-80b4-8dfeec301490


After: invalidate the project details query. The Seer drawer now shows the correct value.


https://github.com/user-attachments/assets/7855cf20-18f1-4675-88b5-a8222d3a7a43

### Root Cause

The table and drawer display the stopping point from different data sources: the table reads from the bulk autofix endpoint (`/organizations/{org}/autofix/automation-settings/`), while the drawer reads from the project details endpoint (`/projects/{org}/{slug}/`). Both read from the same DB table, but after saving, the per-project mutation (`getProjectStoppingPointMutationOptions`) only invalidated the bulk settings and seer preferences queries — not the `useDetailedProject` query. Combined with `staleTime: Infinity` on that query, the drawer kept serving the stale cached `autofixAutomationTuning` value. 

The bulk mutation (`useUpdateBulkAutofixAutomationSettings`) already invalidated all three queries correctly; this was just missed in the per-project path.