### PR TITLE
fix(forms): Preserve choice value types when submitting sentry app forms

### DIFF
--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.spec.tsx
@@ -2,7 +2,7 @@ import type {ComponentProps} from 'react';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 import {SentryAppInstallationFixture} from 'sentry-fixture/sentryAppInstallation';
 
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
 import {SentryAppExternalFormNew} from 'sentry/views/settings/organizationIntegrations/sentryAppExternalForm.new';
@@ -109,5 +109,56 @@ describe('SentryAppExternalFormNew', () => {
 
     expect(screen.getByText('board R')).toBeInTheDocument();
     expect(screen.getByText('Bug')).toBeInTheDocument();
+  });
+
+  it('submits choice values with their original types (numbers stay numbers)', async () => {
+    const submitUrl = `/sentry-app-installations/${sentryAppInstallation.uuid}/external-issue-actions/`;
+    const submitRequest = MockApiClient.addMockResponse({
+      method: 'POST',
+      url: submitUrl,
+      body: {},
+    });
+
+    const config: ComponentProps<typeof SentryAppExternalFormNew>['config'] = {
+      uri: '/integrations/sentry/issues/create',
+      required_fields: [
+        {
+          type: 'select',
+          name: 'project_id',
+          label: 'Project',
+          choices: [
+            [12345, 'project A'],
+            [67890, 'project B'],
+          ],
+        },
+      ],
+    };
+
+    render(
+      <SentryAppExternalFormNew
+        sentryAppInstallationUuid={sentryAppInstallation.uuid}
+        appName={sentryApp.name}
+        config={config}
+        action="create"
+        element="issue-link"
+        onSubmitSuccess={jest.fn()}
+      />
+    );
+
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Project'}), 'project A');
+    await userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+    await waitFor(() =>
+      expect(submitRequest).toHaveBeenCalledWith(
+        submitUrl,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            project_id: 12345,
+            action: 'create',
+            uri: '/integrations/sentry/issues/create',
+          }),
+        })
+      )
+    );
   });
 });

--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.tsx
@@ -150,16 +150,6 @@ function cloneFieldGroups(fieldGroups: FieldGroups): FieldGroups {
   };
 }
 
-function normalizeChoices(
-  choices: readonly Choice[] | undefined
-): Array<[string, string]> {
-  return (
-    choices?.map(
-      ([value, label]) => [String(value), choiceLabelToString(label)] as [string, string]
-    ) ?? []
-  );
-}
-
 function omitValues(
   values: Record<string, unknown>,
   fieldNames: Set<string>
@@ -242,11 +232,8 @@ function updateSchemaFieldChoices(
   fieldName: string,
   choices: Choices
 ): FieldGroups {
-  const normalizedChoices = normalizeChoices(choices);
   const updateGroup = (fields?: FieldFromSchema[]) =>
-    fields?.map(field =>
-      field.name === fieldName ? {...field, choices: normalizedChoices} : field
-    ) ?? [];
+    fields?.map(field => (field.name === fieldName ? {...field, choices} : field)) ?? [];
 
   return {
     required_fields: updateGroup(fieldGroups.required_fields),
@@ -271,26 +258,27 @@ function choiceLabelToString(label: Choice[1]) {
 function mergeFieldChoices(
   field: FieldFromSchema,
   resetValues: ResetValues | undefined
-): Array<[string, string]> {
-  const choices = normalizeChoices(field.choices);
+): Choices {
+  const choices = field.choices ?? [];
 
   const savedSetting = getSavedSetting(resetValues, field.name);
   const savedValue = savedSetting?.value;
   if (
     (typeof savedValue === 'string' || typeof savedValue === 'number') &&
     savedSetting?.label &&
-    !choices.some(([value]) => value === String(savedValue))
+    !choices.some(([value]) => String(value) === String(savedValue))
   ) {
-    return [[String(savedValue), savedSetting.label], ...choices];
+    return [[savedValue, savedSetting.label], ...choices];
   }
 
   return choices;
 }
 
-function toSelectValues(
-  choices: ReadonlyArray<[string, string]>
-): Array<SelectValue<string>> {
-  return choices.map(([value, label]) => ({value, label}));
+function toSelectValues(choices: Choices): Array<SelectValue<string>> {
+  return choices.map(([value, label]) => ({
+    value: value as unknown as string,
+    label: choiceLabelToString(label),
+  }));
 }
 
 function getBaseFieldDefaultValue(
@@ -758,7 +746,15 @@ export function SentryAppExternalFormNew({
           };
         case 'select':
           return {
-            choices: mergeFieldChoices(field, normalizedResetValues),
+            // The adapter types choices as [string, string], but react-select
+            // round-trips the original value type at runtime — see
+            // BackendJsonSubmitForm's transformChoices which only renames
+            // tuple positions to {value, label}. Cast so a schema choice with
+            // a numeric value (e.g. an integration's project/board ID) reaches
+            // the wire with its type preserved.
+            choices: mergeFieldChoices(field, normalizedResetValues) as Array<
+              [string, string]
+            >,
             default: defaultValue,
             disabled,
             help: field.help,
@@ -829,15 +825,10 @@ export function SentryAppExternalFormNew({
 
             setAsyncOptionsCache(prev => ({
               ...prev,
-              [field.name]: normalizeChoices(choices),
+              [field.name]: choices,
             }));
 
-            return toSelectValues(
-              choices.map(
-                ([value, label]) =>
-                  [String(value), choiceLabelToString(label)] as [string, string]
-              )
-            );
+            return toSelectValues(choices);
           },
         });
     }


### PR DESCRIPTION
The migrated `SentryAppExternalForm` stringified every choice value via `normalizeChoices`, so a select option whose schema value was a number (e.g. a Shortcut/ClickUp project ID) reached the wire as a string. External Sentry App APIs that validate types reject that payload with HTTP 400, which the backend re-raises as a 500 `InternalServerError` (`JAVASCRIPT-39N0`).

The string typing on `JsonFormAdapterSelect.choices` is a TypeScript constraint, not a runtime one — the adapter's `transformChoices` only renames tuple positions and react-select round-trips the original value untouched. Drop the normalization and add a single `as Array<[string, string]>` cast where we hand choices to `BackendJsonSubmitForm`.

Refs JAVASCRIPT-39N0