### PR TITLE
fix(preprod): Remove native lazy loading from LazyImage component

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -325,8 +325,6 @@ function LazyImage({
         ref={refCallback}
         src={src}
         alt={alt}
-        loading="lazy"
-        decoding="async"
         width={width || undefined}
         height={height || undefined}
         onLoad={onLoad}


### PR DESCRIPTION
Remove `loading="lazy"` and `decoding="async"` from the `LazyImage` component
in the snapshot diff view.

`LazyImage` already manages its own visibility via `loaded` state and
`opacity: 0` positioning — it renders the `<img>` immediately but hides it
until `onLoad` fires. Stacking the browser's native `loading="lazy"` on top
caused the browser to defer fetching images it considered off-screen (inside
scrollable containers with `opacity: 0`), so the `onLoad` event never fired
and base images stayed blank.

Introduced in #115836.