### PR TITLE
fix(profiles): indicate invalid page URL state as error

### DIFF
--- a/static/app/views/explore/profiling/profilesProvider.tsx
+++ b/static/app/views/explore/profiling/profilesProvider.tsx
@@ -1,7 +1,10 @@
 import {createContext, useContext, useLayoutEffect, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
+import {Container} from '@sentry/scraps/layout';
+
 import type {Client} from 'sentry/api';
+import {LoadingError} from 'sentry/components/loadingError';
 import {t} from 'sentry/locale';
 import type {RequestState} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
@@ -199,6 +202,8 @@ export function ContinuousProfileProvider({
   const api = useApi();
   const {projects} = useProjects();
 
+  const project = projects.find(p => p.slug === projectSlug);
+
   useLayoutEffect(() => {
     if (!profileMeta) {
       Sentry.captureMessage(
@@ -207,7 +212,6 @@ export function ContinuousProfileProvider({
       return;
     }
 
-    const project = projects.find(p => p.slug === projectSlug);
     if (!project) {
       Sentry.captureMessage('Failed to fetch continuous profile - project not found.');
       return;
@@ -228,7 +232,27 @@ export function ContinuousProfileProvider({
       });
 
     return () => api.clear();
-  }, [api, profileMeta, orgSlug, projectSlug, projects, setProfile]);
+  }, [api, profileMeta, orgSlug, project, setProfile]);
+
+  if (!profileMeta) {
+    return (
+      <UnresolvedArea>
+        <LoadingError message="This page is missing URL parameters." />
+      </UnresolvedArea>
+    );
+  }
+
+  if (!project) {
+    return (
+      <UnresolvedArea>
+        <LoadingError message="This page's project slug is not known." />
+      </UnresolvedArea>
+    );
+  }
 
   return <ProfileContext value={profile}>{children}</ProfileContext>;
+}
+
+function UnresolvedArea({children}: React.PropsWithChildren) {
+  return <Container padding="xl">{children}</Container>;
 }

--- a/static/app/views/explore/profiling/profilesProvider.tsx
+++ b/static/app/views/explore/profiling/profilesProvider.tsx
@@ -237,7 +237,7 @@ export function ContinuousProfileProvider({
   if (!profileMeta) {
     return (
       <UnresolvedArea>
-        <LoadingError message="This page is missing URL parameters." />
+        <LoadingError message={t('This page is missing URL parameters.')} />
       </UnresolvedArea>
     );
   }

--- a/static/app/views/explore/profiling/profilesProvider.tsx
+++ b/static/app/views/explore/profiling/profilesProvider.tsx
@@ -242,7 +242,7 @@ export function ContinuousProfileProvider({
     );
   }
 
-  if (!project) {
+  if (!project && ['errored', 'resolved'].includes(profile.type)) {
     return (
       <UnresolvedArea>
         <LoadingError message="This page's project slug is not known." />

--- a/static/app/views/explore/profiling/profilesProvider.tsx
+++ b/static/app/views/explore/profiling/profilesProvider.tsx
@@ -242,14 +242,6 @@ export function ContinuousProfileProvider({
     );
   }
 
-  if (!project && ['errored', 'resolved'].includes(profile.type)) {
-    return (
-      <UnresolvedArea>
-        <LoadingError message="This page's project slug is not known." />
-      </UnresolvedArea>
-    );
-  }
-
   return <ProfileContext value={profile}>{children}</ProfileContext>;
 }
 


### PR DESCRIPTION
Uses our snazzy [`<LoadingError>` Scraps component](https://lucidsoftware.sentry.io/stories/product/components/loadingerror) to make it clear that the page is invalid.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="953" height="530" alt="image" src="https://github.com/user-attachments/assets/8a0c46b3-51b3-43e0-9157-6a8bfc2acc2d" />
</td>
<td>
<img width="953" height="530" alt="image" src="https://github.com/user-attachments/assets/3167b1cb-e8f4-425b-ae9c-9f7ef433e9bd" />
</td>
</tr>
</tbody>
</table>

Closes PRO-43.