### PR TITLE
o11y(seer): Track block content copy in Seer Explorer

### DIFF
--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -119,6 +119,7 @@ export type SeerAnalyticsEventsParameters = {
     has_legacy_seer: boolean;
     has_seat_based_seer: boolean;
   };
+  'seer.explorer.block_copied': Record<string, unknown>;
   'seer.explorer.feedback_submitted': {
     block_index: number;
     block_message: string;
@@ -173,6 +174,7 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'coding_integration.setup_handoff_clicked': 'Coding Integration: Setup Handoff Clicked',
   'seer.autofix.feedback_submitted': 'Seer: Autofix Feedback Submitted',
   'seer.config_reminder.rendered': 'Seer: Config Reminder Rendered',
+  'seer.explorer.block_copied': 'Seer Explorer: Block Content Copied',
   'seer.explorer.feedback_submitted': 'Seer Explorer: Feedback Submitted',
   'seer.explorer.global_panel.opened': 'Seer Explorer: Global Panel Opened',
   'seer.explorer.global_panel.tool_link_navigation': 'Seer Explorer: Tool Link Visited',

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -251,6 +251,7 @@ export function BlockComponent({
   const handleCopyClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     copy(block.message.content ?? '');
+    trackAnalytics('seer.explorer.block_copied', {organization});
   };
 
   const showActions =


### PR DESCRIPTION
## Summary
- Register a new `seer.explorer.block_copied` analytics event mapped to **Seer Explorer: Block Content Copied**, so we can measure how often users copy block content from the Seer Explorer global panel.
- Wire the event into the existing copy-to-clipboard handler in `BlockComponent`.

## Test plan
- [ ] Open the Seer Explorer global panel and click the copy button on an assistant block; confirm the `Seer Explorer: Block Content Copied` event fires in analytics.