### PR TITLE
fix(alerts): Surface API error messages in create/update toasts

### DIFF
--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -162,8 +162,11 @@ export function useCreateAutomation() {
         queryKey: automationsApiOptions(org).queryKey,
       });
     },
-    onError: _ => {
-      addErrorMessage(t('Unable to create alert'));
+    onError: error => {
+      addErrorMessage(
+        getWorkflowEngineResponseErrorMessage(error.responseJSON) ??
+          t('Unable to create alert')
+      );
     },
   });
 }
@@ -269,8 +272,11 @@ export function useUpdateAutomation() {
         queryKey: automationsApiOptions(org).queryKey,
       });
     },
-    onError: _ => {
-      addErrorMessage(t('Unable to update alert'));
+    onError: error => {
+      addErrorMessage(
+        getWorkflowEngineResponseErrorMessage(error.responseJSON) ??
+          t('Unable to update alert')
+      );
     },
   });
 }

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -667,6 +667,36 @@ describe('AutomationNewSettings', () => {
     expect(await screen.findByText('member-project')).toBeInTheDocument();
   });
 
+  it('surfaces API error message when automation creation fails', async () => {
+    jest.spyOn(indicators, 'addErrorMessage');
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      method: 'POST',
+      statusCode: 400,
+      body: ['You may not exceed 1000 workflows per organization.'],
+    });
+
+    render(<AutomationNewSettings />, {
+      organization,
+      initialRouterConfig: {
+        location: {pathname: '/', query: {connectedIds: '123'}},
+      },
+    });
+
+    // Add an action so builder validation passes
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Add action'}), 'Slack');
+    await userEvent.type(screen.getByRole('textbox', {name: 'Target'}), '#alerts');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Create Alert'}));
+
+    await waitFor(() => {
+      expect(indicators.addErrorMessage).toHaveBeenCalledWith(
+        'You may not exceed 1000 workflows per organization.'
+      );
+    });
+  });
+
   it('surfaces error details when test notification fails', async () => {
     jest.spyOn(indicators, 'addErrorMessage');
 


### PR DESCRIPTION
The create and update automation mutation hooks were showing a generic "Unable to create alert" / "Unable to update alert" toast on any API failure, swallowing whatever message the backend actually returned. The detectors hooks already use `getWorkflowEngineResponseErrorMessage` to extract the first human-readable string from the error response JSON, so this applies the same pattern to `useCreateAutomation` and `useUpdateAutomation`.