### PR TITLE
fix(replays): disable breadcrumbs autoscroll on user scroll

### DIFF
--- a/static/app/views/explore/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/explore/replays/detail/breadcrumbs/index.tsx
@@ -29,6 +29,7 @@ export function Breadcrumbs() {
   const {currentTime} = useReplayContext();
   const {onClickTimestamp} = useCrumbHandlers();
   const [showSnippetSet, setShowSnippetSet] = useState(new Set());
+  const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
 
   const startTimestampMs = replay?.getStartTimestampMs() ?? 0;
   const frames = replay?.getChapterFrames();
@@ -92,6 +93,7 @@ export function Breadcrumbs() {
   // Callback for jump buttons to scroll directly
   const handleScrollToRow = useCallback(
     (row: number) => {
+      setAutoScrollEnabled(true);
       virtualizer.scrollToIndex(row, {align: 'center'});
     },
     [virtualizer]
@@ -110,6 +112,8 @@ export function Breadcrumbs() {
   });
 
   useScrollToCurrentItem({
+    autoScrollEnabled,
+    currentTime,
     frames: items,
     virtualizer: scrollContainerRef.current ? virtualizer : null,
   });
@@ -132,7 +136,11 @@ export function Breadcrumbs() {
       <BreadcrumbFilters frames={frames} {...filterProps} />
       <TabItemContainer data-test-id="replay-details-breadcrumbs-tab">
         {frames ? (
-          <ScrollContainer ref={scrollContainerRef}>
+          <ScrollContainer
+            ref={scrollContainerRef}
+            onPointerDown={() => setAutoScrollEnabled(false)}
+            onWheel={() => setAutoScrollEnabled(false)}
+          >
             {items.length === 0 ? (
               <NoRowRenderer unfilteredItems={frames} clearSearchTerm={clearSearchTerm}>
                 {t('No breadcrumbs recorded')}

--- a/static/app/views/explore/replays/detail/breadcrumbs/useScrollToCurrentItem.spec.tsx
+++ b/static/app/views/explore/replays/detail/breadcrumbs/useScrollToCurrentItem.spec.tsx
@@ -1,0 +1,168 @@
+import type {Virtualizer} from '@tanstack/react-virtual';
+import {ReplayClickFrameFixture} from 'sentry-fixture/replay/replayBreadcrumbFrameData';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {hydrateBreadcrumbs} from 'sentry/utils/replays/hydrateBreadcrumbs';
+
+import {useScrollToCurrentItem} from './useScrollToCurrentItem';
+
+const frames = hydrateBreadcrumbs(
+  ReplayRecordFixture({started_at: new Date('2024-01-01T00:00:00.000Z')}),
+  [
+    ReplayClickFrameFixture({timestamp: new Date('2024-01-01T00:00:01.000Z')}), // offsetMs ~1000
+    ReplayClickFrameFixture({timestamp: new Date('2024-01-01T00:00:02.000Z')}), // offsetMs ~2000
+    ReplayClickFrameFixture({timestamp: new Date('2024-01-01T00:00:03.000Z')}), // offsetMs ~3000
+  ]
+);
+
+function makeVirtualizer() {
+  const scrollToIndex = jest.fn();
+  return {
+    scrollToIndex,
+    virtualizer: {scrollToIndex} as unknown as Virtualizer<HTMLDivElement, Element>,
+  };
+}
+
+describe('useScrollToCurrentItem', () => {
+  it('scrolls to the current frame when autoScrollEnabled is true', () => {
+    const {scrollToIndex, virtualizer} = makeVirtualizer();
+
+    renderHookWithProviders(() =>
+      useScrollToCurrentItem({
+        autoScrollEnabled: true,
+        currentTime: 1500,
+        frames,
+        virtualizer,
+      })
+    );
+
+    // frame at ~1000ms (index 0) is the last frame before currentTime=1500
+    expect(scrollToIndex).toHaveBeenCalledWith(0, {align: 'center', behavior: 'smooth'});
+  });
+
+  it('scrolls to the correct index as currentTime advances', () => {
+    const {scrollToIndex, virtualizer} = makeVirtualizer();
+
+    renderHookWithProviders(() =>
+      useScrollToCurrentItem({
+        autoScrollEnabled: true,
+        currentTime: 2500,
+        frames,
+        virtualizer,
+      })
+    );
+
+    // frame at ~2000ms (index 1) is the last frame before currentTime=2500
+    expect(scrollToIndex).toHaveBeenCalledWith(1, {align: 'center', behavior: 'smooth'});
+  });
+
+  it('does not scroll when autoScrollEnabled is false', () => {
+    const {scrollToIndex, virtualizer} = makeVirtualizer();
+
+    renderHookWithProviders(() =>
+      useScrollToCurrentItem({
+        autoScrollEnabled: false,
+        currentTime: 1500,
+        frames,
+        virtualizer,
+      })
+    );
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it('does not scroll when virtualizer is null', () => {
+    const {scrollToIndex} = makeVirtualizer();
+
+    renderHookWithProviders(() =>
+      useScrollToCurrentItem({
+        autoScrollEnabled: true,
+        currentTime: 1500,
+        frames,
+        virtualizer: null,
+      })
+    );
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it('does not scroll when frames is undefined', () => {
+    const {scrollToIndex, virtualizer} = makeVirtualizer();
+
+    renderHookWithProviders(() =>
+      useScrollToCurrentItem({
+        autoScrollEnabled: true,
+        currentTime: 1500,
+        frames: undefined,
+        virtualizer,
+      })
+    );
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it('does not scroll when currentTime is before all frames', () => {
+    const {scrollToIndex, virtualizer} = makeVirtualizer();
+
+    renderHookWithProviders(() =>
+      useScrollToCurrentItem({
+        autoScrollEnabled: true,
+        currentTime: 0,
+        frames,
+        virtualizer,
+      })
+    );
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it('scrolls when autoScrollEnabled switches from false to true', () => {
+    const {scrollToIndex, virtualizer} = makeVirtualizer();
+
+    const {rerender} = renderHookWithProviders(
+      ({enabled}: {enabled: boolean}) =>
+        useScrollToCurrentItem({
+          autoScrollEnabled: enabled,
+          currentTime: 1500,
+          frames,
+          virtualizer,
+        }),
+      {initialProps: {enabled: false}}
+    );
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+
+    rerender({enabled: true});
+
+    expect(scrollToIndex).toHaveBeenCalledWith(0, {align: 'center', behavior: 'smooth'});
+  });
+
+  it('scrolls to the new frame when currentTime advances to the next frame', () => {
+    const {scrollToIndex, virtualizer} = makeVirtualizer();
+
+    const {rerender} = renderHookWithProviders(
+      ({currentTime}: {currentTime: number}) =>
+        useScrollToCurrentItem({
+          autoScrollEnabled: true,
+          currentTime,
+          frames,
+          virtualizer,
+        }),
+      {initialProps: {currentTime: 1500}}
+    );
+
+    expect(scrollToIndex).toHaveBeenLastCalledWith(0, {
+      align: 'center',
+      behavior: 'smooth',
+    });
+
+    rerender({currentTime: 2500});
+
+    expect(scrollToIndex).toHaveBeenLastCalledWith(1, {
+      align: 'center',
+      behavior: 'smooth',
+    });
+  });
+});

--- a/static/app/views/explore/replays/detail/breadcrumbs/useScrollToCurrentItem.tsx
+++ b/static/app/views/explore/replays/detail/breadcrumbs/useScrollToCurrentItem.tsx
@@ -1,17 +1,22 @@
 import {useEffect, useMemo} from 'react';
 import type {Virtualizer} from '@tanstack/react-virtual';
 
-import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {getPrevReplayFrame} from 'sentry/utils/replays/getReplayEvent';
 import type {ReplayFrame} from 'sentry/utils/replays/types';
 
 interface Opts {
+  autoScrollEnabled: boolean;
+  currentTime: number;
   frames: undefined | ReplayFrame[];
   virtualizer: Virtualizer<HTMLDivElement, Element> | null;
 }
 
-export function useScrollToCurrentItem({frames, virtualizer}: Opts) {
-  const {currentTime} = useReplayContext();
+export function useScrollToCurrentItem({
+  autoScrollEnabled,
+  currentTime,
+  frames,
+  virtualizer,
+}: Opts) {
   const currentItem = useMemo(
     () =>
       getPrevReplayFrame({
@@ -22,12 +27,12 @@ export function useScrollToCurrentItem({frames, virtualizer}: Opts) {
   );
 
   useEffect(() => {
-    if (virtualizer && currentItem && frames) {
+    if (autoScrollEnabled && virtualizer && currentItem && frames) {
       const index = frames.indexOf(currentItem);
       if (index >= 0) {
         // Center the current item in the viewport
         virtualizer.scrollToIndex(index, {align: 'center', behavior: 'smooth'});
       }
     }
-  }, [frames, currentItem, virtualizer]);
+  }, [autoScrollEnabled, frames, currentItem, virtualizer]);
 }


### PR DESCRIPTION
Switches the Replay auto-scroll feature off after the user scrolls themselves. It's turned back on if they press a 'Jump to current timestamp' button.

There's probably a more design-y way to do this (e.g. an 'autoscroll enabled' checkbox), but that'll have to be a separate followup. 

Closes REPLAY-854.