### PR TITLE
fix(tracemetrics): Drop placeholder unit and always use none

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -509,7 +509,7 @@ describe('Incident Rules Form', () => {
           ...rule,
           id: undefined,
           eventTypes: [EventTypes.TRACE_ITEM_METRIC],
-          aggregate: 'sum(value,my_metric,counter,-)',
+          aggregate: 'sum(value,my_metric,counter,none)',
           dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
         },
       });

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
@@ -59,7 +59,7 @@ describe('TraceMetricsConfig', () => {
 
   describe('formatTraceMetricsFunction', () => {
     it('formats a single parseable function string', () => {
-      expect(formatTraceMetricsFunction('avg(value,test_metric,millisecond,-)')).toBe(
+      expect(formatTraceMetricsFunction('avg(value,test_metric,millisecond,none)')).toBe(
         'avg(test_metric)'
       );
     });
@@ -73,16 +73,16 @@ describe('TraceMetricsConfig', () => {
     });
 
     it('formats a single parseable function in an array', () => {
-      expect(formatTraceMetricsFunction(['avg(value,test_metric,millisecond,-)'])).toBe(
-        'avg(test_metric)'
-      );
+      expect(
+        formatTraceMetricsFunction(['avg(value,test_metric,millisecond,none)'])
+      ).toBe('avg(test_metric)');
     });
 
     it('formats multiple parseable functions in an array', () => {
       expect(
         formatTraceMetricsFunction([
-          'p50(value,test_metric,millisecond,-)',
-          'p75(value,test_metric,millisecond,-)',
+          'p50(value,test_metric,millisecond,none)',
+          'p75(value,test_metric,millisecond,none)',
         ])
       ).toBe('p50, p75(test_metric)');
     });
@@ -97,7 +97,7 @@ describe('TraceMetricsConfig', () => {
       const data: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [],
             meta: {
@@ -114,7 +114,7 @@ describe('TraceMetricsConfig', () => {
         fields: [],
         columns: [],
         fieldAliases: [],
-        aggregates: ['avg(value,test_metric,millisecond,-)'],
+        aggregates: ['avg(value,test_metric,millisecond,none)'],
         conditions: '',
         orderby: '',
       };
@@ -129,7 +129,7 @@ describe('TraceMetricsConfig', () => {
       const data: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [],
             meta: {
@@ -139,7 +139,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'p50(value,test_metric,millisecond,-)',
+            yAxis: 'p50(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 80}],
             meta: {
               interval: 0,
@@ -156,8 +156,8 @@ describe('TraceMetricsConfig', () => {
         columns: [],
         fieldAliases: [],
         aggregates: [
-          'avg(value,test_metric,millisecond,-)',
-          'p50(value,test_metric,millisecond,-)',
+          'avg(value,test_metric,millisecond,none)',
+          'p50(value,test_metric,millisecond,none)',
         ],
         conditions: '',
         orderby: '',
@@ -174,7 +174,7 @@ describe('TraceMetricsConfig', () => {
       const data: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [{key: 'project', value: 'frontend'}],
             meta: {
@@ -184,7 +184,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 200}],
             groupBy: [{key: 'project', value: 'backend'}],
             meta: {
@@ -201,7 +201,7 @@ describe('TraceMetricsConfig', () => {
         fields: [],
         columns: ['project'],
         fieldAliases: [],
-        aggregates: ['avg(value,test_metric,millisecond,-)'],
+        aggregates: ['avg(value,test_metric,millisecond,none)'],
         conditions: '',
         orderby: '',
       };
@@ -218,7 +218,7 @@ describe('TraceMetricsConfig', () => {
       const data: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [{key: 'project', value: 'frontend'}],
             meta: {
@@ -228,7 +228,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 200}],
             groupBy: [{key: 'project', value: 'backend'}],
             meta: {
@@ -238,7 +238,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'p50(value,test_metric,millisecond,-)',
+            yAxis: 'p50(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 80}],
             groupBy: [{key: 'project', value: 'frontend'}],
             meta: {
@@ -248,7 +248,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'p50(value,test_metric,millisecond,-)',
+            yAxis: 'p50(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 160}],
             groupBy: [{key: 'project', value: 'backend'}],
             meta: {
@@ -266,8 +266,8 @@ describe('TraceMetricsConfig', () => {
         columns: ['project'],
         fieldAliases: [],
         aggregates: [
-          'avg(value,test_metric,millisecond,-)',
-          'p50(value,test_metric,millisecond,-)',
+          'avg(value,test_metric,millisecond,none)',
+          'p50(value,test_metric,millisecond,none)',
         ],
         conditions: '',
         orderby: '',
@@ -288,7 +288,7 @@ describe('TraceMetricsConfig', () => {
       const data: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [
               {key: 'project', value: 'frontend'},
@@ -301,7 +301,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 200}],
             groupBy: [
               {key: 'project', value: 'frontend'},
@@ -314,7 +314,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'p50(value,test_metric,millisecond,-)',
+            yAxis: 'p50(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 80}],
             groupBy: [
               {key: 'project', value: 'frontend'},
@@ -327,7 +327,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'p50(value,test_metric,millisecond,-)',
+            yAxis: 'p50(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 160}],
             groupBy: [
               {key: 'project', value: 'frontend'},
@@ -348,8 +348,8 @@ describe('TraceMetricsConfig', () => {
         columns: ['project', 'environment'],
         fieldAliases: [],
         aggregates: [
-          'avg(value,test_metric,millisecond,-)',
-          'p50(value,test_metric,millisecond,-)',
+          'avg(value,test_metric,millisecond,none)',
+          'p50(value,test_metric,millisecond,none)',
         ],
         conditions: '',
         orderby: '',
@@ -369,7 +369,7 @@ describe('TraceMetricsConfig', () => {
       const data: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [{key: 'project', value: null}],
             meta: {
@@ -379,7 +379,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'p50(value,test_metric,millisecond,-)',
+            yAxis: 'p50(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 80}],
             groupBy: [{key: 'project', value: null}],
             meta: {
@@ -397,8 +397,8 @@ describe('TraceMetricsConfig', () => {
         columns: ['project'],
         fieldAliases: [],
         aggregates: [
-          'avg(value,test_metric,millisecond,-)',
-          'p50(value,test_metric,millisecond,-)',
+          'avg(value,test_metric,millisecond,none)',
+          'p50(value,test_metric,millisecond,none)',
         ],
         conditions: '',
         orderby: '',
@@ -416,7 +416,7 @@ describe('TraceMetricsConfig', () => {
       const data: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [],
             meta: {
@@ -433,7 +433,7 @@ describe('TraceMetricsConfig', () => {
         fields: [],
         columns: [],
         fieldAliases: [],
-        aggregates: ['avg(value,test_metric,millisecond,-)'],
+        aggregates: ['avg(value,test_metric,millisecond,none)'],
         conditions: '',
         orderby: '',
       };
@@ -448,7 +448,7 @@ describe('TraceMetricsConfig', () => {
       const data: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [],
             meta: {
@@ -458,7 +458,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'p50(value,test_metric,millisecond,-)',
+            yAxis: 'p50(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 80}],
             groupBy: [],
             meta: {
@@ -476,8 +476,8 @@ describe('TraceMetricsConfig', () => {
         columns: [],
         fieldAliases: [],
         aggregates: [
-          'avg(value,test_metric,millisecond,-)',
-          'p50(value,test_metric,millisecond,-)',
+          'avg(value,test_metric,millisecond,none)',
+          'p50(value,test_metric,millisecond,none)',
         ],
         conditions: '',
         orderby: '',
@@ -494,7 +494,7 @@ describe('TraceMetricsConfig', () => {
       const data: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [{key: 'project', value: 'frontend'}],
             meta: {
@@ -504,7 +504,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 200}],
             groupBy: [{key: 'project', value: 'backend'}],
             meta: {
@@ -521,7 +521,7 @@ describe('TraceMetricsConfig', () => {
         fields: [],
         columns: ['project'],
         fieldAliases: [],
-        aggregates: ['avg(value,test_metric,millisecond,-)'],
+        aggregates: ['avg(value,test_metric,millisecond,none)'],
         conditions: '',
         orderby: '',
       };
@@ -537,7 +537,7 @@ describe('TraceMetricsConfig', () => {
       const data: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [{key: 'project', value: 'frontend'}],
             meta: {
@@ -547,7 +547,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 200}],
             groupBy: [{key: 'project', value: 'backend'}],
             meta: {
@@ -557,7 +557,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'p50(value,test_metric,millisecond,-)',
+            yAxis: 'p50(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 80}],
             groupBy: [{key: 'project', value: 'frontend'}],
             meta: {
@@ -567,7 +567,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'p50(value,test_metric,millisecond,-)',
+            yAxis: 'p50(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 160}],
             groupBy: [{key: 'project', value: 'backend'}],
             meta: {
@@ -585,8 +585,8 @@ describe('TraceMetricsConfig', () => {
         columns: ['project'],
         fieldAliases: [],
         aggregates: [
-          'avg(value,test_metric,millisecond,-)',
-          'p50(value,test_metric,millisecond,-)',
+          'avg(value,test_metric,millisecond,none)',
+          'p50(value,test_metric,millisecond,none)',
         ],
         conditions: '',
         orderby: '',
@@ -607,7 +607,7 @@ describe('TraceMetricsConfig', () => {
       const data1: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,db_latency,millisecond,-)',
+            yAxis: 'avg(value,db_latency,millisecond,none)',
             values: [{timestamp: 1, value: 150}],
             groupBy: [{key: 'environment', value: 'prod'}],
             meta: {
@@ -617,7 +617,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'avg(value,db_latency,millisecond,-)',
+            yAxis: 'avg(value,db_latency,millisecond,none)',
             values: [{timestamp: 1, value: 75}],
             groupBy: [{key: 'environment', value: 'dev'}],
             meta: {
@@ -634,7 +634,7 @@ describe('TraceMetricsConfig', () => {
         fields: [],
         columns: ['environment'],
         fieldAliases: [],
-        aggregates: ['avg(value,db_latency,millisecond,-)'],
+        aggregates: ['avg(value,db_latency,millisecond,none)'],
         conditions: '',
         orderby: '',
       };
@@ -643,7 +643,7 @@ describe('TraceMetricsConfig', () => {
       const data2: EventsTimeSeriesResponse = {
         timeSeries: [
           {
-            yAxis: 'avg(value,cache_hits,counter,-)',
+            yAxis: 'avg(value,cache_hits,counter,none)',
             values: [{timestamp: 1, value: 980}],
             groupBy: [{key: 'environment', value: 'prod'}],
             meta: {
@@ -653,7 +653,7 @@ describe('TraceMetricsConfig', () => {
             },
           },
           {
-            yAxis: 'avg(value,cache_hits,counter,-)',
+            yAxis: 'avg(value,cache_hits,counter,none)',
             values: [{timestamp: 1, value: 920}],
             groupBy: [{key: 'environment', value: 'dev'}],
             meta: {
@@ -670,7 +670,7 @@ describe('TraceMetricsConfig', () => {
         fields: [],
         columns: ['environment'],
         fieldAliases: [],
-        aggregates: ['avg(value,cache_hits,counter,-)'],
+        aggregates: ['avg(value,cache_hits,counter,none)'],
         conditions: '',
         orderby: '',
       };
@@ -733,7 +733,10 @@ describe('TraceMetricsConfig', () => {
             location: {
               pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
-                yAxis: ['avg(value,metric_a,counter,-)', 'avg(value,metric_b,gauge,-)'],
+                yAxis: [
+                  'avg(value,metric_a,counter,none)',
+                  'avg(value,metric_b,gauge,none)',
+                ],
                 dataset: WidgetType.TRACEMETRICS,
                 displayType: DisplayType.LINE,
               },
@@ -760,7 +763,7 @@ describe('TraceMetricsConfig', () => {
             location: {
               pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
-                yAxis: ['avg(value,my_metric,counter,-)'],
+                yAxis: ['avg(value,my_metric,counter,none)'],
                 dataset: WidgetType.TRACEMETRICS,
                 displayType: DisplayType.LINE,
               },
@@ -788,8 +791,8 @@ describe('TraceMetricsConfig', () => {
               pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
                 yAxis: [
-                  'avg(value,same_metric,counter,-)',
-                  'p50(value,same_metric,counter,-)',
+                  'avg(value,same_metric,counter,none)',
+                  'p50(value,same_metric,counter,none)',
                 ],
                 dataset: WidgetType.TRACEMETRICS,
                 displayType: DisplayType.LINE,
@@ -841,7 +844,10 @@ describe('TraceMetricsConfig', () => {
             location: {
               pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
-                yAxis: ['avg(value,metric_a,counter,-)', 'avg(value,metric_b,gauge,-)'],
+                yAxis: [
+                  'avg(value,metric_a,counter,none)',
+                  'avg(value,metric_b,gauge,none)',
+                ],
                 dataset: WidgetType.TRACEMETRICS,
                 displayType: DisplayType.LINE,
               },
@@ -871,8 +877,8 @@ describe('TraceMetricsConfig', () => {
               pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
                 yAxis: [
-                  'avg(value,same_metric,counter,-)',
-                  'p50(value,same_metric,counter,-)',
+                  'avg(value,same_metric,counter,none)',
+                  'p50(value,same_metric,counter,none)',
                 ],
                 dataset: WidgetType.TRACEMETRICS,
                 displayType: DisplayType.LINE,

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.spec.tsx
@@ -40,7 +40,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Query 1',
             fields: [],
-            aggregates: ['avg(value,duration,d,-)'],
+            aggregates: ['avg(value,duration,d,none)'],
             columns: [],
             conditions: 'transaction:"/api/users"',
             orderby: '',
@@ -74,9 +74,9 @@ describe('getWidgetMetricsUrl', () => {
             name: 'Query 1',
             fields: [],
             aggregates: [
-              'avg(value,duration,d,-)',
-              'p95(value,duration,d,-)',
-              'count(value,duration,d,-)',
+              'avg(value,duration,d,none)',
+              'p95(value,duration,d,none)',
+              'count(value,duration,d,none)',
             ],
             columns: [],
             conditions: 'transaction:"/api/users"',
@@ -106,7 +106,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Query 1',
             fields: [],
-            aggregates: ['avg(value,duration,d,-)'],
+            aggregates: ['avg(value,duration,d,none)'],
             columns: ['transaction', 'http.status_code'],
             conditions: '',
             orderby: '',
@@ -126,7 +126,7 @@ describe('getWidgetMetricsUrl', () => {
       // Should have visualize + 2 group bys
       expect(metricQuery.aggregateFields).toHaveLength(3);
       expect(metricQuery.aggregateFields).toEqual([
-        {chartType: ChartType.LINE, yAxes: ['avg(value,duration,d,-)']},
+        {chartType: ChartType.LINE, yAxes: ['avg(value,duration,d,none)']},
         {groupBy: 'transaction'},
         {groupBy: 'http.status_code'},
       ]);
@@ -143,7 +143,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Query 1',
             fields: [],
-            aggregates: ['avg(value,duration,d,-)'],
+            aggregates: ['avg(value,duration,d,none)'],
             columns: [],
             conditions: 'transaction:"/api/users"',
             orderby: '',
@@ -179,10 +179,10 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Query 1',
             fields: [],
-            aggregates: ['avg(value,duration,d,-)'],
+            aggregates: ['avg(value,duration,d,none)'],
             columns: ['transaction'],
             conditions: '',
-            orderby: '-avg(value,duration,d,-)',
+            orderby: '-avg(value,duration,d,none)',
             fieldAliases: [],
           },
         ],
@@ -196,7 +196,7 @@ describe('getWidgetMetricsUrl', () => {
       const metricQuery = JSON.parse(metrics[0]!);
       expect(metricQuery.aggregateSortBys).toBeDefined();
       expect(metricQuery.aggregateSortBys).toHaveLength(1);
-      expect(metricQuery.aggregateSortBys[0].field).toBe('avg(value,duration,d,-)');
+      expect(metricQuery.aggregateSortBys[0].field).toBe('avg(value,duration,d,none)');
       expect(metricQuery.aggregateSortBys[0].kind).toBe('desc');
     });
 
@@ -238,9 +238,9 @@ describe('getWidgetMetricsUrl', () => {
             name: 'Query 1',
             fields: [],
             aggregates: [
-              'avg(value,test_metric_a,duration,-)',
-              'p95(value,test_metric_b,gauge,-)',
-              'count(value,test_metric_c,counter,-)',
+              'avg(value,test_metric_a,duration,none)',
+              'p95(value,test_metric_b,gauge,none)',
+              'count(value,test_metric_c,counter,none)',
             ],
             columns: [],
             conditions: 'transaction:"/api/users"',
@@ -279,7 +279,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Query 1',
             fields: [],
-            aggregates: ['avg(value,duration,d,-)', 'p95(value,duration,d,-)'],
+            aggregates: ['avg(value,duration,d,none)', 'p95(value,duration,d,none)'],
             columns: [],
             conditions: 'transaction:"/api/users"',
             orderby: '',
@@ -288,7 +288,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Query 2',
             fields: [],
-            aggregates: ['avg(value,duration,d,-)', 'p95(value,duration,d,-)'],
+            aggregates: ['avg(value,duration,d,none)', 'p95(value,duration,d,none)'],
             columns: [],
             conditions: 'transaction:"/api/posts"',
             orderby: '',
@@ -328,7 +328,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Success',
             fields: [],
-            aggregates: ['avg(value,duration,d,-)'],
+            aggregates: ['avg(value,duration,d,none)'],
             columns: [],
             conditions: 'http.status_code:200',
             orderby: '',
@@ -337,7 +337,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Errors',
             fields: [],
-            aggregates: ['avg(value,duration,d,-)'],
+            aggregates: ['avg(value,duration,d,none)'],
             columns: [],
             conditions: 'http.status_code:500',
             orderby: '',
@@ -372,7 +372,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Query 1',
             fields: [],
-            aggregates: ['avg(value,duration,d,-)'],
+            aggregates: ['avg(value,duration,d,none)'],
             columns: [],
             conditions: '',
             orderby: '',
@@ -400,7 +400,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Query 1',
             fields: [],
-            aggregates: ['count(value,duration,d,-)'],
+            aggregates: ['count(value,duration,d,none)'],
             columns: [],
             conditions: '',
             orderby: '',
@@ -428,7 +428,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Query 1',
             fields: [],
-            aggregates: ['sum(value,duration,d,-)'],
+            aggregates: ['sum(value,duration,d,none)'],
             columns: [],
             conditions: '',
             orderby: '',
@@ -457,7 +457,7 @@ describe('getWidgetMetricsUrl', () => {
         {
           name: 'Query 1',
           fields: [],
-          aggregates: ['avg(value,duration,d,-)'],
+          aggregates: ['avg(value,duration,d,none)'],
           columns: [],
           conditions: '',
           orderby: '',
@@ -498,7 +498,7 @@ describe('getWidgetMetricsUrl', () => {
           {
             name: 'Query 1',
             fields: [],
-            aggregates: ['avg(value,duration,d,-)'],
+            aggregates: ['avg(value,duration,d,none)'],
             columns: [],
             conditions: '',
             orderby: '',

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.spec.tsx
@@ -260,9 +260,9 @@ describe('getWidgetMetricsUrl', () => {
       const parsedMetrics = metrics.map(metric => JSON.parse(metric!));
       expect(parsedMetrics).toHaveLength(3);
       expect(parsedMetrics.map(m => m.metric)).toEqual([
-        {name: 'test_metric_a', type: 'duration'},
-        {name: 'test_metric_b', type: 'gauge'},
-        {name: 'test_metric_c', type: 'counter'},
+        {name: 'test_metric_a', type: 'duration', unit: 'none'},
+        {name: 'test_metric_b', type: 'gauge', unit: 'none'},
+        {name: 'test_metric_c', type: 'counter', unit: 'none'},
       ]);
     });
   });

--- a/static/app/views/dashboards/utils/prebuiltConfigs/utils/traceMetricField.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/utils/traceMetricField.ts
@@ -1,4 +1,5 @@
 import type {DataUnit} from 'sentry/utils/discover/fields';
+import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetricTypeValue} from 'sentry/views/explore/metrics/types';
 
 type TraceMetricAggregation = 'avg' | 'sum' | 'max';
@@ -10,5 +11,5 @@ export function traceMetricField(
   metricType: TraceMetricTypeValue,
   unit: DataUnit
 ) {
-  return `${aggregation}(value,${name},${metricType},${unit ?? '-'})`;
+  return `${aggregation}(value,${name},${metricType},${unit ?? NONE_UNIT})`;
 }

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -1923,7 +1923,7 @@ describe('Visualize', () => {
           location: {
             pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
-              yAxis: ['sum(value,alpha_metric,counter,-)'],
+              yAxis: ['sum(value,alpha_metric,counter,none)'],
               dataset: WidgetType.TRACEMETRICS,
               displayType: DisplayType.LINE,
             },

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.spec.tsx
@@ -99,8 +99,8 @@ describe('MetricSelectRow', () => {
             pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               yAxis: [
-                'per_second(value,alpha_metric,counter,-)',
-                'sum(value,alpha_metric,counter,-)',
+                'per_second(value,alpha_metric,counter,none)',
+                'sum(value,alpha_metric,counter,none)',
               ],
               dataset: WidgetType.TRACEMETRICS,
               displayType: DisplayType.LINE,
@@ -153,8 +153,8 @@ describe('MetricSelectRow', () => {
             pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               yAxis: [
-                'per_second(value,alpha_metric,counter,-)',
-                'sum(value,alpha_metric,counter,-)',
+                'per_second(value,alpha_metric,counter,none)',
+                'sum(value,alpha_metric,counter,none)',
               ],
               dataset: WidgetType.TRACEMETRICS,
               displayType: DisplayType.LINE,
@@ -197,7 +197,7 @@ describe('MetricSelectRow', () => {
           location: {
             pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
-              yAxis: ['p50(value,distribution_metric,distribution,-)'],
+              yAxis: ['p50(value,distribution_metric,distribution,none)'],
               dataset: WidgetType.TRACEMETRICS,
               displayType: DisplayType.LINE,
             },
@@ -249,7 +249,7 @@ describe('MetricSelectRow', () => {
           location: {
             pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
-              yAxis: ['sum(value,counter_metric,counter,-)'],
+              yAxis: ['sum(value,counter_metric,counter,none)'],
               dataset: WidgetType.TRACEMETRICS,
               displayType: DisplayType.LINE,
             },
@@ -302,9 +302,9 @@ describe('MetricSelectRow', () => {
             pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               yAxis: [
-                'per_second(value,distribution_metric,distribution,-)',
-                'p99(value,distribution_metric,distribution,-)',
-                'count(value,distribution_metric,distribution,-)',
+                'per_second(value,distribution_metric,distribution,none)',
+                'p99(value,distribution_metric,distribution,none)',
+                'count(value,distribution_metric,distribution,none)',
               ],
               dataset: WidgetType.TRACEMETRICS,
               displayType: DisplayType.LINE,
@@ -371,7 +371,7 @@ describe('MetricSelectRow', () => {
           location: {
             pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
-              field: ['avg(value,gauge_metric,gauge,-)'],
+              field: ['avg(value,gauge_metric,gauge,none)'],
               dataset: WidgetType.TRACEMETRICS,
               displayType: DisplayType.BIG_NUMBER,
             },
@@ -421,7 +421,7 @@ describe('MetricSelectRow', () => {
           location: {
             pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
-              yAxis: ['p50(value,distribution_metric,distribution,-)'],
+              yAxis: ['p50(value,distribution_metric,distribution,none)'],
               dataset: WidgetType.TRACEMETRICS,
               displayType: DisplayType.LINE,
             },

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.spec.tsx
@@ -138,7 +138,7 @@ describe('MetricSelectRow', () => {
       },
       {
         kind: 'function',
-        function: ['sum', 'value', 'alpha_metric', 'counter', '-'],
+        function: ['sum', 'value', 'alpha_metric', 'counter', 'none'],
       },
     ];
     render(
@@ -186,7 +186,7 @@ describe('MetricSelectRow', () => {
         <MetricSelectRow
           field={{
             kind: 'function',
-            function: ['p50', 'value', 'distribution_metric', 'distribution', '-'],
+            function: ['p50', 'value', 'distribution_metric', 'distribution', 'none'],
           }}
           index={0}
           disabled={false}
@@ -222,7 +222,7 @@ describe('MetricSelectRow', () => {
             yAxis: serializeFields([
               {
                 kind: FieldValueKind.FUNCTION,
-                function: ['sum', 'value', 'counter_metric', 'counter', '-'],
+                function: ['sum', 'value', 'counter_metric', 'counter', 'none'],
               },
             ]),
           }),
@@ -238,7 +238,7 @@ describe('MetricSelectRow', () => {
         <MetricSelectRow
           field={{
             kind: 'function',
-            function: ['sum', 'value', 'counter_metric', 'counter', '-'],
+            function: ['sum', 'value', 'counter_metric', 'counter', 'none'],
           }}
           index={0}
           disabled={false}
@@ -274,7 +274,7 @@ describe('MetricSelectRow', () => {
             yAxis: serializeFields([
               {
                 kind: FieldValueKind.FUNCTION,
-                function: ['sum', 'value', 'distribution_metric', 'distribution', '-'],
+                function: ['sum', 'value', 'distribution_metric', 'distribution', 'none'],
               },
             ]),
           }),
@@ -290,7 +290,7 @@ describe('MetricSelectRow', () => {
         <MetricSelectRow
           field={{
             kind: 'function',
-            function: ['sum', 'value', 'distribution_metric', 'distribution', '-'],
+            function: ['sum', 'value', 'distribution_metric', 'distribution', 'none'],
           }}
           index={0}
           disabled={false}
@@ -335,16 +335,16 @@ describe('MetricSelectRow', () => {
                   'value',
                   'counter_metric',
                   'counter',
-                  '-',
+                  'none',
                 ],
               },
               {
                 kind: FieldValueKind.FUNCTION,
-                function: ['sum', 'value', 'counter_metric', 'counter', '-'],
+                function: ['sum', 'value', 'counter_metric', 'counter', 'none'],
               },
               {
                 kind: FieldValueKind.FUNCTION,
-                function: ['sum', 'value', 'counter_metric', 'counter', '-'],
+                function: ['sum', 'value', 'counter_metric', 'counter', 'none'],
               },
             ]),
           }),
@@ -360,7 +360,7 @@ describe('MetricSelectRow', () => {
         <MetricSelectRow
           field={{
             kind: 'function',
-            function: ['avg', 'value', 'gauge_metric', 'gauge', '-'],
+            function: ['avg', 'value', 'gauge_metric', 'gauge', 'none'],
           }}
           index={0}
           disabled={false}
@@ -394,7 +394,7 @@ describe('MetricSelectRow', () => {
             field: serializeFields([
               {
                 kind: FieldValueKind.FUNCTION,
-                function: ['sum', 'value', 'counter_metric', 'counter', '-'],
+                function: ['sum', 'value', 'counter_metric', 'counter', 'none'],
               },
             ]),
           }),
@@ -410,7 +410,7 @@ describe('MetricSelectRow', () => {
         <MetricSelectRow
           field={{
             kind: 'function',
-            function: ['p50', 'value', 'distribution_metric', 'distribution', '-'],
+            function: ['p50', 'value', 'distribution_metric', 'distribution', 'none'],
           }}
           index={0}
           disabled={false}
@@ -446,7 +446,7 @@ describe('MetricSelectRow', () => {
             yAxis: serializeFields([
               {
                 kind: FieldValueKind.FUNCTION,
-                function: ['avg', 'value', 'gauge_metric', 'gauge', '-'],
+                function: ['avg', 'value', 'gauge_metric', 'gauge', 'none'],
               },
             ]),
           }),
@@ -454,5 +454,50 @@ describe('MetricSelectRow', () => {
         expect.anything()
       );
     });
+  });
+
+  it('converts - to none for unit', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <MetricSelectRow
+          field={{
+            kind: 'function',
+            function: ['sum', 'value', 'counter_metric', 'counter', '-'],
+          }}
+          index={0}
+          disabled={false}
+        />
+      </WidgetBuilderProvider>,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+            query: {
+              yAxis: ['sum(value,counter_metric,counter,-)'],
+              dataset: WidgetType.TRACEMETRICS,
+              displayType: DisplayType.LINE,
+            },
+          },
+        },
+      }
+    );
+
+    const metricSelector = await screen.findByRole('button', {name: 'counter_metric'});
+    await userEvent.click(metricSelector);
+    await userEvent.click(await screen.findByRole('option', {name: 'counter_metric'}));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          yAxis: serializeFields([
+            {
+              kind: FieldValueKind.FUNCTION,
+              function: ['sum', 'value', 'counter_metric', 'counter', 'none'],
+            },
+          ]),
+        }),
+      }),
+      expect.anything()
+    );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useIsEquationMode.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useIsEquationMode.spec.tsx
@@ -63,7 +63,7 @@ describe('useIsEquationMode', () => {
           query: {
             dataset: WidgetType.TRACEMETRICS,
             displayType: DisplayType.LINE,
-            yAxis: ['sum(value,alpha_metric,counter,-)'],
+            yAxis: ['sum(value,alpha_metric,counter,none)'],
           },
         },
       },
@@ -82,7 +82,7 @@ describe('useIsEquationMode', () => {
           query: {
             dataset: WidgetType.TRACEMETRICS,
             displayType: DisplayType.LINE,
-            yAxis: ['sum(value,alpha_metric,counter,-)'],
+            yAxis: ['sum(value,alpha_metric,counter,none)'],
           },
         },
       },
@@ -102,7 +102,7 @@ describe('useIsEquationMode', () => {
             dataset: WidgetType.TRACEMETRICS,
             displayType: DisplayType.LINE,
             yAxis: [
-              'equation|sum(value,alpha_metric,counter,-) + avg(value,beta_metric,counter,-)',
+              'equation|sum(value,alpha_metric,counter,none) + avg(value,beta_metric,counter,none)',
             ],
           },
         },

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -1953,7 +1953,7 @@ describe('useWidgetBuilderState', () => {
           payload: [
             {
               kind: 'function',
-              function: ['avg', 'value', 'other.metric', 'gauge', '-'],
+              function: ['avg', 'value', 'other.metric', 'gauge', 'none'],
             },
           ] as Column[],
         });
@@ -1989,11 +1989,11 @@ describe('useWidgetBuilderState', () => {
           payload: [
             {
               kind: 'function',
-              function: ['sum', 'value', 'my.metric', 'counter', '-'],
+              function: ['sum', 'value', 'my.metric', 'counter', 'none'],
             },
             {
               kind: 'function',
-              function: ['avg', 'value', 'my.metric', 'counter', '-'],
+              function: ['avg', 'value', 'my.metric', 'counter', 'none'],
             },
           ] as Column[],
         });
@@ -2028,12 +2028,12 @@ describe('useWidgetBuilderState', () => {
       // stores all args in the args array when there are more than 3.
       expect(result.current.state.yAxis).toEqual([
         {
-          function: ['sum', 'value', 'my.metric', 'counter', '-'],
+          function: ['sum', 'value', 'my.metric', 'counter', 'none'],
           alias: undefined,
           kind: 'function',
         },
         {
-          function: ['per_second', 'value', 'my.metric', 'counter', '-'],
+          function: ['per_second', 'value', 'my.metric', 'counter', 'none'],
           alias: undefined,
           kind: 'function',
         },
@@ -2066,7 +2066,7 @@ describe('useWidgetBuilderState', () => {
               {kind: FieldValueKind.FIELD, field: 'project'},
               {
                 kind: FieldValueKind.FUNCTION,
-                function: ['sum', 'value', 'my.metric', 'counter', '-'],
+                function: ['sum', 'value', 'my.metric', 'counter', 'none'],
               },
               {
                 kind: FieldValueKind.FUNCTION,
@@ -2075,7 +2075,7 @@ describe('useWidgetBuilderState', () => {
                   'value',
                   'my.metric',
                   'counter',
-                  '-',
+                  'none',
                 ],
               },
             ]),

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -1936,8 +1936,8 @@ describe('useWidgetBuilderState', () => {
             dataset: WidgetType.TRACEMETRICS,
             displayType: DisplayType.LINE,
             field: ['project'],
-            yAxis: ['sum(value,my.metric,counter,-)'],
-            sort: ['-sum(value,my.metric,counter,-)'],
+            yAxis: ['sum(value,my.metric,counter,none)'],
+            sort: ['-sum(value,my.metric,counter,none)'],
           },
         })
       );
@@ -1961,7 +1961,7 @@ describe('useWidgetBuilderState', () => {
 
       // Sort should be updated to the new aggregate
       expect(result.current.state.sort).toEqual([
-        {kind: 'desc', field: 'avg(value,other.metric,gauge,-)'},
+        {kind: 'desc', field: 'avg(value,other.metric,gauge,none)'},
       ]);
     });
 
@@ -1972,8 +1972,8 @@ describe('useWidgetBuilderState', () => {
             dataset: WidgetType.TRACEMETRICS,
             displayType: DisplayType.LINE,
             field: ['project'],
-            yAxis: ['sum(value,my.metric,counter,-)'],
-            sort: ['-sum(value,my.metric,counter,-)'],
+            yAxis: ['sum(value,my.metric,counter,none)'],
+            sort: ['-sum(value,my.metric,counter,none)'],
           },
         })
       );
@@ -2001,7 +2001,7 @@ describe('useWidgetBuilderState', () => {
 
       // Sort should remain on sum since it's still present
       expect(result.current.state.sort).toEqual([
-        {kind: 'desc', field: 'sum(value,my.metric,counter,-)'},
+        {kind: 'desc', field: 'sum(value,my.metric,counter,none)'},
       ]);
     });
 
@@ -2012,8 +2012,8 @@ describe('useWidgetBuilderState', () => {
             dataset: WidgetType.TRACEMETRICS,
             displayType: DisplayType.LINE,
             yAxis: [
-              'sum(value,my.metric,counter,-)',
-              'per_second(value,my.metric,counter,-)',
+              'sum(value,my.metric,counter,none)',
+              'per_second(value,my.metric,counter,none)',
             ],
           },
         })
@@ -2088,7 +2088,7 @@ describe('useWidgetBuilderState', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
-            sort: ['-per_second(value,my.metric,counter,-)'],
+            sort: ['-per_second(value,my.metric,counter,none)'],
           }),
         }),
         expect.anything()

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.spec.tsx
@@ -31,7 +31,10 @@ describe('useWidgetBuilderTraceItemConfig', () => {
         query: {
           dataset: WidgetType.TRACEMETRICS,
           displayType: 'line',
-          yAxis: ['avg(value,metric_one,gauge,-)', 'sum(value,metric_two,counter,-)'],
+          yAxis: [
+            'avg(value,metric_one,gauge,none)',
+            'sum(value,metric_two,counter,none)',
+          ],
         },
       })
     );
@@ -59,7 +62,7 @@ describe('useWidgetBuilderTraceItemConfig', () => {
         query: {
           dataset: WidgetType.TRACEMETRICS,
           displayType: 'line',
-          yAxis: ['avg(value,metric_one,gauge,-)', 'max(value,metric_one,gauge,-)'],
+          yAxis: ['avg(value,metric_one,gauge,none)', 'max(value,metric_one,gauge,none)'],
         },
       })
     );

--- a/static/app/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate.ts
@@ -7,6 +7,7 @@ import {DisplayType} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
+import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 
 export function buildTraceMetricAggregate(
@@ -20,7 +21,7 @@ export function buildTraceMetricAggregate(
       'value',
       traceMetric.name,
       traceMetric.type,
-      traceMetric.unit ?? '-',
+      traceMetric.unit ?? NONE_UNIT,
     ],
   };
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate.ts
@@ -1,3 +1,4 @@
+import {defined} from 'sentry/utils';
 import type {
   AggregationKeyWithAlias,
   Column,
@@ -21,7 +22,9 @@ export function buildTraceMetricAggregate(
       'value',
       traceMetric.name,
       traceMetric.type,
-      traceMetric.unit ?? NONE_UNIT,
+      defined(traceMetric.unit) && traceMetric.unit !== '-'
+        ? traceMetric.unit
+        : NONE_UNIT,
     ],
   };
 }
@@ -36,7 +39,7 @@ export function extractTraceMetricFromColumn(column: Column): TraceMetric | unde
   if (column.kind === 'function' && column.function) {
     const [, , name, type, unit] = column.function;
     if (name && type) {
-      return {name, type, unit: unit === '-' ? undefined : unit};
+      return {name, type, unit: defined(unit) && unit !== '-' ? unit : NONE_UNIT};
     }
   }
   return undefined;

--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.spec.tsx
@@ -32,8 +32,8 @@ describe('useTraceMetricsSeriesQuery', () => {
       queries: [
         {
           name: 'test',
-          fields: ['avg(value,test_metric,millisecond,-)'],
-          aggregates: ['avg(value,test_metric,millisecond,-)'],
+          fields: ['avg(value,test_metric,millisecond,none)'],
+          aggregates: ['avg(value,test_metric,millisecond,none)'],
           columns: [],
           conditions: '',
           orderby: '',
@@ -46,7 +46,7 @@ describe('useTraceMetricsSeriesQuery', () => {
       body: {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [],
             meta: {
@@ -73,7 +73,7 @@ describe('useTraceMetricsSeriesQuery', () => {
         '/organizations/org-slug/events-timeseries/',
         expect.objectContaining({
           query: expect.objectContaining({
-            yAxis: ['avg(value,test_metric,millisecond,-)'],
+            yAxis: ['avg(value,test_metric,millisecond,none)'],
           }),
         })
       );
@@ -86,8 +86,8 @@ describe('useTraceMetricsSeriesQuery', () => {
       queries: [
         {
           name: 'test',
-          fields: ['avg(value,test_metric,millisecond,-)'],
-          aggregates: ['avg(value,test_metric,millisecond,-)'],
+          fields: ['avg(value,test_metric,millisecond,none)'],
+          aggregates: ['avg(value,test_metric,millisecond,none)'],
           columns: [],
           conditions: 'environment:production',
           orderby: '',
@@ -100,7 +100,7 @@ describe('useTraceMetricsSeriesQuery', () => {
       body: {
         timeSeries: [
           {
-            yAxis: 'avg(value,test_metric,millisecond,-)',
+            yAxis: 'avg(value,test_metric,millisecond,none)',
             values: [{timestamp: 1, value: 100}],
             groupBy: [],
             meta: {
@@ -143,8 +143,8 @@ describe('useTraceMetricsSeriesQuery', () => {
       queries: [
         {
           name: 'test',
-          fields: ['project', 'avg(value,test_metric,millisecond,-)'],
-          aggregates: ['avg(value,test_metric,millisecond,-)'],
+          fields: ['project', 'avg(value,test_metric,millisecond,none)'],
+          aggregates: ['avg(value,test_metric,millisecond,none)'],
           columns: ['project'],
           conditions: '',
           orderby: '',
@@ -197,8 +197,8 @@ describe('useTraceMetricsTableQuery', () => {
       queries: [
         {
           name: 'test',
-          fields: ['project', 'avg(value,test_metric,millisecond,-)'],
-          aggregates: ['avg(value,test_metric,millisecond,-)'],
+          fields: ['project', 'avg(value,test_metric,millisecond,none)'],
+          aggregates: ['avg(value,test_metric,millisecond,none)'],
           columns: ['project'],
           conditions: '',
           orderby: '',
@@ -212,7 +212,7 @@ describe('useTraceMetricsTableQuery', () => {
         data: [
           {
             project: 'frontend',
-            'avg(value,test_metric,millisecond,-)': 150,
+            'avg(value,test_metric,millisecond,none)': 150,
           },
         ],
       },
@@ -245,8 +245,8 @@ describe('useTraceMetricsTableQuery', () => {
       queries: [
         {
           name: 'test',
-          fields: ['project', 'avg(value,test_metric,millisecond,-)'],
-          aggregates: ['avg(value,test_metric,millisecond,-)'],
+          fields: ['project', 'avg(value,test_metric,millisecond,none)'],
+          aggregates: ['avg(value,test_metric,millisecond,none)'],
           columns: ['project'],
           conditions: '',
           orderby: '',
@@ -260,7 +260,7 @@ describe('useTraceMetricsTableQuery', () => {
         data: [
           {
             project: 'frontend',
-            'avg(value,test_metric,millisecond,-)': 150,
+            'avg(value,test_metric,millisecond,none)': 150,
           },
         ],
       },

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx
@@ -27,8 +27,8 @@ describe('traceMetricsWidgetQueries', () => {
       queries: [
         {
           name: '',
-          aggregates: ['avg(value,duration,d,-)'],
-          fields: ['avg(value,duration,d,-)'],
+          aggregates: ['avg(value,duration,d,none)'],
+          fields: ['avg(value,duration,d,none)'],
           columns: [],
           conditions: '',
           orderby: '',
@@ -41,7 +41,7 @@ describe('traceMetricsWidgetQueries', () => {
       body: {
         timeSeries: [
           {
-            yAxis: 'avg(value,duration,d,-)',
+            yAxis: 'avg(value,duration,d,none)',
             meta: {
               interval: 3600000,
               valueType: 'duration',

--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
@@ -228,7 +228,7 @@ describe('getDetectorOpenInDestination', () => {
         expect(result?.to).toContain('interval=5m');
         // Metric query params are JSON-encoded then URL-encoded
         expect(result?.to).toContain('my_metric');
-        expect(result?.to).toContain('sum%28value%2Cmy_metric%2Ccounter%2C-%29');
+        expect(result?.to).toContain('sum%28value%2Cmy_metric%2Ccounter%2Cnone%29');
       });
 
       it('expands equation aggregates into per-function rows plus an equation row', () => {

--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
@@ -200,7 +200,7 @@ describe('getDetectorOpenInDestination', () => {
                 subscription: '1',
                 snubaQuery: {
                   id: '1',
-                  aggregate: 'sum(value,my_metric,counter,-)',
+                  aggregate: 'sum(value,my_metric,counter,none)',
                   dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
                   eventTypes: [EventTypes.TRACE_ITEM_METRIC],
                   query: '',
@@ -241,7 +241,8 @@ describe('getDetectorOpenInDestination', () => {
                 subscription: '1',
                 snubaQuery: {
                   id: '1',
-                  aggregate: 'equation|sum(value,a,counter,-) + sum(value,b,counter,-)',
+                  aggregate:
+                    'equation|sum(value,a,counter,none) + sum(value,b,counter,none)',
                   dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
                   eventTypes: [EventTypes.TRACE_ITEM_METRIC],
                   query: 'foo:bar',
@@ -271,16 +272,16 @@ describe('getDetectorOpenInDestination', () => {
         const parsedMetrics = metricParams.map(value => JSON.parse(value));
         expect(parsedMetrics[0].metric.name).toBe('a');
         expect(parsedMetrics[0].aggregateFields[0].yAxes).toEqual([
-          'sum(value,a,counter,-)',
+          'sum(value,a,counter,none)',
         ]);
         expect(parsedMetrics[1].metric.name).toBe('b');
         expect(parsedMetrics[1].aggregateFields[0].yAxes).toEqual([
-          'sum(value,b,counter,-)',
+          'sum(value,b,counter,none)',
         ]);
         // Equation row carries the top-level filter and the full equation text.
         expect(parsedMetrics[2].query).toBe('foo:bar');
         expect(parsedMetrics[2].aggregateFields[0].yAxes[0]).toBe(
-          'equation|sum(value,a,counter,-) + sum(value,b,counter,-)'
+          'equation|sum(value,a,counter,none) + sum(value,b,counter,none)'
         );
       });
     });

--- a/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.spec.tsx
@@ -35,7 +35,7 @@ describe('useAddMetricToDashboard', () => {
   });
 
   it('opens the dashboard modal with the trace metrics widget configuration', () => {
-    const yAxis = 'avg(value,metric.a,counter,-)';
+    const yAxis = 'avg(value,metric.a,counter,none)';
     const visualize = new VisualizeFunction(yAxis, {chartType: ChartType.BAR});
     const metricQuery: BaseMetricQuery = {
       metric: {name: 'metric.a', type: 'counter'},
@@ -86,8 +86,8 @@ describe('useAddMetricToDashboard', () => {
   });
 
   it('includes all yAxes when multiple visualizes are present', () => {
-    const yAxis1 = 'p50(value,metric.a,counter,-)';
-    const yAxis2 = 'p75(value,metric.a,counter,-)';
+    const yAxis1 = 'p50(value,metric.a,counter,none)';
+    const yAxis2 = 'p75(value,metric.a,counter,none)';
     const visualize1 = new VisualizeFunction(yAxis1, {chartType: ChartType.BAR});
     const visualize2 = new VisualizeFunction(yAxis2, {chartType: ChartType.LINE});
     const metricQuery: BaseMetricQuery = {
@@ -139,7 +139,7 @@ describe('useAddMetricToDashboard', () => {
   });
 
   it('does not pass an orderby if there are no group bys', () => {
-    const yAxis = 'avg(value,metric.a,counter,-)';
+    const yAxis = 'avg(value,metric.a,counter,none)';
     const visualize = new VisualizeFunction(yAxis, {chartType: ChartType.BAR});
     const metricQuery: BaseMetricQuery = {
       metric: {name: 'metric.a', type: 'counter'},

--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.spec.tsx
@@ -136,7 +136,7 @@ describe('useMetricAggregatesTable', () => {
             'sum(value,test-metric,none)',
             'count(value,test-metric,none)',
             // The count aggregate includes metric details: count(metric.name,<name>,<type>,none)
-            expect.stringMatching(/^count\(metric\.name,test-metric,counter,-\)$/),
+            expect.stringMatching(/^count\(metric\.name,test-metric,counter,none\)$/),
           ]),
         }),
       })
@@ -201,7 +201,9 @@ describe('useMetricAggregatesTable', () => {
             'avg(value,test-metric,none)',
             'p95(value,test-metric,none)',
             // The count aggregate includes metric details: count(metric.name,<name>,<type>,none)
-            expect.stringMatching(/^count\(metric\.name,test-metric,distribution,-\)$/),
+            expect.stringMatching(
+              /^count\(metric\.name,test-metric,distribution,none\)$/
+            ),
           ]),
         }),
       })

--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.spec.tsx
@@ -81,9 +81,9 @@ describe('useMetricAggregatesTable', () => {
   });
 
   it('includes multiple yAxis fields when multiple visualizes are configured', async () => {
-    const visualize1 = new VisualizeFunction('avg(value,test-metric,-)');
-    const visualize2 = new VisualizeFunction('sum(value,test-metric,-)');
-    const visualize3 = new VisualizeFunction('count(value,test-metric,-)');
+    const visualize1 = new VisualizeFunction('avg(value,test-metric,none)');
+    const visualize2 = new VisualizeFunction('sum(value,test-metric,none)');
+    const visualize3 = new VisualizeFunction('count(value,test-metric,none)');
 
     const queryParams = new ReadableQueryParams({
       extrapolate: true,
@@ -132,10 +132,10 @@ describe('useMetricAggregatesTable', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           field: expect.arrayContaining([
-            'avg(value,test-metric,-)',
-            'sum(value,test-metric,-)',
-            'count(value,test-metric,-)',
-            // The count aggregate includes metric details: count(metric.name,<name>,<type>,-)
+            'avg(value,test-metric,none)',
+            'sum(value,test-metric,none)',
+            'count(value,test-metric,none)',
+            // The count aggregate includes metric details: count(metric.name,<name>,<type>,none)
             expect.stringMatching(/^count\(metric\.name,test-metric,counter,-\)$/),
           ]),
         }),
@@ -146,8 +146,8 @@ describe('useMetricAggregatesTable', () => {
   it('includes groupBys and all visualize yAxes in fields', async () => {
     const groupBy1: GroupBy = {groupBy: 'environment'};
     const groupBy2: GroupBy = {groupBy: 'service'};
-    const visualize1 = new VisualizeFunction('avg(value,test-metric,-)');
-    const visualize2 = new VisualizeFunction('p95(value,test-metric,-)');
+    const visualize1 = new VisualizeFunction('avg(value,test-metric,none)');
+    const visualize2 = new VisualizeFunction('p95(value,test-metric,none)');
 
     const queryParams = new ReadableQueryParams({
       extrapolate: true,
@@ -158,7 +158,7 @@ describe('useMetricAggregatesTable', () => {
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
       aggregateFields: [groupBy1, groupBy2, visualize1, visualize2],
-      aggregateSortBys: [{field: 'avg(value,test-metric,-)', kind: 'desc'}],
+      aggregateSortBys: [{field: 'avg(value,test-metric,none)', kind: 'desc'}],
     });
 
     const mockRequest = MockApiClient.addMockResponse({
@@ -198,9 +198,9 @@ describe('useMetricAggregatesTable', () => {
           field: expect.arrayContaining([
             'environment',
             'service',
-            'avg(value,test-metric,-)',
-            'p95(value,test-metric,-)',
-            // The count aggregate includes metric details: count(metric.name,<name>,<type>,-)
+            'avg(value,test-metric,none)',
+            'p95(value,test-metric,none)',
+            // The count aggregate includes metric details: count(metric.name,<name>,<type>,none)
             expect.stringMatching(/^count\(metric\.name,test-metric,distribution,-\)$/),
           ]),
         }),

--- a/static/app/views/explore/metrics/hooks/useMetricTimeseries.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTimeseries.spec.tsx
@@ -30,11 +30,11 @@ function MockMetricQueryParamsContextWithMultiVisualize({
     sortBys: [{field: 'timestamp', kind: 'desc'}],
     aggregateCursor: '',
     aggregateFields: [
-      new VisualizeFunction('p50(value,test_metric,distribution,-)'),
-      new VisualizeFunction('p75(value,test_metric,distribution,-)'),
-      new VisualizeFunction('p99(value,test_metric,distribution,-)'),
+      new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+      new VisualizeFunction('p75(value,test_metric,distribution,none)'),
+      new VisualizeFunction('p99(value,test_metric,distribution,none)'),
     ],
-    aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+    aggregateSortBys: [{field: 'p50(value,test_metric,distribution,none)', kind: 'desc'}],
   });
 
   return (
@@ -140,15 +140,15 @@ describe('useMetricTimeseries', () => {
         timeSeries: [
           {
             ...mockTimeSeries1,
-            yAxis: 'p50(value,test_metric,distribution,-)',
+            yAxis: 'p50(value,test_metric,distribution,none)',
           },
           {
             ...mockTimeSeries2,
-            yAxis: 'p75(value,test_metric,distribution,-)',
+            yAxis: 'p75(value,test_metric,distribution,none)',
           },
           {
             ...mockTimeSeries3,
-            yAxis: 'p99(value,test_metric,distribution,-)',
+            yAxis: 'p99(value,test_metric,distribution,none)',
           },
         ],
       },
@@ -172,9 +172,9 @@ describe('useMetricTimeseries', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           yAxis: [
-            'p50(value,test_metric,distribution,-)',
-            'p75(value,test_metric,distribution,-)',
-            'p99(value,test_metric,distribution,-)',
+            'p50(value,test_metric,distribution,none)',
+            'p75(value,test_metric,distribution,none)',
+            'p99(value,test_metric,distribution,none)',
           ],
         }),
       })
@@ -190,7 +190,7 @@ describe('useMetricTimeseries', () => {
         timeSeries: [
           {
             ...mockTimeSeries,
-            yAxis: 'p50(value,test_metric,distribution,-)',
+            yAxis: 'p50(value,test_metric,distribution,none)',
             values: [
               {
                 ...mockTimeSeries.values[0]!,
@@ -204,7 +204,7 @@ describe('useMetricTimeseries', () => {
           },
           {
             ...mockTimeSeries,
-            yAxis: 'p75(value,test_metric,distribution,-)',
+            yAxis: 'p75(value,test_metric,distribution,none)',
             values: [
               {
                 ...mockTimeSeries.values[0]!,
@@ -218,7 +218,7 @@ describe('useMetricTimeseries', () => {
           },
           {
             ...mockTimeSeries,
-            yAxis: 'p99(value,test_metric,distribution,-)',
+            yAxis: 'p99(value,test_metric,distribution,none)',
             values: [
               {
                 ...mockTimeSeries.values[0]!,
@@ -270,9 +270,9 @@ describe('useMetricTimeseries', () => {
         query: expect.objectContaining({
           sampling: SAMPLING_MODE.HIGH_ACCURACY,
           yAxis: [
-            'p50(value,test_metric,distribution,-)',
-            'p75(value,test_metric,distribution,-)',
-            'p99(value,test_metric,distribution,-)',
+            'p50(value,test_metric,distribution,none)',
+            'p75(value,test_metric,distribution,none)',
+            'p99(value,test_metric,distribution,none)',
           ],
         }),
       })

--- a/static/app/views/explore/metrics/hooks/useSortableMetricQueries.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useSortableMetricQueries.spec.tsx
@@ -4,8 +4,10 @@ import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {useSortableMetricQueries} from 'sentry/views/explore/metrics/hooks/useSortableMetricQueries';
-import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
-import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {
+  MultiMetricsQueryParamsProvider,
+  useMultiMetricsQueryParams,
+} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {
   isVisualizeEquation,
   VisualizeEquation,
@@ -29,7 +31,7 @@ describe('useSortableMetricQueries', () => {
                 metric: {name: 'foo', type: 'counter'},
                 query: '',
                 aggregateFields: [
-                  new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                  new VisualizeFunction('sum(value,foo,counter,none)').serialize(),
                 ],
                 aggregateSortBys: [],
                 mode: 'samples',
@@ -38,7 +40,7 @@ describe('useSortableMetricQueries', () => {
                 metric: {name: 'bar', type: 'counter'},
                 query: '',
                 aggregateFields: [
-                  new VisualizeFunction('sum(value,bar,counter,-)').serialize(),
+                  new VisualizeFunction('sum(value,bar,counter,none)').serialize(),
                 ],
                 aggregateSortBys: [],
                 mode: 'samples',
@@ -73,7 +75,7 @@ describe('useSortableMetricQueries', () => {
                   metric: {name: 'foo', type: 'counter'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                    new VisualizeFunction('sum(value,foo,counter,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',
@@ -82,7 +84,7 @@ describe('useSortableMetricQueries', () => {
                   metric: {name: 'bar', type: 'counter'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('sum(value,bar,counter,-)').serialize(),
+                    new VisualizeFunction('sum(value,bar,counter,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',
@@ -143,7 +145,7 @@ describe('useSortableMetricQueries', () => {
                   metric: {name: 'foo', type: 'counter'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                    new VisualizeFunction('sum(value,foo,counter,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',
@@ -179,7 +181,7 @@ describe('useSortableMetricQueries', () => {
     const duplicateQuery = JSON.stringify({
       metric: {name: 'foo', type: 'counter'},
       query: '',
-      aggregateFields: [new VisualizeFunction('sum(value,foo,counter,-)').serialize()],
+      aggregateFields: [new VisualizeFunction('sum(value,foo,counter,none)').serialize()],
       aggregateSortBys: [],
       mode: 'samples',
     });

--- a/static/app/views/explore/metrics/metricQuery.spec.tsx
+++ b/static/app/views/explore/metrics/metricQuery.spec.tsx
@@ -17,9 +17,9 @@ describe('decodeMetricsQueryParams', () => {
       metric: {name: 'test_metric', type: 'distribution'},
       query: '',
       aggregateFields: [
-        {yAxes: ['p50(value,test_metric,distribution,-)']},
-        {yAxes: ['p75(value,test_metric,distribution,-)']},
-        {yAxes: ['p99(value,test_metric,distribution,-)']},
+        {yAxes: ['p50(value,test_metric,distribution,none)']},
+        {yAxes: ['p75(value,test_metric,distribution,none)']},
+        {yAxes: ['p99(value,test_metric,distribution,none)']},
       ],
       aggregateSortBys: [],
       mode: 'samples',
@@ -28,9 +28,9 @@ describe('decodeMetricsQueryParams', () => {
     const result = decodeMetricsQueryParams(json);
 
     expect(result?.queryParams.aggregateFields).toEqual([
-      new VisualizeFunction('p50(value,test_metric,distribution,-)'),
-      new VisualizeFunction('p75(value,test_metric,distribution,-)'),
-      new VisualizeFunction('p99(value,test_metric,distribution,-)'),
+      new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+      new VisualizeFunction('p75(value,test_metric,distribution,none)'),
+      new VisualizeFunction('p99(value,test_metric,distribution,none)'),
     ]);
   });
 
@@ -69,8 +69,8 @@ describe('decodeMetricsQueryParams', () => {
       metric: {name: 'test_metric', type: 'distribution'},
       query: '',
       aggregateFields: [
-        {yAxes: ['p50(value,test_metric,distribution,-)']},
-        {yAxes: ['p75(value,test_metric,distribution,-)']},
+        {yAxes: ['p50(value,test_metric,distribution,none)']},
+        {yAxes: ['p75(value,test_metric,distribution,none)']},
         {groupBy: 'environment'},
       ],
       aggregateSortBys: [],
@@ -80,8 +80,8 @@ describe('decodeMetricsQueryParams', () => {
     const result = decodeMetricsQueryParams(json);
 
     expect(result?.queryParams.aggregateFields).toEqual([
-      new VisualizeFunction('p50(value,test_metric,distribution,-)'),
-      new VisualizeFunction('p75(value,test_metric,distribution,-)'),
+      new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+      new VisualizeFunction('p75(value,test_metric,distribution,none)'),
       {groupBy: 'environment'},
     ]);
   });
@@ -98,11 +98,11 @@ describe('decodeMetricsQueryParams', () => {
         sortBys: [{field: 'timestamp', kind: 'desc'}],
         aggregateCursor: '',
         aggregateFields: [
-          new VisualizeFunction('per_second(value,test_metric,counter,-)'),
-          new VisualizeFunction('sum(value,test_metric,counter,-)'),
+          new VisualizeFunction('per_second(value,test_metric,counter,none)'),
+          new VisualizeFunction('sum(value,test_metric,counter,none)'),
         ],
         aggregateSortBys: [
-          {field: 'per_second(value,test_metric,counter,-)', kind: 'desc'},
+          {field: 'per_second(value,test_metric,counter,none)', kind: 'desc'},
         ],
       }),
     };
@@ -128,9 +128,9 @@ describe('decodeMetricsQueryParams', () => {
         fields: ['id', 'timestamp'],
         sortBys: [{field: 'value', kind: 'asc' as const}],
         aggregateCursor: '',
-        aggregateFields: [new VisualizeFunction('sum(value,test_metric,counter,-)')],
+        aggregateFields: [new VisualizeFunction('sum(value,test_metric,counter,none)')],
         aggregateSortBys: [
-          {field: 'sum(value,test_metric,counter,-)', kind: 'desc' as const},
+          {field: 'sum(value,test_metric,counter,none)', kind: 'desc' as const},
         ],
       }),
     };
@@ -145,7 +145,7 @@ describe('decodeMetricsQueryParams', () => {
     const json = JSON.stringify({
       metric: {name: 'test_metric', type: 'counter'},
       query: '',
-      aggregateFields: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+      aggregateFields: [{yAxes: ['sum(value,test_metric,counter,none)']}],
       aggregateSortBys: [],
       mode: 'samples',
     });
@@ -159,7 +159,7 @@ describe('decodeMetricsQueryParams', () => {
     const json = JSON.stringify({
       metric: {name: 'test_metric', type: 'counter'},
       query: '',
-      aggregateFields: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+      aggregateFields: [{yAxes: ['sum(value,test_metric,counter,none)']}],
       aggregateSortBys: [],
       sortBys: [{field: 'arbitrary_field', kind: 'desc'}],
       mode: 'samples',
@@ -174,7 +174,7 @@ describe('decodeMetricsQueryParams', () => {
     const json = JSON.stringify({
       metric: {name: 'test_metric', type: 'counter'},
       query: '',
-      aggregateFields: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+      aggregateFields: [{yAxes: ['sum(value,test_metric,counter,none)']}],
       aggregateSortBys: [],
       sortBys: [{field: 'value', kind: 'invalid'}],
       mode: 'samples',

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
@@ -34,8 +34,8 @@ function createWrapper(options: WrapperOptions = {}) {
     fields: ['id', 'timestamp'],
     sortBys: [{field: 'timestamp', kind: 'desc'}],
     aggregateCursor: '',
-    aggregateFields: [new VisualizeFunction('sum(value,test_metric,distribution,-)')],
-    aggregateSortBys: [{field: 'sum(value,test_metric,distribution,-)', kind: 'desc'}],
+    aggregateFields: [new VisualizeFunction('sum(value,test_metric,distribution,none)')],
+    aggregateSortBys: [{field: 'sum(value,test_metric,distribution,none)', kind: 'desc'}],
   });
 
   return function Wrapper({children}: {children: ReactNode}) {
@@ -93,10 +93,12 @@ describe('AggregateDropdown', () => {
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
       aggregateFields: [
-        new VisualizeFunction('p50(value,test_metric,distribution,-)'),
-        new VisualizeFunction('p75(value,test_metric,distribution,-)'),
+        new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+        new VisualizeFunction('p75(value,test_metric,distribution,none)'),
       ],
-      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateSortBys: [
+        {field: 'p50(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(
@@ -140,8 +142,12 @@ describe('AggregateDropdown', () => {
       fields: ['id', 'timestamp'],
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
-      aggregateFields: [new VisualizeFunction('p50(value,test_metric,distribution,-)')],
-      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateFields: [
+        new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+      ],
+      aggregateSortBys: [
+        {field: 'p50(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(
@@ -186,10 +192,12 @@ describe('AggregateDropdown', () => {
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
       aggregateFields: [
-        new VisualizeFunction('p50(value,test_metric,distribution,-)'),
-        new VisualizeFunction('p90(value,test_metric,distribution,-)'),
+        new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+        new VisualizeFunction('p90(value,test_metric,distribution,none)'),
       ],
-      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateSortBys: [
+        {field: 'p50(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(
@@ -237,9 +245,11 @@ describe('AggregateDropdown', () => {
       fields: ['id', 'timestamp'],
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
-      aggregateFields: [new VisualizeFunction('per_second(value,test_metric,counter,-)')],
+      aggregateFields: [
+        new VisualizeFunction('per_second(value,test_metric,counter,none)'),
+      ],
       aggregateSortBys: [
-        {field: 'per_second(value,test_metric,counter,-)', kind: 'desc'},
+        {field: 'per_second(value,test_metric,counter,none)', kind: 'desc'},
       ],
     });
 
@@ -275,10 +285,12 @@ describe('AggregateDropdown', () => {
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
       aggregateFields: [
-        new VisualizeFunction('p50(value,test_metric,distribution,-)'),
-        new VisualizeFunction('p90(value,test_metric,distribution,-)'),
+        new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+        new VisualizeFunction('p90(value,test_metric,distribution,none)'),
       ],
-      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateSortBys: [
+        {field: 'p50(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(
@@ -330,8 +342,12 @@ describe('AggregateDropdown', () => {
       fields: ['id', 'timestamp'],
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
-      aggregateFields: [new VisualizeFunction('p50(value,test_metric,distribution,-)')],
-      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateFields: [
+        new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+      ],
+      aggregateSortBys: [
+        {field: 'p50(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(
@@ -378,8 +394,12 @@ describe('AggregateDropdown', () => {
       fields: ['id', 'timestamp'],
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
-      aggregateFields: [new VisualizeFunction('sum(value,test_metric,distribution,-)')],
-      aggregateSortBys: [{field: 'sum(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateFields: [
+        new VisualizeFunction('sum(value,test_metric,distribution,none)'),
+      ],
+      aggregateSortBys: [
+        {field: 'sum(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(
@@ -424,8 +444,12 @@ describe('AggregateDropdown', () => {
       fields: ['id', 'timestamp'],
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
-      aggregateFields: [new VisualizeFunction('p50(value,test_metric,distribution,-)')],
-      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateFields: [
+        new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+      ],
+      aggregateSortBys: [
+        {field: 'p50(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(
@@ -452,11 +476,13 @@ describe('AggregateDropdown', () => {
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
       aggregateFields: [
-        new VisualizeFunction('p50(value,test_metric,distribution,-)'),
-        new VisualizeFunction('p75(value,test_metric,distribution,-)'),
-        new VisualizeFunction('p90(value,test_metric,distribution,-)'),
+        new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+        new VisualizeFunction('p75(value,test_metric,distribution,none)'),
+        new VisualizeFunction('p90(value,test_metric,distribution,none)'),
       ],
-      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateSortBys: [
+        {field: 'p50(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(
@@ -482,8 +508,12 @@ describe('AggregateDropdown', () => {
       fields: ['id', 'timestamp'],
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
-      aggregateFields: [new VisualizeFunction('p50(value,test_metric,distribution,-)')],
-      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateFields: [
+        new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+      ],
+      aggregateSortBys: [
+        {field: 'p50(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(
@@ -519,8 +549,12 @@ describe('AggregateDropdown', () => {
       fields: ['id', 'timestamp'],
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
-      aggregateFields: [new VisualizeFunction('p50(value,test_metric,distribution,-)')],
-      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateFields: [
+        new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+      ],
+      aggregateSortBys: [
+        {field: 'p50(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -112,8 +112,12 @@ describe('MetricToolbar', () => {
       fields: ['id', 'timestamp'],
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
-      aggregateFields: [new VisualizeFunction('sum(value,test_metric,distribution,-)')],
-      aggregateSortBys: [{field: 'sum(value,test_metric,distribution,-)', kind: 'desc'}],
+      aggregateFields: [
+        new VisualizeFunction('sum(value,test_metric,distribution,none)'),
+      ],
+      aggregateSortBys: [
+        {field: 'sum(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
     });
 
     render(

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.spec.tsx
@@ -422,7 +422,7 @@ describe('MetricSelector', () => {
       );
     });
 
-    it('preserves null units when selecting between same-name metrics', async () => {
+    it('deduplicates null and none units into a single option', async () => {
       MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/events/`,
@@ -469,11 +469,10 @@ describe('MetricSelector', () => {
         ],
       });
 
-      const onChange = jest.fn();
       render(
         <MetricSelector
           traceMetric={{name: 'lighthouse.cls', type: 'distribution', unit: 'none'}}
-          onChange={onChange}
+          onChange={jest.fn()}
         />,
         {organization}
       );
@@ -482,18 +481,7 @@ describe('MetricSelector', () => {
 
       const options = await screen.findAllByRole('option', {name: 'lighthouse.cls'});
 
-      expect(options).toHaveLength(2);
-      expect(
-        options.filter(option => option.getAttribute('aria-selected') === 'true')
-      ).toHaveLength(1);
-
-      await userEvent.click(options[1]!);
-
-      expect(onChange).toHaveBeenCalledWith({
-        name: 'lighthouse.cls',
-        type: 'distribution',
-        unit: null,
-      });
+      expect(options).toHaveLength(1);
     });
 
     it('shows unselected metrics as aria-selected="false"', async () => {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -46,8 +46,6 @@ import {
 const METRIC_SELECTOR_OPTION_HEIGHT = 42;
 const METRIC_SELECTOR_DROPDOWN_MAX_HEIGHT = 400;
 const METRIC_SELECTOR_DROPDOWN_MIN_HEIGHT = 0;
-const NULL_METRIC_UNIT_SELECT_VALUE = '__null__';
-
 function maybePortal(element: React.ReactElement, portal?: boolean) {
   return portal ? createPortal(element, document.body) : element;
 }
@@ -118,8 +116,7 @@ export function MetricSelector({
   const traceMetricSelectValue = makeMetricSelectValue({
     name: traceMetric.name,
     type: traceMetric.type,
-    unit:
-      traceMetric.unit === null ? NULL_METRIC_UNIT_SELECT_VALUE : traceMetricDisplayUnit,
+    unit: traceMetricDisplayUnit,
   });
   const traceMetricType = isTraceMetricTypeValue(traceMetric.type)
     ? traceMetric.type
@@ -160,25 +157,35 @@ export function MetricSelector({
   // find when the dropdown is reopened. Filter it out of the API results to
   // avoid duplication.
   const metricOptions = useMemo((): MetricSelectorOption[] => {
+    const seenValues = new Set<string>();
     const apiOptions =
-      metricOptionsData?.data?.map(option => {
+      metricOptionsData?.data?.flatMap(option => {
         const metricName = option[TraceMetricKnownFieldKey.METRIC_NAME];
 
         const metricType = option[TraceMetricKnownFieldKey.METRIC_TYPE];
         const rawMetricUnit: unknown = option[TraceMetricKnownFieldKey.METRIC_UNIT];
         const metricUnit =
-          typeof rawMetricUnit === 'string' || rawMetricUnit === null
-            ? rawMetricUnit
-            : undefined;
+          rawMetricUnit === null || rawMetricUnit === NONE_UNIT
+            ? null
+            : typeof rawMetricUnit === 'string'
+              ? rawMetricUnit
+              : undefined;
         const metricDisplayUnit =
           metricUnit && metricUnit !== '-' ? metricUnit : NONE_UNIT;
-        const metricSelectValueUnit =
-          metricUnit === null ? NULL_METRIC_UNIT_SELECT_VALUE : metricDisplayUnit;
         const value = makeMetricSelectValue({
           name: metricName,
           type: metricType,
-          unit: metricSelectValueUnit,
+          unit: metricDisplayUnit,
         });
+
+        // Skip duplicate options. This can happen specifically for the edge case where
+        // the API returns both null and "none" units for the same metric name and type
+        // Since we treat them the same, we need to deduplicate them.
+        if (seenValues.has(value)) {
+          return [];
+        }
+        seenValues.add(value);
+
         const countField = option[`count(${TraceMetricKnownFieldKey.METRIC_NAME})`];
         const count =
           typeof countField === 'number'
@@ -192,23 +199,26 @@ export function MetricSelector({
             : Number(option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]) /
               1_000_000;
 
-        return {
-          label: metricName,
-          value,
-          metricType,
-          metricName,
-          metricUnit,
-          count,
-          lastSeen,
-          trailingItems: () => (
-            <MetricOptionTrailingItems
-              hasMetricUnitsUI={hasMetricUnitsUI}
-              metricType={metricType}
-              metricUnit={metricDisplayUnit}
-            />
-          ),
-        };
+        return [
+          {
+            label: metricName,
+            value,
+            metricType,
+            metricName,
+            metricUnit,
+            count,
+            lastSeen,
+            trailingItems: () => (
+              <MetricOptionTrailingItems
+                hasMetricUnitsUI={hasMetricUnitsUI}
+                metricType={metricType}
+                metricUnit={metricDisplayUnit}
+              />
+            ),
+          },
+        ];
       }) ?? [];
+
     let hasMatchedSelectedMetric = false;
     const hasExactSelectedMetric = apiOptions.some(
       option => option.value === traceMetricSelectValue

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -165,17 +165,13 @@ export function MetricSelector({
         const metricType = option[TraceMetricKnownFieldKey.METRIC_TYPE];
         const rawMetricUnit: unknown = option[TraceMetricKnownFieldKey.METRIC_UNIT];
         const metricUnit =
-          rawMetricUnit === null || rawMetricUnit === NONE_UNIT
-            ? null
-            : typeof rawMetricUnit === 'string'
-              ? rawMetricUnit
-              : undefined;
-        const metricDisplayUnit =
-          metricUnit && metricUnit !== '-' ? metricUnit : NONE_UNIT;
+          rawMetricUnit && typeof rawMetricUnit === 'string' && rawMetricUnit !== '-'
+            ? rawMetricUnit
+            : NONE_UNIT;
         const value = makeMetricSelectValue({
           name: metricName,
           type: metricType,
-          unit: metricDisplayUnit,
+          unit: metricUnit,
         });
 
         // Skip duplicate options. This can happen specifically for the edge case where
@@ -212,7 +208,7 @@ export function MetricSelector({
               <MetricOptionTrailingItems
                 hasMetricUnitsUI={hasMetricUnitsUI}
                 metricType={metricType}
-                metricUnit={metricDisplayUnit}
+                metricUnit={metricUnit}
               />
             ),
           },

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -654,7 +654,7 @@ describe('MetricsTabContent', () => {
                   metric: {name: 'bar', type: 'distribution'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('p50(value,bar,distribution,-)').serialize(),
+                    new VisualizeFunction('p50(value,bar,distribution,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -20,6 +20,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import {
   defaultAggregateSortBys,
   encodeMetricQueryParams,
@@ -142,7 +143,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
             metric_context: {
               metric_name: traceMetric.name,
               metric_type: traceMetric.type,
-              metric_unit: traceMetric.unit ?? 'none',
+              metric_unit: traceMetric.unit ?? NONE_UNIT,
             },
           },
         },
@@ -398,7 +399,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           metric_context: {
             metric_name: traceMetric.name,
             metric_type: traceMetric.type,
-            metric_unit: traceMetric.unit ?? 'none',
+            metric_unit: traceMetric.unit ?? NONE_UNIT,
           },
         }}
         applySeerSearchQuery={applySeerSearchQuery}

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -82,7 +82,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       expect.objectContaining({
         metric: {name: 'foo', type: 'counter'},
         queryParams: expect.objectContaining({
-          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,-)')],
+          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,none)')],
         }),
       }),
     ]);
@@ -92,7 +92,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       expect.objectContaining({
         metric: {name: 'bar', type: 'gauge'},
         queryParams: expect.objectContaining({
-          aggregateFields: [new VisualizeFunction('avg(value,bar,gauge,-)')],
+          aggregateFields: [new VisualizeFunction('avg(value,bar,gauge,none)')],
         }),
       }),
     ]);
@@ -102,7 +102,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       expect.objectContaining({
         metric: {name: 'qux', type: 'distribution'},
         queryParams: expect.objectContaining({
-          aggregateFields: [new VisualizeFunction('avg(value,qux,distribution,-)')],
+          aggregateFields: [new VisualizeFunction('avg(value,qux,distribution,none)')],
         }),
       }),
     ]);
@@ -117,7 +117,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
     act(() =>
       result.current[0]!.setQueryParams(
         result.current[0]!.queryParams.replace({
-          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,-)')],
+          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,none)')],
         })
       )
     );
@@ -125,7 +125,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       expect.objectContaining({
         metric: {name: 'foo', type: 'counter'},
         queryParams: expect.objectContaining({
-          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,-)')],
+          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,none)')],
         }),
       }),
     ]);
@@ -135,7 +135,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       expect.objectContaining({
         metric: {name: 'qux', type: 'gauge'},
         queryParams: expect.objectContaining({
-          aggregateFields: [new VisualizeFunction('avg(value,qux,gauge,-)')],
+          aggregateFields: [new VisualizeFunction('avg(value,qux,gauge,none)')],
         }),
       }),
     ]);
@@ -143,7 +143,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
     act(() =>
       result.current[0]!.setQueryParams(
         result.current[0]!.queryParams.replace({
-          aggregateFields: [new VisualizeFunction('last(value,qux,gauge,-)')],
+          aggregateFields: [new VisualizeFunction('last(value,qux,gauge,none)')],
         })
       )
     );
@@ -151,7 +151,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       expect.objectContaining({
         metric: {name: 'qux', type: 'gauge'},
         queryParams: expect.objectContaining({
-          aggregateFields: [new VisualizeFunction('last(value,qux,gauge,-)')],
+          aggregateFields: [new VisualizeFunction('last(value,qux,gauge,none)')],
         }),
       }),
     ]);
@@ -161,7 +161,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       expect.objectContaining({
         metric: {name: 'bar', type: 'distribution'},
         queryParams: expect.objectContaining({
-          aggregateFields: [new VisualizeFunction('sum(value,bar,distribution,-)')],
+          aggregateFields: [new VisualizeFunction('sum(value,bar,distribution,none)')],
         }),
       }),
     ]);
@@ -169,7 +169,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
     act(() =>
       result.current[0]!.setQueryParams(
         result.current[0]!.queryParams.replace({
-          aggregateFields: [new VisualizeFunction('p99(value,bar,distribution,-)')],
+          aggregateFields: [new VisualizeFunction('p99(value,bar,distribution,none)')],
         })
       )
     );
@@ -177,7 +177,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       expect.objectContaining({
         metric: {name: 'bar', type: 'distribution'},
         queryParams: expect.objectContaining({
-          aggregateFields: [new VisualizeFunction('p99(value,bar,distribution,-)')],
+          aggregateFields: [new VisualizeFunction('p99(value,bar,distribution,none)')],
         }),
       }),
     ]);
@@ -187,7 +187,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       expect.objectContaining({
         metric: {name: 'foo', type: 'counter'},
         queryParams: expect.objectContaining({
-          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,-)')],
+          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,none)')],
         }),
       }),
     ]);
@@ -198,9 +198,9 @@ describe('MultiMetricsQueryParamsProvider', () => {
       metric: {name: 'test_metric', type: 'distribution'},
       query: '',
       aggregateFields: [
-        {yAxes: ['p50(value,test_metric,distribution,-)']},
-        {yAxes: ['p75(value,test_metric,distribution,-)']},
-        {yAxes: ['p99(value,test_metric,distribution,-)']},
+        {yAxes: ['p50(value,test_metric,distribution,none)']},
+        {yAxes: ['p75(value,test_metric,distribution,none)']},
+        {yAxes: ['p99(value,test_metric,distribution,none)']},
       ],
       aggregateSortBys: [],
       mode: 'samples',
@@ -223,9 +223,9 @@ describe('MultiMetricsQueryParamsProvider', () => {
         metric: {name: 'test_metric', type: 'distribution'},
         queryParams: expect.objectContaining({
           aggregateFields: [
-            new VisualizeFunction('p50(value,test_metric,distribution,-)'),
-            new VisualizeFunction('p75(value,test_metric,distribution,-)'),
-            new VisualizeFunction('p99(value,test_metric,distribution,-)'),
+            new VisualizeFunction('p50(value,test_metric,distribution,none)'),
+            new VisualizeFunction('p75(value,test_metric,distribution,none)'),
+            new VisualizeFunction('p99(value,test_metric,distribution,none)'),
           ],
         }),
       }),
@@ -242,9 +242,9 @@ describe('MultiMetricsQueryParamsProvider', () => {
       result.current[0]!.setQueryParams(
         result.current[0]!.queryParams.replace({
           aggregateFields: [
-            new VisualizeFunction('p50(value,foo,distribution,-)'),
-            new VisualizeFunction('p75(value,foo,distribution,-)'),
-            new VisualizeFunction('p99(value,foo,distribution,-)'),
+            new VisualizeFunction('p50(value,foo,distribution,none)'),
+            new VisualizeFunction('p75(value,foo,distribution,none)'),
+            new VisualizeFunction('p99(value,foo,distribution,none)'),
           ],
         })
       )
@@ -255,9 +255,9 @@ describe('MultiMetricsQueryParamsProvider', () => {
         metric: {name: 'foo', type: 'distribution'},
         queryParams: expect.objectContaining({
           aggregateFields: [
-            new VisualizeFunction('p50(value,foo,distribution,-)'),
-            new VisualizeFunction('p75(value,foo,distribution,-)'),
-            new VisualizeFunction('p99(value,foo,distribution,-)'),
+            new VisualizeFunction('p50(value,foo,distribution,none)'),
+            new VisualizeFunction('p75(value,foo,distribution,none)'),
+            new VisualizeFunction('p99(value,foo,distribution,none)'),
           ],
         }),
       }),
@@ -274,8 +274,8 @@ describe('MultiMetricsQueryParamsProvider', () => {
       result.current[0]!.setQueryParams(
         result.current[0]!.queryParams.replace({
           aggregateFields: [
-            new VisualizeFunction('p50(value,foo,distribution,-)'),
-            new VisualizeFunction('p75(value,foo,distribution,-)'),
+            new VisualizeFunction('p50(value,foo,distribution,none)'),
+            new VisualizeFunction('p75(value,foo,distribution,none)'),
           ],
         })
       )
@@ -285,7 +285,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
 
     // Only the first visualize is updated when changing metric type
     expect(result.current[0]!.queryParams.aggregateFields).toEqual([
-      new VisualizeFunction('p50(value,bar,distribution,-)'),
+      new VisualizeFunction('p50(value,bar,distribution,none)'),
     ]);
   });
 
@@ -391,7 +391,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                   metric: {name: 'foo', type: 'counter'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                    new VisualizeFunction('sum(value,foo,counter,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',
@@ -400,7 +400,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                   metric: {name: 'bar', type: 'counter'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('sum(value,bar,counter,-)').serialize(),
+                    new VisualizeFunction('sum(value,bar,counter,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',
@@ -434,7 +434,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                   metric: {name: 'foo', type: 'counter'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                    new VisualizeFunction('sum(value,foo,counter,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',
@@ -475,7 +475,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                     metric: {name: 'foo', type: 'counter'},
                     query: '',
                     aggregateFields: [
-                      new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                      new VisualizeFunction('sum(value,foo,counter,none)').serialize(),
                     ],
                     aggregateSortBys: [],
                     mode: 'samples',
@@ -484,7 +484,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                     metric: {name: 'bar', type: 'counter'},
                     query: '',
                     aggregateFields: [
-                      new VisualizeFunction('sum(value,bar,counter,-)').serialize(),
+                      new VisualizeFunction('sum(value,bar,counter,none)').serialize(),
                     ],
                     aggregateSortBys: [],
                     mode: 'samples',
@@ -533,7 +533,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                   metric: {name: 'foo', type: 'distribution'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('p50(value,foo,distribution,-)').serialize(),
+                    new VisualizeFunction('p50(value,foo,distribution,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',
@@ -553,7 +553,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
           metric: {name: 'foo', type: 'distribution'},
           query: '',
           aggregateFields: [
-            new VisualizeFunction('p50(value,foo,distribution,-)').serialize(),
+            new VisualizeFunction('p50(value,foo,distribution,none)').serialize(),
           ],
         })
       );
@@ -564,7 +564,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
           metric: {name: 'foo', type: 'distribution'},
           query: '',
           aggregateFields: [
-            new VisualizeFunction('p50(value,foo,distribution,-)').serialize(),
+            new VisualizeFunction('p50(value,foo,distribution,none)').serialize(),
           ],
         })
       );
@@ -585,7 +585,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                   metric: {name: 'foo', type: 'distribution'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('p50(value,foo,distribution,-)').serialize(),
+                    new VisualizeFunction('p50(value,foo,distribution,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',
@@ -612,7 +612,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
           metric: {name: 'foo', type: 'distribution'},
           query: '',
           aggregateFields: [
-            new VisualizeFunction('p50(value,foo,distribution,-)').serialize(),
+            new VisualizeFunction('p50(value,foo,distribution,none)').serialize(),
           ],
         })
       );
@@ -623,7 +623,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
           metric: {name: 'foo', type: 'distribution'},
           query: '',
           aggregateFields: [
-            new VisualizeFunction('p50(value,foo,distribution,-)').serialize(),
+            new VisualizeFunction('p50(value,foo,distribution,none)').serialize(),
           ],
         })
       );
@@ -652,7 +652,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                   metric: {name: 'foo', type: 'distribution'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('p50(value,foo,distribution,-)').serialize(),
+                    new VisualizeFunction('p50(value,foo,distribution,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',
@@ -662,7 +662,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                   query: '',
                   aggregateFields: [
                     new VisualizeEquation(
-                      `${EQUATION_PREFIX}p50(value,foo,distribution,-)`
+                      `${EQUATION_PREFIX}p50(value,foo,distribution,none)`
                     ).serialize(),
                   ],
                   aggregateSortBys: [],
@@ -686,7 +686,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
           metric: {name: 'foo', type: 'distribution'},
           query: '',
           aggregateFields: [
-            new VisualizeFunction('p50(value,foo,distribution,-)').serialize(),
+            new VisualizeFunction('p50(value,foo,distribution,none)').serialize(),
           ],
         })
       );
@@ -698,7 +698,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
           query: '',
           aggregateFields: [
             new VisualizeEquation(
-              `${EQUATION_PREFIX}p50(value,foo,distribution,-)`
+              `${EQUATION_PREFIX}p50(value,foo,distribution,none)`
             ).serialize(),
           ],
         })
@@ -728,7 +728,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                   metric: {name: 'foo', type: 'counter'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                    new VisualizeFunction('sum(value,foo,counter,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',
@@ -769,7 +769,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                   metric: {name: 'foo', type: 'counter'},
                   query: '',
                   aggregateFields: [
-                    new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                    new VisualizeFunction('sum(value,foo,counter,none)').serialize(),
                   ],
                   aggregateSortBys: [],
                   mode: 'samples',

--- a/static/app/views/explore/metrics/parseAggregateExpression.spec.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.spec.tsx
@@ -6,7 +6,7 @@ import {
 
 describe('parseAggregateExpression', () => {
   it('parses a single aggregate into one row with label A', () => {
-    const result = parseAggregateExpression('sum(value,foo,counter,-)');
+    const result = parseAggregateExpression('sum(value,foo,counter,none)');
 
     expect(result.compactExpression).toBeNull();
     expect(result.equationRow).toBeNull();
@@ -18,13 +18,13 @@ describe('parseAggregateExpression', () => {
       })
     );
     expect(result.metricQueries[0]!.queryParams.aggregateFields).toEqual([
-      new VisualizeFunction('sum(value,foo,counter,-)'),
+      new VisualizeFunction('sum(value,foo,counter,none)'),
     ]);
   });
 
   it('parses an equation with two distinct metrics into two labeled rows', () => {
     const result = parseAggregateExpression(
-      'equation|sum(value,metricA,counter,-) + avg(value,metricB,gauge,-)'
+      'equation|sum(value,metricA,counter,none) + avg(value,metricB,gauge,none)'
     );
 
     expect(result.metricQueries).toHaveLength(2);
@@ -43,14 +43,14 @@ describe('parseAggregateExpression', () => {
     expect(result.compactExpression).toBe('A + B');
     expect(result.equationRow?.queryParams.aggregateFields).toEqual([
       new VisualizeEquation(
-        'equation|sum(value,metricA,counter,-) + avg(value,metricB,gauge,-)'
+        'equation|sum(value,metricA,counter,none) + avg(value,metricB,gauge,none)'
       ),
     ]);
   });
 
   it('dedupes identical function calls into a single row', () => {
     const result = parseAggregateExpression(
-      'equation|sum(value,metricA,counter,-) + sum(value,metricA,counter,-)'
+      'equation|sum(value,metricA,counter,none) + sum(value,metricA,counter,none)'
     );
 
     expect(result.metricQueries).toHaveLength(1);
@@ -64,7 +64,9 @@ describe('parseAggregateExpression', () => {
   });
 
   it('preserves numeric literals alongside references', () => {
-    const result = parseAggregateExpression('equation|sum(value,metricA,counter,-) / 2');
+    const result = parseAggregateExpression(
+      'equation|sum(value,metricA,counter,none) / 2'
+    );
 
     expect(result.metricQueries).toHaveLength(1);
     expect(result.compactExpression).toBe('A / 2');
@@ -72,7 +74,7 @@ describe('parseAggregateExpression', () => {
 
   it('assigns labels in order of first appearance within nested parens', () => {
     const result = parseAggregateExpression(
-      'equation|(sum(value,metricB,counter,-) + sum(value,metricA,counter,-)) / sum(value,metricC,counter,-)'
+      'equation|(sum(value,metricB,counter,none) + sum(value,metricA,counter,none)) / sum(value,metricC,counter,none)'
     );
 
     expect(result.metricQueries).toHaveLength(3);
@@ -141,7 +143,7 @@ describe('parseAggregateExpression', () => {
 
   it('dedupes identical _if calls and distinguishes different filters', () => {
     const result = parseAggregateExpression(
-      'equation|sum_if(`env:prod`,value,metricA,counter,-) + sum_if(`env:dev`,value,metricA,counter,-) + sum_if(`env:prod`,value,metricA,counter,-)'
+      'equation|sum_if(`env:prod`,value,metricA,counter,none) + sum_if(`env:dev`,value,metricA,counter,none) + sum_if(`env:prod`,value,metricA,counter,none)'
     );
 
     expect(result.metricQueries).toHaveLength(2);

--- a/static/app/views/explore/metrics/parseAggregateExpression.spec.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.spec.tsx
@@ -14,7 +14,7 @@ describe('parseAggregateExpression', () => {
     expect(result.metricQueries[0]).toEqual(
       expect.objectContaining({
         label: 'A',
-        metric: {name: 'foo', type: 'counter', unit: undefined},
+        metric: {name: 'foo', type: 'counter', unit: 'none'},
       })
     );
     expect(result.metricQueries[0]!.queryParams.aggregateFields).toEqual([
@@ -31,13 +31,13 @@ describe('parseAggregateExpression', () => {
     expect(result.metricQueries[0]).toEqual(
       expect.objectContaining({
         label: 'A',
-        metric: {name: 'metricA', type: 'counter', unit: undefined},
+        metric: {name: 'metricA', type: 'counter', unit: 'none'},
       })
     );
     expect(result.metricQueries[1]).toEqual(
       expect.objectContaining({
         label: 'B',
-        metric: {name: 'metricB', type: 'gauge', unit: undefined},
+        metric: {name: 'metricB', type: 'gauge', unit: 'none'},
       })
     );
     expect(result.compactExpression).toBe('A + B');
@@ -57,7 +57,7 @@ describe('parseAggregateExpression', () => {
     expect(result.metricQueries[0]).toEqual(
       expect.objectContaining({
         label: 'A',
-        metric: {name: 'metricA', type: 'counter', unit: undefined},
+        metric: {name: 'metricA', type: 'counter', unit: 'none'},
       })
     );
     expect(result.compactExpression).toBe('A + A');

--- a/static/app/views/explore/metrics/parseMetricsAggregate.tsx
+++ b/static/app/views/explore/metrics/parseMetricsAggregate.tsx
@@ -1,4 +1,5 @@
 import {parseFunction} from 'sentry/utils/discover/fields';
+import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 
 export function parseMetricAggregate(aggregate: string): {
@@ -18,7 +19,7 @@ export function parseMetricAggregate(aggregate: string): {
   const offset = parsed.name.endsWith('_if') ? 1 : 0;
   const metricName = args[1 + offset] ?? '';
   const metricType = args[2 + offset] ?? '';
-  const metricUnit = args[3 + offset] === '-' ? undefined : args[3 + offset];
+  const metricUnit = args[3 + offset] === '-' ? NONE_UNIT : args[3 + offset];
 
   return {
     aggregation: parsed.name,

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -166,8 +166,8 @@ describe('useSaveAsMetricItems', () => {
   });
 
   it('formats add-to-dashboard submenu labels for multiple visualizes', () => {
-    const yAxis1 = 'p50(value,metric.a,counter,-)';
-    const yAxis2 = 'p75(value,metric.a,counter,-)';
+    const yAxis1 = 'p50(value,metric.a,counter,none)';
+    const yAxis2 = 'p75(value,metric.a,counter,none)';
     const encodedMetricQuery = encodeMetricQueryParams({
       metric: {name: 'metric.a', type: 'counter'},
       queryParams: new ReadableQueryParams({

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -22,9 +22,9 @@ describe('mapMetricUnitToFieldType', () => {
     ['megabyte', {fieldType: 'size', unit: 'megabyte'}],
     ['ratio', {fieldType: 'percentage', unit: 'ratio'}],
     ['percent', {fieldType: 'percentage', unit: 'percent'}],
-    [undefined, {fieldType: 'number', unit: undefined}],
-    ['-', {fieldType: 'number', unit: undefined}],
-    ['custom_unit', {fieldType: 'number', unit: undefined}],
+    [undefined, {fieldType: 'number', unit: 'none'}],
+    ['-', {fieldType: 'number', unit: 'none'}],
+    ['custom_unit', {fieldType: 'number', unit: 'none'}],
   ])('maps %s to the correct field type', (unit, expected) => {
     expect(mapMetricUnitToFieldType(unit)).toEqual(expected);
   });

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -59,8 +59,8 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
             query: '',
             fields: ['id', 'timestamp'],
             orderby: '-value',
-            aggregateOrderby: '-sum(value,test_metric,counter,-)',
-            aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+            aggregateOrderby: '-sum(value,test_metric,counter,none)',
+            aggregateField: [{yAxes: ['sum(value,test_metric,counter,none)']}],
             metric: {name: 'test_metric', type: 'counter'},
           },
         ],
@@ -91,8 +91,8 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
             query: '',
             fields: ['id', 'timestamp'],
             orderby: '-timestamp',
-            aggregateOrderby: '-sum(value,test_metric,counter,-)',
-            aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+            aggregateOrderby: '-sum(value,test_metric,counter,none)',
+            aggregateField: [{yAxes: ['sum(value,test_metric,counter,none)']}],
             metric: {name: 'test_metric', type: 'counter'},
           },
         ],
@@ -102,7 +102,7 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
     const decoded = decodeMetricFromUrl(url);
     expect(decoded?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
     expect(decoded?.queryParams.aggregateSortBys).toEqual([
-      {field: 'sum(value,test_metric,counter,-)', kind: 'desc'},
+      {field: 'sum(value,test_metric,counter,none)', kind: 'desc'},
     ]);
   });
 
@@ -125,8 +125,8 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
             mode: Mode.SAMPLES,
             query: '',
             fields: ['id', 'timestamp'],
-            orderby: '-sum(value,test_metric,counter,-)',
-            aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+            orderby: '-sum(value,test_metric,counter,none)',
+            aggregateField: [{yAxes: ['sum(value,test_metric,counter,none)']}],
             metric: {name: 'test_metric', type: 'counter'},
           },
         ],
@@ -136,7 +136,7 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
     const decoded = decodeMetricFromUrl(url);
     expect(decoded?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
     expect(decoded?.queryParams.aggregateSortBys).toEqual([
-      {field: 'sum(value,test_metric,counter,-)', kind: 'desc'},
+      {field: 'sum(value,test_metric,counter,none)', kind: 'desc'},
     ]);
   });
 
@@ -161,7 +161,7 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
             fields: ['id', 'timestamp'],
             orderby: 'timestamp',
             aggregateField: [
-              {yAxes: ['sum(value,test_metric,counter,-)']},
+              {yAxes: ['sum(value,test_metric,counter,none)']},
               {groupBy: 'timestamp'},
             ],
             metric: {name: 'test_metric', type: 'counter'},
@@ -198,7 +198,7 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
             fields: ['id', 'timestamp'],
             orderby: '-value',
             aggregateOrderby: '',
-            aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+            aggregateField: [{yAxes: ['sum(value,test_metric,counter,none)']}],
             metric: {name: 'test_metric', type: 'counter'},
           },
         ],
@@ -208,7 +208,7 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
     const decoded = decodeMetricFromUrl(url);
     expect(decoded?.queryParams.sortBys).toEqual([{field: 'value', kind: 'desc'}]);
     expect(decoded?.queryParams.aggregateSortBys).toEqual([
-      {field: 'sum(value,test_metric,counter,-)', kind: 'desc'},
+      {field: 'sum(value,test_metric,counter,none)', kind: 'desc'},
     ]);
   });
 
@@ -232,7 +232,7 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
             query: '',
             fields: ['id', 'timestamp'],
             orderby: '',
-            aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+            aggregateField: [{yAxes: ['sum(value,test_metric,counter,none)']}],
             metric: {name: 'test_metric', type: 'counter'},
           },
         ],

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -22,9 +22,9 @@ describe('mapMetricUnitToFieldType', () => {
     ['megabyte', {fieldType: 'size', unit: 'megabyte'}],
     ['ratio', {fieldType: 'percentage', unit: 'ratio'}],
     ['percent', {fieldType: 'percentage', unit: 'percent'}],
-    [undefined, {fieldType: 'number', unit: 'none'}],
-    ['-', {fieldType: 'number', unit: 'none'}],
-    ['custom_unit', {fieldType: 'number', unit: 'none'}],
+    [undefined, {fieldType: 'number', unit: undefined}],
+    ['-', {fieldType: 'number', unit: undefined}],
+    ['custom_unit', {fieldType: 'number', unit: undefined}],
   ])('maps %s to the correct field type', (unit, expected) => {
     expect(mapMetricUnitToFieldType(unit)).toEqual(expected);
   });

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -309,7 +309,7 @@ export function mapMetricUnitToFieldType(metricUnit: string | null | undefined):
   unit: string | undefined;
 } {
   if (!metricUnit || metricUnit === '-') {
-    return {fieldType: 'number', unit: NONE_UNIT};
+    return {fieldType: 'number', unit: undefined};
   }
   if (DURATION_UNIT_VALUES.has(metricUnit)) {
     return {fieldType: 'duration', unit: metricUnit};
@@ -320,7 +320,7 @@ export function mapMetricUnitToFieldType(metricUnit: string | null | undefined):
   if (PERCENTAGE_UNIT_VALUES.has(metricUnit)) {
     return {fieldType: 'percentage', unit: metricUnit};
   }
-  return {fieldType: 'number', unit: NONE_UNIT};
+  return {fieldType: 'number', unit: undefined};
 }
 
 /**

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -307,7 +307,7 @@ export function mapMetricUnitToFieldType(metricUnit: string | null | undefined):
   unit: string | undefined;
 } {
   if (!metricUnit || metricUnit === '-') {
-    return {fieldType: 'number', unit: undefined};
+    return {fieldType: 'number', unit: NONE_UNIT};
   }
   if (DURATION_UNIT_VALUES.has(metricUnit)) {
     return {fieldType: 'duration', unit: metricUnit};
@@ -318,7 +318,7 @@ export function mapMetricUnitToFieldType(metricUnit: string | null | undefined):
   if (PERCENTAGE_UNIT_VALUES.has(metricUnit)) {
     return {fieldType: 'percentage', unit: metricUnit};
   }
-  return {fieldType: 'number', unit: undefined};
+  return {fieldType: 'number', unit: NONE_UNIT};
 }
 
 /**

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -108,7 +108,9 @@ export function hasDisplayMetricUnit(
 }
 
 export function makeMetricSelectValue(metric: TraceMetric): string {
-  return `${metric.name}||${metric.type}||${metric.unit ?? NONE_UNIT}`;
+  // Coerce '-' to NONE_UNIT because we do not want to allow the UI to query '-' as a unit, it's a catch-all
+  // that queries for all metrics with the same name and type regardless of the unit. These should be kept separate for now.
+  return `${metric.name}||${metric.type}||${defined(metric.unit) && metric.unit !== '-' ? metric.unit : NONE_UNIT}`;
 }
 
 export function getMetricsUnit(

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -108,7 +108,7 @@ export function hasDisplayMetricUnit(
 }
 
 export function makeMetricSelectValue(metric: TraceMetric): string {
-  return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
+  return `${metric.name}||${metric.type}||${metric.unit ?? NONE_UNIT}`;
 }
 
 export function getMetricsUnit(
@@ -263,7 +263,7 @@ export function makeMetricsAggregate({
     attribute ?? 'value', // hard coded to `value` for now, but can be other attributes
     traceMetric.name,
     traceMetric.type,
-    traceMetric.unit ?? '-',
+    traceMetric.unit ?? NONE_UNIT,
   ];
   return `${aggregate}(${args.join(',')})`;
 }


### PR DESCRIPTION
Since we don't want to use `-` anymore as a placeholder, we should really be coercing any `null` values to the string `"none"`, which adds special filters in both the frontend and backend code.

This PR removes all fallbacks to `-` so we can just continue passing `"none"` along in the future. Anything that's saved also gets coerced to `"none"` when editing, which is the behaviour we want moving forward.

I also de-duplicate selector options so the edge case when a metric name and type return with `null` and `"none"` units simultaneously get treated as the same value.

All of the tests are also updated to drop using `-` and use `"none"`. There's a test added that shows stuff that still uses `-` gets changed into `"none"`