### PR TITLE
ref(admin): drop browserHistory and HOCs from ResultGrid

### DIFF
--- a/static/gsAdmin/components/beacons/beaconCheckins.tsx
+++ b/static/gsAdmin/components/beacons/beaconCheckins.tsx
@@ -3,7 +3,7 @@ import moment from 'moment-timezone';
 import {Truncate} from 'sentry/components/truncate';
 
 import type {BeaconData} from 'admin/components/beacons/beaconOverview';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = {
   data: BeaconData;

--- a/static/gsAdmin/components/beacons/relatedBeacons.tsx
+++ b/static/gsAdmin/components/beacons/relatedBeacons.tsx
@@ -5,7 +5,7 @@ import {Link} from '@sentry/scraps/link';
 import {Truncate} from 'sentry/components/truncate';
 
 import type {BeaconData} from 'admin/components/beacons/beaconOverview';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = {
   data: BeaconData;

--- a/static/gsAdmin/components/customerGrid.tsx
+++ b/static/gsAdmin/components/customerGrid.tsx
@@ -9,7 +9,7 @@ import {CustomerContact} from 'admin/components/customerContact';
 import {CustomerName} from 'admin/components/customerName';
 import {CustomerStatus} from 'admin/components/customerStatus';
 import {PercentChange} from 'admin/components/percentChange';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 import type {Subscription} from 'getsentry/types';
 import {displayPrice} from 'getsentry/views/amCheckout/utils';
 

--- a/static/gsAdmin/components/customers/customerAuditLog.tsx
+++ b/static/gsAdmin/components/customers/customerAuditLog.tsx
@@ -1,6 +1,6 @@
 import {DateTime} from 'sentry/components/dateTime';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgSlug: string;

--- a/static/gsAdmin/components/customers/customerCharges.tsx
+++ b/static/gsAdmin/components/customers/customerCharges.tsx
@@ -3,7 +3,7 @@ import {ExternalLink, Link} from '@sentry/scraps/link';
 
 import {DateTime} from 'sentry/components/dateTime';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;

--- a/static/gsAdmin/components/customers/customerHistory.tsx
+++ b/static/gsAdmin/components/customers/customerHistory.tsx
@@ -5,7 +5,7 @@ import {Stack, Container} from '@sentry/scraps/layout';
 import {DataCategory} from 'sentry/types/core';
 import {oxfordizeArray} from 'sentry/utils/oxfordizeArray';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
 import type {BillingHistory, ReservedBudgetMetricHistory} from 'getsentry/types';
 import {formatReservedWithUnits, formatUsageWithUnits} from 'getsentry/utils/billing';

--- a/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
+++ b/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
@@ -8,7 +8,7 @@ import {Heading} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;

--- a/static/gsAdmin/components/customers/customerIntegrations.tsx
+++ b/static/gsAdmin/components/customers/customerIntegrations.tsx
@@ -3,7 +3,7 @@ import {ExternalLink} from '@sentry/scraps/link';
 
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;

--- a/static/gsAdmin/components/customers/customerInvoices.tsx
+++ b/static/gsAdmin/components/customers/customerInvoices.tsx
@@ -3,7 +3,7 @@ import moment from 'moment-timezone';
 import {Tag} from '@sentry/scraps/badge';
 import {Link} from '@sentry/scraps/link';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;

--- a/static/gsAdmin/components/customers/customerMembers.tsx
+++ b/static/gsAdmin/components/customers/customerMembers.tsx
@@ -8,7 +8,7 @@ import {Link} from '@sentry/scraps/link';
 
 import {IconMail} from 'sentry/icons';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = {
   orgId: string;

--- a/static/gsAdmin/components/customers/customerOnboardingTasks.tsx
+++ b/static/gsAdmin/components/customers/customerOnboardingTasks.tsx
@@ -5,7 +5,7 @@ import {Tag, type TagProps} from '@sentry/scraps/badge';
 import {getOnboardingTasks} from 'sentry/components/onboardingWizard/taskConfig';
 import {IconCheckmark, IconClock, IconNot} from 'sentry/icons';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;

--- a/static/gsAdmin/components/customers/customerPlatforms.tsx
+++ b/static/gsAdmin/components/customers/customerPlatforms.tsx
@@ -3,7 +3,7 @@ import {PlatformIcon} from 'platformicons';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;

--- a/static/gsAdmin/components/customers/customerPolicies.tsx
+++ b/static/gsAdmin/components/customers/customerPolicies.tsx
@@ -2,7 +2,7 @@ import moment from 'moment-timezone';
 
 import {ExternalLink} from '@sentry/scraps/link';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 const getRow = (row: any) => [
   <td key="name">

--- a/static/gsAdmin/components/customers/customerProjects.tsx
+++ b/static/gsAdmin/components/customers/customerProjects.tsx
@@ -7,7 +7,7 @@ import {Link} from '@sentry/scraps/link';
 
 import {IconProject} from 'sentry/icons';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = {
   orgId: string;

--- a/static/gsAdmin/components/eventUsers.tsx
+++ b/static/gsAdmin/components/eventUsers.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import {Button} from '@sentry/scraps/button';
 
 import {AdminConfirmationModal} from 'admin/components/adminConfirmationModal';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = {
   onRemoveEmail: (hash: string) => void;

--- a/static/gsAdmin/components/policies/policyRevisions.tsx
+++ b/static/gsAdmin/components/policies/policyRevisions.tsx
@@ -5,7 +5,7 @@ import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {ExternalLink} from '@sentry/scraps/link';
 
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 import type {Policy, PolicyRevision} from 'getsentry/types';
 
 type Props = {

--- a/static/gsAdmin/components/promoCodes/promoCodeClaimants.tsx
+++ b/static/gsAdmin/components/promoCodes/promoCodeClaimants.tsx
@@ -5,7 +5,7 @@ import {Link} from '@sentry/scraps/link';
 import type {User} from 'sentry/types/user';
 
 import {CustomerContact} from 'admin/components/customerContact';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 import type {PromoCode} from 'admin/types';
 
 type Props = {

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -17,12 +17,11 @@ import {Panel} from 'sentry/components/panels/panel';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {IconList, IconSearch} from 'sentry/icons';
 import {ConfigStore} from 'sentry/stores/configStore';
-import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
 import type {Region} from 'sentry/types/system';
-import {browserHistory} from 'sentry/utils/browserHistory';
-import {withApi} from 'sentry/utils/withApi';
-// eslint-disable-next-line no-restricted-imports
-import {withSentryRouter} from 'sentry/utils/withSentryRouter';
+import {useApi} from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {ResultTable} from 'admin/components/resultTable';
 
@@ -38,6 +37,7 @@ type FilterProps = {
 };
 
 function Filter({name, queryKey, options, path, location, value}: FilterProps) {
+  const navigate = useNavigate();
   const {query, pathname} = location ?? {};
   const resolvedPath = path ?? pathname ?? '';
 
@@ -52,7 +52,7 @@ function Filter({name, queryKey, options, path, location, value}: FilterProps) {
       [queryKey]: filter,
       cursor: '', // reset cursor for pagination
     };
-    browserHistory.push({pathname: resolvedPath, query: newQuery});
+    navigate({pathname: resolvedPath, query: newQuery});
   };
 
   return (
@@ -67,26 +67,15 @@ function Filter({name, queryKey, options, path, location, value}: FilterProps) {
   );
 }
 
-type SortFn = (value: string, path: string, query: Location['query']) => void;
-
 type SortByProps = {
   options: Option[];
   path: string;
   value: string;
   location?: Location;
-  onSort?: SortFn;
 };
 
-const defaultOnSort: SortFn = (value, path, query) => {
-  const newQuery = {
-    ...query,
-    sortBy: value,
-    cursor: '', // reset cursor for pagination
-  };
-  browserHistory.push({pathname: path, query: newQuery});
-};
-
-function SortBy({options, path, location, value, onSort = defaultOnSort}: SortByProps) {
+function SortBy({options, path, location, value}: SortByProps) {
+  const navigate = useNavigate();
   const {query, pathname} = location ?? {};
   const resolvedPath = path ?? pathname;
 
@@ -100,7 +89,12 @@ function SortBy({options, path, location, value, onSort = defaultOnSort}: SortBy
         />
       )}
       value={value}
-      onChange={opt => onSort(opt.value, resolvedPath, query ?? {})}
+      onChange={opt =>
+        navigate({
+          pathname: resolvedPath,
+          query: {...query, sortBy: opt.value, cursor: ''},
+        })
+      }
       options={options.map(item => ({value: item[0], label: item[1]}))}
     />
   );
@@ -111,7 +105,7 @@ type FilterDescriptor = {
   options: Option[];
 };
 
-interface ResultGridProps extends WithRouterProps {
+interface ResultGridProps {
   api: Client;
   /**
    * A list of table header column labels
@@ -121,6 +115,8 @@ interface ResultGridProps extends WithRouterProps {
    * The API path to get the grid data from
    */
   endpoint: string;
+  location: Location;
+  navigate: ReactRouter3Navigate;
   /**
    * The relative path to map result URLs to
    */
@@ -228,7 +224,7 @@ export type State = {
 const extractQuery = (query: Location['query'][string], defaultVal = '') =>
   (Array.isArray(query) ? query[0] : query) ?? defaultVal;
 
-class ResultGrid extends Component<ResultGridProps, State> {
+class ResultGridImpl extends Component<ResultGridProps, State> {
   static defaultProps: Partial<ResultGridProps> = {
     method: 'GET',
     endpoint: '',
@@ -281,10 +277,13 @@ class ResultGrid extends Component<ResultGridProps, State> {
     // Remove regionalUrl after setting state
     const needsRegion = this.props.isRegional || this.props.isCellScoped;
     if (needsRegion && this.props.location?.query?.regionUrl) {
-      browserHistory.replace({
-        pathname: this.props.location.pathname,
-        query: {...this.props.location.query, regionUrl: undefined},
-      });
+      this.props.navigate(
+        {
+          pathname: this.props.location.pathname,
+          query: {...this.props.location.query, regionUrl: undefined},
+        },
+        {replace: true}
+      );
     }
   }
 
@@ -373,7 +372,7 @@ class ResultGrid extends Component<ResultGridProps, State> {
     e.preventDefault();
 
     if (this.props.useQueryString) {
-      browserHistory.push({
+      this.props.navigate({
         pathname: this.props.path,
         query: {...queryParams, ...query},
       });
@@ -616,4 +615,20 @@ const ErrorAlert = styled(Alert)`
   margin-bottom: ${p => p.theme.space.lg};
 `;
 
-export default withApi(withSentryRouter(ResultGrid));
+type ResultGridWrapperProps = Omit<ResultGridProps, 'api' | 'location' | 'navigate'> & {
+  api?: Client;
+};
+
+export function ResultGrid({api, ...props}: ResultGridWrapperProps) {
+  const defaultApi = useApi();
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <ResultGridImpl
+      {...props}
+      api={api ?? defaultApi}
+      location={location}
+      navigate={navigate}
+    />
+  );
+}

--- a/static/gsAdmin/views/beacons.tsx
+++ b/static/gsAdmin/views/beacons.tsx
@@ -5,7 +5,7 @@ import {Link} from '@sentry/scraps/link';
 import {Truncate} from 'sentry/components/truncate';
 
 import {PageHeader} from 'admin/components/pageHeader';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 const getRow = (row: any) => [
   <td key="beacon">

--- a/static/gsAdmin/views/billingAdmins.tsx
+++ b/static/gsAdmin/views/billingAdmins.tsx
@@ -1,5 +1,5 @@
 import {PageHeader} from 'admin/components/pageHeader';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 const getRow = (row: any) => [
   <td key="id">{row.id}</td>,

--- a/static/gsAdmin/views/broadcasts.tsx
+++ b/static/gsAdmin/views/broadcasts.tsx
@@ -8,7 +8,7 @@ import {ConfigStore} from 'sentry/stores/configStore';
 
 import {CreateBroadcastModal} from 'admin/components/createBroadcastModal';
 import {PageHeader} from 'admin/components/pageHeader';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 import {getBroadcastSchema} from 'admin/schemas/broadcasts';
 
 const getRow = (row: any) => [

--- a/static/gsAdmin/views/docIntegrations.tsx
+++ b/static/gsAdmin/views/docIntegrations.tsx
@@ -9,7 +9,7 @@ import type {DocIntegration} from 'sentry/types/integrations';
 
 import {DocIntegrationModal} from 'admin/components/docIntegrationModal';
 import {PageHeader} from 'admin/components/pageHeader';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 const getRow = (doc: DocIntegration) => [
   <td key="name" style={{textAlign: 'left'}}>

--- a/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuth.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuth.tsx
@@ -5,7 +5,7 @@ import {useModal} from '@sentry/scraps/modal';
 import {DateTime} from 'sentry/components/dateTime';
 
 import {PageHeader} from 'admin/components/pageHeader';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 import {NewInstanceLevelOAuthClient} from 'admin/views/instanceLevelOAuth/components/newInstanceLevelOAuthClient';
 
 const getRow = (row: any) => [

--- a/static/gsAdmin/views/invoices.tsx
+++ b/static/gsAdmin/views/invoices.tsx
@@ -7,7 +7,7 @@ import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {IconDownload} from 'sentry/icons';
 
 import {PageHeader} from 'admin/components/pageHeader';
-import ResultGrid, {type State as ResultGridState} from 'admin/components/resultGrid';
+import {ResultGrid, type State as ResultGridState} from 'admin/components/resultGrid';
 import {prettyDate} from 'admin/utils';
 
 const getRow = (row: any, _rows: any[], state: ResultGridState) => [

--- a/static/gsAdmin/views/options.tsx
+++ b/static/gsAdmin/views/options.tsx
@@ -10,7 +10,7 @@ import {IconEdit, IconStack} from 'sentry/icons';
 
 import {EditAdminOptionModal} from 'admin/components/editAdminOptionModal';
 import {PageHeader} from 'admin/components/pageHeader';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 export interface SerializedOption {
   fieldType: 'bool' | 'rate';

--- a/static/gsAdmin/views/overview.tsx
+++ b/static/gsAdmin/views/overview.tsx
@@ -19,7 +19,7 @@ import type {DocIntegration} from 'sentry/types/integrations';
 import {CustomerContact} from 'admin/components/customerContact';
 import {CustomerStatus} from 'admin/components/customerStatus';
 import {PercentChange} from 'admin/components/percentChange';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 /**
  * DEPRECATION WARNING

--- a/static/gsAdmin/views/policies.tsx
+++ b/static/gsAdmin/views/policies.tsx
@@ -8,7 +8,7 @@ import {ConfigStore} from 'sentry/stores/configStore';
 
 import {PageHeader} from 'admin/components/pageHeader';
 import {AddPolicyModal} from 'admin/components/policies/addPolicyModal';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 const getRow = (row: any) => [
   <td key="policy">

--- a/static/gsAdmin/views/promoCodes.tsx
+++ b/static/gsAdmin/views/promoCodes.tsx
@@ -7,7 +7,7 @@ import {useModal} from '@sentry/scraps/modal';
 
 import {PageHeader} from 'admin/components/pageHeader';
 import {AddPromoCodeModal as PromoCodeModal} from 'admin/components/promoCodes/promoCodeModal';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 import {titleCase} from 'getsentry/utils/titleCase';
 
 const getRow = (row: any) => [

--- a/static/gsAdmin/views/relocationDetails.tsx
+++ b/static/gsAdmin/views/relocationDetails.tsx
@@ -36,7 +36,7 @@ import {RelocationCancelModal} from 'admin/components/relocationCancelModal';
 import {RelocationPauseModal} from 'admin/components/relocationPauseModal';
 import {RelocationRetryModal} from 'admin/components/relocationRetryModal';
 import {RelocationUnpauseModal} from 'admin/components/relocationUnpauseModal';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 import type {Relocation} from 'admin/types';
 import {RelocationSteps} from 'admin/types';
 import {titleCase} from 'getsentry/utils/titleCase';

--- a/static/gsAdmin/views/relocations.tsx
+++ b/static/gsAdmin/views/relocations.tsx
@@ -5,7 +5,7 @@ import {Link} from '@sentry/scraps/link';
 
 import {PageHeader} from 'admin/components/pageHeader';
 import {RelocationBadge} from 'admin/components/relocationBadge';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 import type {Relocation} from 'admin/types';
 import {titleCase} from 'getsentry/utils/titleCase';
 

--- a/static/gsAdmin/views/sentryApps.tsx
+++ b/static/gsAdmin/views/sentryApps.tsx
@@ -4,7 +4,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 
 import {PageHeader} from 'admin/components/pageHeader';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 const getRow = (row: any) => [
   <td key="name">

--- a/static/gsAdmin/views/sentryEmployees.tsx
+++ b/static/gsAdmin/views/sentryEmployees.tsx
@@ -8,7 +8,7 @@ import {IconEdit} from 'sentry/icons';
 import {ConfigStore} from 'sentry/stores/configStore';
 
 import {PageHeader} from 'admin/components/pageHeader';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 import {UserPermissionsModal} from 'admin/components/users/userPermissionsModal';
 
 export function SentryEmployees() {

--- a/static/gsAdmin/views/users.tsx
+++ b/static/gsAdmin/views/users.tsx
@@ -6,7 +6,7 @@ import {UserBadge} from 'sentry/components/idBadge/userBadge';
 import {Truncate} from 'sentry/components/truncate';
 
 import {PageHeader} from 'admin/components/pageHeader';
-import ResultGrid from 'admin/components/resultGrid';
+import {ResultGrid} from 'admin/components/resultGrid';
 
 const getRow = (row: any) => [
   <td key="user">


### PR DESCRIPTION
Replace the deprecated `browserHistory` shim, `withApi`, and `withSentryRouter` wrappers around the gsAdmin `ResultGrid` with direct calls to `useApi`, `useLocation`, and `useNavigate` in a small function wrapper.

The internal class is renamed to `ResultGridImpl` and the public export keeps the name `ResultGrid` (now a named export). All 33 callers move from a default import to a named import; the local identifier is unchanged.

`api` remains an optional override prop so callers like `relocationDetails.tsx` can keep passing a region-scoped client.

Drops `browserHistory` usages in `static/` from 66 → 61.