### PR TITLE
ref(flags): Move organizations:init-sentry-toolbar to permanent

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from sentry.features.base import (
     FeatureHandlerStrategy,
     OrganizationFeature,
@@ -5,6 +7,13 @@ from sentry.features.base import (
     SystemFeature,
 )
 from sentry.features.manager import FeatureManager
+
+
+@dataclass(frozen=True)
+class FlagpoleFeature:
+    default: bool = False
+    api_expose: bool = False
+
 
 # XXX: See `features/__init__.py` for documentation on how to use feature flags
 
@@ -134,9 +143,11 @@ def register_permanent_features(manager: FeatureManager) -> None:
     }
 
     # Permanent organization features that are controlled via flagpole
-    permanent_flagpole_organization_features = {
+    permanent_flagpole_organization_features: dict[str, FlagpoleFeature] = {
+        # Enable the rendering of @sentry/toolbar inside the sentry app. See `useInitSentryToolbar()`
+        "organizations:init-sentry-toolbar": FlagpoleFeature(default=False, api_expose=True),
         # Opt orgs in to logging workflow evaluations (bypasses sample rate when enabled).
-        "organizations:workflow-engine-log-evaluations": False,
+        "organizations:workflow-engine-log-evaluations": FlagpoleFeature(default=False),
     }
 
     # Flagpole cannot control system-scoped flags — keep these as INTERNAL.
@@ -165,13 +176,13 @@ def register_permanent_features(manager: FeatureManager) -> None:
             api_expose=True,
         )
 
-    for org_feature, default in permanent_flagpole_organization_features.items():
+    for org_feature, config in permanent_flagpole_organization_features.items():
         manager.add(
             org_feature,
             OrganizationFeature,
             FeatureHandlerStrategy.FLAGPOLE,
-            default=default,
-            api_expose=False,
+            default=config.default,
+            api_expose=config.api_expose,
         )
 
     for system_feature, default in permanent_system_features.items():

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -337,8 +337,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:session-replay-recording-scrubbing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable core Session Replay link in the sidebar
     manager.add("organizations:session-replay-ui", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
-    # Enable the rendering of @sentry/toolbar inside the sentry app. See `useInitSentryToolbar()`
-    manager.add("organizations:init-sentry-toolbar", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable new stack trace component for issue details
     manager.add("organizations:issue-details-new-stack-trace", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable double-reading from EAP for issue feed search queries


### PR DESCRIPTION
Move from temporary.py to permanent.py's flagpole section. The flag remains controllable via flagpole YAML config but is now classified as a permanent feature rather than a temporary one.

No behavior change — the flag keeps the same strategy (FLAGPOLE), default (false), and api_expose (true via the flagpole registration path).