### PR TITLE
feat(preprod): Display skipped images in snapshots UI

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -166,7 +166,7 @@ export const ImageCard = memo(function ImageCard({
   onCopyLink,
   onCopyMetadata,
 }: {
-  cardType: 'added' | 'removed' | 'renamed' | 'solo' | 'unchanged';
+  cardType: 'added' | 'removed' | 'renamed' | 'solo' | 'unchanged' | 'skipped';
   copyUrl: string;
   image: SnapshotImage;
   imageBaseUrl: string;
@@ -181,16 +181,25 @@ export const ImageCard = memo(function ImageCard({
   const [isDark, setIsDark] = useState(false);
   const imageUrl = `${imageBaseUrl}${image.key}/`;
   let status: DiffStatus | null;
-  if (cardType === 'solo') {
-    status = null;
-  } else if (cardType === 'added') {
-    status = DiffStatus.ADDED;
-  } else if (cardType === 'removed') {
-    status = DiffStatus.REMOVED;
-  } else if (cardType === 'renamed') {
-    status = DiffStatus.RENAMED;
-  } else {
-    status = DiffStatus.UNCHANGED;
+  switch (cardType) {
+    case 'solo':
+      status = null;
+      break;
+    case 'added':
+      status = DiffStatus.ADDED;
+      break;
+    case 'removed':
+      status = DiffStatus.REMOVED;
+      break;
+    case 'renamed':
+      status = DiffStatus.RENAMED;
+      break;
+    case 'skipped':
+      status = DiffStatus.SKIPPED;
+      break;
+    case 'unchanged':
+    default:
+      status = DiffStatus.UNCHANGED;
   }
 
   const handleSelect = onSelectSnapshot
@@ -347,6 +356,7 @@ const STATUS_VARIANT: Record<DiffStatus, ContentVariant | 'muted' | 'secondary'>
   [DiffStatus.REMOVED]: 'danger',
   [DiffStatus.RENAMED]: 'warning',
   [DiffStatus.UNCHANGED]: 'secondary',
+  [DiffStatus.SKIPPED]: 'muted',
 };
 
 const StatusBadge = memo(function StatusBadge({
@@ -372,6 +382,9 @@ const StatusBadge = memo(function StatusBadge({
       break;
     case DiffStatus.RENAMED:
       label = t('Renamed');
+      break;
+    case DiffStatus.SKIPPED:
+      label = t('Skipped');
       break;
     default:
       label = t('Unchanged');

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -64,7 +64,7 @@ type GroupCard =
       type: 'pair-card';
     }
   | {
-      cardType: 'added' | 'removed' | 'renamed' | 'solo' | 'unchanged';
+      cardType: 'added' | 'removed' | 'renamed' | 'solo' | 'unchanged' | 'skipped';
       estimatedHeight: number;
       id: string;
       image: SnapshotImage;

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -341,14 +341,22 @@ export function SnapshotMainContent({
   }
   const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
   let status: DiffStatus | null;
-  if (selectedItem.type === 'solo') {
-    status = null;
-  } else if (selectedItem.type === 'added') {
-    status = DiffStatus.ADDED;
-  } else if (selectedItem.type === 'removed') {
-    status = DiffStatus.REMOVED;
-  } else {
-    status = DiffStatus.UNCHANGED;
+  switch (selectedItem.type) {
+    case 'solo':
+      status = null;
+      break;
+    case 'added':
+      status = DiffStatus.ADDED;
+      break;
+    case 'removed':
+      status = DiffStatus.REMOVED;
+      break;
+    case 'skipped':
+      status = DiffStatus.SKIPPED;
+      break;
+    case 'unchanged':
+    default:
+      status = DiffStatus.UNCHANGED;
   }
 
   return (

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
@@ -45,6 +45,7 @@ const statusCounts: Record<DiffStatus, number> = {
   [DiffStatus.REMOVED]: 0,
   [DiffStatus.RENAMED]: 0,
   [DiffStatus.UNCHANGED]: 2,
+  [DiffStatus.SKIPPED]: 0,
 };
 
 describe('SnapshotSidebarContent', () => {

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.spec.tsx
@@ -26,6 +26,7 @@ const statusCounts: Record<DiffStatus, number> = {
   [DiffStatus.REMOVED]: 0,
   [DiffStatus.RENAMED]: 0,
   [DiffStatus.UNCHANGED]: 1,
+  [DiffStatus.SKIPPED]: 0,
 };
 
 function renderSidebar(sections: SidebarSection[]) {

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -28,6 +28,7 @@ export const DIFF_TYPE_ORDER: Record<string, number> = {
   [DiffStatus.ADDED]: 2,
   [DiffStatus.RENAMED]: 3,
   [DiffStatus.UNCHANGED]: 4,
+  [DiffStatus.SKIPPED]: 5,
 };
 
 type StatusCounts = Record<DiffStatus, number>;
@@ -44,6 +45,7 @@ const STATUS_PILLS: ReadonlyArray<{
   {status: DiffStatus.ADDED, color: 'success', label: t('added')},
   {status: DiffStatus.RENAMED, color: 'warning', label: t('renamed')},
   {status: DiffStatus.UNCHANGED, color: 'muted', label: t('unchanged')},
+  {status: DiffStatus.SKIPPED, color: 'muted', label: t('skipped')},
 ];
 
 const STATUS_META: Record<DiffStatus, {color: PillColor; label: string}> = {
@@ -52,6 +54,7 @@ const STATUS_META: Record<DiffStatus, {color: PillColor; label: string}> = {
   [DiffStatus.REMOVED]: {color: 'danger', label: t('Removed')},
   [DiffStatus.RENAMED]: {color: 'warning', label: t('Renamed')},
   [DiffStatus.UNCHANGED]: {color: 'muted', label: t('Unchanged')},
+  [DiffStatus.SKIPPED]: {color: 'muted', label: t('Skipped')},
 };
 
 type VirtualRow =

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -293,7 +293,7 @@ export default function SnapshotsPage() {
 
       const pushImages = (
         imgs: SnapshotImage[],
-        type: 'added' | 'removed' | 'unchanged'
+        type: 'added' | 'removed' | 'unchanged' | 'skipped'
       ) => {
         for (const [groupKey, images] of groupByKey(imgs, imageGroupKey)) {
           items.push({
@@ -311,6 +311,7 @@ export default function SnapshotsPage() {
       pushImages(data.added, 'added');
       pushImages(data.removed, 'removed');
       pushImages(data.unchanged, 'unchanged');
+      pushImages(data.skipped ?? [], 'skipped');
 
       items.sort(
         (a, b) => (DIFF_TYPE_ORDER[a.type] ?? 99) - (DIFF_TYPE_ORDER[b.type] ?? 99)
@@ -396,6 +397,7 @@ export default function SnapshotsPage() {
       DiffStatus.ADDED,
       DiffStatus.RENAMED,
       DiffStatus.UNCHANGED,
+      DiffStatus.SKIPPED,
     ];
     const byType = new Map<
       DiffStatus,
@@ -426,6 +428,7 @@ export default function SnapshotsPage() {
       [DiffStatus.REMOVED]: 0,
       [DiffStatus.RENAMED]: 0,
       [DiffStatus.UNCHANGED]: 0,
+      [DiffStatus.SKIPPED]: 0,
     };
     for (const item of searchFilteredItems) {
       if (item.type in counts) {

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -61,6 +61,8 @@ export interface SnapshotDetailsApiResponse {
   renamed_count?: number;
   unchanged: SnapshotImage[];
   unchanged_count: number;
+  skipped?: SnapshotImage[];
+  skipped_count?: number;
 }
 
 export enum DiffStatus {
@@ -69,6 +71,7 @@ export enum DiffStatus {
   REMOVED = 'removed',
   RENAMED = 'renamed',
   UNCHANGED = 'unchanged',
+  SKIPPED = 'skipped',
 }
 
 export function getImageName(image: SnapshotImage): string {
@@ -86,6 +89,6 @@ export type SidebarItem =
   | (SidebarItemBase & {type: 'changed'; pairs: SnapshotDiffPair[]})
   | (SidebarItemBase & {type: 'renamed'; pairs: SnapshotDiffPair[]})
   | (SidebarItemBase & {
-      type: 'added' | 'removed' | 'unchanged';
+      type: 'added' | 'removed' | 'unchanged' | 'skipped';
       images: SnapshotImage[];
     });


### PR DESCRIPTION
The backend already sends `skipped` and `skipped_count` in the snapshot API
response for selective snapshot uploads, but the frontend was completely
ignoring these fields. This wires up the skipped category so it appears as
its own collapsible section in the sidebar alongside Changed, Removed, Added,
Renamed, and Unchanged.

When a selective snapshot upload only includes a subset of images, the
remaining images that exist in the base but weren't re-uploaded are classified
as "skipped" by the comparison task. Previously these were invisible in the
UI — for example, a build with 392 skipped images would show no indication
of their existence.

Changes:
- Add `SKIPPED` to `DiffStatus` enum and `SidebarItem` union type
- Add `skipped`/`skipped_count` optional fields to `SnapshotDetailsApiResponse`
- Wire skipped images into sidebar sections, status pills, and status counts
- Add skipped handling to card rendering, list view, and single view
- Convert two if/else chains to switch statements for consistency