### PR TITLE
ref(🥞): add no-z-index lint rule banning z-index declarations

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -469,6 +469,7 @@ export default typescript.config([
       '@sentry/scraps/no-core-import': 'error',
       '@sentry/scraps/no-token-import': 'error',
       '@sentry/scraps/prefer-info-text': 'error',
+      '@sentry/scraps/no-z-index': 'warn',
       '@sentry/scraps/use-semantic-token': [
         'error',
         {enabledCategories: ['background', 'border', 'content']},

--- a/static/eslint/eslintPluginScraps/src/rules/index.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/index.ts
@@ -1,5 +1,6 @@
 import {noCoreImport} from './no-core-import';
 import {noTokenImport} from './no-token-import';
+import {noZIndex} from './no-z-index';
 import {preferInfoText} from './prefer-info-text';
 import {restrictJsxSlotChildren} from './restrict-jsx-slot-children';
 import {useSemanticToken} from './use-semantic-token';
@@ -7,6 +8,7 @@ import {useSemanticToken} from './use-semantic-token';
 export const rules = {
   'no-core-import': noCoreImport,
   'no-token-import': noTokenImport,
+  'no-z-index': noZIndex,
   'prefer-info-text': preferInfoText,
   'restrict-jsx-slot-children': restrictJsxSlotChildren,
   'use-semantic-token': useSemanticToken,

--- a/static/eslint/eslintPluginScraps/src/rules/no-z-index.spec.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/no-z-index.spec.ts
@@ -1,0 +1,120 @@
+import {RuleTester} from '@typescript-eslint/rule-tester';
+
+import {noZIndex} from './no-z-index';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {jsx: true},
+    },
+  },
+});
+
+ruleTester.run('no-z-index', noZIndex, {
+  valid: [
+    // z-index: 1 is the approved local override in CSS
+    {
+      code: "const Foo = styled('div')`z-index: 1;`;",
+      filename: '/static/app/components/foo.tsx',
+    },
+    // zIndex: 1 in object form is allowed
+    {
+      code: 'const style = { zIndex: 1 };',
+      filename: '/static/app/components/foo.tsx',
+    },
+    // zIndex: 1 in JSX style prop is allowed
+    {
+      code: '<div style={{ zIndex: 1 }} />;',
+      filename: '/static/app/components/foo.tsx',
+    },
+    // zIndex={1} as JSX prop is allowed
+    {
+      code: '<Foo zIndex={1} />;',
+      filename: '/static/app/components/foo.tsx',
+    },
+    // No z-index at all is fine
+    {
+      code: "const Bar = styled('div')`color: red;`;",
+      filename: '/static/app/components/bar.tsx',
+    },
+    // Regular objects without zIndex are fine
+    {
+      code: 'const style = { color: "red" };',
+      filename: '/static/app/components/bar.tsx',
+    },
+    // z-index: 1 with !important is allowed
+    {
+      code: "const Foo = styled('div')`z-index: 1 !important;`;",
+      filename: '/static/app/components/foo.tsx',
+    },
+  ],
+
+  invalid: [
+    // z-index in tagged template with value other than 1
+    {
+      code: "const Foo = styled('div')`z-index: 10;`;",
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+    // z-index: 0
+    {
+      code: "const Foo = styled('div')`z-index: 0;`;",
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+    // z-index with negative value
+    {
+      code: "const Foo = styled('div')`z-index: -1;`;",
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+    // z-index with theme expression (expression is in a quasi boundary, the literal part is just `z-index: `)
+    {
+      code: "const Foo = styled('div')`z-index: ${theme.zIndex.modal};`;",
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+    // z-index: 9999
+    {
+      code: "const Foo = styled('div')`z-index: 9999;`;",
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+    // zIndex in style object with non-1 value
+    {
+      code: 'const style = { zIndex: 10 };',
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+    // zIndex: 0 in object
+    {
+      code: 'const style = { zIndex: 0 };',
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+    // zIndex in JSX style prop with non-1 value
+    {
+      code: '<div style={{ zIndex: 100 }} />;',
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+    // zIndex as JSX prop with expression
+    {
+      code: '<PositionWrapper zIndex={theme.zIndex.tooltip} />;',
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+    // zIndex as JSX prop with non-1 literal
+    {
+      code: '<Foo zIndex={10} />;',
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+    // zIndex as string value JSX prop
+    {
+      code: '<Foo zIndex="10" />;',
+      filename: '/static/app/components/foo.tsx',
+      errors: [{messageId: 'noZIndex'}],
+    },
+  ],
+});

--- a/static/eslint/eslintPluginScraps/src/rules/no-z-index.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/no-z-index.ts
@@ -1,0 +1,102 @@
+/**
+ * ESLint rule: no-z-index
+ *
+ * Bans z-index CSS declarations and zIndex props/style properties.
+ * The only allowed value is z-index: 1 / zIndex: 1 (local override within a Layer).
+ *
+ * Use the Layer primitive for stacking context isolation instead.
+ */
+import type {TSESTree} from '@typescript-eslint/utils';
+import {ESLintUtils} from '@typescript-eslint/utils';
+
+const MESSAGE =
+  'Avoid z-index. Use the Layer primitive for stacking context isolation, or z-index: 1 for local overrides within a Layer.';
+
+/**
+ * Matches `z-index: <value>` in CSS text, capturing the value.
+ * Handles multiline, whitespace variations, and !important.
+ */
+const Z_INDEX_CSS_RE = /z-index\s*:\s*([^;}\n]+)/gi;
+
+/**
+ * Returns true if the CSS value is exactly `1` (possibly with !important).
+ */
+function isAllowedCssValue(raw: string): boolean {
+  const trimmed = raw.replace(/!important/gi, '').trim();
+  return trimmed === '1';
+}
+
+/**
+ * Returns true if a JS/TS expression node represents the numeric literal 1.
+ */
+function isNumericLiteralOne(node: TSESTree.Node): boolean {
+  return node.type === 'Literal' && node.value === 1;
+}
+
+export const noZIndex = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow z-index CSS declarations and zIndex props/style properties. Use the Layer primitive instead.',
+    },
+    schema: [],
+    messages: {
+      noZIndex: MESSAGE,
+    },
+  },
+  create(context) {
+    return {
+      // 1. CSS `z-index` in tagged template literals (styled components, css``)
+      TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression) {
+        for (const quasi of node.quasi.quasis) {
+          const text = quasi.value.raw;
+          const matches = text.matchAll(Z_INDEX_CSS_RE);
+
+          for (const match of matches) {
+            const value = match[1];
+            if (isAllowedCssValue(value)) {
+              continue;
+            }
+            context.report({
+              node: quasi,
+              messageId: 'noZIndex',
+            });
+          }
+        }
+      },
+
+      // 2. `zIndex` key in object expressions (style objects, css() calls)
+      // 3. `zIndex` prop on JSX elements
+      Property(node: TSESTree.Property) {
+        if (
+          node.key.type === 'Identifier' &&
+          node.key.name === 'zIndex' &&
+          !isNumericLiteralOne(node.value)
+        ) {
+          context.report({
+            node,
+            messageId: 'noZIndex',
+          });
+        }
+      },
+
+      // zIndex as a JSX attribute (e.g. <Foo zIndex={10} />)
+      JSXAttribute(node: TSESTree.JSXAttribute) {
+        if (node.name.type === 'JSXIdentifier' && node.name.name === 'zIndex') {
+          // Allow zIndex={1}
+          if (
+            node.value?.type === 'JSXExpressionContainer' &&
+            isNumericLiteralOne(node.value.expression as TSESTree.Node)
+          ) {
+            return;
+          }
+          context.report({
+            node,
+            messageId: 'noZIndex',
+          });
+        }
+      },
+    };
+  },
+});

--- a/static/eslint/eslintPluginScraps/src/rules/no-z-index.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/no-z-index.ts
@@ -87,7 +87,7 @@ export const noZIndex = ESLintUtils.RuleCreator.withoutDocs({
           // Allow zIndex={1}
           if (
             node.value?.type === 'JSXExpressionContainer' &&
-            isNumericLiteralOne(node.value.expression as TSESTree.Node)
+            isNumericLiteralOne(node.value.expression)
           ) {
             return;
           }

--- a/static/eslint/eslintPluginScraps/src/rules/no-z-index.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/no-z-index.ts
@@ -54,7 +54,7 @@ export const noZIndex = ESLintUtils.RuleCreator.withoutDocs({
           const matches = text.matchAll(Z_INDEX_CSS_RE);
 
           for (const match of matches) {
-            const value = match[1];
+            const value = match[1] ?? '';
             if (isAllowedCssValue(value)) {
               continue;
             }


### PR DESCRIPTION
## Summary
- New `no-z-index` rule in `eslintPluginScraps`
- Bans `z-index` in CSS, `zIndex` in style objects, and `zIndex` JSX props
- Allows `z-index: 1` / `zIndex: 1` as the approved local override within a Layer
- Starts as `warn` — will promote to `error` after cleanup is complete

## 🥞 Layer Primitive Series
- [x] #114516 `nm/zindex/layer-primitive` — Layer component + hooks
- [x] #114520 `nm/zindex/dom-order` — DOM restructuring for paint-order stacking
- [x] #114549 `nm/zindex/wire-portals` — Wire portal consumers to Layer outlets
- [ ] #115959 `nm/zindex/remove-structural-zindex` — Remove structural z-index refs
- [ ] #115957 `nm/zindex/remove-portal-zindex` — Remove portal z-index refs
- [ ] #115956 `nm/zindex/remove-local-zindex` — Replace local z-index refs with bare z-index: 1
- [ ] #115961 `nm/zindex/deprecate-zindex` — Deprecate theme.zIndex scale
- [ ] #115963 `nm/zindex/lint-ban` — Lint rule banning z-index/zIndex ← this PR
- [ ] #115964 `nm/zindex/final-cleanup` — Remove theme.zIndex entirely

## Test plan
- [ ] Rule tests pass: `pnpm test-ci static/eslint/eslintPluginScraps/src/rules/no-z-index.spec.ts`
- [ ] No new lint warnings on clean codebase (after removal PRs merge)
- [ ] `z-index: 1` is not flagged
- [ ] `z-index: 10` IS flagged as warning