### PR TITLE
feat(low-value-spans): Add low-value span issue UI

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -310,8 +310,9 @@ export function GlobalCommandPaletteActions() {
           />
           {Object.values(ISSUE_TAXONOMY_CONFIG)
             .filter(
-              ({featureFlag}) =>
-                !featureFlag || organization.features.includes(featureFlag)
+              ({featureFlags}) =>
+                !featureFlags ||
+                featureFlags.some(feature => organization.features.includes(feature))
             )
             .map(config => (
               <CMDKAction

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -217,6 +217,7 @@ export enum IssueType {
 
   // Configuration Issues
   SOURCEMAP_CONFIGURATION = 'sourcemap_configuration',
+  LOW_VALUE_SPAN_CONFIGURATION = 'low_value_span_configuration',
 }
 
 // Issue types that should not be visible to users anywhere in the UI
@@ -302,6 +303,7 @@ export enum IssueTitle {
 
   // Configuration Issues
   SOURCEMAP_CONFIGURATION = 'Missing or Broken Source Maps',
+  LOW_VALUE_SPAN_CONFIGURATION = 'AI Detected Low-Value Span',
 }
 
 const ISSUE_TYPE_TO_ISSUE_TITLE = {
@@ -354,6 +356,7 @@ const ISSUE_TYPE_TO_ISSUE_TITLE = {
   preprod_size_analysis: IssueTitle.PREPROD_SIZE_ANALYSIS,
 
   sourcemap_configuration: IssueTitle.SOURCEMAP_CONFIGURATION,
+  low_value_span_configuration: IssueTitle.LOW_VALUE_SPAN_CONFIGURATION,
 };
 
 export function getIssueTitleFromType(issueType: string): IssueTitle | undefined {

--- a/static/app/utils/issueTypeConfig/configurationIssuesConfig.tsx
+++ b/static/app/utils/issueTypeConfig/configurationIssuesConfig.tsx
@@ -3,6 +3,17 @@ import {IssueType} from 'sentry/types/group';
 import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
 import {Tab} from 'sentry/views/issueDetails/types';
 
+const staticConfigurationIssueDetails = {
+  evidence: null,
+  header: {
+    filterBar: {enabled: false},
+    graph: {enabled: false},
+    eventNavigation: {enabled: false},
+    tagDistribution: {enabled: false},
+    occurrenceSummary: {enabled: false},
+  },
+};
+
 export const configurationIssuesConfig: IssueCategoryConfigMapping = {
   _categoryDefaults: {
     actions: {
@@ -53,14 +64,6 @@ export const configurationIssuesConfig: IssueCategoryConfigMapping = {
     discover: {enabled: false},
     groupingInfo: {enabled: false},
   },
-  [IssueType.SOURCEMAP_CONFIGURATION]: {
-    evidence: null,
-    header: {
-      filterBar: {enabled: false},
-      graph: {enabled: false},
-      eventNavigation: {enabled: false},
-      tagDistribution: {enabled: false},
-      occurrenceSummary: {enabled: false},
-    },
-  },
+  [IssueType.SOURCEMAP_CONFIGURATION]: staticConfigurationIssueDetails,
+  [IssueType.LOW_VALUE_SPAN_CONFIGURATION]: staticConfigurationIssueDetails,
 };

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.tsx
@@ -1,0 +1,23 @@
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {SectionDivider} from 'sentry/views/issueDetails/streamline/foldSection';
+
+import {ProblemSection} from './problemSection';
+import {TroubleshootingSection} from './troubleshootingSection';
+
+interface LowValueSpanIssueDetailsProps {
+  event: Event;
+  group: Group;
+  project: Project;
+}
+
+export function LowValueSpanIssueDetails(_props: LowValueSpanIssueDetailsProps) {
+  return (
+    <div>
+      <ProblemSection />
+      <SectionDivider orientation="horizontal" />
+      <TroubleshootingSection />
+    </div>
+  );
+}

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
@@ -1,0 +1,17 @@
+import {Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+
+export function ProblemSection() {
+  return (
+    <Stack gap="lg" padding="lg">
+      <Heading as="h3">{t('Problem')}</Heading>
+      <Text>
+        {t(
+          'This span adds low-value detail to traces, which can make useful telemetry harder to scan. Review the instrumentation and remove or rename the span if it does not describe work you need to debug.'
+        )}
+      </Text>
+    </Stack>
+  );
+}

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
@@ -1,0 +1,47 @@
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+
+export function TroubleshootingSection() {
+  return (
+    <Stack gap="md" padding="lg">
+      <Heading as="h3">{t('Troubleshooting suggestions')}</Heading>
+      <Stack gap="sm">
+        <Disclosure size="md" defaultExpanded>
+          <Disclosure.Title>{t('Confirm the Span Is Useful')}</Disclosure.Title>
+          <Disclosure.Content>
+            <Text>
+              {t(
+                'Keep spans that describe meaningful work, such as database calls, RPCs, jobs, or expensive operations. Remove spans that duplicate parent spans or only wrap framework internals.'
+              )}
+            </Text>
+          </Disclosure.Content>
+        </Disclosure>
+        <Disclosure size="md">
+          <Disclosure.Title>{t('Adjust Instrumentation')}</Disclosure.Title>
+          <Disclosure.Content>
+            <Text>
+              {t(
+                'Update custom instrumentation to skip this operation, or change its name and attributes so it groups with spans that share the same purpose.'
+              )}
+            </Text>
+          </Disclosure.Content>
+        </Disclosure>
+        <Disclosure size="md">
+          <Disclosure.Title>
+            {t('Review SDK and OpenTelemetry Configuration')}
+          </Disclosure.Title>
+          <Disclosure.Content>
+            <Text>
+              {t(
+                'Check automatic instrumentation settings before changing application code. Some SDK or OpenTelemetry integrations can be tuned to avoid noisy spans at the source.'
+              )}
+            </Text>
+          </Disclosure.Content>
+        </Disclosure>
+      </Stack>
+    </Stack>
+  );
+}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -69,6 +69,7 @@ import {
 } from 'sentry/utils/platform';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {LowValueSpanIssueDetails} from 'sentry/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails';
 import {SourceMapIssueDetails} from 'sentry/views/issueDetails/configurationIssues/sourceMapIssues/sourceMapIssueDetails';
 import {MetricIssuesSection} from 'sentry/views/issueDetails/metricIssues/metricIssuesSection';
 import {
@@ -129,6 +130,10 @@ export function EventDetailsContent({
 
   if (group.issueType === IssueType.SOURCEMAP_CONFIGURATION) {
     return <SourceMapIssueDetails group={group} event={event} project={project} />;
+  }
+
+  if (group.issueType === IssueType.LOW_VALUE_SPAN_CONFIGURATION) {
+    return <LowValueSpanIssueDetails group={group} event={event} project={project} />;
   }
 
   return (

--- a/static/app/views/issueList/pages/sentryConfiguration.tsx
+++ b/static/app/views/issueList/pages/sentryConfiguration.tsx
@@ -13,7 +13,7 @@ export default function SentryConfigurationPage() {
   const organization = useOrganization();
 
   return (
-    <Feature features={CONFIG.featureFlag ?? []} renderDisabled>
+    <Feature features={CONFIG.featureFlags ?? []} requireAll={false} renderDisabled>
       <IssueListContainer title={CONFIG.label}>
         <PageFiltersContainer>
           <NoProjectMessage organization={organization}>

--- a/static/app/views/issueList/taxonomies.tsx
+++ b/static/app/views/issueList/taxonomies.tsx
@@ -3,6 +3,11 @@ import type {ReactNode} from 'react';
 import {t} from 'sentry/locale';
 import {IssueCategory} from 'sentry/types/group';
 
+export const SENTRY_CONFIGURATION_FEATURE_FLAGS = [
+  'issue-sourcemap-configuration-visible',
+  'issue-low-value-span-configuration-visible',
+];
+
 export enum IssueTaxonomy {
   ERRORS_AND_OUTAGES = 'errors-outages',
   BREACHED_METRICS = 'breached-metrics',
@@ -17,7 +22,7 @@ export const ISSUE_TAXONOMY_CONFIG: Record<
     description: ReactNode;
     key: string;
     label: string;
-    featureFlag?: string;
+    featureFlags?: string[];
   }
 > = {
   [IssueTaxonomy.ERRORS_AND_OUTAGES]: {
@@ -56,6 +61,6 @@ export const ISSUE_TAXONOMY_CONFIG: Record<
     description: t(
       'Issues detected from SDK or tooling configuration problems that degrade your ability to debug telemetry using Sentry.'
     ),
-    featureFlag: 'issue-sourcemap-configuration-visible',
+    featureFlags: SENTRY_CONFIGURATION_FEATURE_FLAGS,
   },
 };

--- a/static/app/views/issueList/taxonomies.tsx
+++ b/static/app/views/issueList/taxonomies.tsx
@@ -3,7 +3,7 @@ import type {ReactNode} from 'react';
 import {t} from 'sentry/locale';
 import {IssueCategory} from 'sentry/types/group';
 
-export const SENTRY_CONFIGURATION_FEATURE_FLAGS = [
+const SENTRY_CONFIGURATION_FEATURE_FLAGS = [
   'issue-sourcemap-configuration-visible',
   'issue-low-value-span-configuration-visible',
 ];

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -40,8 +40,9 @@ export function IssuesSecondaryNavigation() {
           <SecondaryNavigation.List>
             {Object.values(ISSUE_TAXONOMY_CONFIG)
               .filter(
-                ({featureFlag}) =>
-                  !featureFlag || organization.features.includes(featureFlag)
+                ({featureFlags}) =>
+                  !featureFlags ||
+                  featureFlags.some(feature => organization.features.includes(feature))
               )
               .map(({key, label}) => (
                 <SecondaryNavigation.ListItem key={key}>


### PR DESCRIPTION
Add frontend support for low-value span configuration issues once the backend group type is available.

**Configuration Issue UI**

The new issue type maps to "AI Detected Low-Value Span" and gets a simple details view that follows the existing source-map configuration issue layout.

**Feature Gating**

The shared Sentry Configuration taxonomy now appears when either the source-map configuration flag or the low-value span configuration flag is enabled, including navigation and Command Palette entries.

**Note:** ATM no low-value span feature flag is enabled. This is just code scaffolding and not yet visible to anyone.

Depends on https://github.com/getsentry/sentry/pull/115868
Refs TET-2198