### PR TITLE
fix(static): add missing nonce attribute on app.js preload link

### DIFF
--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -33,7 +33,7 @@
 
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
-  <link rel="preload" href="{% frontend_app_asset_url "sentry" "entrypoints/app.js" %}" as="script" crossorigin="anonymous" />
+  <link rel="preload" href="{% frontend_app_asset_url "sentry" "entrypoints/app.js" %}" as="script" crossorigin="anonymous"{% if request.csp_nonce %} nonce="{{ request.csp_nonce }}"{% endif %} />
 
   <link href="{% frontend_app_asset_url "sentry" "entrypoints/sentry.css" %}" rel="stylesheet"/>
 


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/115800
Fixes SENTRY-CSP-13Y8