### PR TITLE
ref(webhooks): Log headers in legacy webhook dry-run path

### DIFF
--- a/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from requests import Request
 from requests.exceptions import ConnectionError, ReadTimeout
 from taskbroker_client.retry import Retry
 
@@ -43,11 +44,13 @@ def send_legacy_webhook_task(url: str, payload: LegacyWebhookPayload, **kwargs: 
     organization = group.project.organization
 
     if features.has("organizations:legacy-webhook-dry-run", organization):
+        prepared = Request(method="POST", url=url, json=payload).prepare()
         logger.info(
             "legacy_webhook.dry_run",
             extra={
                 "url": url,
                 "payload": payload,
+                "headers": dict(prepared.headers),
             },
         )
         return

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
@@ -60,3 +60,5 @@ class TestSendLegacyWebhookTask(BaseWorkflowTest):
         assert call_args[0][0] == "legacy_webhook.dry_run"
         assert call_args[1]["extra"]["url"] == "http://example.com/hook"
         assert call_args[1]["extra"]["payload"] == payload
+        headers = call_args[1]["extra"]["headers"]
+        assert headers["Content-Type"] == "application/json"


### PR DESCRIPTION
## Summary
- Prepares the HTTP request without sending it during the dry-run path and logs the resulting headers alongside the payload
- Allows us to compare headers between the old plugin path and the new standalone service during rollout validation

## Related
- https://linear.app/getsentry/project/migrate-legacy-webhooks-away-from-plugins-c7549d6ed29b/overview

## Test plan
- [ ] Run `pytest tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py -svv`
- [ ] Verify dry-run log entry now includes `headers` dict with `Content-Type: application/json`