### PR TITLE
fix(monitors): Surface schedule config errors on cron form fields

### DIFF
--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -53,6 +53,16 @@ const mapCronDetectorFormErrors = (error: unknown) => {
       if ('slug' in error.dataSources) {
         return {...error, name: error.dataSources.slug};
       }
+      if ('config' in error.dataSources) {
+        const {schedule, ...rest} = error.dataSources.config as Record<string, unknown>;
+        return {
+          ...error,
+          ...rest,
+          ...(schedule
+            ? {scheduleCrontab: schedule, scheduleIntervalValue: schedule}
+            : {}),
+        };
+      }
       return {...error, ...error.dataSources};
     }
   }

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -1284,5 +1284,36 @@ describe('DetectorEdit', () => {
         await screen.findByText('The slug "new-test-cron-job" is already in use.')
       ).toBeInTheDocument();
     });
+
+    it('displays schedule config errors on the schedule field and in a toast', async () => {
+      const mockAddErrorMessage = jest.spyOn(indicators, 'addErrorMessage');
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
+        method: 'POST',
+        statusCode: 400,
+        body: {
+          dataSources: {
+            config: {schedule: ['Invalid schedule for schedule unit count']},
+          },
+        },
+      });
+
+      render(<DetectorNewSettings />, {
+        organization,
+        initialRouterConfig: cronRouterConfig,
+      });
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Create Monitor'}));
+
+      await waitFor(() => {
+        expect(mockAddErrorMessage).toHaveBeenCalledWith(
+          'Invalid schedule for schedule unit count'
+        );
+      });
+
+      expect(
+        await screen.findByText('Invalid schedule for schedule unit count')
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
When creating a cron monitor with an invalid interval schedule, the API returns errors nested under `dataSources.config.schedule`, but the form's error mapper (`mapCronDetectorFormErrors`) had no handling for the `config` key, so the error was not placed into the form correctly.

This PR adds the mapping so that the error gets displayed next to the proper form field.

<img width="562" height="263" alt="CleanShot 2026-05-20 at 14 37 42" src="https://github.com/user-attachments/assets/d408bb78-8f82-49b2-9c8a-c6f7f7d72baf" />
