### PR TITLE
feat(ux): allow enter on timerange selector with single item

### DIFF
--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -42,6 +42,8 @@ import type {
 } from './types';
 import {getSearchConfig} from './utils';
 
+type SearchEnterHandler = () => boolean;
+
 // autoFocus react attribute is sync called on render, this causes
 // layout thrashing and is bad for performance. This thin wrapper function
 // will defer the focus call until the next frame, after the browser and react
@@ -72,6 +74,7 @@ interface ControlContextValue {
    * selector.
    */
   overlayState?: OverlayTriggerState;
+  registerSearchEnterHandler?: (handler: SearchEnterHandler) => () => void;
   /**
    * Custom function to determine whether an option matches the search query.
    */
@@ -260,6 +263,15 @@ export function Control({
   const [search, setSearch] = useState('');
   const [searchInputValue, setSearchInputValue] = useState(search);
   const searchRef = useRef<HTMLInputElement>(null);
+  const searchEnterHandlerRef = useRef<SearchEnterHandler | null>(null);
+  const registerSearchEnterHandler = useCallback((handler: SearchEnterHandler) => {
+    searchEnterHandlerRef.current = handler;
+    return () => {
+      if (searchEnterHandlerRef.current === handler) {
+        searchEnterHandlerRef.current = null;
+      }
+    };
+  }, []);
   const updateSearch = (newValue: string) => {
     normalizedSearch?.onChange?.(newValue);
     setSearchInputValue(newValue);
@@ -282,6 +294,9 @@ export function Control({
       // Prevent form submissions on Enter key press in search box
       if (e.key === 'Enter') {
         e.preventDefault();
+        if (searchEnterHandlerRef.current?.()) {
+          return;
+        }
       }
 
       // Continue propagation, otherwise the overlay won't close on Esc key press
@@ -475,8 +490,18 @@ export function Control({
       size,
       disabled,
       searchMatcher: searchFilter,
+      registerSearchEnterHandler,
     };
-  }, [overlayState, overlayIsOpen, search, searchEnabled, size, disabled, searchFilter]);
+  }, [
+    overlayState,
+    overlayIsOpen,
+    search,
+    searchEnabled,
+    size,
+    disabled,
+    searchFilter,
+    registerSearchEnterHandler,
+  ]);
 
   const theme = useTheme();
 

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -1,4 +1,4 @@
-import {createContext, Fragment, useContext, useId, useMemo} from 'react';
+import {createContext, Fragment, useContext, useEffect, useId, useMemo} from 'react';
 import {useFocusManager} from '@react-aria/focus';
 import type {AriaGridListOptions} from '@react-aria/gridlist';
 import type {AriaListBoxOptions} from '@react-aria/listbox';
@@ -168,8 +168,14 @@ export function List<Value extends SelectKey>({
   closeOnSelect,
   ...props
 }: SingleListProps<Value> | MultipleListProps<Value>) {
-  const {overlayState, search, searchable, overlayIsOpen, searchMatcher} =
-    useContext(ControlContext);
+  const {
+    overlayState,
+    search,
+    searchable,
+    overlayIsOpen,
+    searchMatcher,
+    registerSearchEnterHandler,
+  } = useContext(ControlContext);
 
   const {hidden: hiddenOptions, scores} = useMemo(
     () => getHiddenOptions(items, search, sizeLimit, searchMatcher),
@@ -252,6 +258,42 @@ export function List<Value extends SelectKey>({
     ...listStateProps,
     items: sortedItems,
   });
+
+  const visibleOptionKeys = useMemo<SelectKey[]>(() => {
+    return [...listState.collection]
+      .flatMap(item => (item.type === 'section' ? [...item.childNodes] : [item]))
+      .map(item => item.key)
+      .filter(
+        key => !hiddenOptions.has(key) && !listState.selectionManager.isDisabled(key)
+      );
+  }, [hiddenOptions, listState.collection, listState.selectionManager]);
+
+  useEffect(() => {
+    return registerSearchEnterHandler?.(() => {
+      if (!searchable || !overlayIsOpen || visibleOptionKeys.length !== 1) {
+        return false;
+      }
+
+      const key = visibleOptionKeys[0];
+      if (key === undefined) {
+        return false;
+      }
+
+      if (multiple) {
+        listState.selectionManager.toggleSelection(key);
+      } else {
+        listState.selectionManager.replaceSelection(key);
+      }
+      return true;
+    });
+  }, [
+    listState.selectionManager,
+    multiple,
+    overlayIsOpen,
+    registerSearchEnterHandler,
+    searchable,
+    visibleOptionKeys,
+  ]);
 
   // In composite selects, focus should seamlessly move from one region (list) to
   // another when the ArrowUp/Down key is pressed

--- a/static/app/components/timeRangeSelector/index.spec.tsx
+++ b/static/app/components/timeRangeSelector/index.spec.tsx
@@ -246,6 +246,19 @@ describe('TimeRangeSelector', () => {
     });
   });
 
+  it('selects the only visible arbitrary relative time range with Enter', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+    await userEvent.type(screen.getByRole('textbox'), '24h{Enter}');
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      relative: '24h',
+      start: undefined,
+      end: undefined,
+    });
+  });
+
   it('respects maxPickableDays for defaults', async () => {
     renderComponent({maxPickableDays: 30});
 


### PR DESCRIPTION
Allows users to press enter after entering a valid timerange string:


https://github.com/user-attachments/assets/730a4181-cb87-4dd1-ac86-4b575728b9de

