### PR TITLE
fix(workflow): Use Group cache in get_group_to_groupevent

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -665,7 +665,7 @@ def get_group_to_groupevent(
     groups_to_dcgs: dict[GroupId, set[DataConditionGroup]],
     project: Project,
 ) -> dict[Group, tuple[GroupEvent, datetime | None]]:
-    groups = Group.objects.filter(id__in=event_data.group_ids)
+    groups = Group.objects.get_many_from_cache(event_data.group_ids)
     group_id_to_group = {group.id: group for group in groups}
 
     bulk_event_id_to_events = bulk_fetch_events(list(event_data.event_ids), project)


### PR DESCRIPTION
We're doing a group PK lookup, and it's usually quite fast, but we've seen cases where contention on Group can make it very slow. It's easy enough to switch to the cache here, so we can do that and reduce our exposure.
