### PR TITLE
chore(deps): Update sentry conventions package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ dependencies = [
   "rfc3986-validator>=0.1.1",
   # [end] jsonschema format validators
   "sentry-arroyo>=2.39.2",
-  "sentry-conventions>=0.6.0",
+  "sentry-conventions>=0.8.0",
   "sentry-forked-email-reply-parser>=0.5.12.post1",
   "sentry-kafka-schemas>=2.1.27",
   "sentry-ophio>=1.1.3",

--- a/uv.lock
+++ b/uv.lock
@@ -2431,7 +2431,7 @@ requires-dist = [
     { name = "rfc3339-validator", specifier = ">=0.1.2" },
     { name = "rfc3986-validator", specifier = ">=0.1.1" },
     { name = "sentry-arroyo", specifier = ">=2.39.2" },
-    { name = "sentry-conventions", specifier = ">=0.6.0" },
+    { name = "sentry-conventions", specifier = ">=0.8.0" },
     { name = "sentry-forked-email-reply-parser", specifier = ">=0.5.12.post1" },
     { name = "sentry-kafka-schemas", specifier = ">=2.1.27" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
@@ -2543,10 +2543,10 @@ wheels = [
 
 [[package]]
 name = "sentry-conventions"
-version = "0.6.0"
+version = "0.8.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_conventions-0.6.0-py3-none-any.whl", hash = "sha256:672604d689a5e1e7833fe3ef9508550fd826e06c57ba0aab95086a973abf9bba" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_conventions-0.8.0-py3-none-any.whl", hash = "sha256:a4c788d78f8ab09068d25fe1fc0345fa874a7e733016571368938698ae2168c9" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR brings the Sentry conventions package up to date. This dep update brings in the new `visibility` field on attributes that we'll be using to remove those that are internal from non-staff users from seeing in-app.