### PR TITLE
ref(test): Remove router return from initializeOrg

### DIFF
--- a/static/app/actionCreators/navigation.spec.tsx
+++ b/static/app/actionCreators/navigation.spec.tsx
@@ -1,5 +1,6 @@
 import {isValidElement} from 'react';
 import type {Location} from 'history';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
@@ -20,7 +21,7 @@ describe('navigation ActionCreator', () => {
     ProjectsStore.init();
     const initialData = initializeOrg();
     navigate = jest.fn();
-    location = {...initialData.router.location, query: {}};
+    location = LocationFixture({query: {}});
     ProjectsStore.loadInitialData(initialData.projects);
     configState = ConfigStore.getState();
   });

--- a/static/app/components/charts/eventsAreaChart.spec.tsx
+++ b/static/app/components/charts/eventsAreaChart.spec.tsx
@@ -1,3 +1,5 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
 import {mockZoomRange} from 'sentry-test/charts';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -10,7 +12,7 @@ jest.mock('sentry/components/charts/baseChart', () => ({
 }));
 
 describe('EventsChart with legend', () => {
-  const {router, organization} = initializeOrg();
+  const {organization} = initializeOrg();
 
   beforeEach(() => {
     mockZoomRange(1543449600000, 1543708800000);
@@ -47,7 +49,7 @@ describe('EventsChart with legend', () => {
         start={null}
         end={null}
         utc={false}
-        location={router.location}
+        location={LocationFixture()}
         showLegend
       />
     );

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -5,6 +5,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {ProjectAlertRuleFixture} from 'sentry-fixture/projectAlertRule';
 import {ProjectAlertRuleConfigurationFixture} from 'sentry-fixture/projectAlertRuleConfiguration';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -78,8 +79,19 @@ const projectAlertRuleDetailsRoutes: PlainRoute[] = [
   {path: ':ruleId/'},
 ];
 
-const createWrapper = (props = {}) => {
-  const {organization, project, router} = initializeOrg(props);
+const createWrapper = (props: Parameters<typeof initializeOrg>[0] = {}) => {
+  const {organization, project} = initializeOrg(props);
+  const propsRouterParams = props.router?.params as
+    | Record<string, string | undefined>
+    | undefined;
+  const router = RouterFixture({
+    ...props.router,
+    params: {
+      orgId: organization.slug,
+      projectId: project.slug,
+      ...propsRouterParams,
+    },
+  });
   const params = {
     projectId: project.slug,
     organizationId: organization.slug,

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.spec.tsx
@@ -1,3 +1,5 @@
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -12,11 +14,12 @@ import {
 import type {AlertType} from 'sentry/views/alerts/wizard/options';
 
 describe('RuleConditionsForm', () => {
-  const {organization, projects, router} = initializeOrg({
+  const {organization, projects} = initializeOrg({
     organization: {
       features: ['search-query-builder-alerts', 'visibility-explore-view'],
     },
   });
+  const router = RouterFixture();
   ProjectsStore.loadInitialData(projects);
 
   const mockSearch = jest.fn();

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -1,6 +1,7 @@
 import {useTheme} from '@emotion/react';
 import {EventsStatsFixture} from 'sentry-fixture/events';
 import {IncidentTriggerFixture} from 'sentry-fixture/incidentTrigger';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {MetricRuleFixture} from 'sentry-fixture/metricRule';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -67,7 +68,7 @@ describe('Incident Rules Form', () => {
     });
     organization = initialData.organization;
     project = initialData.project;
-    location = initialData.router.location;
+    location = LocationFixture();
     ProjectsStore.loadInitialData([project]);
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/tags/',

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
@@ -1,4 +1,5 @@
 import {EventsStatsFixture} from 'sentry-fixture/events';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {ThemeFixture} from 'sentry-fixture/theme';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -42,13 +43,13 @@ describe('Incident Rules Create', () => {
   const api = new MockApiClient();
 
   it('renders a metric', async () => {
-    const {organization, project, router} = initializeOrg();
+    const {organization, project} = initializeOrg();
 
     render(
       <TriggersChart
         api={api}
         anomalies={[]}
-        location={router.location}
+        location={LocationFixture()}
         organization={organization}
         theme={theme}
         projects={[project]}
@@ -101,13 +102,13 @@ describe('Incident Rules Create', () => {
   });
 
   it('does not show & query total count if showTotalCount === false', async () => {
-    const {organization, project, router} = initializeOrg();
+    const {organization, project} = initializeOrg();
 
     render(
       <TriggersChart
         theme={theme}
         api={api}
-        location={router.location}
+        location={LocationFixture()}
         organization={organization}
         projects={[project]}
         query="event.type:error"
@@ -158,13 +159,13 @@ describe('Incident Rules Create', () => {
   });
 
   it('queries the errors dataset if dataset is errors', async () => {
-    const {organization, project, router} = initializeOrg();
+    const {organization, project} = initializeOrg();
 
     render(
       <TriggersChart
         theme={theme}
         api={api}
-        location={router.location}
+        location={LocationFixture()}
         organization={organization}
         projects={[project]}
         query="event.type:error"
@@ -216,13 +217,13 @@ describe('Incident Rules Create', () => {
   });
 
   it('uses normal sampling for span alerts', async () => {
-    const {organization, project, router} = initializeOrg();
+    const {organization, project} = initializeOrg();
 
     render(
       <TriggersChart
         theme={theme}
         api={api}
-        location={router.location}
+        location={LocationFixture()}
         organization={organization}
         projects={[project]}
         query=""
@@ -263,13 +264,13 @@ describe('Incident Rules Create', () => {
   });
 
   it('uses sample weighted extrapolation mode for editing a migrated alert', async () => {
-    const {organization, project, router} = initializeOrg();
+    const {organization, project} = initializeOrg();
 
     render(
       <TriggersChart
         theme={theme}
         api={api}
-        location={router.location}
+        location={LocationFixture()}
         organization={organization}
         projects={[project]}
         query=""

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -768,7 +768,7 @@ describe('Dashboards > Dashboard', () => {
       mount({
         dashboard: dashboardWithOneWidget,
         org: testData.organization,
-        location: testData.router.location,
+        location: LocationFixture(),
         onEditWidget: mockOnEditWidget,
       });
 

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -269,7 +269,7 @@ describe('Dashboards > Detail', () => {
         makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/default-overview/',
           route: DASHBOARD_ROUTE,
-          query: initialData.router.location.query,
+          query: {},
         })
       );
 
@@ -475,7 +475,7 @@ describe('Dashboards > Detail', () => {
         makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/',
           route: DASHBOARD_ROUTE,
-          query: initialData.router.location.query,
+          query: {},
         })
       );
 
@@ -530,7 +530,7 @@ describe('Dashboards > Detail', () => {
         makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/',
           route: DASHBOARD_ROUTE,
-          query: initialData.router.location.query,
+          query: {},
         })
       );
 
@@ -555,7 +555,7 @@ describe('Dashboards > Detail', () => {
         makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/',
           route: DASHBOARD_ROUTE,
-          query: initialData.router.location.query,
+          query: {},
         })
       );
 
@@ -583,7 +583,7 @@ describe('Dashboards > Detail', () => {
           ...makeDashboardRouterConfig({
             pathname: '/organizations/org-slug/dashboard/1/',
             route: DASHBOARD_ROUTE,
-            query: initialData.router.location.query,
+            query: {},
           }),
           organization: initialData.organization,
         }
@@ -634,7 +634,7 @@ describe('Dashboards > Detail', () => {
         makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/',
           route: DASHBOARD_ROUTE,
-          query: initialData.router.location.query,
+          query: {},
         })
       );
 
@@ -688,7 +688,7 @@ describe('Dashboards > Detail', () => {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/',
           route: DASHBOARD_ROUTE,
-          query: initialData.router.location.query,
+          query: {},
         }),
         organization: initialData.organization,
       });
@@ -727,7 +727,7 @@ describe('Dashboards > Detail', () => {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/',
           route: DASHBOARD_ROUTE,
-          query: initialData.router.location.query,
+          query: {},
         }),
         organization: initialData.organization,
       });
@@ -769,7 +769,7 @@ describe('Dashboards > Detail', () => {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/',
           route: DASHBOARD_ROUTE,
-          query: initialData.router.location.query,
+          query: {},
         }),
         organization: initialData.organization,
       });
@@ -853,7 +853,7 @@ describe('Dashboards > Detail', () => {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/widget/0/',
           route: DASHBOARD_WIDGET_ROUTE,
-          query: initialData.router.location.query,
+          query: {},
         }),
         organization: initialData.organization,
       });
@@ -874,7 +874,7 @@ describe('Dashboards > Detail', () => {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/widget/123/',
           routes: [DASHBOARD_WIDGET_ROUTE, DASHBOARD_ROUTE],
-          query: initialData.router.location.query,
+          query: {},
         }),
         organization: initialData.organization,
       });
@@ -902,20 +902,15 @@ describe('Dashboards > Detail', () => {
         method: 'POST',
         body: [],
       });
-      const locationWithFilters = {
-        ...initialData.router.location,
-        query: {
-          ...initialData.router.location.query,
-          statsPeriod: '7d',
-          project: [2],
-          environment: ['alpha', 'beta'],
-        },
-      };
       render(<CreateDashboard />, {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboards/new/',
           route: DASHBOARD_NEW_ROUTE,
-          query: locationWithFilters.query,
+          query: {
+            statsPeriod: '7d',
+            project: ['2'],
+            environment: ['alpha', 'beta'],
+          },
         }),
         organization: initialData.organization,
       });
@@ -946,7 +941,7 @@ describe('Dashboards > Detail', () => {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/widget/1/',
           route: DASHBOARD_WIDGET_ROUTE,
-          query: initialData.router.location.query,
+          query: {},
         }),
         organization: initialData.organization,
       });
@@ -974,7 +969,6 @@ describe('Dashboards > Detail', () => {
           pathname: '/organizations/org-slug/dashboard/1/widget/1/',
           route: DASHBOARD_WIDGET_ROUTE,
           query: {
-            ...initialData.router.location.query,
             release: ['unsaved-release-filter@1.2.0'],
           },
         }),
@@ -1001,7 +995,7 @@ describe('Dashboards > Detail', () => {
         ...makeDashboardRouterConfig({
           pathname: '/organizations/org-slug/dashboard/1/widget/0/',
           route: DASHBOARD_WIDGET_ROUTE,
-          query: {...initialData.router.location.query, rd: 'show', rdRelease: '1.0.0'},
+          query: {rd: 'show', rdRelease: '1.0.0'},
         }),
         organization: initialData.organization,
       });

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -3,7 +3,6 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   renderGlobalModal,
@@ -25,7 +24,7 @@ describe('Dashboards - DashboardTable', () => {
     features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
   });
 
-  const {router} = initializeOrg();
+  const location = LocationFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -111,7 +110,7 @@ describe('Dashboards - DashboardTable', () => {
         onDashboardsChange={jest.fn()}
         organization={organization}
         dashboards={[]}
-        location={router.location}
+        location={location}
       />
     );
 
@@ -127,7 +126,7 @@ describe('Dashboards - DashboardTable', () => {
         onDashboardsChange={jest.fn()}
         organization={organization}
         dashboards={dashboards}
-        location={router.location}
+        location={location}
       />
     );
 
@@ -141,7 +140,7 @@ describe('Dashboards - DashboardTable', () => {
         onDashboardsChange={jest.fn()}
         organization={organization}
         dashboards={dashboards}
-        location={router.location}
+        location={location}
       />
     );
 
@@ -266,7 +265,7 @@ describe('Dashboards - DashboardTable', () => {
         onDashboardsChange={jest.fn()}
         organization={organizationWithEditAccess}
         dashboards={dashboards}
-        location={router.location}
+        location={location}
       />
     );
 
@@ -292,7 +291,7 @@ describe('Dashboards - DashboardTable', () => {
         onDashboardsChange={jest.fn()}
         organization={organizationWithFavorite}
         dashboards={dashboards}
-        location={router.location}
+        location={location}
       />,
       {
         organization: organizationWithFavorite,

--- a/static/app/views/explore/releases/detail/utils.spec.tsx
+++ b/static/app/views/explore/releases/detail/utils.spec.tsx
@@ -1,7 +1,6 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {ReleaseFixture} from 'sentry-fixture/release';
 import {ThemeFixture} from 'sentry-fixture/theme';
-
-import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {
   generateReleaseMarkLines,
@@ -13,24 +12,19 @@ const theme = ThemeFixture();
 describe('releases/detail/utils', () => {
   describe('generateReleaseMarkLines', () => {
     const {created, adopted, unadopted} = releaseMarkLinesLabels;
-    const {router} = initializeOrg();
+    const location = LocationFixture();
     const release = ReleaseFixture();
     const project = release.projects[0]!;
 
     it('generates "Created" markline', () => {
-      const marklines = generateReleaseMarkLines(
-        release,
-        project,
-        theme,
-        router.location
-      );
+      const marklines = generateReleaseMarkLines(release, project, theme, location);
 
       expect(marklines.map(markline => markline.seriesName)).toEqual([created]);
     });
 
     it('generates also Adoption marklines if exactly one env is selected', () => {
       const marklines = generateReleaseMarkLines(release, project, theme, {
-        ...router.location,
+        ...location,
         query: {environment: 'prod'},
       });
 
@@ -71,7 +65,7 @@ describe('releases/detail/utils', () => {
         {...project, platform: 'javascript'},
         theme,
         {
-          ...router.location,
+          ...location,
           query: {environment: 'prod'},
         }
       );
@@ -81,7 +75,7 @@ describe('releases/detail/utils', () => {
 
     it('shows only marklines that are in current time window', () => {
       const marklines = generateReleaseMarkLines(release, project, theme, {
-        ...router.location,
+        ...location,
         query: {
           environment: 'prod',
           pageStart: '2020-03-24T01:00:30Z',
@@ -97,7 +91,7 @@ describe('releases/detail/utils', () => {
         {...release, dateCreated: '2010-03-24T01:00:30Z'},
         project,
         theme,
-        router.location
+        location
       );
 
       expect(marklines).toEqual([]);

--- a/static/app/views/explore/releases/list/releasesRequest.spec.tsx
+++ b/static/app/views/explore/releases/list/releasesRequest.spec.tsx
@@ -1,3 +1,4 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {
   SessionStatusCountByProjectInPeriodFixture,
   SessionStatusCountByReleaseInPeriodFixture,
@@ -18,7 +19,8 @@ import ReleasesRequest, {
 } from 'sentry/views/explore/releases/list/releasesRequest';
 
 describe('ReleasesRequest', () => {
-  const {organization, router} = initializeOrg();
+  const {organization} = initializeOrg();
+  const location = LocationFixture();
   const projectId = 123;
   const selection = {
     projects: [projectId],
@@ -188,7 +190,7 @@ describe('ReleasesRequest', () => {
         ]}
         organization={organization}
         location={{
-          ...router.location,
+          ...location,
           query: {
             project: [`${projectId}`],
           },
@@ -418,7 +420,7 @@ describe('ReleasesRequest', () => {
         ]}
         organization={organization}
         location={{
-          ...router.location,
+          ...location,
           query: {
             project: [`${projectId}`],
           },
@@ -646,7 +648,7 @@ describe('ReleasesRequest', () => {
         ]}
         organization={organization}
         location={{
-          ...router.location,
+          ...location,
           query: {
             project: [`${projectId}`],
           },

--- a/static/app/views/explore/releases/utils/index.spec.tsx
+++ b/static/app/views/explore/releases/utils/index.spec.tsx
@@ -1,6 +1,5 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {ReleaseFixture} from 'sentry-fixture/release';
-
-import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {getReleaseBounds, getReleaseParams, searchReleaseVersion} from './index';
 
@@ -105,12 +104,12 @@ describe('releases/utils', () => {
   });
 
   describe('getReleaseParams', () => {
-    const {router} = initializeOrg();
+    const locationFixture = LocationFixture();
     const releaseBounds = getReleaseBounds(ReleaseFixture());
 
     it('returns params related to a release', () => {
       const location = {
-        ...router.location,
+        ...locationFixture,
         query: {
           pageStatsPeriod: '30d',
           project: ['456'],
@@ -134,7 +133,7 @@ describe('releases/utils', () => {
     it('returns release start/end if no other datetime is present', () => {
       expect(
         getReleaseParams({
-          location: {...router.location, query: {}},
+          location: {...locationFixture, query: {}},
           releaseBounds,
         })
       ).toEqual({
@@ -147,7 +146,7 @@ describe('releases/utils', () => {
       expect(
         getReleaseParams({
           location: {
-            ...router.location,
+            ...locationFixture,
             query: {pageStart: '2021-03-23T01:02:30Z', pageEnd: '2022-03-23T01:02:30Z'},
           },
           releaseBounds,

--- a/static/app/views/issueDetails/groupMerged/index.spec.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.spec.tsx
@@ -1,5 +1,6 @@
 import {DetailedEventsFixture} from 'sentry-fixture/events';
 import {GroupFixture} from 'sentry-fixture/group';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -36,14 +37,18 @@ describe('Issues -> Merged View', () => {
   });
 
   it('renders merged groups', async () => {
-    const {organization, project, router} = initializeOrg({
+    const {organization, project} = initializeOrg({
       router: {
         params: {groupId: 'groupId'},
       },
     });
 
     render(
-      <GroupMergedView project={project} groupId={group.id} location={router.location} />,
+      <GroupMergedView
+        project={project}
+        groupId={group.id}
+        location={LocationFixture()}
+      />,
       {
         organization,
       }

--- a/static/app/views/performance/landing/utils.spec.tsx
+++ b/static/app/views/performance/landing/utils.spec.tsx
@@ -1,3 +1,4 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -14,17 +15,14 @@ function initializeData(projects: Project[], query: any = {}) {
   });
   const initialData = initializeOrg({
     organization,
-    router: {
-      location: {
-        query: query || {},
-      },
-    },
     projects,
   });
-  const eventView = EventView.fromLocation(initialData.router.location);
+  const location = LocationFixture({query});
+  const eventView = EventView.fromLocation(location);
   ProjectsStore.loadInitialData(initialData.projects);
   return {
     ...initialData,
+    location,
     eventView,
   };
 }
@@ -34,14 +32,14 @@ describe('Utils', () => {
     it('returns all by default', () => {
       const projects = [ProjectFixture()];
       const data = initializeData(projects);
-      expect(getCurrentLandingDisplay(data.router.location, projects).label).toBe(
+      expect(getCurrentLandingDisplay(data.location, projects).label).toBe(
         'All Transactions'
       );
     });
     it('returns specific landing display if query is set', () => {
       const projects = [ProjectFixture()];
       const data = initializeData(projects, {landingDisplay: 'frontend_pageload'});
-      expect(getCurrentLandingDisplay(data.router.location, projects).label).toBe(
+      expect(getCurrentLandingDisplay(data.location, projects).label).toBe(
         'All Transactions'
       );
     });
@@ -49,28 +47,28 @@ describe('Utils', () => {
       const projects = [ProjectFixture({id: '22', platform: 'javascript-react'})];
       const data = initializeData(projects, {project: 22});
       expect(
-        getCurrentLandingDisplay(data.router.location, projects, data.eventView).label
+        getCurrentLandingDisplay(data.location, projects, data.eventView).label
       ).toBe('Frontend');
     });
     it('returns backend display if project matches', () => {
       const projects = [ProjectFixture({id: '22', platform: 'php'})];
       const data = initializeData(projects, {project: 22});
       expect(
-        getCurrentLandingDisplay(data.router.location, projects, data.eventView).label
+        getCurrentLandingDisplay(data.location, projects, data.eventView).label
       ).toBe('Backend');
     });
     it('returns all display for native platform', () => {
       const projects = [ProjectFixture({id: '22', platform: 'native'})];
       const data = initializeData(projects, {project: [22]});
       expect(
-        getCurrentLandingDisplay(data.router.location, projects, data.eventView).label
+        getCurrentLandingDisplay(data.location, projects, data.eventView).label
       ).toBe('All Transactions');
     });
     it('returns all display if multiple projects', () => {
       const projects = [ProjectFixture()];
       const data = initializeData(projects, {project: [1, 2]});
       expect(
-        getCurrentLandingDisplay(data.router.location, projects, data.eventView).label
+        getCurrentLandingDisplay(data.location, projects, data.eventView).label
       ).toBe('All Transactions');
     });
   });

--- a/static/app/views/performance/transactionSummary/header.spec.tsx
+++ b/static/app/views/performance/transactionSummary/header.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -21,18 +22,17 @@ function initializeData(opts?: InitialOpts) {
     features: features ?? [],
   });
 
-  const initialData = initializeOrg({
+  initializeOrg({
     organization,
-    router: {
-      location: {
-        query: {
-          project: project.id,
-        },
-      },
-    },
     projects: [],
   });
-  const router = initialData.router;
+  const router = RouterFixture({
+    location: {
+      query: {
+        project: project.id,
+      },
+    },
+  });
   const eventView = EventView.fromSavedQuery({
     id: undefined,
     version: 2,

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
@@ -23,19 +24,19 @@ function initializeData() {
   });
   const initialData = initializeOrg({
     organization,
-    router: {
-      location: {
-        query: {
-          transaction: '/performance',
-          project: '1',
-          transactionCursor: '1:0:0',
-        },
-      },
-    },
     projects: [],
   });
+  const router = RouterFixture({
+    location: {
+      query: {
+        transaction: '/performance',
+        project: '1',
+        transactionCursor: '1:0:0',
+      },
+    },
+  });
   act(() => ProjectsStore.loadInitialData(initialData.projects));
-  return initialData;
+  return {...initialData, router};
 }
 
 describe('Performance Transaction Events Content', () => {

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {ThemeFixture} from 'sentry-fixture/theme';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -26,19 +27,19 @@ function initializeData({features: additionalFeatures = []}: Data = {}) {
   });
   const initialData = initializeOrg({
     organization,
-    router: {
-      location: {
-        query: {
-          transaction: '/performance',
-          project: '1',
-          transactionCursor: '1:0:0',
-        },
-      },
-    },
     projects: [],
   });
+  const router = RouterFixture({
+    location: {
+      query: {
+        transaction: '/performance',
+        project: '1',
+        transactionCursor: '1:0:0',
+      },
+    },
+  });
   ProjectsStore.loadInitialData(initialData.projects);
-  return initialData;
+  return {...initialData, router};
 }
 
 describe('Performance GridEditable Table', () => {

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -17,12 +18,12 @@ function initialize(query: Record<string, string>, additionalFeatures: string[] 
   });
   const initialData = initializeOrg({
     organization,
-    router: {
-      location: {
-        query: {...query},
-      },
-    },
     projects: [],
+  });
+  const router = RouterFixture({
+    location: {
+      query: {...query},
+    },
   });
   const eventView = EventView.fromNewQueryWithLocation(
     {
@@ -32,7 +33,7 @@ function initialize(query: Record<string, string>, additionalFeatures: string[] 
       fields: ['id', 'user.display', 'transaction.duration', 'trace', 'timestamp'],
       projects: [],
     },
-    initialData.router.location
+    router.location
   );
 
   const spanOperationBreakdownFilter = SpanOperationBreakdownFilter.NONE;
@@ -42,8 +43,9 @@ function initialize(query: Record<string, string>, additionalFeatures: string[] 
     ...initialData,
     spanOperationBreakdownFilter,
     transactionName,
-    location: initialData.router.location,
+    location: router.location,
     eventView,
+    router,
   };
 }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -54,15 +55,15 @@ function initializeData({
   const initialData = initializeOrg({
     organization,
     projects: projects ? projects : [project],
-    router: {
-      location: {
-        pathname: '/performance/summary/',
-        query: {
-          transaction: '/performance',
-          project: project.id,
-          transactionCursor: '1:0:0',
-          ...query,
-        },
+  });
+  const router = RouterFixture({
+    location: {
+      pathname: '/performance/summary/',
+      query: {
+        transaction: '/performance',
+        project: project.id,
+        transactionCursor: '1:0:0',
+        ...query,
       },
     },
   });
@@ -70,14 +71,14 @@ function initializeData({
   ProjectsStore.loadInitialData(initialData.projects);
   TeamStore.loadInitialData(teams, false, null);
 
-  return initialData;
+  return {...initialData, router};
 }
 
 const renderWithLayout = (data: ReturnType<typeof initializeData>) => {
   return render(<TransactionSummaryLayout />, {
     organization: data.organization,
     initialRouterConfig: {
-      location: data.routerProps.location,
+      location: data.router.location,
       route: '/performance/',
       children: [
         {

--- a/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.spec.tsx
@@ -1,7 +1,7 @@
 import {GroupsFixture} from 'sentry-fixture/groups';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {RelatedIssues} from 'sentry/views/performance/transactionSummary/transactionOverview/relatedIssues';
@@ -11,16 +11,11 @@ describe('RelatedIssues', () => {
   const issues = GroupsFixture();
   const transaction = 'test-transaction';
 
-  const initialData = initializeOrg({
-    organization,
-    router: {
-      location: {
-        query: {
-          transaction: 'test-transaction',
-          project: '1',
-          statsPeriod: '14d',
-        },
-      },
+  const location = LocationFixture({
+    query: {
+      transaction: 'test-transaction',
+      project: '1',
+      statsPeriod: '14d',
     },
   });
 
@@ -45,7 +40,7 @@ describe('RelatedIssues', () => {
     render(
       <RelatedIssues
         organization={organization}
-        location={initialData.router.location}
+        location={location}
         transaction={transaction}
         statsPeriod="14d"
       />
@@ -76,7 +71,7 @@ describe('RelatedIssues', () => {
     render(
       <RelatedIssues
         organization={organization}
-        location={initialData.router.location}
+        location={location}
         transaction={transaction}
         statsPeriod="14d"
       />
@@ -88,23 +83,19 @@ describe('RelatedIssues', () => {
   });
 
   it('remaps request.method to http.method', async () => {
-    const eapData = initializeOrg({
-      router: {
-        location: {
-          query: {
-            transaction: 'test-transaction',
-            project: '1',
-            statsPeriod: '14d',
-            query: 'request.method:GET',
-          },
-        },
+    const eapLocation = LocationFixture({
+      query: {
+        transaction: 'test-transaction',
+        project: '1',
+        statsPeriod: '14d',
+        query: 'request.method:GET',
       },
     });
 
     render(
       <RelatedIssues
         organization={organization}
-        location={eapData.router.location}
+        location={eapLocation}
         transaction={transaction}
         statsPeriod="14d"
       />

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.tsx
@@ -1,3 +1,4 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -26,17 +27,10 @@ function initialize(query: Record<string, string>, additionalFeatures = []) {
   const organization = OrganizationFixture({
     features,
   });
-  const initialOrgData = {
-    organization,
-    router: {
-      location: {
-        query: {...query},
-      },
-    },
-  };
-  const initialData = initializeOrg(initialOrgData);
+  const initialData = initializeOrg({organization});
+  const location = LocationFixture({query: {...query}});
   ProjectsStore.loadInitialData(initialData.projects);
-  const eventView = EventView.fromLocation(initialData.router.location);
+  const eventView = EventView.fromLocation(location);
 
   const spanOperationBreakdownFilter = SpanOperationBreakdownFilter.NONE;
   const transactionName = 'example-transaction';
@@ -45,7 +39,7 @@ function initialize(query: Record<string, string>, additionalFeatures = []) {
     ...initialData,
     spanOperationBreakdownFilter,
     transactionName,
-    location: initialData.router.location,
+    location,
     eventView,
   };
 }

--- a/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -24,18 +25,16 @@ function initializeData({query} = {query: {}}) {
     ...query,
   };
 
-  const initialData = initializeOrg({
-    organization,
-    router: {
-      location: {
-        query: newQuery,
-      },
+  const initialData = initializeOrg({organization});
+  const router = RouterFixture({
+    location: {
+      query: newQuery,
     },
   });
 
   act(() => ProjectsStore.loadInitialData(initialData.projects));
 
-  return initialData;
+  return {...initialData, router};
 }
 
 const renderWithLayout = (data: ReturnType<typeof initializeData>) => {
@@ -44,7 +43,7 @@ const renderWithLayout = (data: ReturnType<typeof initializeData>) => {
     initialRouterConfig: {
       location: {
         pathname: '/performance/summary/tags/',
-        query: data.routerProps.location.query,
+        query: data.router.location.query,
       },
       route: '/performance/summary/',
       children: [

--- a/static/app/views/projectDetail/projectCharts.spec.tsx
+++ b/static/app/views/projectDetail/projectCharts.spec.tsx
@@ -1,3 +1,4 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {SessionsFieldFixture} from 'sentry-fixture/sessions';
 
@@ -8,17 +9,10 @@ import type {PlatformKey} from 'sentry/types/project';
 import ProjectCharts from 'sentry/views/projectDetail/projectCharts';
 
 function renderProjectCharts(platform?: PlatformKey, chartDisplay?: string) {
-  const {organization, router, project} = initializeOrg({
+  const {organization, project} = initializeOrg({
     organization: OrganizationFixture(),
     projects: [{platform}],
-    router: {
-      params: {orgId: 'org-slug', projectId: 'project-slug'},
-      location: {
-        pathname: '/organizations/org-slug/projects/project-slug/',
-        query: {chart1: chartDisplay ?? 'crash_free'},
-      },
-    },
-  } as Parameters<typeof initializeOrg>[0]);
+  });
 
   return render(
     <ProjectCharts
@@ -26,7 +20,10 @@ function renderProjectCharts(platform?: PlatformKey, chartDisplay?: string) {
       chartIndex={0}
       hasSessions
       hasTransactions
-      location={router.location}
+      location={LocationFixture({
+        pathname: '/organizations/org-slug/projects/project-slug/',
+        query: {chart1: chartDisplay ?? 'crash_free'},
+      })}
       organization={organization}
       visibleCharts={['chart1', 'chart2']}
       project={project}

--- a/static/app/views/projectDetail/projectLatestAlerts.spec.tsx
+++ b/static/app/views/projectDetail/projectLatestAlerts.spec.tsx
@@ -11,7 +11,7 @@ import {ProjectLatestAlerts} from './projectLatestAlerts';
 describe('ProjectDetail > ProjectLatestAlerts', () => {
   let endpointMock: jest.Mock;
   let rulesEndpointMock: jest.Mock;
-  const {organization, project, router} = initializeOrg();
+  const {organization, project} = initializeOrg();
 
   beforeEach(() => {
     endpointMock = MockApiClient.addMockResponse({
@@ -37,7 +37,7 @@ describe('ProjectDetail > ProjectLatestAlerts', () => {
       <ProjectLatestAlerts
         organization={organization}
         projectSlug={project.slug}
-        location={router.location}
+        location={LocationFixture()}
         isProjectStabilized
       />
     );
@@ -81,7 +81,7 @@ describe('ProjectDetail > ProjectLatestAlerts', () => {
       <ProjectLatestAlerts
         organization={organization}
         projectSlug={project.slug}
-        location={router.location}
+        location={LocationFixture()}
         isProjectStabilized
       />
     );
@@ -109,7 +109,7 @@ describe('ProjectDetail > ProjectLatestAlerts', () => {
       <ProjectLatestAlerts
         organization={organization}
         projectSlug={project.slug}
-        location={router.location}
+        location={LocationFixture()}
         isProjectStabilized
       />
     );
@@ -159,7 +159,7 @@ describe('ProjectDetail > ProjectLatestAlerts', () => {
       <ProjectLatestAlerts
         organization={organization}
         projectSlug={project.slug}
-        location={router.location}
+        location={LocationFixture()}
         isProjectStabilized
       />
     );
@@ -172,7 +172,7 @@ describe('ProjectDetail > ProjectLatestAlerts', () => {
       <ProjectLatestAlerts
         organization={organization}
         projectSlug={project.slug}
-        location={router.location}
+        location={LocationFixture()}
         isProjectStabilized={false}
       />
     );
@@ -191,7 +191,7 @@ describe('ProjectDetail > ProjectLatestAlerts', () => {
       <ProjectLatestAlerts
         organization={organization}
         projectSlug={project.slug}
-        location={router.location}
+        location={LocationFixture()}
         isProjectStabilized
       />
     );

--- a/static/app/views/projectDetail/projectLatestReleases.spec.tsx
+++ b/static/app/views/projectDetail/projectLatestReleases.spec.tsx
@@ -14,7 +14,7 @@ import {ProjectLatestReleases} from 'sentry/views/projectDetail/projectLatestRel
 describe('ProjectDetail > ProjectLatestReleases', () => {
   let endpointMock: jest.Mock;
   let endpointOlderReleasesMock: jest.Mock;
-  const {organization, project, router} = initializeOrg();
+  const {organization, project} = initializeOrg();
 
   beforeEach(() => {
     endpointMock = MockApiClient.addMockResponse({
@@ -36,7 +36,7 @@ describe('ProjectDetail > ProjectLatestReleases', () => {
       <ProjectLatestReleases
         organization={organization}
         projectSlug={project.slug}
-        location={router.location}
+        location={LocationFixture()}
         project={project}
         isProjectStabilized
       />
@@ -68,7 +68,7 @@ describe('ProjectDetail > ProjectLatestReleases', () => {
       <ProjectLatestReleases
         organization={organization}
         projectSlug={project.slug}
-        location={router.location}
+        location={LocationFixture()}
         project={project}
         isProjectStabilized
       />
@@ -91,7 +91,7 @@ describe('ProjectDetail > ProjectLatestReleases', () => {
       <ProjectLatestReleases
         organization={organization}
         projectSlug={project.slug}
-        location={router.location}
+        location={LocationFixture()}
         project={project}
         isProjectStabilized
       />

--- a/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.spec.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.spec.tsx
@@ -1,3 +1,5 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -8,12 +10,9 @@ describe('ProjectDetail > ProjectAnr', () => {
   let endpointMock: jest.Mock;
   let endpointMockPreviousPeriod: jest.Mock;
 
-  const {organization, router} = initializeOrg({
-    router: {
-      location: {
-        query: {project: '1', statsPeriod: '7d'},
-      },
-    },
+  const {organization} = initializeOrg();
+  const location = LocationFixture({
+    query: {project: '1', statsPeriod: '7d'},
   });
 
   const selection = {
@@ -72,7 +71,7 @@ describe('ProjectDetail > ProjectAnr', () => {
         selection={selection}
         isProjectStabilized
         query="release:abc"
-        location={router.location}
+        location={location}
       />
     );
 
@@ -121,7 +120,7 @@ describe('ProjectDetail > ProjectAnr', () => {
         selection={selection}
         isProjectStabilized
         query="release:abc"
-        location={router.location}
+        location={location}
       />
     );
 

--- a/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsProviderRow.spec.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsProviderRow.spec.tsx
@@ -1,3 +1,4 @@
+import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 import {SecretFixture} from 'sentry-fixture/secret';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -12,7 +13,7 @@ import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {OrganizationFeatureFlagsProviderRow} from 'sentry/views/settings/featureFlags/changeTracking/organizationFeatureFlagsProviderRow';
 
 describe('OrganizationFeatureFlagsProviderRow', () => {
-  const {organization, router} = initializeOrg();
+  const {organization} = initializeOrg();
 
   const removeSecret = jest.fn();
 
@@ -23,12 +24,8 @@ describe('OrganizationFeatureFlagsProviderRow', () => {
     isRemoving: false,
     secret,
     removeSecret,
-    router,
-    location: router.location,
-    params: {orgId: organization.slug},
-    routes: router.routes,
+    ...RouteComponentPropsFixture({params: {orgId: organization.slug}}),
     route: {},
-    routeParams: router.params,
   };
 
   beforeEach(() => {

--- a/static/app/views/settings/organizationAuthTokens/authTokenRow.spec.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenRow.spec.tsx
@@ -1,4 +1,5 @@
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -14,7 +15,7 @@ import type {OrgAuthToken} from 'sentry/types/user';
 import {OrganizationAuthTokensAuthTokenRow} from 'sentry/views/settings/organizationAuthTokens/authTokenRow';
 
 describe('OrganizationAuthTokensAuthTokenRow', () => {
-  const {organization, router} = initializeOrg();
+  const {organization} = initializeOrg();
 
   const revokeToken = jest.fn();
   const token: OrgAuthToken = {
@@ -31,12 +32,8 @@ describe('OrganizationAuthTokensAuthTokenRow', () => {
     token,
     revokeToken,
     projectLastUsed: undefined,
-    router,
-    location: router.location,
-    params: {orgId: organization.slug},
-    routes: router.routes,
+    ...RouteComponentPropsFixture({params: {orgId: organization.slug}}),
     route: {},
-    routeParams: router.params,
   };
 
   beforeEach(() => {

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.spec.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -31,7 +32,7 @@ function TestComponent({
 }
 
 function getProps(props?: Parameters<typeof initializeOrg>[0]) {
-  const {organization, router, project} = initializeOrg({
+  const {organization, project} = initializeOrg({
     router: props?.router,
   });
 
@@ -39,9 +40,7 @@ function getProps(props?: Parameters<typeof initializeOrg>[0]) {
     api: new MockApiClient(),
     organization,
     project,
-    router,
-    isLoading: false,
-    location: router.location,
+    location: LocationFixture(props?.router?.location),
   };
 }
 

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -81,10 +81,6 @@ export function initializeOrg<RouterParams = {orgId: string; projectId: string}>
     organization,
     project: project!,
     projects,
-    /**
-     * @deprecated Use `initialRouterConfig` and the router returned from `render` instead.
-     */
-    router,
     routerProps,
   };
 }

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
@@ -44,11 +45,12 @@ export function initializeData(settings?: InitializeDataSettings) {
     routerLocation.query.project = project || settings?.project;
     initialRouterConfig.location.query.project = project || settings?.project;
   }
-  const router = {
+  const router = RouterFixture({
     location: routerLocation,
-  };
-  const initialData = initializeOrg({organization, projects, router});
-  const location = initialData.router.location;
+    params: {orgId: organization.slug, projectId: projects[0]?.slug},
+  });
+  const initialData = initializeOrg({organization, projects});
+  const location = router.location;
   const eventView = EventView.fromLocation(initialRouterConfig.location as any);
 
   return {
@@ -56,7 +58,7 @@ export function initializeData(settings?: InitializeDataSettings) {
     /**
      * @deprecated use initialRouterConfig instead. Avoid deprecatedRouterMocks.
      */
-    router: initialData.router,
+    router,
     location,
     eventView,
     initialRouterConfig,


### PR DESCRIPTION
Most callers only needed `router.location`, which is now sourced from `LocationFixture` directly. Specs that needed the full router instance construct one with `RouterFixture` inline.