### PR TITLE
ref(🥞): deprecate theme.zIndex scale

### DIFF
--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -188,35 +188,41 @@ type Colors = typeof lightColors;
 const commonTheme = {
   motion: generateMotion(),
 
-  // Try to keep these ordered plz
+  /**
+   * @deprecated Use the `Layer` primitive for stacking context isolation.
+   * The only z-index value needed is `z-index: 1` for local overrides
+   * within a Layer (e.g., sticky headers, hover states).
+   */
+  /**
+   * @deprecated Use the `Layer` primitive for stacking context isolation.
+   * The only z-index value needed is `z-index: 1` for local overrides
+   * within a Layer (e.g., sticky headers, hover states).
+   */
   zIndex: {
-    // Generic z-index when you hope your component is isolated and
-    // does not need to battle others for z-index priority
+    /** @deprecated Use `z-index: 1` instead */
     initial: 1,
+    /** @deprecated Use `z-index: 1` instead */
     truncationFullValue: 10,
-
+    /** @deprecated Use `<Layer variant="nav">` instead */
     header: 1000,
-
-    // dashboard widget builder backdrop sits behind the sidebar
-    // because it renders on the right next to the sidebar
-    // @TODO(design-engineering): resolve this inconsistency
+    /** @deprecated Use `<Layer variant="overlay">` instead */
     widgetBuilderDrawer: 1016,
-
+    /** @deprecated Use `<Layer variant="nav">` instead */
     sidebarPanel: 1019,
+    /** @deprecated Handled by Layer portal outlets */
     dropdown: 1020,
+    /** @deprecated Use `<Layer variant="nav">` instead */
     sidebar: 1020,
-
-    // Sentry user feedback modal
     sentryErrorEmbed: 1090,
-
-    // If you change modal also update shared-components.less
-    // as the z-index for bootstrap modals lives there.
+    /** @deprecated Use `<Layer variant="overlay">` instead */
     drawer: 9999,
+    /** @deprecated Use `<Layer variant="overlay">` instead */
     modal: 10000,
+    /** @deprecated Use `<Layer variant="overlay">` instead */
     toast: 10001,
-
-    // tooltips and hovercards can be inside modals sometimes.
+    /** @deprecated Handled by Layer portal outlets */
     hovercard: 10002,
+    /** @deprecated Handled by Layer portal outlets */
     tooltip: 10003,
   },
 


### PR DESCRIPTION
## Summary
- Add `@deprecated` JSDoc to `theme.zIndex` object and all properties (except `sentryErrorEmbed`)
- No behavioral change — purely documentation to guide developers toward the Layer primitive

## 🥞 Layer Primitive Series
- [x] #114516 `nm/zindex/layer-primitive` — Layer component + hooks
- [x] #114520 `nm/zindex/dom-order` — DOM restructuring for paint-order stacking
- [x] #114549 `nm/zindex/wire-portals` — Wire portal consumers to Layer outlets
- [ ] #115959 `nm/zindex/remove-structural-zindex` — Remove structural z-index refs
- [ ] #115957 `nm/zindex/remove-portal-zindex` — Remove portal z-index refs
- [ ] #115956 `nm/zindex/remove-local-zindex` — Replace local z-index refs with bare z-index: 1
- [ ] #115961 `nm/zindex/deprecate-zindex` — Deprecate theme.zIndex scale ← this PR
- [ ] #115963 `nm/zindex/lint-ban` — Lint rule banning z-index/zIndex
- [ ] #115964 `nm/zindex/final-cleanup` — Remove theme.zIndex entirely

## Test plan
- [ ] No behavioral change — verify `pnpm run typecheck` passes