### PR TITLE
ref(dashboards): migrate utils.tsx off browserHistory

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1166,6 +1166,7 @@ class DashboardDetail extends Component<Props, State> {
   renderDashboardDetail() {
     const {
       api,
+      navigate,
       organization,
       dashboard,
       location,
@@ -1313,7 +1314,7 @@ class DashboardDetail extends Component<Props, State> {
                               storageNamespace={this.props.storageNamespace}
                               widgetLimitReached={widgetLimitReached}
                               onCancel={() => {
-                                resetPageFilters(dashboard, location);
+                                resetPageFilters(dashboard, location, navigate);
                                 trackAnalytics('dashboards2.filter.cancel', {
                                   organization,
                                 });

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -19,7 +19,6 @@ import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {EventView} from 'sentry/utils/discover/eventView';
 import {DURATION_UNITS} from 'sentry/utils/discover/fieldRenderers';
@@ -35,6 +34,7 @@ import {DisplayModes, type SavedQueryDatasets} from 'sentry/utils/discover/types
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {getMeasurements} from 'sentry/utils/measurements/measurements';
 import {decodeList} from 'sentry/utils/queryString';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import type {
   DashboardDetails,
   DashboardFilters,
@@ -435,11 +435,18 @@ export function getSavedPageFilters(dashboard: DashboardDetails) {
   };
 }
 
-export function resetPageFilters(dashboard: DashboardDetails, location: Location) {
-  browserHistory.replace({
-    ...location,
-    query: getSavedPageFilters(dashboard),
-  });
+export function resetPageFilters(
+  dashboard: DashboardDetails,
+  location: Location,
+  navigate: ReactRouter3Navigate
+) {
+  navigate(
+    {
+      ...location,
+      query: getSavedPageFilters(dashboard),
+    },
+    {replace: true}
+  );
 }
 
 export function getCurrentPageFilters(


### PR DESCRIPTION
Thread `navigate` into `resetPageFilters` from its caller (`detail.tsx`) so the utility no longer reaches for the deprecated `browserHistory` shim.