### PR TITLE
fix(relay): Make trustedRelays optional on Organization type

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -98,7 +98,6 @@ export interface Organization extends OrganizationSummary {
   streamlineOnly: boolean | null;
   targetSampleRate: number;
   teamRoleList: TeamRole[];
-  trustedRelays: Relay[];
   consoleSdkInviteQuota?: number;
   dashboardsAsyncQueueParallelLimit?: number;
   defaultAutofixAutomationTuning?:
@@ -123,6 +122,7 @@ export interface Organization extends OrganizationSummary {
   ingestThroughTrustedRelaysOnly?: 'enabled' | 'disabled';
   orgRole?: string;
   planSampleRate?: number | null;
+  trustedRelays?: Relay[];
 }
 
 export interface Team {

--- a/static/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -39,7 +39,8 @@ export function RelayWrapper() {
 
   const organization = useOrganization();
   const api = useApi();
-  const [relays, setRelays] = useState(organization.trustedRelays);
+  const [relays, setRelays] = useState(organization.trustedRelays ?? []);
+
   const disabled = !organization.access.includes('org:write');
 
   const handleOpenAddDialog = () => {
@@ -51,7 +52,7 @@ export function RelayWrapper() {
         orgSlug={organization.slug}
         onSubmitSuccess={response => {
           addSuccessMessage(t('Successfully added Relay public key'));
-          setRelays(response.trustedRelays);
+          setRelays(response.trustedRelays ?? []);
         }}
       />
     ));
@@ -191,7 +192,7 @@ function RelayUsageList({
         relay={editRelay}
         onSubmitSuccess={response => {
           addSuccessMessage(t('Successfully updated Relay public key'));
-          onRelaysChange(response.trustedRelays);
+          onRelaysChange(response.trustedRelays ?? []);
         }}
       />
     ));
@@ -208,7 +209,7 @@ function RelayUsageList({
         data: {trustedRelays},
       });
       addSuccessMessage(t('Successfully deleted Relay public key'));
-      onRelaysChange(response.trustedRelays);
+      onRelaysChange(response.trustedRelays ?? []);
     } catch {
       addErrorMessage(t('An unknown error occurred while deleting Relay public key'));
     }


### PR DESCRIPTION
The `Organization` TypeScript type declared `trustedRelays` as a required `Relay[]`, but the backend's `OrganizationSummarySerializer` (used when `detailed=0` and the user lacks `org:read`) does not include this field. This caused a runtime crash (`Cannot read properties of undefined (reading 'length')`) on the Relay settings page.

Mark `trustedRelays` as optional on the `Organization` type and add nullish coalescing fallbacks in the relay wrapper component.

fixes JAVASCRIPT-39V9