### PR TITLE
fix(settings): Stop trimming repo owner & name whitespaces

### DIFF
--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -52,8 +52,8 @@ class BranchOverrideSerializer(CamelSnakeSerializer):
 
 class RepositorySerializer(CamelSnakeSerializer):
     provider = serializers.CharField(required=True)
-    owner = serializers.CharField(required=True)
-    name = serializers.CharField(required=True)
+    owner = serializers.CharField(required=True, trim_whitespace=False)
+    name = serializers.CharField(required=True, trim_whitespace=False)
     external_id = serializers.CharField(required=True)
     organization_id = serializers.IntegerField(required=False, allow_null=True)
     integration_id = serializers.CharField(required=False, allow_null=True)

--- a/tests/sentry/seer/endpoints/test_project_seer_preferences.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_preferences.py
@@ -535,6 +535,45 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert seer_repos[0].project_repository.repository_id == gitlab_repo.id
 
     @with_feature("organizations:seer-gitlab-support")
+    def test_post_accepts_gitlab_repo_with_whitespace_in_name(self) -> None:
+        gitlab_repo = self.create_repo(
+            project=self.project,
+            name="seer-sandbox / seer-test-sandbox",
+            provider="integrations:gitlab",
+            external_id="gitlab.com:82098515",
+            integration_id=418966,
+        )
+
+        request_data = {
+            "repositories": [
+                {
+                    "organization_id": self.org.id,
+                    "integration_id": "418966",
+                    "provider": "gitlab",
+                    "owner": "seer-sandbox ",
+                    "name": " seer-test-sandbox",
+                    "external_id": "gitlab.com:82098515",
+                    "branch_name": "",
+                    "instructions": "",
+                    "branch_overrides": [],
+                }
+            ],
+            "automated_run_stopping_point": "root_cause",
+            "automation_handoff": None,
+        }
+
+        response = self.client.post(self.url, data=request_data)
+
+        assert response.status_code == 204
+        seer_repos = list(
+            SeerProjectRepository.objects.filter(
+                project_repository__project=self.project
+            ).select_related("project_repository__repository")
+        )
+        assert len(seer_repos) == 1
+        assert seer_repos[0].project_repository.repository_id == gitlab_repo.id
+
+    @with_feature("organizations:seer-gitlab-support")
     def test_post_accepts_gitlab_bare_provider_with_feature_flag(self) -> None:
         gitlab_repo = self.create_repo(
             project=self.project,


### PR DESCRIPTION
DRF's `CharField` has `trim_whitespace=True` by default, which strips spaces from `owner` and `name` before the DB lookup in `filter_repo_by_provider`. GitLab repos can have spaces around the `/` in their stored name (e.g. `"seer-sandbox / seer-test-sandbox"`), so the trimmed values produce a different lookup string and the query returns no match, causing a 400 "Invalid repository" error.

Set `trim_whitespace=False` on the `owner` and `name` fields in the base `RepositorySerializer` so the values round-trip correctly.

Fixes CW-1380