### PR TITLE
ref(snuba): Stop dropping deprecated spans dataset in reset_snuba

### DIFF
--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -337,7 +337,6 @@ def call_snuba(settings):
 def reset_snuba(call_snuba):
     init_endpoints = [
         "/tests/events_analytics_platform/drop",
-        "/tests/spans/drop",
         "/tests/events/drop",
         "/tests/functions/drop",
         "/tests/groupedmessage/drop",


### PR DESCRIPTION
Remove `/tests/spans/drop` from the `reset_snuba` test fixture so the
matching Snuba PR can land cleanly.

The standalone `spans` dataset/storage in Snuba is `readiness_state:
deprecate` and is being removed in getsentry/snuba#7955. Without this
change, every Snuba-backed Sentry test fails at setup because the
removed dataset makes `/tests/spans/drop` return 404 and the fixture's
`assert all(... status_code == 200 ...)` flips to false.

This change should land **before or together with** the Snuba PR.

Refs getsentry/snuba#7955


Agent transcript: https://claudescope.sentry.dev/share/sUX6tMR0k8BkW8MdTy2kMYcnEKXmBBWcPaOEkdpPmL8