### PR TITLE
ref(ts): Remove unused RouteContextInterface type

### DIFF
--- a/static/app/components/deprecatedAsyncComponent.tsx
+++ b/static/app/components/deprecatedAsyncComponent.tsx
@@ -7,10 +7,7 @@ import {Client} from 'sentry/api';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import type {
-  RouteComponentProps,
-  RouteContextInterface,
-} from 'sentry/types/legacyReactRouter';
+import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {PermissionDenied} from 'sentry/views/permissionDenied';
 import {RouteError} from 'sentry/views/routeError';
 
@@ -101,8 +98,6 @@ export class DeprecatedAsyncComponent<
     this.api.clear();
     document.removeEventListener('visibilitychange', this.visibilityReloader);
   }
-
-  declare context: {router: RouteContextInterface};
 
   /**
    * Override this flag to have the component reload its state when the window

--- a/static/app/types/legacyReactRouter.tsx
+++ b/static/app/types/legacyReactRouter.tsx
@@ -1,4 +1,3 @@
-import type {UIMatch} from 'react-router-dom';
 /**
  * These are vendored from react-router v3
  *
@@ -57,13 +56,5 @@ export interface InjectedRouter<P = Record<string, string | undefined>, Q = any>
   params: P;
   push: LocationFunction;
   replace: LocationFunction;
-  routes: PlainRoute[];
-}
-
-export interface RouteContextInterface<P = Record<string, string | undefined>, Q = any> {
-  location: Location<Q>;
-  matches: UIMatch[];
-  params: P;
-  router: InjectedRouter<P, Q>;
   routes: PlainRoute[];
 }

--- a/static/app/types/overrides.tsx
+++ b/static/app/types/overrides.tsx
@@ -1,3 +1,6 @@
+import type {UIMatch} from 'react-router-dom';
+import type {Location} from 'history';
+
 import type {ButtonProps} from '@sentry/scraps/button';
 
 import type {ChildrenRenderFn} from 'sentry/components/acl/feature';
@@ -25,7 +28,6 @@ import type {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProv
 import type {NavigationSection} from 'sentry/views/settings/types';
 
 import type {Integration, IntegrationProvider} from './integrations';
-import type {RouteContextInterface} from './legacyReactRouter';
 import type {Member, Organization, OrgRole} from './organization';
 import type {User} from './user';
 
@@ -332,9 +334,10 @@ type SpendVisibilityOverrides = {
  * Overrides that are actually React overrides as well
  */
 type ReactHookOverrides = {
-  'react-hook:route-activated': (
-    props: Pick<RouteContextInterface, 'location' | 'matches'>
-  ) => React.ContextType<typeof RouteAnalyticsContext>;
+  'react-hook:route-activated': (props: {
+    location: Location;
+    matches: UIMatch[];
+  }) => React.ContextType<typeof RouteAnalyticsContext>;
   'react-hook:use-billing-navigation-config': () => NavigationSection | null;
   'react-hook:use-button-tracking': (props: ButtonProps) => () => void;
   'react-hook:use-dashboard-dataset-retention-limit': (props: {


### PR DESCRIPTION
`RouteContextInterface` was a legacy react-router 3 type that ended up with only two consumers, both of which were trivially removable:

- `overrides.tsx` used `Pick<RouteContextInterface, 'location' | 'matches'>` to type the `react-hook:route-activated` override prop. Replaced with an inline literal `{location: Location; matches: UIMatch[]}` — same shape, no indirection through a legacy interface.
- `DeprecatedAsyncComponent` had a `declare context: {router: RouteContextInterface}` field. Nothing in the codebase reads `this.context.router` on any subclass — it was a leftover type annotation for a class context that's never wired up.

With those gone the interface itself has no consumers, so it's deleted from `legacyReactRouter.tsx`.

Small step toward eventually killing the rest of the legacy router types (`PlainRoute`, `InjectedRouter`, `RouteComponentProps`), but each of those still has real consumers and is its own track.