### PR TITLE
fix(monitors): add tooltip for disabled project in edits

### DIFF
--- a/static/app/views/detectors/components/forms/common/projectField.tsx
+++ b/static/app/views/detectors/components/forms/common/projectField.tsx
@@ -30,6 +30,11 @@ export function ProjectField() {
       placeholder={t('Project')}
       aria-label={t('Select Project')}
       disabled={fetching || isEditing}
+      disabledReason={
+        isEditing
+          ? t("A monitor's project can't be changed after it's been created.")
+          : undefined
+      }
       size="sm"
       required
       validate={() => {


### PR DESCRIPTION
<img width="304" height="129" alt="image" src="https://github.com/user-attachments/assets/4b1e39c2-a961-4f67-aaae-fe7cb7f867bc" />

Closes ISWF-2678.