### PR TITLE
feat(explore): heatmap tooltip trace links

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -764,6 +764,11 @@ const getTooltipStyles = (p: {theme: Theme}) => css`
     justify-content: flex-start;
     align-items: baseline;
   }
+  .tooltip-label-centered {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
   .tooltip-code-no-margin {
     padding-left: 0;
     margin-left: 0;

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -3,6 +3,7 @@ import 'echarts/lib/component/tooltip';
 import type {Theme} from '@emotion/react';
 import {useTheme} from '@emotion/react';
 import type {TooltipComponentFormatterCallback} from 'echarts';
+import type {CallbackDataParams} from 'echarts/types/dist/shared';
 import moment from 'moment-timezone';
 
 import type {BaseChart, BaseChartProps} from 'sentry/components/charts/baseChart';
@@ -11,6 +12,7 @@ import {t} from 'sentry/locale';
 import type {DataPoint} from 'sentry/types/echarts';
 import {toArray} from 'sentry/utils/array/toArray';
 import {getFormattedDate, getTimeFormat} from 'sentry/utils/dates';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 
 export const CHART_TOOLTIP_VIEWPORT_OFFSET = 20;
 
@@ -74,7 +76,7 @@ function defaultMarkerFormatter(value: string) {
   return value;
 }
 
-function getSeriesValue(series: any, offset: number) {
+export function getSeriesValue(series: any, offset: number) {
   if (!series.data) {
     return;
   }
@@ -114,6 +116,10 @@ export type FormatterOptions = Pick<
      */
     addSecondsToTimeFormat?: boolean;
     /**
+     * Content that IS NOT part of the series data but is shown on the tooltip.
+     */
+    extraContent?: (seriesParams: CallbackDataParams) => string | null;
+    /**
      * Limit the number of series rendered in the tooltip and display "+X more".
      */
     limit?: number;
@@ -138,6 +144,7 @@ export function getFormatter({
   valueFormatter = defaultValueFormatter,
   nameFormatter = defaultNameFormatter,
   markerFormatter = defaultMarkerFormatter,
+  extraContent,
   subLabels = [],
   addSecondsToTimeFormat = false,
   limit,
@@ -244,16 +251,28 @@ export function getFormatter({
         );
 
         if (serie.seriesType === 'heatmap') {
-          const zAxisCountValue = (getSeriesValue(serie, 2) ?? 0).toString();
+          const zAxisCountValue = formatAbbreviatedNumber(
+            getSeriesValue(serie, 2) ?? 0,
+            4,
+            false
+          );
           const yAxisValue = valueFormatter(
             getSeriesValue(serie, 1),
             serie.seriesName,
             serie
           );
 
-          acc.series.push(
-            `<div><span class="tooltip-label"><strong>${yAxisValue}</strong></span> ${zAxisCountValue}</div>`
-          );
+          const additionalContent = extraContent ? extraContent(serie) : null;
+
+          if (additionalContent) {
+            acc.series.push(
+              `<div><span class="tooltip-label"><strong>${yAxisValue}</strong></span> ${zAxisCountValue}</div><div><span class="tooltip-label tooltip-label-centered">${additionalContent}</span></div>`
+            );
+          } else {
+            acc.series.push(
+              `<div><span class="tooltip-label"><strong>${yAxisValue}</strong></span> ${zAxisCountValue}</div>`
+            );
+          }
 
           return acc;
         }

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -74,7 +74,7 @@ function defaultMarkerFormatter(value: string) {
   return value;
 }
 
-export function getSeriesValue(series: any, offset: number) {
+function getSeriesValue(series: any, offset: number) {
   if (!series.data) {
     return;
   }

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -3,7 +3,6 @@ import 'echarts/lib/component/tooltip';
 import type {Theme} from '@emotion/react';
 import {useTheme} from '@emotion/react';
 import type {TooltipComponentFormatterCallback} from 'echarts';
-import type {CallbackDataParams} from 'echarts/types/dist/shared';
 import moment from 'moment-timezone';
 
 import type {BaseChart, BaseChartProps} from 'sentry/components/charts/baseChart';
@@ -12,7 +11,6 @@ import {t} from 'sentry/locale';
 import type {DataPoint} from 'sentry/types/echarts';
 import {toArray} from 'sentry/utils/array/toArray';
 import {getFormattedDate, getTimeFormat} from 'sentry/utils/dates';
-import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 
 export const CHART_TOOLTIP_VIEWPORT_OFFSET = 20;
 
@@ -116,10 +114,6 @@ export type FormatterOptions = Pick<
      */
     addSecondsToTimeFormat?: boolean;
     /**
-     * Content that IS NOT part of the series data but is shown on the tooltip.
-     */
-    extraContent?: (seriesParams: CallbackDataParams) => string | null;
-    /**
      * Limit the number of series rendered in the tooltip and display "+X more".
      */
     limit?: number;
@@ -144,7 +138,6 @@ export function getFormatter({
   valueFormatter = defaultValueFormatter,
   nameFormatter = defaultNameFormatter,
   markerFormatter = defaultMarkerFormatter,
-  extraContent,
   subLabels = [],
   addSecondsToTimeFormat = false,
   limit,
@@ -249,33 +242,6 @@ export function getFormatter({
           truncationFormatter(serie.seriesName ?? '', truncate),
           serie
         );
-
-        if (serie.seriesType === 'heatmap') {
-          const zAxisCountValue = formatAbbreviatedNumber(
-            getSeriesValue(serie, 2) ?? 0,
-            4,
-            false
-          );
-          const yAxisValue = valueFormatter(
-            getSeriesValue(serie, 1),
-            serie.seriesName,
-            serie
-          );
-
-          const additionalContent = extraContent ? extraContent(serie) : null;
-
-          if (additionalContent) {
-            acc.series.push(
-              `<div><span class="tooltip-label"><strong>${yAxisValue}</strong></span> ${zAxisCountValue}</div><div><span class="tooltip-label tooltip-label-centered">${additionalContent}</span></div>`
-            );
-          } else {
-            acc.series.push(
-              `<div><span class="tooltip-label"><strong>${yAxisValue}</strong></span> ${zAxisCountValue}</div>`
-            );
-          }
-
-          return acc;
-        }
 
         const value = valueFormatter(getSeriesValue(serie, 1), serie.seriesName, serie);
 

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -6,20 +6,24 @@ import type {
   TooltipFormatterCallback,
   TopLevelFormatterParams,
 } from 'echarts/types/dist/shared';
+import type {LocationDescriptor} from 'history';
 
 import {Flex} from '@sentry/scraps/layout';
 
 import {BaseChart} from 'sentry/components/charts/baseChart';
-import {getFormatter} from 'sentry/components/charts/components/tooltip';
+import {getFormatter, getSeriesValue} from 'sentry/components/charts/components/tooltip';
 import {isChartHovered, truncationFormatter} from 'sentry/components/charts/utils';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {t} from 'sentry/locale';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {NO_PLOTTABLE_VALUES} from 'sentry/views/dashboards/widgets/common/settings';
 import {plottablesCanBeVisualized} from 'sentry/views/dashboards/widgets/plottablesCanBeVisualized';
 import {formatTooltipValue} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue';
 import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp';
 import {formatYAxisValue} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue';
 import {FALLBACK_TYPE} from 'sentry/views/dashboards/widgets/timeSeriesWidget/settings';
+import {getExploreUrl, type GetExploreUrlArgs} from 'sentry/views/explore/utils';
 
 import {HeatMap} from './plottables/heatMap';
 import type {HeatMapPlottable} from './plottables/heatMapPlottable';
@@ -34,11 +38,16 @@ interface HeatMapWidgetVisualizationProps {
    * Experimental! Specify the Z-axis scale type. Logarithmic scales can be much more useful for values with a high range.
    */
   scale?: 'linear' | 'log';
+  /**
+   * getExploreUrl props that will be used to generate an explore link for the tooltip. Omitting this will not generate an explore link.
+   */
+  tooltipExploreUrlArgs?: Omit<GetExploreUrlArgs, 'organization'>;
 }
 
 export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProps) {
   const {plottables} = props;
   const theme = useTheme();
+  const organization = useOrganization();
 
   const pageFilters = usePageFilters();
   const {start, end, period, utc} = pageFilters.selection.datetime;
@@ -94,6 +103,11 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
           fieldType,
           heatMapPlottable.yAxisValueUnit ?? undefined
         );
+
+        if (bucketSize === 0) {
+          return yAxisMinValueFormatted;
+        }
+
         const yAxisMaxValueFormatted = formatTooltipValue(
           value + bucketSize,
           fieldType,
@@ -102,6 +116,50 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
 
         return `${yAxisMinValueFormatted} – ${yAxisMaxValueFormatted}`;
       },
+      extraContent: props.tooltipExploreUrlArgs
+        ? function (contentParams) {
+            // TODO(nikki): the y axis values might have to be changed if it's on a log scale :(
+            const yAxisBucketSize = heatMapPlottable.heatMapSeries.meta.yAxis.bucketSize;
+            const yAxisMinValue = getSeriesValue(contentParams, 1) as number;
+            const yAxisMaxValue = yAxisMinValue + yAxisBucketSize;
+
+            const xAxisBucketSize = heatMapPlottable.heatMapSeries.meta.xAxis.bucketSize;
+            const xAxisMinValue = getSeriesValue(contentParams, 0) as number;
+            const xAxisMaxValue = xAxisMinValue + xAxisBucketSize * 1000;
+
+            const exploreUrlProps: GetExploreUrlArgs = {
+              selection: {
+                ...pageFilters.selection,
+                datetime: {
+                  ...pageFilters.selection.datetime,
+                  start: new Date(xAxisMinValue),
+                  end: new Date(xAxisMaxValue),
+                  period: null,
+                },
+              },
+              organization,
+              // TODO(nikki): we're only handling metrics for now but if we're looking to support other explore
+              // surfaces then we'll need to add more logic here
+              ...props.tooltipExploreUrlArgs,
+              crossEvents: props.tooltipExploreUrlArgs?.crossEvents?.map(crossEvent => {
+                if (crossEvent.type === 'metrics') {
+                  return {
+                    ...crossEvent,
+                    query:
+                      yAxisBucketSize === 0
+                        ? `value:<=${yAxisMinValue}`
+                        : `value:>=${yAxisMinValue} value:<${yAxisMaxValue}`,
+                  };
+                }
+                return crossEvent;
+              }),
+            };
+
+            const tracesLink = getExploreUrl(exploreUrlProps);
+
+            return `<a href="${toHref(tracesLink)}">${t('View related traces')}</a>`;
+          }
+        : undefined,
       truncate: false,
       utc: utc ?? false,
     })(params, asyncTicket);
@@ -118,6 +176,8 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
         ref={chartRef}
         tooltip={{
           show: true,
+          enterable: true,
+          extraCssText: 'pointer-events: auto !important;',
           axisPointer: {
             show: false,
           },
@@ -196,4 +256,12 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
       />
     </Flex>
   );
+}
+
+function toHref(to: LocationDescriptor): string {
+  if (typeof to === 'string') {
+    return to;
+  }
+  const {pathname = '', search = '', hash = ''} = to;
+  return `${pathname}${search}${hash}`;
 }

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -179,6 +179,8 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
               const yAxisMaxValue = rawYValue + yAxisBucketSize;
 
               const exploreUrlProps: GetExploreUrlArgs = {
+                organization,
+                ...props.tooltipExploreUrlArgs,
                 selection: {
                   ...pageFilters.selection,
                   datetime: {
@@ -188,10 +190,8 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
                     period: null,
                   },
                 },
-                organization,
                 // TODO(nikki): we're only handling metrics for now but if we're looking to support other explore
                 // surfaces then we'll need to add more logic here
-                ...props.tooltipExploreUrlArgs,
                 crossEvents: props.tooltipExploreUrlArgs?.crossEvents?.map(crossEvent => {
                   if (crossEvent.type === 'metrics') {
                     return {
@@ -247,7 +247,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
         tooltip={{
           show: true,
           enterable: true,
-          extraCssText: 'pointer-events: auto !important;',
+          extraCssText: `box-shadow: 0 0 0 1px ${theme.tokens.border.transparent.neutral.muted}, ${theme.shadow.high}; z-index: ${theme.zIndex.tooltip} !important; pointer-events: auto !important;`,
           axisPointer: {
             show: false,
           },

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -89,9 +89,6 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
     if (typeof data === 'number') {
       return data;
     }
-    if (typeof data === 'string') {
-      return parseFloat(data);
-    }
 
     const value = (data as {value?: unknown} | null | undefined)?.value;
     return typeof value === 'number' ? value : null;

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -113,15 +113,15 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
 
     let formattedXValue = ECHARTS_MISSING_DATA_VALUE;
 
+    const xAxisBucketSize = heatMapPlottable.heatMapSeries.meta.xAxis.bucketSize;
+    const yAxisBucketSize = heatMapPlottable.heatMapSeries.meta.yAxis.bucketSize;
+    const yAxisUnit = heatMapPlottable?.yAxisValueUnit;
+    const yAxisValueType = heatMapPlottable?.yAxisValueType ?? FALLBACK_TYPE;
+
     return renderToString(
       <Fragment>
         <div className="tooltip-series">
           {filteredParams.map(param => {
-            const xAxisBucketSize = heatMapPlottable.heatMapSeries.meta.xAxis.bucketSize;
-            const yAxisBucketSize = heatMapPlottable.heatMapSeries.meta.yAxis.bucketSize;
-            const yAxisUnit = heatMapPlottable?.yAxisValueUnit;
-            const yAxisValueType = heatMapPlottable?.yAxisValueType ?? FALLBACK_TYPE;
-
             let rawXValue: number | undefined;
             let rawYValue: number | undefined;
 

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -174,7 +174,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
 
             let exploreLink: ReactNode;
 
-            if (defined(rawXValue) && defined(rawYValue)) {
+            if (defined(rawXValue) && defined(rawYValue) && props.tooltipExploreUrlArgs) {
               const xAxisMaxValue = rawXValue + xAxisBucketSize * 1000;
               const yAxisMaxValue = rawYValue + yAxisBucketSize;
 

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -1,21 +1,24 @@
 import 'echarts/lib/chart/heatmap';
 
-import {useRef} from 'react';
+import {Fragment, useRef, type ReactNode} from 'react';
 import {useTheme} from '@emotion/react';
 import type {
   TooltipFormatterCallback,
   TopLevelFormatterParams,
 } from 'echarts/types/dist/shared';
-import type {LocationDescriptor} from 'history';
 
 import {Flex} from '@sentry/scraps/layout';
+import {useRenderToString} from '@sentry/scraps/renderToString';
 
 import {BaseChart} from 'sentry/components/charts/baseChart';
-import {getFormatter, getSeriesValue} from 'sentry/components/charts/components/tooltip';
-import {isChartHovered, truncationFormatter} from 'sentry/components/charts/utils';
+import {defaultFormatAxisLabel} from 'sentry/components/charts/components/tooltip';
+import {isChartHovered} from 'sentry/components/charts/utils';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
+import {defined} from 'sentry/utils';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {ECHARTS_MISSING_DATA_VALUE} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {NO_PLOTTABLE_VALUES} from 'sentry/views/dashboards/widgets/common/settings';
 import {plottablesCanBeVisualized} from 'sentry/views/dashboards/widgets/plottablesCanBeVisualized';
@@ -48,6 +51,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   const {plottables} = props;
   const theme = useTheme();
   const organization = useOrganization();
+  const renderToString = useRenderToString();
 
   const pageFilters = usePageFilters();
   const {start, end, period, utc} = pageFilters.selection.datetime;
@@ -77,92 +81,158 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   const Zmax =
     scale === 'log' ? Math.log1p(heatMapPlottable.Zend) : heatMapPlottable.Zend;
 
+  /** Extract the numeric value from ECharts tooltip param.value. */
+  function extractValue(data: unknown): number | null {
+    // param.value can be either:
+    // 1. The numeric value directly (for heatmap charts with axis trigger)
+    // 2. An object {name, value} (depends on series config)
+    if (typeof data === 'number') {
+      return data;
+    }
+    if (typeof data === 'string') {
+      return parseFloat(data);
+    }
+
+    const value = (data as {value?: unknown} | null | undefined)?.value;
+    return typeof value === 'number' ? value : null;
+  }
+
   // Create tooltip formatter
-  const formatTooltip: TooltipFormatterCallback<TopLevelFormatterParams> = (
-    params,
-    asyncTicket
-  ) => {
+  const formatTooltip: TooltipFormatterCallback<TopLevelFormatterParams> = params => {
     // Only show the tooltip of the current chart. Otherwise, all tooltips
     // in the chart group appear.
     if (!isChartHovered(chartRef?.current)) {
       return '';
     }
 
-    return getFormatter({
-      isGroupedByDate: true,
-      showTimeInTooltip: true,
-      nameFormatter: function (seriesName, _nameFormatterParams) {
-        return truncationFormatter(seriesName, true, false);
-      },
-      valueFormatter: function (value, _field, _valueFormatterParams) {
-        const bucketSize = heatMapPlottable.heatMapSeries.meta.yAxis.bucketSize;
-        const fieldType = heatMapPlottable?.yAxisValueType ?? FALLBACK_TYPE;
+    const seriesParams = Array.isArray(params) ? params : [params];
 
-        const yAxisMinValueFormatted = formatTooltipValue(
-          value,
-          fieldType,
-          heatMapPlottable.yAxisValueUnit ?? undefined
-        );
+    // Filter null values from tooltip
+    const filteredParams = seriesParams.filter(param => {
+      // @ts-expect-error ECharts types param.value as unknown, but we know it's [xAxis, yAxis, zAxis] from our HeatMap plottable
+      const value = extractValue(param.value[2]);
+      return value !== null;
+    });
 
-        if (bucketSize === 0) {
-          return yAxisMinValueFormatted;
-        }
+    let formattedXValue = ECHARTS_MISSING_DATA_VALUE;
 
-        const yAxisMaxValueFormatted = formatTooltipValue(
-          value + bucketSize,
-          fieldType,
-          heatMapPlottable.yAxisValueUnit ?? undefined
-        );
-
-        return `${yAxisMinValueFormatted} – ${yAxisMaxValueFormatted}`;
-      },
-      extraContent: props.tooltipExploreUrlArgs
-        ? function (contentParams) {
-            // TODO(nikki): the y axis values might have to be changed if it's on a log scale :(
-            const yAxisBucketSize = heatMapPlottable.heatMapSeries.meta.yAxis.bucketSize;
-            const yAxisMinValue = getSeriesValue(contentParams, 1) as number;
-            const yAxisMaxValue = yAxisMinValue + yAxisBucketSize;
-
+    return renderToString(
+      <Fragment>
+        <div className="tooltip-series">
+          {filteredParams.map(param => {
             const xAxisBucketSize = heatMapPlottable.heatMapSeries.meta.xAxis.bucketSize;
-            const xAxisMinValue = getSeriesValue(contentParams, 0) as number;
-            const xAxisMaxValue = xAxisMinValue + xAxisBucketSize * 1000;
+            const yAxisBucketSize = heatMapPlottable.heatMapSeries.meta.yAxis.bucketSize;
+            const yAxisUnit = heatMapPlottable?.yAxisValueUnit;
+            const yAxisValueType = heatMapPlottable?.yAxisValueType ?? FALLBACK_TYPE;
 
-            const exploreUrlProps: GetExploreUrlArgs = {
-              selection: {
-                ...pageFilters.selection,
-                datetime: {
-                  ...pageFilters.selection.datetime,
-                  start: new Date(xAxisMinValue),
-                  end: new Date(xAxisMaxValue),
-                  period: null,
-                },
-              },
-              organization,
-              // TODO(nikki): we're only handling metrics for now but if we're looking to support other explore
-              // surfaces then we'll need to add more logic here
-              ...props.tooltipExploreUrlArgs,
-              crossEvents: props.tooltipExploreUrlArgs?.crossEvents?.map(crossEvent => {
-                if (crossEvent.type === 'metrics') {
-                  return {
-                    ...crossEvent,
-                    query:
-                      yAxisBucketSize === 0
-                        ? `value:<=${yAxisMinValue}`
-                        : `value:>=${yAxisMinValue} value:<${yAxisMaxValue}`,
-                  };
+            let rawXValue: number | undefined;
+            let rawYValue: number | undefined;
+
+            let formattedYValue = ECHARTS_MISSING_DATA_VALUE;
+            let formattedZValue = ECHARTS_MISSING_DATA_VALUE;
+            if (Array.isArray(param.value) && param.value.length === 3) {
+              const [xValue, yValue, zValue] = param.value;
+
+              if (defined(xValue) && typeof xValue === 'number') {
+                rawXValue = xValue;
+                // bucket size seems to be in seconds but we need to convert to milliseconds
+                formattedXValue = defaultFormatAxisLabel(
+                  xValue,
+                  true,
+                  utc ?? false,
+                  true,
+                  false,
+                  xAxisBucketSize * 1000
+                ).toString();
+              }
+
+              if (defined(yValue) && typeof yValue === 'number') {
+                rawYValue = yValue;
+                const yAxisMinValueFormatted = formatTooltipValue(
+                  yValue,
+                  yAxisValueType,
+                  yAxisUnit ?? undefined
+                );
+
+                if (yAxisBucketSize === 0) {
+                  formattedYValue = yAxisMinValueFormatted;
+                } else {
+                  const yAxisMaxValueFormatted = formatTooltipValue(
+                    yValue + yAxisBucketSize,
+                    yAxisValueType,
+                    yAxisUnit ?? undefined
+                  );
+
+                  formattedYValue = `${yAxisMinValueFormatted} – ${yAxisMaxValueFormatted}`;
                 }
-                return crossEvent;
-              }),
-            };
+              }
 
-            const tracesLink = getExploreUrl(exploreUrlProps);
+              if (defined(zValue) && typeof zValue === 'number') {
+                formattedZValue = formatAbbreviatedNumber(zValue, 4, false);
+              }
+            }
 
-            return `<a href="${toHref(tracesLink)}">${t('View related traces')}</a>`;
-          }
-        : undefined,
-      truncate: false,
-      utc: utc ?? false,
-    })(params, asyncTicket);
+            let exploreLink: ReactNode;
+
+            if (defined(rawXValue) && defined(rawYValue)) {
+              const xAxisMaxValue = rawXValue + xAxisBucketSize * 1000;
+              const yAxisMaxValue = rawYValue + yAxisBucketSize;
+
+              const exploreUrlProps: GetExploreUrlArgs = {
+                selection: {
+                  ...pageFilters.selection,
+                  datetime: {
+                    ...pageFilters.selection.datetime,
+                    start: new Date(rawXValue),
+                    end: new Date(xAxisMaxValue),
+                    period: null,
+                  },
+                },
+                organization,
+                // TODO(nikki): we're only handling metrics for now but if we're looking to support other explore
+                // surfaces then we'll need to add more logic here
+                ...props.tooltipExploreUrlArgs,
+                crossEvents: props.tooltipExploreUrlArgs?.crossEvents?.map(crossEvent => {
+                  if (crossEvent.type === 'metrics') {
+                    return {
+                      ...crossEvent,
+                      query:
+                        yAxisBucketSize === 0
+                          ? `value:<=${rawYValue}`
+                          : `value:>=${rawYValue} value:<${yAxisMaxValue}`,
+                    };
+                  }
+                  return crossEvent;
+                }),
+              };
+
+              const tracesLink = getExploreUrl(exploreUrlProps);
+              exploreLink = <a href={tracesLink}>{t('View related traces')}</a>;
+            }
+
+            return (
+              <Fragment key={param.seriesIndex}>
+                <div>
+                  <span className="tooltip-label">
+                    <strong>{formattedYValue}</strong>
+                  </span>{' '}
+                  {formattedZValue}
+                </div>
+                {exploreLink && (
+                  <div>
+                    <span className="tooltip-label tooltip-label-centered">
+                      {exploreLink}
+                    </span>
+                  </div>
+                )}
+              </Fragment>
+            );
+          })}
+        </div>
+        <div className="tooltip-footer tooltip-footer-centered">{formattedXValue}</div>
+        <div className="tooltip-arrow" />
+      </Fragment>
+    );
   };
 
   return (
@@ -256,12 +326,4 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
       />
     </Flex>
   );
-}
-
-function toHref(to: LocationDescriptor): string {
-  if (typeof to === 'string') {
-    return to;
-  }
-  const {pathname = '', search = '', hash = ''} = to;
-  return `${pathname}${search}${hash}`;
 }

--- a/static/app/views/dashboards/widgets/heatMapWidget/plottables/heatMap.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/plottables/heatMap.tsx
@@ -49,7 +49,7 @@ export class HeatMap implements HeatMapPlottable {
 
   toSeries(plottingOptions: HeatMapPlottingOptions): SeriesOption[] {
     const {heatMapSeries} = this;
-    const {scale = 'linear'} = plottingOptions;
+    const {scale = 'linear', theme} = plottingOptions;
 
     return [
       {
@@ -64,7 +64,10 @@ export class HeatMap implements HeatMapPlottable {
           ];
         }),
         emphasis: {
-          disabled: true,
+          itemStyle: {
+            borderColor: theme.tokens.content.primary,
+            borderWidth: 2,
+          },
         },
       },
     ];

--- a/static/app/views/dashboards/widgets/heatMapWidget/plottables/heatMap.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/plottables/heatMap.tsx
@@ -65,8 +65,8 @@ export class HeatMap implements HeatMapPlottable {
         }),
         emphasis: {
           itemStyle: {
-            borderColor: theme.tokens.content.primary,
-            borderWidth: 2,
+            borderColor: theme.tokens.border.onVibrant.dark,
+            borderWidth: parseInt(theme.border.xl.replace('px', ''), 10),
           },
         },
       },

--- a/static/app/views/explore/metrics/metricsHeatMap.tsx
+++ b/static/app/views/explore/metrics/metricsHeatMap.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import type {UseQueryResult} from '@tanstack/react-query';
 
 import {t} from 'sentry/locale';
@@ -12,9 +13,10 @@ import {
   useMetricName,
   useMetricVisualize,
   useMetricVisualizes,
+  useTraceMetric,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {STACKED_GRAPH_HEIGHT} from 'sentry/views/explore/metrics/settings';
-import {prettifyAggregation} from 'sentry/views/explore/utils';
+import {prettifyAggregation, type GetExploreUrlArgs} from 'sentry/views/explore/utils';
 
 interface MetricsHeatMapProps {
   actions: React.ReactNode;
@@ -27,6 +29,7 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
   const visualizes = useMetricVisualizes();
   const metricLabel = useMetricLabel();
   const metricName = useMetricName();
+  const metric = useTraceMetric();
 
   const {data: heatMapSeries, isPending, error} = heatmapResult;
 
@@ -35,6 +38,18 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
     visualizes.length > 1
       ? metricName
       : (title ?? metricLabel ?? prettifyAggregation(aggregate) ?? aggregate);
+
+  const tooltipExploreUrlArgs: Omit<GetExploreUrlArgs, 'organization'> = useMemo(() => {
+    return {
+      crossEvents: [
+        {
+          type: 'metrics',
+          query: '',
+          metric,
+        },
+      ],
+    };
+  }, [metric]);
 
   return (
     <WidgetWrapper>
@@ -52,6 +67,7 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
             <HeatMapWidgetVisualization
               plottables={[new HeatMap(heatMapSeries)]}
               scale="log"
+              tooltipExploreUrlArgs={tooltipExploreUrlArgs}
             />
           )
         }


### PR DESCRIPTION
I've added a `View related traces` link in the tooltip so that users can use heat maps to dig in to problem areas or general trends. The link should direct them to the traces page with the correct cross-event and page filters populated.

Couple things to note here:
1. I think we're using a logarithmic y-axis scale so i might have to fix some of the link data
2. the tooltip renderer for e-charts does not accept react components (which is why i've done the hacks that i've done)

Closes DAIN-1641

| Before | After |
|--------|--------|
| <img width="376" height="173" alt="image" src="https://github.com/user-attachments/assets/38e330c3-d894-4858-a833-d6c238acd242" /> | <img width="356" height="213" alt="image" src="https://github.com/user-attachments/assets/cfd475e3-c00c-4201-9082-0b11007a0e90" /> | 