### PR TITLE
ref(utils): Make ParityChecker print out mismatches in a PII safe way

### DIFF
--- a/src/sentry/testutils/helpers/serializer_parity.py
+++ b/src/sentry/testutils/helpers/serializer_parity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from sentry.utils.payload_comparison import PayloadComparator
+from sentry.utils.payload_comparison import ParityChecker
 
 
 def assert_serializer_parity(
@@ -51,7 +51,7 @@ def assert_serializer_parity(
     """
     known_diffs = frozenset(known_differences or ())
     unreliable_fields = frozenset(unreliable or ())
-    checker = PayloadComparator(format_value=repr)
+    checker = ParityChecker(format_value=repr)
     checker.compare(old, new, known_diffs, unreliable=unreliable_fields)
 
     assert not checker.mismatches, "Serializer differences:\n" + "\n".join(checker.mismatches)

--- a/src/sentry/testutils/helpers/serializer_parity.py
+++ b/src/sentry/testutils/helpers/serializer_parity.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, field
 from typing import Any
+
+from sentry.utils.payload_comparison import PayloadComparator
 
 
 def assert_serializer_parity(
@@ -50,7 +51,7 @@ def assert_serializer_parity(
     """
     known_diffs = frozenset(known_differences or ())
     unreliable_fields = frozenset(unreliable or ())
-    checker = _ParityChecker()
+    checker = PayloadComparator(format_value=repr)
     checker.compare(old, new, known_diffs, unreliable=unreliable_fields)
 
     assert not checker.mismatches, "Serializer differences:\n" + "\n".join(checker.mismatches)
@@ -61,99 +62,3 @@ def assert_serializer_parity(
         "Unnecessary known_differences (no actual difference found):\n"
         + "\n".join(sorted(unnecessary))
     )
-
-
-def _qualify(prefix: str, name: str) -> str:
-    return f"{prefix}.{name}" if prefix else name
-
-
-@dataclass
-class _ParityChecker:
-    mismatches: list[str] = field(default_factory=list)
-
-    # known_diffs entries confirmed to be actual differences.
-    confirmed: set[str] = field(default_factory=set)
-
-    def _nested_fields(self, field_set: frozenset[str], key: str) -> frozenset[str]:
-        """Extract child paths for *key* from a dot-separated field set.
-
-        E.g. ``_nested_fields({"activities.id", "title"}, "activities")``
-        returns ``{"id"}``.
-        """
-        prefix = key + "."
-        return frozenset(e[len(prefix) :] for e in field_set if e.startswith(prefix))
-
-    def compare(
-        self,
-        old: Mapping[str, Any],
-        new: Mapping[str, Any],
-        known_diffs: frozenset[str],
-        path: str = "",
-        diffs_path: str = "",
-        *,
-        unreliable: frozenset[str] = frozenset(),
-    ) -> None:
-        for key in set(list(old.keys()) + list(new.keys())):
-            if key in known_diffs:
-                full_diffs_key = _qualify(diffs_path, key)
-                if key not in new or key not in old or old[key] != new[key]:
-                    self.confirmed.add(full_diffs_key)
-                continue
-
-            if key in unreliable:
-                full_path = _qualify(path, key)
-                if key not in new:
-                    self.mismatches.append(f"Missing from new: {full_path}")
-                elif key not in old:
-                    self.mismatches.append(f"Extra in new: {full_path}")
-                continue
-
-            full_path = _qualify(path, key)
-
-            if key not in new:
-                self.mismatches.append(f"Missing from new: {full_path}")
-                continue
-            if key not in old:
-                self.mismatches.append(f"Extra in new: {full_path}")
-                continue
-
-            old_val = old[key]
-            new_val = new[key]
-            nested_diffs = self._nested_fields(known_diffs, key)
-            nested_unreliable = self._nested_fields(unreliable, key)
-
-            if nested_diffs or nested_unreliable:
-                child_diffs_path = _qualify(diffs_path, key)
-                if isinstance(old_val, list) and isinstance(new_val, list):
-                    if len(old_val) != len(new_val):
-                        self.mismatches.append(
-                            f"{full_path} count: old={len(old_val)}, new={len(new_val)}"
-                        )
-                    for i, (old_item, new_item) in enumerate(zip(old_val, new_val)):
-                        item_path = f"{full_path}[{i}]"
-                        if isinstance(old_item, Mapping) and isinstance(new_item, Mapping):
-                            self.compare(
-                                old_item,
-                                new_item,
-                                nested_diffs,
-                                item_path,
-                                child_diffs_path,
-                                unreliable=nested_unreliable,
-                            )
-                        elif old_item != new_item:
-                            self.mismatches.append(
-                                f"{item_path}: old={old_item!r}, new={new_item!r}"
-                            )
-                elif isinstance(old_val, Mapping) and isinstance(new_val, Mapping):
-                    self.compare(
-                        old_val,
-                        new_val,
-                        nested_diffs,
-                        full_path,
-                        child_diffs_path,
-                        unreliable=nested_unreliable,
-                    )
-                elif old_val != new_val:
-                    self.mismatches.append(f"{full_path}: old={old_val!r}, new={new_val!r}")
-            elif old_val != new_val:
-                self.mismatches.append(f"{full_path}: old={old_val!r}, new={new_val!r}")

--- a/src/sentry/utils/payload_comparison.py
+++ b/src/sentry/utils/payload_comparison.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
-def qualify(prefix: str, name: str) -> str:
+def _qualify(prefix: str, name: str) -> str:
     return f"{prefix}.{name}" if prefix else name
 
 
@@ -29,7 +29,7 @@ def describe_value(value: Any) -> str:
 
 
 @dataclass
-class PayloadComparator:
+class ParityChecker:
     """Recursive dict comparator with dot-separated field paths.
 
     ``format_value`` controls how values appear in mismatch messages.
@@ -64,20 +64,20 @@ class PayloadComparator:
     ) -> None:
         for key in set(list(old.keys()) + list(new.keys())):
             if key in known_diffs:
-                full_diffs_key = qualify(diffs_path, key)
+                full_diffs_key = _qualify(diffs_path, key)
                 if key not in new or key not in old or old[key] != new[key]:
                     self.confirmed.add(full_diffs_key)
                 continue
 
             if key in unreliable:
-                full_path = qualify(path, key)
+                full_path = _qualify(path, key)
                 if key not in new:
                     self.mismatches.append(f"Missing from new: {full_path}")
                 elif key not in old:
                     self.mismatches.append(f"Extra in new: {full_path}")
                 continue
 
-            full_path = qualify(path, key)
+            full_path = _qualify(path, key)
 
             if key not in new:
                 self.mismatches.append(f"Missing from new: {full_path}")
@@ -92,7 +92,7 @@ class PayloadComparator:
             nested_unreliable = self._nested_fields(unreliable, key)
 
             if nested_diffs or nested_unreliable:
-                child_diffs_path = qualify(diffs_path, key)
+                child_diffs_path = _qualify(diffs_path, key)
                 if isinstance(old_val, list) and isinstance(new_val, list):
                     if len(old_val) != len(new_val):
                         self.mismatches.append(

--- a/src/sentry/utils/payload_comparison.py
+++ b/src/sentry/utils/payload_comparison.py
@@ -126,6 +126,23 @@ class ParityChecker:
                     self.mismatches.append(
                         f"{full_path}: old={self.format_value(old_val)}, new={self.format_value(new_val)}"
                     )
+            elif isinstance(old_val, Mapping) and isinstance(new_val, Mapping):
+                self.compare(old_val, new_val, frozenset(), full_path, _qualify(diffs_path, key))
+            elif isinstance(old_val, list) and isinstance(new_val, list):
+                if len(old_val) != len(new_val):
+                    self.mismatches.append(
+                        f"{full_path} count: old={len(old_val)}, new={len(new_val)}"
+                    )
+                for i, (old_item, new_item) in enumerate(zip(old_val, new_val)):
+                    item_path = f"{full_path}[{i}]"
+                    if isinstance(old_item, Mapping) and isinstance(new_item, Mapping):
+                        self.compare(
+                            old_item, new_item, frozenset(), item_path, _qualify(diffs_path, key)
+                        )
+                    elif old_item != new_item:
+                        self.mismatches.append(
+                            f"{item_path}: old={self.format_value(old_item)}, new={self.format_value(new_item)}"
+                        )
             elif old_val != new_val:
                 self.mismatches.append(
                     f"{full_path}: old={self.format_value(old_val)}, new={self.format_value(new_val)}"

--- a/src/sentry/utils/payload_comparison.py
+++ b/src/sentry/utils/payload_comparison.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def qualify(prefix: str, name: str) -> str:
+    return f"{prefix}.{name}" if prefix else name
+
+
+def describe_value(value: Any) -> str:
+    """PII-safe value descriptor for production logging."""
+    if value is None:
+        return "None"
+    if isinstance(value, str):
+        return f"str(len={len(value)})"
+    if isinstance(value, bool):
+        return f"bool({value})"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, list):
+        return f"list(len={len(value)})"
+    if isinstance(value, dict):
+        return f"dict(keys={sorted(value.keys())})"
+    return type(value).__name__
+
+
+@dataclass
+class PayloadComparator:
+    """Recursive dict comparator with dot-separated field paths.
+
+    ``format_value`` controls how values appear in mismatch messages.
+    Use ``repr`` (default) for test output with full values, or
+    ``describe_value`` for PII-safe structural metadata in production.
+    """
+
+    format_value: Callable[[Any], str] = repr
+    mismatches: list[str] = field(default_factory=list)
+
+    # known_diffs entries confirmed to be actual differences.
+    confirmed: set[str] = field(default_factory=set)
+
+    def _nested_fields(self, field_set: frozenset[str], key: str) -> frozenset[str]:
+        """Extract child paths for *key* from a dot-separated field set.
+
+        E.g. ``_nested_fields({"activities.id", "title"}, "activities")``
+        returns ``{"id"}``.
+        """
+        prefix = key + "."
+        return frozenset(e[len(prefix) :] for e in field_set if e.startswith(prefix))
+
+    def compare(
+        self,
+        old: Mapping[str, Any],
+        new: Mapping[str, Any],
+        known_diffs: frozenset[str],
+        path: str = "",
+        diffs_path: str = "",
+        *,
+        unreliable: frozenset[str] = frozenset(),
+    ) -> None:
+        for key in set(list(old.keys()) + list(new.keys())):
+            if key in known_diffs:
+                full_diffs_key = qualify(diffs_path, key)
+                if key not in new or key not in old or old[key] != new[key]:
+                    self.confirmed.add(full_diffs_key)
+                continue
+
+            if key in unreliable:
+                full_path = qualify(path, key)
+                if key not in new:
+                    self.mismatches.append(f"Missing from new: {full_path}")
+                elif key not in old:
+                    self.mismatches.append(f"Extra in new: {full_path}")
+                continue
+
+            full_path = qualify(path, key)
+
+            if key not in new:
+                self.mismatches.append(f"Missing from new: {full_path}")
+                continue
+            if key not in old:
+                self.mismatches.append(f"Extra in new: {full_path}")
+                continue
+
+            old_val = old[key]
+            new_val = new[key]
+            nested_diffs = self._nested_fields(known_diffs, key)
+            nested_unreliable = self._nested_fields(unreliable, key)
+
+            if nested_diffs or nested_unreliable:
+                child_diffs_path = qualify(diffs_path, key)
+                if isinstance(old_val, list) and isinstance(new_val, list):
+                    if len(old_val) != len(new_val):
+                        self.mismatches.append(
+                            f"{full_path} count: old={len(old_val)}, new={len(new_val)}"
+                        )
+                    for i, (old_item, new_item) in enumerate(zip(old_val, new_val)):
+                        item_path = f"{full_path}[{i}]"
+                        if isinstance(old_item, Mapping) and isinstance(new_item, Mapping):
+                            self.compare(
+                                old_item,
+                                new_item,
+                                nested_diffs,
+                                item_path,
+                                child_diffs_path,
+                                unreliable=nested_unreliable,
+                            )
+                        elif old_item != new_item:
+                            self.mismatches.append(
+                                f"{item_path}: old={self.format_value(old_item)}, new={self.format_value(new_item)}"
+                            )
+                elif isinstance(old_val, Mapping) and isinstance(new_val, Mapping):
+                    self.compare(
+                        old_val,
+                        new_val,
+                        nested_diffs,
+                        full_path,
+                        child_diffs_path,
+                        unreliable=nested_unreliable,
+                    )
+                elif old_val != new_val:
+                    self.mismatches.append(
+                        f"{full_path}: old={self.format_value(old_val)}, new={self.format_value(new_val)}"
+                    )
+            elif old_val != new_val:
+                self.mismatches.append(
+                    f"{full_path}: old={self.format_value(old_val)}, new={self.format_value(new_val)}"
+                )

--- a/tests/sentry/testutils/helpers/test_serializer_parity.py
+++ b/tests/sentry/testutils/helpers/test_serializer_parity.py
@@ -1,6 +1,71 @@
 import pytest
 
 from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
+from sentry.utils.payload_comparison import ParityChecker, describe_value
+
+
+class TestNestedRecursion:
+    def test_nested_dict_reports_leaf_path(self) -> None:
+        old = {"event": {"event_id": "abc", "level": "error"}}
+        new = {"event": {"event_id": "xyz", "level": "error"}}
+        checker = ParityChecker(format_value=repr)
+        checker.compare(old, new, frozenset())
+        assert checker.mismatches == ["event.event_id: old='abc', new='xyz'"]
+
+    def test_deeply_nested_dict(self) -> None:
+        old = {"a": {"b": {"c": "old"}}}
+        new = {"a": {"b": {"c": "new"}}}
+        checker = ParityChecker(format_value=repr)
+        checker.compare(old, new, frozenset())
+        assert checker.mismatches == ["a.b.c: old='old', new='new'"]
+
+    def test_list_length_mismatch(self) -> None:
+        old = {"items": [1, 2, 3]}
+        new = {"items": [1, 2]}
+        checker = ParityChecker(format_value=repr)
+        checker.compare(old, new, frozenset())
+        assert checker.mismatches == ["items count: old=3, new=2"]
+
+    def test_list_scalar_element_diff(self) -> None:
+        old = {"tags": ["alpha", "beta"]}
+        new = {"tags": ["alpha", "gamma"]}
+        checker = ParityChecker(format_value=repr)
+        checker.compare(old, new, frozenset())
+        assert checker.mismatches == ["tags[1]: old='beta', new='gamma'"]
+
+    def test_list_of_dicts_element_diff(self) -> None:
+        old = {"items": [{"name": "a", "val": 1}, {"name": "b", "val": 2}]}
+        new = {"items": [{"name": "a", "val": 1}, {"name": "b", "val": 99}]}
+        checker = ParityChecker(format_value=repr)
+        checker.compare(old, new, frozenset())
+        assert checker.mismatches == ["items[1].val: old=2, new=99"]
+
+    def test_nested_dict_missing_key(self) -> None:
+        old = {"event": {"id": "1", "level": "error"}}
+        new = {"event": {"id": "1"}}
+        checker = ParityChecker(format_value=repr)
+        checker.compare(old, new, frozenset())
+        assert checker.mismatches == ["Missing from new: event.level"]
+
+    def test_nested_dict_extra_key(self) -> None:
+        old = {"event": {"id": "1"}}
+        new = {"event": {"id": "1", "extra": "val"}}
+        checker = ParityChecker(format_value=repr)
+        checker.compare(old, new, frozenset())
+        assert checker.mismatches == ["Extra in new: event.extra"]
+
+    def test_identical_nested_no_mismatches(self) -> None:
+        payload = {"event": {"tags": [["a", "b"]], "level": "error"}}
+        checker = ParityChecker(format_value=repr)
+        checker.compare(payload, payload, frozenset())
+        assert checker.mismatches == []
+
+    def test_format_value_used_in_nested_mismatch(self) -> None:
+        old = {"event": {"msg": "hello"}}
+        new = {"event": {"msg": "world"}}
+        checker = ParityChecker(format_value=describe_value)
+        checker.compare(old, new, frozenset())
+        assert checker.mismatches == ["event.msg: old=str(len=5), new=str(len=5)"]
 
 
 class TestUnreliable:


### PR DESCRIPTION
Context, I want to use ParityChecker (PC) for programmatically validating webhook payloads so we don't log PII. Currently, PC if it finds differences will output the repr. describe_value instead will give us a "censored" form of what the mismatches were. See the [tests](https://github.com/getsentry/sentry/pull/116040/changes#diff-3cf9089808b49038e6e0fd114234ee7ed9952ff2b57da7e947c04a0310f384c7R69-R100) in https://github.com/getsentry/sentry/pull/116040 

This is 99% the same as the old ParityChecker but 
1. moves the class to be in utils
2. Takes in a function parameter (`format_value`) that when a mismatch is found gets run on the old/new value so the default was repr.