### PR TITLE
feat(spans): Add separate Redis cluster setting for span deduplication

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -188,7 +188,12 @@ SENTRY_MONITORS_REDIS_CLUSTER = "default"
 SENTRY_STATISTICAL_DETECTORS_REDIS_CLUSTER = "default"
 SENTRY_METRIC_META_REDIS_CLUSTER = "default"
 SENTRY_ESCALATION_THRESHOLDS_REDIS_CLUSTER = "default"
+# Redis cluster for span buffer data and flush locks. Flush locks must remain
+# on this cluster because add-buffer.lua checks lock existence atomically.
 SENTRY_SPAN_BUFFER_CLUSTER = "default"
+# Redis cluster for span deduplication keys in process_segments consumer.
+# Falls back to SENTRY_SPAN_BUFFER_CLUSTER if not set.
+SENTRY_SPAN_DEDUPE_CLUSTER: str | None = None
 SENTRY_ASSEMBLE_CLUSTER = "default"
 SENTRY_UPTIME_DETECTOR_CLUSTER = "default"
 SENTRY_WORKFLOW_ENGINE_REDIS_CLUSTER = "default"

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -27,6 +27,11 @@ from sentry.utils.kafka_config import get_topic_definition
 logger = logging.getLogger(__name__)
 
 
+def get_dedupe_redis_client():
+    cluster = settings.SENTRY_SPAN_DEDUPE_CLUSTER or settings.SENTRY_SPAN_BUFFER_CLUSTER
+    return redis.redis_clusters.get_binary(cluster)
+
+
 def _check_span_duplicates(spans: list[CompatibleSpan]) -> list[CompatibleSpan]:
     """
     Check for and optionally filter duplicate spans using Redis SETNX.
@@ -49,7 +54,7 @@ def _check_span_duplicates(spans: list[CompatibleSpan]) -> list[CompatibleSpan]:
     filter_duplicates = options.get("spans.process-segments.dedupe-filter-enable")
 
     try:
-        client = redis.redis_clusters.get_binary(settings.SENTRY_SPAN_BUFFER_CLUSTER)
+        client = get_dedupe_redis_client()
         with client.pipeline(transaction=False) as p:
             for span in spans:
                 dedupe_key = f"segments-consumer:dedupe:{span['project_id']}:{span['trace_id']}:{span['span_id']}"

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -13,6 +13,8 @@ from arroyo.processing.strategies.produce import Produce
 from arroyo.processing.strategies.unfold import Unfold
 from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partition, Value
 from django.conf import settings
+from redis.client import StrictRedis
+from rediscluster import RedisCluster
 
 from sentry import options
 from sentry.conf.types.kafka_definition import Topic
@@ -27,7 +29,7 @@ from sentry.utils.kafka_config import get_topic_definition
 logger = logging.getLogger(__name__)
 
 
-def get_dedupe_redis_client():
+def get_dedupe_redis_client() -> RedisCluster[bytes] | StrictRedis[bytes]:
     cluster = settings.SENTRY_SPAN_DEDUPE_CLUSTER or settings.SENTRY_SPAN_BUFFER_CLUSTER
     return redis.redis_clusters.get_binary(cluster)
 

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Mapping
 from datetime import datetime


### PR DESCRIPTION
## Summary

- Add `SENTRY_SPAN_DEDUPE_CLUSTER` setting to allow span deduplication keys to be configured independently from the main span buffer cluster
- Defaults to `SENTRY_SPAN_BUFFER_CLUSTER` if not explicitly set, maintaining backwards compatibility
- Enables better resource isolation for dedupe operations in the process_segments consumer

Note: Flush locks remain on `SENTRY_SPAN_BUFFER_CLUSTER` because `add-buffer.lua` checks lock existence atomically during span ingestion.

ref STREAM-1028