### PR TITLE
fix(settings): restore title on accept-invite and accept-transfer pages

### DIFF
--- a/static/app/views/acceptOrganizationInvite/index.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.tsx
@@ -8,6 +8,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 
 import {logout} from 'sentry/actionCreators/account';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -18,7 +19,6 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useApi} from 'sentry/utils/useApi';
 import {useParams} from 'sentry/utils/useParams';
-import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
 type InviteDetails = {
   existingMember: boolean;
@@ -282,7 +282,7 @@ function AcceptOrganizationInvite() {
   return (
     <NarrowLayout>
       <SentryDocumentTitle title={t('Accept Organization Invite')} />
-      <SettingsPageHeader title={t('Accept organization invite')} />
+      <Layout.Title>{t('Accept organization invite')}</Layout.Title>
       {isAcceptError && (
         <Alert.Container>
           <Alert variant="danger" showIcon={false}>

--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -4,6 +4,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {SelectField} from 'sentry/components/forms/fields/selectField';
 import {Form} from 'sentry/components/forms/form';
 import type {Data} from 'sentry/components/forms/types';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -16,7 +17,6 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
 type TransferDetails = {
   organizations: Organization[];
@@ -109,7 +109,7 @@ function AcceptProjectTransfer() {
   return (
     <NarrowLayout>
       <SentryDocumentTitle title={t('Accept Project Transfer')} />
-      <SettingsPageHeader title={t('Approve Transfer Project Request')} />
+      <Layout.Title>{t('Approve Transfer Project Request')}</Layout.Title>
       <p>
         {tct(
           'Projects must be transferred to a specific [organization]. You can grant specific teams access to the project later under the [projectSettings]. (Note that granting access to at least one team is necessary for the project to appear in all parts of the UI.)',


### PR DESCRIPTION
Follow-up to #115815. That PR removed the `hasPageFrame` branch from `SettingsPageHeader`, making it unconditionally render `BreadcrumbTitle` for string titles. `BreadcrumbTitle` returns `null` and only updates breadcrumb context as a side effect — but the accept-invite and accept-transfer pages are routed outside `SettingsWrapper`, so there's no `BreadcrumbProvider` ancestor. The page headings silently disappeared.

These pages aren't settings pages, so they shouldn't use `SettingsPageHeader` at all. Replaced with `Layout.Title` directly.