### PR TITLE
feat(ui): Add debug FeatureBadge variant

### DIFF
--- a/static/app/components/core/badge/featureBadge.figma.tsx
+++ b/static/app/components/core/badge/featureBadge.figma.tsx
@@ -20,7 +20,7 @@ figma.connect(
         beta: 'beta',
         new: 'new',
         experimental: 'experimental',
-        // No figma for 'debug'.
+        debug: 'debug',
       }),
     },
     example: props => <FeatureBadge type={props.type} />,

--- a/static/app/components/core/badge/featureBadge.figma.tsx
+++ b/static/app/components/core/badge/featureBadge.figma.tsx
@@ -20,6 +20,7 @@ figma.connect(
         beta: 'beta',
         new: 'new',
         experimental: 'experimental',
+        // No figma for 'debug'.
       }),
     },
     example: props => <FeatureBadge type={props.type} />,

--- a/static/app/components/core/badge/featureBadge.tsx
+++ b/static/app/components/core/badge/featureBadge.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {Tooltip, type TooltipProps} from '@sentry/scraps/tooltip';
 
 import {IconBroadcast} from 'sentry/icons/iconBroadcast';
+import {IconBug} from 'sentry/icons/iconBug';
 import {IconLab} from 'sentry/icons/iconLab';
 import {t} from 'sentry/locale';
 import type {TagVariant} from 'sentry/utils/theme';
@@ -16,6 +17,7 @@ const defaultTitles: Record<FeatureBadgeProps['type'], string> = {
   experimental: t(
     'This feature is experimental! Try it out and let us know what you think. No promises!'
   ),
+  debug: t('This UI is for debugging purposes only'),
 };
 
 const variantMap: Record<FeatureBadgeProps['type'], TagVariant> = {
@@ -23,6 +25,7 @@ const variantMap: Record<FeatureBadgeProps['type'], TagVariant> = {
   beta: 'warning',
   new: 'success',
   experimental: 'muted',
+  debug: 'info',
 };
 
 const iconMap: Record<FeatureBadgeProps['type'], React.ReactNode> = {
@@ -30,10 +33,11 @@ const iconMap: Record<FeatureBadgeProps['type'], React.ReactNode> = {
   beta: <IconLab isSolid size="xs" aria-hidden />,
   new: <IconBroadcast size="xs" aria-hidden />,
   experimental: <IconLab isSolid size="xs" aria-hidden />,
+  debug: <IconBug size="xs" aria-hidden />,
 };
 
 export interface FeatureBadgeProps extends Omit<TagProps, 'children' | 'variant'> {
-  type: 'alpha' | 'beta' | 'new' | 'experimental';
+  type: 'alpha' | 'beta' | 'new' | 'experimental' | 'debug';
   tooltipProps?: Partial<TooltipProps>;
 }
 

--- a/static/app/components/core/badge/featureBadge.tsx
+++ b/static/app/components/core/badge/featureBadge.tsx
@@ -25,7 +25,7 @@ const variantMap: Record<FeatureBadgeProps['type'], TagVariant> = {
   beta: 'warning',
   new: 'success',
   experimental: 'muted',
-  debug: 'info',
+  debug: 'danger',
 };
 
 const iconMap: Record<FeatureBadgeProps['type'], React.ReactNode> = {

--- a/static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx
@@ -104,7 +104,7 @@ export function NightShift({canWrite, project}: Props) {
       title={
         <Flex gap="xs" align="center">
           {t('Manually trigger night shift')}
-          <FeatureBadge type="alpha" />
+          <FeatureBadge type="debug" />
         </Flex>
       }
     >


### PR DESCRIPTION
Adds a `debug` type to `FeatureBadge` for marking UI that is only intended for debugging or internal experimentation, and uses it on the Night Shift project settings page in place of the previous `alpha` badge.

Agent transcript: https://claudescope.sentry.dev/share/10qokud3YuEflxKruIvQjhjI7ul5gREgy94rRA9BebA