### PR TITLE
feat(dev): Add SENTRY_CELL_ROUTING env var that runs cell-routing mode locally

### DIFF
--- a/.agents/skills/cell-architecture/SKILL.md
+++ b/.agents/skills/cell-architecture/SKILL.md
@@ -137,6 +137,15 @@ Project.objects.filter(teams__organizationmember__user_id=user_id)
 | **Denormalize to control silo** | High QPS, paginated lists, eventual consistency acceptable. Replicate needed fields to a `@control_silo_model` via outboxes — single local query, no RPC. See **hybrid-cloud-outboxes** skill.  |
 | **API gateway fan-out**         | Temporary stopgap only — breaks pagination, latency = slowest cell.                                                                                                                             |
 
+## Running Cell-Routing Locally
+
+```bash
+devservices up --mode cell-routing            # brings up synapse + deps
+SENTRY_CELL_ROUTING=1 sentry devserver        # or devservices serve
+```
+
+Only cell-scoped API XHRs (`/api/0/organizations/{slug}/*`) cross to Synapse on `:13000`; UI HTML and control API stay on the sentry devserver at `:8000`. The env var gates a block in `src/sentry/conf/server.py` that sets `system.region-api-url-template` to the Synapse port and flips `system:multi-region`. The frontend reads `regionUrl` from the bootstrap blob and routes cell XHRs there per `static/app/api.tsx:715`.
+
 ## Active Migration
 
 > Remove this section once the migration is complete.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3326,3 +3326,12 @@ if (val := os.environ.get("SYNAPSE_HMAC_SECRET")) is not None:
 
 if SILO_DEVSERVER or IS_DEV:
     SYNAPSE_HMAC_SECRET = ["synapse-dev-secret"]
+
+if IS_DEV and os.environ.get("SENTRY_CELL_ROUTING"):
+    # Pair with `devservices --mode cell-routing`. Cell-scoped API XHRs cross
+    # to Synapse on :13000; UI HTML and control API stay on the devserver.
+    SENTRY_OPTIONS["system.region-api-url-template"] = "http://dev.getsentry.net:13000"
+    SENTRY_OPTIONS["system.organization-base-hostname"] = "{slug}.dev.getsentry.net:8000"
+    SENTRY_OPTIONS["system.organization-url-template"] = "http://{hostname}"
+    SENTRY_FEATURES["system:multi-region"] = True
+    SENTRY_LOCAL_CELL = SENTRY_LOCAL_CELL or "--monolith--"


### PR DESCRIPTION
When set, configures the dev server so cell-scoped API XHRs (/api/0/organizations/{slug}/*) target Synapse on :13000 while UI rendering and control API stay on the sentry devserver at :8000. Flips system:multi-region and points system.region-api-url-template at the Synapse port so the frontend's regionUrl bootstrap picks it up.

Should be run together with devservices --mode cell-routing for the matching Synapse proxy/ingest-router containers.

Updates agent skill with information about how to run cell-routing mode.
