### PR TITLE
fix(ci): Dont pull the jest-balancer list when we run Just with merge_base_strategy=changedSince

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -188,6 +188,7 @@ jobs:
 
       - name: Download jest-balance.json
         id: download-artifact
+        if: needs.files-changed.outputs.merge_base_strategy != 'changedSince'
         uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
         with:
           workflow: 38531594 # jest-balancer.yml


### PR DESCRIPTION
The problem i was seeing is that runtime under `changedSince` is the same as normal. 

Here's an example run: https://github.com/getsentry/sentry/actions/runs/26233670488/job/77200730906
> Run MERGE_BASE=$(git merge-base HEAD^1 HEAD^2 2>/dev/null) || true
Non-frontend file changed — running full Jest suite

And notice the 8 jest runners still take 3-4mins each:
https://github.com/getsentry/sentry/actions/runs/26233670488

I believe that the runners are basically ignoring the `--changedSince` arg and running the full list of tests that they find from the balance list. 

If we skip downloading the balance list, then we'll save 3s on the job. but as of now there's still 8 runners which will all be doing the same list of tests... oops.
We might also want to add a label that skips all this and re-runs everything, ignoring the changedSince check.