### PR TITLE
chore(flagpole-wildcard-ops): Adding support for not_matches op (python)

### DIFF
--- a/src/flagpole/conditions.py
+++ b/src/flagpole/conditions.py
@@ -30,6 +30,11 @@ class ConditionOperatorKind(str, Enum):
     Provided a list of patterns, check if the property value matches any pattern.
     """
 
+    NOT_MATCHES = "not_matches"
+    """
+    Provided a list of patterns, check if the property value matches none of the patterns.
+    """
+
 
 class ConditionTypeMismatchException(Exception):
     pass
@@ -120,6 +125,23 @@ class ConditionBase:
             return condition_property.lower() == self.value.lower()
 
         return condition_property == self.value
+
+    def _evaluate_matches(self, condition_property: Any, segment_name: str) -> bool:
+        if not isinstance(self.value, list):
+            raise ConditionTypeMismatchException(
+                f"'Matches' condition value must be a list of strings, but was provided a"
+                f" '{get_type_name(self.value)}' of segment {segment_name}"
+            )
+        if isinstance(condition_property, (list, dict)):
+            raise ConditionTypeMismatchException(
+                "'Matches' condition property value must be a string, but was provided a"
+                f" '{get_type_name(condition_property)}' of segment {segment_name}"
+            )
+        if condition_property is None:
+            return False
+        if not isinstance(condition_property, str):
+            return False
+        return any(_glob_star_match(pattern, condition_property) for pattern in self.value)
 
 
 InOperatorValueTypes = list[int] | list[float] | list[str]
@@ -241,21 +263,19 @@ class MatchesCondition(ConditionBase):
     operator: str = dataclasses.field(default="matches")
 
     def _operator_match(self, condition_property: Any, segment_name: str) -> bool:
-        if not isinstance(self.value, list):
-            raise ConditionTypeMismatchException(
-                f"'Matches' condition value must be a list of strings, but was provided a"
-                f" '{get_type_name(self.value)}' of segment {segment_name}"
-            )
-        if isinstance(condition_property, (list, dict)):
-            raise ConditionTypeMismatchException(
-                "'Matches' condition property value must be a string, but was provided a"
-                f" '{get_type_name(condition_property)}' of segment {segment_name}"
-            )
-        if condition_property is None:
-            return False
-        if not isinstance(condition_property, str):
-            return False
-        return any(_glob_star_match(pattern, condition_property) for pattern in self.value)
+        return self._evaluate_matches(
+            condition_property=condition_property, segment_name=segment_name
+        )
+
+
+class NotMatchesCondition(ConditionBase):
+    value: MatchesOperatorValueTypes
+    operator: str = dataclasses.field(default="not_matches")
+
+    def _operator_match(self, condition_property: Any, segment_name: str) -> bool:
+        return not self._evaluate_matches(
+            condition_property=condition_property, segment_name=segment_name
+        )
 
 
 OPERATOR_LOOKUP: Mapping[ConditionOperatorKind, type[ConditionBase]] = {
@@ -266,6 +286,7 @@ OPERATOR_LOOKUP: Mapping[ConditionOperatorKind, type[ConditionBase]] = {
     ConditionOperatorKind.EQUALS: EqualsCondition,
     ConditionOperatorKind.NOT_EQUALS: NotEqualsCondition,
     ConditionOperatorKind.MATCHES: MatchesCondition,
+    ConditionOperatorKind.NOT_MATCHES: NotMatchesCondition,
 }
 
 

--- a/src/flagpole/flagpole-schema.json
+++ b/src/flagpole/flagpole-schema.json
@@ -332,6 +332,31 @@
       },
       "required": ["property", "value"]
     },
+    "NotMatchesCondition": {
+      "title": "NotMatchesCondition",
+      "type": "object",
+      "properties": {
+        "property": {
+          "title": "Property",
+          "description": "The evaluation context property to match against.",
+          "type": "string"
+        },
+        "operator": {
+          "title": "Operator",
+          "default": "not_matches",
+          "enum": ["not_matches"],
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["property", "value"]
+    },
     "Segment": {
       "title": "Segment",
       "type": "object",
@@ -356,7 +381,8 @@
                 "not_contains": "#/definitions/NotContainsCondition",
                 "equals": "#/definitions/EqualsCondition",
                 "not_equals": "#/definitions/NotEqualsCondition",
-                "matches": "#/definitions/MatchesCondition"
+                "matches": "#/definitions/MatchesCondition",
+                "not_matches": "#/definitions/NotMatchesCondition"
               }
             },
             "oneOf": [
@@ -380,6 +406,9 @@
               },
               {
                 "$ref": "#/definitions/MatchesCondition"
+              },
+              {
+                "$ref": "#/definitions/NotMatchesCondition"
               }
             ]
           }

--- a/src/sentry/runner/commands/createflag.py
+++ b/src/sentry/runner/commands/createflag.py
@@ -43,6 +43,7 @@ def condition_wizard(display_sample_condition_properties: bool = False) -> Condi
         ConditionOperatorKind.IN,
         ConditionOperatorKind.NOT_IN,
         ConditionOperatorKind.MATCHES,
+        ConditionOperatorKind.NOT_MATCHES,
     }:
         value = []
     condition = {

--- a/tests/flagpole/test_conditions.py
+++ b/tests/flagpole/test_conditions.py
@@ -10,6 +10,7 @@ from flagpole.conditions import (
     NotContainsCondition,
     NotEqualsCondition,
     NotInCondition,
+    NotMatchesCondition,
     create_case_insensitive_set_from_list,
 )
 
@@ -301,5 +302,126 @@ class TestMatchesConditions:
 
     def test_type_mismatch_dict_property(self) -> None:
         condition = MatchesCondition(property="foo", value=["bar*"])
+        with pytest.raises(ConditionTypeMismatchException):
+            condition.match(context=EvaluationContext({"foo": {"key": "val"}}), segment_name="test")
+
+
+class TestNotMatchesConditions:
+    def test_literal_match(self) -> None:
+        condition = NotMatchesCondition(property="slug", value=["sentry"])
+        # Exact match → not_matches returns False
+        assert not condition.match(
+            context=EvaluationContext({"slug": "sentry"}), segment_name="test"
+        )
+        # No match → not_matches returns True
+        assert condition.match(
+            context=EvaluationContext({"slug": "getsentry"}), segment_name="test"
+        )
+
+    def test_prefix_wildcard(self) -> None:
+        condition = NotMatchesCondition(property="slug", value=["jayonb*"])
+        assert not condition.match(
+            context=EvaluationContext({"slug": "jayonb73"}), segment_name="test"
+        )
+        assert not condition.match(
+            context=EvaluationContext({"slug": "jayonb"}), segment_name="test"
+        )
+        assert condition.match(
+            context=EvaluationContext({"slug": "dangoldonb1"}), segment_name="test"
+        )
+
+    def test_prefix_and_suffix_wildcard(self) -> None:
+        condition = NotMatchesCondition(property="email", value=["jay.goss+onboarding*@sentry.io"])
+        assert not condition.match(
+            context=EvaluationContext({"email": "jay.goss+onboarding70@sentry.io"}),
+            segment_name="test",
+        )
+        assert not condition.match(
+            context=EvaluationContext({"email": "jay.goss+onboarding@sentry.io"}),
+            segment_name="test",
+        )
+        assert condition.match(
+            context=EvaluationContext({"email": "jay.goss+onboarding70@example.com"}),
+            segment_name="test",
+        )
+
+    def test_suffix_wildcard(self) -> None:
+        condition = NotMatchesCondition(property="email", value=["*@sentry.io"])
+        assert not condition.match(
+            context=EvaluationContext({"email": "user@sentry.io"}), segment_name="test"
+        )
+        assert condition.match(
+            context=EvaluationContext({"email": "user@example.com"}), segment_name="test"
+        )
+
+    def test_multi_segment_wildcard(self) -> None:
+        condition = NotMatchesCondition(property="name", value=["a*b*c"])
+        assert not condition.match(context=EvaluationContext({"name": "abc"}), segment_name="test")
+        assert not condition.match(
+            context=EvaluationContext({"name": "aXbYc"}), segment_name="test"
+        )
+        assert not condition.match(
+            context=EvaluationContext({"name": "aXXbYYc"}), segment_name="test"
+        )
+        assert condition.match(context=EvaluationContext({"name": "aXXc"}), segment_name="test")
+
+    def test_star_only_pattern(self) -> None:
+        # "*" matches everything — not_matches always returns False
+        condition = NotMatchesCondition(property="slug", value=["*"])
+        assert not condition.match(
+            context=EvaluationContext({"slug": "anything"}), segment_name="test"
+        )
+        assert not condition.match(context=EvaluationContext({"slug": ""}), segment_name="test")
+
+    def test_case_insensitive(self) -> None:
+        condition = NotMatchesCondition(property="slug", value=["JAYONB*"])
+        assert not condition.match(
+            context=EvaluationContext({"slug": "jayonb73"}), segment_name="test"
+        )
+        condition2 = NotMatchesCondition(property="slug", value=["jayonb*"])
+        assert not condition2.match(
+            context=EvaluationContext({"slug": "JAYONB73"}), segment_name="test"
+        )
+
+    def test_no_match(self) -> None:
+        condition = NotMatchesCondition(property="slug", value=["jayonb*"])
+        assert condition.match(
+            context=EvaluationContext({"slug": "dangoldonb1"}), segment_name="test"
+        )
+
+    def test_multiple_patterns_all_must_not_match(self) -> None:
+        condition = NotMatchesCondition(
+            property="slug", value=["jayonb*", "dangoldonb*", "value-disc-*"]
+        )
+        # Any match → False
+        assert not condition.match(
+            context=EvaluationContext({"slug": "jayonb73"}), segment_name="test"
+        )
+        assert not condition.match(
+            context=EvaluationContext({"slug": "dangoldonb3"}), segment_name="test"
+        )
+        assert not condition.match(
+            context=EvaluationContext({"slug": "value-disc-7"}), segment_name="test"
+        )
+        # No pattern matches → True
+        assert condition.match(
+            context=EvaluationContext({"slug": "other-org"}), segment_name="test"
+        )
+
+    def test_overlapping_prefix_suffix_anchors(self) -> None:
+        # "a*a" requires at least "aa" — "a" alone doesn't match → not_matches returns True
+        condition = NotMatchesCondition(property="slug", value=["a*a"])
+        assert condition.match(context=EvaluationContext({"slug": "a"}), segment_name="test")
+        assert not condition.match(context=EvaluationContext({"slug": "aa"}), segment_name="test")
+
+    def test_type_mismatch_list_property(self) -> None:
+        condition = NotMatchesCondition(property="foo", value=["bar*"])
+        with pytest.raises(ConditionTypeMismatchException):
+            condition.match(
+                context=EvaluationContext({"foo": ["bar1", "bar2"]}), segment_name="test"
+            )
+
+    def test_type_mismatch_dict_property(self) -> None:
+        condition = NotMatchesCondition(property="foo", value=["bar*"])
         with pytest.raises(ConditionTypeMismatchException):
             condition.match(context=EvaluationContext({"foo": {"key": "val"}}), segment_name="test")

--- a/tests/sentry/runner/commands/test_createflag.py
+++ b/tests/sentry/runner/commands/test_createflag.py
@@ -83,7 +83,7 @@ class TestCreateFlag(CliTestCase):
         assert new_segment.name == "New segment"
         assert new_segment.rollout == 100
 
-        assert len(new_segment.conditions) == 7
+        assert len(new_segment.conditions) == 8
 
         for c_idx in range(len(conditions_tuples)):
             condition_tuple = conditions_tuples[c_idx]


### PR DESCRIPTION
Notes:

- In par with sentry-options: https://github.com/getsentry/sentry-options/pull/127
- Task documentation: [link](https://www.notion.so/sentry/Adding-wildcard-support-to-flagpole-condition-operators-3598b10e4b5d819e8c16e207ee3a4349)
- Test Duplication: Unlike simpler pairs like in/not_in, glob matching has enough edge cases (overlapping anchors, multi-segment wildcards, case folding) that explicit mirrored coverage is worth it.

Adds a new `not_matches` condition operator that accepts a list of glob patterns and returns true if the context property value matches none of them. Reuses the existing `_glob_star_match` helper and `_evaluate_matches` shared method introduced for matches.

Changes:

`src/flagpole/conditions.py` — adds NOT_MATCHES to `ConditionOperatorKind`, refactors `MatchesCondition._operator_match` into a shared _evaluate_matches method on `ConditionBase`, adds `NotMatchesCondition` class (returns not `self._evaluate_matches(...)`), and registers it in `OPERATOR_LOOKUP`.

`src/flagpole/flagpole-schema.json` — adds `NotMatchesCondition` definition and registers it in the `Segment.conditions` discriminator and `oneOf`.

`src/sentry/runner/commands/createflag.py` — adds `NOT_MATCHES` to the set of operators that initialize value as a list in the condition wizard.

`tests/flagpole/test_conditions.py` — adds `TestNotMatchesConditions` mirroring all TestMatchesConditions cases with inverted assertions: literal match, prefix wildcard, prefix+suffix wildcard, suffix wildcard, multi-star wildcard, star-only pattern, case insensitivity, no-match, multiple patterns, overlapping prefix/suffix anchor guard, and type mismatch errors for list/dict context properties.