### PR TITLE
ref(utils): Various clarifications in `SafeRolloutComparator` code

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -152,7 +152,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         # Feature flag the occurrence endpoint
         if (
             dataset_label == SupportedTraceItemType.OCCURRENCES.value
-            and not EAPOccurrencesComparator.should_use_experiment("api.events.endpoints")
+            and not EAPOccurrencesComparator.should_use_experimental_data("api.events.endpoints")
         ):
             raise ParseError(detail=f"{dataset_label} is not supported currently")
         elif dataset_label == SupportedTraceItemType.REPLAYS.value and not features.has(

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -360,7 +360,7 @@ class TraceEvent:
                             control_data=occurrence_ids,
                             experimental_data=eap_occurrence_ids,
                             callsite=callsite,
-                            is_experimental_data_a_null_result=len(eap_occurrence_ids) == 0,
+                            is_experimental_data_nullish=len(eap_occurrence_ids) == 0,
                             reasonable_match_comparator=lambda snuba, eap: {
                                 row["occurrence_id"] for row in eap
                             }.issubset({row["occurrence_id"] for row in snuba}),
@@ -827,7 +827,7 @@ def query_trace_data(
             control_data=transformed_results[1],
             experimental_data=eap_errors,
             callsite=errors_callsite,
-            is_experimental_data_a_null_result=len(eap_errors) == 0,
+            is_experimental_data_nullish=len(eap_errors) == 0,
             reasonable_match_comparator=lambda snuba, eap: {e["id"] for e in eap}.issubset(
                 {e["id"] for e in snuba}
             ),

--- a/src/sentry/api/endpoints/organization_trace_meta.py
+++ b/src/sentry/api/endpoints/organization_trace_meta.py
@@ -94,7 +94,7 @@ def run_errors_query(trace_id: str, snuba_params: SnubaParams) -> int:
             snuba_count,
             eap_count,
             callsite,
-            is_experimental_data_a_null_result=(eap_count == 0),
+            is_experimental_data_nullish=(eap_count == 0),
             reasonable_match_comparator=lambda snuba, eap: eap <= snuba,
             debug_context={
                 "trace_id": trace_id,

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -369,7 +369,7 @@ class TracesExecutor:
                 traces_errors,
                 eap_traces_errors,
                 errors_callsite,
-                is_experimental_data_a_null_result=len(eap_traces_errors) == 0,
+                is_experimental_data_nullish=len(eap_traces_errors) == 0,
                 reasonable_match_comparator=_reasonable_trace_count_map_match,
                 debug_context=debug_context,
             )
@@ -386,7 +386,7 @@ class TracesExecutor:
                 traces_occurrences,
                 eap_traces_occurrences,
                 occurrences_callsite,
-                is_experimental_data_a_null_result=len(eap_traces_occurrences) == 0,
+                is_experimental_data_nullish=len(eap_traces_occurrences) == 0,
                 reasonable_match_comparator=_reasonable_trace_count_map_match,
                 debug_context=debug_context,
             )

--- a/src/sentry/api/endpoints/release_thresholds/utils/get_errors_counts_timeseries.py
+++ b/src/sentry/api/endpoints/release_thresholds/utils/get_errors_counts_timeseries.py
@@ -61,7 +61,7 @@ def get_errors_counts_timeseries_by_project_and_release(
             snuba_results,
             eap_results,
             "release_thresholds.get_errors_counts_timeseries",
-            is_experimental_data_a_null_result=len(eap_results) == 0,
+            is_experimental_data_nullish=len(eap_results) == 0,
             reasonable_match_comparator=lambda snuba_rows, eap_rows: keyed_counts_subset_match(
                 snuba_rows,
                 eap_rows,

--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -191,7 +191,7 @@ def run_group_events_query(
             snuba_data,
             eap_data,
             callsite,
-            is_experimental_data_a_null_result=len(eap_data) == 0,
+            is_experimental_data_nullish=len(eap_data) == 0,
             reasonable_match_comparator=_reasonable_group_events_match,
             debug_context={
                 "group_id": group.id,

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -594,7 +594,7 @@ class PRCommentWorkflow(ABC):
                 snuba_results,
                 eap_results,
                 "integrations.pr_comment.get_top_5_issues_by_count",
-                is_experimental_data_a_null_result=len(eap_results) == 0,
+                is_experimental_data_nullish=len(eap_results) == 0,
                 reasonable_match_comparator=lambda snuba_rows, eap_rows: keyed_counts_subset_match(
                     snuba_rows,
                     eap_rows,

--- a/src/sentry/issues/escalating/escalating.py
+++ b/src/sentry/issues/escalating/escalating.py
@@ -103,7 +103,7 @@ def query_groups_past_counts(groups: Iterable[Group]) -> list[GroupsCountRespons
             snuba_results,
             eap_results,
             "issues.escalating.query_groups_past_counts",
-            is_experimental_data_a_null_result=len(eap_results) == 0,
+            is_experimental_data_nullish=len(eap_results) == 0,
             reasonable_match_comparator=lambda snuba_rows, eap_rows: keyed_counts_subset_match(
                 snuba_rows,
                 eap_rows,

--- a/src/sentry/issues/related/trace_connected.py
+++ b/src/sentry/issues/related/trace_connected.py
@@ -134,7 +134,7 @@ def trace_connected_issues(event: Event | GroupEvent) -> tuple[list[int], dict[s
             snuba_results,
             eap_results,
             "issues.related.trace_connected_issues",
-            is_experimental_data_a_null_result=len(eap_results) == 0,
+            is_experimental_data_nullish=len(eap_results) == 0,
             reasonable_match_comparator=lambda snuba, eap: eap.issubset(snuba),
             debug_context={
                 "trace_id": event.trace_id,

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -277,7 +277,7 @@ def fetch_associated_groups(
             snuba_result,
             eap_result,
             callsite,
-            is_experimental_data_a_null_result=len(eap_result) == 0,
+            is_experimental_data_nullish=len(eap_result) == 0,
             reasonable_match_comparator=lambda snuba, eap: (
                 eap.keys() <= snuba.keys() and all(eap[gid] <= snuba[gid] for gid in eap)
             ),

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -664,7 +664,7 @@ def start_group_reprocessing(
             control_data=snuba_count,
             experimental_data=eap_count,
             callsite=callsite,
-            is_experimental_data_a_null_result=eap_count == 0,
+            is_experimental_data_nullish=eap_count == 0,
             reasonable_match_comparator=lambda snuba, eap: eap <= snuba,
             debug_context={
                 "organization_id": organization.id,

--- a/src/sentry/search/eap/occurrences/rollout_utils.py
+++ b/src/sentry/search/eap/occurrences/rollout_utils.py
@@ -3,3 +3,11 @@ from sentry.utils.rollout import SafeRolloutComparator
 
 class EAPOccurrencesComparator(SafeRolloutComparator):
     ROLLOUT_NAME = "occurrences_on_eap"
+
+
+EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION = (
+    EAPOccurrencesComparator._should_run_experiment_option()
+)
+EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION = (
+    EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option()
+)

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -564,7 +564,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             try:
                 return EAPOccurrencesComparator.check_and_choose_with_timings(
                     control_data_func=_run_snuba_query,
-                    experimental_thunk=_run_eap_query,
+                    experimental_data_func=_run_eap_query,
                     callsite=callsite,
                     null_result_determiner=lambda r: len(r[0]) == 0,
                     reasonable_match_comparator=_reasonable_search_result_match,

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -563,7 +563,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         ):
             try:
                 return EAPOccurrencesComparator.check_and_choose_with_timings(
-                    control_thunk=_run_snuba_query,
+                    control_data_func=_run_snuba_query,
                     experimental_thunk=_run_eap_query,
                     callsite=callsite,
                     null_result_determiner=lambda r: len(r[0]) == 0,

--- a/src/sentry/services/eventstore/snuba/backend.py
+++ b/src/sentry/services/eventstore/snuba/backend.py
@@ -410,7 +410,7 @@ class SnubaEventStorage(EventStorage):
                     control_data=control_data,
                     experimental_data=experimental_data,
                     callsite=callsite,
-                    is_experimental_data_a_null_result=eap_results is None,
+                    is_experimental_data_nullish=eap_results is None,
                     reasonable_match_comparator=lambda ctl, exp: exp.issubset(ctl),
                     debug_context={
                         "project_ids": list(filter.project_ids) if filter.project_ids else [],
@@ -584,7 +584,7 @@ class SnubaEventStorage(EventStorage):
                     control_data=control_group_id,
                     experimental_data=eap_group_id,
                     callsite=callsite,
-                    is_experimental_data_a_null_result=eap_result is None,
+                    is_experimental_data_nullish=eap_result is None,
                     reasonable_match_comparator=lambda snuba, eap: snuba == eap,
                     debug_context={
                         "project_id": project_id,

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -697,7 +697,7 @@ def query_trace_data(
             control_data=errors_data,
             experimental_data=eap_errors_data,
             callsite=callsite,
-            is_experimental_data_a_null_result=len(eap_errors_data) == 0,
+            is_experimental_data_nullish=len(eap_errors_data) == 0,
             reasonable_match_comparator=lambda snuba, eap: {e["id"] for e in eap}.issubset(
                 {e["id"] for e in snuba}
             ),

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -508,7 +508,7 @@ class SnubaTagStorage(TagStorage):
                     snuba_output,
                     eap_output,
                     eap_callsite,
-                    is_experimental_data_a_null_result=eap_output.count == 0,
+                    is_experimental_data_nullish=eap_output.count == 0,
                     reasonable_match_comparator=reasonable_group_tag_key_match,
                     debug_context={
                         "group_id": group.id,
@@ -917,7 +917,7 @@ class SnubaTagStorage(TagStorage):
                 control_data=snuba_result,
                 experimental_data=eap_result,
                 callsite=callsite,
-                is_experimental_data_a_null_result=len(eap_result) == 0,
+                is_experimental_data_nullish=len(eap_result) == 0,
                 reasonable_match_comparator=_reasonable_group_list_tag_value_match,
                 debug_context={
                     "project_ids": list(project_ids),
@@ -1005,7 +1005,7 @@ class SnubaTagStorage(TagStorage):
                 control_data=snuba_result,
                 experimental_data=eap_result,
                 callsite=callsite,
-                is_experimental_data_a_null_result=len(eap_result) == 0,
+                is_experimental_data_nullish=len(eap_result) == 0,
                 reasonable_match_comparator=_reasonable_group_list_tag_value_match,
                 debug_context={
                     "project_ids": list(project_ids),
@@ -1171,7 +1171,7 @@ class SnubaTagStorage(TagStorage):
                 control_data=snuba_result,
                 experimental_data=eap_result,
                 callsite=callsite,
-                is_experimental_data_a_null_result=eap_result == 0,
+                is_experimental_data_nullish=eap_result == 0,
                 reasonable_match_comparator=lambda control, experimental: experimental <= control,
                 debug_context={
                     "group_id": group.id,
@@ -1401,7 +1401,7 @@ class SnubaTagStorage(TagStorage):
                 control_data=snuba_result,
                 experimental_data=eap_result,
                 callsite=callsite,
-                is_experimental_data_a_null_result=len(eap_result) == 0,
+                is_experimental_data_nullish=len(eap_result) == 0,
                 reasonable_match_comparator=_reasonable_release_tags_match,
                 debug_context={
                     "organization_id": organization_id,
@@ -1596,7 +1596,7 @@ class SnubaTagStorage(TagStorage):
                 control_data=snuba_result,
                 experimental_data=eap_result,
                 callsite=callsite,
-                is_experimental_data_a_null_result=len(eap_result) == 0,
+                is_experimental_data_nullish=len(eap_result) == 0,
                 reasonable_match_comparator=_reasonable_user_counts_match,
                 debug_context={
                     "project_ids": list(project_ids),
@@ -1747,7 +1747,7 @@ class SnubaTagStorage(TagStorage):
                 control_data=snuba_result,
                 experimental_data=eap_result,
                 callsite=callsite,
-                is_experimental_data_a_null_result=len(eap_result) == 0,
+                is_experimental_data_nullish=len(eap_result) == 0,
                 reasonable_match_comparator=_reasonable_user_counts_match,
                 debug_context={
                     "project_ids": list(project_ids),
@@ -2286,7 +2286,7 @@ class SnubaTagStorage(TagStorage):
                 control_data=snuba_result,
                 experimental_data=eap_result,
                 callsite=callsite,
-                is_experimental_data_a_null_result=len(eap_result) == 0,
+                is_experimental_data_nullish=len(eap_result) == 0,
                 reasonable_match_comparator=_reasonable_group_tag_value_iter_match,
                 debug_context={
                     "group_id": group.id,

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -157,7 +157,7 @@ def project_key_errors(
                 snuba_rows,
                 eap_rows,
                 callsite,
-                is_experimental_data_a_null_result=len(eap_rows) == 0,
+                is_experimental_data_nullish=len(eap_rows) == 0,
                 reasonable_match_comparator=lambda snuba, eap: keyed_counts_subset_match(
                     snuba,
                     eap,
@@ -352,7 +352,7 @@ def project_key_performance_issues(ctx: OrganizationReportContext, project: Proj
                 snuba_rows,
                 eap_rows,
                 callsite,
-                is_experimental_data_a_null_result=len(eap_rows) == 0,
+                is_experimental_data_nullish=len(eap_rows) == 0,
                 reasonable_match_comparator=lambda snuba, eap: keyed_counts_subset_match(
                     snuba,
                     eap,

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -69,7 +69,7 @@ class SafeRolloutComparator:
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.should_eval_experimental"
 
     @classmethod
-    def _callsite_blocklist_option_name(cls) -> str:
+    def _callsite_experiment_blocklist_option(cls) -> str:
         """
         This is the callsite-level eval rollout option. If the option contains a callsite,
         the should_check_experiment function will return False. (This is useful if you see
@@ -116,7 +116,7 @@ class SafeRolloutComparator:
             flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
         )
         register(
-            cls._callsite_blocklist_option_name(),
+            cls._callsite_experiment_blocklist_option(),
             type=Sequence,
             default=[],
             flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
@@ -205,7 +205,7 @@ class SafeRolloutComparator:
         if not options.get(cls._should_eval_option_name()):
             return False
 
-        if callsite in options.get(cls._callsite_blocklist_option_name()):
+        if callsite in options.get(cls._callsite_experiment_blocklist_option()):
             return False
 
         sample_rate = options.get(cls._sample_rate_option_name())

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -141,7 +141,7 @@ class SafeRolloutComparator:
         )
 
     @classmethod
-    def should_log_mismatch(cls, callsite: str) -> bool:
+    def _should_log_mismatch(cls, callsite: str) -> bool:
         allowlist = set(options.get(cls._mismatch_log_callsite_allowlist_option_name()))
         return "*" in allowlist or callsite in allowlist
 
@@ -171,7 +171,7 @@ class SafeRolloutComparator:
         debug_context: dict[str, Any] | None,
         data_serializer: Callable[[TData], Any] | None,
     ) -> None:
-        if not cls.should_log_mismatch(callsite):
+        if not cls._should_log_mismatch(callsite):
             return
 
         serialize = data_serializer or cls._default_serialize_for_log

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -78,7 +78,7 @@ class SafeRolloutComparator:
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.eval_callsite_blocklist"
 
     @classmethod
-    def _callsite_allowlist_option_name(cls) -> str:
+    def _callsite_use_experimental_data_allowlist_option(cls) -> str:
         """
         This is the callsite-level use-experimental-path rollout option. If the option
         contains a callsite, then that callsite will use the experimental-path data.
@@ -122,7 +122,7 @@ class SafeRolloutComparator:
             flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
         )
         register(
-            cls._callsite_allowlist_option_name(),
+            cls._callsite_use_experimental_data_allowlist_option(),
             type=Sequence,
             default=[],
             flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
@@ -220,7 +220,9 @@ class SafeRolloutComparator:
         you should instead use check_and_choose (which standardizes the choice logic
         and has better logging).
         """
-        use_experimental_data = callsite in options.get(cls._callsite_allowlist_option_name())
+        use_experimental_data = callsite in options.get(
+            cls._callsite_use_experimental_data_allowlist_option()
+        )
         tags: dict[str, str] = {
             "rollout_name": cls.ROLLOUT_NAME,
             "callsite": callsite,

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -4,19 +4,19 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 from sentry import options
-from sentry.utils import metrics
-from sentry.utils.safe import trim
-
-TData = TypeVar("TData")
-logger = logging.getLogger(__name__)
-
+from sentry.options import register
 from sentry.options.manager import (
     FLAG_ALLOW_EMPTY,
     FLAG_AUTOMATOR_MODIFIABLE,
     FLAG_MODIFIABLE_BOOL,
     FLAG_MODIFIABLE_RATE,
 )
+from sentry.utils import metrics
+from sentry.utils.safe import trim
 from sentry.utils.types import Bool, Float, Sequence
+
+TData = TypeVar("TData")
+logger = logging.getLogger(__name__)
 
 
 class SafeRolloutComparator:
@@ -122,7 +122,6 @@ class SafeRolloutComparator:
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        from sentry.options import register
 
         register(
             cls._should_run_experiment_option(),

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -165,7 +165,7 @@ class SafeRolloutComparator:
         use_experimental: bool,
         is_exact_match: bool,
         is_reasonable_match: bool | None,
-        is_experimental_data_a_null_result: bool | None,
+        is_experimental_data_nullish: bool | None,
         control_data: TData,
         experimental_data: TData,
         debug_context: dict[str, Any] | None,
@@ -184,7 +184,7 @@ class SafeRolloutComparator:
                 "source_of_truth": ("experimental" if use_experimental else "control"),
                 "exact_match": is_exact_match,
                 "reasonable_match": is_reasonable_match,
-                "is_null_result": is_experimental_data_a_null_result,
+                "is_null_result": is_experimental_data_nullish,
                 "debug_context": trim(cls._default_serialize_for_log(debug_context)),
                 "control_data_raw": trim(serialize(control_data)),
                 "experimental_data_raw": trim(serialize(experimental_data)),
@@ -238,7 +238,7 @@ class SafeRolloutComparator:
         control_data: TData,
         experimental_data: TData,
         callsite: str,
-        is_experimental_data_a_null_result: bool | None = None,
+        is_experimental_data_nullish: bool | None = None,
         reasonable_match_comparator: Callable[[TData, TData], bool] | None = None,
         debug_context: dict[str, Any] | None = None,
         data_serializer: Callable[[TData], Any] | None = None,
@@ -276,8 +276,8 @@ class SafeRolloutComparator:
             "source_of_truth": ("experimental" if use_experimental else "control"),
         }
 
-        if is_experimental_data_a_null_result is not None:
-            tags["is_null_result"] = str(is_experimental_data_a_null_result)
+        if is_experimental_data_nullish is not None:
+            tags["is_null_result"] = str(is_experimental_data_nullish)
 
         if reasonable_match_comparator is not None:
             try:
@@ -303,7 +303,7 @@ class SafeRolloutComparator:
                     use_experimental=use_experimental,
                     is_exact_match=is_exact_match,
                     is_reasonable_match=is_reasonable_match,
-                    is_experimental_data_a_null_result=is_experimental_data_a_null_result,
+                    is_experimental_data_nullish=is_experimental_data_nullish,
                     control_data=control_data,
                     experimental_data=experimental_data,
                     debug_context=debug_context,
@@ -365,15 +365,15 @@ class SafeRolloutComparator:
         ):
             experimental_data = experimental_thunk()
 
-        is_experimental_data_a_null_result = None
+        is_experimental_data_nullish = None
         if null_result_determiner is not None:
-            is_experimental_data_a_null_result = null_result_determiner(experimental_data)
+            is_experimental_data_nullish = null_result_determiner(experimental_data)
 
         return cls.check_and_choose(
             control_data=control_data,
             experimental_data=experimental_data,
             callsite=callsite,
-            is_experimental_data_a_null_result=is_experimental_data_a_null_result,
+            is_experimental_data_nullish=is_experimental_data_nullish,
             reasonable_match_comparator=reasonable_match_comparator,
             debug_context=debug_context,
             data_serializer=data_serializer,

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -98,7 +98,7 @@ class SafeRolloutComparator:
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.eval_experimental_sample_rate"
 
     @classmethod
-    def _mismatch_log_callsite_allowlist_option_name(cls) -> str:
+    def _callsite_mismatch_log_allowlist_option(cls) -> str:
         """
         Controls which callsites emit structured mismatch logs. Add a callsite
         string to enable logging for it, or ``"*"`` to enable for all callsites.
@@ -134,7 +134,7 @@ class SafeRolloutComparator:
             flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
         )
         register(
-            cls._mismatch_log_callsite_allowlist_option_name(),
+            cls._callsite_mismatch_log_allowlist_option(),
             type=Sequence,
             default=[],
             flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
@@ -142,7 +142,7 @@ class SafeRolloutComparator:
 
     @classmethod
     def _should_log_mismatch(cls, callsite: str) -> bool:
-        allowlist = set(options.get(cls._mismatch_log_callsite_allowlist_option_name()))
+        allowlist = set(options.get(cls._callsite_mismatch_log_allowlist_option()))
         return "*" in allowlist or callsite in allowlist
 
     @classmethod

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -32,7 +32,7 @@ class SafeRolloutComparator:
       1. Set up your SafeRolloutComparator class & options.
       2. Add your first callsite. (Further callsites can be added at any time.)
       3. Start rolling out the "evaluate experimental branch" option.
-      4. Monitor correctness through standard dashboard. (TODO @cpaul: build dashboard)
+      4. Monitor correctness through standard dashboard.
       5. Start adding known-good callsites to the "use experimental branch" allowlist.
       6. Complete your migration, secure in your knowledge that it's safe to do so.
       7. Clean up your control branch & SafeRolloutComparator when you're done. Success!
@@ -57,7 +57,6 @@ class SafeRolloutComparator:
 
     # This is your rollout, which determines your option names and which you can filter
     # the DataDog dashboards to show.
-    # TODO @cpaul: construct DataDog dashboards once you have a rollout using this.
     ROLLOUT_NAME: str
 
     @classmethod

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -15,8 +15,9 @@ from sentry.utils import metrics
 from sentry.utils.safe import trim
 from sentry.utils.types import Bool, Float, Sequence
 
-TData = TypeVar("TData")
 logger = logging.getLogger(__name__)
+
+TData = TypeVar("TData")
 
 
 class SafeRolloutComparator:

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -88,7 +88,7 @@ class SafeRolloutComparator:
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.use_experimental_data_callsite_allowlist"
 
     @classmethod
-    def _sample_rate_option_name(cls) -> str:
+    def _experiment_sample_rate_option(cls) -> str:
         """
         This is the sample rate for evaluating the experimental branch. When set to a value
         less than 1.0, only that percentage of requests will actually perform the double-read.
@@ -128,7 +128,7 @@ class SafeRolloutComparator:
             flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
         )
         register(
-            cls._sample_rate_option_name(),
+            cls._experiment_sample_rate_option(),
             type=Float,
             default=1.0,
             flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
@@ -208,7 +208,7 @@ class SafeRolloutComparator:
         if callsite in options.get(cls._callsite_experiment_blocklist_option()):
             return False
 
-        sample_rate = options.get(cls._sample_rate_option_name())
+        sample_rate = options.get(cls._experiment_sample_rate_option())
         return random.random() < sample_rate
 
     @classmethod

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -212,7 +212,7 @@ class SafeRolloutComparator:
         return random.random() < sample_rate
 
     @classmethod
-    def should_use_experiment(cls, callsite: str) -> bool:
+    def should_use_experimental_data(cls, callsite: str) -> bool:
         """
         This function should control whether you use the result of your experimental
         data. Useful for allowlisting known-safe callsites.
@@ -264,7 +264,7 @@ class SafeRolloutComparator:
         * data_serializer: Optional serializer for control/experimental payloads in
             logs. Defaults to `_default_serialize_for_log`.
         """
-        use_experimental = cls.should_use_experiment(callsite)
+        use_experimental = cls.should_use_experimental_data(callsite)
         is_exact_match = control_data == experimental_data
         is_reasonable_match: bool | None = None
 

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -23,84 +23,100 @@ class SafeRolloutComparator:
     """
     SafeRolloutComparator is a tool designed to help you roll out a change to existing logic safely.
 
-    In particular, it can (at a callsite-by-callsite granularity) help to track both the
-    _exact_ and _reasonable_ rate at which the experimental branch matches the control branch.
-    Once a callsite looks correct enough, you can switch the code behavior to actually use the
-    data from the experimental branch.
+    In particular, it can (with callsite-by-callsite granularity) help to track rate at which the
+    experimental branch both exactly matches and "reasonably" matches the control branch. (What
+    counts as a "reasonable" (close enough) match is definable by providing a comparison function.)
+    Once a callsite looks correct enough, you can switch the code behavior to actually use the data
+    from the experimental branch by adding the callsite indentifier to the "use experimental data"
+    allowlist option provided by the class.
 
     The flow is generally:
-      1. Set up your SafeRolloutComparator class & options.
-      2. Add your first callsite. (Further callsites can be added at any time.)
-      3. Start rolling out the "evaluate experimental branch" option.
-      4. Monitor correctness through standard dashboard.
-      5. Start adding known-good callsites to the "use experimental branch" allowlist.
+      1. Set up your `SafeRolloutComparator` subclass (in Sentry) & options (in options automator).
+      2. Use the comparator in your first callsite (see example below). (More callsites can be added
+         at any time.)
+      3. Start rolling out the experiment by switching the "should run experiment" option to True
+         and, if you've set a sample rate option, increasing the sample rate. (If not set, the
+         sample rate defaults to 100%.)
+      4. Monitor correctness using the metrics and optional mismatch logs emitted when the
+         experimental branch is run.
+      5. Start adding known-good callsites to the "use experimental data" allowlist.
       6. Complete your migration, secure in your knowledge that it's safe to do so.
-      7. Clean up your control branch & SafeRolloutComparator when you're done. Success!
+      7. Clean up your control branch & `SafeRolloutComparator` when you're done. Success!
 
     Used like:
-    ```python
-    callsite = "BarClass::baz"
-    control_data = old_slow_trustworthy_method()
-    if FooComparator.should_check_experiment(callsite):
-        experimental_data = new_fast_risky_method()
-        data = FooComparator.check_and_choose(
-            control_data,
-            experimental_data,
-            callsite,
-            len(experimental_data) == 0,
-            lambda ctl, exp: exp.issubset(ctl)
-        )
-    else:
-        data = control_data
+    ```
+    # Setup
+    class FooComparator(SafeRolloutComparator):
+        ROLLOUT_NAME="some_new_feature"
+
+    # Example callsite:
+    def some_function():
+        # ...
+
+        # A unique identifier for the callsite, for option names and metrics/logs tagging
+        callsite = "some.module.path.some_function"
+
+        control_data = old_slow_trustworthy_method()
+        if FooComparator.should_check_experiment(callsite):
+            experimental_data = new_fast_risky_method()
+            data = FooComparator.check_and_choose(
+                control_data,
+                experimental_data,
+                callsite,
+                is_experimental_data_nullish=len(experimental_data) == 0,
+                reasonable_match_comparator=lambda ctl, exp: exp.issubset(ctl)
+            )
+        else:
+            data = control_data
     ```
     """
 
-    # This is your rollout, which determines your option names and which you can filter
-    # the DataDog dashboards to show.
+    # This identifies your overall rollout, and is used in option names and metrics/log tagging
     ROLLOUT_NAME: str
 
     @classmethod
     def _should_run_experiment_option(cls) -> str:
         """
-        This is the high-level eval rollout option. If this option is disabled, the
-        should_check_experiment function will return False.
+        This is the high-level experiment rollout option. If this option is disabled (the default),
+        the `should_check_experiment` function will return False.
         """
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.should_eval_experimental"
 
     @classmethod
     def _callsite_experiment_blocklist_option(cls) -> str:
         """
-        This is the callsite-level eval rollout option. If the option contains a callsite,
-        the should_check_experiment function will return False. (This is useful if you see
-        one callsite in particular start throwing.)
+        This is the callsite-level experimemt rollout option. If the option value contains a
+        callsite, the `should_check_experiment` function will return False. (This is useful if you
+        see one callsite in particular start throwing.) Defaults to an empty list.
         """
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.eval_callsite_blocklist"
 
     @classmethod
     def _callsite_use_experimental_data_allowlist_option(cls) -> str:
         """
-        This is the callsite-level use-experimental-path rollout option. If the option
-        contains a callsite, then that callsite will use the experimental-path data.
-        This should generally only be used once you've determined that there is a high
-        rate of partial- or exact- match at the callsite.
+        This is the callsite-level use-experimental-path rollout option. If the option value
+        contains a callsite, then that callsite will use the experimental-path data. This should
+        generally only be used once you've determined that there is a high rate of partial- or
+        exact- match at the callsite. Defaults to an empty list.
         """
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.use_experimental_data_callsite_allowlist"
 
     @classmethod
     def _experiment_sample_rate_option(cls) -> str:
         """
-        This is the sample rate for evaluating the experimental branch. When set to a value
-        less than 1.0, only that percentage of requests will actually perform the double-read.
-        This is useful for limiting latency impact on high-traffic callsites while still
-        collecting representative metrics. Default is 1.0 (100% of requests are evaluated).
+        This is the sample rate for evaluating the experimental branch. When set to a value less
+        than 1.0, only that percentage of requests will actually evaluate both branches. This is
+        useful for limiting latency impact on high-traffic callsites while still collecting
+        representative metrics. Default is 1.0 (100% of requests are evaluated).
         """
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.eval_experimental_sample_rate"
 
     @classmethod
     def _callsite_mismatch_log_allowlist_option(cls) -> str:
         """
-        Controls which callsites emit structured mismatch logs. Add a callsite
-        string to enable logging for it, or ``"*"`` to enable for all callsites.
+        Controls which callsites emit structured mismatch logs. Add a callsite identifier to enable
+        logging for it, or set the option to `["*"]` to enable logging for all callsites. Defaults
+        to an empty list (no mismatch logging).
         """
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.mismatch_log_callsite_allowlist"
 
@@ -193,8 +209,8 @@ class SafeRolloutComparator:
     @classmethod
     def should_check_experiment(cls, callsite: str) -> bool:
         """
-        This function should control whether you evaluate your experimental branch at
-        all. Useful for rolling out by region or blocklisting callsites that throw.
+        This function controls whether you evaluate your experimental branch at all. Useful for
+        rolling out by region or blocklisting callsites that throw.
 
         The check includes:
         1. Global eval option must be enabled
@@ -213,11 +229,12 @@ class SafeRolloutComparator:
     @classmethod
     def should_use_experimental_data(cls, callsite: str) -> bool:
         """
-        This function should control whether you use the result of your experimental
-        data. Useful for allowlisting known-safe callsites.
-        If you are transitioning from an existing, intended-to-be equivalent dataset,
-        you should instead use check_and_choose (which standardizes the choice logic
-        and has better logging).
+        This function controls whether you use the result of your experimental data. Useful for
+        allowlisting known-safe callsites.
+
+        Note: If you are transitioning from an existing, intended-to-be-equivalent dataset, you
+        should instead use `check_and_choose` (which has this check built in and has better
+        logging).
         """
         use_experimental_data = callsite in options.get(
             cls._callsite_use_experimental_data_allowlist_option()
@@ -245,25 +262,24 @@ class SafeRolloutComparator:
         data_serializer: Callable[[TData], Any] | None = None,
     ) -> TData:
         """
-        This function does two things.
-        First, it compares control & experimental data and logs info to DataDog.
-        Second, it determines which of the inputs should be returned & used downstream.
+        This function does two things:
+        - First, it compares control & experimental data and logs info to DataDog.
+        - Second, it determines which of the inputs should be returned & used downstream.
 
         Inputs:
         * control_data: Some data from the control branch (e.g. dict[str, str])
         * experimental_data: Some data from the experimental branch (of same type as control)
-        * callsite: A unique string for each place that uses this class. Should be the
-            same as passed to should_check_experiment.
-        * is_null_result: Whether the result is a "null result" (e.g. empty array). This
-            helps to determine whether a "match" is significant.
-        * reasonable_match_comparator: Optional predicate for semantic correctness
-            (e.g. subset semantics with retention gaps), returning True if the read is
-            "reasonable" and False otherwise. An example might be checking whether the
-            experimental data is a subset of the control data (useful in case of migrating
-            something where you don't yet have full retention in the experimental branch).
+        * callsite: A unique string identifying place that uses this class. Should be the same as
+            what's passed to `should_check_experiment`.
+        * is_experimental_data_nullish: Whether the result is a "null result" (e.g. empty array).
+            This helps to determine whether a "match" is significant.
+        * reasonable_match_comparator: Optional predicate for semantic correctness, returning True
+            if the data is "reasonably the same" and False otherwise. An example might be checking
+            whether the experimental data is a subset of the control data (useful in case of
+            migrating something where you don't yet have full retention in the experimental branch).
         * debug_context: Optional structured metadata included on mismatch logs.
-        * data_serializer: Optional serializer for control/experimental payloads in
-            logs. Defaults to `_default_serialize_for_log`.
+        * data_serializer: Optional serializer for control/experimental payloads in logs. Defaults
+            to `_default_serialize_for_log`.
         """
         use_experimental_data = cls.should_use_experimental_data(callsite)
         is_exact_match = control_data == experimental_data
@@ -336,14 +352,15 @@ class SafeRolloutComparator:
         data_serializer: Callable[[TData], Any] | None = None,
     ) -> TData:
         """
-        This method is essentially the same as check_and_choose, but captures timing
-        information around the control/experimental branches.
-
-        This information is captured with Sentry spans, not in Datadog.
+        This method is a wrapper for `check_and_choose` which also captures timing information for
+        the control/experimental branches. To enable that, instead of taking the control and
+        experimental values, it instead takes callbacks which calculate them. It also takes a
+        callback for determining if the experimental result is nullish, rather than a boolean. All
+        other parameters match those of `check_and_choose`.
         """
+        # Insurance - this should already have been checked by the caller
         if not cls.should_check_experiment(callsite):
-            # Don't bother collecting data in the case where we're only evaluating the
-            # control branch.
+            # Don't bother collecting data if we're only evaluating the control branch
             return control_data_func()
 
         with metrics.timer(

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -163,7 +163,7 @@ class SafeRolloutComparator:
         *,
         callsite: str,
         use_experimental: bool,
-        exact_match: bool,
+        is_exact_match: bool,
         is_reasonable_match: bool | None,
         is_experimental_data_a_null_result: bool | None,
         control_data: TData,
@@ -182,7 +182,7 @@ class SafeRolloutComparator:
                 "rollout_name": cls.ROLLOUT_NAME,
                 "callsite": callsite,
                 "source_of_truth": ("experimental" if use_experimental else "control"),
-                "exact_match": exact_match,
+                "exact_match": is_exact_match,
                 "reasonable_match": is_reasonable_match,
                 "is_null_result": is_experimental_data_a_null_result,
                 "debug_context": trim(cls._default_serialize_for_log(debug_context)),
@@ -265,14 +265,14 @@ class SafeRolloutComparator:
             logs. Defaults to `_default_serialize_for_log`.
         """
         use_experimental = cls.should_use_experiment(callsite)
-        exact_match = control_data == experimental_data
+        is_exact_match = control_data == experimental_data
         is_reasonable_match: bool | None = None
 
         # Part 1: Compare results, log debug info, and emit metrics
         tags: dict[str, str] = {
             "rollout_name": cls.ROLLOUT_NAME,
             "callsite": callsite,
-            "exact_match": str(exact_match),
+            "exact_match": str(is_exact_match),
             "source_of_truth": ("experimental" if use_experimental else "control"),
         }
 
@@ -294,14 +294,14 @@ class SafeRolloutComparator:
         # Log mismatch only for true mismatches: when a reasonable comparator
         # exists, only log if it returned False; otherwise log on exact mismatch.
         has_mismatch = is_reasonable_match is False or (
-            is_reasonable_match is None and exact_match is False
+            is_reasonable_match is None and is_exact_match is False
         )
         if has_mismatch:
             try:
                 cls._maybe_log_mismatch(
                     callsite=callsite,
                     use_experimental=use_experimental,
-                    exact_match=exact_match,
+                    is_exact_match=is_exact_match,
                     is_reasonable_match=is_reasonable_match,
                     is_experimental_data_a_null_result=is_experimental_data_a_null_result,
                     control_data=control_data,

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -162,7 +162,7 @@ class SafeRolloutComparator:
         cls,
         *,
         callsite: str,
-        use_experimental: bool,
+        use_experimental_data: bool,
         is_exact_match: bool,
         is_reasonable_match: bool | None,
         is_experimental_data_nullish: bool | None,
@@ -181,7 +181,7 @@ class SafeRolloutComparator:
             extra={
                 "rollout_name": cls.ROLLOUT_NAME,
                 "callsite": callsite,
-                "source_of_truth": ("experimental" if use_experimental else "control"),
+                "source_of_truth": ("experimental" if use_experimental_data else "control"),
                 "exact_match": is_exact_match,
                 "reasonable_match": is_reasonable_match,
                 "is_null_result": is_experimental_data_nullish,
@@ -220,17 +220,17 @@ class SafeRolloutComparator:
         you should instead use check_and_choose (which standardizes the choice logic
         and has better logging).
         """
-        use_experimental = callsite in options.get(cls._callsite_allowlist_option_name())
+        use_experimental_data = callsite in options.get(cls._callsite_allowlist_option_name())
         tags: dict[str, str] = {
             "rollout_name": cls.ROLLOUT_NAME,
             "callsite": callsite,
-            "use_experimental": ("true" if use_experimental else "false"),
+            "use_experimental": ("true" if use_experimental_data else "false"),
         }
         metrics.incr(
             "SafeRolloutComparator.should_use_experiment",
             tags=tags,
         )
-        return use_experimental
+        return use_experimental_data
 
     @classmethod
     def check_and_choose(
@@ -264,7 +264,7 @@ class SafeRolloutComparator:
         * data_serializer: Optional serializer for control/experimental payloads in
             logs. Defaults to `_default_serialize_for_log`.
         """
-        use_experimental = cls.should_use_experimental_data(callsite)
+        use_experimental_data = cls.should_use_experimental_data(callsite)
         is_exact_match = control_data == experimental_data
         is_reasonable_match: bool | None = None
 
@@ -273,7 +273,7 @@ class SafeRolloutComparator:
             "rollout_name": cls.ROLLOUT_NAME,
             "callsite": callsite,
             "exact_match": str(is_exact_match),
-            "source_of_truth": ("experimental" if use_experimental else "control"),
+            "source_of_truth": ("experimental" if use_experimental_data else "control"),
         }
 
         if is_experimental_data_nullish is not None:
@@ -300,7 +300,7 @@ class SafeRolloutComparator:
             try:
                 cls._maybe_log_mismatch(
                     callsite=callsite,
-                    use_experimental=use_experimental,
+                    use_experimental_data=use_experimental_data,
                     is_exact_match=is_exact_match,
                     is_reasonable_match=is_reasonable_match,
                     is_experimental_data_nullish=is_experimental_data_nullish,
@@ -321,7 +321,7 @@ class SafeRolloutComparator:
         )
 
         # Part 2: determine which data to return
-        return experimental_data if use_experimental else control_data
+        return experimental_data if use_experimental_data else control_data
 
     @classmethod
     def check_and_choose_with_timings(

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -164,7 +164,7 @@ class SafeRolloutComparator:
         callsite: str,
         use_experimental: bool,
         exact_match: bool,
-        reasonable_match: bool | None,
+        is_reasonable_match: bool | None,
         is_experimental_data_a_null_result: bool | None,
         control_data: TData,
         experimental_data: TData,
@@ -183,7 +183,7 @@ class SafeRolloutComparator:
                 "callsite": callsite,
                 "source_of_truth": ("experimental" if use_experimental else "control"),
                 "exact_match": exact_match,
-                "reasonable_match": reasonable_match,
+                "reasonable_match": is_reasonable_match,
                 "is_null_result": is_experimental_data_a_null_result,
                 "debug_context": trim(cls._default_serialize_for_log(debug_context)),
                 "control_data_raw": trim(serialize(control_data)),
@@ -266,7 +266,7 @@ class SafeRolloutComparator:
         """
         use_experimental = cls.should_use_experiment(callsite)
         exact_match = control_data == experimental_data
-        reasonable_match: bool | None = None
+        is_reasonable_match: bool | None = None
 
         # Part 1: Compare results, log debug info, and emit metrics
         tags: dict[str, str] = {
@@ -281,20 +281,20 @@ class SafeRolloutComparator:
 
         if reasonable_match_comparator is not None:
             try:
-                reasonable_match = reasonable_match_comparator(control_data, experimental_data)
+                is_reasonable_match = reasonable_match_comparator(control_data, experimental_data)
             except Exception:
                 logger.exception(
                     "saferollout.comparator_error",
                     extra={"rollout_name": cls.ROLLOUT_NAME, "callsite": callsite},
                 )
-                reasonable_match = None
+                is_reasonable_match = None
             else:
-                tags["reasonable_match"] = str(reasonable_match)
+                tags["reasonable_match"] = str(is_reasonable_match)
 
         # Log mismatch only for true mismatches: when a reasonable comparator
         # exists, only log if it returned False; otherwise log on exact mismatch.
-        has_mismatch = reasonable_match is False or (
-            reasonable_match is None and exact_match is False
+        has_mismatch = is_reasonable_match is False or (
+            is_reasonable_match is None and exact_match is False
         )
         if has_mismatch:
             try:
@@ -302,7 +302,7 @@ class SafeRolloutComparator:
                     callsite=callsite,
                     use_experimental=use_experimental,
                     exact_match=exact_match,
-                    reasonable_match=reasonable_match,
+                    is_reasonable_match=is_reasonable_match,
                     is_experimental_data_a_null_result=is_experimental_data_a_null_result,
                     control_data=control_data,
                     experimental_data=experimental_data,

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -327,7 +327,7 @@ class SafeRolloutComparator:
     def check_and_choose_with_timings(
         cls,
         control_data_func: Callable[[], TData],
-        experimental_thunk: Callable[[], TData],
+        experimental_data_func: Callable[[], TData],
         callsite: str,
         null_result_determiner: Callable[[TData], bool] | None = None,
         reasonable_match_comparator: Callable[[TData, TData], bool] | None = None,
@@ -363,7 +363,7 @@ class SafeRolloutComparator:
                 "branch": "experimental",
             },
         ):
-            experimental_data = experimental_thunk()
+            experimental_data = experimental_data_func()
 
         is_experimental_data_nullish = None
         if null_result_determiner is not None:

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -61,7 +61,7 @@ class SafeRolloutComparator:
     ROLLOUT_NAME: str
 
     @classmethod
-    def _should_eval_option_name(cls) -> str:
+    def _should_run_experiment_option(cls) -> str:
         """
         This is the high-level eval rollout option. If this option is disabled, the
         should_check_experiment function will return False.
@@ -110,7 +110,7 @@ class SafeRolloutComparator:
         from sentry.options import register
 
         register(
-            cls._should_eval_option_name(),
+            cls._should_run_experiment_option(),
             type=Bool,
             default=False,
             flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
@@ -202,7 +202,7 @@ class SafeRolloutComparator:
         2. Callsite must not be in the blocklist
         3. Random sampling based on the sample_rate option (default 1.0 = 100%)
         """
-        if not options.get(cls._should_eval_option_name()):
+        if not options.get(cls._should_run_experiment_option()):
             return False
 
         if callsite in options.get(cls._callsite_experiment_blocklist_option()):

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -326,7 +326,7 @@ class SafeRolloutComparator:
     @classmethod
     def check_and_choose_with_timings(
         cls,
-        control_thunk: Callable[[], TData],
+        control_data_func: Callable[[], TData],
         experimental_thunk: Callable[[], TData],
         callsite: str,
         null_result_determiner: Callable[[TData], bool] | None = None,
@@ -343,7 +343,7 @@ class SafeRolloutComparator:
         if not cls.should_check_experiment(callsite):
             # Don't bother collecting data in the case where we're only evaluating the
             # control branch.
-            return control_thunk()
+            return control_data_func()
 
         with metrics.timer(
             "SafeRolloutComparator.check_and_choose_with_timings",
@@ -353,7 +353,7 @@ class SafeRolloutComparator:
                 "branch": "control",
             },
         ):
-            control_data = control_thunk()
+            control_data = control_data_func()
 
         with metrics.timer(
             "SafeRolloutComparator.check_and_choose_with_timings",

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -590,7 +590,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
 
         url = f"/api/0/issues/{event_1.group.id}/events/"
 
-        with self.options({EAPOccurrencesComparator._should_eval_option_name(): True}):
+        with self.options({EAPOccurrencesComparator._should_run_experiment_option(): True}):
             response = self.do_request(url)
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -8,7 +8,7 @@ from urllib3.exceptions import ReadTimeoutError
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.models.group import Group
-from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.search.eap.occurrences.rollout_utils import EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
@@ -590,7 +590,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
 
         url = f"/api/0/issues/{event_1.group.id}/events/"
 
-        with self.options({EAPOccurrencesComparator._should_run_experiment_option(): True}):
+        with self.options({EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION: True}):
             response = self.do_request(url)
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/services/eventstore/snuba/test_backend.py
+++ b/tests/sentry/services/eventstore/snuba/test_backend.py
@@ -1051,7 +1051,9 @@ class EAPEventStorageTest(TestCase, SnubaTestCase, OccurrenceTestCase):
         with self.options(
             {
                 EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_allowlist_option_name(): [callsite],
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
+                    callsite
+                ],
             }
         ):
             events = self.eventstore.get_events(

--- a/tests/sentry/services/eventstore/snuba/test_backend.py
+++ b/tests/sentry/services/eventstore/snuba/test_backend.py
@@ -1050,7 +1050,7 @@ class EAPEventStorageTest(TestCase, SnubaTestCase, OccurrenceTestCase):
 
         with self.options(
             {
-                EAPOccurrencesComparator._should_eval_option_name(): True,
+                EAPOccurrencesComparator._should_run_experiment_option(): True,
                 EAPOccurrencesComparator._callsite_allowlist_option_name(): [callsite],
             }
         ):

--- a/tests/sentry/services/eventstore/snuba/test_backend.py
+++ b/tests/sentry/services/eventstore/snuba/test_backend.py
@@ -10,7 +10,10 @@ from sentry.search.eap.occurrences.query_utils import (
     build_group_id_in_filter,
     build_keyset_pagination_filter,
 )
-from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.search.eap.occurrences.rollout_utils import (
+    EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION,
+    EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION,
+)
 from sentry.search.eap.rpc_utils import and_trace_item_filters
 from sentry.services.eventstore.base import Filter
 from sentry.services.eventstore.models import Event
@@ -1050,10 +1053,8 @@ class EAPEventStorageTest(TestCase, SnubaTestCase, OccurrenceTestCase):
 
         with self.options(
             {
-                EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
-                    callsite
-                ],
+                EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: [callsite],
             }
         ):
             events = self.eventstore.get_events(

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -94,19 +94,19 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {TestRolloutComparator._mismatch_log_callsite_allowlist_option_name(): []}
         ):
-            assert TestRolloutComparator.should_log_mismatch("callsite") is False
+            assert TestRolloutComparator._should_log_mismatch("callsite") is False
 
         with override_options(
             {TestRolloutComparator._mismatch_log_callsite_allowlist_option_name(): ["callsite"]}
         ):
-            assert TestRolloutComparator.should_log_mismatch("callsite") is True
-            assert TestRolloutComparator.should_log_mismatch("other") is False
+            assert TestRolloutComparator._should_log_mismatch("callsite") is True
+            assert TestRolloutComparator._should_log_mismatch("other") is False
 
         with override_options(
             {TestRolloutComparator._mismatch_log_callsite_allowlist_option_name(): ["*"]}
         ):
-            assert TestRolloutComparator.should_log_mismatch("callsite") is True
-            assert TestRolloutComparator.should_log_mismatch("other") is True
+            assert TestRolloutComparator._should_log_mismatch("callsite") is True
+            assert TestRolloutComparator._should_log_mismatch("other") is True
 
     @patch("sentry.utils.rollout.SafeRolloutComparator.check_and_choose")
     def test_check_and_choose_with_timings_forwards_debug_args(

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -124,7 +124,7 @@ class SafeRolloutComparatorTestCase(TestCase):
         ):
             TestRolloutComparator.check_and_choose_with_timings(
                 control_data_func=lambda: "control",
-                experimental_thunk=lambda: "experimental",
+                experimental_data_func=lambda: "experimental",
                 callsite="test_callsite",
                 debug_context={"x": "y"},
                 data_serializer=serializer,

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -19,7 +19,9 @@ class SafeRolloutComparatorTestCase(TestCase):
         option_names = [o.name for o in all_options()]
 
         assert TestRolloutComparator._should_run_experiment_option() in option_names
-        assert TestRolloutComparator._callsite_allowlist_option_name() in option_names
+        assert (
+            TestRolloutComparator._callsite_use_experimental_data_allowlist_option() in option_names
+        )
         assert TestRolloutComparator._callsite_experiment_blocklist_option() in option_names
         assert TestRolloutComparator._sample_rate_option_name() in option_names
         assert TestRolloutComparator._mismatch_log_callsite_allowlist_option_name() in option_names
@@ -40,7 +42,9 @@ class SafeRolloutComparatorTestCase(TestCase):
 
         with override_options(
             {
-                TestRolloutComparator._callsite_allowlist_option_name(): ["test_allowed"],
+                TestRolloutComparator._callsite_use_experimental_data_allowlist_option(): [
+                    "test_allowed"
+                ],
                 TestRolloutComparator._mismatch_log_callsite_allowlist_option_name(): [],
             }
         ):

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -20,7 +20,7 @@ class SafeRolloutComparatorTestCase(TestCase):
 
         assert TestRolloutComparator._should_eval_option_name() in option_names
         assert TestRolloutComparator._callsite_allowlist_option_name() in option_names
-        assert TestRolloutComparator._callsite_blocklist_option_name() in option_names
+        assert TestRolloutComparator._callsite_experiment_blocklist_option() in option_names
         assert TestRolloutComparator._sample_rate_option_name() in option_names
         assert TestRolloutComparator._mismatch_log_callsite_allowlist_option_name() in option_names
 
@@ -31,7 +31,7 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {
                 TestRolloutComparator._should_eval_option_name(): True,
-                TestRolloutComparator._callsite_blocklist_option_name(): ["test_blocked"],
+                TestRolloutComparator._callsite_experiment_blocklist_option(): ["test_blocked"],
                 TestRolloutComparator._sample_rate_option_name(): 1.0,
             }
         ):
@@ -51,7 +51,7 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {
                 TestRolloutComparator._should_eval_option_name(): True,
-                TestRolloutComparator._callsite_blocklist_option_name(): [],
+                TestRolloutComparator._callsite_experiment_blocklist_option(): [],
                 TestRolloutComparator._sample_rate_option_name(): 0.5,
             }
         ):
@@ -71,7 +71,7 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {
                 TestRolloutComparator._should_eval_option_name(): True,
-                TestRolloutComparator._callsite_blocklist_option_name(): ["test_blocked"],
+                TestRolloutComparator._callsite_experiment_blocklist_option(): ["test_blocked"],
                 TestRolloutComparator._sample_rate_option_name(): 1.0,
             }
         ):
@@ -84,7 +84,7 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {
                 TestRolloutComparator._should_eval_option_name(): False,
-                TestRolloutComparator._callsite_blocklist_option_name(): [],
+                TestRolloutComparator._callsite_experiment_blocklist_option(): [],
                 TestRolloutComparator._sample_rate_option_name(): 1.0,
             }
         ):
@@ -118,7 +118,7 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {
                 TestRolloutComparator._should_eval_option_name(): True,
-                TestRolloutComparator._callsite_blocklist_option_name(): [],
+                TestRolloutComparator._callsite_experiment_blocklist_option(): [],
                 TestRolloutComparator._sample_rate_option_name(): 1.0,
             }
         ):

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -123,7 +123,7 @@ class SafeRolloutComparatorTestCase(TestCase):
             }
         ):
             TestRolloutComparator.check_and_choose_with_timings(
-                control_thunk=lambda: "control",
+                control_data_func=lambda: "control",
                 experimental_thunk=lambda: "experimental",
                 callsite="test_callsite",
                 debug_context={"x": "y"},

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -10,6 +10,19 @@ class TestRolloutComparator(SafeRolloutComparator):
     ROLLOUT_NAME = "test_rollout"
 
 
+TEST_SHOULD_RUN_EXPERIMENT_OPTION = TestRolloutComparator._should_run_experiment_option()
+TEST_EXPERIMENT_SAMPLE_RATE_OPTION = TestRolloutComparator._experiment_sample_rate_option()
+TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION = (
+    TestRolloutComparator._callsite_use_experimental_data_allowlist_option()
+)
+TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION = (
+    TestRolloutComparator._callsite_experiment_blocklist_option()
+)
+TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION = (
+    TestRolloutComparator._callsite_mismatch_log_allowlist_option()
+)
+
+
 class SafeRolloutComparatorTestCase(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -18,23 +31,21 @@ class SafeRolloutComparatorTestCase(TestCase):
     def test_options_registered(self) -> None:
         option_names = [o.name for o in all_options()]
 
-        assert TestRolloutComparator._should_run_experiment_option() in option_names
-        assert (
-            TestRolloutComparator._callsite_use_experimental_data_allowlist_option() in option_names
-        )
-        assert TestRolloutComparator._callsite_experiment_blocklist_option() in option_names
-        assert TestRolloutComparator._experiment_sample_rate_option() in option_names
-        assert TestRolloutComparator._callsite_mismatch_log_allowlist_option() in option_names
+        assert TEST_SHOULD_RUN_EXPERIMENT_OPTION in option_names
+        assert TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION in option_names
+        assert TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION in option_names
+        assert TEST_EXPERIMENT_SAMPLE_RATE_OPTION in option_names
+        assert TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION in option_names
 
     def test_return_as_expected(self) -> None:
-        with override_options({TestRolloutComparator._should_run_experiment_option(): False}):
+        with override_options({TEST_SHOULD_RUN_EXPERIMENT_OPTION: False}):
             assert TestRolloutComparator.should_check_experiment("test_1") is False
 
         with override_options(
             {
-                TestRolloutComparator._should_run_experiment_option(): True,
-                TestRolloutComparator._callsite_experiment_blocklist_option(): ["test_blocked"],
-                TestRolloutComparator._experiment_sample_rate_option(): 1.0,
+                TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: ["test_blocked"],
+                TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
             }
         ):
             assert TestRolloutComparator.should_check_experiment("test_2") is True
@@ -42,10 +53,8 @@ class SafeRolloutComparatorTestCase(TestCase):
 
         with override_options(
             {
-                TestRolloutComparator._callsite_use_experimental_data_allowlist_option(): [
-                    "test_allowed"
-                ],
-                TestRolloutComparator._callsite_mismatch_log_allowlist_option(): [],
+                TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: ["test_allowed"],
+                TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION: [],
             }
         ):
             assert TestRolloutComparator.check_and_choose("ctl", "exp", "test_3") == "ctl"
@@ -54,9 +63,9 @@ class SafeRolloutComparatorTestCase(TestCase):
     def test_eval_experimental_sample_rate(self) -> None:
         with override_options(
             {
-                TestRolloutComparator._should_run_experiment_option(): True,
-                TestRolloutComparator._callsite_experiment_blocklist_option(): [],
-                TestRolloutComparator._experiment_sample_rate_option(): 0.5,
+                TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
+                TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 0.5,
             }
         ):
             with patch("sentry.utils.rollout.random.random", return_value=0.3):
@@ -74,9 +83,9 @@ class SafeRolloutComparatorTestCase(TestCase):
     def test_eval_experimental_respects_blocklist(self) -> None:
         with override_options(
             {
-                TestRolloutComparator._should_run_experiment_option(): True,
-                TestRolloutComparator._callsite_experiment_blocklist_option(): ["test_blocked"],
-                TestRolloutComparator._experiment_sample_rate_option(): 1.0,
+                TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: ["test_blocked"],
+                TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
             }
         ):
             # Even with 100% sample rate, blocklisted callsites should be blocked
@@ -87,28 +96,22 @@ class SafeRolloutComparatorTestCase(TestCase):
     def test_eval_experimental_sample_rate_respects_eval_disabled(self) -> None:
         with override_options(
             {
-                TestRolloutComparator._should_run_experiment_option(): False,
-                TestRolloutComparator._callsite_experiment_blocklist_option(): [],
-                TestRolloutComparator._experiment_sample_rate_option(): 1.0,
+                TEST_SHOULD_RUN_EXPERIMENT_OPTION: False,
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
+                TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
             }
         ):
             assert TestRolloutComparator.should_check_experiment("test_disabled") is False
 
     def test_should_log_mismatch_allowlist(self) -> None:
-        with override_options(
-            {TestRolloutComparator._callsite_mismatch_log_allowlist_option(): []}
-        ):
+        with override_options({TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION: []}):
             assert TestRolloutComparator._should_log_mismatch("callsite") is False
 
-        with override_options(
-            {TestRolloutComparator._callsite_mismatch_log_allowlist_option(): ["callsite"]}
-        ):
+        with override_options({TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION: ["callsite"]}):
             assert TestRolloutComparator._should_log_mismatch("callsite") is True
             assert TestRolloutComparator._should_log_mismatch("other") is False
 
-        with override_options(
-            {TestRolloutComparator._callsite_mismatch_log_allowlist_option(): ["*"]}
-        ):
+        with override_options({TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION: ["*"]}):
             assert TestRolloutComparator._should_log_mismatch("callsite") is True
             assert TestRolloutComparator._should_log_mismatch("other") is True
 
@@ -121,9 +124,9 @@ class SafeRolloutComparatorTestCase(TestCase):
 
         with override_options(
             {
-                TestRolloutComparator._should_run_experiment_option(): True,
-                TestRolloutComparator._callsite_experiment_blocklist_option(): [],
-                TestRolloutComparator._experiment_sample_rate_option(): 1.0,
+                TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
+                TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
             }
         ):
             TestRolloutComparator.check_and_choose_with_timings(

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -24,7 +24,7 @@ class SafeRolloutComparatorTestCase(TestCase):
         )
         assert TestRolloutComparator._callsite_experiment_blocklist_option() in option_names
         assert TestRolloutComparator._experiment_sample_rate_option() in option_names
-        assert TestRolloutComparator._mismatch_log_callsite_allowlist_option_name() in option_names
+        assert TestRolloutComparator._callsite_mismatch_log_allowlist_option() in option_names
 
     def test_return_as_expected(self) -> None:
         with override_options({TestRolloutComparator._should_run_experiment_option(): False}):
@@ -45,7 +45,7 @@ class SafeRolloutComparatorTestCase(TestCase):
                 TestRolloutComparator._callsite_use_experimental_data_allowlist_option(): [
                     "test_allowed"
                 ],
-                TestRolloutComparator._mismatch_log_callsite_allowlist_option_name(): [],
+                TestRolloutComparator._callsite_mismatch_log_allowlist_option(): [],
             }
         ):
             assert TestRolloutComparator.check_and_choose("ctl", "exp", "test_3") == "ctl"
@@ -96,18 +96,18 @@ class SafeRolloutComparatorTestCase(TestCase):
 
     def test_should_log_mismatch_allowlist(self) -> None:
         with override_options(
-            {TestRolloutComparator._mismatch_log_callsite_allowlist_option_name(): []}
+            {TestRolloutComparator._callsite_mismatch_log_allowlist_option(): []}
         ):
             assert TestRolloutComparator._should_log_mismatch("callsite") is False
 
         with override_options(
-            {TestRolloutComparator._mismatch_log_callsite_allowlist_option_name(): ["callsite"]}
+            {TestRolloutComparator._callsite_mismatch_log_allowlist_option(): ["callsite"]}
         ):
             assert TestRolloutComparator._should_log_mismatch("callsite") is True
             assert TestRolloutComparator._should_log_mismatch("other") is False
 
         with override_options(
-            {TestRolloutComparator._mismatch_log_callsite_allowlist_option_name(): ["*"]}
+            {TestRolloutComparator._callsite_mismatch_log_allowlist_option(): ["*"]}
         ):
             assert TestRolloutComparator._should_log_mismatch("callsite") is True
             assert TestRolloutComparator._should_log_mismatch("other") is True

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -23,7 +23,7 @@ class SafeRolloutComparatorTestCase(TestCase):
             TestRolloutComparator._callsite_use_experimental_data_allowlist_option() in option_names
         )
         assert TestRolloutComparator._callsite_experiment_blocklist_option() in option_names
-        assert TestRolloutComparator._sample_rate_option_name() in option_names
+        assert TestRolloutComparator._experiment_sample_rate_option() in option_names
         assert TestRolloutComparator._mismatch_log_callsite_allowlist_option_name() in option_names
 
     def test_return_as_expected(self) -> None:
@@ -34,7 +34,7 @@ class SafeRolloutComparatorTestCase(TestCase):
             {
                 TestRolloutComparator._should_run_experiment_option(): True,
                 TestRolloutComparator._callsite_experiment_blocklist_option(): ["test_blocked"],
-                TestRolloutComparator._sample_rate_option_name(): 1.0,
+                TestRolloutComparator._experiment_sample_rate_option(): 1.0,
             }
         ):
             assert TestRolloutComparator.should_check_experiment("test_2") is True
@@ -56,7 +56,7 @@ class SafeRolloutComparatorTestCase(TestCase):
             {
                 TestRolloutComparator._should_run_experiment_option(): True,
                 TestRolloutComparator._callsite_experiment_blocklist_option(): [],
-                TestRolloutComparator._sample_rate_option_name(): 0.5,
+                TestRolloutComparator._experiment_sample_rate_option(): 0.5,
             }
         ):
             with patch("sentry.utils.rollout.random.random", return_value=0.3):
@@ -76,7 +76,7 @@ class SafeRolloutComparatorTestCase(TestCase):
             {
                 TestRolloutComparator._should_run_experiment_option(): True,
                 TestRolloutComparator._callsite_experiment_blocklist_option(): ["test_blocked"],
-                TestRolloutComparator._sample_rate_option_name(): 1.0,
+                TestRolloutComparator._experiment_sample_rate_option(): 1.0,
             }
         ):
             # Even with 100% sample rate, blocklisted callsites should be blocked
@@ -89,7 +89,7 @@ class SafeRolloutComparatorTestCase(TestCase):
             {
                 TestRolloutComparator._should_run_experiment_option(): False,
                 TestRolloutComparator._callsite_experiment_blocklist_option(): [],
-                TestRolloutComparator._sample_rate_option_name(): 1.0,
+                TestRolloutComparator._experiment_sample_rate_option(): 1.0,
             }
         ):
             assert TestRolloutComparator.should_check_experiment("test_disabled") is False
@@ -123,7 +123,7 @@ class SafeRolloutComparatorTestCase(TestCase):
             {
                 TestRolloutComparator._should_run_experiment_option(): True,
                 TestRolloutComparator._callsite_experiment_blocklist_option(): [],
-                TestRolloutComparator._sample_rate_option_name(): 1.0,
+                TestRolloutComparator._experiment_sample_rate_option(): 1.0,
             }
         ):
             TestRolloutComparator.check_and_choose_with_timings(

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -26,7 +26,8 @@ TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION = (
 class SafeRolloutComparatorTestCase(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.comp = TestRolloutComparator()
+        # We need to instantiate the comparator class in order for the options to be registered
+        TestRolloutComparator()
 
     def test_options_registered(self) -> None:
         option_names = [o.name for o in all_options()]

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -18,19 +18,19 @@ class SafeRolloutComparatorTestCase(TestCase):
     def test_options_registered(self) -> None:
         option_names = [o.name for o in all_options()]
 
-        assert TestRolloutComparator._should_eval_option_name() in option_names
+        assert TestRolloutComparator._should_run_experiment_option() in option_names
         assert TestRolloutComparator._callsite_allowlist_option_name() in option_names
         assert TestRolloutComparator._callsite_experiment_blocklist_option() in option_names
         assert TestRolloutComparator._sample_rate_option_name() in option_names
         assert TestRolloutComparator._mismatch_log_callsite_allowlist_option_name() in option_names
 
     def test_return_as_expected(self) -> None:
-        with override_options({TestRolloutComparator._should_eval_option_name(): False}):
+        with override_options({TestRolloutComparator._should_run_experiment_option(): False}):
             assert TestRolloutComparator.should_check_experiment("test_1") is False
 
         with override_options(
             {
-                TestRolloutComparator._should_eval_option_name(): True,
+                TestRolloutComparator._should_run_experiment_option(): True,
                 TestRolloutComparator._callsite_experiment_blocklist_option(): ["test_blocked"],
                 TestRolloutComparator._sample_rate_option_name(): 1.0,
             }
@@ -50,7 +50,7 @@ class SafeRolloutComparatorTestCase(TestCase):
     def test_eval_experimental_sample_rate(self) -> None:
         with override_options(
             {
-                TestRolloutComparator._should_eval_option_name(): True,
+                TestRolloutComparator._should_run_experiment_option(): True,
                 TestRolloutComparator._callsite_experiment_blocklist_option(): [],
                 TestRolloutComparator._sample_rate_option_name(): 0.5,
             }
@@ -70,7 +70,7 @@ class SafeRolloutComparatorTestCase(TestCase):
     def test_eval_experimental_respects_blocklist(self) -> None:
         with override_options(
             {
-                TestRolloutComparator._should_eval_option_name(): True,
+                TestRolloutComparator._should_run_experiment_option(): True,
                 TestRolloutComparator._callsite_experiment_blocklist_option(): ["test_blocked"],
                 TestRolloutComparator._sample_rate_option_name(): 1.0,
             }
@@ -83,7 +83,7 @@ class SafeRolloutComparatorTestCase(TestCase):
     def test_eval_experimental_sample_rate_respects_eval_disabled(self) -> None:
         with override_options(
             {
-                TestRolloutComparator._should_eval_option_name(): False,
+                TestRolloutComparator._should_run_experiment_option(): False,
                 TestRolloutComparator._callsite_experiment_blocklist_option(): [],
                 TestRolloutComparator._sample_rate_option_name(): 1.0,
             }
@@ -117,7 +117,7 @@ class SafeRolloutComparatorTestCase(TestCase):
 
         with override_options(
             {
-                TestRolloutComparator._should_eval_option_name(): True,
+                TestRolloutComparator._should_run_experiment_option(): True,
                 TestRolloutComparator._callsite_experiment_blocklist_option(): [],
                 TestRolloutComparator._sample_rate_option_name(): 1.0,
             }

--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -7,7 +7,9 @@ from django.test.utils import CaptureQueriesContext
 from rest_framework.response import Response
 
 from sentry.models.group import Group
-from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.search.eap.occurrences.rollout_utils import (
+    EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION,
+)
 from sentry.testutils.cases import OccurrenceTestCase
 from sentry.testutils.helpers.datetime import before_now
 from tests.snuba.api.endpoints.test_organization_events import (
@@ -25,9 +27,7 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
 
     def request_with_feature_flag(self, payload: dict) -> Response:
         with self.options(
-            {
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): self.callsite_name
-            }
+            {EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: self.callsite_name}
         ):
             response = self.do_request({**payload, "dataset": "occurrences"})
         assert response.status_code == 200, response.content
@@ -526,9 +526,7 @@ class OrganizationEventsOccurrencesArrayQueryTest(
             "organizations:trace-item-details-array-fields": True,
         }
         with self.options(
-            {
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): self.callsite_name
-            }
+            {EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: self.callsite_name}
         ):
             response = self.do_request({**payload, "dataset": "occurrences"}, features=features)
         assert response.status_code == 200, response.content
@@ -786,9 +784,7 @@ class OrganizationEventsOccurrencesArrayQueryTest(
         expected_http_url = expected[0]["http_url"]
 
         with self.options(
-            {
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): self.callsite_name
-            }
+            {EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: self.callsite_name}
         ):
             response = self.do_request(
                 {

--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -25,7 +25,9 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
 
     def request_with_feature_flag(self, payload: dict) -> Response:
         with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+            {
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): self.callsite_name
+            }
         ):
             response = self.do_request({**payload, "dataset": "occurrences"})
         assert response.status_code == 200, response.content
@@ -524,7 +526,9 @@ class OrganizationEventsOccurrencesArrayQueryTest(
             "organizations:trace-item-details-array-fields": True,
         }
         with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+            {
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): self.callsite_name
+            }
         ):
             response = self.do_request({**payload, "dataset": "occurrences"}, features=features)
         assert response.status_code == 200, response.content
@@ -782,7 +786,9 @@ class OrganizationEventsOccurrencesArrayQueryTest(
         expected_http_url = expected[0]["http_url"]
 
         with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+            {
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): self.callsite_name
+            }
         ):
             response = self.do_request(
                 {

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
@@ -71,7 +71,9 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
         ]
         self.store_eap_items(occurrences)
         with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+            {
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): self.callsite_name
+            }
         ):
             return self._do_request(
                 data={

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
@@ -5,7 +5,9 @@ from typing import Any
 import pytest
 from django.urls import reverse
 
-from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.search.eap.occurrences.rollout_utils import (
+    EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION,
+)
 from sentry.testutils.cases import OccurrenceTestCase
 from sentry.testutils.helpers.datetime import before_now
 from tests.snuba.api.endpoints.test_organization_events import (
@@ -71,9 +73,7 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
         ]
         self.store_eap_items(occurrences)
         with self.options(
-            {
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): self.callsite_name
-            }
+            {EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: self.callsite_name}
         ):
             return self._do_request(
                 data={

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1504,7 +1504,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase, O
         with self.options(
             {
                 EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_allowlist_option_name(): [
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
                     "api.trace.load_performance_issues"
                 ],
             }
@@ -1564,7 +1564,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase, O
         with self.options(
             {
                 EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_allowlist_option_name(): [
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
                     "api.trace.query_trace_data.errors"
                 ],
             }
@@ -1699,7 +1699,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         with self.options(
             {
                 EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_allowlist_option_name(): [
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
                     "api.trace.count_performance_issues"
                 ],
             }

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1503,7 +1503,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase, O
 
         with self.options(
             {
-                EAPOccurrencesComparator._should_eval_option_name(): True,
+                EAPOccurrencesComparator._should_run_experiment_option(): True,
                 EAPOccurrencesComparator._callsite_allowlist_option_name(): [
                     "api.trace.load_performance_issues"
                 ],
@@ -1563,7 +1563,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase, O
 
         with self.options(
             {
-                EAPOccurrencesComparator._should_eval_option_name(): True,
+                EAPOccurrencesComparator._should_run_experiment_option(): True,
                 EAPOccurrencesComparator._callsite_allowlist_option_name(): [
                     "api.trace.query_trace_data.errors"
                 ],
@@ -1698,7 +1698,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         )
         with self.options(
             {
-                EAPOccurrencesComparator._should_eval_option_name(): True,
+                EAPOccurrencesComparator._should_run_experiment_option(): True,
                 EAPOccurrencesComparator._callsite_allowlist_option_name(): [
                     "api.trace.count_performance_issues"
                 ],

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -13,7 +13,10 @@ from sentry.issues.grouptype import (
 )
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
-from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.search.eap.occurrences.rollout_utils import (
+    EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION,
+    EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION,
+)
 from sentry.search.events.types import SnubaParams
 from sentry.testutils.cases import OccurrenceTestCase, TraceTestCase
 from sentry.utils.samples import load_data
@@ -1503,8 +1506,8 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase, O
 
         with self.options(
             {
-                EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
+                EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: [
                     "api.trace.load_performance_issues"
                 ],
             }
@@ -1563,8 +1566,8 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase, O
 
         with self.options(
             {
-                EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
+                EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: [
                     "api.trace.query_trace_data.errors"
                 ],
             }
@@ -1698,8 +1701,8 @@ class OrganizationEventsTraceMetaEndpointTest(
         )
         with self.options(
             {
-                EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
+                EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: [
                     "api.trace.count_performance_issues"
                 ],
             }

--- a/tests/snuba/api/endpoints/test_organization_trace_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_meta.py
@@ -115,7 +115,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         )
         with self.options(
             {
-                EAPOccurrencesComparator._should_eval_option_name(): True,
+                EAPOccurrencesComparator._should_run_experiment_option(): True,
                 EAPOccurrencesComparator._callsite_allowlist_option_name(): [
                     "api.trace.count_performance_issues"
                 ],
@@ -180,7 +180,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         )
         with self.options(
             {
-                EAPOccurrencesComparator._should_eval_option_name(): True,
+                EAPOccurrencesComparator._should_run_experiment_option(): True,
                 EAPOccurrencesComparator._callsite_allowlist_option_name(): [],
             }
         ):
@@ -212,7 +212,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         )
         with self.options(
             {
-                EAPOccurrencesComparator._should_eval_option_name(): True,
+                EAPOccurrencesComparator._should_run_experiment_option(): True,
                 EAPOccurrencesComparator._callsite_allowlist_option_name(): [
                     "api.trace.count_errors"
                 ],

--- a/tests/snuba/api/endpoints/test_organization_trace_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_meta.py
@@ -116,7 +116,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         with self.options(
             {
                 EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_allowlist_option_name(): [
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
                     "api.trace.count_performance_issues"
                 ],
             }
@@ -181,7 +181,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         with self.options(
             {
                 EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_allowlist_option_name(): [],
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [],
             }
         ):
             with self.feature(self.FEATURES):
@@ -213,7 +213,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         with self.options(
             {
                 EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_allowlist_option_name(): [
+                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
                     "api.trace.count_errors"
                 ],
             }

--- a/tests/snuba/api/endpoints/test_organization_trace_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_meta.py
@@ -3,7 +3,10 @@ from uuid import uuid4
 import pytest
 from django.urls import NoReverseMatch, reverse
 
-from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.search.eap.occurrences.rollout_utils import (
+    EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION,
+    EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION,
+)
 from sentry.testutils.cases import OccurrenceTestCase, TraceMetricsTestCase, UptimeResultEAPTestCase
 from sentry.testutils.helpers.datetime import before_now
 from tests.snuba.api.endpoints.test_organization_events_trace import (
@@ -115,8 +118,8 @@ class OrganizationEventsTraceMetaEndpointTest(
         )
         with self.options(
             {
-                EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
+                EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: [
                     "api.trace.count_performance_issues"
                 ],
             }
@@ -180,8 +183,8 @@ class OrganizationEventsTraceMetaEndpointTest(
         )
         with self.options(
             {
-                EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [],
+                EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: [],
             }
         ):
             with self.feature(self.FEATURES):
@@ -212,10 +215,8 @@ class OrganizationEventsTraceMetaEndpointTest(
         )
         with self.options(
             {
-                EAPOccurrencesComparator._should_run_experiment_option(): True,
-                EAPOccurrencesComparator._callsite_use_experimental_data_allowlist_option(): [
-                    "api.trace.count_errors"
-                ],
+                EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                EAP_OCCURRENCES_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: ["api.trace.count_errors"],
             }
         ):
             with self.feature(self.FEATURES):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -1203,7 +1203,7 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
             assert total_count == 15
 
     def test_eap_read_path(self) -> None:
-        with self.options({EAPOccurrencesComparator._should_eval_option_name(): True}):
+        with self.options({EAPOccurrencesComparator._should_run_experiment_option(): True}):
             gk = self.ts.get_group_tag_key(
                 self.proj1group1,
                 None,

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -10,7 +10,7 @@ from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.models.environment import Environment
 from sentry.models.release import Release
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment, ReleaseStages
-from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.search.eap.occurrences.rollout_utils import EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION
 from sentry.search.events.constants import (
     RELEASE_STAGE_ALIAS,
     SEMVER_ALIAS,
@@ -1203,7 +1203,7 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
             assert total_count == 15
 
     def test_eap_read_path(self) -> None:
-        with self.options({EAPOccurrencesComparator._should_run_experiment_option(): True}):
+        with self.options({EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION: True}):
             gk = self.ts.get_group_tag_key(
                 self.proj1group1,
                 None,


### PR DESCRIPTION
This makes some clarifying changes to the `SafeRolloutComparator` utility, based on my experience getting oriented to using it. No behavioral changes.

- Rename the internal option-name-generation methods to make it clearer a) that "eval" means "run the experimental code" and b) what is being block- or allowlisted per callsite (either running the experiment or using the results of the experiment).
- Expand the example code in the docstring.
- Tweak docstrings and comments for various methods.
- Rename a few other variables.
- Remove TODOs about creating a dashboard, since that's been done.
- Consolidate imports.
- Create constants for option names in tests, just to cut down on verbosity.