### PR TITLE
feat(snapshots): Add viewport width support to snapshot testing framework

### DIFF
--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -110,9 +110,7 @@ function snapshotTest(
     const details = parseSnapshotDetails(currentTestName ?? '', name);
 
     const viewportSuffix = resolved ? `@${resolved.label}` : '';
-    const displayName = viewportSuffix
-      ? details.displayName.replace(new RegExp(`\\s*${viewportSuffix}$`), '')
-      : details.displayName;
+    const displayName = details.displayName;
     const fileSlug = viewportSuffix
       ? details.fileSlug.replace(new RegExp(`${viewportSuffix}$`, 'i'), '')
       : details.fileSlug;

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -14,10 +14,7 @@ type BreakpointName = keyof typeof BREAKPOINT_WIDTHS;
 
 type SnapshotViewport = BreakpointName | number | {width: number; height?: number};
 
-interface SnapshotOptions {
-  metadata?: SnapshotTestMetadata;
-  viewport?: SnapshotViewport;
-}
+type SnapshotTestInput = SnapshotTestMetadata & {viewport?: SnapshotViewport};
 
 interface SnapshotDetails {
   displayName: string;
@@ -79,23 +76,12 @@ function resolveViewport(input: SnapshotViewport): {
   return {width: input.width, height: input.height, label: name ?? `${input.width}w`};
 }
 
-function isSnapshotOptions(
-  options: SnapshotTestMetadata | SnapshotOptions | undefined
-): options is SnapshotOptions {
-  if (!options) {
-    return false;
-  }
-  return 'viewport' in options || 'metadata' in options;
-}
-
 function snapshotTest(
   name: string,
   renderFn: () => ReactElement,
-  options?: SnapshotTestMetadata | SnapshotOptions
+  metadata: SnapshotTestInput = {}
 ): void {
-  const {metadata = {}, viewport: viewportInput} = isSnapshotOptions(options)
-    ? options
-    : {metadata: options ?? ({} as SnapshotTestMetadata), viewport: undefined};
+  const {viewport: viewportInput, ...restMetadata} = metadata;
 
   const resolved = viewportInput ? resolveViewport(viewportInput) : undefined;
 
@@ -123,7 +109,7 @@ function snapshotTest(
       testFilePath: testPath,
       group: details.group,
       theme: details.theme,
-      metadata,
+      metadata: restMetadata,
       viewport: resolved ? {width: resolved.width, height: resolved.height} : undefined,
       viewportLabel: resolved?.label,
     });
@@ -134,11 +120,11 @@ snapshotTest.each = function snapshotEach<T>(table: T[]) {
   return (
     name: string,
     renderFn: (value: T) => ReactElement,
-    optionsFn?: (value: T) => SnapshotTestMetadata | SnapshotOptions
+    metadataFn?: (value: T) => SnapshotTestInput
   ) => {
     for (const value of table) {
       const testName = name.replace('%s', String(value));
-      snapshotTest(testName, () => renderFn(value), optionsFn?.(value));
+      snapshotTest(testName, () => renderFn(value), metadataFn?.(value));
     }
   };
 };
@@ -150,7 +136,7 @@ snapshotTest.breakpoints = function snapshotBreakpoints(
   metadata: SnapshotTestMetadata = {}
 ): void {
   for (const bp of breakpoints) {
-    snapshotTest(name, renderFn, {viewport: bp, metadata});
+    snapshotTest(name, renderFn, {...metadata, viewport: bp});
   }
 };
 
@@ -175,7 +161,7 @@ declare global {
         ) => (
           name: string,
           renderFn: (value: T) => ReactElement,
-          optionsFn?: (value: T) => SnapshotTestMetadata | SnapshotOptions
+          metadataFn?: (value: T) => SnapshotTestInput
         ) => void;
       };
     }

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -1,7 +1,23 @@
 import type {ReactElement} from 'react';
 
+// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
+import {lightTheme} from 'sentry/utils/theme/theme';
+
 import {closeBrowser, takeSnapshot} from './snapshot';
 import type {SnapshotTestMetadata} from './snapshot-image-metadata';
+
+const BREAKPOINT_WIDTHS = Object.fromEntries(
+  Object.entries(lightTheme.breakpoints).map(([k, v]) => [k, parseInt(v, 10)])
+) as Record<keyof typeof lightTheme.breakpoints, number>;
+
+type BreakpointName = keyof typeof BREAKPOINT_WIDTHS;
+
+type SnapshotViewport = BreakpointName | number | {width: number; height?: number};
+
+interface SnapshotOptions {
+  metadata?: SnapshotTestMetadata;
+  viewport?: SnapshotViewport;
+}
 
 interface SnapshotDetails {
   displayName: string;
@@ -41,12 +57,52 @@ function parseSnapshotDetails(testName: string, fallbackName: string): SnapshotD
   return {displayName, fileSlug, group, theme: themeMatch?.[1]};
 }
 
+function resolveViewport(input: SnapshotViewport): {
+  label: string;
+  width: number;
+  height?: number;
+} {
+  if (typeof input === 'string') {
+    const width = BREAKPOINT_WIDTHS[input];
+    if (width <= 0) {
+      throw new Error(
+        `Breakpoint "${input}" resolves to ${width}px — too small for a snapshot`
+      );
+    }
+    return {width, label: input};
+  }
+  if (typeof input === 'number') {
+    const name = Object.entries(BREAKPOINT_WIDTHS).find(([, w]) => w === input)?.[0];
+    return {width: input, label: name ?? `${input}w`};
+  }
+  const name = Object.entries(BREAKPOINT_WIDTHS).find(([, w]) => w === input.width)?.[0];
+  return {width: input.width, height: input.height, label: name ?? `${input.width}w`};
+}
+
+function isSnapshotOptions(
+  options: SnapshotTestMetadata | SnapshotOptions | undefined
+): options is SnapshotOptions {
+  if (!options) {
+    return false;
+  }
+  return 'viewport' in options || 'metadata' in options;
+}
+
 function snapshotTest(
   name: string,
   renderFn: () => ReactElement,
-  metadata: SnapshotTestMetadata = {}
+  options?: SnapshotTestMetadata | SnapshotOptions
 ): void {
-  test(`snapshot: ${name}`, async () => {
+  const {metadata = {}, viewport: viewportInput} = isSnapshotOptions(options)
+    ? options
+    : {metadata: options ?? ({} as SnapshotTestMetadata), viewport: undefined};
+
+  const resolved = viewportInput ? resolveViewport(viewportInput) : undefined;
+
+  const suffix = resolved ? ' @' + resolved.label : '';
+
+  // eslint-disable-next-line jest/valid-title -- title is always a non-empty string built from user-provided name
+  test('snapshot: ' + name + suffix, async () => {
     const {testPath, currentTestName} = expect.getState();
     if (!testPath) {
       throw new Error('Could not determine test file path');
@@ -54,14 +110,19 @@ function snapshotTest(
 
     const details = parseSnapshotDetails(currentTestName ?? '', name);
 
+    const finalFileSlug = resolved
+      ? `${details.fileSlug}-${resolved.label}`
+      : details.fileSlug;
+
     await takeSnapshot({
-      fileSlug: details.fileSlug,
+      fileSlug: finalFileSlug,
       displayName: details.displayName,
       renderFn,
       testFilePath: testPath,
       group: details.group,
       theme: details.theme,
       metadata,
+      viewport: resolved ? {width: resolved.width, height: resolved.height} : undefined,
     });
   });
 }
@@ -70,13 +131,24 @@ snapshotTest.each = function snapshotEach<T>(table: T[]) {
   return (
     name: string,
     renderFn: (value: T) => ReactElement,
-    metadataFn?: (value: T) => SnapshotTestMetadata
+    optionsFn?: (value: T) => SnapshotTestMetadata | SnapshotOptions
   ) => {
     for (const value of table) {
       const testName = name.replace('%s', String(value));
-      snapshotTest(testName, () => renderFn(value), metadataFn?.(value));
+      snapshotTest(testName, () => renderFn(value), optionsFn?.(value));
     }
   };
+};
+
+snapshotTest.breakpoints = function snapshotBreakpoints(
+  breakpoints: BreakpointName[],
+  name: string,
+  renderFn: () => ReactElement,
+  metadata: SnapshotTestMetadata = {}
+): void {
+  for (const bp of breakpoints) {
+    snapshotTest(name, renderFn, {viewport: bp, metadata});
+  }
 };
 
 afterAll(async () => {
@@ -89,12 +161,18 @@ declare global {
   namespace jest {
     interface It {
       snapshot: typeof snapshotTest & {
+        breakpoints: (
+          breakpoints: BreakpointName[],
+          name: string,
+          renderFn: () => ReactElement,
+          metadata?: SnapshotTestMetadata
+        ) => void;
         each: <T>(
           table: T[]
         ) => (
           name: string,
           renderFn: (value: T) => ReactElement,
-          metadataFn?: (value: T) => SnapshotTestMetadata
+          optionsFn?: (value: T) => SnapshotTestMetadata | SnapshotOptions
         ) => void;
       };
     }

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -101,7 +101,6 @@ function snapshotTest(
 
   const suffix = resolved ? ' @' + resolved.label : '';
 
-  // eslint-disable-next-line jest/valid-title -- title is always a non-empty string built from user-provided name
   test('snapshot: ' + name + suffix, async () => {
     const {testPath, currentTestName} = expect.getState();
     if (!testPath) {

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -109,13 +109,18 @@ function snapshotTest(
 
     const details = parseSnapshotDetails(currentTestName ?? '', name);
 
-    const finalFileSlug = resolved
-      ? `${details.fileSlug}-${resolved.label}`
+    const viewportSuffix = resolved ? `@${resolved.label}` : '';
+    const displayName = viewportSuffix
+      ? details.displayName.replace(new RegExp(`\\s*${viewportSuffix}$`), '')
+      : details.displayName;
+    const fileSlug = viewportSuffix
+      ? details.fileSlug.replace(new RegExp(`${viewportSuffix}$`, 'i'), '')
       : details.fileSlug;
+    const finalFileSlug = resolved ? `${fileSlug}-${resolved.label}` : fileSlug;
 
     await takeSnapshot({
       fileSlug: finalFileSlug,
-      displayName: details.displayName,
+      displayName,
       renderFn,
       testFilePath: testPath,
       group: details.group,

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -125,6 +125,7 @@ function snapshotTest(
       theme: details.theme,
       metadata,
       viewport: resolved ? {width: resolved.width, height: resolved.height} : undefined,
+      viewportLabel: resolved?.label,
     });
   });
 }

--- a/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
@@ -6,6 +6,8 @@ export interface SnapshotImageMetadata {
   };
   group?: string | null;
   tags?: Record<string, string>;
+  viewport_height?: string;
+  viewport_width?: string;
   // Skip height, width and image_file_name as they're handled by the CLI
 }
 

--- a/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
@@ -6,8 +6,6 @@ export interface SnapshotImageMetadata {
   };
   group?: string | null;
   tags?: Record<string, string>;
-  viewport_height?: string;
-  viewport_width?: string;
   // Skip height, width and image_file_name as they're handled by the CLI
 }
 

--- a/tests/js/sentry-test/snapshots/snapshot.ts
+++ b/tests/js/sentry-test/snapshots/snapshot.ts
@@ -41,7 +41,10 @@ function getFontFaceCSS(): string {
   `;
 }
 
-function renderToHTML(element: ReactElement): string {
+function renderToHTML(
+  element: ReactElement,
+  rootDisplay: 'inline-block' | 'block' = 'inline-block'
+): string {
   const cache = createCache({key: 'snap'});
   const {extractCriticalToChunks, constructStyleTagsFromChunks} =
     createEmotionServer(cache);
@@ -60,7 +63,7 @@ function renderToHTML(element: ReactElement): string {
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; animation: none !important; transition: none !important; }
     body { font-family: 'Rubik', sans-serif; background: transparent; }
-    #root { display: inline-block; }
+    #root { display: ${rootDisplay}; }
   </style>
 </head>
 <body>
@@ -108,6 +111,7 @@ interface TakeSnapshotOptions {
   renderFn: () => ReactElement;
   testFilePath: string;
   theme: string | undefined;
+  viewport?: {width: number; height?: number};
 }
 
 export async function takeSnapshot({
@@ -118,13 +122,17 @@ export async function takeSnapshot({
   group,
   theme,
   metadata,
+  viewport,
 }: TakeSnapshotOptions): Promise<void> {
   const element = renderFn();
-  const fullHTML = renderToHTML(element);
+  const fullHTML = renderToHTML(element, viewport ? 'block' : 'inline-block');
 
   const browser = await getBrowser();
   const context = await browser.newContext({
     deviceScaleFactor: 2,
+    ...(viewport && {
+      viewport: {width: viewport.width, height: viewport.height ?? 720},
+    }),
   });
 
   try {
@@ -158,6 +166,10 @@ export async function takeSnapshot({
       group: metadata.group ?? group,
       tags: Object.keys(tags).length > 0 ? tags : undefined,
       context: {test_file_path: relativePath},
+      ...(viewport && {
+        viewport_width: String(viewport.width),
+        ...(viewport.height != null ? {viewport_height: String(viewport.height)} : {}),
+      }),
     };
 
     await Promise.all([

--- a/tests/js/sentry-test/snapshots/snapshot.ts
+++ b/tests/js/sentry-test/snapshots/snapshot.ts
@@ -112,6 +112,7 @@ interface TakeSnapshotOptions {
   testFilePath: string;
   theme: string | undefined;
   viewport?: {width: number; height?: number};
+  viewportLabel?: string;
 }
 
 export async function takeSnapshot({
@@ -123,6 +124,7 @@ export async function takeSnapshot({
   theme,
   metadata,
   viewport,
+  viewportLabel,
 }: TakeSnapshotOptions): Promise<void> {
   const element = renderFn();
   const fullHTML = renderToHTML(element, viewport ? 'block' : 'inline-block');
@@ -159,6 +161,9 @@ export async function takeSnapshot({
     if (theme) {
       autoTags.theme = theme;
     }
+    if (viewportLabel) {
+      autoTags.viewport = viewportLabel;
+    }
     const tags = {...autoTags, ...metadata.tags};
 
     const meta: SnapshotImageMetadata = {
@@ -166,10 +171,6 @@ export async function takeSnapshot({
       group: metadata.group ?? group,
       tags: Object.keys(tags).length > 0 ? tags : undefined,
       context: {test_file_path: relativePath},
-      ...(viewport && {
-        viewport_width: String(viewport.width),
-        ...(viewport.height == null ? {} : {viewport_height: String(viewport.height)}),
-      }),
     };
 
     await Promise.all([

--- a/tests/js/sentry-test/snapshots/snapshot.ts
+++ b/tests/js/sentry-test/snapshots/snapshot.ts
@@ -168,7 +168,7 @@ export async function takeSnapshot({
       context: {test_file_path: relativePath},
       ...(viewport && {
         viewport_width: String(viewport.width),
-        ...(viewport.height != null ? {viewport_height: String(viewport.height)} : {}),
+        ...(viewport.height == null ? {} : {viewport_height: String(viewport.height)}),
       }),
     };
 


### PR DESCRIPTION
Snapshot tests can now specify a viewport width to test responsive breakpoints. CSS media queries fire at the requested width, and `#root` switches to `display: block` so percentage-based layouts fill the viewport realistically.

**New `it.snapshot` API**

The third argument now accepts a `SnapshotOptions` object with an optional `viewport` field. Viewport can be a named theme breakpoint (`'sm'`, `'lg'`), a pixel number, or `{width, height}`. Breakpoint values are derived from the theme tokens so they stay in sync automatically. The legacy `Record<string, string>` metadata form is still supported — existing tests are unchanged.

```tsx
it.snapshot('stacked-buttons', () => <Controls {...props} />, { viewport: 'sm' });
it.snapshot.breakpoints(['xs', 'sm', 'lg'], 'controls', () => <Controls {...props} />);
```

**Viewport-aware rendering**

When a viewport is specified, Playwright's browser context is created with that viewport size and `#root` uses `display: block` instead of `inline-block`. Viewport dimensions are written into snapshot metadata JSON (`viewport_width`, `viewport_height`) for downstream consumption — no Python changes needed since the manifest uses `extra = "allow"`.