### PR TITLE
fix(billing): added fix to convert snuba sentry enum to the proto enum for usage stats

### DIFF
--- a/src/sentry/billing/platform/services/usage/_outcomes_query.py
+++ b/src/sentry/billing/platform/services/usage/_outcomes_query.py
@@ -183,11 +183,8 @@ def _build_response(rows: list[dict], last_usage_ts: datetime | None) -> GetUsag
     # Each row already contains all 7 sumIf-aggregated fields from ClickHouse.
     #
     # NOTE: CategoryUsage.category carries Relay/Sentry int values (not proto
-    # DataCategory ints).  The proto field is typed as DataCategory but every
-    # existing consumer (getsentry postgres backend, shadow comparison,
-    # UsagePricerService, customer_usage, projection, etc.) interprets it as a
-    # Relay int.  Converting to proto ints here would break all consumers and
-    # the shadow comparison.  See the TODO in getsentry's
+    # DataCategory ints). We need to convert this to proto enum values because
+    # downstream consumers indiscriminately convert the values from proto to relay values. See the TODO in getsentry's
     # usage_pricer/service.py for the planned migration.
     days_map: defaultdict[str, dict[int, dict[str, int]]] = defaultdict(dict)
 

--- a/src/sentry/billing/platform/services/usage/_outcomes_query.py
+++ b/src/sentry/billing/platform/services/usage/_outcomes_query.py
@@ -28,7 +28,10 @@ from snuba_sdk import (
 )
 from snuba_sdk.orderby import Direction
 
-from sentry.billing.platform.services.category_mapping import proto_to_sentry_category
+from sentry.billing.platform.services.category_mapping import (
+    proto_to_sentry_category,
+    sentry_to_proto_category,
+)
 from sentry.snuba.referrer import Referrer
 from sentry.utils import metrics
 from sentry.utils.outcomes import Outcome
@@ -190,7 +193,7 @@ def _build_response(rows: list[dict], last_usage_ts: datetime | None) -> GetUsag
 
     for row in rows:
         day = row["time"]
-        category = int(row["category"])
+        category = sentry_to_proto_category(int(row["category"]))
         days_map[day][category] = {
             "total": int(row["total"]),
             "accepted": int(row["accepted"]),

--- a/tests/sentry/billing/platform/services/usage/test_outcomes_query.py
+++ b/tests/sentry/billing/platform/services/usage/test_outcomes_query.py
@@ -11,6 +11,7 @@ from sentry_protos.billing.v1.services.usage.v1.endpoint_usage_pb2 import (
 )
 from snuba_sdk import Column, Function, Op
 
+from sentry.billing.platform.services.category_mapping import sentry_to_proto_category
 from sentry.billing.platform.services.usage._outcomes_query import (
     _BILLABLE_OUTCOMES,
     _build_query,
@@ -115,13 +116,11 @@ class TestBuildResponse:
         assert len(response.days) == 1
         day = response.days[0]
         assert len(day.usage) == 3
-        assert day.usage[0].category == 1
-        assert day.usage[1].category == 2
-        assert day.usage[2].category == 9
 
-        assert day.usage[0].data.accepted == 100
-        assert day.usage[1].data.accepted == 50
-        assert day.usage[2].data.accepted == 25
+        usage_by_cat = {u.category: u.data.accepted for u in day.usage}
+        assert usage_by_cat[sentry_to_proto_category(1)] == 100
+        assert usage_by_cat[sentry_to_proto_category(2)] == 50
+        assert usage_by_cat[sentry_to_proto_category(9)] == 25
 
     def test_build_response_preserves_overlapping_semantics(self):
         """dropped >= over_quota + spike_protection — all values preserved as-is from query."""

--- a/tests/snuba/billing/platform/services/usage/test_outcomes_integration.py
+++ b/tests/snuba/billing/platform/services/usage/test_outcomes_integration.py
@@ -357,7 +357,7 @@ class TestOutcomesIntegration(OutcomesSnubaTest, TestCase):
         # Should find the ATTACHMENT data (Relay category 4), not errors
         assert len(response.days) == 1
         assert len(response.days[0].usage) == 1
-        assert response.days[0].usage[0].category == DataCategory.ATTACHMENT
+        assert response.days[0].usage[0].category == ProtoDataCategory.DATA_CATEGORY_ATTACHMENT
         assert response.days[0].usage[0].data.accepted == 512
 
     def test_overlapping_semantics(self):


### PR DESCRIPTION
When displaying usage stats, we indiscriminately convert all returned proto category enum values into sentry relay enum values. In the usage service, Postgres returns proto category enum values, whereas Clickhouse returns sentry relay enum values, resulting in customers getting a flat line for their projected usage on their subscription page. This PR makes sure to convert Clickhouse's sentry enum output into proto enums for the usage response, which is then converted back to sentry enums to display to the customer.  
