### PR TITLE
fix(replays): Allow org admins to bulk delete replays

### DIFF
--- a/static/app/components/replays/table/deleteReplays.tsx
+++ b/static/app/components/replays/table/deleteReplays.tsx
@@ -63,9 +63,9 @@ export function DeleteReplays({selectedIds, replays, queryOptions}: Props) {
           ? projects[0]?.id
           : undefined,
   });
-  const hasOneProjectSelected = Boolean(project);
 
-  const oneProjectEligible = hasOneProjectSelected || hasOnlyOneProject;
+  // Only allow bulk delete if we have successfully resolved a project
+  const oneProjectEligible = Boolean(project);
 
   const {bulkDelete, hasAccess, queryOptionsToPayload} = useDeleteReplays({
     projectSlug: project?.slug ?? '',
@@ -90,7 +90,9 @@ export function DeleteReplays({selectedIds, replays, queryOptions}: Props) {
     >
       <Tooltip
         disabled={!oneProjectEligible || hasAccess}
-        title={t('You must have project:write or project:admin access to delete replays')}
+        title={t(
+          'You must have project:write, project:admin, or org:admin access to delete replays'
+        )}
       >
         <Button
           disabled={!oneProjectEligible || !hasAccess}

--- a/static/app/utils/replays/hooks/useDeleteReplays.tsx
+++ b/static/app/utils/replays/hooks/useDeleteReplays.tsx
@@ -27,8 +27,10 @@ export function useDeleteReplays({projectSlug}: Props) {
   const project = useProjectFromSlug({organization, projectSlug});
   const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
   const hasAdminAccess = hasEveryAccess(['project:admin'], {organization, project});
+  const hasOrgAdminAccess = hasEveryAccess(['org:admin'], {organization});
 
-  const hasAccess = Boolean(projectSlug) && (hasWriteAccess || hasAdminAccess);
+  const hasAccess =
+    Boolean(projectSlug) && (hasWriteAccess || hasAdminAccess || hasOrgAdminAccess);
 
   const {mutate} = useMutation({
     mutationFn: ([data]: Vars) => {

--- a/static/app/utils/replays/useDeleteReplays.spec.tsx
+++ b/static/app/utils/replays/useDeleteReplays.spec.tsx
@@ -1,3 +1,4 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
@@ -96,6 +97,86 @@ describe('useDeleteReplays', () => {
         environments: [],
         query: 'id:[1,2]',
       });
+    });
+  });
+
+  describe('hasAccess', () => {
+    const project = ProjectFixture({access: []});
+    const projectSlug = project.slug;
+
+    beforeEach(() => {
+      const configstate = ConfigStore.getState();
+      ConfigStore.loadInitialData({
+        ...configstate,
+        user: {
+          ...configstate.user,
+          options: {
+            ...configstate.user?.options,
+            timezone: 'America/New_York',
+          },
+        },
+      });
+
+      ProjectsStore.loadInitialData([project]);
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/projects/',
+        body: [project],
+      });
+    });
+
+    it('should grant access to users with project:write', () => {
+      const organization = OrganizationFixture({access: ['project:write']});
+
+      const {result} = renderHookWithProviders(useDeleteReplays, {
+        initialProps: {projectSlug},
+        organization,
+      });
+
+      expect(result.current.hasAccess).toBe(true);
+    });
+
+    it('should grant access to users with project:admin', () => {
+      const organization = OrganizationFixture({access: ['project:admin']});
+
+      const {result} = renderHookWithProviders(useDeleteReplays, {
+        initialProps: {projectSlug},
+        organization,
+      });
+
+      expect(result.current.hasAccess).toBe(true);
+    });
+
+    it('should grant access to org owners with org:admin', () => {
+      const organization = OrganizationFixture({access: ['org:admin']});
+
+      const {result} = renderHookWithProviders(useDeleteReplays, {
+        initialProps: {projectSlug},
+        organization,
+      });
+
+      expect(result.current.hasAccess).toBe(true);
+    });
+
+    it('should deny access to users without proper permissions', () => {
+      const organization = OrganizationFixture({access: ['org:read']});
+
+      const {result} = renderHookWithProviders(useDeleteReplays, {
+        initialProps: {projectSlug},
+        organization,
+      });
+
+      expect(result.current.hasAccess).toBe(false);
+    });
+
+    it('should deny access when projectSlug is empty', () => {
+      const organization = OrganizationFixture({access: ['org:admin']});
+
+      const {result} = renderHookWithProviders(useDeleteReplays, {
+        initialProps: {projectSlug: ''},
+        organization,
+      });
+
+      expect(result.current.hasAccess).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Problem

Users with Org Owner or Manager roles were unable to bulk delete Session Replays, even when a single project was explicitly selected. The Delete button remained disabled despite having the necessary organizational permissions.

Fixes: REPLAY-850

## Solution

The issue was that the permission check in `useDeleteReplays` only looked for `project:write` and `project:admin` scopes, but Org Owners/Managers have `org:admin` scope instead. This PR:

1. **Adds `org:admin` scope check** to the `useDeleteReplays` hook, allowing users with organization-level admin access to delete replays
2. **Updates the permission tooltip** to reflect that `org:admin` access is sufficient
3. **Fixes the `oneProjectEligible` logic** to only be true when a project is successfully resolved (prevents confusing tooltip states)
4. **Adds comprehensive tests** for all permission scenarios
