### PR TITLE
ref(project-detail): migrate projectCharts off browserHistory

### DIFF
--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -29,10 +29,11 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {withApi} from 'sentry/utils/withApi';
 import {
   getSessionTermDescription,
@@ -69,6 +70,7 @@ type Props = {
   hasSessions: boolean | null;
   hasTransactions: boolean;
   location: Location;
+  navigate: ReactRouter3Navigate;
   organization: Organization;
   theme: Theme;
   visibleCharts: string[];
@@ -299,14 +301,14 @@ class ProjectCharts extends Component<Props, State> {
   }
 
   handleDisplayModeChange = (value: string) => {
-    const {location, chartId, chartIndex, organization} = this.props;
+    const {navigate, location, chartId, chartIndex, organization} = this.props;
     trackAnalytics('project_detail.change_chart', {
       organization,
       metric: value,
       chart_index: chartIndex,
     });
 
-    browserHistory.push({
+    navigate({
       pathname: location.pathname,
       query: {...location.query, [chartId]: value},
     });
@@ -543,4 +545,9 @@ class ProjectCharts extends Component<Props, State> {
   }
 }
 
-export default withApi(withTheme(ProjectCharts));
+function ProjectChartsWithNavigate(props: Omit<Props, 'navigate'>) {
+  const navigate = useNavigate();
+  return <ProjectCharts {...props} navigate={navigate} />;
+}
+
+export default withApi(withTheme(ProjectChartsWithNavigate));


### PR DESCRIPTION
Replace the `browserHistory.push` call in `ProjectCharts` with a navigate prop supplied by a function wrapper that calls `useNavigate()`.