### PR TITLE
chore(alerts): Remove legacy issue alert delete endpoint code

### DIFF
--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -56,7 +56,7 @@ class WorkflowEngineRuleEndpoint(RuleEndpoint):
             raise ResourceDoesNotExist
 
         method_flag = self.workflow_engine_method_flags.get(request.method or "")
-        use_workflow_engine = request.method == "GET" or (
+        use_workflow_engine = request.method in ("GET", "DELETE") or (
             method_flag is not None and features.has(method_flag, project.organization)
         )
         if use_workflow_engine:

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -102,9 +102,6 @@ class ProjectRuleDetailsPutSerializer(serializers.Serializer):
 @extend_schema(tags=["Alerts"])
 @cell_silo_endpoint
 class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
-    workflow_engine_method_flags = {
-        "DELETE": "organizations:workflow-engine-issue-alert-endpoints-delete",
-    }
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PRIVATE,
@@ -368,7 +365,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-workflow-details",
     )
-    def delete(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
+    def delete(self, request: Request, project: Project, rule: Workflow) -> Response:
         """
         ## Deprecated
          🚧 Use [Delete an Alert](/api/monitors/delete-an-alert) instead.
@@ -381,59 +378,39 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
          - Filters: help control noise by triggering an alert only if the issue matches the specified criteria.
          - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
-        if isinstance(rule, Workflow):
-            with transaction.atomic(router.db_for_write(Workflow)):
-                rule.update(status=ObjectStatus.PENDING_DELETION)
-                scheduled = CellScheduledDeletion.schedule(rule, days=0, actor=request.user)
-            self.create_audit_entry(
-                request=request,
-                organization=project.organization,
-                target_object=rule.id,
-                event=audit_log.get_event_id("WORKFLOW_REMOVE"),
-                data=rule.get_audit_log_data(),
-                transaction_id=scheduled.id,
-            )
-            try:
-                ard = AlertRuleWorkflow.objects.get(workflow_id=rule.id)
-                rule = Rule.objects.get(id=ard.rule_id, project=project)
+        with transaction.atomic(router.db_for_write(Workflow)):
+            rule.update(status=ObjectStatus.PENDING_DELETION)
+            scheduled = CellScheduledDeletion.schedule(rule, days=0, actor=request.user)
+        self.create_audit_entry(
+            request=request,
+            organization=project.organization,
+            target_object=rule.id,
+            event=audit_log.get_event_id("WORKFLOW_REMOVE"),
+            data=rule.get_audit_log_data(),
+            transaction_id=scheduled.id,
+        )
+        try:
+            ard = AlertRuleWorkflow.objects.get(workflow_id=rule.id)
+            legacy_rule = Rule.objects.get(id=ard.rule_id, project=project)
 
-                report_used_legacy_models()
-                with transaction.atomic(router.db_for_write(Rule)):
-                    rule.update(status=ObjectStatus.PENDING_DELETION)
-                    RuleActivity.objects.create(
-                        rule=rule, user_id=request.user.id, type=RuleActivityType.DELETED.value
-                    )
-                    scheduled = CellScheduledDeletion.schedule(rule, days=0, actor=request.user)
-                self.create_audit_entry(
-                    request=request,
-                    organization=project.organization,
-                    target_object=rule.id,
-                    event=audit_log.get_event_id("RULE_REMOVE"),
-                    data=rule.get_audit_log_data(),
-                    transaction_id=scheduled.id,
-                )
-            except (AlertRuleWorkflow.DoesNotExist, Rule.DoesNotExist):
-                return Response(status=202)
-
-        else:
             report_used_legacy_models()
             with transaction.atomic(router.db_for_write(Rule)):
-                rule.update(status=ObjectStatus.PENDING_DELETION)
+                legacy_rule.update(status=ObjectStatus.PENDING_DELETION)
                 RuleActivity.objects.create(
-                    rule=rule, user_id=request.user.id, type=RuleActivityType.DELETED.value
+                    rule=legacy_rule,
+                    user_id=request.user.id,
+                    type=RuleActivityType.DELETED.value,
                 )
-                scheduled = CellScheduledDeletion.schedule(rule, days=0, actor=request.user)
-                # The Rule's scheduled deletion should take care of the workflow, but
-                # we mark it pending immediately so we don't return it while the deletion is in progress.
-                for workflow in Workflow.objects.filter(alertruleworkflow__rule_id=rule.id):
-                    workflow.update(status=ObjectStatus.PENDING_DELETION)
-
+                scheduled = CellScheduledDeletion.schedule(legacy_rule, days=0, actor=request.user)
             self.create_audit_entry(
                 request=request,
                 organization=project.organization,
-                target_object=rule.id,
+                target_object=legacy_rule.id,
                 event=audit_log.get_event_id("RULE_REMOVE"),
-                data=rule.get_audit_log_data(),
+                data=legacy_rule.get_audit_log_data(),
                 transaction_id=scheduled.id,
             )
+        except (AlertRuleWorkflow.DoesNotExist, Rule.DoesNotExist):
+            pass
+
         return Response(status=202)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -415,9 +415,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for legacy metric alert rule.put results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-metric-alert-endpoints-put", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for legacy issue alert rule.delete
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-issue-alert-endpoints-delete", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable seer activities to be evaluated in workflow engine

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -20,7 +20,7 @@ from sentry.sentry_apps.services.app.model import RpcAlertRuleActionResult
 from sentry.sentry_apps.utils.errors import SentryAppErrorType
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import install_slack, with_feature
+from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
@@ -1371,7 +1371,6 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             id=self.rule.id, project=self.project, status=ObjectStatus.PENDING_DELETION
         ).exists()
 
-    @with_feature("organizations:workflow-engine-issue-alert-endpoints-delete")
     def test_single_written_workflow_passed(self) -> None:
         self.get_success_response(
             self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=202
@@ -1383,43 +1382,6 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert not DetectorWorkflow.objects.filter(id=self.detector_workflow.id).exists()
         assert not DataConditionGroup.objects.filter(id=self.workflow_triggers.id).exists()
         assert not Action.objects.filter(id=self.action.id).exists()
-
-    @with_feature("organizations:workflow-engine-rule-serializers")
-    def test_dual_delete_workflow_engine_flag_enabled(self) -> None:
-        rule = self.create_project_rule(
-            self.project,
-            condition_data=[
-                {
-                    "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
-                    "name": "A new issue is created",
-                },
-                {
-                    "id": "sentry.rules.filters.latest_release.LatestReleaseFilter",
-                    "name": "The event occurs",
-                },
-            ],
-        )
-
-        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id)
-        workflow = alert_rule_workflow.workflow
-        when_dcg = workflow.when_condition_group
-        assert when_dcg
-        if_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
-
-        self.get_success_response(
-            self.organization.slug, rule.project.slug, rule.id, status_code=202
-        )
-
-        with self.tasks():
-            run_scheduled_deletions()
-
-        assert not AlertRuleWorkflow.objects.filter(rule_id=rule.id).exists()
-        assert not Workflow.objects.filter(id=workflow.id).exists()
-        assert not DataConditionGroup.objects.filter(id=when_dcg.id).exists()
-        assert not DataConditionGroup.objects.filter(id=if_dcg.id).exists()
-        assert not DataCondition.objects.filter(condition_group=when_dcg).exists()
-        assert not DataCondition.objects.filter(condition_group=if_dcg).exists()
-        assert not Rule.objects.filter(id=rule.id).exists()
 
     def test_dual_delete_workflow_engine(self) -> None:
         rule = self.create_project_rule(
@@ -1455,6 +1417,7 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert not DataConditionGroup.objects.filter(id=if_dcg.id).exists()
         assert not DataCondition.objects.filter(condition_group=when_dcg).exists()
         assert not DataCondition.objects.filter(condition_group=if_dcg).exists()
+        assert not Rule.objects.filter(id=rule.id).exists()
 
 
 class GetProjectRuleDetailsDeltaTest(ProjectRuleDetailsBaseTestCase):


### PR DESCRIPTION
The flag is fully GA'd so we're not going down the legacy path anymore - remove all of the related code.