### PR TITLE
fix(ci) Don't capture log messages in RPC schema generation

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -62,7 +62,7 @@ jobs:
         if: steps.changes.outputs.api_docs == 'true'
         run: |
           mkdir schemas
-          sentry rpcschema > rpc_method_schema.json
+          sentry rpcschema --loglevel=WARNING > rpc_method_schema.json
 
       - name: Output RPC schema comparison
         uses: oasdiff/oasdiff-action/breaking@a2ff6682b27d175162a74c09ace8771bd3d512f8 # A few commits after v0.0.19 to get fixes

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Build RPC method schema
         if: steps.changes.outputs.api_docs == 'true'
         run: |
-          sentry rpcschema > rpc_method_schema.json
+          sentry rpcschema --loglevel=WARNING > rpc_method_schema.json
 
       - name: Copy artifacts into getsentry/sentry-api-schema
         if: steps.changes.outputs.api_docs == 'true'

--- a/src/sentry/runner/commands/rpcschema.py
+++ b/src/sentry/runner/commands/rpcschema.py
@@ -7,7 +7,7 @@ from typing import Any
 import click
 from django.urls import reverse
 
-from sentry.runner.decorators import configuration
+from sentry.runner.decorators import configuration, log_options
 from sentry.utils import json
 
 
@@ -24,6 +24,7 @@ from sentry.utils import json
     default=False,
     help="List RPC methods that produce errors and suppress all other output.",
 )
+@log_options()
 @configuration
 def rpcschema(diagnose: bool, partial: bool) -> None:
     # Defered imports because openapi_pydantic is only installed as a dev dependency


### PR DESCRIPTION
Set loglevel to WARNING so that we don't get options.seen logs captured in the RPC schema file.
