### PR TITLE
fix(dynamic-sampling): update run_eap_spans_table_query_in_chunks to yield individual rows and adjust tests accordingly

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/tasks/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/queries.py
@@ -27,7 +27,7 @@ def _get_aggregate_int(row: Mapping[str, Any], column: str) -> int:
 def run_eap_spans_table_query_in_chunks(
     query: dict[str, Any],
     chunk_size: int = 1000,
-) -> Iterator[list[dict[str, Any]]]:
+) -> Iterator[dict[str, Any]]:
     offset = 0
 
     while True:
@@ -39,7 +39,7 @@ def run_eap_spans_table_query_in_chunks(
             data = data[:chunk_size]
 
         if data:
-            yield data
+            yield from data
 
         if not more_results:
             return

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
@@ -47,7 +47,7 @@ class EAPSpansTableQueryChunkingTest(TestCase, SnubaTestCase, SpanTestCase):
             ]
         )
 
-        batches = list(
+        rows = list(
             run_eap_spans_table_query_in_chunks(
                 {
                     "params": SnubaParams(
@@ -70,9 +70,8 @@ class EAPSpansTableQueryChunkingTest(TestCase, SnubaTestCase, SpanTestCase):
             )
         )
 
-        assert len(batches) == 2
-        assert [len(batch) for batch in batches] == [1, 1]
-        assert {row["project.id"] for batch in batches for row in batch} == {
+        assert len(rows) == 2
+        assert {row["project.id"] for row in rows} == {
             project.id,
             other_project.id,
         }


### PR DESCRIPTION
Contributes to TET-2306

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
