### PR TITLE
ref(trace): migrate virtualizedViewManager off browserHistory

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -2,13 +2,13 @@ import type {Theme} from '@emotion/react';
 import {mat3, vec2} from 'gl-matrix';
 import * as qs from 'query-string';
 
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {getDuration} from 'sentry/utils/duration/getDuration';
 import {clamp} from 'sentry/utils/number/clamp';
 import {
   cancelAnimationTimeout,
   requestAnimationTimeout,
 } from 'sentry/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import {TraceRowWidthMeasurer} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer';
@@ -128,6 +128,7 @@ export class VirtualizedViewManager {
 
   // Column configuration
   columns: Record<'list' | 'span_list', ViewColumn>;
+  navigate: ReactRouter3Navigate | null = null;
   scheduler: TraceScheduler;
   view: TraceView;
 
@@ -733,13 +734,16 @@ export class VirtualizedViewManager {
     }
 
     this.timers.onFovChange = requestAnimationTimeout(() => {
-      browserHistory.replace({
-        pathname: location.pathname,
-        query: {
-          ...qs.parse(location.search),
-          fov: `${view.trace_view.x},${view.trace_view.width}`,
+      this.navigate?.(
+        {
+          pathname: location.pathname,
+          query: {
+            ...qs.parse(location.search),
+            fov: `${view.trace_view.x},${view.trace_view.width}`,
+          },
         },
-      });
+        {replace: true}
+      );
       this.timers.onFovChange = null;
     }, 500);
   }

--- a/static/app/views/performance/newTraceDetails/useTraceWaterfallModels.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceWaterfallModels.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useTraceState} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 
 import {TraceScheduler} from './traceRenderers/traceScheduler';
@@ -9,6 +10,7 @@ import {VirtualizedViewManager} from './traceRenderers/virtualizedViewManager';
 
 export function useTraceWaterfallModels() {
   const theme = useTheme();
+  const navigate = useNavigate();
   const traceState = useTraceState();
   const traceView = useMemo(() => new TraceView(), []);
   const traceScheduler = useMemo(() => new TraceScheduler(), []);
@@ -26,6 +28,8 @@ export function useTraceWaterfallModels() {
     // We only care about initial state when we initialize the view manager
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  viewManager.navigate = navigate;
 
   return {traceView, traceScheduler, viewManager};
 }


### PR DESCRIPTION
Add a public `navigate` field on `VirtualizedViewManager` and assign it from `useTraceWaterfallModels` (which calls `useNavigate()`). The FOV query-param sync now goes through it instead of the deprecated `browserHistory` shim.

The field is nullable so existing test constructors don't have to pass anything.