### PR TITLE
fix(preprod): Reapply "Include image key and field path in snapshot validation errors"

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -142,13 +142,42 @@ def validate_preprod_snapshot_post_schema(
         jsonschema.validate(data, SNAPSHOT_POST_REQUEST_SCHEMA)
         return data, None
     except jsonschema.ValidationError as e:
-        error_message = e.message
-        if e.path:
-            if field := e.path[0]:
-                error_message = SNAPSHOT_POST_REQUEST_ERROR_MESSAGES.get(str(field), error_message)
-        return {}, error_message
+        return {}, _format_validation_error(e)
     except (orjson.JSONDecodeError, TypeError):
         return {}, "Invalid json body"
+
+
+def _format_validation_error(e: jsonschema.ValidationError) -> str:
+    path = list(e.absolute_path)
+
+    if len(path) >= 2 and path[0] == "images":
+        image_key = path[1]
+        if rest := path[2:]:
+            field_path = ".".join(str(p) for p in rest)
+            return f'Validation error in image "{image_key}", field "{field_path}": {e.message}'
+        return f'Validation error in image "{image_key}": {e.message}'
+
+    if path:
+        field = str(path[0])
+        if friendly := SNAPSHOT_POST_REQUEST_ERROR_MESSAGES.get(field):
+            return friendly
+
+    return e.message
+
+
+def _format_pydantic_error(e: pydantic.ValidationError) -> str:
+    err = e.errors()[0]
+    loc = err.get("loc", ())
+    msg = err["msg"]
+
+    if len(loc) >= 2 and loc[0] == "images":
+        image_key = loc[1]
+        if rest := loc[2:]:
+            field_path = ".".join(str(p) for p in rest)
+            return f'Validation error in image "{image_key}", field "{field_path}": {msg}'
+        return f'Validation error in image "{image_key}": {msg}'
+
+    return f"Invalid image metadata: {msg}"
 
 
 @cell_silo_endpoint
@@ -580,7 +609,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             )
         except pydantic.ValidationError as e:
             return Response(
-                {"detail": f"Invalid image metadata: {e.errors()[0]['msg']}"},
+                {"detail": _format_pydantic_error(e)},
                 status=400,
             )
 

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -186,7 +186,46 @@ class ProjectPreprodSnapshotTest(APITestCase):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
-        assert "detail" in response.data
+        assert 'Validation error in image "hash1"' in response.data["detail"]
+
+    def test_snapshot_missing_content_hash_error_message(self) -> None:
+        url = self._get_create_url()
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "screen.png": {
+                    "width": 375,
+                    "height": 812,
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 400
+        assert 'Validation error in image "screen.png"' in response.data["detail"]
+        assert "content_hash" in response.data["detail"]
+
+    def test_snapshot_negative_width_error_message(self) -> None:
+        url = self._get_create_url()
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "login.png": {
+                    "content_hash": "abc123",
+                    "width": -100,
+                    "height": 812,
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 400
+        assert 'Validation error in image "login.png"' in response.data["detail"]
+        assert "width" in response.data["detail"]
 
     def test_snapshot_negative_dimensions(self) -> None:
         url = self._get_create_url()


### PR DESCRIPTION
## Summary

Reapplies #115736 which was reverted in 950ef17777c.

The original PR improved snapshot validation error formatting so that:
- **jsonschema errors** use `absolute_path` for full context when `best_match` selects a nested error
- **Pydantic errors** include the image key and field path (e.g. `Validation error in image "screen.png", field "width": ...`)

This makes error messages actionable when uploading hundreds of images via sentry-cli.