### PR TITLE
fix(tracemetrics): Expand selector dropdown menu width to 100%

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -541,6 +541,7 @@ export function MetricSelector({
                     borderTop={
                       isOverlayAboveTrigger ? {xs: 'primary', md: undefined} : undefined
                     }
+                    width="100%"
                   >
                     <Flex align="center" justify="between" padding="sm lg">
                       <Text size="sm" bold wrap="nowrap">


### PR DESCRIPTION
Fixes some funky spacing when the screen is wide on dashboards since the dropdown trigger is longer

Before:
<img width="1629" height="599" alt="Screenshot 2026-05-21 at 12 52 14 PM" src="https://github.com/user-attachments/assets/302cc445-0816-4f06-8eea-d70ed6aa286b" />

After:
<img width="1644" height="567" alt="Screenshot 2026-05-21 at 12 57 17 PM" src="https://github.com/user-attachments/assets/532f2f47-712c-4446-a159-c0d329a5c398" />
