### PR TITLE
fix(alerts): Update migration to not remove FK to group

### DIFF
--- a/src/sentry/notifications/migrations/0010_remove_metric_alert_columns_notificationmessage.py
+++ b/src/sentry/notifications/migrations/0010_remove_metric_alert_columns_notificationmessage.py
@@ -41,12 +41,8 @@ class Migration(CheckedMigration):
             database_operations=[
                 SafeRunSQL(
                     sql="""
-                    DO $$
-                    BEGIN
-                        ALTER TABLE "sentry_notificationmessage" ADD CONSTRAINT "sentry_notificationmessage_group_id_notnull" CHECK ("group_id" IS NOT NULL) NOT VALID;
-                    EXCEPTION
-                        WHEN duplicate_object THEN NULL;
-                    END $$;
+                    ALTER TABLE "sentry_notificationmessage" DROP CONSTRAINT IF EXISTS "sentry_notificationmessage_group_id_notnull";
+                    ALTER TABLE "sentry_notificationmessage" ADD CONSTRAINT "sentry_notificationmessage_group_id_notnull" CHECK ("group_id" IS NOT NULL) NOT VALID;
                     """,
                     reverse_sql='ALTER TABLE "sentry_notificationmessage" DROP CONSTRAINT IF EXISTS "sentry_notificationmessage_group_id_notnull";',
                     hints={"tables": ["sentry_notificationmessage"]},

--- a/src/sentry/notifications/migrations/0010_remove_metric_alert_columns_notificationmessage.py
+++ b/src/sentry/notifications/migrations/0010_remove_metric_alert_columns_notificationmessage.py
@@ -40,7 +40,12 @@ class Migration(CheckedMigration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 SafeRunSQL(
-                    sql='ALTER TABLE "sentry_notificationmessage" ALTER COLUMN "group_id" SET NOT NULL',
+                    sql="""
+                    ALTER TABLE "sentry_notificationmessage" ADD CONSTRAINT "sentry_notificationmessage_group_id_notnull" CHECK ("group_id" IS NOT NULL) NOT VALID;
+                    ALTER TABLE "sentry_notificationmessage" VALIDATE CONSTRAINT "sentry_notificationmessage_group_id_notnull";
+                    ALTER TABLE "sentry_notificationmessage" ALTER COLUMN "group_id" SET NOT NULL;
+                    ALTER TABLE "sentry_notificationmessage" DROP CONSTRAINT "sentry_notificationmessage_group_id_notnull";
+                    """,
                     reverse_sql='ALTER TABLE "sentry_notificationmessage" ALTER COLUMN "group_id" DROP NOT NULL',
                     hints={"tables": ["sentry_notificationmessage"]},
                 ),

--- a/src/sentry/notifications/migrations/0010_remove_metric_alert_columns_notificationmessage.py
+++ b/src/sentry/notifications/migrations/0010_remove_metric_alert_columns_notificationmessage.py
@@ -40,9 +40,18 @@ class Migration(CheckedMigration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 SafeRunSQL(
+                    sql='ALTER TABLE "sentry_notificationmessage" ADD CONSTRAINT "sentry_notificationmessage_group_id_notnull" CHECK ("group_id" IS NOT NULL) NOT VALID;',
+                    reverse_sql='ALTER TABLE "sentry_notificationmessage" DROP CONSTRAINT IF EXISTS "sentry_notificationmessage_group_id_notnull";',
+                    hints={"tables": ["sentry_notificationmessage"]},
+                ),
+                SafeRunSQL(
+                    sql='ALTER TABLE "sentry_notificationmessage" VALIDATE CONSTRAINT "sentry_notificationmessage_group_id_notnull";',
+                    reverse_sql=migrations.RunSQL.noop,
+                    hints={"tables": ["sentry_notificationmessage"]},
+                    use_statement_timeout=False,
+                ),
+                SafeRunSQL(
                     sql="""
-                    ALTER TABLE "sentry_notificationmessage" ADD CONSTRAINT "sentry_notificationmessage_group_id_notnull" CHECK ("group_id" IS NOT NULL) NOT VALID;
-                    ALTER TABLE "sentry_notificationmessage" VALIDATE CONSTRAINT "sentry_notificationmessage_group_id_notnull";
                     ALTER TABLE "sentry_notificationmessage" ALTER COLUMN "group_id" SET NOT NULL;
                     ALTER TABLE "sentry_notificationmessage" DROP CONSTRAINT "sentry_notificationmessage_group_id_notnull";
                     """,

--- a/src/sentry/notifications/migrations/0010_remove_metric_alert_columns_notificationmessage.py
+++ b/src/sentry/notifications/migrations/0010_remove_metric_alert_columns_notificationmessage.py
@@ -40,7 +40,14 @@ class Migration(CheckedMigration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 SafeRunSQL(
-                    sql='ALTER TABLE "sentry_notificationmessage" ADD CONSTRAINT "sentry_notificationmessage_group_id_notnull" CHECK ("group_id" IS NOT NULL) NOT VALID;',
+                    sql="""
+                    DO $$
+                    BEGIN
+                        ALTER TABLE "sentry_notificationmessage" ADD CONSTRAINT "sentry_notificationmessage_group_id_notnull" CHECK ("group_id" IS NOT NULL) NOT VALID;
+                    EXCEPTION
+                        WHEN duplicate_object THEN NULL;
+                    END $$;
+                    """,
                     reverse_sql='ALTER TABLE "sentry_notificationmessage" DROP CONSTRAINT IF EXISTS "sentry_notificationmessage_group_id_notnull";',
                     hints={"tables": ["sentry_notificationmessage"]},
                 ),
@@ -53,7 +60,7 @@ class Migration(CheckedMigration):
                 SafeRunSQL(
                     sql="""
                     ALTER TABLE "sentry_notificationmessage" ALTER COLUMN "group_id" SET NOT NULL;
-                    ALTER TABLE "sentry_notificationmessage" DROP CONSTRAINT "sentry_notificationmessage_group_id_notnull";
+                    ALTER TABLE "sentry_notificationmessage" DROP CONSTRAINT IF EXISTS "sentry_notificationmessage_group_id_notnull";
                     """,
                     reverse_sql='ALTER TABLE "sentry_notificationmessage" ALTER COLUMN "group_id" DROP NOT NULL',
                     hints={"tables": ["sentry_notificationmessage"]},

--- a/src/sentry/notifications/migrations/0010_remove_metric_alert_columns_notificationmessage.py
+++ b/src/sentry/notifications/migrations/0010_remove_metric_alert_columns_notificationmessage.py
@@ -5,6 +5,7 @@ import sentry.db.models.fields.foreignkey
 from django.db import migrations
 
 from sentry.new_migrations.migrations import CheckedMigration
+from sentry.new_migrations.monkey.special import SafeRunSQL
 
 
 class Migration(CheckedMigration):
@@ -36,12 +37,23 @@ class Migration(CheckedMigration):
                 on_delete=django.db.models.deletion.CASCADE, to="workflow_engine.action"
             ),
         ),
-        migrations.AlterField(
-            model_name="notificationmessage",
-            name="group",
-            field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                on_delete=django.db.models.deletion.CASCADE, to="sentry.group"
-            ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                SafeRunSQL(
+                    sql='ALTER TABLE "sentry_notificationmessage" ALTER COLUMN "group_id" SET NOT NULL',
+                    reverse_sql='ALTER TABLE "sentry_notificationmessage" ALTER COLUMN "group_id" DROP NOT NULL',
+                    hints={"tables": ["sentry_notificationmessage"]},
+                ),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="notificationmessage",
+                    name="group",
+                    field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="sentry.group"
+                    ),
+                ),
+            ],
         ),
         migrations.AlterField(
             model_name="notificationmessage",


### PR DESCRIPTION
This migration fails when applying due to a timeout because it can't get a lock on the group column - the default generated migration when making a column nullable has Django drop and re-create the foreign key, so the fix (hopefully) is to add a `SeparateDatabaseAndState` to not do the unnecessary extra step of removing the FK first.