### PR TITLE
ref(🥞): remove structural z-index references (drawer, modal, toast, sidebar)

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -321,7 +321,7 @@ export async function openWidgetViewerModal({
     openModal(deps => <Modal {...deps} {...options} />, {
       closeEvents: 'none',
       modalCss,
-      backdrop: {zIndex: 'widgetBuilderDrawer'},
+      backdrop: {},
       onClose,
     });
   } else {
@@ -330,7 +330,7 @@ export async function openWidgetViewerModal({
     openModal(deps => <Modal {...deps} {...options} />, {
       closeEvents: 'none',
       modalCss,
-      backdrop: {zIndex: 'widgetBuilderDrawer'},
+      backdrop: {},
       onClose,
     });
   }

--- a/static/app/components/core/backdrop/backdrop.tsx
+++ b/static/app/components/core/backdrop/backdrop.tsx
@@ -5,13 +5,12 @@ interface BackdropProps extends Omit<
   React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
   'style' | 'className' | `on${string}`
 > {
-  zIndex: 'widgetBuilderDrawer' | 'drawer' | 'modal';
   'data-drawer-backdrop'?: string;
   'data-test-id'?: string;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
-export function Backdrop({onClick, zIndex, ...props}: BackdropProps) {
+export function Backdrop({onClick, ...props}: BackdropProps) {
   const theme = useTheme();
   // TODO(design-engineering): These should be exposed as `theme.tokens`
   const background = theme.type === 'light' ? '#10082845' : '#10082080';
@@ -27,7 +26,6 @@ export function Backdrop({onClick, zIndex, ...props}: BackdropProps) {
         background,
         position: 'fixed',
         inset: '0',
-        zIndex: theme.zIndex[zIndex],
       }}
       animate={{opacity: 1}}
       exit={{opacity: 0}}

--- a/static/app/components/core/drawer/components.tsx
+++ b/static/app/components/core/drawer/components.tsx
@@ -186,7 +186,7 @@ const Header = styled('header')<{
 }>`
   position: sticky;
   top: 0;
-  z-index: ${p => p.theme.zIndex.drawer + 1};
+  z-index: 1;
   background: ${p => p.theme.tokens.background.primary};
   justify-content: flex-start;
   display: flex;
@@ -218,7 +218,6 @@ export const DrawerBody = styled('aside')`
 const DrawerContainer = styled('div')<{mode?: DrawerOptions['mode']}>`
   position: fixed;
   inset: 0;
-  z-index: ${p => p.theme.zIndex.drawer};
   pointer-events: none;
 
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
@@ -292,7 +291,7 @@ const ResizeHandle = styled('div')`
   bottom: 0;
   width: 8px;
   cursor: ew-resize;
-  z-index: ${p => p.theme.zIndex.drawer + 2};
+  z-index: 1;
 
   &[data-at-min-width='true'] {
     cursor: w-resize;

--- a/static/app/components/core/drawer/index.tsx
+++ b/static/app/components/core/drawer/index.tsx
@@ -221,7 +221,7 @@ export function GlobalDrawer({children}: any) {
       >
         <AnimatePresence>
           {isDrawerOpen && currentDrawerConfig.options.mode !== 'passive' ? (
-            <Backdrop zIndex="drawer" key="backdrop" data-drawer-backdrop="" />
+            <Backdrop key="backdrop" data-drawer-backdrop="" />
           ) : null}
           {isDrawerOpen && (
             <DrawerComponents.DrawerPanel

--- a/static/app/components/core/modal/index.tsx
+++ b/static/app/components/core/modal/index.tsx
@@ -233,11 +233,7 @@ export function GlobalModal({onClose}: Props) {
     <Fragment>
       <AnimatePresence>
         {backdrop && visible && (
-          <Backdrop
-            key="backdrop"
-            zIndex="modal"
-            {...(typeof backdrop === 'object' ? backdrop : {})}
-          />
+          <Backdrop key="backdrop" {...(typeof backdrop === 'object' ? backdrop : {})} />
         )}
       </AnimatePresence>
       <ModalContainer
@@ -371,7 +367,6 @@ const fullPageCss = css`
 const ModalContainer = styled('div')`
   ${fullPageCss};
   right: var(--scrollbar-size, 0);
-  z-index: ${p => p.theme.zIndex.modal};
   display: flex;
   justify-content: center;
   align-items: flex-start;

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -62,7 +62,7 @@ const getStylesConfig = ({
   theme,
   size = 'md',
   maxMenuWidth,
-  isInsideModal,
+  isInsideModal: _isInsideModal,
   isSearchable,
   isDisabled,
 }: {
@@ -139,7 +139,6 @@ const getStylesConfig = ({
     menuPortal: provided => ({
       ...provided,
       maxWidth: maxMenuWidth ?? '24rem',
-      zIndex: isInsideModal ? theme.zIndex.modal + 1 : theme.zIndex.dropdown,
     }),
 
     option: provided => ({

--- a/static/app/components/core/slideOverPanel/slideOverPanel.tsx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.tsx
@@ -143,7 +143,6 @@ const _SlideOverPanel = styled(motion.div, {
   pointer-events: auto;
   overscroll-behavior: contain;
 
-  z-index: ${p => p.theme.zIndex.modal - 1};
   background: ${p => p.theme.tokens.background.overlay};
   box-shadow: ${p => p.theme.shadow.high};
   color: ${p => p.theme.tokens.content.primary};

--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -98,7 +98,6 @@ const Wrapper = styled('div')`
   white-space: nowrap;
 
   border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-  z-index: ${p => p.theme.zIndex.sidebarPanel - 1};
 
   @media (max-width: ${p => p.theme.breakpoints.md}) {
     height: 54px;

--- a/static/app/components/feedbackButton/floatingFeedbackButton.tsx
+++ b/static/app/components/feedbackButton/floatingFeedbackButton.tsx
@@ -1,5 +1,4 @@
 import {useEffect} from 'react';
-import {css, Global, useTheme} from '@emotion/react';
 
 import {useFeedbackSDKIntegration} from 'sentry/components/feedbackButton/useFeedbackSDKIntegration';
 
@@ -12,7 +11,6 @@ import {useFeedbackSDKIntegration} from 'sentry/components/feedbackButton/useFee
  * which allows taking screenshots of what's visible on the page.
  */
 export function FloatingFeedbackButton() {
-  const theme = useTheme();
   const {feedback, defaultOptions} = useFeedbackSDKIntegration();
 
   useEffect(() => {
@@ -30,14 +28,5 @@ export function FloatingFeedbackButton() {
     return null;
   }
 
-  // z-index needs to be below our indicators which is 10001
-  return (
-    <Global
-      styles={css`
-        #sentry-feedback {
-          --z-index: ${theme.zIndex.toast - 1};
-        }
-      `}
-    />
-  );
+  return null;
 }

--- a/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
+++ b/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
@@ -54,8 +54,6 @@ const StyledHovercardWithBodyClass = styled(HovercardWithBodyClass)`
 `;
 
 const StyledHovercard = styled(Hovercard)<{hide?: boolean}>`
-  /* Lower z-index to match the modals (10000 vs 10002) to allow stackTraceLinkModal be on top of stack trace preview. */
-  z-index: ${p => p.theme.zIndex.modal};
   width: auto;
 
   ${p =>

--- a/static/app/components/indicators.tsx
+++ b/static/app/components/indicators.tsx
@@ -39,5 +39,4 @@ const Toasts = styled('div')`
   position: fixed;
   right: calc(30px + var(--scrollbar-size, 0px));
   bottom: 30px;
-  z-index: ${p => p.theme.zIndex.toast};
 `;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -1,7 +1,6 @@
 import {Fragment, useMemo, useState, type ReactNode} from 'react';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -61,7 +60,6 @@ export function GroupBySelector({
   const organization = useOrganization();
   const source = useDashboardWidgetSource();
   const isEditing = useIsEditingWidget();
-  const theme = useTheme();
   const builderVersion = WidgetBuilderVersion.SLIDEOUT;
 
   function handleAdd() {
@@ -228,11 +226,7 @@ export function GroupBySelector({
                 ))}
               </SortableQueryFields>
             </SortableContext>
-            <DragOverlay
-              dropAnimation={null}
-              zIndex={theme.zIndex.modal}
-              modifiers={[correctDragOverlayOffset]}
-            >
+            <DragOverlay dropAnimation={null} modifiers={[correctDragOverlayOffset]}>
               {activeId ? (
                 <Ghost>
                   <QueryField

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -163,7 +163,7 @@ export function WidgetBuilderV2({
               }
             `}
           />
-          <Backdrop zIndex="widgetBuilderDrawer" />
+          <Backdrop />
           <WidgetBuilderProvider>
             <CustomMeasurementsProvider organization={organization} selection={selection}>
               <ContainerWithoutSidebar
@@ -271,12 +271,7 @@ export function WidgetPreviewContainer({
     top: isDragEnabled ? (top ?? 0) : undefined,
     left: isDragEnabled ? (left ?? 0) : undefined,
     opacity: isDragging ? 0.5 : 1,
-    zIndex: isDragEnabled
-      ? theme.zIndex.modal
-      : isSmallScreen
-        ? theme.zIndex.initial
-        : // if not responsive, set z-index to default in styled component
-          undefined,
+    zIndex: isDragEnabled ? 1 : undefined,
     cursor: isDragEnabled ? 'grab' : undefined,
     margin: isDragEnabled ? '0' : undefined,
     alignSelf: isDragEnabled ? 'flex-start' : undefined,
@@ -412,13 +407,12 @@ const SampleWidgetCard = styled(motion.div)`
   border: 1px dashed ${p => p.theme.colors.gray400};
   background-color: ${p => p.theme.tokens.background.primary};
   border-radius: ${p => p.theme.radius.md};
-  z-index: ${p => p.theme.zIndex.initial};
   position: relative;
 
   @media (min-width: ${p => p.theme.breakpoints.sm}) {
     width: 40vw;
     min-width: 300px;
-    z-index: ${p => p.theme.zIndex.modal};
+    z-index: 1;
     cursor: auto;
   }
 
@@ -431,20 +425,18 @@ const SampleWidgetCard = styled(motion.div)`
 
 const DraggableWidgetContainer = styled('div')`
   align-content: center;
-  z-index: ${p => p.theme.zIndex.initial};
   position: relative;
   margin: auto;
   cursor: auto;
 
   @media (min-width: ${p => p.theme.breakpoints.sm}) {
-    z-index: ${p => p.theme.zIndex.modal};
+    z-index: 1;
     transform: none;
     cursor: auto;
   }
 `;
 
 const ContainerWithoutSidebar = styled('div')`
-  z-index: ${p => p.theme.zIndex.widgetBuilderDrawer};
   position: fixed;
   top: 0;
   right: 0;
@@ -456,7 +448,6 @@ const ContainerWithoutSidebar = styled('div')`
 `;
 
 const WidgetBuilderContainer = styled('div')`
-  z-index: ${p => p.theme.zIndex.widgetBuilderDrawer};
   display: flex;
   align-items: center;
   position: absolute;
@@ -507,7 +498,7 @@ const FilterBarContainer = styled(motion.div)`
   @media (min-width: ${p => p.theme.breakpoints.sm}) {
     width: 40vw;
     min-width: 300px;
-    z-index: ${p => p.theme.zIndex.modal};
+    z-index: 1;
     cursor: auto;
   }
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useCallback, useMemo, useState, type ReactNode} from 'react';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
-import {css, useTheme} from '@emotion/react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -292,7 +292,6 @@ export function Visualize({
 }: VisualizeProps) {
   const [activeId, setActiveId] = useState<string | null>(null);
   const organization = useOrganization();
-  const theme = useTheme();
   const {state, dispatch} = useWidgetBuilderContext();
   const tags = useTags();
   const {customMeasurements} = useCustomMeasurements();
@@ -1044,11 +1043,7 @@ export function Visualize({
                   })}
                 </Stack>
               </SortableContext>
-              <DragOverlay
-                dropAnimation={null}
-                zIndex={theme.zIndex.modal}
-                modifiers={[correctDragOverlayOffset]}
-              >
+              <DragOverlay dropAnimation={null} modifiers={[correctDragOverlayOffset]}>
                 {activeId && (
                   <VisualizeGhostField
                     activeId={Number(activeId)}

--- a/static/app/views/discover/table/columnEditCollection.tsx
+++ b/static/app/views/discover/table/columnEditCollection.tsx
@@ -92,7 +92,6 @@ class ColumnEditCollection extends Component<Props, State> {
       portal.style.position = 'absolute';
       portal.style.top = '0';
       portal.style.left = '0';
-      portal.style.zIndex = String(this.props.theme.zIndex.modal);
 
       this.portal = portal;
 

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -441,7 +441,7 @@ class _QueryField extends Component<Props> {
       skipParameterPlaceholder,
       fieldValue,
       useMenuPortal,
-      theme,
+      theme: _theme,
       disableParameterSelector,
     } = this.props;
 
@@ -468,16 +468,6 @@ class _QueryField extends Component<Props> {
         const portalProps = useMenuPortal
           ? {
               menuPortalTarget: document.body,
-              styles: {
-                menuPortal: (provided: CSSObject) => ({
-                  ...provided,
-                  // This ensures that the dropdown appears above the widget builder
-                  // because the default dropdown z-index is too low
-                  zIndex: theme?.zIndex.widgetBuilderDrawer
-                    ? theme.zIndex.widgetBuilderDrawer + 1
-                    : undefined,
-                }),
-              },
             }
           : {};
 
@@ -493,7 +483,6 @@ class _QueryField extends Component<Props> {
             disabled={disabled || disableParameterSelector}
             menuPortalTarget={portalProps.menuPortalTarget}
             styles={{
-              ...portalProps.styles,
               ...(inFieldLabels ? undefined : this.FieldSelectStyles),
             }}
             components={this.FieldSelectComponents}

--- a/static/app/views/navigation/index.tsx
+++ b/static/app/views/navigation/index.tsx
@@ -97,7 +97,6 @@ function UserOnlyNavigation() {
 }
 
 function NavigationLayout({children}: {children: React.ReactNode}) {
-  const theme = useTheme();
   const {layout} = usePrimaryNavigation();
   const {currentStepId} = useNavigationTour();
   const hoverProps = useResetActiveNavigationGroup();
@@ -111,7 +110,6 @@ function NavigationLayout({children}: {children: React.ReactNode}) {
       bottom={layout === 'mobile' ? undefined : 0}
       height={layout === 'mobile' ? undefined : `calc(100dvh - ${barTop})`}
       style={{
-        zIndex: currentStepId ? undefined : theme.zIndex.sidebarPanel,
         userSelect: 'none',
       }}
       {...hoverProps}
@@ -166,8 +164,6 @@ function SkipLink() {
 
 const SkipLinkContainer = styled(Container)`
   top: -100%;
-  z-index: ${p => p.theme.zIndex.toast};
-
   &:focus-within {
     top: ${p => p.theme.space.sm};
   }

--- a/static/app/views/navigation/mobileNavigation.tsx
+++ b/static/app/views/navigation/mobileNavigation.tsx
@@ -1,6 +1,5 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
-import {useTheme} from '@emotion/react';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, type FlexProps, Grid, Stack} from '@sentry/scraps/layout';
@@ -149,7 +148,6 @@ export function MobileNavigation() {
 }
 
 function MobileNavigationHeader(props: FlexProps<'header'>) {
-  const theme = useTheme();
   return (
     <Flex
       top={0}
@@ -165,7 +163,6 @@ function MobileNavigationHeader(props: FlexProps<'header'>) {
       justify="between"
       position="sticky"
       overscrollBehavior="none"
-      style={{zIndex: theme.zIndex.sidebar}}
       {...props}
     />
   );
@@ -194,7 +191,6 @@ function MobilePrimaryNavigation() {
 }
 
 export function MobilePageFrameNavigation() {
-  const theme = useTheme();
   const [isOpen, setIsOpen] = useState(false);
   const navPanelRef = useRef<HTMLDivElement>(null);
   const toggleButtonRef = useRef<HTMLButtonElement>(null);
@@ -272,7 +268,6 @@ export function MobilePageFrameNavigation() {
             bottom={0}
             width="100vw"
             maxWidth="368px"
-            style={{zIndex: theme.zIndex.modal}}
           >
             <MobilePrimaryNavigation />
           </Flex>,
@@ -290,7 +285,6 @@ interface NavigationOverlayPortalProps {
 }
 
 function NavigationOverlayPortal(props: NavigationOverlayPortalProps) {
-  const theme = useTheme();
   const ref = useRef<HTMLDivElement | null>(null);
   const hasPageFrame = useHasPageFrameFeature();
 
@@ -315,7 +309,6 @@ function NavigationOverlayPortal(props: NavigationOverlayPortalProps) {
       right={0}
       bottom={0}
       left={0}
-      style={{zIndex: theme.zIndex.modal}}
     >
       {props.children}
     </Flex>,

--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -53,7 +53,6 @@ interface PrimaryNavigationSidebarProps {
 }
 
 function PrimaryNavigationSidebar({children, ...props}: PrimaryNavigationSidebarProps) {
-  const theme = useTheme();
   const hasPageFrame = useHasPageFrameFeature();
 
   return (
@@ -66,7 +65,6 @@ function PrimaryNavigationSidebar({children, ...props}: PrimaryNavigationSidebar
       background="primary"
       direction="column"
       align="center"
-      style={{zIndex: theme.zIndex.sidebarPanel}}
       {...props}
     >
       {children}
@@ -358,7 +356,6 @@ interface PrimaryNavigationMenuProps extends PrimaryNavigationItemBaseProps {
 
 function PrimaryNavigationMenu(props: PrimaryNavigationMenuProps) {
   const TriggerWrap = props.triggerWrap ?? Fragment;
-  const theme = useTheme();
   const organization = useOrganization({allowNull: true});
   const {layout} = usePrimaryNavigation();
   const hasPageFrame = useHasPageFrameFeature();
@@ -377,7 +374,6 @@ function PrimaryNavigationMenu(props: PrimaryNavigationMenuProps) {
       usePortal
       size={sizeContext}
       portalContainerRef={portalContainerRef}
-      zIndex={theme.zIndex.modal}
       renderWrapAs={PassthroughWrapper}
       position={layout === 'mobile' ? 'bottom' : 'right-end'}
       shouldApplyMinWidth={false}
@@ -766,7 +762,7 @@ function PrimaryNavigationButtonOverlay(props: PrimaryNavigationButtonOverlayPro
 
   return createPortal(
     <FocusScope restoreFocus autoFocus>
-      <PositionWrapper zIndex={theme.zIndex.modal} {...props.overlayProps}>
+      <PositionWrapper {...props.overlayProps}>
         <motion.div
           initial={isDesktop ? {opacity: 0, scale: 0.98} : undefined}
           animate={isDesktop ? {opacity: 1, scale: 1} : undefined}

--- a/static/app/views/navigation/primary/organizationDropdown.tsx
+++ b/static/app/views/navigation/primary/organizationDropdown.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useRef} from 'react';
-import {useTheme} from '@emotion/react';
 import orderBy from 'lodash/orderBy';
 import partition from 'lodash/partition';
 
@@ -38,7 +37,6 @@ interface OrganizationDropdownProps {
 export function OrganizationDropdown(props: OrganizationDropdownProps) {
   const navigate = useNavigate();
   const config = useLegacyStore(ConfigStore);
-  const theme = useTheme();
   const portalContainerRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -67,7 +65,6 @@ export function OrganizationDropdown(props: OrganizationDropdownProps) {
     <DropdownMenu
       usePortal
       portalContainerRef={portalContainerRef}
-      zIndex={theme.zIndex.modal}
       trigger={triggerProps => (
         <AvatarButton
           avatar={

--- a/static/app/views/navigation/primary/userDropdown.tsx
+++ b/static/app/views/navigation/primary/userDropdown.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useRef} from 'react';
-import {useTheme} from '@emotion/react';
 
 import {UserAvatar} from '@sentry/scraps/avatar';
 import {AvatarButton} from '@sentry/scraps/avatarButton';
@@ -30,7 +29,6 @@ export function UserDropdown() {
   const organization = useOrganization({allowNull: true});
   const {layout} = usePrimaryNavigation();
   const portalContainerRef = useRef<HTMLElement | null>(null);
-  const theme = useTheme();
   const hasPageFrame = useHasPageFrameFeature();
 
   useEffect(() => {
@@ -67,7 +65,6 @@ export function UserDropdown() {
       usePortal
       size={size}
       portalContainerRef={portalContainerRef}
-      zIndex={theme.zIndex.modal}
       renderWrapAs={PassthroughWrapper}
       position={layout === 'mobile' ? 'bottom' : 'right-end'}
       minMenuWidth={200}

--- a/static/app/views/navigation/secondary/components.tsx
+++ b/static/app/views/navigation/secondary/components.tsx
@@ -26,7 +26,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
-import {css, useTheme, type Theme} from '@emotion/react';
+import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {mergeProps, mergeRefs} from '@react-aria/utils';
 import {AnimatePresence, motion} from 'framer-motion';
@@ -180,8 +180,6 @@ function SecondarySidebar({children}: SecondarySidebarProps) {
 }
 
 function SecondarySidebarWrapper(props: NavigationTourElementProps) {
-  const theme = useTheme();
-
   return (
     <Container
       background="secondary"
@@ -189,18 +187,13 @@ function SecondarySidebarWrapper(props: NavigationTourElementProps) {
       position="relative"
       height="100%"
     >
-      {p => (
-        <NavigationTourElement
-          {...mergeProps(p, props)}
-          style={{zIndex: theme.zIndex.sidebarPanel}}
-        />
-      )}
+      {p => <NavigationTourElement {...mergeProps(p, props)} />}
     </Container>
   );
 }
 
 const ResizeHandle = styled('div')<{atMaxWidth: boolean; atMinWidth: boolean}>`
-  z-index: ${p => p.theme.zIndex.drawer + 2};
+  z-index: 1;
   cursor: ${p => (p.atMinWidth ? 'e-resize' : p.atMaxWidth ? 'w-resize' : 'ew-resize')};
 
   &:hover,

--- a/static/app/views/navigation/topBar.tsx
+++ b/static/app/views/navigation/topBar.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useMemo} from 'react';
-import {useTheme} from '@emotion/react';
 
 import {Flex} from '@sentry/scraps/layout';
 import {SizeProvider} from '@sentry/scraps/sizeContext';
@@ -27,7 +26,6 @@ import {
 const Slot = slot(['title', 'search', 'actions', 'feedback'] as const);
 
 function TopBarContent({className}: {className?: string}) {
-  const theme = useTheme();
   const hasPageFrame = useHasPageFrameFeature();
   const {barTop, contentTop} = useTopOffset();
 
@@ -68,9 +66,6 @@ function TopBarContent({className}: {className?: string}) {
       position="sticky"
       borderBottom="primary"
       top={barTop}
-      style={{
-        zIndex: theme.zIndex.sidebarPanel - 1,
-      }}
     >
       <SizeProvider size="sm">
         <Slot.Outlet name="title">

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -84,7 +84,7 @@ export function AppSizeInsightsSidebar({
   return (
     <Fragment>
       <AnimatePresence>
-        {isOpen && <Backdrop key="backdrop" zIndex="drawer" onClick={onClose} />}
+        {isOpen && <Backdrop key="backdrop" onClick={onClose} />}
       </AnimatePresence>
       {isOpen && (
         <SlideOverPanel


### PR DESCRIPTION
## Summary
- Remove `theme.zIndex.drawer`, `modal`, `toast`, `sidebar`, `sidebarPanel`, and `widgetBuilderDrawer` references
- These are now handled by Layer DOM order (stacking context isolation)
- Internal ordering within surfaces replaced with bare `z-index: 1`

## 🥞 Layer Primitive Series
- [x] #114516 `nm/zindex/layer-primitive` — Layer component + hooks
- [x] #114520 `nm/zindex/dom-order` — DOM restructuring for paint-order stacking
- [x] #114549 `nm/zindex/wire-portals` — Wire portal consumers to Layer outlets
- [ ] #115959 `nm/zindex/remove-structural-zindex` — Remove structural z-index refs ← this PR
- [ ] #115957 `nm/zindex/remove-portal-zindex` — Remove portal z-index refs
- [ ] #115956 `nm/zindex/remove-local-zindex` — Replace local z-index refs with bare z-index: 1
- [ ] #115961 `nm/zindex/deprecate-zindex` — Deprecate theme.zIndex scale
- [ ] #115963 `nm/zindex/lint-ban` — Lint rule banning z-index/zIndex
- [ ] #115964 `nm/zindex/final-cleanup` — Remove theme.zIndex entirely

## Test plan
- [ ] Open drawer, verify it paints above content
- [ ] Open modal, verify it paints above drawer
- [ ] Trigger toast, verify it paints above modal
- [ ] Verify sidebar panels stack correctly in navigation
- [ ] `pnpm run typecheck`