### PR TITLE
fix(onboarding): Remove broken aria-label from RadioGroup radio inputs

### DIFF
--- a/static/app/components/forms/controls/radioGroup.tsx
+++ b/static/app/components/forms/controls/radioGroup.tsx
@@ -73,6 +73,11 @@ export function RadioGroup<C extends string>({
         const disabledChoiceReason = disabledChoice?.[1];
         const disabled = !!disabledChoice || groupDisabled;
 
+        // TODO(epurkhiser): There should be a `name` and `label` attribute in
+        // the options type to allow for the aria label to work correctly. For
+        // now we slap a `toString` on there, but it may sometimes return
+        // [object Object] if the name is a react node.
+
         return (
           <Tooltip
             key={index}
@@ -84,6 +89,7 @@ export function RadioGroup<C extends string>({
             <RadioLineItem index={index} aria-checked={value === id} disabled={disabled}>
               <Radio
                 name={groupName}
+                aria-label={typeof name === 'string' ? name : undefined}
                 disabled={disabled}
                 checked={value === id}
                 onChange={e => !disabled && onChange(id, e)}

--- a/static/app/components/forms/controls/radioGroup.tsx
+++ b/static/app/components/forms/controls/radioGroup.tsx
@@ -73,11 +73,6 @@ export function RadioGroup<C extends string>({
         const disabledChoiceReason = disabledChoice?.[1];
         const disabled = !!disabledChoice || groupDisabled;
 
-        // TODO(epurkhiser): There should be a `name` and `label` attribute in
-        // the options type to allow for the aria label to work correctly. For
-        // now we slap a `toString` on there, but it may sometimes return
-        // [object Object] if the name is a react node.
-
         return (
           <Tooltip
             key={index}
@@ -89,7 +84,6 @@ export function RadioGroup<C extends string>({
             <RadioLineItem index={index} aria-checked={value === id} disabled={disabled}>
               <Radio
                 name={groupName}
-                aria-label={name?.toString()} // eslint-disable-line @typescript-eslint/no-base-to-string
                 disabled={disabled}
                 checked={value === id}
                 onChange={e => !disabled && onChange(id, e)}

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -747,7 +747,9 @@ describe('CreateProject', () => {
       );
       expect(getSubmitButton()).toBeDisabled();
 
-      await userEvent.click(screen.getByText("I'll create my own alerts later"));
+      await userEvent.click(
+        screen.getByRole('radio', {name: /create my own alerts later/i})
+      );
       expect(getSubmitButton()).toBeEnabled();
 
       await userEvent.click(getSubmitButton());
@@ -858,7 +860,9 @@ describe('CreateProject', () => {
         teamSlug: teamWithAccess.slug,
       });
       render(<CreateProject />, {organization});
-      expect(screen.getByLabelText(/Alert me on high priority issues/i)).toBeChecked();
+      expect(
+        screen.getByRole('radio', {name: /Alert me on high priority issues/i})
+      ).toBeChecked();
       await userEvent.click(screen.getByTestId('platform-javascript-react'));
       await userEvent.click(screen.getByRole('button', {name: 'Create Project'}));
       expect(projectCreationMockRequest).toHaveBeenCalledWith(
@@ -880,8 +884,12 @@ describe('CreateProject', () => {
         teamSlug: teamWithAccess.slug,
       });
       render(<CreateProject />, {organization});
-      await userEvent.click(screen.getByText(/create my own alerts later/i));
-      expect(screen.getByLabelText(/create my own alerts later/i)).toBeChecked();
+      await userEvent.click(
+        screen.getByRole('radio', {name: /create my own alerts later/i})
+      );
+      expect(
+        screen.getByRole('radio', {name: /create my own alerts later/i})
+      ).toBeChecked();
       await userEvent.click(screen.getByTestId('platform-javascript-react'));
       await userEvent.click(screen.getByRole('button', {name: 'Create Project'}));
       expect(projectCreationMockRequest).toHaveBeenCalledWith(


### PR DESCRIPTION
`RadioGroup` was calling `.toString()` on a `React.ReactNode` to build `aria-label` for each radio input, which produced `aria-label="[object Object]"` whenever the label was JSX. The wrapping `<label>` element already provides the accessible name, so the explicit `aria-label` was redundant and actively harmful.