### PR TITLE
ref(ourlogs): remove `expanded` and window virtualizer from LogsInfiniteTable

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -161,7 +161,6 @@ export function OurlogsDrawer({
             <LogsInfiniteTable
               embedded
               embeddedOptions={embeddedOptions}
-              expanded
               additionalData={additionalData}
               analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
             />

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -539,7 +539,6 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
               {tableTab === 'logs' ? (
                 <LogsInfiniteTable
                   analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-                  expanded
                   booleanAttributes={booleanAttributes}
                   stringAttributes={stringAttributes}
                   numberAttributes={numberAttributes}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -142,7 +142,6 @@ export const LogTable = styled(ContentsTable)<{minWidth: string}>`
 
 export const LogTableBody = styled(TableBody)<{
   disableBodyPadding?: boolean;
-  expanded?: boolean;
   showHeader?: boolean;
 }>`
   ${p =>
@@ -160,14 +159,6 @@ export const LogTableBody = styled(TableBody)<{
 
   /* If a parent renderer bails out, the element might default to 0px: which causes Tanstack Virtual to stay at 0. */
   min-height: 1px;
-
-  ${p =>
-    p.expanded === undefined
-      ? ''
-      : `
-    overflow-y: auto;
-    height: 100%;
-    `}
 `;
 
 export const LogDetailTableBodyCell = styled(TableBodyCell)`

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -102,7 +102,6 @@ type LogsTableProps = {
     showVerticalScrollbar?: boolean;
   };
   emptyRenderer?: () => React.ReactNode;
-  expanded?: boolean;
   localOnlyItemFilters?: {
     filterText: string;
     filteredItems: OurLogsResponseItem[];
@@ -119,7 +118,6 @@ const LOGS_GRID_SCROLL_PIXEL_REVERSE_THRESHOLD = LOGS_GRID_BODY_ROW_HEIGHT * 2; 
 
 export function LogsInfiniteTable({
   embedded = false,
-  expanded,
   localOnlyItemFilters,
   emptyRenderer,
   analyticsPageSource,
@@ -265,7 +263,7 @@ export function LogsInfiniteTable({
   const virtualizer = useVirtualizer<HTMLElement, Element>({
     count: data?.length ?? 0,
     estimateSize,
-    overscan: expanded ? 50 : 25,
+    overscan: 35,
     getScrollElement: () => tableBodyRef?.current,
     getItemKey: (index: number) => data?.[index]?.[OurLogKnownFieldKey.ID] ?? index,
   });
@@ -503,7 +501,6 @@ export function LogsInfiniteTable({
           showHeader={!embedded}
           ref={tableBodyRef}
           disableBodyPadding={embeddedStyling?.disableBodyPadding}
-          expanded={expanded}
         >
           {paddingTop > 0 && (
             <TableRow>
@@ -574,7 +571,7 @@ export function LogsInfiniteTable({
         </LogTableBody>
       </LogTable>
       <FloatingBackToTopContainer
-        position={expanded === undefined ? 'fixed' : 'absolute'}
+        position="absolute"
         inReplay={!!embeddedOptions?.replay}
         tableWidth={tableWidth}
       >

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -262,10 +262,8 @@ export function LogsInfiniteTable({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchString, localOnlyItemFilters?.filterText]);
 
-  const isContainedVirtualizer = expanded !== undefined;
-
   const virtualizer = useVirtualizer<HTMLElement, Element>({
-    count: isContainedVirtualizer ? (data?.length ?? 0) : 0,
+    count: data?.length ?? 0,
     estimateSize,
     overscan: expanded ? 50 : 25,
     getScrollElement: () => tableBodyRef?.current,

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -12,7 +12,7 @@ import {
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import type {Virtualizer} from '@tanstack/react-virtual';
-import {useVirtualizer, useWindowVirtualizer} from '@tanstack/react-virtual';
+import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -264,15 +264,7 @@ export function LogsInfiniteTable({
 
   const isContainedVirtualizer = expanded !== undefined;
 
-  const windowVirtualizer = useWindowVirtualizer({
-    count: isContainedVirtualizer ? 0 : (data?.length ?? 0),
-    estimateSize,
-    overscan: 50,
-    getItemKey: (index: number) => data?.[index]?.[OurLogKnownFieldKey.ID] ?? index,
-    scrollMargin: tableBodyRef.current?.offsetTop ?? 0,
-  });
-
-  const containerVirtualizer = useVirtualizer<HTMLElement, Element>({
+  const virtualizer = useVirtualizer<HTMLElement, Element>({
     count: isContainedVirtualizer ? (data?.length ?? 0) : 0,
     estimateSize,
     overscan: expanded ? 50 : 25,
@@ -280,11 +272,9 @@ export function LogsInfiniteTable({
     getItemKey: (index: number) => data?.[index]?.[OurLogKnownFieldKey.ID] ?? index,
   });
 
-  const virtualizer = isContainedVirtualizer ? containerVirtualizer : windowVirtualizer;
-
   useLayoutEffect(() => {
     virtualizer.measure();
-  }, [expanded, virtualizer]);
+  }, [virtualizer]);
 
   const virtualItems = virtualizer.getVirtualItems();
 

--- a/static/app/views/explore/replays/detail/ourlogs/index.tsx
+++ b/static/app/views/explore/replays/detail/ourlogs/index.tsx
@@ -132,7 +132,6 @@ function OurLogsContent({replayId, startTimestampMs}: OurLogsContentProps) {
             allowPagination
             embedded
             embeddedOptions={embeddedOptions}
-            expanded
             localOnlyItemFilters={{
               filteredItems: filteredLogItems,
               filterText: filterProps.searchTerm,

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -1,14 +1,14 @@
 import {useEffect, useMemo, useRef} from 'react';
-import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
-import {Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
+import {Flex, type FlexProps} from '@sentry/scraps/layout';
 
 import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {ViewportConstrainedPage} from 'sentry/views/explore/components/viewportConstrainedPage';
 import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {isLogsEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
@@ -196,7 +196,7 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
       orgSlug={organization.slug}
     >
       <NoProjectMessage organization={organization}>
-        <LayoutPageWithHiddenFooter flex={1}>
+        <ViewportConstrainedPage>
           <TraceMetaDataHeader
             rootEventResults={rootEventResults}
             tree={tree}
@@ -254,21 +254,13 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
               <TraceAiTab traceSlug={traceSlug} />
             ) : null}
           </TraceInnerLayout>
-        </LayoutPageWithHiddenFooter>
+        </ViewportConstrainedPage>
       </NoProjectMessage>
     </SentryDocumentTitle>
   );
 }
 
 const TraceViewImpl = registerLLMContext('trace', TraceViewImplInner);
-
-// @TODO(JonasBadalic): Remove this component once the page-frame feature is GA'd
-// When that feature is enabled, the footer is no longer rendered at the bottom of the page.
-const LayoutPageWithHiddenFooter = styled(Stack)`
-  ~ footer {
-    display: none;
-  }
-`;
 
 function TraceInnerLayout(props: FlexProps) {
   const hasPageFrame = useHasPageFrameFeature();

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -80,7 +80,6 @@ function LogsSectionContent() {
         <LogsInfiniteTable
           analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
           embedded
-          expanded
           showCellActions
           showExploreSimilarSpansLink
         />


### PR DESCRIPTION
Prior to this area of work, `LogsInfiniteTable` could use either a _contained_ virtualizer (non-expanded mode) or _window_ virtualizer (expanded mode). Now that we're always constrained to the page, I suspect we can stick with just _contained_.

Trying this out, it seems to work effectively the same. Which I think makes sense: that the table is now always constrained to a parent element & size.

As a part of this, I also removed the `expanded` prop. All but one uses of the table were using it, and it didn't do much else beyond changing the `overscan` amount.

Closes LOGS-813.