### PR TITLE
ref(🥞): remove theme.zIndex and remaining z-index infrastructure

### DIFF
--- a/static/app/components/core/backdrop/backdrop.tsx
+++ b/static/app/components/core/backdrop/backdrop.tsx
@@ -5,13 +5,12 @@ interface BackdropProps extends Omit<
   React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
   'style' | 'className' | `on${string}`
 > {
-  zIndex: 'widgetBuilderDrawer' | 'drawer' | 'modal';
   'data-drawer-backdrop'?: string;
   'data-test-id'?: string;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
-export function Backdrop({onClick, zIndex, ...props}: BackdropProps) {
+export function Backdrop({onClick, ...props}: BackdropProps) {
   const theme = useTheme();
   // TODO(design-engineering): These should be exposed as `theme.tokens`
   const background = theme.type === 'light' ? '#10082845' : '#10082080';
@@ -27,7 +26,6 @@ export function Backdrop({onClick, zIndex, ...props}: BackdropProps) {
         background,
         position: 'fixed',
         inset: '0',
-        zIndex: theme.zIndex[zIndex],
       }}
       animate={{opacity: 1}}
       exit={{opacity: 0}}

--- a/static/app/components/core/drawer/index.tsx
+++ b/static/app/components/core/drawer/index.tsx
@@ -221,7 +221,7 @@ export function GlobalDrawer({children}: any) {
       >
         <AnimatePresence>
           {isDrawerOpen && currentDrawerConfig.options.mode !== 'passive' ? (
-            <Backdrop zIndex="drawer" key="backdrop" data-drawer-backdrop="" />
+            <Backdrop key="backdrop" data-drawer-backdrop="" />
           ) : null}
           {isDrawerOpen && (
             <DrawerComponents.DrawerPanel

--- a/static/app/components/core/modal/index.tsx
+++ b/static/app/components/core/modal/index.tsx
@@ -233,11 +233,7 @@ export function GlobalModal({onClose}: Props) {
     <Fragment>
       <AnimatePresence>
         {backdrop && visible && (
-          <Backdrop
-            key="backdrop"
-            zIndex="modal"
-            {...(typeof backdrop === 'object' ? backdrop : {})}
-          />
+          <Backdrop key="backdrop" {...(typeof backdrop === 'object' ? backdrop : {})} />
         )}
       </AnimatePresence>
       <ModalContainer

--- a/static/app/components/overlay.tsx
+++ b/static/app/components/overlay.tsx
@@ -154,11 +154,6 @@ const OverlayInner = styled(motion.div)<{
 
 interface PositionWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
-  /**
-   * @deprecated Stacking is handled by Layer portal outlets. Only pass
-   * this when rendering outside a Layer.
-   */
-  zIndex?: number;
 }
 
 /**
@@ -182,7 +177,6 @@ export function PositionWrapper({
   onDragStart: _onDragStart,
   onDragEnd: _onDragEnd,
   onDrag: _onDrag,
-  zIndex,
   style,
   ...props
 }: PositionWrapperProps) {
@@ -191,7 +185,7 @@ export function PositionWrapper({
     <motion.div
       {...props}
       ref={ref}
-      style={{...style, zIndex, pointerEvents: isPresent ? 'auto' : 'none'}}
+      style={{...style, pointerEvents: isPresent ? 'auto' : 'none'}}
     />
   );
 }

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -157,7 +157,9 @@ const styles = (theme: Theme, darkTheme: Theme) => css`
 
   body {
     .sentry-error-embed-wrapper {
-      z-index: ${theme.zIndex.sentryErrorEmbed};
+      /* External Sentry error-feedback widget — hardcoded because it lives
+         outside the React tree and cannot use the Layer primitive. */
+      z-index: 1090;
     }
 
     .loading .loading-indicator {

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -188,38 +188,6 @@ type Colors = typeof lightColors;
 const commonTheme = {
   motion: generateMotion(),
 
-  // Try to keep these ordered plz
-  zIndex: {
-    // Generic z-index when you hope your component is isolated and
-    // does not need to battle others for z-index priority
-    initial: 1,
-    truncationFullValue: 10,
-
-    header: 1000,
-
-    // dashboard widget builder backdrop sits behind the sidebar
-    // because it renders on the right next to the sidebar
-    // @TODO(design-engineering): resolve this inconsistency
-    widgetBuilderDrawer: 1016,
-
-    sidebarPanel: 1019,
-    dropdown: 1020,
-    sidebar: 1020,
-
-    // Sentry user feedback modal
-    sentryErrorEmbed: 1090,
-
-    // If you change modal also update shared-components.less
-    // as the z-index for bootstrap modals lives there.
-    drawer: 9999,
-    modal: 10000,
-    toast: 10001,
-
-    // tooltips and hovercards can be inside modals sometimes.
-    hovercard: 10002,
-    tooltip: 10003,
-  },
-
   form: {
     md: {
       height: '36px',

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -163,7 +163,7 @@ export function WidgetBuilderV2({
               }
             `}
           />
-          <Backdrop zIndex="widgetBuilderDrawer" />
+          <Backdrop />
           <WidgetBuilderProvider>
             <CustomMeasurementsProvider organization={organization} selection={selection}>
               <ContainerWithoutSidebar

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -91,6 +91,7 @@ export function SaveAsDropdown({
   const {isOpen, triggerProps, overlayProps, arrowProps} = useOverlay({
     position: 'bottom',
   });
+<<<<<<< HEAD
   const layerPortal = usePortalContainer();
 
   return (

--- a/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {AvatarList, TeamAvatar, UserAvatar} from '@sentry/scraps/avatar';
@@ -27,7 +26,6 @@ export function ParticipantList({users, teams, hideTimestamp}: DropdownListProps
     isKeyboardDismissDisabled: false,
   });
 
-  const theme = useTheme();
   const showHeaders = users.length > 0 && teams && teams.length > 0;
 
   return (
@@ -52,7 +50,7 @@ export function ParticipantList({users, teams, hideTimestamp}: DropdownListProps
         />
       </Button>
       {isOpen && (
-        <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>
+        <PositionWrapper {...overlayProps}>
           <StyledOverlay>
             <ParticipantListWrapper>
               {showHeaders && teams && teams.length > 0 && (

--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -766,7 +766,7 @@ function PrimaryNavigationButtonOverlay(props: PrimaryNavigationButtonOverlayPro
 
   return createPortal(
     <FocusScope restoreFocus autoFocus>
-      <PositionWrapper zIndex={theme.zIndex.modal} {...props.overlayProps}>
+      <PositionWrapper {...props.overlayProps}>
         <motion.div
           initial={isDesktop ? {opacity: 0, scale: 0.98} : undefined}
           animate={isDesktop ? {opacity: 1, scale: 1} : undefined}

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -84,7 +84,7 @@ export function AppSizeInsightsSidebar({
   return (
     <Fragment>
       <AnimatePresence>
-        {isOpen && <Backdrop key="backdrop" zIndex="drawer" onClick={onClose} />}
+        {isOpen && <Backdrop key="backdrop" onClick={onClose} />}
       </AnimatePresence>
       {isOpen && (
         <SlideOverPanel


### PR DESCRIPTION
## Summary
- Remove `theme.zIndex` object from theme.tsx
- Remove Backdrop `zIndex` prop and all callsites
- Remove PositionWrapper `zIndex` prop and all callsites
- Remove PortalOutlet `z-index: 2147483647`
- `sentryErrorEmbed` z-index (1090) preserved as hardcoded value at its single usage site in global styles

**This PR should be merged last**, after all removal PRs are complete. CI is expected to fail until then.

## 🥞 Layer Primitive Series
- [x] #114516 `nm/zindex/layer-primitive` — Layer component + hooks
- [x] #114520 `nm/zindex/dom-order` — DOM restructuring for paint-order stacking
- [x] #114549 `nm/zindex/wire-portals` — Wire portal consumers to Layer outlets
- [ ] #115959 `nm/zindex/remove-structural-zindex` — Remove structural z-index refs
- [ ] #115957 `nm/zindex/remove-portal-zindex` — Remove portal z-index refs
- [ ] #115956 `nm/zindex/remove-local-zindex` — Replace local z-index refs with bare z-index: 1
- [ ] #115961 `nm/zindex/deprecate-zindex` — Deprecate theme.zIndex scale
- [ ] #115963 `nm/zindex/lint-ban` — Lint rule banning z-index/zIndex
- [ ] #115964 `nm/zindex/final-cleanup` — Remove theme.zIndex entirely ← this PR

## Test plan
- [ ] `pnpm run typecheck` passes (after prior removal PRs are merged)
- [ ] `pnpm run lint:js` passes (after prior removal PRs are merged)
- [ ] No runtime errors related to theme.zIndex access
- [ ] Layer portal outlets still render above Layer content (DOM order, not z-index)