### PR TITLE
feat(ourlogs): use `truncate` parameter in page-level logs requests

### DIFF
--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -165,6 +165,7 @@ export type EventQuery = {
   referrer?: string;
   sort?: string | string[];
   team?: string | string[];
+  truncate?: number;
 };
 
 export type TagSegment = {

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -1,5 +1,5 @@
 import type {ComponentProps, SyntheticEvent} from 'react';
-import React, {Fragment, memo, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {Fragment, memo, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
@@ -13,7 +13,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
-import {IconAdd, IconJson, IconSubtract, IconWarning} from 'sentry/icons';
+import {IconAdd, IconJson, IconPin, IconSubtract, IconWarning} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
@@ -27,6 +27,7 @@ import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -63,6 +64,7 @@ import {
 } from 'sentry/views/explore/logs/fieldRenderers';
 import {useLogsFrozenIsFrozen} from 'sentry/views/explore/logs/logsFrozenContext';
 import {useLogsAnalyticsPageSource} from 'sentry/views/explore/logs/logsQueryParamsProvider';
+import {useLogsPinning} from 'sentry/views/explore/logs/pinning/useLogsPinning';
 import {
   DetailsBody,
   DetailsContent,
@@ -76,6 +78,7 @@ import {
   LogsTableBodyFirstCell,
   LogTableBodyCell,
   LogTableRow,
+  LogPinButton,
   StyledChevronButton,
   TraceIconStyleWrapper,
 } from 'sentry/views/explore/logs/styles';
@@ -115,6 +118,7 @@ type LogsRowProps = {
     openWithExpandedIds?: string[];
     replay?: ReplayEmbeddedTableOptions;
   };
+  expansionKey?: string;
   isExpanded?: boolean;
   logEnd?: string;
   logStart?: string;
@@ -204,6 +208,7 @@ export const LogRowContent = memo(function LogRowContent({
   isExpanded,
   onExpand,
   onCollapse,
+  expansionKey: expansionKeyProp,
   onExpandHeight,
   blockRowExpanding,
   onEmbeddedRowClick,
@@ -213,6 +218,7 @@ export const LogRowContent = memo(function LogRowContent({
   showExploreSimilarSpansLink,
 }: LogsRowProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const fields = useQueryParamsFields();
@@ -221,16 +227,19 @@ export const LogRowContent = memo(function LogRowContent({
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const setAutorefresh = useSetLogsAutoRefresh();
   const measureRef = useRef<HTMLTableRowElement>(null);
-  const [shouldRenderHoverElements, setShouldRenderHoverElements] = useState(false);
+
+  const rowId = String(dataRow[OurLogKnownFieldKey.ID]);
+  const expansionKey = expansionKeyProp ?? rowId;
+  const logsPinning = useLogsPinning();
+  const isPinned = logsPinning?.pinnedRows.has(rowId);
+
+  const [shouldRenderHoverElements, setShouldRenderHoverElements] = useState(isPinned);
 
   // This only applies in embedded views where clicking doesn't expand row details.
   function onClick(event: SyntheticEvent) {
     if (onEmbeddedRowClick && event.nativeEvent instanceof MouseEvent) {
       event.preventDefault();
-      onEmbeddedRowClick(
-        String(dataRow[OurLogKnownFieldKey.ID]),
-        event as React.MouseEvent
-      );
+      onEmbeddedRowClick(rowId, event as React.MouseEvent);
       return;
     }
   }
@@ -265,9 +274,9 @@ export const LogRowContent = memo(function LogRowContent({
   function toggleExpanded() {
     if (onExpand) {
       if (isExpanded) {
-        onCollapse?.(String(dataRow[OurLogKnownFieldKey.ID]));
+        onCollapse?.(expansionKey);
       } else {
-        onExpand?.(String(dataRow[OurLogKnownFieldKey.ID]));
+        onExpand?.(expansionKey);
       }
     } else {
       setExpanded(e => !e);
@@ -277,7 +286,7 @@ export const LogRowContent = memo(function LogRowContent({
     }
 
     trackAnalytics('logs.table.row_expanded', {
-      log_id: String(dataRow[OurLogKnownFieldKey.ID]),
+      log_id: rowId,
       page_source: analyticsPageSource,
       organization,
     });
@@ -285,12 +294,9 @@ export const LogRowContent = memo(function LogRowContent({
 
   useLayoutEffect(() => {
     if (measureRef.current && isExpanded) {
-      onExpandHeight?.(
-        String(dataRow[OurLogKnownFieldKey.ID]),
-        measureRef.current.clientHeight
-      );
+      onExpandHeight?.(expansionKey, measureRef.current.clientHeight);
     }
-  }, [isExpanded, onExpandHeight, dataRow]);
+  }, [expansionKey, isExpanded, onExpandHeight]);
 
   const addSearchFilter = useAddSearchFilter();
   const {copy} = useCopyToClipboard();
@@ -311,7 +317,7 @@ export const LogRowContent = memo(function LogRowContent({
     ? DEFAULT_TRACE_ITEM_HOVER_TIMEOUT_WITH_AUTO_REFRESH
     : DEFAULT_TRACE_ITEM_HOVER_TIMEOUT;
   const {hoverProps, traceItemsResult} = useFetchTraceItemDetailsOnHover({
-    traceItemId: String(dataRow[OurLogKnownFieldKey.ID]),
+    traceItemId: rowId,
     projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
     traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID]),
     traceItemType: TraceItemDataset.LOGS,
@@ -327,6 +333,7 @@ export const LogRowContent = memo(function LogRowContent({
     logColors,
     useFullSeverityText: false,
     location,
+    navigate,
     organization,
     attributes: dataRow as OurLogsResponseItem,
     attributeTypes: meta?.fields ?? {},
@@ -386,14 +393,16 @@ export const LogRowContent = memo(function LogRowContent({
     <Fragment>
       <LogTableRow
         data-test-id="log-table-row"
-        data-row-highlighted={isPseudoRow}
+        highlighted={isPseudoRow}
+        pinned={isPinned}
         {...omit(rowInteractProps, 'className')}
         className={classNames(rowInteractProps.className, replayTimeClasses)}
         onMouseEnter={e => {
           setShouldRenderHoverElements(true);
-          if (rowInteractProps.onMouseEnter) {
-            rowInteractProps.onMouseEnter(e);
-          }
+          rowInteractProps.onMouseEnter?.(e);
+        }}
+        onMouseLeave={e => {
+          rowInteractProps.onMouseLeave?.(e);
         }}
       >
         <LogsTableBodyFirstCell key="first">
@@ -430,11 +439,49 @@ export const LogRowContent = memo(function LogRowContent({
             )}
           </LogFirstCellContent>
         </LogsTableBodyFirstCell>
-        {fields?.map(field => {
+        {fields?.map((field, index) => {
+          const pin =
+            logsPinning && index === fields.length - 1 ? (
+              <LogPinButton
+                aria-label={isPinned ? t('Unpin log row') : t('Pin log row')}
+                icon={
+                  <IconPin isSolid={isPinned} variant={isPinned ? 'accent' : 'primary'} />
+                }
+                isPinned={isPinned}
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  logsPinning.togglePinnedRow(rowId);
+                }}
+                size="xs"
+                variant="transparent"
+              />
+            ) : null;
+
+          const shouldRenderActions =
+            (showCellActions ?? !embedded) && shouldRenderHoverElements;
+
           const value = (dataRow as OurLogsResponseItem)[field];
 
+          const extraMenuItems =
+            field === OurLogKnownFieldKey.MESSAGE
+              ? getExploreSimilarSpansMenuItems({
+                  message: value,
+                  organization,
+                  selection,
+                  showExploreSimilarSpansLink,
+                })
+              : undefined;
+
           if (!defined(value)) {
-            return <LogTableBodyCell key={field} />;
+            return (
+              <LogTableBodyCell key={field}>
+                {shouldRenderActions ? (
+                  <Flex position="relative" height="100%" width="100%" justify="end">
+                    {pin}
+                  </Flex>
+                ) : null}
+              </LogTableBodyCell>
+            );
           }
 
           const renderedField = (
@@ -459,18 +506,6 @@ export const LogRowContent = memo(function LogRowContent({
             isSortable: true,
             type: FieldValueType.STRING,
           };
-
-          const shouldRenderActions =
-            (showCellActions ?? !embedded) && shouldRenderHoverElements;
-          const extraMenuItems =
-            field === OurLogKnownFieldKey.MESSAGE
-              ? getExploreSimilarSpansMenuItems({
-                  message: value,
-                  organization,
-                  selection,
-                  showExploreSimilarSpansLink,
-                })
-              : undefined;
 
           return (
             <LogTableBodyCell key={field} data-test-id={'log-table-cell-' + field}>
@@ -519,6 +554,7 @@ export const LogRowContent = memo(function LogRowContent({
                   }}
                   allowActions={ALLOWED_CELL_ACTIONS}
                   extraMenuItems={extraMenuItems}
+                  pin={pin}
                   triggerType={ActionTriggerType.ELLIPSIS}
                 >
                   {renderedField}
@@ -557,6 +593,7 @@ function LogRowDetails({
   ref: React.RefObject<HTMLTableRowElement | null>;
 }) {
   const location = useLocation();
+  const navigate = useNavigate();
   const organization = useOrganization();
   const project = useProjectFromId({
     project_id: '' + dataRow[OurLogKnownFieldKey.PROJECT_ID],
@@ -615,7 +652,7 @@ function LogRowDetails({
   }
 
   const colSpan = fields.length + 1; // Number of dynamic fields + first cell which is always rendered.
-  const fullMessage = String(
+  const message = String(
     attributes[OurLogKnownFieldKey.MESSAGE] ||
       String(dataRow[OurLogKnownFieldKey.MESSAGE])
   );
@@ -632,13 +669,14 @@ function LogRowDetails({
                   <LogBodyRenderer
                     item={{
                       ...getLogRowItem(OurLogKnownFieldKey.MESSAGE, dataRow, meta),
-                      value: fullMessage,
+                      value: message,
                     }}
                     extra={{
                       highlightTerms,
                       logColors,
                       wrapBody: true,
                       location,
+                      navigate,
                       organization,
                       caseSensitiveHighlighting: !caseInsensitivity,
                       projectSlug,
@@ -650,7 +688,7 @@ function LogRowDetails({
                     }}
                   />
                 ) : (
-                  <span>{fullMessage}</span>
+                  <span>{message}</span>
                 )}
               </DetailsBody>
               <LogAttributeTreeWrapper>
@@ -666,6 +704,7 @@ function LogRowDetails({
                     highlightTerms,
                     logColors,
                     location,
+                    navigate,
                     organization,
                     projectSlug,
                     attributes,
@@ -701,7 +740,7 @@ function LogRowDetails({
   );
 }
 
-function LogRowDetailsFilterActions({fullMessage: fullMessage}: {fullMessage: string}) {
+function LogRowDetailsFilterActions({message}: {message: string}) {
   const addSearchFilter = useAddSearchFilter();
   return (
     <LogDetailTableActionsButtonBar>
@@ -712,7 +751,7 @@ function LogRowDetailsFilterActions({fullMessage: fullMessage}: {fullMessage: st
         onClick={() => {
           addSearchFilter({
             key: OurLogKnownFieldKey.MESSAGE,
-            value: fullMessage,
+            value: message,
           });
         }}
       >
@@ -725,7 +764,7 @@ function LogRowDetailsFilterActions({fullMessage: fullMessage}: {fullMessage: st
         onClick={() => {
           addSearchFilter({
             key: OurLogKnownFieldKey.MESSAGE,
-            value: fullMessage,
+            value: message,
             negated: true,
           });
         }}
@@ -747,7 +786,7 @@ function LogRowDetailsActions({
   const isFrozen = useLogsFrozenIsFrozen();
   const organization = useOrganization();
   const showFilterButtons = !isFrozen;
-  const fullMessage = String(
+  const message = String(
     data?.attributes?.find(attr => attr.name === OurLogKnownFieldKey.MESSAGE)?.value ||
       tableDataRow[OurLogKnownFieldKey.MESSAGE]
   );
@@ -774,11 +813,7 @@ function LogRowDetailsActions({
 
   return (
     <Fragment>
-      {showFilterButtons ? (
-        <LogRowDetailsFilterActions fullMessage={fullMessage} />
-      ) : (
-        <span />
-      )}
+      {showFilterButtons ? <LogRowDetailsFilterActions message={message} /> : <span />}
       <LogDetailTableActionsButtonBar>
         <Button
           variant="transparent"

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -1,5 +1,5 @@
 import type {ComponentProps, SyntheticEvent} from 'react';
-import {Fragment, memo, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import React, {Fragment, memo, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
@@ -13,7 +13,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
-import {IconAdd, IconJson, IconPin, IconSubtract, IconWarning} from 'sentry/icons';
+import {IconAdd, IconJson, IconSubtract, IconWarning} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
@@ -27,7 +27,6 @@ import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -64,7 +63,6 @@ import {
 } from 'sentry/views/explore/logs/fieldRenderers';
 import {useLogsFrozenIsFrozen} from 'sentry/views/explore/logs/logsFrozenContext';
 import {useLogsAnalyticsPageSource} from 'sentry/views/explore/logs/logsQueryParamsProvider';
-import {useLogsPinning} from 'sentry/views/explore/logs/pinning/useLogsPinning';
 import {
   DetailsBody,
   DetailsContent,
@@ -78,7 +76,6 @@ import {
   LogsTableBodyFirstCell,
   LogTableBodyCell,
   LogTableRow,
-  LogPinButton,
   StyledChevronButton,
   TraceIconStyleWrapper,
 } from 'sentry/views/explore/logs/styles';
@@ -118,7 +115,6 @@ type LogsRowProps = {
     openWithExpandedIds?: string[];
     replay?: ReplayEmbeddedTableOptions;
   };
-  expansionKey?: string;
   isExpanded?: boolean;
   logEnd?: string;
   logStart?: string;
@@ -208,7 +204,6 @@ export const LogRowContent = memo(function LogRowContent({
   isExpanded,
   onExpand,
   onCollapse,
-  expansionKey: expansionKeyProp,
   onExpandHeight,
   blockRowExpanding,
   onEmbeddedRowClick,
@@ -218,7 +213,6 @@ export const LogRowContent = memo(function LogRowContent({
   showExploreSimilarSpansLink,
 }: LogsRowProps) {
   const location = useLocation();
-  const navigate = useNavigate();
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const fields = useQueryParamsFields();
@@ -227,19 +221,16 @@ export const LogRowContent = memo(function LogRowContent({
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const setAutorefresh = useSetLogsAutoRefresh();
   const measureRef = useRef<HTMLTableRowElement>(null);
-
-  const rowId = String(dataRow[OurLogKnownFieldKey.ID]);
-  const expansionKey = expansionKeyProp ?? rowId;
-  const logsPinning = useLogsPinning();
-  const isPinned = logsPinning?.pinnedRows.has(rowId);
-
-  const [shouldRenderHoverElements, setShouldRenderHoverElements] = useState(isPinned);
+  const [shouldRenderHoverElements, setShouldRenderHoverElements] = useState(false);
 
   // This only applies in embedded views where clicking doesn't expand row details.
   function onClick(event: SyntheticEvent) {
     if (onEmbeddedRowClick && event.nativeEvent instanceof MouseEvent) {
       event.preventDefault();
-      onEmbeddedRowClick(rowId, event as React.MouseEvent);
+      onEmbeddedRowClick(
+        String(dataRow[OurLogKnownFieldKey.ID]),
+        event as React.MouseEvent
+      );
       return;
     }
   }
@@ -274,9 +265,9 @@ export const LogRowContent = memo(function LogRowContent({
   function toggleExpanded() {
     if (onExpand) {
       if (isExpanded) {
-        onCollapse?.(expansionKey);
+        onCollapse?.(String(dataRow[OurLogKnownFieldKey.ID]));
       } else {
-        onExpand?.(expansionKey);
+        onExpand?.(String(dataRow[OurLogKnownFieldKey.ID]));
       }
     } else {
       setExpanded(e => !e);
@@ -286,7 +277,7 @@ export const LogRowContent = memo(function LogRowContent({
     }
 
     trackAnalytics('logs.table.row_expanded', {
-      log_id: rowId,
+      log_id: String(dataRow[OurLogKnownFieldKey.ID]),
       page_source: analyticsPageSource,
       organization,
     });
@@ -294,9 +285,12 @@ export const LogRowContent = memo(function LogRowContent({
 
   useLayoutEffect(() => {
     if (measureRef.current && isExpanded) {
-      onExpandHeight?.(expansionKey, measureRef.current.clientHeight);
+      onExpandHeight?.(
+        String(dataRow[OurLogKnownFieldKey.ID]),
+        measureRef.current.clientHeight
+      );
     }
-  }, [expansionKey, isExpanded, onExpandHeight]);
+  }, [isExpanded, onExpandHeight, dataRow]);
 
   const addSearchFilter = useAddSearchFilter();
   const {copy} = useCopyToClipboard();
@@ -317,7 +311,7 @@ export const LogRowContent = memo(function LogRowContent({
     ? DEFAULT_TRACE_ITEM_HOVER_TIMEOUT_WITH_AUTO_REFRESH
     : DEFAULT_TRACE_ITEM_HOVER_TIMEOUT;
   const {hoverProps, traceItemsResult} = useFetchTraceItemDetailsOnHover({
-    traceItemId: rowId,
+    traceItemId: String(dataRow[OurLogKnownFieldKey.ID]),
     projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
     traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID]),
     traceItemType: TraceItemDataset.LOGS,
@@ -333,7 +327,6 @@ export const LogRowContent = memo(function LogRowContent({
     logColors,
     useFullSeverityText: false,
     location,
-    navigate,
     organization,
     attributes: dataRow as OurLogsResponseItem,
     attributeTypes: meta?.fields ?? {},
@@ -393,16 +386,14 @@ export const LogRowContent = memo(function LogRowContent({
     <Fragment>
       <LogTableRow
         data-test-id="log-table-row"
-        highlighted={isPseudoRow}
-        pinned={isPinned}
+        data-row-highlighted={isPseudoRow}
         {...omit(rowInteractProps, 'className')}
         className={classNames(rowInteractProps.className, replayTimeClasses)}
         onMouseEnter={e => {
           setShouldRenderHoverElements(true);
-          rowInteractProps.onMouseEnter?.(e);
-        }}
-        onMouseLeave={e => {
-          rowInteractProps.onMouseLeave?.(e);
+          if (rowInteractProps.onMouseEnter) {
+            rowInteractProps.onMouseEnter(e);
+          }
         }}
       >
         <LogsTableBodyFirstCell key="first">
@@ -439,49 +430,11 @@ export const LogRowContent = memo(function LogRowContent({
             )}
           </LogFirstCellContent>
         </LogsTableBodyFirstCell>
-        {fields?.map((field, index) => {
-          const pin =
-            logsPinning && index === fields.length - 1 ? (
-              <LogPinButton
-                aria-label={isPinned ? t('Unpin log row') : t('Pin log row')}
-                icon={
-                  <IconPin isSolid={isPinned} variant={isPinned ? 'accent' : 'primary'} />
-                }
-                isPinned={isPinned}
-                onClick={(e: React.MouseEvent) => {
-                  e.stopPropagation();
-                  logsPinning.togglePinnedRow(rowId);
-                }}
-                size="xs"
-                variant="transparent"
-              />
-            ) : null;
-
-          const shouldRenderActions =
-            (showCellActions ?? !embedded) && shouldRenderHoverElements;
-
+        {fields?.map(field => {
           const value = (dataRow as OurLogsResponseItem)[field];
 
-          const extraMenuItems =
-            field === OurLogKnownFieldKey.MESSAGE
-              ? getExploreSimilarSpansMenuItems({
-                  message: value,
-                  organization,
-                  selection,
-                  showExploreSimilarSpansLink,
-                })
-              : undefined;
-
           if (!defined(value)) {
-            return (
-              <LogTableBodyCell key={field}>
-                {shouldRenderActions ? (
-                  <Flex position="relative" height="100%" width="100%" justify="end">
-                    {pin}
-                  </Flex>
-                ) : null}
-              </LogTableBodyCell>
-            );
+            return <LogTableBodyCell key={field} />;
           }
 
           const renderedField = (
@@ -506,6 +459,18 @@ export const LogRowContent = memo(function LogRowContent({
             isSortable: true,
             type: FieldValueType.STRING,
           };
+
+          const shouldRenderActions =
+            (showCellActions ?? !embedded) && shouldRenderHoverElements;
+          const extraMenuItems =
+            field === OurLogKnownFieldKey.MESSAGE
+              ? getExploreSimilarSpansMenuItems({
+                  message: value,
+                  organization,
+                  selection,
+                  showExploreSimilarSpansLink,
+                })
+              : undefined;
 
           return (
             <LogTableBodyCell key={field} data-test-id={'log-table-cell-' + field}>
@@ -554,7 +519,6 @@ export const LogRowContent = memo(function LogRowContent({
                   }}
                   allowActions={ALLOWED_CELL_ACTIONS}
                   extraMenuItems={extraMenuItems}
-                  pin={pin}
                   triggerType={ActionTriggerType.ELLIPSIS}
                 >
                   {renderedField}
@@ -593,7 +557,6 @@ function LogRowDetails({
   ref: React.RefObject<HTMLTableRowElement | null>;
 }) {
   const location = useLocation();
-  const navigate = useNavigate();
   const organization = useOrganization();
   const project = useProjectFromId({
     project_id: '' + dataRow[OurLogKnownFieldKey.PROJECT_ID],
@@ -652,7 +615,10 @@ function LogRowDetails({
   }
 
   const colSpan = fields.length + 1; // Number of dynamic fields + first cell which is always rendered.
-  const message = String(dataRow[OurLogKnownFieldKey.MESSAGE] ?? '');
+  const fullMessage = String(
+    attributes[OurLogKnownFieldKey.MESSAGE] ||
+      String(dataRow[OurLogKnownFieldKey.MESSAGE])
+  );
 
   return (
     <DetailsWrapper ref={isPending ? undefined : ref}>
@@ -664,13 +630,15 @@ function LogRowDetails({
               <DetailsBody>
                 {isRegularLogResponseItem(dataRow) ? (
                   <LogBodyRenderer
-                    item={getLogRowItem(OurLogKnownFieldKey.MESSAGE, dataRow, meta)}
+                    item={{
+                      ...getLogRowItem(OurLogKnownFieldKey.MESSAGE, dataRow, meta),
+                      value: fullMessage,
+                    }}
                     extra={{
                       highlightTerms,
                       logColors,
                       wrapBody: true,
                       location,
-                      navigate,
                       organization,
                       caseSensitiveHighlighting: !caseInsensitivity,
                       projectSlug,
@@ -682,7 +650,7 @@ function LogRowDetails({
                     }}
                   />
                 ) : (
-                  <span>{message}</span>
+                  <span>{fullMessage}</span>
                 )}
               </DetailsBody>
               <LogAttributeTreeWrapper>
@@ -698,7 +666,6 @@ function LogRowDetails({
                     highlightTerms,
                     logColors,
                     location,
-                    navigate,
                     organization,
                     projectSlug,
                     attributes,
@@ -734,7 +701,7 @@ function LogRowDetails({
   );
 }
 
-function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowItem}) {
+function LogRowDetailsFilterActions({fullMessage: fullMessage}: {fullMessage: string}) {
   const addSearchFilter = useAddSearchFilter();
   return (
     <LogDetailTableActionsButtonBar>
@@ -745,7 +712,7 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
         onClick={() => {
           addSearchFilter({
             key: OurLogKnownFieldKey.MESSAGE,
-            value: tableDataRow[OurLogKnownFieldKey.MESSAGE],
+            value: fullMessage,
           });
         }}
       >
@@ -758,7 +725,7 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
         onClick={() => {
           addSearchFilter({
             key: OurLogKnownFieldKey.MESSAGE,
-            value: tableDataRow[OurLogKnownFieldKey.MESSAGE],
+            value: fullMessage,
             negated: true,
           });
         }}
@@ -780,6 +747,10 @@ function LogRowDetailsActions({
   const isFrozen = useLogsFrozenIsFrozen();
   const organization = useOrganization();
   const showFilterButtons = !isFrozen;
+  const fullMessage = String(
+    data?.attributes?.find(attr => attr.name === OurLogKnownFieldKey.MESSAGE)?.value ||
+      tableDataRow[OurLogKnownFieldKey.MESSAGE]
+  );
 
   const {copy} = useCopyToClipboard();
 
@@ -804,7 +775,7 @@ function LogRowDetailsActions({
   return (
     <Fragment>
       {showFilterButtons ? (
-        <LogRowDetailsFilterActions tableDataRow={tableDataRow} />
+        <LogRowDetailsFilterActions fullMessage={fullMessage} />
       ) : (
         <span />
       )}

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -653,8 +653,7 @@ function LogRowDetails({
 
   const colSpan = fields.length + 1; // Number of dynamic fields + first cell which is always rendered.
   const message = String(
-    attributes[OurLogKnownFieldKey.MESSAGE] ||
-      String(dataRow[OurLogKnownFieldKey.MESSAGE])
+    attributes[OurLogKnownFieldKey.MESSAGE] ?? dataRow[OurLogKnownFieldKey.MESSAGE] ?? ''
   );
 
   return (

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -786,8 +786,9 @@ function LogRowDetailsActions({
   const organization = useOrganization();
   const showFilterButtons = !isFrozen;
   const message = String(
-    data?.attributes?.find(attr => attr.name === OurLogKnownFieldKey.MESSAGE)?.value ||
-      tableDataRow[OurLogKnownFieldKey.MESSAGE]
+    data?.attributes?.find(attr => attr.name === OurLogKnownFieldKey.MESSAGE)?.value ??
+      tableDataRow[OurLogKnownFieldKey.MESSAGE] ??
+      ''
   );
 
   const {copy} = useCopyToClipboard();

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -43,6 +43,7 @@ import {
   OurLogKnownFieldKey,
   type EventsLogsResult,
 } from 'sentry/views/explore/logs/types';
+import {useLogsQueryTruncate} from 'sentry/views/explore/logs/useLogsQueryTruncate';
 import {
   isRowVisibleInVirtualStream,
   useVirtualStreaming,
@@ -98,6 +99,7 @@ function useLogsApiOptions({
   const projectIds = useLogsFrozenProjectIds();
   const groupBys = useQueryParamsGroupBys();
   const [caseInsensitive] = useCaseInsensitivity();
+  const truncate = useLogsQueryTruncate();
 
   const search = baseSearch ? _search.copy() : _search;
   if (baseSearch) {
@@ -139,6 +141,7 @@ function useLogsApiOptions({
     referrer,
     sampling: highFidelity ? SAMPLING_MODE.FLEX_TIME : SAMPLING_MODE.NORMAL,
     caseInsensitive: caseInsensitive ? '1' : undefined,
+    truncate,
   };
 
   const path = {organizationIdOrSlug: organization.slug};

--- a/static/app/views/explore/logs/useLogsQueryTruncate.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQueryTruncate.spec.tsx
@@ -1,0 +1,23 @@
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useWindowSize} from 'sentry/utils/window/useWindowSize';
+
+import {useLogsQueryTruncate} from './useLogsQueryTruncate';
+
+jest.mock('sentry/utils/window/useWindowSize');
+
+const mockUseWindowSize = jest.mocked(useWindowSize);
+
+describe('useLogsQueryTruncate', () => {
+  it('returns 256 for narrow viewports where the formula yields less', () => {
+    mockUseWindowSize.mockReturnValue({innerWidth: 800, innerHeight: 600});
+    const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
+    expect(result.current).toBe(256);
+  });
+
+  it('returns the formula result for wide viewports where it exceeds 256', () => {
+    mockUseWindowSize.mockReturnValue({innerWidth: 6400, innerHeight: 1080});
+    const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
+    expect(result.current).toBe(400);
+  });
+});

--- a/static/app/views/explore/logs/useLogsQueryTruncate.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQueryTruncate.spec.tsx
@@ -9,10 +9,10 @@ jest.mock('sentry/utils/window/useWindowSize');
 const mockUseWindowSize = jest.mocked(useWindowSize);
 
 describe('useLogsQueryTruncate', () => {
-  it('returns 256 for narrow viewports where the formula yields less', () => {
+  it('returns 64 for narrow viewports where the formula yields less', () => {
     mockUseWindowSize.mockReturnValue({innerWidth: 800, innerHeight: 600});
     const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
-    expect(result.current).toBe(256);
+    expect(result.current).toBe(64);
   });
 
   it('returns the formula result for wide viewports where it exceeds 256', () => {

--- a/static/app/views/explore/logs/useLogsQueryTruncate.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQueryTruncate.spec.tsx
@@ -9,14 +9,20 @@ jest.mock('sentry/utils/window/useWindowSize');
 const mockUseWindowSize = jest.mocked(useWindowSize);
 
 describe('useLogsQueryTruncate', () => {
-  it('returns 64 for narrow viewports where the formula yields less', () => {
+  it('returns 64 for narrow viewports when the formula yields less', () => {
     mockUseWindowSize.mockReturnValue({innerWidth: 800, innerHeight: 600});
     const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
     expect(result.current).toBe(64);
   });
 
-  it('returns the formula result for wide viewports where it exceeds 256', () => {
+  it('returns the formula result when the viewport exceeds narrow width', () => {
     mockUseWindowSize.mockReturnValue({innerWidth: 6400, innerHeight: 1080});
+    const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
+    expect(result.current).toBe(400);
+  });
+
+  it('returns the formula result as a floored int when the viewport math would make it a float', () => {
+    mockUseWindowSize.mockReturnValue({innerWidth: 6412.3, innerHeight: 1080});
     const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
     expect(result.current).toBe(400);
   });

--- a/static/app/views/explore/logs/useLogsQueryTruncate.tsx
+++ b/static/app/views/explore/logs/useLogsQueryTruncate.tsx
@@ -1,0 +1,6 @@
+import {useWindowSize} from 'sentry/utils/window/useWindowSize';
+
+export function useLogsQueryTruncate(): number {
+  const {innerWidth} = useWindowSize();
+  return Math.max(256, innerWidth / 16);
+}

--- a/static/app/views/explore/logs/useLogsQueryTruncate.tsx
+++ b/static/app/views/explore/logs/useLogsQueryTruncate.tsx
@@ -2,5 +2,5 @@ import {useWindowSize} from 'sentry/utils/window/useWindowSize';
 
 export function useLogsQueryTruncate(): number {
   const {innerWidth} = useWindowSize();
-  return Math.max(256, innerWidth / 16);
+  return Math.max(64, innerWidth / 16);
 }

--- a/static/app/views/explore/logs/useLogsQueryTruncate.tsx
+++ b/static/app/views/explore/logs/useLogsQueryTruncate.tsx
@@ -2,5 +2,5 @@ import {useWindowSize} from 'sentry/utils/window/useWindowSize';
 
 export function useLogsQueryTruncate(): number {
   const {innerWidth} = useWindowSize();
-  return Math.max(64, innerWidth / 16);
+  return Math.max(64, Math.floor(innerWidth / 16));
 }


### PR DESCRIPTION
Sends a viewport-proportional `truncate` query parameter with each page-level `events/` logs API request to reduce payload size. This can reduce response payload size nicely when there are huge log fields, such as -but not limited to- `message`.

The expanded log row detail panel still queries full fields for each log, and prefers those over the potentially truncated ones.

Split out of #115638. #116008 has the corresponding backend changes.

Closes LOGS-817.