### PR TITLE
ref(api): migrate auth-error navigation off browserHistory

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -12,14 +12,26 @@ import {
 } from 'sentry/constants/apiErrorCodes';
 import {controlsiloUrlPatterns} from 'sentry/data/controlsiloUrlPatterns';
 import {metric} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {getCsrfToken} from 'sentry/utils/getCsrfToken';
 import {uniqueId} from 'sentry/utils/guid';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {sanitizePath} from 'sentry/utils/requestError/sanitizePath';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 
 import {ConfigStore} from './stores/configStore';
+
+/**
+ * `api.tsx` is consumed outside React, so it can't use the `useNavigate` hook.
+ * The app's bootstrap (alongside `DANGEROUS_SET_REACT_ROUTER_6_HISTORY`) calls
+ * `setApiNavigate` once to install a navigate function the auth-error handler
+ * can use.
+ */
+let apiNavigate: ReactRouter3Navigate | null = null;
+
+export function setApiNavigate(navigate: ReactRouter3Navigate) {
+  apiNavigate = navigate;
+}
 
 export class Request {
   /**
@@ -167,7 +179,7 @@ export const initApiClientErrorHandling = () =>
     }
 
     if (code === 'member-disabled-over-limit') {
-      browserHistory.replace(extra.next);
+      apiNavigate?.(extra.next, {replace: true});
       return true;
     }
 
@@ -177,7 +189,7 @@ export const initApiClientErrorHandling = () =>
     }
 
     if (EXPERIMENTAL_SPA) {
-      browserHistory.replace('/auth/login/');
+      apiNavigate?.('/auth/login/', {replace: true});
     } else {
       window.location.reload();
     }

--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -7,6 +7,7 @@ import {pacerDevtoolsPlugin} from '@tanstack/react-pacer-devtools';
 import {ReactQueryDevtoolsPanel} from '@tanstack/react-query-devtools';
 import {NuqsAdapter} from 'nuqs/adapters/react-router/v6';
 
+import {setApiNavigate} from 'sentry/api';
 import {AppQueryClientProvider} from 'sentry/appQueryClient';
 import {CommandPaletteProvider} from 'sentry/components/commandPalette/ui/cmdk';
 import {FrontendVersionProvider} from 'sentry/components/frontendVersionContext';
@@ -17,11 +18,13 @@ import {preload} from 'sentry/router/preload';
 import {RouteConfigProvider} from 'sentry/router/routeConfigContext';
 import {routes} from 'sentry/router/routes';
 import {DANGEROUS_SET_REACT_ROUTER_6_HISTORY} from 'sentry/utils/browserHistory';
+import {createReactRouter3Navigate} from 'sentry/utils/useNavigate';
 
 function buildRouter() {
   const sentryCreateBrowserRouter = wrapCreateBrowserRouterV6(createBrowserRouter);
   const router = sentryCreateBrowserRouter(routes());
   DANGEROUS_SET_REACT_ROUTER_6_HISTORY(router);
+  setApiNavigate(createReactRouter3Navigate(router));
 
   return router;
 }

--- a/static/app/utils/useNavigate.tsx
+++ b/static/app/utils/useNavigate.tsx
@@ -1,5 +1,6 @@
 import {useCallback} from 'react';
 import {useNavigate as useReactRouter6Navigate} from 'react-router-dom';
+import type {Router} from '@remix-run/router';
 import type {LocationDescriptor} from 'history';
 
 import {locationDescriptorToTo} from './reactRouter6Compat/location';
@@ -36,4 +37,22 @@ export function useNavigate(): ReactRouter3Navigate {
   );
 
   return navigate;
+}
+
+/**
+ * @deprecated Prefer `useNavigate` in React code. This helper exists only for
+ * the narrow set of non-React modules (e.g. the api client) that need an
+ * imperative navigate function. Reach for it as a last resort.
+ *
+ * Build a `ReactRouter3Navigate`-compatible function from a react-router 6
+ * `Router` instance.
+ */
+export function createReactRouter3Navigate(router: Router): ReactRouter3Navigate {
+  return (to: LocationDescriptor | number, options: NavigateOptions = {}) => {
+    if (typeof to === 'number') {
+      router.navigate(to);
+      return;
+    }
+    router.navigate(locationDescriptorToTo(to), options);
+  };
 }

--- a/static/gsAdmin/init.tsx
+++ b/static/gsAdmin/init.tsx
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {NuqsAdapter} from 'nuqs/adapters/react-router/v6';
 
+import {setApiNavigate} from 'sentry/api';
 import {commonInitialization} from 'sentry/bootstrap/commonInitialization';
 import {initializeSdk} from 'sentry/bootstrap/initializeSdk';
 import {DocumentTitleManager} from 'sentry/components/sentryDocumentTitle/documentTitleManager';
@@ -12,6 +13,7 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
 import {DANGEROUS_SET_REACT_ROUTER_6_HISTORY} from 'sentry/utils/browserHistory';
 import {DEFAULT_QUERY_CLIENT_CONFIG} from 'sentry/utils/queryClient';
+import {createReactRouter3Navigate} from 'sentry/utils/useNavigate';
 
 import {routes} from 'admin/routes';
 
@@ -30,6 +32,7 @@ const sentryCreateBrowserRouter = wrapCreateBrowserRouterV6(createBrowserRouter)
 const router = sentryCreateBrowserRouter(routes);
 
 DANGEROUS_SET_REACT_ROUTER_6_HISTORY(router);
+setApiNavigate(createReactRouter3Navigate(router));
 
 export function renderApp() {
   const rootEl = document.getElementById('blk_router')!;


### PR DESCRIPTION
`api.tsx` is consumed outside React, so it can't use the `useNavigate` hook. Replace its two `browserHistory.replace` calls with a once-cell pattern:

- `api.tsx` exports `setApiNavigate(navigate)` which stores a module-level `ReactRouter3Navigate` function.
- The app bootstrap (`static/app/main.tsx` and `static/gsAdmin/init.tsx`) calls it alongside `DANGEROUS_SET_REACT_ROUTER_6_HISTORY` with a navigate function built from the router.
- The auth-error handler invokes the stored navigate (or no-ops if not yet installed).

`createReactRouter3Navigate(router)` is added to `useNavigate.tsx` so any other non-React module that needs an imperative navigate can reuse the same helper.