### PR TITLE
ref: Drop unused 'unmigratable' status literal from repo query types

### DIFF
--- a/static/app/utils/repositories/repoQueryOptions.ts
+++ b/static/app/utils/repositories/repoQueryOptions.ts
@@ -35,7 +35,7 @@ export function organizationRepositoriesInfiniteOptions({
     per_page?: number;
     query?: string;
     sort?: Sort;
-    status?: 'active' | 'deleted' | 'unmigratable';
+    status?: 'active' | 'deleted';
   };
   staleTime?: number;
 }) {
@@ -62,7 +62,7 @@ export function organizationRepositoriesWithSettingsInfiniteOptions({
     per_page?: number;
     query?: string;
     sort?: Sort;
-    status?: 'active' | 'deleted' | 'unmigratable';
+    status?: 'active' | 'deleted';
   };
   staleTime?: number;
 }) {


### PR DESCRIPTION
Follow-up to #115905, which removed the backend `?status=unmigratable` path on the org repositories endpoint.

The `'unmigratable'` literal in the two `status?:` type unions in `static/app/utils/repositories/repoQueryOptions.ts` was the last reference to that mode anywhere in `static/`, and nothing has passed it since the migration UI was removed in #17823 (March 2020).
