### PR TITLE
feat(ci): Add merge_base_strategy tag to Jest CI runs

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,6 +30,7 @@ jobs:
       mdx_typecheckable: ${{ steps.changes.outputs.mdx_typecheckable }}
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
       merge_base: ${{ steps.merge_base.outputs.merge_base }}
+      merge_base_strategy: ${{ steps.merge_base.outputs.merge_base_strategy }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -57,13 +58,17 @@ jobs:
             if echo "$CHANGED" | grep -qvE '^static/'; then
               echo "Non-frontend file changed — running full Jest suite"
               MERGE_BASE=""
+              STRATEGY="non_frontend_changes"
             else
               echo "Merge base: $MERGE_BASE (Jest will use --changedSince)"
+              STRATEGY="changedSince"
             fi
           else
             echo "Could not compute merge base — running full Jest suite"
+            STRATEGY="no_merge_base"
           fi
           echo "merge_base=${MERGE_BASE:-}" >> "$GITHUB_OUTPUT"
+          echo "merge_base_strategy=${STRATEGY}" >> "$GITHUB_OUTPUT"
 
   typescript:
     if: needs.files-changed.outputs.frontend_all == 'true'
@@ -220,6 +225,7 @@ jobs:
           # When set, Jest uses --changedSince to run only tests affected by this PR.
           # Empty on master or when non-frontend files changed (falls back to full suite).
           MERGE_BASE: ${{ needs.files-changed.outputs.merge_base }}
+          MERGE_BASE_STRATEGY: ${{ needs.files-changed.outputs.merge_base_strategy }}
         run: pnpm run test-ci --forceExit
 
   form-field-registry:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -39,6 +39,8 @@ const {
   GITHUB_PR_REF,
   GITHUB_RUN_ID,
   GITHUB_RUN_ATTEMPT,
+  MERGE_BASE,
+  MERGE_BASE_STRATEGY,
 } = process.env;
 
 const IS_MASTER_BRANCH = GITHUB_PR_REF === 'refs/heads/master';
@@ -46,8 +48,12 @@ const IS_MASTER_BRANCH = GITHUB_PR_REF === 'refs/heads/master';
 const optionalTags: {
   balancer?: boolean;
   balancer_strategy?: string;
+  merge_base: string;
+  merge_base_strategy: string;
 } = {
   balancer: false,
+  merge_base: MERGE_BASE || '',
+  merge_base_strategy: MERGE_BASE_STRATEGY || 'full',
 };
 
 if (!!JEST_TEST_BALANCER && !CI) {
@@ -64,13 +70,9 @@ if (CI && !process.env.JEST_LIST_TESTS_INNER) {
   try {
     const listTestArguments = ['exec', 'jest', '--listTests', '--json'];
 
-    if (process.env.MERGE_BASE) {
-      console.log('MERGE_BASE detected:', process.env.MERGE_BASE);
-      listTestArguments.push(
-        '--changedSince',
-        process.env.MERGE_BASE,
-        '--passWithNoTests'
-      );
+    if (MERGE_BASE) {
+      console.log('MERGE_BASE detected:', MERGE_BASE);
+      listTestArguments.push('--changedSince', MERGE_BASE, '--passWithNoTests');
     }
 
     const stdout = execFileSync('pnpm', listTestArguments, {
@@ -311,7 +313,7 @@ const config: Config.InitialOptions = {
     // window/cookies state.
     '@sentry/toolbar': '<rootDir>/tests/js/sentry-test/mocks/sentryToolbarMock.js',
   },
-  passWithNoTests: !!process.env.MERGE_BASE,
+  passWithNoTests: !!MERGE_BASE,
   setupFiles: [
     '<rootDir>/static/app/utils/silence-react-unsafe-warnings.ts',
     'jest-canvas-mock',


### PR DESCRIPTION
## Summary

- Adds a `merge_base_strategy` output to the "Get merge base for changedSince" step in `frontend.yml`, surfacing the reason behind the MERGE_BASE decision
- Passes `MERGE_BASE_STRATEGY` env var through to the jest step
- Tags Sentry transactions with `merge_base` (the SHA) and `merge_base_strategy` so we can query/filter CI runs by which code path was taken

### Strategy values

| Value | Meaning |
|---|---|
| `changedSince` | Merge base found, all changes under `static/` → Jest uses `--changedSince` |
| `non_frontend_changes` | Merge base found, but non-frontend files changed → full suite |
| `no_merge_base` | `git merge-base` failed (no common ancestor) → full suite |
| `full` | Default fallback (push to master, or step skipped) |

## Test plan

- [ ] Verify tags appear in Sentry transaction data after a CI run on this PR