### PR TITLE
fix(cursored-scheduler): recalculate batch size on tick interval change

### DIFF
--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -193,8 +193,10 @@ class CursoredScheduler[M: Model]:
 
         if cursor == 0:
             batch_size = self._initialize_cycle()
+        elif self._has_tick_interval_changed():
+            batch_size = self._recalculate_batch_size(cursor)
         else:
-            batch_size = self._maybe_recalculate_batch_size(cursor) or self._get_batch_size()
+            batch_size = self._get_batch_size()
 
         items = self._get_cached_pks_page(cursor, batch_size)
 
@@ -280,29 +282,28 @@ class CursoredScheduler[M: Model]:
         batch_size = math.ceil(total_rows / ticks_per_cycle)
         return max(batch_size, MIN_BATCH_SIZE)
 
-    def _maybe_recalculate_batch_size(self, cursor: int) -> int | None:
+    def _has_tick_interval_changed(self) -> bool:
         cached_interval = cache.get(self.tick_interval_cache_key)
         if cached_interval is None:
-            return None
+            return False
+        return float(cached_interval) != self.tick_interval.total_seconds()
 
+    def _recalculate_batch_size(self, cursor: int) -> int:
+        cached_interval = cache.get(self.tick_interval_cache_key)
         current_interval = self.tick_interval
-        if float(cached_interval) == current_interval.total_seconds():
-            return None
 
         total_pks = self._get_redis_client().llen(self.pk_list_cache_key)
         remaining = total_pks - cursor
-        if remaining <= 0:
-            return None
-
         old_batch_size = self._get_batch_size()
-        if old_batch_size <= 0:
-            return None
+
+        if remaining <= 0 or old_batch_size <= 0 or cached_interval is None:
+            return self._get_batch_size()
 
         remaining_ticks_at_old_rate = math.ceil(remaining / old_batch_size)
         remaining_time = remaining_ticks_at_old_rate * timedelta(seconds=float(cached_interval))
         remaining_ticks_at_new_rate = remaining_time / current_interval
         if remaining_ticks_at_new_rate <= 0:
-            return None
+            return self._get_batch_size()
 
         new_batch_size = max(math.ceil(remaining / remaining_ticks_at_new_rate), MIN_BATCH_SIZE)
 

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -78,6 +78,7 @@ CURSOR_CACHE_KEY_PREFIX = "cursored_scheduler_offset"
 BATCH_SIZE_CACHE_KEY_PREFIX = "cursored_scheduler_batch_size"
 CYCLE_START_CACHE_KEY_PREFIX = "cursored_scheduler_cycle_start"
 PK_LIST_CACHE_KEY_PREFIX = "cursored_scheduler_pks"
+TICK_INTERVAL_CACHE_KEY_PREFIX = "cursored_scheduler_tick_interval"
 LOCK_PREFIX = "cursored_scheduler_lock"
 DEFAULT_LOCK_DURATION_SECONDS = 120
 MIN_BATCH_SIZE = 1
@@ -142,6 +143,7 @@ class CursoredScheduler[M: Model]:
         self.batch_size_cache_key = f"{BATCH_SIZE_CACHE_KEY_PREFIX}:{name}"
         self.cycle_start_cache_key = f"{CYCLE_START_CACHE_KEY_PREFIX}:{name}"
         self.pk_list_cache_key = f"{PK_LIST_CACHE_KEY_PREFIX}:{name}"
+        self.tick_interval_cache_key = f"{TICK_INTERVAL_CACHE_KEY_PREFIX}:{name}"
         self.lock_key = f"{LOCK_PREFIX}:{name}"
         self.queryset = queryset
         self.task = task
@@ -192,7 +194,7 @@ class CursoredScheduler[M: Model]:
         if cursor == 0:
             batch_size = self._initialize_cycle()
         else:
-            batch_size = self._get_batch_size()
+            batch_size = self._maybe_recalculate_batch_size(cursor) or self._get_batch_size()
 
         items = self._get_cached_pks_page(cursor, batch_size)
 
@@ -245,6 +247,11 @@ class CursoredScheduler[M: Model]:
 
         batch_size = self._calculate_batch_size(len(all_pks))
         cache.set(self.batch_size_cache_key, batch_size, self.cache_ttl)
+        cache.set(
+            self.tick_interval_cache_key,
+            self.tick_interval.total_seconds(),
+            self.cache_ttl,
+        )
         cache.set(self.cycle_start_cache_key, time.time(), self.cache_ttl)
 
         metrics.timing(
@@ -260,6 +267,7 @@ class CursoredScheduler[M: Model]:
         cache.set(self.batch_size_cache_key, 0, self.cache_ttl)
         self._get_redis_client().delete(self.pk_list_cache_key)
         cache.delete(self.cycle_start_cache_key)
+        cache.delete(self.tick_interval_cache_key)
         metrics.incr("cursored_scheduler.cycle_complete", tags=self._metric_tags)
 
     def _calculate_batch_size(self, total_rows: int) -> int:
@@ -271,6 +279,39 @@ class CursoredScheduler[M: Model]:
         ticks_per_cycle = self.cycle_duration / self.tick_interval
         batch_size = math.ceil(total_rows / ticks_per_cycle)
         return max(batch_size, MIN_BATCH_SIZE)
+
+    def _maybe_recalculate_batch_size(self, cursor: int) -> int | None:
+        cached_interval = cache.get(self.tick_interval_cache_key)
+        if cached_interval is None:
+            return None
+
+        current_interval = self.tick_interval
+        if float(cached_interval) == current_interval.total_seconds():
+            return None
+
+        total_pks = self._get_redis_client().llen(self.pk_list_cache_key)
+        remaining = total_pks - cursor
+        if remaining <= 0:
+            return None
+
+        old_batch_size = self._get_batch_size()
+        if old_batch_size <= 0:
+            return None
+
+        remaining_ticks_at_old_rate = math.ceil(remaining / old_batch_size)
+        remaining_time = remaining_ticks_at_old_rate * timedelta(seconds=float(cached_interval))
+        remaining_ticks_at_new_rate = remaining_time / current_interval
+        if remaining_ticks_at_new_rate <= 0:
+            return None
+
+        new_batch_size = max(math.ceil(remaining / remaining_ticks_at_new_rate), MIN_BATCH_SIZE)
+
+        cache.set(self.batch_size_cache_key, new_batch_size, self.cache_ttl)
+        cache.set(self.tick_interval_cache_key, current_interval.total_seconds(), self.cache_ttl)
+
+        metrics.incr("cursored_scheduler.interval_recalculated", tags=self._metric_tags)
+
+        return new_batch_size
 
     def _emit_cycle_duration(self) -> None:
         """Emit timing metrics for the completed cycle."""

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -13,6 +13,7 @@ from sentry.utils.cursored_scheduler import (
     BATCH_SIZE_CACHE_KEY_PREFIX,
     CURSOR_CACHE_KEY_PREFIX,
     PK_LIST_CACHE_KEY_PREFIX,
+    TICK_INTERVAL_CACHE_KEY_PREFIX,
     CursoredScheduler,
     _get_tick_interval,
 )
@@ -42,9 +43,11 @@ class CursoredSchedulerTest(TestCase):
         self.cache_key = f"{CURSOR_CACHE_KEY_PREFIX}:test_scheduler"
         self.batch_size_key = f"{BATCH_SIZE_CACHE_KEY_PREFIX}:test_scheduler"
         self.pk_list_key = f"{PK_LIST_CACHE_KEY_PREFIX}:test_scheduler"
+        self.tick_interval_key = f"{TICK_INTERVAL_CACHE_KEY_PREFIX}:test_scheduler"
         self.redis_client = redis_clusters.get("default")
         cache.delete(self.cache_key)
         cache.delete(self.batch_size_key)
+        cache.delete(self.tick_interval_key)
         self.redis_client.delete(self.pk_list_key)
 
     _oi_counter = 0
@@ -406,6 +409,65 @@ class CursoredSchedulerTest(TestCase):
         cursor = cache.get(f"{CURSOR_CACHE_KEY_PREFIX}:test_scheduler")
         assert cursor is not None
         assert int(cursor) == 10
+
+    def test_recalculates_batch_size_on_interval_change(self):
+        """When tick interval changes mid-cycle, batch size adjusts for remaining items."""
+        self._create_org_integrations(30)
+        # Start with 1-min tick, 3-min cycle → 3 ticks → batch_size=10
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+        assert self.mock_task.delay.call_count == 10
+        self.mock_task.reset_mock()
+
+        # Change tick interval to 2 minutes mid-cycle.
+        # 20 remaining items, old rate was 10/tick at 1-min intervals → 2 ticks left → 2 min remaining.
+        # At 2-min intervals → 1 tick left → new batch_size=20
+        new_schedules = {
+            **TEST_SCHEDULES,
+            "test-scheduler-beat": {
+                "task": "test:sentry.test_task",
+                "schedule": timedelta(minutes=2),
+            },
+        }
+        with override_settings(TASKWORKER_SCHEDULES=new_schedules):
+            scheduler.tick()
+            assert self.mock_task.delay.call_count == 20
+
+    def test_no_recalculation_when_interval_unchanged(self):
+        """Batch size stays the same when tick interval hasn't changed."""
+        self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+        assert self.mock_task.delay.call_count == 10
+        self.mock_task.reset_mock()
+
+        # Same interval, batch size should stay at 10
+        scheduler.tick()
+        assert self.mock_task.delay.call_count == 10
+
+    def test_interval_decrease_halves_batch_size(self):
+        """When tick interval is halved, batch size is halved for remaining items."""
+        self._create_org_integrations(30)
+        # Start with 2-min tick, 6-min cycle → 3 ticks → batch_size=10
+        new_schedules = {
+            **TEST_SCHEDULES,
+            "test-scheduler-beat": {
+                "task": "test:sentry.test_task",
+                "schedule": timedelta(minutes=2),
+            },
+        }
+        with override_settings(TASKWORKER_SCHEDULES=new_schedules):
+            scheduler = self._make_scheduler(cycle_duration=timedelta(minutes=6))
+            scheduler.tick()
+            assert self.mock_task.delay.call_count == 10
+            self.mock_task.reset_mock()
+
+        # Change to 1-min ticks. 20 remaining, old: 10/tick at 2-min → 2 ticks → 4 min left.
+        # At 1-min ticks → 4 ticks → batch_size = ceil(20/4) = 5
+        scheduler.tick()
+        assert self.mock_task.delay.call_count == 5
 
 
 @override_settings(TASKWORKER_SCHEDULES=TEST_SCHEDULES)


### PR DESCRIPTION
CursoredScheduler now caches the tick interval at cycle start and checks it on each tick. If the interval changed , it recalculates the batch size for remaining items to maintain constant throughput. Previously, the the interval changed, it would run at the new interval, but maintain the previous batch size.
