### PR TITLE
ref(snapshots): Use selective upload and filter to DiffImageDisplay only

### DIFF
--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -87,6 +87,10 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SNAPSHOTS_AUTH_TOKEN }}
           BASE_SHA: ${{ steps.merge-base.outputs.sha }}
         run: |
+          if [ ! -d "$SNAPSHOT_OUTPUT_DIR" ]; then
+            echo "Snapshot output directory does not exist, creating it"
+            mkdir -p "$SNAPSHOT_OUTPUT_DIR"
+          fi
           sentry-cli \
             --log-level=debug \
             build snapshots "$SNAPSHOT_OUTPUT_DIR" \

--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -61,8 +61,23 @@ jobs:
         if: steps.nodemodulescache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Playwright browser cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium
+
+      - name: Install Playwright system dependencies
+        run: pnpm exec playwright install-deps chromium
 
       - name: Run snapshot tests
         run: pnpm exec jest --config jest.config.snapshots.ts --testPathPattern="diffImageDisplay"

--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -80,7 +80,7 @@ jobs:
         run: pnpm exec playwright install-deps chromium
 
       - name: Run snapshot tests
-        run: pnpm exec jest --config jest.config.snapshots.ts --testPathPattern="diffImageDisplay"
+        run: pnpm exec jest --config jest.config.snapshots.ts --testPathPatterns="diffImageDisplay"
 
       - name: Compute merge base SHA
         if: github.event_name == 'pull_request' && !cancelled()

--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -65,7 +65,7 @@ jobs:
         run: pnpm exec playwright install chromium --with-deps
 
       - name: Run snapshot tests
-        run: pnpm run snapshots
+        run: pnpm run snapshots -- --testPathPattern="diffImageDisplay"
 
       - name: Compute merge base SHA
         if: github.event_name == 'pull_request' && !cancelled()
@@ -92,6 +92,7 @@ jobs:
             build snapshots "$SNAPSHOT_OUTPUT_DIR" \
             --app-id sentry-frontend \
             --project sentry-frontend \
+            --selective \
             ${BASE_SHA:+--base-sha "$BASE_SHA"}
 
       - name: Report upload failure to Sentry

--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -65,7 +65,7 @@ jobs:
         run: pnpm exec playwright install chromium --with-deps
 
       - name: Run snapshot tests
-        run: pnpm run snapshots -- --testPathPattern="diffImageDisplay"
+        run: pnpm exec jest --config jest.config.snapshots.ts --testPathPattern="diffImageDisplay"
 
       - name: Compute merge base SHA
         if: github.event_name == 'pull_request' && !cancelled()

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -41,7 +41,7 @@ export function DiffImageDisplay({
   diffImageBaseUrl,
   overlayColor,
   diffMode,
-  headLabel = t('Head'),
+  headLabel = t('Latest'),
 }: DiffImageDisplayProps) {
   const [onionOpacity, setOnionOpacity] = useState(50);
 
@@ -300,7 +300,7 @@ function OnionView({
           />
         </Flex>
         <Text size="sm" variant="muted">
-          {t('Head')}
+          {headLabel}
         </Text>
       </Flex>
     </Flex>


### PR DESCRIPTION
Test selective snapshot upload by filtering the Jest snapshot run to only
generate DiffImageDisplay snapshots, and passing `--selective` to
`sentry-cli build snapshots` for the upload step.

This is a test to verify the selective upload workflow works correctly
before rolling it out more broadly.