### PR TITLE
feat(seer): Add structured LLM context for issue detail sub-tabs

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -565,37 +565,39 @@ function GroupDetailsContentError({
   }
 }
 
-function getIssueDetailContextHint(
-  view: 'specific-event' | 'events-list' | 'issue-overview'
-): string {
+type IssueView =
+  | 'specific-event'
+  | 'events-list'
+  | 'issue-overview'
+  | 'replays'
+  | 'attachments'
+  | 'distributions'
+  | 'distributions-tag-detail';
+
+const ISSUE_VIEW_PREAMBLES: Record<IssueView, string> = {
+  'specific-event':
+    'Sentry issue detail page. The user is viewing a specific event — You can get event details with the eventId below to see what they see.',
+  'events-list':
+    'Sentry issue events list. The user is browsing all events for this issue. You can search live telemetry to query events matching this issue.',
+  replays:
+    'Sentry issue replays tab. The user is viewing session replays where this issue occurred. You can search replays to find sessions that encountered this error, or get replay details for a specific session.',
+  attachments:
+    'Sentry issue attachments tab. The user is viewing files attached to events for this issue (screenshots, crash reports, minidumps). You can get event attachments to inspect specific files.',
+  distributions:
+    'Sentry issue distributions (tags) tab. The user is viewing how this issue is distributed across tag values. You can get issue tag values for breakdown by browser, environment, URL, release, OS, device, or any other tag.',
+  'distributions-tag-detail':
+    'Sentry issue tag detail page. The user is drilling into a specific tag distribution. You can get issue tag values for the tagKey below to see exact counts and percentages.',
+  'issue-overview':
+    'Sentry issue detail page. Shows a single grouped issue with its latest event.',
+};
+
+function getIssueDetailContextHint(view: IssueView): string {
+  const preamble = ISSUE_VIEW_PREAMBLES[view];
+  const shortIdNote = 'shortId is the human-readable issue identifier (e.g. PROJ-123). ';
   const tools =
     'You can get issue details for aggregate stats and stack trace, get event details for a specific error event, ' +
     'and search live telemetry for related spans/errors/logs/metrics.';
-  const shortIdNote = 'shortId is the human-readable issue identifier (e.g. PROJ-123). ';
-
-  if (view === 'specific-event') {
-    return (
-      'Sentry issue detail page. The user is viewing a specific event — ' +
-      'You can get event details with the eventId below to see what they see. ' +
-      shortIdNote +
-      tools
-    );
-  }
-
-  if (view === 'events-list') {
-    return (
-      'Sentry issue events list. The user is browsing all events for this issue. ' +
-      'You can search live telemetry to query events matching this issue. ' +
-      shortIdNote +
-      tools
-    );
-  }
-
-  return (
-    'Sentry issue detail page. Shows a single grouped issue with its latest event. ' +
-    shortIdNote +
-    tools
-  );
+  return `${preamble} ${shortIdNote}${tools}`;
 }
 
 function GroupDetailsContentInner({
@@ -669,13 +671,22 @@ function GroupDetailsContentInner({
 
   useEngagedViewTracking({group, project});
 
-  const {eventId: eventIdParam} = useParams<{eventId?: string}>();
+  const {eventId: eventIdParam, tagKey} = useParams<{
+    eventId?: string;
+    tagKey?: string;
+  }>();
 
-  let issueView: 'specific-event' | 'events-list' | 'issue-overview' = 'issue-overview';
+  let issueView: IssueView = 'issue-overview';
   if (eventIdParam && !RESERVED_EVENT_IDS.has(eventIdParam)) {
     issueView = 'specific-event';
   } else if (currentTab === Tab.EVENTS) {
     issueView = 'events-list';
+  } else if (currentTab === Tab.REPLAYS) {
+    issueView = 'replays';
+  } else if (currentTab === Tab.ATTACHMENTS) {
+    issueView = 'attachments';
+  } else if (currentTab === Tab.DISTRIBUTIONS) {
+    issueView = tagKey ? 'distributions-tag-detail' : 'distributions';
   }
 
   useLLMContext({
@@ -692,6 +703,8 @@ function GroupDetailsContentInner({
     lastSeen: group.lastSeen,
     projectSlug: project.slug,
     eventId: event?.id,
+    currentTab,
+    ...(tagKey ? {tagKey} : {}),
   });
 
   const isDisplayingEventDetails = [

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -150,6 +150,47 @@ describe('useSeerExplorer', () => {
       });
     });
 
+    it.each([
+      '/issues/:groupId/replays/',
+      '/issues/:groupId/attachments/',
+      '/issues/:groupId/distributions/',
+      '/issues/:groupId/distributions/:tagKey/',
+    ])('sends structured JSON on issue sub-tab route %s', async (route: string) => {
+      jest.spyOn(seerExplorerUtils, 'usePageReferrer').mockReturnValue({
+        getPageReferrer: () => route,
+      });
+      const org = OrganizationFixture({
+        features: ['seer-explorer', 'seer-explorer-context-engine'],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/`,
+        method: 'GET',
+        body: {session: null},
+      });
+      const postMock = MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/`,
+        method: 'POST',
+        body: {run_id: 1},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/1/`,
+        method: 'GET',
+        body: {session: {blocks: [], run_id: 1, status: 'completed', updated_at: ''}},
+      });
+
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
+        organization: org,
+      });
+      act(() => {
+        result.current.sendMessage('q');
+      });
+
+      await waitFor(() => {
+        const ctx = postMock.mock.calls[0][1].data.on_page_context;
+        expect(JSON.parse(ctx)).toHaveProperty('nodes');
+      });
+    });
+
     it('falls back to ASCII screenshot on non-structured-context page', async () => {
       jest.spyOn(seerExplorerUtils, 'usePageReferrer').mockReturnValue({
         getPageReferrer: () => '/monitors/mobile-builds/',

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -53,6 +53,10 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/issues/:groupId/',
   '/issues/:groupId/events/',
   '/issues/:groupId/events/:eventId/',
+  '/issues/:groupId/replays/',
+  '/issues/:groupId/attachments/',
+  '/issues/:groupId/distributions/',
+  '/issues/:groupId/distributions/:tagKey/',
 ]);
 /** New experimental routes where the LLMContext tree provides structured page context. */
 const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>();


### PR DESCRIPTION
+ Add replays, attachments, distributions, and distributions/:tagKey routes to STRUCTURED_CONTEXT_ROUTES so Seer receives structured JSON context instead of ASCII screenshots on these pages.

+ Enhance the issue detail LLM context with tab-specific hints that tell Seer which tools to use (replay search, event attachments, issue tag values) and include currentTab and tagKey in the context data.
