### PR TITLE
ref(dashboards): migrate detail.tsx off browserHistory to useNavigate

### DIFF
--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -24,7 +24,6 @@ import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import CreateDashboard from 'sentry/views/dashboards/create';
 import {DashboardDetailWithInjectedProps as DashboardDetail} from 'sentry/views/dashboards/detail';
 import {EditAccessSelector} from 'sentry/views/dashboards/editAccessSelector';
@@ -1099,7 +1098,7 @@ describe('Dashboards > Detail', () => {
           },
         },
       });
-      render(<ViewEditDashboard />, {
+      const {router} = render(<ViewEditDashboard />, {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/',
           route: DASHBOARD_ROUTE,
@@ -1109,7 +1108,6 @@ describe('Dashboards > Detail', () => {
         }),
         organization: testData.organization,
       });
-      const browserHistoryPush = jest.spyOn(browserHistory, 'push');
 
       await userEvent.click(await screen.findByText('sentry-android-shop@1.2.0'));
       await userEvent.click(screen.getAllByText('Clear')[0]!);
@@ -1117,12 +1115,10 @@ describe('Dashboards > Detail', () => {
       await userEvent.click(document.body);
 
       await waitFor(() => {
-        expect(browserHistoryPush).toHaveBeenCalledWith(
+        expect(router.location.query).toEqual(
           expect.objectContaining({
-            query: expect.objectContaining({
-              release: [''],
-              globalFilter: [''],
-            }),
+            release: '',
+            globalFilter: '',
           })
         );
       });
@@ -1195,7 +1191,7 @@ describe('Dashboards > Detail', () => {
           },
         },
       });
-      render(<ViewEditDashboard />, {
+      const {router} = render(<ViewEditDashboard />, {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/',
           route: DASHBOARD_ROUTE,
@@ -1206,25 +1202,22 @@ describe('Dashboards > Detail', () => {
         }),
         organization: testData.organization,
       });
-      const browserHistoryPush = jest.spyOn(browserHistory, 'push');
 
       await userEvent.click(await screen.findByText('All Releases'));
       await userEvent.click(screen.getByText('sentry-android-shop@1.2.0'));
       await userEvent.keyboard('{Escape}');
 
-      await userEvent.click(screen.getByTestId('filter-bar-cancel'));
-
-      screen.getByText('All Releases');
-
       await waitFor(() => {
-        expect(browserHistoryPush).toHaveBeenCalledWith(
+        expect(router.location.query).toEqual(
           expect.objectContaining({
-            query: expect.objectContaining({
-              release: ['sentry-android-shop@1.2.0'],
-            }),
+            release: 'sentry-android-shop@1.2.0',
           })
         );
       });
+
+      await userEvent.click(screen.getByTestId('filter-bar-cancel'));
+
+      screen.getByText('All Releases');
     });
 
     it('disables the edit-dashboard button when there are unsaved filters', async () => {
@@ -1417,7 +1410,7 @@ describe('Dashboards > Detail', () => {
           location: LocationFixture(),
         },
       });
-      render(<ViewEditDashboard />, {
+      const {router} = render(<ViewEditDashboard />, {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/',
           route: DASHBOARD_ROUTE,
@@ -1425,18 +1418,15 @@ describe('Dashboards > Detail', () => {
         }),
         organization: testData.organization,
       });
-      const browserHistoryPush = jest.spyOn(browserHistory, 'push');
 
       await userEvent.click(await screen.findByText('All Releases'));
       await userEvent.click(screen.getByText('sentry-android-shop@1.2.0'));
       await userEvent.click(document.body);
 
       await waitFor(() => {
-        expect(browserHistoryPush).toHaveBeenCalledWith(
+        expect(router.location.query).toEqual(
           expect.objectContaining({
-            query: expect.objectContaining({
-              release: ['sentry-android-shop@1.2.0'],
-            }),
+            release: 'sentry-android-shop@1.2.0',
           })
         );
       });

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -42,7 +42,6 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {EventView} from 'sentry/utils/discover/eventView';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
@@ -463,7 +462,7 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   onDelete = (dashboard: State['modifiedDashboard']) => () => {
-    const {api, organization, location, queryClient} = this.props;
+    const {api, navigate, organization, location, queryClient} = this.props;
     if (!dashboard?.id) {
       return;
     }
@@ -475,10 +474,13 @@ class DashboardDetail extends Component<Props, State> {
         .then(() => {
           addSuccessMessage(t('Dashboard deleted'));
           trackAnalytics('dashboards2.delete', {organization});
-          browserHistory.replace({
-            pathname: `/organizations/${organization.slug}/dashboards/`,
-            query: location.query,
-          });
+          navigate(
+            {
+              pathname: `/organizations/${organization.slug}/dashboards/`,
+              query: location.query,
+            },
+            {replace: true}
+          );
         })
         .catch(() => {
           this.setState({
@@ -489,7 +491,7 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   onCancel = () => {
-    const {organization, dashboard, location, params} = this.props;
+    const {navigate, organization, dashboard, location, params} = this.props;
     const {modifiedDashboard} = this.state;
 
     let hasDashboardChanged = !isEqual(modifiedDashboard, dashboard);
@@ -524,16 +526,17 @@ class DashboardDetail extends Component<Props, State> {
       return;
     }
     trackAnalytics('dashboards2.create.cancel', {organization});
-    browserHistory.replace(
+    navigate(
       normalizeUrl({
         pathname: `/organizations/${organization.slug}/dashboards/`,
         query: location.query,
-      })
+      }),
+      {replace: true}
     );
   };
 
   handleChangeFilter = (activeFilters: DashboardFilters) => {
-    const {dashboard, location} = this.props;
+    const {dashboard, location, navigate} = this.props;
 
     const filterParams: Record<string, string[]> = {};
     filterParams[DashboardFilterKeys.RELEASE] = activeFilters[DashboardFilterKeys.RELEASE]
@@ -558,7 +561,7 @@ class DashboardDetail extends Component<Props, State> {
         return;
       })
     ) {
-      browserHistory.push({
+      navigate({
         ...location,
         query: {
           ...location.query,
@@ -849,8 +852,15 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   onCommit = () => {
-    const {api, organization, location, dashboard, onDashboardUpdate, queryClient} =
-      this.props;
+    const {
+      api,
+      navigate,
+      organization,
+      location,
+      dashboard,
+      onDashboardUpdate,
+      queryClient,
+    } = this.props;
     const {modifiedDashboard, dashboardState} = this.state;
 
     switch (dashboardState) {
@@ -884,11 +894,12 @@ class DashboardDetail extends Component<Props, State> {
                 },
                 () => {
                   // redirect to new dashboard
-                  browserHistory.replace(
+                  navigate(
                     normalizeUrl({
                       pathname: `/organizations/${organization.slug}/dashboard/${newDashboard.id}/`,
                       query: omit(location.query, Object.values(DashboardFilterKeys)),
-                    })
+                    }),
+                    {replace: true}
                   );
                 }
               );
@@ -963,13 +974,14 @@ class DashboardDetail extends Component<Props, State> {
                 },
                 () => {
                   if (dashboard && newDashboard.id !== dashboard.id) {
-                    browserHistory.replace(
+                    navigate(
                       normalizeUrl({
                         pathname: `/organizations/${organization.slug}/dashboard/${newDashboard.id}/`,
                         query: {
                           ...location.query,
                         },
-                      })
+                      }),
+                      {replace: true}
                     );
                   }
                 }
@@ -1357,14 +1369,15 @@ class DashboardDetail extends Component<Props, State> {
                                     });
 
                                     const navigateToDashboard = () => {
-                                      browserHistory.replace(
+                                      this.props.navigate(
                                         normalizeUrl({
                                           pathname: `/organizations/${organization.slug}/dashboard/${newDashboard.id}/`,
                                           query: omit(
                                             location.query,
                                             Object.values(DashboardFilterKeys)
                                           ),
-                                        })
+                                        }),
+                                        {replace: true}
                                       );
                                     };
 


### PR DESCRIPTION
The class component already receives `navigate` as a prop via the function wrapper at the bottom of the file. Thread it through the remaining handlers (`onDelete`, `onCancel`, `handleChangeFilter`, `onCommit`) and use `this.props.navigate` in render so the deprecated `browserHistory` shim can eventually be removed.

`browserHistory.replace(loc)` becomes `navigate(loc, {replace: true})`; `browserHistory.push(loc)` becomes `navigate(loc)`.

Drops `browserHistory` usages in `static/` from 72 → 66.