### PR TITLE
ref(api): Resolve suggested_api from Django route names

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -130,7 +130,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/workflows/:workflow_id/",
+        suggested_api="sentry-api-0-organization-workflow-details",
     )
     def get(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         """
@@ -197,7 +197,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     @track_alert_endpoint_execution("PUT", "sentry-api-0-project-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/workflows/:workflow_id/",
+        suggested_api="sentry-api-0-organization-workflow-details",
     )
     def put(self, request: Request, project: Project, rule: Rule) -> Response:
         """
@@ -378,7 +378,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-project-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/workflows/:workflow_id/",
+        suggested_api="sentry-api-0-organization-workflow-details",
     )
     def delete(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         """

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -849,7 +849,9 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         examples=IssueAlertExamples.LIST_PROJECT_RULES,
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-rules")
-    @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/workflows/")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-workflow-index"
+    )
     def get(self, request: Request, project: Project) -> Response:
         """
         ## Deprecated
@@ -909,7 +911,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     @track_alert_endpoint_execution("POST", "sentry-api-0-project-rules")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/workflows/",
+        suggested_api="sentry-api-0-organization-workflow-index",
     )
     def post(self, request: Request, project) -> Response:
         """

--- a/src/sentry/api/helpers/deprecation.py
+++ b/src/sentry/api/helpers/deprecation.py
@@ -101,6 +101,52 @@ def _add_deprecation_headers(
         response[SUGGESTED_API_HEADER] = suggested_api
 
 
+def _resolve_route_name(route_name: str, request: Request) -> str | None:
+    """Resolve a Django route name into a URL path for the deprecation header.
+
+    Uses the URL resolver's reverse_dict to get the URL template and substitutes
+    parameters from the current request where available. Missing parameters are
+    replaced with :param_name placeholders.
+    """
+    from django.urls import get_resolver
+
+    try:
+        resolver = get_resolver()
+        entries = resolver.reverse_dict.getlist(route_name)
+        if not entries:
+            logger.warning("deprecation.unknown_route_name", extra={"route_name": route_name})
+            return None
+
+        bits, _pattern, _defaults, _converters = entries[0]
+        template, params = bits[0]
+
+        if not template:
+            logger.warning("deprecation.empty_route_template", extra={"route_name": route_name})
+            return None
+
+        request_kwargs: dict[str, str] = {}
+        if request.resolver_match is not None:
+            request_kwargs = request.resolver_match.kwargs
+
+        subs = {}
+        for param in params:
+            if param in request_kwargs:
+                subs[param] = str(request_kwargs[param])
+            else:
+                subs[param] = f":{param}"
+
+        return "/" + (template % subs)
+    except Exception:
+        logger.exception("deprecation.route_resolution_failed", extra={"route_name": route_name})
+        return None
+
+
+def _resolve_suggested_api(suggested_api: str | None, request: Request) -> str | None:
+    if suggested_api is None:
+        return None
+    return _resolve_route_name(suggested_api, request)
+
+
 SelfT = TypeVar("SelfT")
 P = ParamSpec("P")
 EndpointT = Callable[Concatenate[SelfT, Request, P], HttpResponseBase]
@@ -128,7 +174,10 @@ def deprecated(
     This decorator will do nothing if the environment is self-hosted and not set to 'development'.
 
     :param deprecation_date: The date at which the endpoint is starts brownouts;
-    :param suggested_api: The suggested API to use instead of the deprecated one;
+    :param suggested_api: A Django route name for the replacement endpoint
+                          (e.g. "sentry-api-0-organization-projects"). Resolved at request time,
+                          interpolating URL parameters from the current request and using
+                          :param_name placeholders for the rest.
     :param key: The key prefix for an option use for the brownout schedule and duration
                 If not set 'api.deprecation.brownout' will be used, which currently
                 is using schedule of a 1 minute blackout at noon UTC.
@@ -172,7 +221,8 @@ def deprecated(
                         "action": metric_action,
                     },
                 )
-                _add_deprecation_headers(response, deprecation_date, suggested_api)
+                resolved_api = _resolve_suggested_api(suggested_api, request)
+                _add_deprecation_headers(response, deprecation_date, resolved_api)
 
             return response
 

--- a/src/sentry/core/endpoints/project_index.py
+++ b/src/sentry/core/endpoints/project_index.py
@@ -26,7 +26,7 @@ class ProjectIndexEndpoint(Endpoint):
     }
     permission_classes = (ProjectPermission,)
 
-    @deprecated(CELL_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/projects/")
+    @deprecated(CELL_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-projects")
     def get(self, request: Request) -> Response:
         """
         List your Projects

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -389,7 +389,7 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+        suggested_api="sentry-api-0-organization-detector-details",
     )
     @_check_project_access
     def get(
@@ -426,7 +426,7 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-alert-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+        suggested_api="sentry-api-0-organization-detector-details",
     )
     @_check_project_access
     def put(
@@ -466,7 +466,7 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-organization-alert-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+        suggested_api="sentry-api-0-organization-detector-details",
     )
     @_check_project_access
     def delete(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -784,7 +784,9 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         examples=MetricAlertExamples.LIST_METRIC_ALERT_RULES,  # TODO: make
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rules")
-    @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/detectors/")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-detector-index"
+    )
     def get(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
         ## Deprecated
@@ -816,7 +818,9 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         examples=MetricAlertExamples.CREATE_METRIC_ALERT_RULE,
     )
     @track_alert_endpoint_execution("POST", "sentry-api-0-organization-alert-rules")
-    @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/detectors/")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-detector-index"
+    )
     def post(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
         ## Deprecated

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -34,7 +34,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+        suggested_api="sentry-api-0-organization-detector-details",
     )
     def get(self, request: Request, project: Project, alert_rule: AlertRule | Detector) -> Response:
         """
@@ -47,7 +47,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
     @track_alert_endpoint_execution("PUT", "sentry-api-0-project-alert-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+        suggested_api="sentry-api-0-organization-detector-details",
     )
     def put(self, request: Request, project: Project, alert_rule: AlertRule | Detector) -> Response:
         """
@@ -60,7 +60,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-project-alert-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+        suggested_api="sentry-api-0-organization-detector-details",
     )
     def delete(
         self, request: Request, project: Project, alert_rule: AlertRule | Detector

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -34,7 +34,9 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
     }
 
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rules")
-    @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/detectors/")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-detector-index"
+    )
     def get(self, request: Request, project: Project) -> HttpResponseBase:
         """
         Fetches metric alert rules for a project - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.
@@ -42,7 +44,9 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
         return self.fetch_metric_alerts(request, project.organization, [project])
 
     @track_alert_endpoint_execution("POST", "sentry-api-0-project-alert-rules")
-    @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/detectors/")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-detector-index"
+    )
     def post(self, request: Request, project: Project) -> HttpResponseBase:
         """
         Create an alert rule - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.

--- a/tests/sentry/api/helpers/test_deprecation.py
+++ b/tests/sentry/api/helpers/test_deprecation.py
@@ -16,7 +16,8 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import no_silo_test
 
-replacement_api = "replacement-api"
+replacement_api = "sentry-api-0-organization-projects"
+replacement_api_resolved = "/api/0/organizations/:organization_id_or_slug/projects/"
 test_date = datetime.fromisoformat("2020-01-01T00:00:00+00:00:00")
 timeiter = CronSim("0 12 * * *", test_date)
 default_duration = timedelta(minutes=1)
@@ -43,6 +44,14 @@ class DummyEndpoint(Endpoint):
     def delete(self, request):
         return Response({"ok": True})
 
+    @deprecated(test_date, suggested_api="sentry-api-0-organization-projects")
+    def put(self, request):
+        return Response({"ok": True})
+
+    @deprecated(test_date, suggested_api="sentry-api-0-organization-workflow-details")
+    def patch(self, request):
+        return Response({"ok": True})
+
 
 dummy_endpoint = DummyEndpoint.as_view()
 
@@ -56,7 +65,7 @@ class TestDeprecationDecorator(APITestCase):
         assert "X-Sentry-Deprecation-Date" in response
         assert "X-Sentry-Replacement-Endpoint" in response
         assert response["X-Sentry-Deprecation-Date"] == test_date.isoformat()
-        assert response["X-Sentry-Replacement-Endpoint"] == replacement_api
+        assert response["X-Sentry-Replacement-Endpoint"] == replacement_api_resolved
 
     def assert_not_deprecated(self, method):
         request = self.make_request(method=method)
@@ -283,3 +292,69 @@ class TestDeprecationDecorator(APITestCase):
             resp = dummy_endpoint(request)
             assert resp.status_code == HTTP_200_OK
             assert "X-Sentry-Deprecation-Date" not in resp
+
+    def test_suggested_api_route_name_resolves(self) -> None:
+        with self.settings(SENTRY_SELF_HOSTED=False), freeze_time(test_date - timedelta(seconds=1)):
+            request = self.make_request(method="PUT")
+            request.resolver_match = ResolverMatch(
+                func=dummy_endpoint,
+                args=tuple(),
+                kwargs={"organization_id_or_slug": "my-org"},
+                url_name="sentry-api-0-project-index",
+            )
+
+            resp = dummy_endpoint(request)
+            assert resp.status_code == HTTP_200_OK
+            assert resp["X-Sentry-Replacement-Endpoint"] == "/api/0/organizations/my-org/projects/"
+
+    def test_suggested_api_route_name_missing_params(self) -> None:
+        with self.settings(SENTRY_SELF_HOSTED=False), freeze_time(test_date - timedelta(seconds=1)):
+            request = self.make_request(method="PATCH")
+            request.resolver_match = ResolverMatch(
+                func=dummy_endpoint,
+                args=tuple(),
+                kwargs={"organization_id_or_slug": "my-org"},
+                url_name="sentry-api-0-some-endpoint",
+            )
+
+            resp = dummy_endpoint(request)
+            assert resp.status_code == HTTP_200_OK
+            assert (
+                resp["X-Sentry-Replacement-Endpoint"]
+                == "/api/0/organizations/my-org/workflows/:workflow_id/"
+            )
+
+    def test_suggested_api_route_name_no_resolver_match(self) -> None:
+        with self.settings(SENTRY_SELF_HOSTED=False), freeze_time(test_date - timedelta(seconds=1)):
+            request = self.make_request(method="PUT")
+
+            resp = dummy_endpoint(request)
+            assert resp.status_code == HTTP_200_OK
+            assert (
+                resp["X-Sentry-Replacement-Endpoint"]
+                == "/api/0/organizations/:organization_id_or_slug/projects/"
+            )
+
+    def test_suggested_api_unknown_route_name(self) -> None:
+        with self.settings(SENTRY_SELF_HOSTED=False), freeze_time(test_date - timedelta(seconds=1)):
+
+            class UnknownRouteEndpoint(Endpoint):
+                permission_classes = ()
+
+                @deprecated(test_date, suggested_api="nonexistent-route-name")
+                def get(self, request):
+                    return Response({"ok": True})
+
+            endpoint = UnknownRouteEndpoint.as_view()
+            request = self.make_request(method="GET")
+            resp = endpoint(request)
+            assert resp.status_code == HTTP_200_OK
+            assert "X-Sentry-Deprecation-Date" in resp
+            assert "X-Sentry-Replacement-Endpoint" not in resp
+
+    def test_suggested_api_route_name_resolved_in_header(self) -> None:
+        with self.settings(SENTRY_SELF_HOSTED=False), freeze_time(test_date - timedelta(seconds=1)):
+            request = self.make_request(method="GET")
+            resp = dummy_endpoint(request)
+            assert resp.status_code == HTTP_200_OK
+            assert resp["X-Sentry-Replacement-Endpoint"] == replacement_api_resolved


### PR DESCRIPTION
The `@deprecated` decorator's `suggested_api` parameter previously required hardcoded URL paths like `"/api/0/organizations/:slug/projects/"`, duplicating patterns already defined in Django's URL configuration. It now accepts Django route names (e.g. `"sentry-api-0-organization-projects"`) and resolves them at request time.

- By migrating all 16 `suggested_api` usages in this PR from hardcoded URL paths to route names, we don't have to support backwards compatibility.. 
- The `X-Sentry-Replacement-Endpoint` header now uses the actual URL parameter names (e.g. `:organization_id_or_slug` instead of the previous shorthand `:slug`).

Refs LINEAR-INFRENG-223