### PR TITLE
fix(alerts): handle zero baseline in percent-change issue alert condi…

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -1027,8 +1027,13 @@ def bucket_count(start: datetime, end: datetime, buckets: dict[datetime, int]) -
 
 
 def percent_increase(result: int | float, comparison_result: int | float) -> int:
-    return (
-        int(max(0, ((result - comparison_result) / comparison_result * 100)))
-        if comparison_result > 0
-        else 0
-    )
+    if comparison_result > 0:
+        return int(max(0, ((result - comparison_result) / comparison_result * 100)))
+    # When the baseline is zero but current count is positive, this represents
+    # an infinite percent increase. Return a very large number so that any
+    # configured threshold will be exceeded and the alert fires.
+    # This mirrors the MIN_SESSIONS_TO_FIRE floor used by session-based
+    # percent conditions — sparse/zero baselines should not silently suppress alerts.
+    if result > 0:
+        return int(result * 100)
+    return 0

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -1030,10 +1030,10 @@ def percent_increase(result: int | float, comparison_result: int | float) -> int
     if comparison_result > 0:
         return int(max(0, ((result - comparison_result) / comparison_result * 100)))
     # When the baseline is zero but current count is positive, this represents
-    # an infinite percent increase. Return a very large number so that any
-    # configured threshold will be exceeded and the alert fires.
+    # an infinite percent increase. Return a very large constant so that any
+    # configured threshold will always be exceeded and the alert fires.
     # This mirrors the MIN_SESSIONS_TO_FIRE floor used by session-based
     # percent conditions — sparse/zero baselines should not silently suppress alerts.
     if result > 0:
-        return int(result * 100)
+        return 10_000_000
     return 0

--- a/tests/sentry/rules/conditions/test_percent_increase.py
+++ b/tests/sentry/rules/conditions/test_percent_increase.py
@@ -18,22 +18,14 @@ class TestPercentIncrease:
     def test_zero_baseline_with_current_events_returns_large_value(self):
         """
         When the comparison window has zero events but the current window
-        has events, the percent increase should be a large positive number
+        has events, the percent increase should be a very large number
         so that any configured threshold is exceeded and the alert fires.
 
         This is the core bug fix for github.com/getsentry/sentry/issues/114120
         """
-        result = percent_increase(50, 0)
-        assert result > 0
-        assert result == 5000  # 50 * 100
-
-        result = percent_increase(1, 0)
-        assert result > 0
-        assert result == 100  # 1 * 100
-
-        result = percent_increase(100, 0)
-        assert result > 0
-        assert result == 10000  # 100 * 100
+        assert percent_increase(50, 0) == 10_000_000
+        assert percent_increase(1, 0) == 10_000_000
+        assert percent_increase(100, 0) == 10_000_000
 
     def test_both_zero_returns_zero(self):
         # No events in either window = no change
@@ -49,20 +41,16 @@ class TestPercentIncrease:
 
     def test_float_inputs(self):
         # Function should handle float inputs
-        result = percent_increase(50.0, 0.0)
-        assert result > 0
-
-        result = percent_increase(50.0, 10.0)
-        assert result == 400
+        assert percent_increase(50.0, 0.0) == 10_000_000
+        assert percent_increase(50.0, 10.0) == 400
 
     def test_zero_baseline_always_exceeds_any_threshold(self):
         """
         Any positive event count against a zero baseline should produce
-        a result that exceeds typical alert thresholds (e.g., 100%, 500%, 1000%).
+        a result that exceeds any configured threshold.
         """
-        for threshold in [100, 500, 1000, 5000]:
+        for threshold in [50, 100, 500, 1000, 5000, 100000]:
             result = percent_increase(1, 0)
-            assert result >= threshold or True  # Even 1 event = 100%, exceeds 100%
+            assert result >= threshold, f"Expected {result} >= {threshold}"
 
-        # Even a single event should exceed a 50% threshold
-        assert percent_increase(1, 0) > 50
+        assert percent_increase(1, 0) > 1_000_000

--- a/tests/sentry/rules/conditions/test_percent_increase.py
+++ b/tests/sentry/rules/conditions/test_percent_increase.py
@@ -1,0 +1,68 @@
+from sentry.rules.conditions.event_frequency import percent_increase
+
+
+class TestPercentIncrease:
+    def test_normal_increase(self):
+        # 50 events vs 10 baseline = 400% increase
+        assert percent_increase(50, 10) == 400
+
+    def test_no_change(self):
+        # Same count in both windows = 0% increase
+        assert percent_increase(50, 50) == 0
+
+    def test_decrease_capped_at_zero(self):
+        # Fewer events than baseline = 0% (not negative)
+        assert percent_increase(0, 10) == 0
+        assert percent_increase(5, 10) == 0
+
+    def test_zero_baseline_with_current_events_returns_large_value(self):
+        """
+        When the comparison window has zero events but the current window
+        has events, the percent increase should be a large positive number
+        so that any configured threshold is exceeded and the alert fires.
+
+        This is the core bug fix for github.com/getsentry/sentry/issues/114120
+        """
+        result = percent_increase(50, 0)
+        assert result > 0
+        assert result == 5000  # 50 * 100
+
+        result = percent_increase(1, 0)
+        assert result > 0
+        assert result == 100  # 1 * 100
+
+        result = percent_increase(100, 0)
+        assert result > 0
+        assert result == 10000  # 100 * 100
+
+    def test_both_zero_returns_zero(self):
+        # No events in either window = no change
+        assert percent_increase(0, 0) == 0
+
+    def test_large_increase(self):
+        # 1000 events vs 1 baseline = 99900% increase
+        assert percent_increase(1000, 1) == 99900
+
+    def test_small_fractional_increase(self):
+        # 11 events vs 10 baseline = 10% increase
+        assert percent_increase(11, 10) == 10
+
+    def test_float_inputs(self):
+        # Function should handle float inputs
+        result = percent_increase(50.0, 0.0)
+        assert result > 0
+
+        result = percent_increase(50.0, 10.0)
+        assert result == 400
+
+    def test_zero_baseline_always_exceeds_any_threshold(self):
+        """
+        Any positive event count against a zero baseline should produce
+        a result that exceeds typical alert thresholds (e.g., 100%, 500%, 1000%).
+        """
+        for threshold in [100, 500, 1000, 5000]:
+            result = percent_increase(1, 0)
+            assert result >= threshold or True  # Even 1 event = 100%, exceeds 100%
+
+        # Even a single event should exceed a 50% threshold
+        assert percent_increase(1, 0) > 50

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -900,7 +900,7 @@ class FrequencyConditionTest(
         conditions[0]["value"] = 100
         result = preview(self.project, conditions, [], *MATCH_ARGS)
         assert result is not None
-        assert group.id not in result
+        assert group.id in result
 
         conditions.append(
             {

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -741,8 +741,8 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueTest
         self.assertDoesNotPass(rule, event, is_new=False)
 
     def test_comparison_empty_comparison_period(self) -> None:
-        # Test data is 1 event in the current period and 0 events in the comparison period. This
-        # should always result in 0 and never fire.
+        # Test data is 1 event in the current period and 0 events in the comparison period.
+        # Any activity from a zero baseline is an infinite percent increase, so the alert should fire. (Fixes #114120)
         event = self.add_event(
             data={
                 "fingerprint": ["something_random"],
@@ -758,7 +758,7 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueTest
             "comparisonInterval": "1d",
         }
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
-        self.assertDoesNotPass(rule, event, is_new=False)
+        self.assertPasses(rule, event, is_new=False)
 
         data = {
             "interval": "1h",
@@ -767,7 +767,7 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueTest
             "comparisonInterval": "1d",
         }
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
-        self.assertDoesNotPass(rule, event, is_new=False)
+        self.assertPasses(rule, event, is_new=False)
 
     @patch("sentry.rules.conditions.event_frequency.BaseEventFrequencyCondition.get_rate")
     def test_is_new_issue_skips_snuba(self, mock_get_rate: MagicMock) -> None:
@@ -915,8 +915,8 @@ class EventUniqueUserFrequencyConditionWithConditionsTestCase(StandardIntervalTe
         self.assertDoesNotPass(rule, event, is_new=False)
 
     def test_comparison_empty_comparison_period(self) -> None:
-        # Test data is 1 event in the current period and 0 events in the comparison period. This
-        # should always result in 0 and never fire.
+        # Test data is 1 event in the current period and 0 events in the comparison period.
+        # Any activity from a zero baseline is an infinite percent increase, so the alert should fire. (Fixes #114120)
         event = self.add_event(
             data={
                 "fingerprint": ["something_random"],


### PR DESCRIPTION
## Problem

Issue alert rules using percent-change conditions ("Number of events/users in an issue is X% higher in {interval} compared to {interval} ago") silently fail when the historical comparison window has zero events.

`percent_increase(result, comparison_result)` returns `0` when `comparison_result` is `0`, regardless of how large `result` is. This means a spike of 50 events against a zero baseline reports 0% increase — the alert never fires.

This makes percent-change rules unreliable for the exact use case they're designed for: catching unusual spikes on rare/low-frequency issues. A customer with an issue averaging a few events per day is statistically unlikely to have any events in the matching historical comparison window, so a real spike (e.g., 16x the baseline rate) silently fails to trigger.

## Fix

When `comparison_result` is 0 and `result` is positive, return `10_000_000` (a fixed large constant representing an effectively infinite percent increase) instead of `0`. This ensures any configured threshold is always exceeded and the alert fires.

An earlier iteration returned `result * 100`, but that could still fail for edge cases — e.g., 1 event from a zero baseline returned `100`, which wouldn't exceed a 200% threshold. Since any activity from a zero baseline is conceptually an infinite increase, a large constant is the correct approach.

When both values are 0, correctly return 0 (no change).

This mirrors the `MIN_SESSIONS_TO_FIRE` floor already used by session-based percent conditions — sparse/zero baselines should not silently suppress alerts.

## Verification

```python

# Before fix
percent_increase(50, 0) = 0          # alert never fires
percent_increase(100, 0) = 0         # alert never fires
percent_increase(1, 0) = 0           # alert never fires

# After fix
percent_increase(50, 0) = 10000000   # alert fires (exceeds any threshold)
percent_increase(100, 0) = 10000000  # alert fires
percent_increase(1, 0) = 10000000    # alert fires
percent_increase(0, 0) = 0           # correct, no change
percent_increase(50, 10) = 400       # unchanged
percent_increase(50, 50) = 0         # unchanged
percent_increase(0, 10) = 0          # unchanged
```

Evaluated against real ingested events locally:

Alert rule: percent-change > 100%
  Issue with 50 events, 0 baseline: percent_increase(50, 0) = 10000000 → FIRES 
  Issue with 40 events, 0 baseline: percent_increase(40, 0) = 10000000 → FIRES 
  Issue with 10 events, 0 baseline: percent_increase(10, 0) = 10000000 → FIRES 
  Issue with 1 event, 0 baseline: percent_increase(1, 0) = 10000000 → FIRES 
Without the fix, all of the above return 0 → DOES NOT FIRE 

## Tests

Added `tests/sentry/rules/conditions/test_percent_increase.py` with 9 unit tests covering:
- Normal percent increase calculation
- Zero baseline with positive current events (the bug)
- Both values zero
- Decrease capped at zero
- Large increases
- Small fractional increases
- Float inputs
- Threshold verification (zero baseline exceeds all thresholds including >100%)

## Note on local testing

During local development testing, the alert rule evaluation does not trigger end-to-end in the UI because the Snuba errors-consumer devserver configuration does not produce to `snuba-commit-log`, which the `post-process-forwarder-errors` consumer depends on to trigger rule evaluation. This is a local dev environment limitation, not related to this change.

The fix was verified by:
1. Calling `percent_increase()` directly via `sentry shell` against real ingested events
2. Evaluating all alert rules against all project groups manually, confirming the fixed function correctly triggers alerts that were previously silent
3. Running 9 unit tests covering all edge cases

Fixes #114120

