### PR TITLE
chore(cells) Remove rollout option for connection pooling

### DIFF
--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -32,7 +32,6 @@ from requests.adapters import HTTPAdapter, Retry
 from sentry import options
 from sentry.hybridcloud.rpc import ArgumentDict, DelegatedBySiloMode, RpcModel
 from sentry.hybridcloud.rpc.sig import SerializableFunctionSignature
-from sentry.options.rollout import in_random_rollout
 from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.types.cell import Cell, CellMappingNotFound
 from sentry.utils import json, metrics
@@ -520,9 +519,6 @@ def _get_connection(retry_count: int) -> requests.Session:
     Because retry limits are part of the session definition,
     each unique retry value creates a different connection pool.
     """
-    if not in_random_rollout("hybridcloud.rpc.use_pooling.rate"):
-        return _create_request_session(retry_count)
-
     if not hasattr(_connections, "lookup"):
         _connections.lookup = {}
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2482,12 +2482,6 @@ register(
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "hybridcloud.rpc.use_pooling.rate",
-    default=0.0,
-    type=Float,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Webhook processing controls
 register(


### PR DESCRIPTION
This has been rolled out and we don't need this anymore.

Refs INFRENG-321