### PR TITLE
ref(organization-create): drop dead browserHistory comment

### DIFF
--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -114,7 +114,6 @@ function OrganizationCreate() {
               nextUrl = `${createdOrg.links.organizationUrl}${nextUrl}`;
             }
             // redirect to project creation *(BYPASS REACT ROUTER AND FORCE PAGE REFRESH TO GRAB CSRF TOKEN)*
-            // browserHistory.pushState(null, `/organizations/${data.slug}/projects/new/`);
             testableWindowLocation.assign(nextUrl);
           }}
           onSubmitError={error => {


### PR DESCRIPTION
Remove a stale commented-out `browserHistory.pushState` call that's been superseded by `testableWindowLocation.assign` (and which referenced a method that doesn't even exist on the current shim).