### PR TITLE
feat(self-healing): Add support for seer activities in workflow engine

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -444,6 +444,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:workflow-engine-orgalertruledetails-delete", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable seer activities to be evaluated in workflow engine
+    manager.add("organization:workflow-engine-evaluate-seer-activities", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable our logs product (known internally as ourlogs) in UI and backend
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -1,21 +1,37 @@
 import logging
 
+from sentry import features
 from sentry.issues.status_change_consumer import group_status_update_registry
 from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.activity import Activity
 from sentry.models.group import Group
+from sentry.models.organization import Organization
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
+SEER_ACTIVITIES = [
+    ActivityType.SEER_RCA_STARTED.value,
+    ActivityType.SEER_RCA_COMPLETED.value,
+    ActivityType.SEER_SOLUTION_STARTED.value,
+    ActivityType.SEER_SOLUTION_COMPLETED.value,
+    ActivityType.SEER_CODING_STARTED.value,
+    ActivityType.SEER_CODING_COMPLETED.value,
+    ActivityType.SEER_PR_CREATED.value,
+]
 
-SUPPORTED_ACTIVITIES = [ActivityType.SET_RESOLVED.value]
+SUPPORTED_ACTIVITIES = [
+    ActivityType.SET_RESOLVED.value,
+    *SEER_ACTIVITIES,
+]
 
 
 @group_status_update_registry.register("workflow_status_update")
 def workflow_status_update_handler(
-    group: Group, status_change_message: StatusChangeMessageData, activity: Activity
+    group: Group,
+    status_change_message: StatusChangeMessageData,
+    activity: Activity,
 ) -> None:
     """
     Hook the process_workflow_task into the activity creation registry.
@@ -40,6 +56,16 @@ def workflow_status_update_handler(
         # We should not hit this case, it's should only occur if there is a bug
         # passing it from the workflow_engine to the issue platform.
         metrics.incr("workflow_engine.tasks.error.no_detector_id")
+        return
+
+    organization = Organization.objects.get_from_cache(pk=activity.project.organization_id)
+    can_process_seer_activities = features.has(
+        "organization:workflow_engine_evaluate_seer_activities", organization
+    )
+
+    if activity.type in SEER_ACTIVITIES and not can_process_seer_activities:
+        # Don't process these activities yet
+        # If the processing is enabled, then it's ok because no workflows can be triggered
         return
 
     process_workflow_activity.delay(

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -55,12 +55,15 @@ def workflow_status_update_handler(
     if detector_id is None:
         # We should not hit this case, it's should only occur if there is a bug
         # passing it from the workflow_engine to the issue platform.
-        metrics.incr("workflow_engine.tasks.error.no_detector_id")
+        metrics.incr(
+            "workflow_engine.tasks.error.no_detector_id",
+            tags={"activity_type": activity.type},
+        )
         return
 
     organization = Organization.objects.get_from_cache(pk=activity.project.organization_id)
     can_process_seer_activities = features.has(
-        "organization:workflow_engine_evaluate_seer_activities", organization
+        "organization:workflow-engine-evaluate-seer-activities", organization
     )
 
     if activity.type in SEER_ACTIVITIES and not can_process_seer_activities:

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -7,7 +7,7 @@ from sentry.incidents.grouptype import MetricIssue
 from sentry.issues.status_change_consumer import process_status_change_message, update_status
 from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.activity import Activity
-from sentry.models.group import GroupStatus
+from sentry.models.group import Group, GroupStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -127,7 +127,7 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
 
     def _build_seer_activity_and_message(
         self, activity_type: int
-    ) -> tuple[Activity, StatusChangeMessageData]:
+    ) -> tuple[Group, Activity, StatusChangeMessageData]:
         detector = self.create_detector(project=self.project)
         group = self.create_group(project=self.project, type=MetricIssue.type_id)
         activity = Activity(

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -62,7 +62,10 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
 
         with mock.patch("sentry.workflow_engine.tasks.workflows.metrics.incr") as mock_incr:
             workflow_status_update_handler(group, message, activity)
-            mock_incr.assert_called_with("workflow_engine.tasks.error.no_detector_id")
+            mock_incr.assert_called_with(
+                "workflow_engine.tasks.error.no_detector_id",
+                tags={"activity_type": ActivityType.SET_RESOLVED.value},
+            )
 
     def test_single_processing(self) -> None:
         detector = self.create_detector(project=self.project)
@@ -120,6 +123,65 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
                 activity_id=activity.id,
                 group_id=group.id,
                 detector_id=detector.id,
+            )
+
+    def _build_seer_activity_and_message(
+        self, activity_type: int
+    ) -> tuple[Activity, StatusChangeMessageData]:
+        detector = self.create_detector(project=self.project)
+        group = self.create_group(project=self.project, type=MetricIssue.type_id)
+        activity = Activity(
+            project=self.project,
+            group=group,
+            type=activity_type,
+            data={"fingerprint": ["test_fingerprint"]},
+        )
+        message = StatusChangeMessageData(
+            id="test_message_id",
+            project_id=self.project.id,
+            new_status=GroupStatus.RESOLVED,
+            new_substatus=None,
+            fingerprint=["test_fingerprint"],
+            detector_id=detector.id,
+            activity_data={"test": "test"},
+        )
+        return group, activity, message
+
+    def test_seer_activity_blocked_without_feature(self) -> None:
+        group, activity, message = self._build_seer_activity_and_message(
+            ActivityType.SEER_RCA_STARTED.value
+        )
+
+        with mock.patch(
+            "sentry.workflow_engine.tasks.workflows.process_workflow_activity.delay"
+        ) as mock_delay:
+            workflow_status_update_handler(group, message, activity)
+            mock_delay.assert_not_called()
+
+    def test_seer_activity_processed_with_feature(self) -> None:
+        group, activity, message = self._build_seer_activity_and_message(
+            ActivityType.SEER_RCA_STARTED.value
+        )
+
+        with (
+            self.feature("organization:workflow-engine-evaluate-seer-activities"),
+            mock.patch(
+                "sentry.workflow_engine.tasks.workflows.process_workflow_activity.delay"
+            ) as mock_delay,
+        ):
+            workflow_status_update_handler(group, message, activity)
+            mock_delay.assert_called_once()
+
+    def test_seer_activity_increments_metric(self) -> None:
+        group, activity, message = self._build_seer_activity_and_message(
+            ActivityType.SEER_RCA_STARTED.value
+        )
+
+        with mock.patch("sentry.workflow_engine.tasks.workflows.metrics.incr") as mock_incr:
+            workflow_status_update_handler(group, message, activity)
+            mock_incr.assert_any_call(
+                "workflow_engine.tasks.process_workflows.activity_update",
+                tags={"activity_type": ActivityType.SEER_RCA_STARTED.value},
             )
 
 


### PR DESCRIPTION
# Description
Add the `SEER_ACTIVITIES` to the allow list of activity types, do not process them yet.

This will allow us to have metrics around two critical areas;
1. that seer activities are being created in a way that trigger workflow engine
2. that the seer activities have an associated detector_id (i think it's likely that most of these will be error issues, and not have an associated detector id)