### PR TITLE
ref(sentry-toolbar): Make the init-sentry-toolbar feature permanent & internal

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -44,6 +44,8 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:event-attachments": True,
         # Enable incidents feature
         "organizations:incidents": False,
+        # Enable the rendering of @sentry/toolbar inside the sentry app. See `useInitSentryToolbar()`
+        "organizations:init-sentry-toolbar": False,
         # Enable integration functionality to work with alert rules
         "organizations:integrations-alert-rule": True,
         # Enable integration functionality to work with alert rules (specifically chat integrations)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -337,8 +337,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:session-replay-recording-scrubbing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable core Session Replay link in the sidebar
     manager.add("organizations:session-replay-ui", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
-    # Enable the rendering of @sentry/toolbar inside the sentry app. See `useInitSentryToolbar()`
-    manager.add("organizations:init-sentry-toolbar", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable new stack trace component for issue details
     manager.add("organizations:issue-details-new-stack-trace", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable double-reading from EAP for issue feed search queries


### PR DESCRIPTION
Depends on https://github.com/getsentry/getsentry/pull/20365

Followed by: https://github.com/getsentry/sentry-options-automator/pull/7880