### PR TITLE
feat(cmdk): add mod+j as command palette hotkey

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
@@ -184,7 +184,7 @@ export function CommandPaletteHotkeys() {
 
   useHotkeys([
     {
-      match: ['mod+shift+p', 'mod+k'],
+      match: ['mod+shift+p', 'mod+k', 'mod+j'],
       includeInputs: true,
       callback: () => {
         if (!organization) {


### PR DESCRIPTION
## Summary

- Adds `mod+j` (Cmd+J on Mac, Ctrl+J on Windows/Linux) as an additional hotkey to open the command palette
- Existing shortcuts (`mod+k` and `mod+shift+p`) are unchanged

## Test plan

- [ ] Press Cmd+J — command palette opens
- [ ] Press Cmd+K — command palette still opens
- [ ] Press Cmd+Shift+P — command palette still opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)