### PR TITLE
ref(issue detectors): Switch segment detectors to use a sample rate

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2984,9 +2984,9 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "spans.process-segments.detect-performance-problems.enable",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+    "spans.process-segments.detect-performance-problems.sample_rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "spans.process-segments.schema-validation",

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -28,6 +28,7 @@ from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
+from sentry.options.rollout import in_random_rollout
 from sentry.receivers.features import record_generic_event_processed
 from sentry.receivers.onboarding import record_release_received
 from sentry.signals import first_insight_span_received, first_transaction_received
@@ -287,7 +288,7 @@ def _create_models(
 def _detect_performance_problems(
     segment_span: CompatibleSpan, spans: list[CompatibleSpan], project: Project
 ) -> None:
-    if not options.get("spans.process-segments.detect-performance-problems.enable"):
+    if not in_random_rollout("spans.process-segments.detect-performance-problems.sample_rate"):
         return
 
     event_data = build_shim_event_data(segment_span, spans)

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -153,7 +153,7 @@ class TestSpansTask(TestCase):
             name="a" * 64,
         )
 
-    @override_options({"spans.process-segments.detect-performance-problems.enable": True})
+    @override_options({"spans.process-segments.detect-performance-problems.sample_rate": 1.0})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     def test_n_plus_one_issue_detection(self, mock_eventstream: mock.MagicMock) -> None:
         spans = self.generate_n_plus_one_spans()
@@ -173,7 +173,7 @@ class TestSpansTask(TestCase):
         ]
         assert performance_problem.type == PerformanceStreamedSpansGroupTypeExperimental
 
-    @override_options({"spans.process-segments.detect-performance-problems.enable": True})
+    @override_options({"spans.process-segments.detect-performance-problems.sample_rate": 1.0})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     @pytest.mark.xfail(reason="batches without segment spans are not supported yet")
     def test_n_plus_one_issue_detection_without_segment_span(


### PR DESCRIPTION
This switches the `spans.process-segments.detect-performance-problems.enable` option to be a `spans.process-segments.detect-performance-problems.sample_rate` option. The option isn't set anywhere, so we've just been relying on the default, which has now switched from being False to being 0. As a result, the code it's gating hasn't been running and still won't run, but this allows us to enable it bit by bit rather than turning it on all at once once we get to that point.