### PR TITLE
perf(conversations): Default to 24h period in sidebar link

### DIFF
--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -125,7 +125,11 @@ export function ExploreSecondaryNavigation() {
             <Feature features="gen-ai-conversations">
               <SecondaryNavigation.ListItem>
                 <SecondaryNavigation.Link
-                  to={`${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`}
+                  // TODO: Remove once query performance is improved - defaults to 24h to avoid slow loads
+                  to={{
+                    pathname: `${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`,
+                    query: {statsPeriod: '24h'},
+                  }}
                   analyticsItemName="explore_conversations"
                   trailingItems={<FeatureBadge type="beta" />}
                 >

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -128,7 +128,7 @@ export function ExploreSecondaryNavigation() {
                   // TODO: Remove once query performance is improved - defaults to 24h to avoid slow loads
                   to={{
                     pathname: `${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`,
-                    query: {statsPeriod: '24h'},
+                    search: '?statsPeriod=24h',
                   }}
                   analyticsItemName="explore_conversations"
                   trailingItems={<FeatureBadge type="beta" />}


### PR DESCRIPTION
Clicking the Conversations sidebar link now navigates with `statsPeriod=24h` in the URL. Since the datetime is present in the URL on arrival, `PageFiltersContainer` uses it directly instead of loading whatever was previously stored in localStorage, giving a fast 24h view by default.

This is a temporary measure while query performance for longer time ranges is improved.