### PR TITLE
perf(sdk): Add regex pattern support to traces sampler route matching

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import logging
+import re
 import sys
 import typing
 from collections.abc import Generator, Mapping, Sequence, Sized
@@ -91,6 +92,12 @@ SAMPLED_ROUTES = {
     "/_warmup/": 0.0,
     "/api/0/auth/validate/": 0.0,
 }
+
+# List of (compiled_pattern, sample_rate) tried in order when no exact route matches.
+SAMPLED_ROUTE_PATTERNS: list[tuple[re.Pattern[str], float]] = [
+    # Temporary: monitoring AI Conversations rollout
+    (re.compile(r"^/api/0/organizations/[^/]+/ai-conversations/"), 1.0),
+]
 
 if settings.ADDITIONAL_SAMPLED_TASKS:
     SAMPLED_TASKS.update(settings.ADDITIONAL_SAMPLED_TASKS)
@@ -182,8 +189,12 @@ def get_project_key():
 
 def traces_sampler(sampling_context):
     wsgi_path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
-    if wsgi_path and wsgi_path in SAMPLED_ROUTES:
-        return SAMPLED_ROUTES[wsgi_path]
+    if wsgi_path:
+        if wsgi_path in SAMPLED_ROUTES:
+            return SAMPLED_ROUTES[wsgi_path]
+        for pattern, rate in SAMPLED_ROUTE_PATTERNS:
+            if pattern.search(wsgi_path):
+                return rate
 
     # Apply sample_rate from custom_sampling_context
     custom_sample_rate = sampling_context.get("sample_rate")


### PR DESCRIPTION
Adds `SAMPLED_ROUTE_PATTERNS` — a list of `(compiled_regex, rate)` tuples — as a complement to the existing exact-match `SAMPLED_ROUTES` dict. `traces_sampler` now falls through to pattern matching when no exact route matches.

Uses this to sample all hits to the ai-conversations endpoints at 100% without hardcoding a specific org slug (a previous attempt at this used `/api/0/organizations/sentry/ai-conversations/` directly, which was cleaned up in #108016).

**Routes covered**

```
# urls.py
r"^(?P<organization_id_or_slug>[^/]+)/ai-conversations/$"
r"^(?P<organization_id_or_slug>[^/]+)/ai-conversations/(?P<conversation_id>[^/]+)/$"
```

```python
# sdk.py
SAMPLED_ROUTE_PATTERNS: list[tuple[re.Pattern[str], float]] = [
    (re.compile(r"^/api/0/organizations/[^/]+/ai-conversations/"), 1.0),
]
```