### PR TITLE
fix(autofix): Prevent loading spinner clip in artifact loading card

### DIFF
--- a/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
+++ b/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
@@ -51,7 +51,9 @@ export function ArtifactLoadingDetails({
         })}
         <Flex direction="row" gap="md">
           <StyledLoadingIndicator size={16} />
-          <Text variant="muted">{loadingMessage}</Text>
+          <Text variant="muted" density="compressed">
+            {loadingMessage}
+          </Text>
         </Flex>
       </Flex>
     </ArtifactDetails>


### PR DESCRIPTION
## Summary

The loading row of the autofix Root Cause / Solution / Code Changes cards rendered the spinner partially cut off at the bottom while streaming was in progress.

**Root cause:** the inner scroll container is constrained vertically by a parent flex ancestor to the spinner's intrinsic height (16px), and `overflow-y: auto` removes the flex `min-height: auto` protection that would normally keep the container at content height. The adjacent `<Text>` defaults to `line-height: 19.6px`, so the row's content was 3px taller than the container — `useAutoScroll` then scrolled by exactly that 3px and clipped the top of the spinner.

**Fix:** set `density="compressed"` on the `<Text>` (line-height: 1), so the text's content box matches its font-size and the row fits within the container — no overflow scroll triggered.

**Before**


https://github.com/user-attachments/assets/798eb24c-75bd-4401-9548-84aebeb52cf1


**After**


https://github.com/user-attachments/assets/82466e77-d299-45b5-96da-52b50467f570






