### PR TITLE
feat(settings): Support legacy usage-based Seer in project settings endpoint

### DIFF
--- a/src/sentry/seer/endpoints/project_seer_settings.py
+++ b/src/sentry/seer/endpoints/project_seer_settings.py
@@ -408,8 +408,7 @@ class ProjectSeerSettingsEndpoint(ProjectEndpoint):
             else LegacyProjectSettingsUpdateSerializer
         )
         serializer = serializer_cls(
-            data=request.data,
-            context={"organization": project.organization},
+            data=request.data, context={"organization": project.organization}
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
@@ -478,10 +477,7 @@ class OrganizationSeerProjectSettingsEndpoint(OrganizationEndpoint):
             if is_seer_seat_based_tier_enabled(organization)
             else LegacyBulkProjectSettingsUpdateSerializer
         )
-        serializer = serializer_cls(
-            data=request.data,
-            context={"organization": organization},
-        )
+        serializer = serializer_cls(data=request.data, context={"organization": organization})
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 

--- a/src/sentry/seer/endpoints/project_seer_settings.py
+++ b/src/sentry/seer/endpoints/project_seer_settings.py
@@ -366,8 +366,7 @@ class ProjectSettingsUpdateSerializer(_BaseProjectSettingsUpdateSerializer):
     )
 
     def validate_stopping_point(self, value: str) -> str:
-        valid = get_valid_automated_run_stopping_points(self.context["organization"])
-        if value not in valid:
+        if value not in get_valid_automated_run_stopping_points(self.context["organization"]):
             raise serializers.ValidationError(f'"{value}" is not a valid choice.')
         return value
 

--- a/src/sentry/seer/endpoints/project_seer_settings.py
+++ b/src/sentry/seer/endpoints/project_seer_settings.py
@@ -39,6 +39,7 @@ from sentry.seer.autofix.utils import (
     AutomationCodingAgent,
     get_automation_handoff,
     get_valid_automated_run_stopping_points,
+    is_seer_seat_based_tier_enabled,
     update_seer_project_settings,
 )
 from sentry.seer.models.project_repository import SeerProjectRepository
@@ -313,20 +314,17 @@ def _apply_search_filters(queryset, filters: Sequence[QueryToken]):
     return queryset
 
 
-class ProjectSettingsUpdateSerializer(CamelSnakeSerializer):
+class _BaseProjectSettingsUpdateSerializer(CamelSnakeSerializer):
     agent = serializers.ChoiceField(choices=[*AutomationCodingAgent], required=False)
     integration_id = serializers.IntegerField(required=False)
     stopping_point = serializers.ChoiceField(choices=[*AutofixStoppingPoint], required=False)
     scanner_automation = serializers.BooleanField(required=False)
     automation_tuning = serializers.ChoiceField(
-        choices=[AutofixAutomationTuningSettings.OFF, AutofixAutomationTuningSettings.MEDIUM],
-        required=False,
+        choices=[*AutofixAutomationTuningSettings], required=False
     )
 
-    def validate_stopping_point(self, value: str) -> str:
-        if value not in get_valid_automated_run_stopping_points(self.context["organization"]):
-            raise serializers.ValidationError(f'"{value}" is not a valid choice.')
-        return value
+    def _update_fields(self) -> set[str]:
+        return {"agent", "stopping_point", "scanner_automation", "automation_tuning"}
 
     def validate_integration_id(self, value: int) -> int:
         organization = self.context["organization"]
@@ -353,17 +351,43 @@ class ProjectSettingsUpdateSerializer(CamelSnakeSerializer):
                     {"agent": "Must be an external coding agent when integration_id is provided."}
                 )
 
-        if not any(
-            k in data
-            for k in ("agent", "stopping_point", "scanner_automation", "automation_tuning")
-        ):
+        if not any(k in data for k in self._update_fields()):
             raise serializers.ValidationError("At least one update field must be provided.")
+
+        return data
+
+
+class ProjectSettingsUpdateSerializer(_BaseProjectSettingsUpdateSerializer):
+    """Seat-based (new) Seer: restricted tuning choices, stopping point sync."""
+
+    automation_tuning = serializers.ChoiceField(
+        choices=[AutofixAutomationTuningSettings.OFF, AutofixAutomationTuningSettings.MEDIUM],
+        required=False,
+    )
+
+    def validate_stopping_point(self, value: str) -> str:
+        valid = get_valid_automated_run_stopping_points(self.context["organization"])
+        if value not in valid:
+            raise serializers.ValidationError(f'"{value}" is not a valid choice.')
+        return value
+
+    def validate(self, data):
+        data = super().validate(data)
 
         # Keep stopping point in sync with handoff auto_create_pr.
         if "stopping_point" in data and "auto_create_pr" not in data:
             data["auto_create_pr"] = data["stopping_point"] == AutofixStoppingPoint.OPEN_PR
 
         return data
+
+
+class LegacyProjectSettingsUpdateSerializer(_BaseProjectSettingsUpdateSerializer):
+    """Legacy Seer: accepts auto_create_pr and all tuning/stopping point values."""
+
+    auto_create_pr = serializers.BooleanField(required=False)
+
+    def _update_fields(self) -> set[str]:
+        return super()._update_fields() | {"auto_create_pr"}
 
 
 @cell_silo_endpoint
@@ -379,8 +403,14 @@ class ProjectSeerSettingsEndpoint(ProjectEndpoint):
         return Response(serialize_project(project))
 
     def put(self, request: Request, project: Project) -> Response:
-        serializer = ProjectSettingsUpdateSerializer(
-            data=request.data, context={"organization": project.organization}
+        serializer_cls = (
+            ProjectSettingsUpdateSerializer
+            if is_seer_seat_based_tier_enabled(project.organization)
+            else LegacyProjectSettingsUpdateSerializer
+        )
+        serializer = serializer_cls(
+            data=request.data,
+            context={"organization": project.organization},
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
@@ -400,6 +430,10 @@ class ProjectSeerSettingsEndpoint(ProjectEndpoint):
 
 
 class BulkProjectSettingsUpdateSerializer(ProjectSettingsUpdateSerializer):
+    query = serializers.CharField(required=False, default="")
+
+
+class LegacyBulkProjectSettingsUpdateSerializer(LegacyProjectSettingsUpdateSerializer):
     query = serializers.CharField(required=False, default="")
 
 
@@ -440,8 +474,14 @@ class OrganizationSeerProjectSettingsEndpoint(OrganizationEndpoint):
         )
 
     def put(self, request: Request, organization: Organization) -> Response:
-        serializer = BulkProjectSettingsUpdateSerializer(
-            data=request.data, context={"organization": organization}
+        serializer_cls = (
+            BulkProjectSettingsUpdateSerializer
+            if is_seer_seat_based_tier_enabled(organization)
+            else LegacyBulkProjectSettingsUpdateSerializer
+        )
+        serializer = serializer_cls(
+            data=request.data,
+            context={"organization": organization},
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/tests/sentry/seer/endpoints/test_project_seer_settings.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_settings.py
@@ -821,6 +821,37 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
             assert p.get_option("sentry:seer_automated_run_stopping_point") == "open_pr"
             assert p.get_option("sentry:seer_scanner_automation") is True
 
+    def test_put_legacy_updates_settings(self, mock_is_seat_based) -> None:
+        """Legacy: bulk update with granular tuning, auto_create_pr, and external agent."""
+        mock_is_seat_based.return_value = False
+        project2 = self.create_project(organization=self.organization)
+        integration = self.create_integration(
+            organization=self.organization, external_id="ext", provider="github"
+        )
+
+        response = self.client.put(
+            self.url,
+            data={
+                "automationTuning": "high",
+                "autoCreatePr": True,
+                "agent": "cursor_background_agent",
+                "integrationId": integration.id,
+            },
+            format="json",
+        )
+
+        assert response.status_code == 204
+        for p in (self.project, project2):
+            assert (
+                p.get_option("sentry:autofix_automation_tuning")
+                == AutofixAutomationTuningSettings.HIGH
+            )
+            assert p.get_option("sentry:seer_automation_handoff_auto_create_pr") is True
+            assert (
+                p.get_option("sentry:seer_automation_handoff_target") == "cursor_background_agent"
+            )
+            assert p.get_option("sentry:seer_automation_handoff_integration_id") == integration.id
+
     def test_put_invalid_search_query_returns_400(self, mock_is_seat_based) -> None:
         """A malformed query value should return 400."""
         response = self.client.put(

--- a/tests/sentry/seer/endpoints/test_project_seer_settings.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_settings.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from sentry.constants import ObjectStatus
@@ -6,6 +8,10 @@ from sentry.seer.models import AutofixHandoffPoint
 from sentry.testutils.cases import APITestCase
 
 
+@patch(
+    "sentry.seer.endpoints.project_seer_settings.is_seer_seat_based_tier_enabled",
+    return_value=True,
+)
 class ProjectSeerSettingsEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-seer-settings"
 
@@ -21,7 +27,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
             },
         )
 
-    def test_get_returns_defaults(self) -> None:
+    def test_get_returns_defaults(self, mock_is_seat_based) -> None:
         """A project with no options set should return defaults."""
         response = self.client.get(self.url)
 
@@ -38,7 +44,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
             "reposCount": 0,
         }
 
-    def test_get_returns_configured_project_options(self) -> None:
+    def test_get_returns_configured_project_options(self, mock_is_seat_based) -> None:
         """A project with explicit options should reflect them in the response."""
         self.project.update_option(
             "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
@@ -54,7 +60,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert response.data["automationTuning"] == "medium"
         assert response.data["scannerAutomation"] is False
 
-    def test_get_external_agent_with_integration_id(self) -> None:
+    def test_get_external_agent_with_integration_id(self, mock_is_seat_based) -> None:
         """A project with an external handoff should return the agent, integration ID,
         and autoCreatePr from the handoff config."""
         self.project.update_option(
@@ -72,7 +78,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert response.data["integrationId"] == "42"
         assert response.data["autoCreatePr"] is False
 
-    def test_get_external_agent_with_auto_create_pr(self) -> None:
+    def test_get_external_agent_with_auto_create_pr(self, mock_is_seat_based) -> None:
         """autoCreatePr should reflect the handoff config value."""
         self.project.update_option(
             "sentry:seer_automation_handoff_target", "cursor_background_agent"
@@ -88,7 +94,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["autoCreatePr"] is True
 
-    def test_get_stopping_point_off_when_tuning_off(self) -> None:
+    def test_get_stopping_point_off_when_tuning_off(self, mock_is_seat_based) -> None:
         """stoppingPoint should be 'off' when tuning is OFF."""
         self.project.update_option(
             "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF
@@ -101,7 +107,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert response.data["stoppingPoint"] == "off"
         assert response.data["automationTuning"] == "off"
 
-    def test_get_stopping_point_when_tuning_on(self) -> None:
+    def test_get_stopping_point_when_tuning_on(self, mock_is_seat_based) -> None:
         """When tuning is not OFF, stoppingPoint should reflect the stored value."""
         self.project.update_option(
             "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
@@ -114,7 +120,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert response.data["stoppingPoint"] == "root_cause"
         assert response.data["automationTuning"] == "medium"
 
-    def test_get_repos_count(self) -> None:
+    def test_get_repos_count(self, mock_is_seat_based) -> None:
         """reposCount should reflect active SeerProjectRepository rows."""
         repo1 = self.create_repo(project=self.project, name="owner/repo-1")
         repo2 = self.create_repo(project=self.project, name="owner/repo-2")
@@ -126,7 +132,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["reposCount"] == 2
 
-    def test_get_repos_count_excludes_inactive_repos(self) -> None:
+    def test_get_repos_count_excludes_inactive_repos(self, mock_is_seat_based) -> None:
         """Repos with non-active status should not be counted."""
         active_repo = self.create_repo(project=self.project, name="owner/active")
         disabled_repo = self.create_repo(project=self.project, name="owner/deleted")
@@ -140,7 +146,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["reposCount"] == 1
 
-    def test_put_returns_updated_settings(self) -> None:
+    def test_put_returns_updated_settings(self, mock_is_seat_based) -> None:
         """PUT response should contain the full updated settings object."""
         response = self.client.put(
             self.url,
@@ -156,7 +162,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert "scannerAutomation" in response.data
         assert "reposCount" in response.data
 
-    def test_put_external_agent_with_valid_integration(self) -> None:
+    def test_put_external_agent_with_valid_integration(self, mock_is_seat_based) -> None:
         """Valid external agent + integrationId should succeed and reflect in response."""
         integration = self.create_integration(
             organization=self.organization, external_id="ext", provider="github"
@@ -171,20 +177,20 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert response.data["agent"] == "cursor_background_agent"
         assert response.data["integrationId"] == str(integration.id)
 
-    def test_put_scanner_automation(self) -> None:
+    def test_put_scanner_automation(self, mock_is_seat_based) -> None:
         """PUT scannerAutomation should update and return the new value."""
         response = self.client.put(self.url, data={"scannerAutomation": False}, format="json")
 
         assert response.status_code == 200
         assert response.data["scannerAutomation"] is False
 
-    def test_put_stopping_point(self) -> None:
+    def test_put_stopping_point(self, mock_is_seat_based) -> None:
         response = self.client.put(self.url, data={"stoppingPoint": "open_pr"}, format="json")
 
         assert response.status_code == 200
         assert self.project.get_option("sentry:seer_automated_run_stopping_point") == "open_pr"
 
-    def test_put_stopping_point_open_pr_syncs_auto_create_pr(self) -> None:
+    def test_put_stopping_point_open_pr_syncs_auto_create_pr(self, mock_is_seat_based) -> None:
         """Setting stoppingPoint to open_pr should also set auto_create_pr to True."""
         response = self.client.put(self.url, data={"stoppingPoint": "open_pr"}, format="json")
 
@@ -192,7 +198,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert self.project.get_option("sentry:seer_automated_run_stopping_point") == "open_pr"
         assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is True
 
-    def test_put_stopping_point_non_open_pr_clears_auto_create_pr(self) -> None:
+    def test_put_stopping_point_non_open_pr_clears_auto_create_pr(self, mock_is_seat_based) -> None:
         """Setting stoppingPoint to non-open_pr should clear auto_create_pr."""
         self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
 
@@ -202,8 +208,42 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         assert self.project.get_option("sentry:seer_automated_run_stopping_point") == "code_changes"
         assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
 
-    def test_put_automation_tuning(self) -> None:
-        """automationTuning accepts off and medium."""
+    def test_put_legacy_stopping_point_does_not_sync_auto_create_pr(
+        self, mock_is_seat_based
+    ) -> None:
+        """Legacy: changing stoppingPoint should not touch auto_create_pr."""
+        mock_is_seat_based.return_value = False
+
+        response = self.client.put(self.url, data={"stoppingPoint": "open_pr"}, format="json")
+
+        assert response.status_code == 200
+        assert self.project.get_option("sentry:seer_automated_run_stopping_point") == "open_pr"
+        assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
+
+    def test_put_legacy_auto_create_pr(self, mock_is_seat_based) -> None:
+        """autoCreatePr should update the handoff option directly."""
+        mock_is_seat_based.return_value = False
+
+        response = self.client.put(self.url, data={"autoCreatePr": True}, format="json")
+
+        assert response.status_code == 200
+        assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is True
+
+    def test_put_legacy_auto_create_pr_preserves_stopping_point(self, mock_is_seat_based) -> None:
+        """autoCreatePr should not change the stored stopping_point."""
+        mock_is_seat_based.return_value = False
+
+        self.project.update_option("sentry:seer_automated_run_stopping_point", "root_cause")
+
+        response = self.client.put(self.url, data={"autoCreatePr": True}, format="json")
+
+        assert response.status_code == 200
+        assert self.project.get_option("sentry:seer_automated_run_stopping_point") == "root_cause"
+
+    def test_put_automation_tuning(self, mock_is_seat_based) -> None:
+        """Seat-based: automationTuning accepts off and medium."""
+        mock_is_seat_based.return_value = False
+
         response = self.client.put(self.url, data={"automationTuning": "off"}, format="json")
         assert response.status_code == 200
         assert (
@@ -218,24 +258,35 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
             == AutofixAutomationTuningSettings.MEDIUM
         )
 
-    def test_put_automation_tuning_rejects_granular(self) -> None:
-        """Granular tuning values like 'high' should be rejected."""
+    def test_put_automation_tuning_rejects_granular(self, mock_is_seat_based) -> None:
+        """Seat-based: granular tuning values like 'high' should be rejected."""
         response = self.client.put(self.url, data={"automationTuning": "high"}, format="json")
         assert response.status_code == 400
 
-    def test_put_requires_at_least_one_update_field(self) -> None:
+    def test_put_legacy_automation_tuning_allows_granular(self, mock_is_seat_based) -> None:
+        """Legacy: automationTuning should set tuning directly."""
+        mock_is_seat_based.return_value = False
+        response = self.client.put(self.url, data={"automationTuning": "high"}, format="json")
+
+        assert response.status_code == 200
+        assert (
+            self.project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.HIGH
+        )
+
+    def test_put_requires_at_least_one_update_field(self, mock_is_seat_based) -> None:
         """Sending no update fields should return 400."""
         response = self.client.put(self.url, data={}, format="json")
         assert response.status_code == 400
 
-    def test_put_requires_integration_id_for_external_agent(self) -> None:
+    def test_put_requires_integration_id_for_external_agent(self, mock_is_seat_based) -> None:
         """External agent without integrationId should return 400."""
         response = self.client.put(
             self.url, data={"agent": "cursor_background_agent"}, format="json"
         )
         assert response.status_code == 400
 
-    def test_put_rejects_integration_id_without_agent(self) -> None:
+    def test_put_rejects_integration_id_without_agent(self, mock_is_seat_based) -> None:
         """integrationId without agent should return 400."""
         integration = self.create_integration(
             organization=self.organization, external_id="valid", provider="github"
@@ -243,7 +294,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         response = self.client.put(self.url, data={"integrationId": integration.id}, format="json")
         assert response.status_code == 400
 
-    def test_put_rejects_integration_id_with_seer_agent(self) -> None:
+    def test_put_rejects_integration_id_with_seer_agent(self, mock_is_seat_based) -> None:
         """integrationId with agent=seer should return 400."""
         integration = self.create_integration(
             organization=self.organization, external_id="valid", provider="github"
@@ -253,7 +304,7 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
 
-    def test_put_rejects_integration_id_from_other_org(self) -> None:
+    def test_put_rejects_integration_id_from_other_org(self, mock_is_seat_based) -> None:
         """An integration ID that doesn't belong to this org should return 400."""
         other_org = self.create_organization()
         integration = self.create_integration(
@@ -267,22 +318,22 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
 
-    def test_put_seer_agent_does_not_require_integration_id(self) -> None:
+    def test_put_seer_agent_does_not_require_integration_id(self, mock_is_seat_based) -> None:
         """agent=seer should not require integrationId."""
         response = self.client.put(self.url, data={"agent": "seer"}, format="json")
         assert response.status_code == 200
 
-    def test_put_rejects_invalid_agent(self) -> None:
+    def test_put_rejects_invalid_agent(self, mock_is_seat_based) -> None:
         """An unrecognized agent value should return 400."""
         response = self.client.put(self.url, data={"agent": "invalid"}, format="json")
         assert response.status_code == 400
 
-    def test_put_rejects_invalid_stopping_point(self) -> None:
+    def test_put_rejects_invalid_stopping_point(self, mock_is_seat_based) -> None:
         """An unrecognized stoppingPoint value should return 400."""
         response = self.client.put(self.url, data={"stoppingPoint": "invalid"}, format="json")
         assert response.status_code == 400
 
-    def test_put_creates_audit_log_entry(self) -> None:
+    def test_put_creates_audit_log_entry(self, mock_is_seat_based) -> None:
         """PUT should create an audit log entry with the project ID."""
         from sentry.models.auditlogentry import AuditLogEntry
         from sentry.silo.base import SiloMode
@@ -305,6 +356,10 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
             assert entry.data["project_id"] == self.project.id
 
 
+@patch(
+    "sentry.seer.endpoints.project_seer_settings.is_seer_seat_based_tier_enabled",
+    return_value=True,
+)
 class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-seer-project-settings"
 
@@ -317,7 +372,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
             kwargs={"organization_id_or_slug": self.organization.slug},
         )
 
-    def test_get_returns_defaults(self) -> None:
+    def test_get_returns_defaults(self, mock_is_seat_based) -> None:
         """Projects with no options set should return default values."""
         response = self.client.get(self.url)
 
@@ -335,7 +390,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
             "reposCount": 0,
         }
 
-    def test_get_returns_configured_project_options(self) -> None:
+    def test_get_returns_configured_project_options(self, mock_is_seat_based) -> None:
         """Projects with explicit option values should reflect those in the response."""
         self.project.update_option(
             "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
@@ -351,7 +406,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert response.data[0]["automationTuning"] == "medium"
         assert response.data[0]["scannerAutomation"] is False
 
-    def test_get_external_agent_with_integration_id(self) -> None:
+    def test_get_external_agent_with_integration_id(self, mock_is_seat_based) -> None:
         """A project configured with an external handoff should return the agent,
         integration ID, and autoCreatePr from the handoff config."""
         self.project.update_option(
@@ -369,7 +424,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert response.data[0]["integrationId"] == "42"
         assert response.data[0]["autoCreatePr"] is False
 
-    def test_get_external_agent_with_auto_create_pr(self) -> None:
+    def test_get_external_agent_with_auto_create_pr(self, mock_is_seat_based) -> None:
         """autoCreatePr should reflect the handoff config value."""
         self.project.update_option(
             "sentry:seer_automation_handoff_target", "cursor_background_agent"
@@ -385,7 +440,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data[0]["autoCreatePr"] is True
 
-    def test_get_stopping_point_off_when_tuning_off(self) -> None:
+    def test_get_stopping_point_off_when_tuning_off(self, mock_is_seat_based) -> None:
         """When tuning is OFF, stoppingPoint should be 'off' regardless of the
         stored seer_automated_run_stopping_point value."""
         self.project.update_option(
@@ -399,7 +454,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert response.data[0]["stoppingPoint"] == "off"
         assert response.data[0]["automationTuning"] == "off"
 
-    def test_get_stopping_point_when_tuning_on(self) -> None:
+    def test_get_stopping_point_when_tuning_on(self, mock_is_seat_based) -> None:
         """When tuning is not OFF, stoppingPoint should reflect the stored value."""
         self.project.update_option(
             "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
@@ -412,7 +467,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert response.data[0]["stoppingPoint"] == "root_cause"
         assert response.data[0]["automationTuning"] == "medium"
 
-    def test_get_repos_count(self) -> None:
+    def test_get_repos_count(self, mock_is_seat_based) -> None:
         """reposCount should reflect the number of active SeerProjectRepository rows."""
         repo1 = self.create_repo(project=self.project, name="owner/repo-1")
         repo2 = self.create_repo(project=self.project, name="owner/repo-2")
@@ -424,7 +479,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data[0]["reposCount"] == 2
 
-    def test_get_repos_count_excludes_inactive_repos(self) -> None:
+    def test_get_repos_count_excludes_inactive_repos(self, mock_is_seat_based) -> None:
         """Repos with non-active status should not be counted."""
         active_repo = self.create_repo(project=self.project, name="owner/active")
         disabled_repo = self.create_repo(project=self.project, name="owner/deleted")
@@ -438,7 +493,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data[0]["reposCount"] == 1
 
-    def test_get_only_returns_accessible_projects(self) -> None:
+    def test_get_only_returns_accessible_projects(self, mock_is_seat_based) -> None:
         """Response should only include projects the user has access to."""
         self.organization.flags.allow_joinleave = False
         self.organization.save()
@@ -458,7 +513,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert len(project_ids) == 1
         assert str(inaccessible_project.id) not in project_ids
 
-    def test_get_paginates_results(self) -> None:
+    def test_get_paginates_results(self, mock_is_seat_based) -> None:
         """Results should be paginated with Link headers indicating next/previous."""
         for i in range(5):
             self.create_project(organization=self.organization, slug=f"paginate-{i}")
@@ -473,7 +528,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert 'rel="previous"; results="true"' in response2.headers["Link"]
         assert 'rel="next"; results="false"' in response2.headers["Link"]
 
-    def test_get_sort_by_name(self) -> None:
+    def test_get_sort_by_name(self, mock_is_seat_based) -> None:
         """sortBy=name should order by project slug."""
         project_b = self.create_project(organization=self.organization, slug="banana")
         project_a = self.create_project(organization=self.organization, slug="apple")
@@ -484,7 +539,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         slugs = [r["projectSlug"] for r in response.data]
         assert slugs.index(project_a.slug) < slugs.index(project_b.slug)
 
-    def test_get_sort_by_repos_count(self) -> None:
+    def test_get_sort_by_repos_count(self, mock_is_seat_based) -> None:
         """sortBy=reposCount should order by SeerProjectRepository count."""
         project1 = self.create_project(organization=self.organization)
         for i in range(2):
@@ -498,7 +553,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         ids = [r["projectId"] for r in response.data]
         assert ids.index(str(project2.id)) < ids.index(str(project1.id))
 
-    def test_get_sort_by_agent(self) -> None:
+    def test_get_sort_by_agent(self, mock_is_seat_based) -> None:
         """sortBy=agent should order alphabetically by agent alias."""
         project_seer = self.create_project(organization=self.organization)
 
@@ -517,7 +572,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert ids.index(str(project_claude.id)) < ids.index(str(project_cursor.id))
         assert ids.index(str(project_cursor.id)) < ids.index(str(project_seer.id))
 
-    def test_get_sort_by_stopping_point(self) -> None:
+    def test_get_sort_by_stopping_point(self, mock_is_seat_based) -> None:
         """sortBy=stoppingPoint should order by hierarchy rank (off < root_cause < code_changes < open_pr)."""
         project_open_pr = self.create_project(organization=self.organization)
         project_open_pr.update_option(
@@ -540,19 +595,19 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert ids.index(str(self.project.id)) < ids.index(str(project_root_cause.id))
         assert ids.index(str(project_root_cause.id)) < ids.index(str(project_open_pr.id))
 
-    def test_get_sort_by_invalid_field_returns_400(self) -> None:
+    def test_get_sort_by_invalid_field_returns_400(self, mock_is_seat_based) -> None:
         """An unrecognized sortBy value should return 400."""
         response = self.client.get(self.url, {"sortBy": "invalid"})
         assert response.status_code == 400
 
-    def test_get_filter_empty_results(self) -> None:
+    def test_get_filter_empty_results(self, mock_is_seat_based) -> None:
         """A filter that matches nothing should return an empty list."""
         response = self.client.get(self.url, {"query": "id:999999999"})
 
         assert response.status_code == 200
         assert response.data == []
 
-    def test_get_filter_by_free_text_name(self) -> None:
+    def test_get_filter_by_free_text_name(self, mock_is_seat_based) -> None:
         """Free text query should match against both name and slug."""
         project1 = self.create_project(
             organization=self.organization, name="", slug="matching-slug"
@@ -571,7 +626,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert str(project2.id) in ids
         assert str(project3.id) not in ids
 
-    def test_get_filter_by_id(self) -> None:
+    def test_get_filter_by_id(self, mock_is_seat_based) -> None:
         """id:N should return only the project with that ID."""
         self.create_project(organization=self.organization)
         project = self.create_project(organization=self.organization)
@@ -582,7 +637,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         ids = [r["projectId"] for r in response.data]
         assert ids == [str(project.id)]
 
-    def test_get_filter_by_id_list(self) -> None:
+    def test_get_filter_by_id_list(self, mock_is_seat_based) -> None:
         """id:[N,M] should return only the projects with those IDs."""
         project1 = self.create_project(organization=self.organization)
         project2 = self.create_project(organization=self.organization)
@@ -594,7 +649,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         ids = [r["projectId"] for r in response.data]
         assert sorted(ids) == sorted([str(project1.id), str(project2.id)])
 
-    def test_get_filter_by_repos_count(self) -> None:
+    def test_get_filter_by_repos_count(self, mock_is_seat_based) -> None:
         """reposCount with numeric operators."""
         project1 = self.create_project(organization=self.organization)
         for i in range(2):
@@ -613,7 +668,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert str(project2.id) in ids
         assert str(project1.id) not in ids
 
-    def test_get_filter_by_stopping_point(self) -> None:
+    def test_get_filter_by_stopping_point(self, mock_is_seat_based) -> None:
         """stoppingPoint filter should account for tuning state."""
         project1 = self.create_project(organization=self.organization)
         project1.update_option(
@@ -632,7 +687,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert str(project1.id) in ids
         assert str(self.project.id) not in ids
 
-    def test_get_filter_by_agent_seer(self) -> None:
+    def test_get_filter_by_agent_seer(self, mock_is_seat_based) -> None:
         """agent:seer should return projects with no handoff target (NULL)."""
         project1 = self.create_project(organization=self.organization)
         project1.update_option("sentry:seer_automation_handoff_target", "cursor_background_agent")
@@ -644,7 +699,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert str(self.project.id) in ids
         assert str(project1.id) not in ids
 
-    def test_get_filter_by_agent_external(self) -> None:
+    def test_get_filter_by_agent_external(self, mock_is_seat_based) -> None:
         """agent:cursor_background_agent should return projects with cursor handoff target."""
         project1 = self.create_project(organization=self.organization)
         project1.update_option("sentry:seer_automation_handoff_target", "cursor_background_agent")
@@ -656,7 +711,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert str(project1.id) in ids
         assert str(self.project.id) not in ids
 
-    def test_get_filter_negation(self) -> None:
+    def test_get_filter_negation(self, mock_is_seat_based) -> None:
         """!agent:seer should exclude projects with no handoff target."""
         project1 = self.create_project(organization=self.organization)
         project1.update_option("sentry:seer_automation_handoff_target", "cursor_background_agent")
@@ -668,7 +723,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert str(project1.id) in ids
         assert str(self.project.id) not in ids
 
-    def test_get_multiple_filters(self) -> None:
+    def test_get_multiple_filters(self, mock_is_seat_based) -> None:
         """Combining multiple filters should intersect the results."""
         project1 = self.create_project(organization=self.organization)
         project1.update_option("sentry:seer_automation_handoff_target", "cursor_background_agent")
@@ -686,13 +741,13 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         ids = [r["projectId"] for r in response.data]
         assert ids == [str(project1.id)]
 
-    def test_get_invalid_search_query_returns_400(self) -> None:
+    def test_get_invalid_search_query_returns_400(self, mock_is_seat_based) -> None:
         """A malformed search query should return 400 with detail."""
         response = self.client.get(self.url, {"query": "bogusKey:value"})
         assert response.status_code == 400
         assert "detail" in response.data
 
-    def test_put_updates_all_projects(self) -> None:
+    def test_put_updates_all_projects(self, mock_is_seat_based) -> None:
         """Empty query should update all accessible projects."""
         project2 = self.create_project(organization=self.organization)
 
@@ -702,7 +757,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert self.project.get_option("sentry:seer_scanner_automation") is False
         assert project2.get_option("sentry:seer_scanner_automation") is False
 
-    def test_put_applies_to_filtered_projects_only(self) -> None:
+    def test_put_applies_to_filtered_projects_only(self, mock_is_seat_based) -> None:
         """The query parameter should scope which projects get updated."""
         project2 = self.create_project(organization=self.organization)
         project2.update_option("sentry:seer_automation_handoff_target", "cursor_background_agent")
@@ -717,7 +772,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
         assert project2.get_option("sentry:seer_scanner_automation") is False
         assert self.project.get_option("sentry:seer_scanner_automation") is True
 
-    def test_put_updates_settings(self) -> None:
+    def test_put_updates_settings(self, mock_is_seat_based) -> None:
         """Bulk update with multiple seer agent fields should apply all of them."""
         project2 = self.create_project(organization=self.organization)
 
@@ -741,7 +796,7 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
             )
             assert p.get_option("sentry:seer_scanner_automation") is False
 
-    def test_put_updates_settings_with_external_agent(self) -> None:
+    def test_put_updates_settings_with_external_agent(self, mock_is_seat_based) -> None:
         """Bulk update with external agent fields should set agent, integration, and stopping point."""
         project2 = self.create_project(organization=self.organization)
         integration = self.create_integration(
@@ -768,14 +823,14 @@ class OrganizationSeerProjectSettingsEndpointTest(APITestCase):
             assert p.get_option("sentry:seer_automated_run_stopping_point") == "open_pr"
             assert p.get_option("sentry:seer_scanner_automation") is True
 
-    def test_put_invalid_search_query_returns_400(self) -> None:
+    def test_put_invalid_search_query_returns_400(self, mock_is_seat_based) -> None:
         """A malformed query value should return 400."""
         response = self.client.put(
             self.url, data={"query": "invalidKey:value", "scannerAutomation": False}, format="json"
         )
         assert response.status_code == 400
 
-    def test_put_creates_audit_log_entry(self) -> None:
+    def test_put_creates_audit_log_entry(self, mock_is_seat_based) -> None:
         """Bulk update should create an audit log entry with project count and IDs."""
         from sentry.models.auditlogentry import AuditLogEntry
         from sentry.silo.base import SiloMode

--- a/tests/sentry/seer/endpoints/test_project_seer_settings.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_settings.py
@@ -242,8 +242,6 @@ class ProjectSeerSettingsEndpointTest(APITestCase):
 
     def test_put_automation_tuning(self, mock_is_seat_based) -> None:
         """Seat-based: automationTuning accepts off and medium."""
-        mock_is_seat_based.return_value = False
-
         response = self.client.put(self.url, data={"automationTuning": "off"}, format="json")
         assert response.status_code == 200
         assert (


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/116352 and https://github.com/getsentry/sentry/pull/116356.

Add legacy usage-based Seer support to the project settings endpoints by branching on `is_seer_seat_based_tier_enabled`.

**Serializer split:**
- Extract `_BaseProjectSettingsUpdateSerializer` with shared validation (agent, integration_id, cross-field checks)
- `ProjectSettingsUpdateSerializer` (seat-based): restricted tuning choices (off/medium), stopping_point validation via `get_valid_automated_run_stopping_points`, auto_create_pr synced from stopping_point
- `LegacyProjectSettingsUpdateSerializer` (usage-based): accepts all tuning values, direct `auto_create_pr` field, no stopping_point restrictions

### Example payloads

**Set tuning to a granular value:**
```json
PUT /api/0/projects/{org}/{project}/seer/settings/
{"automationTuning": "high"}
```

**Set stopping point (frontend sends agent=seer to clear any external handoff):**
```json
PUT /api/0/projects/{org}/{project}/seer/settings/
{"stoppingPoint": "code_changes", "agent": "seer"}
```
This clears handoff keys (target, point, integration_id) but preserves `auto_create_pr` so switching back to an external agent restores the previous toggle value.

**Switch to external agent with auto_create_pr:**
```json
PUT /api/0/projects/{org}/{project}/seer/settings/
{"agent": "cursor_background_agent", "integrationId": 1, "autoCreatePr": true}
```

**Toggle auto_create_pr on an existing external agent:**
```json
PUT /api/0/projects/{org}/{project}/seer/settings/
{"autoCreatePr": false}
```

**Turn off automation:**
```json
PUT /api/0/projects/{org}/{project}/seer/settings/
{"automationTuning": "off"}
```
GET response will show `stoppingPoint: "off"`, but the stored stopping point is unchanged — re-enabling restores it.