### PR TITLE
chore(alerts): Remove legacy metric alerts code

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -432,18 +432,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for legacy metric alert rule.put results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-metric-alert-endpoints-put", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for legacy metric alert rule.get results.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-metric-alert-endpoints-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for legacy metric alert endpoint DELETE.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-metric-alert-endpoints-delete", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Use workflow engine exclusively for legacy issue alert rule.delete
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-issue-alert-endpoints-delete", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for OrganizationAlertRuleDetailsEndpoint.delete.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-orgalertruledetails-delete", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product (known internally as ourlogs) in UI and backend

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -107,10 +107,6 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
 
 
 class WorkflowEngineProjectAlertRuleEndpoint(ProjectAlertRuleEndpoint):
-    # Subclasses may set a per-method granular flag (e.g. for GET) that is OR'd
-    # with the broad workflow-engine-rule-serializers flag.
-    workflow_engine_method_flags: dict[str, str] = {}
-
     def convert_args(
         self, request: Request, alert_rule_id: int, *args: Any, **kwargs: Any
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
@@ -127,9 +123,8 @@ class WorkflowEngineProjectAlertRuleEndpoint(ProjectAlertRuleEndpoint):
         if not request.access.has_project_access(project):
             raise PermissionDenied
 
-        method_flag = self.workflow_engine_method_flags.get(request.method or "")
-        if features.has("organizations:workflow-engine-rule-serializers", project.organization) or (
-            method_flag is not None and features.has(method_flag, project.organization)
+        if request.method in ("GET", "DELETE") or features.has(
+            "organizations:workflow-engine-rule-serializers", project.organization
         ):
             try:
                 ard = AlertRuleDetector.objects.get(
@@ -161,10 +156,6 @@ class WorkflowEngineProjectAlertRuleEndpoint(ProjectAlertRuleEndpoint):
 
 
 class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint):
-    # Subclasses may set a per-method granular flag (e.g. for GET) that is OR'd
-    # with the broad workflow-engine-rule-serializers flag.
-    workflow_engine_method_flags: dict[str, str] = {}
-
     def convert_args(
         self, request: Request, alert_rule_id: int, *args: Any, **kwargs: Any
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
@@ -180,9 +171,8 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
         ):
             raise ResourceDoesNotExist
 
-        method_flag = self.workflow_engine_method_flags.get(request.method or "")
-        if features.has("organizations:workflow-engine-rule-serializers", organization) or (
-            method_flag is not None and features.has(method_flag, organization)
+        if request.method in ("GET", "DELETE") or features.has(
+            "organizations:workflow-engine-rule-serializers", organization
         ):
             try:
                 ard = AlertRuleDetector.objects.get(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -3,8 +3,6 @@ import logging
 from collections.abc import Callable
 
 from django.contrib.auth.models import AnonymousUser
-from django.db import router, transaction
-from django.db.models import Q
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -28,10 +26,7 @@ from sentry.apidocs.examples.metric_alert_examples import MetricAlertExamples
 from sentry.apidocs.parameters import GlobalParams, MetricAlertParams
 from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.incidents.endpoints.bases import WorkflowEngineOrganizationAlertRuleEndpoint
-from sentry.incidents.endpoints.serializers.alert_rule import (
-    AlertRuleSerializer,
-    DetailedAlertRuleSerializer,
-)
+from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializer
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     DetailedWorkflowEngineDetectorSerializer,
     WorkflowEngineDetectorSerializer,
@@ -49,12 +44,9 @@ from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
 )
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.models.organization import Organization
-from sentry.models.rulesnooze import RuleSnooze
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
-from sentry.users.services.user.service import user_service
 from sentry.workflow_engine.endpoints.organization_detector_details import remove_detector
-from sentry.workflow_engine.migration_helpers.alert_rule import dual_delete_migrated_alert_rule
 from sentry.workflow_engine.models import AlertRuleDetector, Detector
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
@@ -72,38 +64,13 @@ def fetch_alert_rule(
     request: Request, organization: Organization, alert_rule: AlertRule | Detector
 ) -> Response:
     expand = request.GET.getlist("expand", [])
-    if isinstance(alert_rule, Detector):
-        detector = alert_rule
-        serialized = serialize(
-            detector,
-            request.user,
-            DetailedWorkflowEngineDetectorSerializer(expand=expand, prepare_component_fields=True),
-        )
-        return Response(serialized)
-
-    assert isinstance(alert_rule, AlertRule)
-    report_used_legacy_models()
-    serialized_rule = serialize(
+    assert isinstance(alert_rule, Detector)
+    serialized = serialize(
         alert_rule,
         request.user,
-        DetailedAlertRuleSerializer(expand=expand, prepare_component_fields=True),
+        DetailedWorkflowEngineDetectorSerializer(expand=expand, prepare_component_fields=True),
     )
-
-    rule_snooze = RuleSnooze.objects.filter(
-        Q(user_id=request.user.id) | Q(user_id=None), alert_rule=alert_rule
-    ).first()
-    if rule_snooze:
-        serialized_rule["snooze"] = True
-        if request.user.id == rule_snooze.owner_id:
-            serialized_rule["snoozeCreatedBy"] = "You"
-        else:
-            if rule_snooze.owner_id:
-                user = user_service.get_user(rule_snooze.owner_id)
-                if user:
-                    serialized_rule["snoozeCreatedBy"] = user.get_display_name()
-        serialized_rule["snoozeForEveryone"] = rule_snooze.user_id is None
-
-    return Response(serialized_rule)
+    return Response(serialized)
 
 
 def update_alert_rule(
@@ -182,47 +149,20 @@ def update_alert_rule(
 def remove_alert_rule(
     request: Request, organization: Organization, target: AlertRule | Detector
 ) -> Response:
-    if isinstance(target, Detector):
-        try:
-            remove_detector(request, organization, target)
-            try:
-                ard = AlertRuleDetector.objects_for_deletion.get(detector_id=target.id)
-                target = AlertRule.objects.get(id=ard.alert_rule_id, organization=organization)
-                delete_alert_rule(
-                    target,
-                    user=_anon_to_None(request.user),
-                    ip_address=request.META.get("REMOTE_ADDR"),
-                )
-            except (AlertRuleDetector.DoesNotExist, AlertRule.DoesNotExist):
-                return Response(status=status.HTTP_204_NO_CONTENT)
-
-            return Response(status=status.HTTP_204_NO_CONTENT)
-        except AlreadyDeletedError:
-            return Response(
-                "This rule has already been deleted", status=status.HTTP_400_BAD_REQUEST
-            )
-    report_used_legacy_models()
+    assert isinstance(target, Detector)
     try:
-        # NOTE: we want to run the dual delete regardless of whether the user is flagged into dual writes:
-        # the user could be removed from the dual write flag for whatever reason, and we need to make sure
-        # that the extra table data is deleted. If the rows don't exist, we'll exit early.
-        with transaction.atomic(router.db_for_write(AlertRule)):
-            try:
-                dual_delete_migrated_alert_rule(alert_rule=target)
-            except Exception as e:
-                logger.exception(
-                    "Error when dual deleting alert rule",
-                    extra={"details": str(e)},
-                )
-                return Response(
-                    "Error when dual deleting alert rule",
-                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                )
+        remove_detector(request, organization, target)
+        try:
+            ard = AlertRuleDetector.objects_for_deletion.get(detector_id=target.id)
+            alert_rule = AlertRule.objects.get(id=ard.alert_rule_id, organization=organization)
             delete_alert_rule(
-                target,
+                alert_rule,
                 user=_anon_to_None(request.user),
                 ip_address=request.META.get("REMOTE_ADDR"),
             )
+        except (AlertRuleDetector.DoesNotExist, AlertRule.DoesNotExist):
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
         return Response(status=status.HTTP_204_NO_CONTENT)
     except AlreadyDeletedError:
         return Response("This rule has already been deleted", status=status.HTTP_400_BAD_REQUEST)
@@ -364,10 +304,6 @@ def _check_project_access[T](
 @extend_schema(tags=["Alerts"])
 @cell_silo_endpoint
 class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEndpoint):
-    workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-metric-alert-endpoints-get",
-        "DELETE": "organizations:workflow-engine-orgalertruledetails-delete",
-    }
     owner = ApiOwner.ISSUES
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -107,10 +107,7 @@ from sentry.workflow_engine.models import (
     Workflow,
 )
 from sentry.workflow_engine.types import DetectorPriorityLevel
-from sentry.workflow_engine.utils.legacy_metric_tracking import (
-    report_used_legacy_models,
-    track_alert_endpoint_execution,
-)
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 logger = logging.getLogger(__name__)
 
@@ -239,10 +236,6 @@ class AlertRuleFetchMixin(Endpoint):
     Can be used with any endpoint base class (OrganizationEndpoint, ProjectEndpoint, etc).
     """
 
-    # Subclasses may set a per-method granular flag (e.g. for GET) that is OR'd
-    # with the broad workflow-engine-rule-serializers flag.
-    workflow_engine_method_flags: dict[str, str] = {}
-
     def fetch_metric_alerts(
         self,
         request: Request,
@@ -260,53 +253,30 @@ class AlertRuleFetchMixin(Endpoint):
                 extra={"organization": organization.id},
             )
 
-        method_flag = self.workflow_engine_method_flags.get(request.method or "")
-        use_workflow_engine = (
-            features.has("organizations:workflow-engine-rule-serializers", organization)
-            or method_flag is not None
-            and features.has(method_flag, organization)
+        # Filter to metric alerts only, then check if dual-written or single-written
+        detectors = (
+            Detector.objects.filter(
+                type="metric_issue",
+                project__in=projects,
+            )
+            .filter(
+                Q(alertruledetector__alert_rule_id__isnull=False)  # Dual-written
+                | Q(alertruledetector__isnull=True)  # Single-written
+            )
+            .distinct()
+        )  # Deduplicate after JOIN
+        if not features.has("organizations:performance-view", organization):
+            detectors = filter_detectors_by_datasets(detectors, [Dataset.Events])
+        response = self.paginate(
+            request,
+            queryset=detectors,
+            order_by="-date_added",
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user, WorkflowEngineDetectorSerializer()),
+            default_per_page=25,
+            count_hits=True,
         )
-
-        if use_workflow_engine:
-            # Filter to metric alerts only, then check if dual-written or single-written
-            detectors = (
-                Detector.objects.filter(
-                    type="metric_issue",
-                    project__in=projects,
-                )
-                .filter(
-                    Q(alertruledetector__alert_rule_id__isnull=False)  # Dual-written
-                    | Q(alertruledetector__isnull=True)  # Single-written
-                )
-                .distinct()
-            )  # Deduplicate after JOIN
-            if not features.has("organizations:performance-view", organization):
-                detectors = filter_detectors_by_datasets(detectors, [Dataset.Events])
-            response = self.paginate(
-                request,
-                queryset=detectors,
-                order_by="-date_added",
-                paginator_cls=OffsetPaginator,
-                on_results=lambda x: serialize(x, request.user, WorkflowEngineDetectorSerializer()),
-                default_per_page=25,
-                count_hits=True,
-            )
-            response[ALERT_RULES_COUNT_HEADER] = detectors.count()
-        else:
-            alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
-            report_used_legacy_models()
-            if not features.has("organizations:performance-view", organization):
-                alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
-            response = self.paginate(
-                request,
-                queryset=alert_rules,
-                order_by="-date_added",
-                paginator_cls=OffsetPaginator,
-                on_results=lambda x: serialize(x, request.user),
-                default_per_page=25,
-                count_hits=True,
-            )
-            response[ALERT_RULES_COUNT_HEADER] = alert_rules.count()
+        response[ALERT_RULES_COUNT_HEADER] = detectors.count()
         response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = get_max_metric_alert_subscriptions(organization)
         return response
 
@@ -765,9 +735,6 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (OrganizationAlertRulePermission,)
-    workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-metric-alert-endpoints-get",
-    }
 
     @extend_schema(
         operation_id="(DEPRECATED) List an Organization's Metric Alert Rules",

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -26,10 +26,6 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
-    workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-metric-alert-endpoints-get",
-        "DELETE": "organizations:workflow-engine-metric-alert-endpoints-delete",
-    }
 
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rule-details")
     @deprecated(

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -29,9 +29,6 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     permission_classes = (ProjectAlertRulePermission,)
-    workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-metric-alert-endpoints-get",
-    }
 
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rules")
     @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/detectors/")

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -379,7 +379,12 @@ class WorkflowEngineDetectorSerializer(Serializer):
             snuba_query = query_subscription.snuba_query
             snuba_query_ids.append(snuba_query.id)
             result[detector]["query"] = snuba_query.query
-            result[detector]["aggregate"] = snuba_query.aggregate
+            # Apply transparency: Convert upsampled_count() back to count() for user-facing responses
+            # This hides the internal upsampling implementation from users
+            aggregate = snuba_query.aggregate
+            if aggregate == "upsampled_count()":
+                aggregate = "count()"
+            result[detector]["aggregate"] = aggregate
             result[detector]["timeWindow"] = snuba_query.time_window / 60
             result[detector]["resolution"] = snuba_query.resolution / 60
             env = snuba_query.environment

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -25,8 +25,10 @@ from sentry.auth.access import OrganizationGlobalAccess
 from sentry.conf.server import SEER_ANOMALY_DETECTION_STORE_DATA_URL
 from sentry.constants import ObjectStatus
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
-from sentry.incidents.endpoints.serializers.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
+from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
+    DetailedWorkflowEngineDetectorSerializer,
+)
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import INVALID_TIME_WINDOW
 from sentry.incidents.models.alert_rule import (
@@ -46,9 +48,9 @@ from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
 )
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.auditlogentry import AuditLogEntry
+from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
-from sentry.models.rulesnooze import RuleSnooze
 from sentry.seer.anomaly_detection.store_data import seer_anomaly_detection_connection_pool
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.sentry_apps.services.app import app_service
@@ -64,12 +66,24 @@ from sentry.snuba.tasks import update_subscription_in_snuba
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
+from sentry.types.group import PriorityLevel
 from sentry.utils.snuba import _snuba_pool
-from sentry.workflow_engine.models import DataSource, DataSourceDetector, Detector
+from sentry.workflow_engine.migration_helpers.alert_rule import (
+    dual_write_alert_rule,
+    migrate_alert_rule,
+)
+from sentry.workflow_engine.models import (
+    Action,
+    DataSource,
+    DataSourceDetector,
+    Detector,
+    DetectorWorkflow,
+    IncidentGroupOpenPeriod,
+    WorkflowActionGroupStatus,
+)
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
@@ -306,7 +320,10 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
 
-        assert resp.data == serialize(self.alert_rule, serializer=DetailedAlertRuleSerializer())
+        detector = AlertRuleDetector.objects.get(alert_rule_id=self.alert_rule.id).detector
+        assert resp.data == serialize(
+            detector, self.user, DetailedWorkflowEngineDetectorSerializer()
+        )
 
     @with_feature("organizations:workflow-engine-rule-serializers")
     @with_feature("organizations:incidents")
@@ -352,178 +369,68 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
 
         self.get_error_response(self.organization.slug, fake_detector_id, status_code=404)
 
-    @with_feature("organizations:incidents")
-    @freeze_time("2024-12-11 03:21:34")
-    def test_workflow_engine_serializer_matches_old_serializer(self) -> None:
-        """Verify the new WorkflowEngineDetectorSerializer output matches the old
-        DetailedAlertRuleSerializer output for the same alert rule, so we can
-        turn on the feature flag without breaking clients."""
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-
-        # Get old serializer response (without workflow-engine flag)
-        old_resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
-        old_data = old_resp.data
-
-        # Get new serializer response (with workflow-engine flag)
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            new_resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
-        new_data = new_resp.data
-
-        self.assert_alert_detail_results_match(old_data, new_data)
-
-    @with_feature("organizations:incidents")
-    @freeze_time("2024-12-11 03:21:34")
-    def test_workflow_engine_trigger_order_matches_legacy(self) -> None:
-        """The frontend uses array position to determine critical vs warning.
-        Verify the workflow engine returns triggers in the same order as legacy."""
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-
-        old_resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
-
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            new_resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
-
-        assert_serializer_parity(old=old_resp.data, new=new_resp.data)
-
-    @with_feature("organizations:incidents")
-    @freeze_time("2024-12-11 03:21:34")
-    def test_workflow_engine_serializer_snoozed_alert_rule(self) -> None:
-        """Delta test comparing snoozed alert rule between old and new serializers.
-
-        Tests the migration from RuleSnooze model to Detector.enabled for snooze state.
-
-        Known differences:
-        - Old serializer: Queries RuleSnooze and includes 'snoozeCreatedBy' field
-        - New serializer: Derives snooze from Detector.enabled, omits 'snoozeCreatedBy'
-        """
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-
-        # Snooze the alert rule (snooze for all)
-        # The post_save signal in src/sentry/receivers/rule_snooze.py automatically
-        # sets Detector.enabled = False when user_id is None
-        RuleSnooze.objects.create(
-            alert_rule=self.alert_rule,
-            user_id=None,  # None means snoozed for everyone
-        )
-
-        # Get old serializer response (without workflow-engine flag)
-        old_resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
-        old_data = old_resp.data
-
-        # Get new serializer response (with workflow-engine flag)
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            new_resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
-            new_data = new_resp.data
-
-        # Both should show snooze=True
-        assert old_data["snooze"] is True
-        assert new_data["snooze"] is True
-        assert old_data["snoozeForEveryone"] is True
-        assert new_data["snoozeForEveryone"] is True
-
-        # Compare all fields
-        self.assert_alert_detail_results_match(old_data, new_data)
-
-    @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
-    @freeze_time("2024-12-11 03:21:34")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
-    def test_workflow_engine_serializer_anomaly_detection(self, mock_seer_request) -> None:
-        """Verify anomaly detection alert rules serialize correctly with workflow engine.
-
-        Tests that dynamic detection type, sensitivity, seasonality, and thresholdType
-        fields match between old and new serializers for anomaly detection rules.
-
-        Known breaking change:
-        - Old serializer: status=NOT_ENOUGH_DATA (6) for newly created anomaly detection rules
-        - New serializer: status=PENDING (0) derived from Detector.enabled
-        - The Detector model lacks granular status values like NOT_ENOUGH_DATA
-        - This is an intentional simplification in the workflow engine data model
-        """
-        seer_return_value: StoreDataResponse = {"success": True}
-        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
-
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-
-        # Create anomaly detection alert rule using serializer (ensures dual-write)
-        anomaly_data = deepcopy(self.alert_rule_dict)
-        anomaly_data.update(
-            {
-                "detectionType": AlertRuleDetectionType.DYNAMIC.value,
-                "seasonality": AlertRuleSeasonality.AUTO.value,
-                "sensitivity": AlertRuleSensitivity.HIGH.value,
-                "thresholdType": AlertRuleThresholdType.ABOVE_AND_BELOW.value,
-                "timeWindow": 30,
-                "resolveThreshold": None,  # Anomaly detection doesn't use resolve threshold
-                "triggers": [
-                    {
-                        "label": "critical",
-                        "alertThreshold": 0,  # Anomaly detection uses 0
-                        "actions": [
-                            {
-                                "type": "email",
-                                "targetType": "user",
-                                "targetIdentifier": self.user.id,
-                            }
-                        ],
-                    }
-                ],
-            }
-        )
-        anomaly_rule = self.new_alert_rule(data=anomaly_data)
-
-        # Get old serializer response (without workflow-engine flag)
-        old_resp = self.get_success_response(self.organization.slug, anomaly_rule.id)
-        old_data = old_resp.data
-
-        # Get new serializer response (with workflow-engine flag)
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            new_resp = self.get_success_response(self.organization.slug, anomaly_rule.id)
-        new_data = new_resp.data
-
-        # Known difference: status field differs between old and new data models
-        # Old: AlertRule.status = NOT_ENOUGH_DATA (6) for new anomaly rules
-        # New: Derived from Detector.enabled = PENDING (0)
-        # This is expected - the Detector model doesn't have granular status like NOT_ENOUGH_DATA.
-        # The workflow engine serializer cannot depend on AlertRule to preserve this.
-        assert old_data["status"] == AlertRuleStatus.NOT_ENOUGH_DATA.value
-        assert new_data["status"] == AlertRuleStatus.PENDING.value
-
-        # Compare all fields except status
-        old_data_no_status = {k: v for k, v in old_data.items() if k != "status"}
-        new_data_no_status = {k: v for k, v in new_data.items() if k != "status"}
-        self.assert_alert_detail_results_match(old_data_no_status, new_data_no_status)
-
     def test_aggregate_translation(self) -> None:
+        # The workflow engine serializer does not translate aggregates from the snuba
+        # internal form (`tags[sentry:user]`) back to the user-facing form (`user`); it
+        # returns the snuba_query.aggregate value as-is.
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
         alert_rule = self.create_alert_rule(aggregate="count_unique(tags[sentry:user])")
+        self.create_alert_rule_trigger(alert_rule, "critical", 100)
+        dual_write_alert_rule(alert_rule)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug, alert_rule.id)
-            assert resp.data["aggregate"] == "count_unique(user)"
+            assert resp.data["aggregate"] == "count_unique(tags[sentry:user])"
             assert alert_rule.snuba_query.aggregate == "count_unique(tags[sentry:user])"
 
     def test_expand_latest_incident(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
-        incident = self.create_incident(
+
+        alert_rule = self.create_alert_rule(
             organization=self.organization,
-            title="Incident #1",
             projects=[self.project],
-            alert_rule=self.alert_rule,
-            status=IncidentStatus.CRITICAL.value,
+            name="some rule [crit]",
+            query="",
+            aggregate="count()",
+            time_window=1,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            resolve_threshold=10,
+            threshold_period=1,
         )
+        trigger = self.create_alert_rule_trigger(alert_rule=alert_rule, label="critical")
+        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
+        dual_write_alert_rule(alert_rule)
+
+        detector = AlertRuleDetector.objects.get(alert_rule_id=alert_rule.id).detector
+        workflow = DetectorWorkflow.objects.get(detector=detector).workflow
+        critical_action = Action.objects.filter(
+            dataconditiongroupaction__condition_group__workflowdataconditiongroup__workflow=workflow
+        ).first()
+        assert critical_action is not None
+
+        incident = self.create_incident(status=20, alert_rule=alert_rule)
+
+        group = self.create_group(
+            type=MetricIssue.type_id, project=self.project, priority=PriorityLevel.HIGH
+        )
+        self.create_detector_group(detector=detector, group=group)
+        WorkflowActionGroupStatus.objects.create(
+            action=critical_action, group=group, workflow=workflow
+        )
+        group_open_period = GroupOpenPeriod.objects.get(group=group)
+        group_open_period.update(date_started=incident.date_started)
+        IncidentGroupOpenPeriod.objects.create(
+            group_open_period=group_open_period,
+            incident_id=incident.id,
+            incident_identifier=incident.identifier,
+        )
+
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(
-                self.organization.slug, self.alert_rule.id, expand=["latestIncident"]
+                self.organization.slug, alert_rule.id, expand=["latestIncident"]
             )
-            no_expand_resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
+            no_expand_resp = self.get_success_response(self.organization.slug, alert_rule.id)
 
         assert resp.data["latestIncident"] is not None
         assert resp.data["latestIncident"]["id"] == str(incident.id)
@@ -537,14 +444,16 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         rule = self.create_alert_rule()  # the default detection type is static
         trigger = self.create_alert_rule_trigger(rule, "hi", 1000)
         self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
+        dual_write_alert_rule(rule)
         resp = self.get_success_response(self.organization.slug, rule.id)
         assert rule.detection_type == AlertRuleDetectionType.STATIC
         assert rule.detection_type == resp.data.get("detectionType")
 
         # Confirm that we don't mess up flow for customers who don't know about detection_type field yet
         rule2 = self.create_alert_rule(comparison_delta=60)
-        trigger2 = self.create_alert_rule_trigger(rule, "heyo", 1000)
+        trigger2 = self.create_alert_rule_trigger(rule2, "heyo", 1000)
         self.create_alert_rule_trigger_action(alert_rule_trigger=trigger2)
+        dual_write_alert_rule(rule2)
         resp = self.get_success_response(self.organization.slug, rule2.id)
         assert rule2.detection_type == AlertRuleDetectionType.PERCENT
         assert rule2.detection_type == resp.data.get("detectionType")
@@ -573,6 +482,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         )
         trigger = self.create_alert_rule_trigger(rule, "hi", 1000)
         self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
+        dual_write_alert_rule(rule)
         resp = self.get_success_response(self.organization.slug, rule.id)
         assert rule.detection_type == resp.data.get("detectionType")
 
@@ -623,6 +533,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         )
         trigger = self.create_alert_rule_trigger(rule, "hi", 0)
         self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
+        dual_write_alert_rule(rule)
         resp = self.get_success_response(self.organization.slug, rule.id)
         assert rule.detection_type == resp.data.get("detectionType")
 
@@ -731,11 +642,12 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             sentry_app=sentry_app,
             sentry_app_config=[
                 {"name": "title", "value": "An alert"},
-                {"summary": "Something happened here..."},
+                {"name": "summary", "value": "Something happened here..."},
                 {"name": "points", "value": "3"},
                 {"name": "assignee", "value": "Nisanthan"},
             ],
         )
+        dual_write_alert_rule(rule)
 
         responses.add(
             responses.GET,
@@ -795,11 +707,12 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             sentry_app=sentry_app,
             sentry_app_config=[
                 {"name": "title", "value": "An alert"},
-                {"summary": "Something happened here..."},
+                {"name": "summary", "value": "Something happened here..."},
                 {"name": "points", "value": "3"},
                 {"name": "assignee", "value": "Nisanthan"},
             ],
         )
+        dual_write_alert_rule(rule)
 
         responses.add(
             responses.GET,
@@ -859,24 +772,20 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             sentry_app=self.sentry_app,
             sentry_app_config=[
                 {"name": "title", "value": "An alert"},
-                {"summary": "Something happened here..."},
+                {"name": "summary", "value": "Something happened here..."},
                 {"name": "points", "value": "3"},
                 {"name": "assignee", "value": "Nisanthan"},
             ],
         )
+        dual_write_alert_rule(self.rule)
 
         responses.add(responses.GET, "http://example.com/sentry/members", json={}, status=404)
         with self.feature("organizations:incidents"):
             resp = self.get_response(self.organization.slug, self.rule.id)
 
         assert resp.status_code == 200
-        # Returns errors while fetching
-        assert len(resp.data["errors"]) == 1
-        assert resp.data["errors"][0] == {
-            "detail": "Could not fetch details from Super Awesome App"
-        }
 
-        # Disables the SentryApp
+        # Disables the SentryApp action when the component fetch fails
         assert (
             resp.data["triggers"][0]["actions"][0]["sentryAppInstallationUuid"]
             == self.installation.uuid
@@ -884,27 +793,23 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         assert resp.data["triggers"][0]["actions"][0]["disabled"] is True
 
     def test_with_snooze_rule(self) -> None:
+        # The workflow engine serializer derives snooze from Detector.enabled, which is
+        # only set to False for org-wide snoozes (user_id=None). User-level snoozes don't
+        # affect the detector, so the response reports snooze=False.
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
-        rule_snooze = self.snooze_rule(
-            user_id=self.user.id, owner_id=self.user.id, alert_rule=self.alert_rule
-        )
+        self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, alert_rule=self.alert_rule)
 
         with self.feature("organizations:incidents"):
             response = self.get_success_response(self.organization.slug, self.alert_rule.id)
 
-            assert response.data["snooze"]
-            assert response.data["snoozeCreatedBy"] == "You"
-
-            rule_snooze.owner_id = None
-            rule_snooze.save()
-
-            response = self.get_success_response(self.organization.slug, self.alert_rule.id)
-
-            assert response.data["snooze"]
-            assert "snoozeCreatedBy" not in response.data
+        assert response.data["snooze"] is False
+        assert "snoozeCreatedBy" not in response.data
 
     def test_with_snooze_rule_everyone(self) -> None:
+        # Org-wide snooze (user_id=None) triggers the rule_snooze signal that disables
+        # the Detector. The new serializer derives snooze from Detector.enabled and does
+        # not include snoozeCreatedBy.
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
 
@@ -914,8 +819,9 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         with self.feature("organizations:incidents"):
             response = self.get_success_response(self.organization.slug, self.alert_rule.id)
 
-        assert response.data["snooze"]
-        assert response.data["snoozeCreatedBy"] == user2.get_display_name()
+        assert response.data["snooze"] is True
+        assert response.data["snoozeForEveryone"] is True
+        assert "snoozeCreatedBy" not in response.data
 
     @with_feature("organizations:workflow-engine-rule-serializers")
     @with_feature("organizations:incidents")
@@ -1366,18 +1272,21 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         alert_rule_dict.update({"resolveThreshold": None})
         alert_rule = self.new_alert_rule(data=alert_rule_dict)
 
-        serialized_alert_rule = self.get_serialized_alert_rule()
-        # the new resolution threshold should be the critical alert threshold
-        new_threshold = serialized_alert_rule["triggers"][0]["alertThreshold"]
-        old_threshold = serialized_alert_rule["triggers"][1]["alertThreshold"]
+        triggers = list(AlertRuleTrigger.objects.filter(alert_rule=alert_rule).order_by("id"))
+        critical_trigger = next(t for t in triggers if t.label == "critical")
+        warning_trigger = next(t for t in triggers if t.label == "warning")
+
+        new_threshold = critical_trigger.alert_threshold
+        old_threshold = warning_trigger.alert_threshold
         assert_dual_written_resolution_threshold_equals(alert_rule, old_threshold)
 
-        serialized_alert_rule["triggers"].pop(1)
+        put_payload = deepcopy(alert_rule_dict)
+        # Provide trigger IDs so the serializer treats this as an update, not a create
+        put_payload["triggers"][0]["id"] = critical_trigger.id
+        put_payload["triggers"].pop(1)
 
         with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+            resp = self.get_success_response(self.organization.slug, alert_rule.id, **put_payload)
 
         assert len(resp.data["triggers"]) == 1
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
@@ -1397,27 +1306,30 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         alert_rule_dict.update({"resolveThreshold": None})
         alert_rule = self.new_alert_rule(data=alert_rule_dict)
 
-        serialized_alert_rule = self.get_serialized_alert_rule()
-        # the new resolution threshold should be the critical alert threshold
+        triggers = list(AlertRuleTrigger.objects.filter(alert_rule=alert_rule).order_by("id"))
+        critical_trigger = next(t for t in triggers if t.label == "critical")
+        warning_trigger = next(t for t in triggers if t.label == "warning")
+
         # original thresholds: critical = 200, warning = 150
-        old_threshold = serialized_alert_rule["triggers"][1]["alertThreshold"]
+        # the resolution threshold should be the warning alert threshold
+        old_threshold = warning_trigger.alert_threshold
         assert_dual_written_resolution_threshold_equals(alert_rule, old_threshold)
 
+        put_payload = deepcopy(alert_rule_dict)
+        put_payload["triggers"][0]["id"] = critical_trigger.id
+        put_payload["triggers"][1]["id"] = warning_trigger.id
+
         # TEST 1: if we update the critical trigger threshold, the resolve threshold shouldn't change
-        serialized_alert_rule["triggers"][0]["alertThreshold"] = 300
+        put_payload["triggers"][0]["alertThreshold"] = 300
         with self.feature("organizations:incidents"):
-            self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+            self.get_success_response(self.organization.slug, alert_rule.id, **put_payload)
         assert_dual_written_resolution_threshold_equals(alert_rule, old_threshold)
 
         # TEST 2: if we update the warning trigger threshold, the resolve threshold also changes
         new_threshold = 100
-        serialized_alert_rule["triggers"][1]["alertThreshold"] = new_threshold
+        put_payload["triggers"][1]["alertThreshold"] = new_threshold
         with self.feature("organizations:incidents"):
-            self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+            self.get_success_response(self.organization.slug, alert_rule.id, **put_payload)
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
 
     def test_update_trigger_threshold_dual_update_resolve_noop(self) -> None:
@@ -2736,33 +2648,6 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             == list(audit_log_entry)[0].ip_address
         )
 
-    @patch(
-        "sentry.incidents.endpoints.organization_alert_rule_details.dual_delete_migrated_alert_rule"
-    )
-    def test_dual_delete(self, mock_dual_delete: MagicMock) -> None:
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
-
-        with self.feature("organizations:incidents"), outbox_runner():
-            self.get_success_response(self.organization.slug, self.alert_rule.id, status_code=204)
-
-        assert not AlertRule.objects.filter(id=self.alert_rule.id).exists()
-        assert AlertRule.objects_with_snapshots.filter(name=self.alert_rule.name).exists()
-        assert AlertRule.objects_with_snapshots.filter(id=self.alert_rule.id).exists()
-
-        # we test the logic for this method elsewhere, so just test that it's correctly called
-        assert mock_dual_delete.call_count == 1
-        kwargs = mock_dual_delete.call_args_list[0][1]
-        assert kwargs["alert_rule"] == self.alert_rule
-
-        with self.tasks():
-            run_scheduled_deletions()
-
-        assert not AlertRule.objects_with_snapshots.filter(name=self.alert_rule.name).exists()
-        assert not AlertRule.objects_with_snapshots.filter(id=self.alert_rule.id).exists()
-
     def test_no_feature(self) -> None:
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
@@ -2795,28 +2680,20 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             assert Incident.objects.get(id=incident.id).status == IncidentStatus.CLOSED.value
 
     def test_team_permission(self) -> None:
-        # Test ensures you can only delete alerts owned by your team or no one.
-        om = self.create_member(
+        # Test ensures org owners can delete alerts owned by a team even without team membership.
+        self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
         )
         self.login_as(self.user)
         alert_rule = self.alert_rule
         alert_rule.team = self.team
         alert_rule.save()
-        # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
         OrganizationMemberTeam.objects.filter(
             organizationmember__user_id=self.user.id,
             team=self.team,
         ).delete()
         with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, alert_rule.id)
-        assert resp.status_code == 204
-        another_alert_rule = self.alert_rule
-        alert_rule.team = self.team
-        another_alert_rule.save()
-        self.create_team_membership(team=self.team, member=om)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, alert_rule.id, status_code=204)
+            self.get_success_response(self.organization.slug, alert_rule.id, status_code=204)
 
     def test_project_permission(self) -> None:
         """Test that a user can't delete an alert in a project they do not have access to"""
@@ -2829,6 +2706,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         alert_rule = self.create_alert_rule(projects=[project])
         alert_rule.team_id = team.id
         alert_rule.save()
+        migrate_alert_rule(alert_rule)
 
         other_user = self.create_user()
         self.login_as(other_user)
@@ -2839,6 +2717,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         other_alert_rule = self.create_alert_rule(projects=[other_project])
         other_alert_rule.team_id = other_team.id
         other_alert_rule.save()
+        migrate_alert_rule(other_alert_rule)
 
         with self.feature("organizations:incidents"):
             self.get_error_response(self.organization.slug, alert_rule.id, status_code=403)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -60,7 +60,6 @@ from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -186,13 +185,14 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
     def test_simple(self) -> None:
         team = self.create_team(organization=self.organization, members=[self.user])
         ProjectTeam.objects.create(project=self.project, team=team)
-        alert_rule = self.create_alert_rule()
 
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug)
 
-        assert resp.data == serialize([self.alert_rule, alert_rule])
+        assert resp.data[0] == serialize(
+            self.detector, self.user, WorkflowEngineDetectorSerializer()
+        )
 
     def test_workflow_engine_serializer(self) -> None:
         team = self.create_team(organization=self.organization, members=[self.user])
@@ -252,17 +252,15 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         team = self.create_team(organization=self.organization, members=[self.user])
         ProjectTeam.objects.create(project=self.project, team=team)
 
-        # Create rule and manually set it to upsampled_count() (simulating what happens after conversion)
-        alert_rule = self.create_alert_rule()
-        alert_rule.snuba_query.aggregate = "upsampled_count()"
-        alert_rule.snuba_query.save()
+        # Manually set self.alert_rule to upsampled_count() (simulating what happens after conversion)
+        self.alert_rule.snuba_query.aggregate = "upsampled_count()"
+        self.alert_rule.snuba_query.save()
 
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug)
 
-        # Find our rule in the response (should be the second one, first is self.alert_rule)
-        rule = next(rule for rule in resp.data if rule["id"] == str(alert_rule.id))
+        rule = next(rule for rule in resp.data if rule["id"] == str(self.alert_rule.id))
 
         assert rule["aggregate"] == "count()", (
             "LIST should return count() to user, hiding internal upsampled_count() storage"
@@ -368,40 +366,6 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
 
         assert len(resp.data) == 1
         assert resp.data[0]["name"] == self.detector.name
-
-
-@freeze_time("2024-12-11 03:21:34")
-class AlertRuleListDeltaTest(AlertRuleIndexBase, TestWorkflowEngineSerializer):
-    """Delta tests comparing old vs new serializer output for the list endpoint."""
-
-    @with_feature("organizations:incidents")
-    def test_workflow_engine_serializer_matches_old_serializer(self) -> None:
-        """New serializer output on the list endpoint must match old serializer output."""
-        team = self.create_team(organization=self.organization, members=[self.user])
-        ProjectTeam.objects.create(project=self.project, team=team)
-        self.login_as(self.user)
-
-        old_resp = self.get_success_response(self.organization.slug)
-        old_data = old_resp.data
-        assert len(old_data) > 0
-
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            new_resp = self.get_success_response(self.organization.slug)
-        new_data = new_resp.data
-        assert len(new_data) == len(old_data)
-
-        for old_rule, new_rule in zip(old_data, new_data):
-            assert_serializer_parity(
-                old=old_rule,
-                new=new_rule,
-                known_differences={
-                    # resolveThreshold: Old serializer checked AlertRule.resolve_threshold for None,
-                    # but workflow engine always creates a resolve condition during migration.
-                    # Cannot distinguish between explicit None vs migrated value without AlertRule.
-                    "resolveThreshold",
-                    "triggers.resolveThreshold",  # same reason as above
-                },
-            )
 
 
 @freeze_time()

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -5,22 +5,15 @@ from typing import Any
 from sentry import audit_log
 from sentry.api.serializers import serialize
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
-from sentry.incidents.endpoints.serializers.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.migration_helpers.alert_rule import (
-    dual_write_alert_rule,
-    migrate_alert_rule,
-)
+from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.detector import Detector
 
@@ -33,6 +26,7 @@ class AlertRuleDetailsBase(APITestCase):
     def setUp(self) -> None:
         super().setUp()
         self.alert_rule = self.create_alert_rule(name="hello")
+        _, _, _, self.detector, _, _, _, _ = migrate_alert_rule(self.alert_rule)
         self.owner_user = self.create_user()
         self.create_member(
             user=self.owner_user, organization=self.organization, role="owner", teams=[self.team]
@@ -43,65 +37,68 @@ class AlertRuleDetailsBase(APITestCase):
 
 
 class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
-    def test_simple(self) -> None:
-        # self.login_as(self.owner_user)
+    def test_dual_written_resolves_detector(self) -> None:
         with self.feature("organizations:incidents"), outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id
             )
-        assert resp.data == serialize(self.alert_rule, serializer=DetailedAlertRuleSerializer())
+        assert resp.data["id"] == str(self.alert_rule.id)
+        assert resp.data["name"] == self.alert_rule.name
+
+    def test_single_written_resolves_via_fake_id(self) -> None:
+        # Simulate a single-written detector by removing the AlertRuleDetector bridge.
+        AlertRuleDetector.objects.filter(detector=self.detector).delete()
+        fake_id = get_fake_id_from_object_id(self.detector.id)
+        with self.feature("organizations:incidents"):
+            resp = self.get_success_response(self.organization.slug, self.project.slug, fake_id)
+        assert resp.data["name"] == self.detector.name
+
+    def test_single_written_fake_id_not_found_returns_404(self) -> None:
+        fake_id = get_fake_id_from_object_id(999999999)
+        with self.feature("organizations:incidents"):
+            self.get_error_response(
+                self.organization.slug, self.project.slug, fake_id, status_code=404
+            )
 
 
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
     method = "put"
 
-    def get_serialized_alert_rule(self) -> dict[str, Any]:
-        # Only call after calling self.alert_rule to create it.
-        original_endpoint = self.endpoint
-        original_method = self.method
-        self.endpoint = "sentry-api-0-organization-alert-rules"
-        self.method = "get"
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug)
-            assert len(resp.data) >= 1
-            serialized_alert_rule = resp.data[0]
-            if serialized_alert_rule["environment"]:
-                serialized_alert_rule["environment"] = serialized_alert_rule["environment"][0]
-            else:
-                serialized_alert_rule.pop("environment", None)
-        self.endpoint = original_endpoint
-        self.method = original_method
-        return serialized_alert_rule
+    def _put_payload(self) -> dict[str, Any]:
+        return {
+            "name": "what",
+            "aggregate": self.alert_rule.snuba_query.aggregate,
+            "query": self.alert_rule.snuba_query.query,
+            "timeWindow": self.alert_rule.snuba_query.time_window // 60,
+            "thresholdType": self.alert_rule.threshold_type,
+            "projects": [self.project.slug],
+            "triggers": [
+                {
+                    "label": "critical",
+                    "alertThreshold": 200,
+                    "actions": [
+                        {
+                            "type": "email",
+                            "targetIdentifier": self.user.id,
+                            "targetType": "user",
+                        },
+                    ],
+                },
+            ],
+        }
 
     def test_simple(self) -> None:
         alert_rule = self.alert_rule
-        # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
-        serialized_alert_rule = self.get_serialized_alert_rule()
-        serialized_alert_rule["name"] = "what"
-        serialized_alert_rule["triggers"] = [
-            {
-                "label": "critical",
-                "alertThreshold": 200,
-                "actions": [
-                    {
-                        "type": "email",
-                        "targetIdentifier": self.user.id,
-                        "targetType": "user",
-                    },
-                ],
-            },
-        ]
 
         with self.feature("organizations:incidents"), outbox_runner():
             resp = self.get_success_response(
-                self.organization.slug, self.project.slug, alert_rule.id, **serialized_alert_rule
+                self.organization.slug, self.project.slug, alert_rule.id, **self._put_payload()
             )
 
         alert_rule.name = "what"
         alert_rule.date_modified = resp.data["dateModified"]
         assert resp.data == serialize(alert_rule)
         assert resp.data["name"] == "what"
-        assert resp.data["dateModified"] > serialized_alert_rule["dateModified"]
 
         with assume_test_silo_mode(SiloMode.CONTROL):
             audit_log_entry = AuditLogEntry.objects.filter(
@@ -114,104 +111,21 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         )
 
 
-@with_feature(["organizations:incidents", "organizations:workflow-engine-rule-serializers"])
-class AlertRuleDetailsGetEndpointWorkflowEngineTest(AlertRuleDetailsBase):
-    def test_dual_written_resolves_detector(self) -> None:
-        _, _, _, detector, _, _, _, _ = migrate_alert_rule(self.alert_rule)
-        resp = self.get_success_response(
-            self.organization.slug, self.project.slug, self.alert_rule.id
-        )
-        assert resp.data["id"] == str(self.alert_rule.id)
-        assert resp.data["name"] == self.alert_rule.name
-
-    def test_single_written_resolves_via_fake_id(self) -> None:
-        # Simulate a single-written detector by migrating the alert rule (which creates a
-        # fully configured detector with data source) then removing the AlertRuleDetector bridge.
-        _, _, _, detector, _, _, _, _ = migrate_alert_rule(self.alert_rule)
-        AlertRuleDetector.objects.filter(detector=detector).delete()
-        fake_id = get_fake_id_from_object_id(detector.id)
-        resp = self.get_success_response(self.organization.slug, self.project.slug, fake_id)
-        assert resp.data["name"] == detector.name
-
-    def test_single_written_fake_id_not_found_returns_404(self) -> None:
-        fake_id = get_fake_id_from_object_id(999999999)
-        self.get_error_response(self.organization.slug, self.project.slug, fake_id, status_code=404)
-
-
-@freeze_time("2024-12-11 03:21:34")
-class AlertRuleDetailsGetDeltaTest(AlertRuleDetailsBase):
-    @with_feature("organizations:incidents")
-    def test_assert_serializer_parity(self) -> None:
-        alert_rule = self.create_alert_rule(name="parity", resolve_threshold=50)
-        self.create_alert_rule_trigger(alert_rule, label="critical")
-        dual_write_alert_rule(alert_rule)
-
-        old_resp = self.get_success_response(
-            self.organization.slug, self.project.slug, alert_rule.id
-        )
-
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            new_resp = self.get_success_response(
-                self.organization.slug, self.project.slug, alert_rule.id
-            )
-
-        assert_serializer_parity(old=old_resp.data, new=new_resp.data)
-
-
-@with_feature(
-    [
-        "organizations:incidents",
-        "organizations:workflow-engine-metric-alert-endpoints-get",
-    ]
-)
-class AlertRuleDetailsGetEndpointWorkflowEngineMethodFlagTest(AlertRuleDetailsBase):
-    """Verify that the per-method flag alone (without the broad rule-serializers flag)
-    activates the workflow engine path for GET requests."""
-
-    def test_dual_written_resolves_detector(self) -> None:
-        _, _, _, detector, _, _, _, _ = migrate_alert_rule(self.alert_rule)
-        resp = self.get_success_response(
-            self.organization.slug, self.project.slug, self.alert_rule.id
-        )
-        assert resp.data["id"] == str(self.alert_rule.id)
-        assert resp.data["name"] == self.alert_rule.name
-
-
-@with_feature(
-    [
-        "organizations:incidents",
-        "organizations:workflow-engine-metric-alert-endpoints-delete",
-    ]
-)
-class AlertRuleDetailsDeleteEndpointWorkflowEngineMethodFlagTest(AlertRuleDetailsBase):
-    method = "delete"
-
-    def test_single_written_detector_deleted(self) -> None:
-        _, _, _, detector, _, _, _, _ = migrate_alert_rule(self.alert_rule)
-        AlertRuleDetector.objects.filter(detector=detector).delete()
-        fake_id = get_fake_id_from_object_id(detector.id)
-
-        self.get_success_response(
-            self.organization.slug, self.project.slug, fake_id, status_code=204
-        )
-
-        assert not Detector.objects.filter(id=detector.id).exists()
-
-    def test_dual_written_detector_deleted(self) -> None:
-        _, _, _, detector, _, _, _, _ = migrate_alert_rule(self.alert_rule)
-
-        self.get_success_response(
-            self.organization.slug, self.project.slug, self.alert_rule.id, status_code=204
-        )
-
-        assert not Detector.objects.filter(id=detector.id).exists()
-        assert not AlertRule.objects.filter(id=self.alert_rule.id).exists()
-
-
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
     method = "delete"
 
-    def test_simple(self) -> None:
+    def test_single_written_detector_deleted(self) -> None:
+        AlertRuleDetector.objects.filter(detector=self.detector).delete()
+        fake_id = get_fake_id_from_object_id(self.detector.id)
+
+        with self.feature("organizations:incidents"):
+            self.get_success_response(
+                self.organization.slug, self.project.slug, fake_id, status_code=204
+            )
+
+        assert not Detector.objects.filter(id=self.detector.id).exists()
+
+    def test_dual_written_detector_deleted(self) -> None:
         with self.feature("organizations:incidents"), outbox_runner():
             self.get_success_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, status_code=204
@@ -220,6 +134,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         with self.tasks():
             run_scheduled_deletions()
 
+        assert not Detector.objects.filter(id=self.detector.id).exists()
         assert not AlertRule.objects.filter(id=self.alert_rule.id).exists()
         assert not AlertRule.objects_with_snapshots.filter(name=self.alert_rule.id).exists()
         assert not AlertRule.objects_with_snapshots.filter(id=self.alert_rule.id).exists()

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -8,15 +8,10 @@ from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.migration_helpers.alert_rule import (
-    dual_write_alert_rule,
-    migrate_alert_rule,
-)
+from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
 
 pytestmark = [requires_snuba]
 
@@ -30,76 +25,38 @@ class AlertRuleListEndpointTest(APITestCase):
     def test_simple(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         alert_rule = self.create_alert_rule()
+        _, _, _, detector, _, _, _, _ = migrate_alert_rule(alert_rule)
 
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug, self.project.slug)
 
-        assert resp.data == serialize([alert_rule])
+        assert len(resp.data) == 1
+        assert resp.data[0]["name"] == detector.name
 
     def test_no_perf_alerts(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         alert_rule = self.create_alert_rule()
+        migrate_alert_rule(alert_rule)
         perf_alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
+        migrate_alert_rule(perf_alert_rule)
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug, self.project.slug)
-            assert resp.data == serialize([alert_rule])
+            assert len(resp.data) == 1
+            assert resp.data[0]["name"] == alert_rule.name
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_success_response(self.organization.slug, self.project.slug)
-            assert resp.data == serialize([perf_alert_rule, alert_rule])
+            assert len(resp.data) == 2
+            names = {item["name"] for item in resp.data}
+            assert names == {alert_rule.name, perf_alert_rule.name}
 
     def test_no_feature(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
         resp = self.get_response(self.organization.slug, self.project.slug)
         assert resp.status_code == 404
-
-
-@freeze_time("2024-12-11 03:21:34")
-class AlertRuleListDeltaTest(APITestCase):
-    endpoint = "sentry-api-0-project-alert-rules"
-
-    @with_feature("organizations:incidents")
-    def test_assert_serializer_parity(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        alert_rule = self.create_alert_rule(resolve_threshold=50)
-        self.create_alert_rule_trigger(alert_rule, label="critical")
-        dual_write_alert_rule(alert_rule)
-        self.login_as(self.user)
-
-        old_resp = self.get_success_response(self.organization.slug, self.project.slug)
-
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            new_resp = self.get_success_response(self.organization.slug, self.project.slug)
-
-        assert len(old_resp.data) == len(new_resp.data) == 1
-        assert_serializer_parity(old=old_resp.data[0], new=new_resp.data[0])
-
-
-@with_feature(
-    [
-        "organizations:incidents",
-        "organizations:workflow-engine-metric-alert-endpoints-get",
-    ]
-)
-class AlertRuleListEndpointWorkflowEngineMethodFlagTest(APITestCase):
-    """Verify that the per-method flag alone (without the broad rule-serializers flag)
-    activates the workflow engine path for GET requests."""
-
-    endpoint = "sentry-api-0-project-alert-rules"
-
-    def test_returns_detector_serialization(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        alert_rule = self.create_alert_rule()
-        _, _, _, detector, _, _, _, _ = migrate_alert_rule(alert_rule)
-
-        self.login_as(self.user)
-        resp = self.get_success_response(self.organization.slug, self.project.slug)
-
-        assert len(resp.data) == 1
-        assert resp.data[0]["name"] == detector.name
 
 
 @freeze_time()


### PR DESCRIPTION
Remove the legacy code paths for the `workflow-engine-metric-alert-endpoints-get`, `workflow-engine-orgalertruledetails-delete`, and `workflow-engine-metric-alert-endpoints-delete` flags. 