### PR TITLE
ref(discover): migrate savedQuery off browserHistory

### DIFF
--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -27,11 +27,12 @@ import type {Organization, SavedQuery} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {EventView} from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {getDiscoverQueriesUrl} from 'sentry/utils/discover/urls';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOverlay} from 'sentry/utils/useOverlay';
 import {withApi} from 'sentry/utils/withApi';
 import {withProjects} from 'sentry/utils/withProjects';
@@ -152,6 +153,7 @@ type Props = DefaultProps & {
    * passed down only because it is needed for navigation.
    */
   location: Location;
+  navigate: ReactRouter3Navigate;
   organization: Organization;
   projects: Project[];
   queryDataLoading: boolean;
@@ -280,7 +282,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
 
         Banner.dismiss('discover');
         this.setState({queryName: ''});
-        browserHistory.push(normalizeUrl(view.getResultsViewUrlTarget(organization)));
+        this.props.navigate(normalizeUrl(view.getResultsViewUrlTarget(organization)));
       }
     );
   };
@@ -289,7 +291,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
     event.preventDefault();
     event.stopPropagation();
 
-    const {api, organization, eventView, updateCallback, yAxis, setSavedQuery} =
+    const {api, navigate, organization, eventView, updateCallback, yAxis, setSavedQuery} =
       this.props;
 
     handleUpdateQuery(api, organization, eventView, yAxis).then(
@@ -297,7 +299,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
         const view = EventView.fromSavedQuery(savedQuery);
         setSavedQuery(savedQuery);
         this.setState({queryName: ''});
-        browserHistory.push(view.getResultsViewShortUrlTarget(organization));
+        navigate(view.getResultsViewShortUrlTarget(organization));
         updateCallback();
       }
     );
@@ -307,10 +309,10 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
     event?.preventDefault();
     event?.stopPropagation();
 
-    const {api, organization, eventView} = this.props;
+    const {api, navigate, organization, eventView} = this.props;
 
     handleDeleteQuery(api, organization, eventView).then(() => {
-      browserHistory.push(
+      navigate(
         normalizeUrl({
           pathname: getDiscoverQueriesUrl(organization),
           query: {},
@@ -550,7 +552,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
                 DEFAULT_EVENT_VIEW,
                 location
               );
-              browserHistory.push({
+              this.props.navigate({
                 pathname: location.pathname,
                 query: nextEventView.generateQueryStringObject(),
               });
@@ -736,4 +738,9 @@ export const IconUpdate = styled('div')`
   background-color: ${p => p.theme.colors.yellow400};
 `;
 
-export default withProjects(withApi(SavedQueryButtonGroup));
+function SavedQueryButtonGroupWithNavigate(props: Omit<Props, 'navigate'>) {
+  const navigate = useNavigate();
+  return <SavedQueryButtonGroup {...props} navigate={navigate} />;
+}
+
+export default withProjects(withApi(SavedQueryButtonGroupWithNavigate));


### PR DESCRIPTION
Replace the four `browserHistory.push` calls in `SavedQueryButtonGroup` with `this.props.navigate`, supplied by a small function wrapper that calls `useNavigate()`.

Drops `browserHistory` usages in `static/` from 57 → 53.