### PR TITLE
Auto-create PRs for automated Seer handoffs

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -515,6 +515,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 run_id=run_id,
                 referrer=referrer,
                 integration_id=handoff_config.integration_id,
+                auto_create_pr=True,
             )
             logger.info(
                 "autofix.on_completion_hook.coding_agent_handoff_completed",

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -434,6 +434,7 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
         self,
         handoff_point: AutofixHandoffPoint = AutofixHandoffPoint.ROOT_CAUSE,
         integration_id: int = 123,
+        auto_create_pr: bool = True,
     ) -> SeerAutomationHandoffConfiguration:
         """Helper to create a handoff configuration in ProjectOptions.
 
@@ -443,13 +444,13 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
             "sentry:seer_automation_handoff_target", "cursor_background_agent"
         )
         self.project.update_option("sentry:seer_automation_handoff_integration_id", integration_id)
-        self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
+        self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", auto_create_pr)
 
         return SeerAutomationHandoffConfiguration(
             handoff_point=handoff_point,
             target="cursor_background_agent",
             integration_id=integration_id,
-            auto_create_pr=True,
+            auto_create_pr=auto_create_pr,
         )
 
     @patch("sentry.seer.autofix.on_completion_hook.read_preference_from_sentry_db")
@@ -568,6 +569,25 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
         assert call_kwargs["run_id"] == 123
         assert call_kwargs["integration_id"] == 123
         assert call_kwargs["referrer"] == AutofixReferrer.NIGHT_SHIFT
+        assert call_kwargs["auto_create_pr"] is True
+
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
+    def test_trigger_coding_agent_handoff_always_creates_pr(self, mock_trigger):
+        """Automated handoffs should create a PR even if the stored preference is false."""
+        mock_trigger.return_value = {
+            "successes": [{"repo": "owner/repo"}],
+            "failures": [],
+        }
+        handoff_config = self._make_handoff_config(auto_create_pr=False)
+
+        AutofixOnCompletionHook._trigger_coding_agent_handoff(
+            organization=self.organization,
+            run_id=123,
+            group=self.group,
+            handoff_config=handoff_config,
+        )
+
+        assert mock_trigger.call_args.kwargs["auto_create_pr"] is True
 
 
 class AutofixOnCompletionHookTest(TestCase):


### PR DESCRIPTION
## Summary
- force automated Seer completion handoffs to request PR creation
- leave the lower-level handoff helper's preference/default behavior intact for non-automated callers
- add a regression test proving automated handoff ignores a false stored auto-create preference

## Testing
- git diff --check
- push hooks: mypy, knip, whitespace, large-file checks

Local pytest/prek were not run because this worktree does not have .venv installed; CI will cover the test run.