### PR TITLE
chore(issues): Remove the option gating custom tag resolver logic

### DIFF
--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import options
 from sentry.api.serializers import serialize
 from sentry.issues.grouptype import GroupCategory
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
@@ -87,9 +86,7 @@ def get_query_builder_for_group(
     else:
         orderby_list = [orderby, "id"]
 
-    column_resolver = None
-    if options.get("issues.search.use-tag-aware-condition-resolver"):
-        column_resolver = functools.partial(get_snuba_column_name, dataset=dataset)
+    column_resolver = functools.partial(get_snuba_column_name, dataset=dataset)
 
     return DiscoverQueryBuilder(
         dataset=dataset,

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Min, prefetch_related_objects
 
-from sentry import options, tagstore
+from sentry import tagstore
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.api.serializers.models.plugin import is_plugin_deprecated
@@ -1071,16 +1071,6 @@ class GroupSerializerSnuba(GroupSerializerBase):
         if environment_ids:
             filters["environment"] = environment_ids
 
-        # Match the issue surfacing query's resolver so a tag that collides
-        # with a reserved column name (e.g. user tag `platform` vs the SDK
-        # `platform` column) resolves to the tag — keeping the badge count
-        # consistent with the surfacing result. Gated for safe rollout.
-        condition_resolver = (
-            get_snuba_column_name
-            if options.get("issues.search.use-tag-aware-condition-resolver")
-            else None
-        )
-
         return aliased_query(
             dataset=Dataset.Events,
             start=start,
@@ -1089,7 +1079,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
             conditions=conditions,
             filter_keys=filters,
             aggregations=aggregations,
-            condition_resolver=condition_resolver,
+            condition_resolver=get_snuba_column_name,
             referrer="serializers.GroupSerializerSnuba._execute_error_seen_stats_query",
             tenant_ids=(
                 {"organization_id": item_list[0].project.organization_id} if item_list else None
@@ -1112,12 +1102,6 @@ class GroupSerializerSnuba(GroupSerializerBase):
         if environment_ids:
             filters["environment"] = environment_ids
 
-        condition_resolver = (
-            get_snuba_column_name
-            if options.get("issues.search.use-tag-aware-condition-resolver")
-            else None
-        )
-
         return aliased_query(
             dataset=Dataset.IssuePlatform,
             start=start,
@@ -1126,7 +1110,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
             conditions=conditions,
             filter_keys=filters,
             aggregations=aggregations,
-            condition_resolver=condition_resolver,
+            condition_resolver=get_snuba_column_name,
             referrer="serializers.GroupSerializerSnuba._execute_generic_seen_stats_query",
             tenant_ids=(
                 {"organization_id": item_list[0].project.organization_id} if item_list else None

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -9,7 +9,7 @@ from typing import Any, NamedTuple, NotRequired, Protocol, TypedDict
 from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
 
-from sentry import features, options, release_health, tsdb
+from sentry import features, release_health, tsdb
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializerResponse
 from sentry.api.serializers.models.group import (
@@ -597,20 +597,10 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 generic_issue_ids.append(group.id)
 
         error_conditions = resolve_conditions(conditions, resolve_column(Dataset.Discover))
-        # IssuePlatform's `resolve_column` mis-resolves user-typed names that
-        # collide with column event_names (e.g. tag `platform` vs the SDK
-        # `platform` column) because of the `DATASET_FIELDS` shortcut. Match
-        # the issue surfacing query, which uses `get_snuba_column_name` —
-        # that resolver correctly falls back to `tags[<name>]`. Gated for
-        # safe rollout. (Discover doesn't hit the buggy branch and stays
-        # on `resolve_column`.)
-        if options.get("issues.search.use-tag-aware-condition-resolver"):
-            issue_conditions = resolve_conditions(
-                conditions,
-                functools.partial(get_snuba_column_name, dataset=Dataset.IssuePlatform),
-            )
-        else:
-            issue_conditions = resolve_conditions(conditions, resolve_column(Dataset.IssuePlatform))
+        issue_conditions = resolve_conditions(
+            conditions,
+            functools.partial(get_snuba_column_name, dataset=Dataset.IssuePlatform),
+        )
 
         get_range = functools.partial(
             snuba_tsdb.get_range,

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import Any
 
 from django.contrib.auth.models import AnonymousUser
@@ -13,7 +13,6 @@ from rest_framework.response import Response
 from snuba_sdk import Column, Condition, Op, Or
 from snuba_sdk.legacy import is_condition, parse_condition
 
-from sentry import options
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
@@ -59,7 +58,7 @@ from sentry.utils.snuba import get_snuba_column_name
 def issue_search_query_to_conditions(
     query: str, group: Group, user: User | AnonymousUser, environments: Sequence[Environment]
 ) -> tuple[list[Condition], list[Any]]:
-    from sentry.utils.snuba import resolve_column, resolve_conditions
+    from sentry.utils.snuba import resolve_conditions
 
     dataset = (
         Dataset.Events if group.issue_category == GroupCategory.ERROR else Dataset.IssuePlatform
@@ -101,11 +100,7 @@ def issue_search_query_to_conditions(
 
     # the transformed conditions is generic and isn't 'dataset aware', we need to map the generic columns
     # being queried to the appropriate dataset column
-    column_resolver: Callable[[str], str]
-    if options.get("issues.search.use-tag-aware-condition-resolver"):
-        column_resolver = functools.partial(get_snuba_column_name, dataset=dataset)
-    else:
-        column_resolver = resolve_column(dataset)
+    column_resolver = functools.partial(get_snuba_column_name, dataset=dataset)
 
     resolved_legacy_conditions = resolve_conditions(legacy_conditions, column_resolver) or []
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3766,18 +3766,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Routes the seen-stats / TSDB conditions through `get_snuba_column_name`
-# so a column-name-vs-tag-name collision (e.g. user tag named `platform`)
-# resolves to the tag, matching the issue surfacing query. Without this,
-# `resolve_column`'s DATASET_FIELDS shortcut treats user-typed bare column
-# names as column references and the badge disagrees with surfacing.
-register(
-    "issues.search.use-tag-aware-condition-resolver",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Rate limiting for the occurrence consumer
 register(
     "issues.occurrence-consumer.rate-limit.quota",

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -7,7 +7,6 @@ from typing import cast
 import sentry_sdk
 from snuba_sdk import Column, Condition
 
-from sentry import options
 from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.group import STATUS_QUERY_CHOICES, Group
@@ -124,9 +123,7 @@ def timeseries_query(
     with sentry_sdk.start_span(op="errors", name="timeseries.filter_transform"):
         equations, columns = categorize_columns(selected_columns)
 
-        column_resolver = None
-        if options.get("issues.search.use-tag-aware-condition-resolver"):
-            column_resolver = functools.partial(get_snuba_column_name, dataset=Dataset.Events)
+        column_resolver = functools.partial(get_snuba_column_name, dataset=Dataset.Events)
 
         base_builder = ErrorsTimeseriesQueryBuilder(
             Dataset.Events,

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 import sentry_sdk
 
-from sentry import options
 from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
@@ -153,11 +152,7 @@ def timeseries_query(
     with sentry_sdk.start_span(op="issueplatform", name="timeseries.filter_transform"):
         equations, columns = categorize_columns(selected_columns)
 
-        column_resolver = None
-        if options.get("issues.search.use-tag-aware-condition-resolver"):
-            column_resolver = functools.partial(
-                get_snuba_column_name, dataset=Dataset.IssuePlatform
-            )
+        column_resolver = functools.partial(get_snuba_column_name, dataset=Dataset.IssuePlatform)
 
         base_builder = IssuePlatformTimeseriesQueryBuilder(
             Dataset.IssuePlatform,

--- a/tests/sentry/issues/endpoints/test_group_event_details.py
+++ b/tests/sentry/issues/endpoints/test_group_event_details.py
@@ -573,25 +573,16 @@ class GroupEventDetailsHelpfulEndpointTest(
             events.append(event)
         return event.group, events
 
-    def test_platform_tag_collision_without_option(self) -> None:
-        group, _events = self._store_platform_tag_collision_events()
-        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/recommended/"
-        response = self.client.get(url, {"query": "platform:SJ1"}, format="json")
-        assert response.status_code == 404
-
-    def test_platform_tag_collision_with_option(self) -> None:
+    def test_platform_tag_collision_resolved_correctly(self) -> None:
         group, events = self._store_platform_tag_collision_events()
         url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/recommended/"
-        with self.options({"issues.search.use-tag-aware-condition-resolver": True}):
-            response = self.client.get(url, {"query": "platform:SJ1"}, format="json")
+        response = self.client.get(url, {"query": "platform:SJ1"}, format="json")
         assert response.status_code == 200, response.content
         assert response.data["id"] == events[-1].event_id
 
-    def test_explicit_tag_query_works_regardless_of_option(self) -> None:
+    def test_explicit_tag_query_works(self) -> None:
         group, events = self._store_platform_tag_collision_events()
         url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/recommended/"
-        for option_value in (False, True):
-            with self.options({"issues.search.use-tag-aware-condition-resolver": option_value}):
-                response = self.client.get(url, {"query": "tags[platform]:SJ1"}, format="json")
-            assert response.status_code == 200, response.content
-            assert response.data["id"] == events[-1].event_id
+        response = self.client.get(url, {"query": "tags[platform]:SJ1"}, format="json")
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == events[-1].event_id

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -633,29 +633,18 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             events.append(event)
         return event.group, events
 
-    def test_platform_tag_collision_without_option(self) -> None:
+    def test_platform_tag_collision_resolved_correctly(self) -> None:
         self.login_as(user=self.user)
         group, _events = self._store_platform_tag_collision_events()
         url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/?query=platform:SJ1"
         response = self.do_request(url)
         assert response.status_code == 200
-        assert len(response.data) == 0
-
-    def test_platform_tag_collision_with_option(self) -> None:
-        self.login_as(user=self.user)
-        group, _events = self._store_platform_tag_collision_events()
-        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/?query=platform:SJ1"
-        with self.options({"issues.search.use-tag-aware-condition-resolver": True}):
-            response = self.do_request(url)
-        assert response.status_code == 200
         assert len(response.data) == 3
 
-    def test_explicit_tag_query_works_regardless_of_option(self) -> None:
+    def test_explicit_tag_query_works(self) -> None:
         self.login_as(user=self.user)
         group, _events = self._store_platform_tag_collision_events()
         url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/?query=tags[platform]:SJ1"
-        for option_value in (False, True):
-            with self.options({"issues.search.use-tag-aware-condition-resolver": option_value}):
-                response = self.do_request(url)
-            assert response.status_code == 200
-            assert len(response.data) == 3
+        response = self.do_request(url)
+        assert response.status_code == 200
+        assert len(response.data) == 3

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1287,7 +1287,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             group = event.group
         return group
 
-    def test_platform_tag_collision_without_option(self) -> None:
+    def test_platform_tag_collision_resolved_correctly(self) -> None:
         group = self._store_platform_tag_collision_events()
         response = self.do_request(
             {
@@ -1303,46 +1303,25 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         total = sum(
             attrs[0]["count"] for _time, attrs in response.data["data"] if attrs[0]["count"] > 0
         )
-        assert total == 0
+        assert total == 3
 
-    def test_platform_tag_collision_with_option(self) -> None:
+    def test_explicit_tag_query_works(self) -> None:
         group = self._store_platform_tag_collision_events()
-        with self.options({"issues.search.use-tag-aware-condition-resolver": True}):
-            response = self.do_request(
-                {
-                    "start": self.day_ago,
-                    "end": self.day_ago + timedelta(hours=2),
-                    "interval": "1h",
-                    "query": f"issue:{group.qualified_short_id} platform:SJ1",
-                    "dataset": "errors",
-                    "yAxis": "count()",
-                },
-            )
+        response = self.do_request(
+            {
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=2),
+                "interval": "1h",
+                "query": f"issue:{group.qualified_short_id} tags[platform]:SJ1",
+                "dataset": "errors",
+                "yAxis": "count()",
+            },
+        )
         assert response.status_code == 200, response.content
         total = sum(
             attrs[0]["count"] for _time, attrs in response.data["data"] if attrs[0]["count"] > 0
         )
         assert total == 3
-
-    def test_explicit_tag_query_works_regardless_of_option(self) -> None:
-        group = self._store_platform_tag_collision_events()
-        for option_value in (False, True):
-            with self.options({"issues.search.use-tag-aware-condition-resolver": option_value}):
-                response = self.do_request(
-                    {
-                        "start": self.day_ago,
-                        "end": self.day_ago + timedelta(hours=2),
-                        "interval": "1h",
-                        "query": f"issue:{group.qualified_short_id} tags[platform]:SJ1",
-                        "dataset": "errors",
-                        "yAxis": "count()",
-                    },
-                )
-            assert response.status_code == 200, response.content
-            total = sum(
-                attrs[0]["count"] for _time, attrs in response.data["data"] if attrs[0]["count"] > 0
-            )
-            assert total == 3
 
 
 class OrganizationEventsStatsTopNEventsSpans(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -282,7 +282,7 @@ class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             )
         return event.group
 
-    def test_platform_tag_collision_badge_disagrees_without_option(self) -> None:
+    def test_platform_tag_collision_badge_resolved_correctly(self) -> None:
         group = self._store_platform_tag_collision_events()
         self.login_as(user=self.user)
 
@@ -291,27 +291,13 @@ class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["count"] == "3"
-        assert response.data[0]["filtered"]["count"] == "0"
-
-    def test_platform_tag_collision_badge_agrees_with_option(self) -> None:
-        group = self._store_platform_tag_collision_events()
-        self.login_as(user=self.user)
-
-        with self.options({"issues.search.use-tag-aware-condition-resolver": True}):
-            response = self.get_response(query="platform:SJ1", groups=[group.id])
-
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["count"] == "3"
         assert response.data[0]["filtered"]["count"] == "3"
 
-    def test_explicit_tag_query_works_regardless_of_option(self) -> None:
+    def test_explicit_tag_query_works(self) -> None:
         group = self._store_platform_tag_collision_events()
         self.login_as(user=self.user)
 
-        for option_value in (False, True):
-            with self.options({"issues.search.use-tag-aware-condition-resolver": option_value}):
-                response = self.get_response(query="tags[platform]:SJ1", groups=[group.id])
-            assert response.status_code == 200
-            assert response.data[0]["filtered"]["count"] == "3"
-            assert response.data[0]["count"] == "3"
+        response = self.get_response(query="tags[platform]:SJ1", groups=[group.id])
+        assert response.status_code == 200
+        assert response.data[0]["filtered"]["count"] == "3"
+        assert response.data[0]["count"] == "3"


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/115416.

This custom tag resolver logic has been running safely for >1 week, so this PR removes the option and its usages.