### PR TITLE
feat(seer): Add structured LLM context for explore logs trace route

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -155,7 +155,8 @@ describe('useSeerExplorer', () => {
       '/issues/:groupId/attachments/',
       '/issues/:groupId/distributions/',
       '/issues/:groupId/distributions/:tagKey/',
-    ])('sends structured JSON on issue sub-tab route %s', async (route: string) => {
+      '/explore/logs/trace/:traceSlug/',
+    ])('sends structured JSON on structured-context route %s', async (route: string) => {
       jest.spyOn(seerExplorerUtils, 'usePageReferrer').mockReturnValue({
         getPageReferrer: () => route,
       });

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -42,6 +42,7 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/dashboard/:dashboardId/widget-builder/widget/new/',
   '/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/',
   '/explore/logs/',
+  '/explore/logs/trace/:traceSlug/',
   '/explore/releases/',
   '/explore/traces/',
   '/explore/traces/trace/:traceSlug/',


### PR DESCRIPTION
+ Add /explore/logs/trace/:traceSlug/ to STRUCTURED_CONTEXT_ROUTES. This route uses the same TraceViewImpl component as /explore/traces/trace/:traceSlug/ which already provides full structured context via registerLLMContext('trace', ...).

