### PR TITLE
fix(tracemetrics): Pass project and env in request filters for filter

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -412,7 +412,11 @@ function MetricToolbar({
             />
           </Flex>
           <AggregateDropdown traceMetric={traceMetric} singleSelect />
-          <Filter traceMetric={traceMetric} />
+          <Filter
+            traceMetric={traceMetric}
+            projectIds={projectIds}
+            environments={environments}
+          />
           <DeleteMetricButton disabledReason={deleteDisabledReason} />
         </Fragment>
       ) : isVisualizeEquation(visualize) ? (
@@ -422,7 +426,12 @@ function MetricToolbar({
             referenceMap={referenceMap}
             handleExpressionChange={handleExpressionChange}
           />
-          <Filter traceMetric={traceMetric} skipTraceMetricFilter />
+          <Filter
+            traceMetric={traceMetric}
+            skipTraceMetricFilter
+            projectIds={projectIds}
+            environments={environments}
+          />
           <DeleteMetricButton />
         </Fragment>
       ) : null}

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -174,6 +174,8 @@ export function Filter({
         namespace: traceMetric.name,
         attributeQuery,
         hiddenAttributeKeys: HiddenTraceMetricSearchFields,
+        projects: projectIds,
+        environments,
 
         // Disable the recent searches when not using a trace metric filter or when the metric name
         // is not set because the recent searches for metrics need to be namespaced on the trace metric filter.
@@ -188,6 +190,8 @@ export function Filter({
       traceMetric.name,
       attributeQuery,
       skipTraceMetricFilter,
+      projectIds,
+      environments,
     ]);
 
   const searchQueryBuilderProviderProps = useTraceItemSearchQueryBuilderProps(

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -38,6 +38,8 @@ const EMPTY_ALIASES: TagCollection = {};
 
 interface FilterProps {
   traceMetric: TraceMetric;
+  environments?: string[];
+  projectIds?: number[];
   skipTraceMetricFilter?: boolean;
 }
 
@@ -59,7 +61,12 @@ function MetricsSearchBar({
   return <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />;
 }
 
-export function Filter({traceMetric, skipTraceMetricFilter}: FilterProps) {
+export function Filter({
+  traceMetric,
+  skipTraceMetricFilter,
+  projectIds,
+  environments,
+}: FilterProps) {
   const query = useQueryParamsQuery();
   const setQuery = useSetQueryParamsQuery();
   const organization = useOrganization();
@@ -81,6 +88,8 @@ export function Filter({traceMetric, skipTraceMetricFilter}: FilterProps) {
       selection,
       traceItemType: TraceItemDataset.TRACEMETRICS,
       query: attributeQuery,
+      projectIds,
+      environments,
     }),
     enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
     select: selectTraceItemTagCollection(),

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
@@ -236,6 +236,37 @@ describe('traceItemAttributeKeysOptions', () => {
     expect(cachedRequest).toHaveBeenCalledTimes(1);
     expect(currentRequest).toHaveBeenCalledTimes(1);
   });
+
+  it('project and environment filter overrides selection values', async () => {
+    const request = addAttributeKeysMock({
+      substringMatch: 'foo',
+      body: [makeAttribute('foo.bar')],
+      query: {project: ['2'], environment: ['production']},
+    });
+
+    const result = await fetchAttributeKeys({
+      search: 'foo',
+      projectIds: [2],
+      environments: ['production'],
+      selection: PageFiltersFixture({
+        ...selection,
+        projects: [9999],
+        environments: ['not-production'],
+      }),
+    });
+
+    expect(result.json).toEqual([makeAttribute('foo.bar')]);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/trace-items/attributes/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          project: ['2'],
+          environment: ['production'],
+        }),
+      })
+    );
+  });
 });
 
 describe('getTraceItemTagCollection', () => {

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
@@ -31,6 +31,7 @@ type TraceItemAttributeKeyOptions = Pick<
 > & {
   attributeType: TraceItemAttributeType | TraceItemAttributeType[];
   itemType: TraceItemDataset;
+  environment?: string[];
   project?: string[];
   query?: string;
   substringMatch?: string;
@@ -40,6 +41,7 @@ interface TraceItemAttributeKeysOptions {
   organization: Organization;
   selection: PageFilters;
   traceItemType: TraceItemDataset;
+  environments?: string[];
   projectIds?: Array<string | number>;
   projects?: Project[];
   query?: string;
@@ -56,6 +58,7 @@ export function traceItemAttributeKeysOptions({
   type = ['string', 'number', 'boolean'],
   projects,
   projectIds: explicitProjectIds,
+  environments,
   query,
   search,
 }: TraceItemAttributeKeysOptions) {
@@ -68,6 +71,7 @@ export function traceItemAttributeKeysOptions({
     itemType: traceItemType,
     attributeType: type,
     project: projectIds?.map(String),
+    environment: environments ?? selection.environments,
     query,
     ...normalizeDateTimeParams(selection.datetime),
     ...(substringMatch === undefined ? {} : {substringMatch}),


### PR DESCRIPTION
If we don't pass these along explicitly from the form state, `usePageFilters` gives us the locally stored values which can cause conflicts if it doesn't match the selection.

To repro a problem scenario:
- go to an org
- select a project A from any of the page filters dropdowns
- go to monitors and create a metric alert for application metrics
- open devtools and select the network tab
- change the project to some project B
- change the metric to something in project B

A request for attributes will be made, but it will have the project A ID in it, which conflicts with the metric since it's part of project B

I debated _not_ passing down environment and only project, but since the metric selector already does both maybe it makes sense for us to pass them both along. I can remove them if we decide we just want the user to see everything in that project