### PR TITLE
fix(issues): Use full URL for open link button in breadcrumb messages

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.spec.tsx
@@ -154,9 +154,7 @@ describe('BreadcrumbItemContent', () => {
     const compactItem = render(
       <BreadcrumbItemContent breadcrumb={breadcrumb} fullyExpanded={false} />
     );
-    expect(
-      screen.getByText(longMessage.substring(0, 200) + '\u2026')
-    ).toBeInTheDocument();
+    expect(screen.getByText(longMessage)).toBeInTheDocument();
     expect(screen.getByText('6 items')).toBeInTheDocument();
     compactItem.unmount();
 

--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
@@ -14,7 +14,6 @@ import {
   type RawCrumb,
 } from 'sentry/types/breadcrumbs';
 import {defined} from 'sentry/utils';
-import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {isUrl} from 'sentry/utils/string/isUrl';
 import {usePrismTokens} from 'sentry/utils/usePrismTokens';
 
@@ -23,8 +22,6 @@ const DEFAULT_STRUCTURED_DATA_PROPS = {
   withAnnotatedText: true,
   withOnlyFormattedText: true,
 };
-
-const MESSAGE_PREVIEW_CHAR_LIMIT = 200;
 
 interface BreadcrumbItemContentProps {
   breadcrumb: RawCrumb;
@@ -47,20 +44,7 @@ export function BreadcrumbItemContent({
 
   const defaultMessage = defined(bc.message) ? (
     <BreadcrumbText>
-      {fullyExpanded ? (
-        <StructuredData
-          value={bc.message}
-          meta={meta?.message}
-          {...structuredDataProps}
-        />
-      ) : (
-        <StructuredData
-          value={ellipsize(bc.message, MESSAGE_PREVIEW_CHAR_LIMIT)}
-          // Note: Annotations applying to trimmed content will not be applied.
-          meta={meta?.message}
-          {...structuredDataProps}
-        />
-      )}
+      <StructuredData value={bc.message} meta={meta?.message} {...structuredDataProps} />
     </BreadcrumbText>
   ) : null;
 
@@ -272,6 +256,7 @@ const SQLText = styled('pre')`
 
 const BreadcrumbText = styled(Timeline.Text)`
   white-space: pre-wrap;
+  word-break: break-all;
   font-family: ${p => p.theme.font.family.mono};
   font-size: ${p => p.theme.font.size.sm};
   color: ${p => p.theme.tokens.content.primary};

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
@@ -53,7 +53,7 @@ describe('BreadcrumbsDataSection', () => {
     }
 
     // When expanded, all should be visible
-    const viewAllButton = screen.getByRole('button', {name: 'View All Breadcrumbs'});
+    const viewAllButton = screen.getByRole('button', {name: 'View 2 more'});
     await userEvent.click(viewAllButton);
     const drawer = screen.getByRole('complementary', {name: 'breadcrumb drawer'});
     expect(drawer).toBeInTheDocument();
@@ -64,7 +64,7 @@ describe('BreadcrumbsDataSection', () => {
 
   it('toggles the drawer when view all is clicked', async () => {
     render(<BreadcrumbsDataSection {...MOCK_DATA_SECTION_PROPS} />);
-    const viewAllButton = screen.getByRole('button', {name: 'View All Breadcrumbs'});
+    const viewAllButton = screen.getByRole('button', {name: 'View 2 more'});
     await userEvent.click(viewAllButton);
     const drawer = screen.getByRole('complementary', {name: 'breadcrumb drawer'});
     expect(drawer).toBeInTheDocument();

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -160,7 +160,6 @@ export function BreadcrumbsDataSection({
     </Grid>
   );
 
-  const hasViewAll = summaryCrumbs.length !== enhancedCrumbs.length;
   const numHiddenCrumbs = enhancedCrumbs.length - summaryCrumbs.length;
 
   return (
@@ -176,28 +175,26 @@ export function BreadcrumbsDataSection({
             breadcrumbs={summaryCrumbs}
             startTimeString={startTimeString}
             // We want the timeline to appear connected to the 'View All' button
-            showLastLine={hasViewAll}
+            showLastLine
             fullyExpanded={false}
             containerElement={container}
           />
         </div>
-        {hasViewAll && (
-          <ViewAllContainer>
-            <VerticalEllipsis />
-            <div>
-              <ViewAllButton
-                size="sm"
-                // Since we've disabled the button as an 'outside click' for the drawer we can change
-                // the operation based on the drawer state.
-                onClick={() => (isDrawerOpen ? closeDrawer() : onViewAllBreadcrumbs())}
-                aria-label={t('View All Breadcrumbs')}
-                ref={viewAllButtonRef}
-              >
-                {t('View %s more', numHiddenCrumbs)}
-              </ViewAllButton>
-            </div>
-          </ViewAllContainer>
-        )}
+        <ViewAllContainer>
+          <VerticalEllipsis />
+          <div>
+            <ViewAllButton
+              size="sm"
+              // Since we've disabled the button as an 'outside click' for the drawer we can change
+              // the operation based on the drawer state.
+              onClick={() => (isDrawerOpen ? closeDrawer() : onViewAllBreadcrumbs())}
+              aria-label={t('View All Breadcrumbs')}
+              ref={viewAllButtonRef}
+            >
+              {numHiddenCrumbs > 0 ? t('View %s more', numHiddenCrumbs) : t('View All')}
+            </ViewAllButton>
+          </div>
+        </ViewAllContainer>
       </ErrorBoundary>
     </FoldSection>
   );

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -188,7 +188,6 @@ export function BreadcrumbsDataSection({
               // Since we've disabled the button as an 'outside click' for the drawer we can change
               // the operation based on the drawer state.
               onClick={() => (isDrawerOpen ? closeDrawer() : onViewAllBreadcrumbs())}
-              aria-label={t('View All Breadcrumbs')}
               ref={viewAllButtonRef}
             >
               {numHiddenCrumbs > 0 ? t('View %s more', numHiddenCrumbs) : t('View All')}

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawer.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawer.spec.tsx
@@ -22,7 +22,7 @@ async function renderBreadcrumbDrawer() {
       toJSON: jest.fn(),
     }));
   render(<BreadcrumbsDataSection {...MOCK_DATA_SECTION_PROPS} />);
-  await userEvent.click(screen.getByRole('button', {name: 'View All Breadcrumbs'}));
+  await userEvent.click(screen.getByRole('button', {name: 'View 2 more'}));
   return screen.getByRole('complementary', {name: 'breadcrumb drawer'});
 }
 


### PR DESCRIPTION
Breadcrumb messages were truncated to 200 chars with `ellipsize()` before being passed to `StructuredData`. The `LinkHint` "open link" button inside `StructuredData` then used the truncated value, so clicking it opened an incomplete URL.

Remove the character-based truncation so the full message value reaches `LinkHint`. Also always show the "View All" button at the bottom of the breadcrumbs section so users can open the drawer even when all breadcrumbs are visible in the preview.

fixes #98702