### PR TITLE
fix(tabs): stop tooltips in overflowMenuItems from crashing the page

### DIFF
--- a/static/app/components/core/menuListItem/menuListItem.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.tsx
@@ -249,7 +249,7 @@ function BaseMenuListItem({
   detailsProps = {},
   showDetailsInOverlay = false,
   tooltip,
-  tooltipOptions = {delay: 500},
+  tooltipOptions,
   ref,
   ...props
 }: Props) {
@@ -273,6 +273,7 @@ function BaseMenuListItem({
             ? tooltip({disabled, isFocused, isSelected})
             : tooltip
         }
+        delay={500}
         {...tooltipOptions}
       >
         <StyledInnerWrap

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -265,7 +265,8 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
         value: key,
         label: item.props.children,
         disabled: item.props.disabled,
-        tooltip: item.props.tooltip,
+        tooltip: item.props.tooltip?.title,
+        tooltipOptions: item.props.tooltip,
         textValue: item.textValue,
       };
     });


### PR DESCRIPTION
This is a tricky one that I stumbled upon while fixing `any` types with `no-unsafe-member-access`. TypeScript didn’t catch this because `item.props` comes directly from `react-aria` and is hardcoded to `any` which is really bad.

Basically, `TabList.Item` allows passing in tooltips as `tooltipProps`, so we can do:

```
<TabList.Item tooltip={{ title: 'hello '}}>
```

This renders the tooltip on the TabItem fine, however when we have many tabs, the overflowing ones are rendered into a `MenuItemList`, which has a different type for the `tooltip` prop:

https://github.com/getsentry/sentry/blob/f9bda0535267decaccdedefa0d30cd423d1a2d80/static/app/components/core/menuListItem/menuListItem.tsx#L205-L214

Basically `tooltip` is a ReactNode or a function that produces a ReactNode, and `tooltipOptions` are separate.

So what happens at runtime is that we pass `tooltip={{ title: 'hello '}}` to the `MenuitemList`, which renders it as-is because it's not a function, which makes react crash the page because it cannot render objects.

---

This fix is a hotfix at best to prevent this from happening. I think a proper fix would consolidate how we pass `tooltips` around: Do we just want `tooltip` to be the props object everywhere? The extra `options` are a weird API. However, the functional syntax to produce a tooltip doesn’t go well with extra options in one object. Best I could come up with is:

```
tooltip: Omit<TooltipProps, 'title'> & { title: ReactNode | (state) => ReactNode) }
```

This would be doable in a follow-up but has a larger surface area, would disallow passing string tooltips (which we do a lot, would need to change to `{title: 'hello'}` _and_ with `react-select` and `react-aria` being `any` it's pretty hard to figure out where we produce `options` 