### PR TITLE
feat(low-value-spans): Add low-value span issue type

### DIFF
--- a/src/sentry/processing_errors/grouptype.py
+++ b/src/sentry/processing_errors/grouptype.py
@@ -270,3 +270,21 @@ class SourcemapConfigurationType(GroupType):
     enable_workflow_notifications = False
     # We want to show these separately to normal issue types
     in_default_search = False
+
+
+@dataclass(frozen=True)
+class LowValueSpanConfigurationType(GroupType):
+    type_id = 13002
+    slug = "low_value_span_configuration"
+    description = "Low-Value Span Configuration Issue"
+    category = GroupCategory.CONFIGURATION.value
+    released = False
+    default_priority = PriorityLevel.LOW
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+    creation_quota = Quota(3600, 60, 100)
+    notification_config = NotificationConfig(context=[])
+    enable_user_status_and_priority_changes = False
+    enable_status_change_workflow_notifications = False
+    enable_workflow_notifications = False
+    in_default_search = False


### PR DESCRIPTION
Add an unreleased low-value span configuration issue type so producers can store and query these findings behind the standard issue-type feature gates.

**Issue Type**

The new type uses the configuration issue category, stays unreleased, and remains outside default issue searches to match the existing source-map configuration issue behavior.

Refs TET-2198