### PR TITLE
fix(seer): Keep repo loading indicator active

### DIFF
--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -131,7 +131,7 @@ export function SeerRepoTable() {
     isPending,
     isFetchingNextPage,
   } = result;
-  const isFetchingAllPages = hasNextPage || isFetchingNextPage;
+  const isFetchingAllPages = !isError && (hasNextPage || isFetchingNextPage);
 
   const {mutate: mutateRepositorySettings, mutateAsync: mutateRepositorySettingsAsync} =
     useBulkUpdateRepositorySettings({

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -131,6 +131,7 @@ export function SeerRepoTable() {
     isPending,
     isFetchingNextPage,
   } = result;
+  const isFetchingAllPages = hasNextPage || isFetchingNextPage;
 
   const {mutate: mutateRepositorySettings, mutateAsync: mutateRepositorySettingsAsync} =
     useBulkUpdateRepositorySettings({
@@ -171,7 +172,7 @@ export function SeerRepoTable() {
       <Grid
         minWidth="0"
         gap="md"
-        columns={isFetchingNextPage ? '1fr max-content max-content' : '1fr max-content'}
+        columns={isFetchingAllPages ? '1fr max-content max-content' : '1fr max-content'}
       >
         <InputGroup>
           <InputGroup.LeadingItems disablePointerEvents>
@@ -187,7 +188,7 @@ export function SeerRepoTable() {
           />
         </InputGroup>
 
-        {isFetchingNextPage ? <LoadingIndicator mini /> : null}
+        {isFetchingAllPages ? <LoadingIndicator mini /> : null}
 
         <LinkButton
           variant="primary"
@@ -206,7 +207,7 @@ export function SeerRepoTable() {
         <TablePanel>
           <SeerRepoTableHeader
             gridColumns={GRID_COLUMNS}
-            isFetchingNextPage={isFetchingNextPage}
+            isFetchingNextPage={isFetchingAllPages}
             isPending={isPending}
             mutateRepositorySettings={mutateRepositorySettingsAsync}
             onSortClick={setSort}
@@ -234,7 +235,7 @@ export function SeerRepoTable() {
           ) : (
             <VirtualizedRepoTable
               hasNextPage={hasNextPage}
-              isFetchingNextPage={isFetchingNextPage}
+              isFetchingNextPage={isFetchingAllPages}
               mutateRepositorySettings={mutateRepositorySettings}
               repositories={repositories}
               scrollBodyRef={scrollBodyRef}


### PR DESCRIPTION
The repo table auto-fetches every page, but the spinner was tied to each individual page request. That made it briefly unmount between cursors and restart.

Use a combined flag while more pages remain so the loading indicator stays mounted through the full fetch loop.

[example page](https://sentry.sentry.io/settings/seer/repos/)