### PR TITLE
chore(alerts): Remove PUT and POST legacy paths for metric alerts

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -409,12 +409,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for legacy issue alert rule.put results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-issue-alert-endpoints-put", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for legacy metric alert rule.post results.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-metric-alert-endpoints-post", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for legacy metric alert rule.put results.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-metric-alert-endpoints-put", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable seer activities to be evaluated in workflow engine

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -8,7 +8,6 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -29,7 +28,6 @@ from sentry.incidents.endpoints.bases import WorkflowEngineOrganizationAlertRule
 from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializer
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     DetailedWorkflowEngineDetectorSerializer,
-    WorkflowEngineDetectorSerializer,
 )
 from sentry.incidents.logic import (
     AlreadyDeletedError,
@@ -118,29 +116,6 @@ def update_alert_rule(
             return Response({"uuid": client.uuid}, status=202)
         else:
             updated_rule = validator.save()
-            if features.has(
-                "organizations:workflow-engine-metric-alert-endpoints-put", organization
-            ):
-                try:
-                    detector = Detector.objects.get(
-                        alertruledetector__alert_rule_id=updated_rule.id
-                    )
-                    return Response(
-                        serialize(
-                            detector,
-                            request.user,
-                            WorkflowEngineDetectorSerializer(),
-                        ),
-                        status=status.HTTP_200_OK,
-                    )
-                except Detector.DoesNotExist:
-                    logger.error(
-                        "Alert rule was not dual written. Returning serialized rule instead of detector",
-                        extra={"rule_id": updated_rule.id},
-                    )
-                    return Response(
-                        serialize(updated_rule, request.user), status=status.HTTP_200_OK
-                    )
             return Response(serialize(updated_rule, request.user), status=status.HTTP_200_OK)
 
     return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -28,6 +28,7 @@ from sentry.incidents.endpoints.bases import WorkflowEngineOrganizationAlertRule
 from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializer
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     DetailedWorkflowEngineDetectorSerializer,
+    WorkflowEngineDetectorSerializer,
 )
 from sentry.incidents.logic import (
     AlreadyDeletedError,
@@ -116,7 +117,11 @@ def update_alert_rule(
             return Response({"uuid": client.uuid}, status=202)
         else:
             updated_rule = validator.save()
-            return Response(serialize(updated_rule, request.user), status=status.HTTP_200_OK)
+            detector = Detector.objects.get(alertruledetector__alert_rule_id=updated_rule.id)
+            return Response(
+                serialize(detector, request.user, WorkflowEngineDetectorSerializer()),
+                status=status.HTTP_200_OK,
+            )
 
     return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -208,23 +208,6 @@ def create_metric_alert(
         return Response({"uuid": client.uuid}, status=202)
     else:
         alert_rule = validator.save()
-        if features.has("organizations:workflow-engine-metric-alert-endpoints-post", organization):
-            try:
-                detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
-                return Response(
-                    serialize(
-                        detector,
-                        request.user,
-                        WorkflowEngineDetectorSerializer(),
-                    ),
-                    status=status.HTTP_201_CREATED,
-                )
-            except Detector.DoesNotExist:
-                logger.error(
-                    "Alert rule was not dual written. Returning serialized rule instead of detector",
-                    extra={"rule_id": alert_rule.id},
-                )
-                return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
         return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -208,7 +208,11 @@ def create_metric_alert(
         return Response({"uuid": client.uuid}, status=202)
     else:
         alert_rule = validator.save()
-        return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        return Response(
+            serialize(detector, request.user, WorkflowEngineDetectorSerializer()),
+            status=status.HTTP_201_CREATED,
+        )
 
 
 class AlertRuleFetchMixin(Endpoint):

--- a/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
@@ -2,7 +2,6 @@ from django.http import Http404
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -45,22 +44,15 @@ class ProjectAlertRuleTaskDetailsEndpoint(ProjectEndpoint):
         if rule_id and status == "success":
             try:
                 alert_rule = AlertRule.objects.get(projects=project, id=rule_id)
-                if features.has(
-                    "organizations:workflow-engine-rule-serializers", project.organization
-                ):
-                    try:
-                        detector = Detector.objects.get(
-                            alertruledetector__alert_rule_id=alert_rule.id
-                        )
-                    except Detector.DoesNotExist:
-                        raise Http404
-                    context["alertRule"] = serialize(
-                        detector, request.user, WorkflowEngineDetectorSerializer()
-                    )
-                else:
-                    context["alertRule"] = serialize(alert_rule, request.user)
             except AlertRule.DoesNotExist:
                 raise Http404
+            try:
+                detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+            except Detector.DoesNotExist:
+                raise Http404
+            context["alertRule"] = serialize(
+                detector, request.user, WorkflowEngineDetectorSerializer()
+            )
         if status == "failed":
             context["error"] = error
 

--- a/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
@@ -4,8 +4,6 @@ from django.urls import reverse
 
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.workflow_engine.migration_helpers.alert_rule import (
     migrate_alert_rule,
     migrate_metric_action,
@@ -58,33 +56,17 @@ class ProjectAlertRuleTaskDetailsTest(APITestCase):
     def test_status_success(self) -> None:
         self.set_value("success", self.rule.id)
         self.login_as(user=self.user)
+
+        critical_trigger = self.create_alert_rule_trigger(alert_rule=self.rule, label="critical")
+        critical_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=critical_trigger
+        )
+        migrate_alert_rule(self.rule)
+        migrate_metric_data_conditions(critical_trigger)
+        migrate_metric_action(critical_trigger_action)
+        migrate_resolve_threshold_data_condition(self.rule)
+
         response = self.client.get(self.url, format="json")
-
-        assert response.status_code == 200, response.content
-        assert response.data["status"] == "success"
-
-        rule_data = response.data["alertRule"]
-        assert rule_data["id"] == str(self.rule.id)
-        assert rule_data["name"] == self.rule.name
-
-    def test_workflow_engine_serializer(self) -> None:
-        self.set_value("success", self.rule.id)
-        self.login_as(user=self.user)
-
-        self.critical_trigger = self.create_alert_rule_trigger(
-            alert_rule=self.rule, label="critical"
-        )
-        self.critical_trigger_action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=self.critical_trigger
-        )
-        _, _, _, self.detector, _, _, _, _ = migrate_alert_rule(self.rule)
-        self.critical_detector_trigger, _, _ = migrate_metric_data_conditions(self.critical_trigger)
-
-        self.critical_action, _, _ = migrate_metric_action(self.critical_trigger_action)
-        self.resolve_trigger_data_condition = migrate_resolve_threshold_data_condition(self.rule)
-
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
         assert response.data["status"] == "success"
@@ -101,64 +83,8 @@ class ProjectAlertRuleTaskDetailsTest(APITestCase):
         response = self.client.get(self.url, format="json")
         assert response.status_code == 404
 
-
-@freeze_time("2024-12-11 03:21:34")
-class ProjectAlertRuleTaskDetailsDeltaTest(APITestCase):
-    def setUp(self) -> None:
+    def test_no_detector(self) -> None:
+        self.set_value("success", self.rule.id)
         self.login_as(user=self.user)
-        team = self.create_team()
-        project1 = self.create_project(teams=[team], name="foo", fire_project_created=True)
-        self.rule = self.create_alert_rule(
-            name="My Alert Rule", user=self.user, projects=[project1]
-        )
-        self.critical_trigger = self.create_alert_rule_trigger(
-            alert_rule=self.rule, label="critical"
-        )
-        self.critical_trigger_action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=self.critical_trigger
-        )
-        _, _, _, self.detector, _, _, _, _ = migrate_alert_rule(self.rule)
-        self.critical_detector_trigger, _, _ = migrate_metric_data_conditions(self.critical_trigger)
-        self.critical_action, _, _ = migrate_metric_action(self.critical_trigger_action)
-        self.resolve_trigger_data_condition = migrate_resolve_threshold_data_condition(self.rule)
-
-        self.uuid = uuid4().hex
-        self.url = reverse(
-            "sentry-api-0-project-alert-rule-task-details",
-            kwargs={
-                "organization_id_or_slug": project1.organization.slug,
-                "project_id_or_slug": project1.slug,
-                "task_uuid": self.uuid,
-            },
-        )
-        client = RedisRuleStatus(self.uuid)
-        client.set_value("success", self.rule.id)
-
-    def test_workflow_engine_serializer_matches_old_serializer(self) -> None:
-        """New serializer output on the task details endpoint must match old serializer output."""
-        # Old serializer
-        response_old = self.client.get(self.url, format="json")
-        assert response_old.status_code == 200
-        old_data = response_old.data["alertRule"]
-
-        # New serializer
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            response_new = self.client.get(self.url, format="json")
-        assert response_new.status_code == 200
-        new_data = response_new.data["alertRule"]
-
-        assert_serializer_parity(
-            old=old_data,
-            new=new_data,
-            known_differences={
-                # createdBy: Lost during migration when AlertRuleActivity CREATED type wasn't
-                # tracked. Detector.created_by_id is None if user wasn't provided during migration.
-                # Cannot use AlertRuleActivity as it's being phased out.
-                "createdBy",
-                # resolveThreshold: Old serializer checked AlertRule.resolve_threshold for None,
-                # but workflow engine always creates a resolve condition during migration.
-                # Cannot distinguish between explicit None vs migrated value without AlertRule.
-                "resolveThreshold",
-                "triggers.resolveThreshold",  # same reason as above
-            },
-        )
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == 404

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -64,7 +64,6 @@ from sentry.snuba.models import (
 )
 from sentry.snuba.tasks import update_subscription_in_snuba
 from sentry.testutils.abstract import Abstract
-from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
@@ -1056,29 +1055,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         # Internal storage should be unchanged
         alert_rule.refresh_from_db()
         assert alert_rule.snuba_query.aggregate == original_aggregate  # Still upsampled_count()
-
-    @with_feature("organizations:incidents")
-    @freeze_time("2024-12-11 03:21:34")
-    def test_workflow_engine_serializer(self) -> None:
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-
-        self.login_as(self.user)
-        alert_rule = self.alert_rule
-        # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
-        serialized_alert_rule = self.get_serialized_alert_rule()
-        serialized_alert_rule["name"] = "what"
-
-        with self.feature("organizations:workflow-engine-metric-alert-endpoints-put"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
-
-        rule_resp = self.get_success_response(
-            self.organization.slug, alert_rule.id, **serialized_alert_rule
-        )
-        self.assert_alert_detail_results_match(rule_resp.data, resp.data)
 
     def test_not_updated_fields(self) -> None:
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -28,6 +28,7 @@ from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     DetailedWorkflowEngineDetectorSerializer,
+    WorkflowEngineDetectorSerializer,
 )
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import INVALID_TIME_WINDOW
@@ -969,7 +970,8 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         alert_rule.name = "what"
         alert_rule.date_modified = resp.data["dateModified"]
-        assert resp.data == serialize(alert_rule)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert resp.data["name"] == "what"
         assert resp.data["dateModified"] > serialized_alert_rule["dateModified"]
 
@@ -1075,7 +1077,8 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         alert_rule.refresh_from_db()
         # Alert rule should be exactly the same
-        assert resp.data == serialize(self.alert_rule)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=self.alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         # If the aggregate changed we'd have a new subscription, validate that
         # it hasn't changed explicitly
         updated_alert_rule = AlertRule.objects.get(id=self.alert_rule.id)
@@ -1169,8 +1172,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
+        alert_rule.refresh_from_db()
         assert resp.data["name"] == "AUniqueName"
-        assert resp.data["resolveThreshold"] is None
+        assert alert_rule.resolve_threshold is None
 
     def test_update_resolve_alert_threshold(self) -> None:
         # This is a test to make sure we can remove a resolveThreshold after it has been set.
@@ -1227,10 +1231,10 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule["triggers"].pop(1)
 
         with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
+            self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
-        assert len(resp.data["triggers"]) == 1
+        assert AlertRuleTrigger.objects.filter(alert_rule_id=alert_rule.id).count() == 1
         # we test the logic for this method elsewhere, so just test that it's correctly called
         assert mock_dual_delete.call_count == 1
 
@@ -1538,13 +1542,17 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         serialized_action = serialized_alert_rule["triggers"][1]["actions"].pop(1)
         action = AlertRuleTriggerAction.objects.get(id=serialized_action["id"])
+        warning_trigger_id = serialized_alert_rule["triggers"][1]["id"]
 
         with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
+            self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
-        assert len(resp.data["triggers"][1]["actions"]) == 1
+        assert (
+            AlertRuleTriggerAction.objects.filter(alert_rule_trigger_id=warning_trigger_id).count()
+            == 1
+        )
         # we test the logic for this method elsewhere, so just test that it's correctly called
         assert mock_dual_delete.call_count == 1
         assert mock_dual_delete.call_args_list[0][0][0] == action
@@ -1630,7 +1638,8 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             )
 
         alert_rule.refresh_from_db()
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert resp.data["owner"] is None
 
     def test_team_permission(self) -> None:
@@ -1659,7 +1668,8 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             )
 
         alert_rule.refresh_from_db()
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
     def test_change_name_of_existing_alert(self) -> None:
         self.create_member(
@@ -1678,7 +1688,8 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         self.alert_rule.refresh_from_db()
         self.alert_rule.name = "what"
         self.alert_rule.snuba_query.refresh_from_db()
-        assert resp.data == serialize(self.alert_rule)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=self.alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert resp.data["name"] == "what"
 
         # We validate that there's only been one change to the alert
@@ -1851,7 +1862,8 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert "id" in resp.data
         alert_rule.refresh_from_db()
         assert alert_rule.snuba_query.dataset == "transactions"
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert resp.data["aggregate"] == "count()"
         assert resp.data["dataset"] == "transactions"
         assert (
@@ -2439,7 +2451,8 @@ class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
 
         alert_rule.refresh_from_db()
         alert_rule.name = "ValidSentryAppTestRule"
-        assert resp.data == serialize(alert_rule)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert resp.data["triggers"][0]["actions"][0]["sentryAppId"] == sentry_app.id
 
     def test_no_config_sentry_app(self) -> None:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -532,30 +532,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert "upsampled_count() is not allowed as user input" in str(resp.data)
         assert "Use count() instead" in str(resp.data)
 
-    def test_workflow_engine_serializer(self) -> None:
-        team = self.create_team(organization=self.organization, members=[self.user])
-        ProjectTeam.objects.create(project=self.project, team=team)
-        self.login_as(self.user)
-
-        with (
-            outbox_runner(),
-            self.feature(
-                [
-                    "organizations:incidents",
-                    "organizations:performance-view",
-                    "organizations:workflow-engine-metric-alert-endpoints-post",
-                ]
-            ),
-        ):
-            resp = self.get_success_response(
-                self.organization.slug,
-                status_code=201,
-                **self.alert_rule_dict,
-            )
-
-        detector = Detector.objects.get(alertruledetector__alert_rule_id=int(resp.data.get("id")))
-        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
-
     def test_create_alert_rule_aci(self) -> None:
         with (
             outbox_runner(),

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -440,7 +440,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
         with assume_test_silo_mode(SiloMode.CONTROL):
             audit_log_entry = AuditLogEntry.objects.filter(
@@ -549,7 +550,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         actions = AlertRuleTriggerAction.objects.filter(
             alert_rule_trigger__in=[trigger.id for trigger in triggers]
         )
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert_alert_rule_migrated(alert_rule, self.project.id)
         assert_alert_rule_trigger_migrated(triggers[0])
         assert_alert_rule_trigger_migrated(triggers[1])
@@ -623,7 +625,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert alert_rule.seasonality == resp.data.get("seasonality")
         assert alert_rule.sensitivity == resp.data.get("sensitivity")
         assert mock_seer_request.call_count == 1
@@ -654,7 +657,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert alert_rule.seasonality == resp.data.get("seasonality")
         assert alert_rule.sensitivity == resp.data.get("sensitivity")
         assert mock_seer_request.call_count == 1
@@ -688,7 +692,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert alert_rule.seasonality == resp.data.get("seasonality")
         assert alert_rule.sensitivity == resp.data.get("sensitivity")
         assert mock_seer_request.call_count == 1
@@ -724,7 +729,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert alert_rule.seasonality == resp.data.get("seasonality")
         assert alert_rule.sensitivity == resp.data.get("sensitivity")
         assert mock_seer_request.call_count == 1
@@ -770,7 +776,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
             assert "id" in resp.data
             alert_rule = AlertRule.objects.get(id=resp.data["id"])
-            assert resp.data == serialize(alert_rule, self.user)
+            detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+            assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
     @patch(
         "sentry.snuba.subscriptions.create_subscription_in_snuba.delay",
@@ -810,7 +817,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert (
             SnubaQueryEventType.objects.filter(snuba_query_id=alert_rule.snuba_query_id)
             .order_by("id")[0]
@@ -940,7 +948,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         assert "id" in resp1.data
         alert_rule1 = AlertRule.objects.get(id=resp1.data["id"])
-        assert resp1.data == serialize(alert_rule1, self.user)
+        detector1 = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule1.id)
+        assert resp1.data == serialize(detector1, self.user, WorkflowEngineDetectorSerializer())
         assert resp1.data["aggregate"] == "per_second(value,metric_name_one,counter,-)"
         assert (
             SnubaQueryEventType.objects.filter(snuba_query_id=alert_rule1.snuba_query_id)
@@ -951,7 +960,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         assert "id" in resp2.data
         alert_rule2 = AlertRule.objects.get(id=resp2.data["id"])
-        assert resp2.data == serialize(alert_rule2, self.user)
+        detector2 = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule2.id)
+        assert resp2.data == serialize(detector2, self.user, WorkflowEngineDetectorSerializer())
         assert resp2.data["aggregate"] == "count(metric.name,metric_name_two,distribution,-)"
         assert (
             SnubaQueryEventType.objects.filter(snuba_query_id=alert_rule2.snuba_query_id)
@@ -1067,7 +1077,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert alert_rule.snuba_query.query == "is:unresolved"
 
     def test_performance_score_function(self) -> None:
@@ -1121,7 +1132,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert alert_rule.snuba_query.query == "transaction.op:pageload"
         assert alert_rule.snuba_query.aggregate == "performance_score(measurements.score.fcp)"
 
@@ -1132,7 +1144,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 self.organization.slug, status_code=201, **self.alert_rule_dict
             )
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
         with self.feature("organizations:incidents"):
             resp = self.get_error_response(self.organization.slug, **self.alert_rule_dict)
@@ -1151,7 +1164,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                     self.organization.slug, status_code=201, **self.alert_rule_dict
                 )
             alert_rule = AlertRule.objects.get(id=resp.data["id"])
-            assert resp.data == serialize(alert_rule, self.user)
+            detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+            assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
             alert_rule_dict_2 = self.alert_rule_dict.copy()
             alert_rule_dict_2["name"] = "Test Rule 2"
@@ -1160,7 +1174,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                     self.organization.slug, status_code=201, **alert_rule_dict_2
                 )
             alert_rule_2 = AlertRule.objects.get(id=resp.data["id"])
-            assert resp.data == serialize(alert_rule_2, self.user)
+            detector_2 = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule_2.id)
+            assert resp.data == serialize(detector_2, self.user, WorkflowEngineDetectorSerializer())
 
             alert_rule_dict_3 = self.alert_rule_dict.copy()
             alert_rule_dict_3["name"] = "Test Rule 3"
@@ -1169,7 +1184,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                     self.organization.slug, status_code=201, **alert_rule_dict_3
                 )
             alert_rule_3 = AlertRule.objects.get(id=resp.data["id"])
-            assert resp.data == serialize(alert_rule_3, self.user)
+            detector_3 = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule_3.id)
+            assert resp.data == serialize(detector_3, self.user, WorkflowEngineDetectorSerializer())
 
             alert_rule_dict_4 = self.alert_rule_dict.copy()
             alert_rule_dict_4["name"] = "Test Rule 4"
@@ -1201,7 +1217,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
     def test_missing_sentry_app(self) -> None:
         # install it on another org
@@ -1484,7 +1501,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
     def test_no_triggers(self) -> None:
         rule_no_triggers = {
@@ -1733,7 +1751,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             resp = self.get_success_response(self.organization.slug, status_code=201, **rule_data)
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
     @patch(
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
@@ -1887,7 +1906,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
             assert "id" in resp.data
             alert_rule = AlertRule.objects.get(id=resp.data["id"])
-            assert resp.data == serialize(alert_rule, self.user)
+            detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+            assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
             test_params = {**self.alert_rule_dict, "dataset": "transactions"}
 
@@ -1928,7 +1948,10 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
                 assert "id" in resp.data
                 alert_rule = AlertRule.objects.get(id=resp.data["id"])
-                assert resp.data == serialize(alert_rule, self.user)
+                detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+                assert resp.data == serialize(
+                    detector, self.user, WorkflowEngineDetectorSerializer()
+                )
 
     def test_post_rule_256_char_name(self) -> None:
         char_256_name = "wOOFmsWY80o0RPrlsrrqDp2Ylpr5K2unBWbsrqvuNb4Fy3vzawkNAyFJdqeFLlXNWF2kMfgMT9EQmFF3u3MqW3CTI7L2SLsmS9uSDQtcinjlZrr8BT4v8Q6ySrVY5HmiFO97w3awe4lA8uyVikeaSwPjt8MD5WSjdTI0RRXYeK3qnHTpVswBe9AIcQVMLKQXHgjulpsrxHc0DI0Vb8hKA4BhmzQXhYmAvKK26ZwCSjJurAODJB6mgIdlV7tigsFO"
@@ -2138,7 +2161,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         assert alert_rule.snuba_query.dataset == "transactions"
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert resp.data["aggregate"] == "count()"
         assert resp.data["dataset"] == "transactions"
         assert (
@@ -2363,7 +2387,8 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
     def test_simple_crash_rate_alerts_for_users(self) -> None:
         self.valid_alert_rule.update(
@@ -2377,7 +2402,8 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
     def test_simple_crash_rate_alerts_for_sessions_drops_event_types(self) -> None:
         self.valid_alert_rule["eventTypes"] = ["error"]
@@ -2387,7 +2413,8 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
     def test_simple_crash_rate_alerts_for_sessions_with_invalid_time_window(self) -> None:
         self.valid_alert_rule["timeWindow"] = "90"

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -3,12 +3,8 @@ from __future__ import annotations
 from typing import Any
 
 from sentry import audit_log
-from sentry.api.serializers import serialize
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
-from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
-    WorkflowEngineDetectorSerializer,
-)
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo.base import SiloMode
@@ -98,10 +94,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
                 self.organization.slug, self.project.slug, alert_rule.id, **self._put_payload()
             )
 
-        alert_rule.name = "what"
-        alert_rule.date_modified = resp.data["dateModified"]
-        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
-        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert resp.data["name"] == "what"
 
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -6,6 +6,9 @@ from sentry import audit_log
 from sentry.api.serializers import serialize
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
+from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
+    WorkflowEngineDetectorSerializer,
+)
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo.base import SiloMode
@@ -97,7 +100,8 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         alert_rule.name = "what"
         alert_rule.date_modified = resp.data["dateModified"]
-        assert resp.data == serialize(alert_rule)
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert resp.data["name"] == "what"
 
         with assume_test_silo_mode(SiloMode.CONTROL):


### PR DESCRIPTION
Remove legacy path code using the old serializer for metric alert PUT and POST endpoints.