### PR TITLE
ref(lint): ban React.Fragment in favor of named Fragment import

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -360,6 +360,14 @@ export default typescript.config([
             'Since React 19, it is no longer necessary to use forwardRef - refs can be passed as a normal prop',
         },
         {
+          selector: "MemberExpression[object.name='React'][property.name='Fragment']",
+          message: "Use `import {Fragment} from 'react'` instead of `React.Fragment`",
+        },
+        {
+          selector: "JSXMemberExpression[object.name='React'][property.name='Fragment']",
+          message: "Use `import {Fragment} from 'react'` instead of `React.Fragment`",
+        },
+        {
           selector:
             "CallExpression[callee.object.name='jest'][callee.property.name='mock'][arguments.0.value='sentry/utils/useProjects']",
           message:

--- a/static/app/components/commandPalette/ui/collection.spec.tsx
+++ b/static/app/components/commandPalette/ui/collection.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {createRef, Fragment} from 'react';
 
 import {render} from 'sentry-test/reactTestingLibrary';
 
@@ -36,7 +36,7 @@ function StoreCapture({
 }
 
 function makeStoreRef() {
-  return React.createRef() as React.MutableRefObject<ReturnType<
+  return createRef() as React.MutableRefObject<ReturnType<
     typeof TestCollection.useStore
   > | null>;
 }
@@ -294,7 +294,7 @@ describe('Collection', () => {
     }
 
     render(
-      <React.Fragment>
+      <Fragment>
         <A.Provider>
           <ItemA name="a-item" />
           <CaptureA />
@@ -303,7 +303,7 @@ describe('Collection', () => {
           <ItemB name="b-item" />
           <CaptureB />
         </B.Provider>
-      </React.Fragment>
+      </Fragment>
     );
 
     expect(storeRefA.current!.tree().map(n => n.name)).toEqual(['a-item']);

--- a/static/app/components/core/layout/container.spec.tsx
+++ b/static/app/components/core/layout/container.spec.tsx
@@ -1,4 +1,4 @@
-import React, {createRef} from 'react';
+import {createRef, Fragment} from 'react';
 import {expectTypeOf} from 'expect-type';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -96,14 +96,14 @@ describe('Container', () => {
 
   it('reuses class names for the same props', () => {
     render(
-      <React.Fragment>
+      <Fragment>
         <Container radius="sm" padding="md">
           Padding First
         </Container>
         <Container radius="sm" padding="md">
           PaddingBottom First
         </Container>
-      </React.Fragment>
+      </Fragment>
     );
 
     const paddingFirst = screen.getByText('Padding First').className;

--- a/static/app/components/core/layout/flex.spec.tsx
+++ b/static/app/components/core/layout/flex.spec.tsx
@@ -1,4 +1,4 @@
-import React, {createRef} from 'react';
+import {createRef, Fragment} from 'react';
 import {expectTypeOf} from 'expect-type';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -108,14 +108,14 @@ describe('Flex', () => {
 
   it('reuses class names for the same props', () => {
     render(
-      <React.Fragment>
+      <Fragment>
         <Flex radius="sm" padding="md">
           Padding First
         </Flex>
         <Flex radius="sm" padding="md">
           PaddingBottom First
         </Flex>
-      </React.Fragment>
+      </Fragment>
     );
 
     const paddingFirst = screen.getByText('Padding First').className;

--- a/static/app/components/core/layout/grid.spec.tsx
+++ b/static/app/components/core/layout/grid.spec.tsx
@@ -1,4 +1,4 @@
-import React, {createRef} from 'react';
+import {createRef, Fragment} from 'react';
 import {expectTypeOf} from 'expect-type';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -98,14 +98,14 @@ describe('Grid', () => {
 
   it('reuses class names for the same props', () => {
     render(
-      <React.Fragment>
+      <Fragment>
         <Grid radius="sm" padding="md">
           Padding First
         </Grid>
         <Grid radius="sm" padding="md">
           PaddingBottom First
         </Grid>
-      </React.Fragment>
+      </Fragment>
     );
 
     const paddingFirst = screen.getByText('Padding First').className;

--- a/static/app/components/core/layout/stack.spec.tsx
+++ b/static/app/components/core/layout/stack.spec.tsx
@@ -1,4 +1,4 @@
-import React, {createRef} from 'react';
+import {createRef, Fragment} from 'react';
 import {expectTypeOf} from 'expect-type';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -108,14 +108,14 @@ describe('Stack', () => {
 
   it('reuses class names for the same props', () => {
     render(
-      <React.Fragment>
+      <Fragment>
         <Stack radius="sm" padding="md">
           First Stack
         </Stack>
         <Stack radius="sm" padding="md">
           Second Stack
         </Stack>
-      </React.Fragment>
+      </Fragment>
     );
 
     const firstStack = screen.getByText('First Stack').className;

--- a/static/app/components/core/layout/surface.spec.tsx
+++ b/static/app/components/core/layout/surface.spec.tsx
@@ -1,4 +1,4 @@
-import React, {createRef} from 'react';
+import {createRef, Fragment} from 'react';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -35,14 +35,14 @@ describe('Surface', () => {
 
   it('reuses class names for the same props', () => {
     render(
-      <React.Fragment>
+      <Fragment>
         <Surface variant="primary" radius="md">
           First
         </Surface>
         <Surface variant="primary" radius="md">
           Second
         </Surface>
-      </React.Fragment>
+      </Fragment>
     );
 
     const first = screen.getByText('First').className;
@@ -52,11 +52,11 @@ describe('Surface', () => {
 
   it('applies different class names for different variants', () => {
     render(
-      <React.Fragment>
+      <Fragment>
         <Surface variant="primary">Primary</Surface>
         <Surface variant="secondary">Secondary</Surface>
         <Surface variant="overlay">Overlay</Surface>
-      </React.Fragment>
+      </Fragment>
     );
 
     const primary = screen.getByText('Primary').className;
@@ -70,7 +70,7 @@ describe('Surface', () => {
 
   it('applies different class names for different elevations', () => {
     render(
-      <React.Fragment>
+      <Fragment>
         <Surface variant="overlay" elevation="low">
           Low
         </Surface>
@@ -80,7 +80,7 @@ describe('Surface', () => {
         <Surface variant="overlay" elevation="high">
           High
         </Surface>
-      </React.Fragment>
+      </Fragment>
     );
 
     const low = screen.getByText('Low').className;

--- a/static/app/components/core/markdown/__stories__/components.tsx
+++ b/static/app/components/core/markdown/__stories__/components.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react';
+import {Fragment, useRef, useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
@@ -82,7 +82,7 @@ export function CustomComponentsDemo() {
         Text: ({children}) => {
           const parts = children.split(/(SENTRY-\d+)/);
           return (
-            <React.Fragment>
+            <Fragment>
               {parts.map((part, i) =>
                 /SENTRY-\d+/.test(part) ? (
                   <a
@@ -99,7 +99,7 @@ export function CustomComponentsDemo() {
                   part
                 )
               )}
-            </React.Fragment>
+            </Fragment>
           );
         },
       }}

--- a/static/app/components/core/markdown/defaultComponents.tsx
+++ b/static/app/components/core/markdown/defaultComponents.tsx
@@ -1,4 +1,4 @@
-import React, {type ReactNode} from 'react';
+import {Fragment, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {CodeBlock, InlineCode} from '@sentry/scraps/code';
@@ -151,7 +151,7 @@ export function DefaultHorizontalRule() {
 }
 
 export function DefaultText({children}: {children: string}) {
-  return <React.Fragment>{children}</React.Fragment>;
+  return <Fragment>{children}</Fragment>;
 }
 
 export function DefaultLineBreak() {

--- a/static/app/components/core/markdown/markdown.spec.tsx
+++ b/static/app/components/core/markdown/markdown.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -265,7 +265,7 @@ describe('Markdown', () => {
             Text: ({children}) => {
               const parts = children.split(/(PROJ-\d+)/);
               return (
-                <React.Fragment>
+                <Fragment>
                   {parts.map((part, i) =>
                     /PROJ-\d+/.test(part) ? (
                       <a key={i} href={`/issues/${part}/`}>
@@ -275,7 +275,7 @@ describe('Markdown', () => {
                       part
                     )
                   )}
-                </React.Fragment>
+                </Fragment>
               );
             },
           }}

--- a/static/app/components/events/autofix/autofixHighlightWrapper.tsx
+++ b/static/app/components/events/autofix/autofixHighlightWrapper.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence} from 'framer-motion';
@@ -50,7 +50,7 @@ export function AutofixHighlightWrapper({
   }, [selection]);
 
   return (
-    <React.Fragment>
+    <Fragment>
       <Wrapper
         ref={containerRef}
         className={className}
@@ -76,7 +76,7 @@ export function AutofixHighlightWrapper({
           />
         )}
       </AnimatePresence>
-    </React.Fragment>
+    </Fragment>
   );
 }
 

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion, type MotionNodeAnimationOptions} from 'framer-motion';
 
@@ -73,7 +73,7 @@ export function CodingAgentCard({codingAgentState, groupId, repo}: CodingAgentCa
   );
 
   return (
-    <React.Fragment>
+    <Fragment>
       <VerticalLine />
       <StepCard>
         <ContentWrapper>
@@ -139,7 +139,7 @@ export function CodingAgentCard({codingAgentState, groupId, repo}: CodingAgentCa
                   </Stack>
                 </Content>
                 {hasButtons && (
-                  <React.Fragment>
+                  <Fragment>
                     <BottomDivider />
                     <BottomButtonContainer>
                       <Grid flow="column" align="center" gap="md">
@@ -180,14 +180,14 @@ export function CodingAgentCard({codingAgentState, groupId, repo}: CodingAgentCa
                           ))}
                       </Grid>
                     </BottomButtonContainer>
-                  </React.Fragment>
+                  </Fragment>
                 )}
               </StyledCard>
             </motion.div>
           </AnimatePresence>
         </ContentWrapper>
       </StepCard>
-    </React.Fragment>
+    </Fragment>
   );
 }
 

--- a/static/app/components/events/autofix/insights/autofixInsightCard.tsx
+++ b/static/app/components/events/autofix/insights/autofixInsightCard.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
@@ -142,7 +142,7 @@ export function AutofixInsightCard({
   ]);
 
   const renderCardContent = () => (
-    <React.Fragment>
+    <Fragment>
       {isEditing ? (
         <EditContainer>
           <form onSubmit={handleSubmit}>
@@ -290,7 +290,7 @@ export function AutofixInsightCard({
           </motion.div>
         )}
       </AnimatePresence>
-    </React.Fragment>
+    </Fragment>
   );
 
   return (

--- a/static/app/components/events/autofix/insights/insightSourcesFooter.tsx
+++ b/static/app/components/events/autofix/insights/insightSourcesFooter.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
@@ -124,7 +124,7 @@ export function InsightSourcesFooter({
   };
 
   return (
-    <React.Fragment>
+    <Fragment>
       <BottomDivider />
       <Flex justify="between" paddingTop="xl" paddingBottom="md">
         <Flex justify="start" align="stretch" gap="md" width="100%">
@@ -168,7 +168,7 @@ export function InsightSourcesFooter({
           </FooterInputContainer>
         </Flex>
       </Flex>
-    </React.Fragment>
+    </Fragment>
   );
 }
 

--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 
 import {useEventGroupingInfo} from 'sentry/components/events/groupingInfo/useEventGroupingInfo';
 import {Placeholder} from 'sentry/components/placeholder';
@@ -46,10 +46,10 @@ export function GroupInfoSummary({
     <p data-test-id="loaded-grouping-info">
       <strong>{t('Grouped by:')}</strong> {groupedBy}
       {groupingConfig && (
-        <React.Fragment>
+        <Fragment>
           <br />
           <strong>{t('Grouping Config:')}</strong> {groupingConfig}
-        </React.Fragment>
+        </Fragment>
       )}
     </p>
   );

--- a/static/app/components/group/groupSummaryWithAutofix.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {Variants} from 'framer-motion';
 import {motion} from 'framer-motion';
@@ -307,7 +307,7 @@ export function AutofixSummary({
                         <Placeholder height="1.5rem" />
                       </motion.div>
                     ) : (
-                      <React.Fragment>
+                      <Fragment>
                         {card.insightElement}
                         {card.insight && (
                           <MarkedText
@@ -324,7 +324,7 @@ export function AutofixSummary({
                             }
                           />
                         )}
-                      </React.Fragment>
+                      </Fragment>
                     )}
                   </CardContent>
                 </Stack>

--- a/static/app/components/onboarding/utils/stepsToMarkdown.spec.tsx
+++ b/static/app/components/onboarding/utils/stepsToMarkdown.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Fragment} from 'react';
 
 import type {ContentBlock} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/types';
 import {deriveTabKey} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
@@ -178,7 +178,7 @@ describe('reactNodeToText', () => {
 
     // Build element tree like tct() would: text + link component + text
     const element = React.createElement(
-      React.Fragment,
+      Fragment,
       null,
       'Visit the ',
       React.createElement(
@@ -203,7 +203,7 @@ describe('reactNodeToText', () => {
     }
 
     const element = React.createElement(
-      React.Fragment,
+      Fragment,
       null,
       'Refer to ',
       React.createElement(

--- a/static/app/components/profiling/flamegraph/flamegraphChartTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphChartTooltip.tsx
@@ -1,5 +1,4 @@
-import {useMemo} from 'react';
-import * as React from 'react';
+import {Fragment, useMemo} from 'react';
 import type {vec2} from 'gl-matrix';
 
 import {BoundTooltip} from 'sentry/components/profiling/boundTooltip';
@@ -44,7 +43,7 @@ export function FlamegraphChartTooltip({
     <BoundTooltip cursor={configSpaceCursor} canvas={chartCanvas} canvasView={chartView}>
       {series.map((p, i) => {
         return (
-          <React.Fragment key={i}>
+          <Fragment key={i}>
             <FlamegraphTooltipFrameMainInfo>
               <FlamegraphTooltipColorIndicator
                 backgroundColor={p.fillColor || p.lineColor}
@@ -54,7 +53,7 @@ export function FlamegraphChartTooltip({
                 {chart.tooltipFormatter(p.points[0]!.y)}
               </FlamegraphTooltipTimelineInfo>
             </FlamegraphTooltipFrameMainInfo>
-          </React.Fragment>
+          </Fragment>
         );
       })}
       <FlamegraphTooltipTimelineInfo>

--- a/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
@@ -1,5 +1,4 @@
-import {useMemo} from 'react';
-import * as React from 'react';
+import {Fragment, useMemo} from 'react';
 import type {vec2} from 'gl-matrix';
 
 import {BoundTooltip} from 'sentry/components/profiling/boundTooltip';
@@ -58,7 +57,7 @@ export function FlamegraphUIFramesTooltip({
         const cssColor = toRGBAString(color[0], color[1], color[2], color[3] ?? 1);
 
         return (
-          <React.Fragment key={i}>
+          <Fragment key={i}>
             <FlamegraphTooltipFrameMainInfo>
               <FlamegraphTooltipColorIndicator backgroundColor={cssColor} />
               {uiFrames.formatter(rect.width)}{' '}
@@ -68,7 +67,7 @@ export function FlamegraphUIFramesTooltip({
               {uiFrames.timelineFormatter(rect.left)} {' \u2014 '}
               {uiFrames.timelineFormatter(rect.right)}
             </FlamegraphTooltipTimelineInfo>
-          </React.Fragment>
+          </Fragment>
         );
       })}
     </BoundTooltip>

--- a/static/app/components/superuserStaffAccessForm.tsx
+++ b/static/app/components/superuserStaffAccessForm.tsx
@@ -1,4 +1,4 @@
-import React, {Component, Fragment} from 'react';
+import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -205,14 +205,14 @@ class SuperuserStaffAccessFormContent extends Component<Props, State> {
           isLoading ? (
             <LoadingIndicator />
           ) : (
-            <React.Fragment>
+            <Fragment>
               {error && <Alert variant="danger">{errorType}</Alert>}
               <WebAuthn
                 mode="sudo"
                 authenticators={authenticators}
                 onWebAuthn={this.handleWebAuthn}
               />
-            </React.Fragment>
+            </Fragment>
           )
         ) : (
           <Form

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, PureComponent, type ComponentProps} from 'react';
+import {Fragment, PureComponent, type ComponentProps} from 'react';
 import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -423,12 +423,12 @@ class TriggersChart extends PureComponent<Props, State> {
                   dataScanned={seriesSamplingInfo?.dataScanned}
                 />
               ) : (
-                <React.Fragment>
+                <Fragment>
                   <SectionHeading>{totalCountLabel}</SectionHeading>
                   <SectionValue>
                     {totalCount === null ? '\u2014' : totalCount.toLocaleString()}
                   </SectionValue>
-                </React.Fragment>
+                </Fragment>
               )}
             </InlineContainer>
           ) : (

--- a/static/app/views/explore/components/annotatedAttributeTooltip.tsx
+++ b/static/app/views/explore/components/annotatedAttributeTooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -29,7 +29,7 @@ export function AnnotatedAttributeTooltip({
 
   // Check if there's meta information for this field
   if (!fieldKey || !extra.traceItemMeta) {
-    return <React.Fragment>{children}</React.Fragment>;
+    return <Fragment>{children}</Fragment>;
   }
 
   const metaTooltip = TraceItemMetaInfo.getTooltipText(
@@ -40,7 +40,7 @@ export function AnnotatedAttributeTooltip({
   );
 
   if (!metaTooltip) {
-    return <React.Fragment>{children}</React.Fragment>;
+    return <Fragment>{children}</Fragment>;
   }
 
   return (

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {useQuery} from '@tanstack/react-query';
@@ -350,7 +350,7 @@ function FilteredTooltip({
     value.trim() !== '[Filtered]' ||
     !extra.projectSlug
   ) {
-    return <React.Fragment>{children}</React.Fragment>;
+    return <Fragment>{children}</Fragment>;
   }
 
   if (isAppendingTemplate) {

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -1,5 +1,5 @@
 import type {ComponentProps, SyntheticEvent} from 'react';
-import React, {Fragment, memo, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {Fragment, memo, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
@@ -427,12 +427,12 @@ export const LogRowContent = memo(function LogRowContent({
                 </TraceIconStyleWrapper>
               </Flex>
             ) : (
-              <React.Fragment>
+              <Fragment>
                 <SeverityCircleRenderer extra={rendererExtra} meta={meta} />
                 {project ? (
                   <ProjectBadge project={project} avatarSize={12} hideName />
                 ) : null}
-              </React.Fragment>
+              </Fragment>
             )}
           </LogFirstCellContent>
         </LogsTableBodyFirstCell>

--- a/static/app/views/explore/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/explore/releases/detail/header/releaseHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -50,7 +50,7 @@ export function ReleaseHeader({
   const {commitCount, commitFilesChanged} = releaseMeta;
 
   const titleContent = (
-    <React.Fragment>
+    <Fragment>
       <IdBadge project={project} avatarSize={16} hideName />
       <Version version={version} anchor={false} truncate />
       <CopyToClipboardButton
@@ -70,7 +70,7 @@ export function ReleaseHeader({
           </Tooltip>
         </IconWrapper>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 
   const releasePath = makeReleasesPathname({
@@ -114,14 +114,14 @@ export function ReleaseHeader({
             <FeatureBadge type="new" />
           </BadgeWrapper>
         ) : (
-          <React.Fragment>
+          <Fragment>
             <NavTabsBadge variant="muted">
               {formatAbbreviatedNumber(numberOfMobileBuilds)}
             </NavTabsBadge>
             <BadgeWrapper>
               <FeatureBadge type="new" />
             </BadgeWrapper>
-          </React.Fragment>
+          </Fragment>
         ),
     }),
     textValue: t('Mobile Builds %s', numberOfMobileBuilds),

--- a/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 import {PlatformIcon} from 'platformicons';
 
 import {ellipsize} from 'sentry/utils/string/ellipsize';
@@ -118,17 +118,17 @@ export function TraceEAPSpanRow(props: TraceRowProps<EapSpanNode>) {
             ) : null}
           </div>
           {icon}
-          <React.Fragment>
+          <Fragment>
             {props.node.value.op && props.node.value.op !== 'default' && (
-              <React.Fragment>
+              <Fragment>
                 <span className="TraceOperation">{props.node.value.op}</span>
                 <strong className="TraceEmDash"> — </strong>
-              </React.Fragment>
+              </Fragment>
             )}
             <span className="TraceDescription" title={description}>
               {description ? ellipsize(description, 100) : (spanId ?? 'unknown')}
             </span>
-          </React.Fragment>
+          </Fragment>
         </div>
       </div>
       <div

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 import {PlatformIcon} from 'platformicons';
 
 import {ellipsize} from 'sentry/utils/string/ellipsize';
@@ -70,12 +70,12 @@ export function TraceSpanRow(props: TraceRowProps<SpanNode>) {
             ) : null}
           </div>
           {icon}
-          <React.Fragment>
+          <Fragment>
             {props.node.value.op && props.node.value.op !== 'default' && (
-              <React.Fragment>
+              <Fragment>
                 <span className="TraceOperation">{props.node.value.op}</span>
                 <strong className="TraceEmDash"> — </strong>
-              </React.Fragment>
+              </Fragment>
             )}
             <span className="TraceDescription" title={props.node.description}>
               {isPrefetch ? '(prefetch) ' : ''}
@@ -83,7 +83,7 @@ export function TraceSpanRow(props: TraceRowProps<SpanNode>) {
                 ? ellipsize(props.node.description, 100)
                 : (spanId ?? 'unknown')}
             </span>
-          </React.Fragment>
+          </Fragment>
         </div>
       </div>
       <div

--- a/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 import {PlatformIcon} from 'platformicons';
 
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
@@ -73,10 +73,10 @@ export function TraceTransactionRow(props: TraceRowProps<TransactionNode>) {
             platform={props.projects[props.node.value.project_slug] ?? 'default'}
           />
           {props.node.value['transaction.op'] !== 'default' && (
-            <React.Fragment>
+            <Fragment>
               <span className="TraceOperation">{props.node.value['transaction.op']}</span>
               <strong className="TraceEmDash"> — </strong>
-            </React.Fragment>
+            </Fragment>
           )}
           <span className="TraceDescription">{props.node.value.transaction}</span>
         </div>

--- a/static/app/views/performance/newTraceDetails/traceRow/traceUptimeCheckNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceUptimeCheckNode.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 
 import {IconSentry} from 'sentry/icons';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
@@ -65,19 +65,19 @@ export function TraceUptimeCheckNodeRow(props: TraceRowProps<UptimeCheckNode>) {
             ) : null}
           </div>
           {icon}
-          <React.Fragment>
+          <Fragment>
             {props.node.value.op && props.node.value.op !== 'default' && (
-              <React.Fragment>
+              <Fragment>
                 <span className="TraceOperation">{props.node.value.op}</span>
                 <strong className="TraceEmDash"> — </strong>
-              </React.Fragment>
+              </Fragment>
             )}
             <span className="TraceDescription" title={props.node.description}>
               {props.node.description
                 ? ellipsize(props.node.description, 100)
                 : (spanId ?? 'unknown')}
             </span>
-          </React.Fragment>
+          </Fragment>
         </div>
       </div>
       <div

--- a/static/app/views/performance/newTraceDetails/traceRow/traceUptimeCheckTimingNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceUptimeCheckTimingNode.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 
 import {IconTimer} from 'sentry/icons';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
@@ -65,19 +65,19 @@ export function TraceUptimeCheckTimingNodeRow(
             ) : null}
           </div>
           {icon}
-          <React.Fragment>
+          <Fragment>
             {props.node.value.op && props.node.value.op !== 'default' && (
-              <React.Fragment>
+              <Fragment>
                 <span className="TraceOperation">{props.node.value.op}</span>
                 <strong className="TraceEmDash"> — </strong>
-              </React.Fragment>
+              </Fragment>
             )}
             <span className="TraceDescription" title={props.node.description}>
               {props.node.description
                 ? ellipsize(props.node.description, 100)
                 : (props.node.id ?? 'unknown')}
             </span>
-          </React.Fragment>
+          </Fragment>
         </div>
       </div>
       <div

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button, LinkButton} from '@sentry/scraps/button';
@@ -166,7 +166,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
   };
 
   return (
-    <React.Fragment>
+    <Fragment>
       <Layout.HeaderContent>
         <Flex align="center" gap="sm">
           <Breadcrumbs crumbs={breadcrumbs} />
@@ -182,7 +182,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
       </Layout.HeaderContent>
 
       {hasPageFrameFeature ? (
-        <React.Fragment>
+        <Fragment>
           <TopBar.Slot name="actions">
             <Button
               variant="secondary"
@@ -303,7 +303,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
               {null}
             </FeedbackButton>
           </TopBar.Slot>
-        </React.Fragment>
+        </Fragment>
       ) : (
         <Layout.HeaderActions>
           <Flex align="center" gap="sm" flexShrink={0}>
@@ -421,6 +421,6 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
           </Flex>
         </Layout.HeaderActions>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 }

--- a/static/gsAdmin/components/changePlanAction.tsx
+++ b/static/gsAdmin/components/changePlanAction.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import classNames from 'classnames';
 
 import {Container} from '@sentry/scraps/layout';
@@ -240,7 +240,7 @@ function ChangePlanAction({
   ];
 
   const header = partnerPlanId ? null : (
-    <React.Fragment>
+    <Fragment>
       <Container marginBottom="xl">
         <Tabs
           value={activeTier}
@@ -290,7 +290,7 @@ function ChangePlanAction({
           </a>
         </li>
       </ul>
-    </React.Fragment>
+    </Fragment>
   );
 
   return (

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -1,4 +1,4 @@
-import React, {Component, Fragment, useEffect} from 'react';
+import {Component, Fragment, useEffect} from 'react';
 import {ThemeProvider, useTheme} from '@emotion/react';
 import * as Sentry from '@sentry/react';
 import Cookies from 'js-cookie';
@@ -1040,9 +1040,9 @@ class GSBanner extends Component<Props, State> {
     const overageAlertType = this.overageAlertType;
     if (overageAlertType !== null) {
       return (
-        <React.Fragment>
+        <Fragment>
           {productTrialAlerts && productTrialAlerts.length > 0 && productTrialAlerts}
-        </React.Fragment>
+        </Fragment>
       );
     }
 
@@ -1056,7 +1056,7 @@ class GSBanner extends Component<Props, State> {
       const wrappedNumber = <strong>{membersDeactivatedFromLimit}</strong>;
       // only disabling members if the plan allows exactly one member
       return (
-        <React.Fragment>
+        <Fragment>
           {productTrialAlerts && productTrialAlerts.length > 0 && productTrialAlerts}
           <Alert.Container>
             <InvertedAlert
@@ -1106,7 +1106,7 @@ class GSBanner extends Component<Props, State> {
               )}
             </InvertedAlert>
           </Alert.Container>
-        </React.Fragment>
+        </Fragment>
       );
     }
 

--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -243,7 +243,7 @@ export function ProductTrialAlert(props: ProductTrialAlertProps) {
 
   return (
     <TrialAlert system variant="muted" trailingItems={actions}>
-      <React.Fragment>
+      <Fragment>
         {alertHeader && (
           <Heading>
             <h4>{alertHeader}</h4>
@@ -251,7 +251,7 @@ export function ProductTrialAlert(props: ProductTrialAlertProps) {
           </Heading>
         )}
         {alertText && <div>{alertText}</div>}
-      </React.Fragment>
+      </Fragment>
     </TrialAlert>
   );
 }


### PR DESCRIPTION
Adds `no-restricted-syntax` rules banning both `React.Fragment` and `<React.Fragment>` — enforces `import {Fragment} from 'react'` instead. Same pattern as the existing `React.forwardRef` ban.

`Fragment` was already used in 936 files vs 23 files that used `React.Fragment`. These have been updated. Left snapshot strings and lint rule test fixtures alone.

Unfortunately not autofixable via `no-restricted-syntax`, but agents should take care of these automatically most of the time.