### PR TITLE
feat(seer): Add structured LLM context for replay list and detail pages

### DIFF
--- a/static/app/views/explore/replays/details.tsx
+++ b/static/app/views/explore/replays/details.tsx
@@ -91,7 +91,6 @@ function ReplayDetailsContent() {
     replayId: replayRecord?.id,
     replaySlug,
     projectSlug: readerResult.projectSlug,
-    userName: replayRecord?.user.display_name,
     browser: replayRecord?.browser.name,
     os: replayRecord?.os.name,
     duration: replayRecord?.duration,

--- a/static/app/views/explore/replays/details.tsx
+++ b/static/app/views/explore/replays/details.tsx
@@ -27,8 +27,10 @@ import {ReplayDetailsPageBreadcrumbs} from 'sentry/views/explore/replays/detail/
 import {ReplayDetailsUserBadge} from 'sentry/views/explore/replays/detail/header/replayDetailsUserBadge';
 import {ReplayDetailsPage} from 'sentry/views/explore/replays/detail/page';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
+import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
-export default function ReplayDetails() {
+function ReplayDetailsInner() {
   return (
     <AnalyticsArea name="details">
       <ReplayAccess
@@ -83,6 +85,23 @@ function ReplayDetailsContent() {
     mobile: replay?.isVideoReplay(),
   });
 
+  useLLMContext({
+    contextHint:
+      'Sentry session replay detail page. The user is viewing a specific recorded browser session. You can look up full details for this replay using the replayId below, query for related replay sessions, or search live telemetry for errors and spans associated with this session.',
+    replayId: replayRecord?.id,
+    replaySlug,
+    projectSlug: readerResult.projectSlug,
+    userName: replayRecord?.user.display_name,
+    browser: replayRecord?.browser.name,
+    os: replayRecord?.os.name,
+    duration: replayRecord?.duration,
+    countErrors: replayRecord?.count_errors,
+    countRageClicks: replayRecord?.count_rage_clicks,
+    countDeadClicks: replayRecord?.count_dead_clicks,
+    environment: replayRecord?.environment,
+    platform: replayRecord?.platform,
+  });
+
   const title = replayRecord
     ? `${replayRecord.user.display_name ?? t('Anonymous User')} — Session Replay — ${orgSlug}`
     : `Session Replay — ${orgSlug}`;
@@ -124,3 +143,5 @@ function ReplayDetailsContent() {
     </SentryDocumentTitle>
   );
 }
+
+export default registerLLMContext('replay-detail', ReplayDetailsInner);

--- a/static/app/views/explore/replays/list.tsx
+++ b/static/app/views/explore/replays/list.tsx
@@ -117,22 +117,6 @@ function useReplayListLLMContextData({
   });
 }
 
-function ReplaysListContainerInner() {
-  const organization = useOrganization();
-
-  return (
-    <AnalyticsArea name="list">
-      <SentryDocumentTitle title="Session Replay" orgSlug={organization.slug}>
-        <ReplayPreferencesContextProvider prefsStrategy={LocalStorageReplayPreferences}>
-          <ReplayQueryParamsProvider>
-            <ReplaysListBody />
-          </ReplayQueryParamsProvider>
-        </ReplayPreferencesContextProvider>
-      </SentryDocumentTitle>
-    </AnalyticsArea>
-  );
-}
-
 function ReplaysListBody() {
   useReplayPageview('replay.list-time-spent');
   const organization = useOrganization();
@@ -202,4 +186,20 @@ function ReplaysListBody() {
   );
 }
 
-export default registerLLMContext('replays-list', ReplaysListContainerInner);
+function ReplaysListContainer() {
+  const organization = useOrganization();
+
+  return (
+    <AnalyticsArea name="list">
+      <SentryDocumentTitle title="Session Replay" orgSlug={organization.slug}>
+        <ReplayPreferencesContextProvider prefsStrategy={LocalStorageReplayPreferences}>
+          <ReplayQueryParamsProvider>
+            <ReplaysListBody />
+          </ReplayQueryParamsProvider>
+        </ReplayPreferencesContextProvider>
+      </SentryDocumentTitle>
+    </AnalyticsArea>
+  );
+}
+
+export default registerLLMContext('replays-list', ReplaysListContainer);

--- a/static/app/views/explore/replays/list.tsx
+++ b/static/app/views/explore/replays/list.tsx
@@ -13,6 +13,7 @@ import {
   ReplayAccess,
   ReplayAccessFallbackAlert,
 } from 'sentry/components/replays/replayAccess';
+import {useReplayTableSort} from 'sentry/components/replays/table/useReplayTableSort';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
@@ -35,6 +36,7 @@ import {
   useQueryParamsId,
   useQueryParamsTitle,
 } from 'sentry/views/explore/queryParams/context';
+import {useQueryParamsSearch} from 'sentry/views/explore/queryParams/context';
 import {useAllMobileProj} from 'sentry/views/explore/replays/detail/useAllMobileProj';
 import {ReplayIndexContainer} from 'sentry/views/explore/replays/list/replayIndexContainer';
 import {ReplayListControls} from 'sentry/views/explore/replays/list/replayListControls';
@@ -42,6 +44,8 @@ import {ReplayOnboardingPanel} from 'sentry/views/explore/replays/list/replayOnb
 import {ReplayQueryParamsProvider} from 'sentry/views/explore/replays/list/replayQueryParamsProvider';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
+import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
 const ReplayListPageHeaderHook = OverrideOrDefault({
   overrideName: 'component:replay-list-page-header',
@@ -93,7 +97,28 @@ function ReplaysHeader() {
   );
 }
 
-export default function ReplaysListContainer() {
+function ReplayListLLMContextData({
+  showDeadRageClickCards,
+  widgetIsOpen,
+}: {
+  showDeadRageClickCards: boolean;
+  widgetIsOpen: boolean;
+}) {
+  const searchQuery = useQueryParamsSearch().formatString();
+  const pageFilters = usePageFilters();
+  const {sortType} = useReplayTableSort();
+  useLLMContext({
+    contextHint:
+      'Sentry session replay list page. Users search and filter recorded browser sessions by attributes like error count, rage clicks, dead clicks, browser, OS, and user. You can search events with a replays filter to find sessions matching specific criteria, or look up an individual replay by its ID for full session details.',
+    searchQuery,
+    sort: `${sortType.kind === 'desc' ? '-' : ''}${sortType.field}`,
+    currentSelectedDateRange: pageFilters.selection.datetime,
+    deadRageClickWidgetsVisible: showDeadRageClickCards && widgetIsOpen,
+  });
+  return null;
+}
+
+function ReplaysListContainerInner() {
   useReplayPageview('replay.list-time-spent');
   const organization = useOrganization();
   const hasSentReplays = useHaveSelectedProjectsSentAnyReplayEvents();
@@ -132,6 +157,10 @@ export default function ReplaysListContainer() {
       <SentryDocumentTitle title="Session Replay" orgSlug={organization.slug}>
         <ReplayPreferencesContextProvider prefsStrategy={LocalStorageReplayPreferences}>
           <ReplayQueryParamsProvider>
+            <ReplayListLLMContextData
+              showDeadRageClickCards={showDeadRageClickCards}
+              widgetIsOpen={widgetIsOpen}
+            />
             <Stack flex={1}>
               <ReplaysHeader />
               <PageFiltersContainer>
@@ -167,3 +196,5 @@ export default function ReplaysListContainer() {
     </AnalyticsArea>
   );
 }
+
+export default registerLLMContext('replays-list', ReplaysListContainerInner);

--- a/static/app/views/explore/replays/list.tsx
+++ b/static/app/views/explore/replays/list.tsx
@@ -97,7 +97,7 @@ function ReplaysHeader() {
   );
 }
 
-function ReplayListLLMContextData({
+function useReplayListLLMContextData({
   showDeadRageClickCards,
   widgetIsOpen,
 }: {
@@ -115,10 +115,25 @@ function ReplayListLLMContextData({
     currentSelectedDateRange: pageFilters.selection.datetime,
     deadRageClickWidgetsVisible: showDeadRageClickCards && widgetIsOpen,
   });
-  return null;
 }
 
 function ReplaysListContainerInner() {
+  const organization = useOrganization();
+
+  return (
+    <AnalyticsArea name="list">
+      <SentryDocumentTitle title="Session Replay" orgSlug={organization.slug}>
+        <ReplayPreferencesContextProvider prefsStrategy={LocalStorageReplayPreferences}>
+          <ReplayQueryParamsProvider>
+            <ReplaysListBody />
+          </ReplayQueryParamsProvider>
+        </ReplayPreferencesContextProvider>
+      </SentryDocumentTitle>
+    </AnalyticsArea>
+  );
+}
+
+function ReplaysListBody() {
   useReplayPageview('replay.list-time-spent');
   const organization = useOrganization();
   const hasSentReplays = useHaveSelectedProjectsSentAnyReplayEvents();
@@ -146,6 +161,8 @@ function ReplaysListContainerInner() {
   );
   const toggleWidgets = () => setWidgetIsOpen(isOpen => !isOpen);
 
+  useReplayListLLMContextData({showDeadRageClickCards, widgetIsOpen});
+
   useRouteAnalyticsParams({
     hasSessionReplay,
     hasSentReplays: hasSentReplays.hasSentOneReplay,
@@ -153,47 +170,35 @@ function ReplaysListContainerInner() {
   });
 
   return (
-    <AnalyticsArea name="list">
-      <SentryDocumentTitle title="Session Replay" orgSlug={organization.slug}>
-        <ReplayPreferencesContextProvider prefsStrategy={LocalStorageReplayPreferences}>
-          <ReplayQueryParamsProvider>
-            <ReplayListLLMContextData
+    <Stack flex={1}>
+      <ReplaysHeader />
+      <PageFiltersContainer>
+        <ExploreBodySearch>
+          <Layout.Main width="full">
+            <ReplayListControls
+              onToggleWidgets={toggleWidgets}
               showDeadRageClickCards={showDeadRageClickCards}
               widgetIsOpen={widgetIsOpen}
             />
-            <Stack flex={1}>
-              <ReplaysHeader />
-              <PageFiltersContainer>
-                <ExploreBodySearch>
-                  <Layout.Main width="full">
-                    <ReplayListControls
-                      onToggleWidgets={toggleWidgets}
-                      showDeadRageClickCards={showDeadRageClickCards}
-                      widgetIsOpen={widgetIsOpen}
-                    />
-                  </Layout.Main>
-                </ExploreBodySearch>
-                <ExploreBodyContent>
-                  <ExploreContentSection gap="xl">
-                    <ReplayListPageHeaderHook />
-                    {hasSessionReplay && hasSentReplays.hasSentOneReplay ? (
-                      <ReplayAccess fallback={<ReplayAccessFallbackAlert />}>
-                        <ReplayIndexContainer
-                          showDeadRageClickCards={showDeadRageClickCards}
-                          widgetIsOpen={widgetIsOpen}
-                        />
-                      </ReplayAccess>
-                    ) : (
-                      <ReplayOnboardingPanel />
-                    )}
-                  </ExploreContentSection>
-                </ExploreBodyContent>
-              </PageFiltersContainer>
-            </Stack>
-          </ReplayQueryParamsProvider>
-        </ReplayPreferencesContextProvider>
-      </SentryDocumentTitle>
-    </AnalyticsArea>
+          </Layout.Main>
+        </ExploreBodySearch>
+        <ExploreBodyContent>
+          <ExploreContentSection gap="xl">
+            <ReplayListPageHeaderHook />
+            {hasSessionReplay && hasSentReplays.hasSentOneReplay ? (
+              <ReplayAccess fallback={<ReplayAccessFallbackAlert />}>
+                <ReplayIndexContainer
+                  showDeadRageClickCards={showDeadRageClickCards}
+                  widgetIsOpen={widgetIsOpen}
+                />
+              </ReplayAccess>
+            ) : (
+              <ReplayOnboardingPanel />
+            )}
+          </ExploreContentSection>
+        </ExploreBodyContent>
+      </PageFiltersContainer>
+    </Stack>
   );
 }
 

--- a/static/app/views/seerExplorer/contexts/llmContextTypes.ts
+++ b/static/app/views/seerExplorer/contexts/llmContextTypes.ts
@@ -24,6 +24,8 @@ export type LLMContextNodeType =
   | 'issue-list'
   | 'logs-explorer'
   | 'releases-list'
+  | 'replay-detail'
+  | 'replays-list'
   | 'trace'
   | 'traces-explorer'
   | 'widget'

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -156,6 +156,8 @@ describe('useSeerExplorer', () => {
       '/issues/:groupId/distributions/',
       '/issues/:groupId/distributions/:tagKey/',
       '/explore/logs/trace/:traceSlug/',
+      '/explore/replays/',
+      '/explore/replays/:replaySlug/',
     ])('sends structured JSON on structured-context route %s', async (route: string) => {
       jest.spyOn(seerExplorerUtils, 'usePageReferrer').mockReturnValue({
         getPageReferrer: () => route,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -44,6 +44,8 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/explore/logs/',
   '/explore/logs/trace/:traceSlug/',
   '/explore/releases/',
+  '/explore/replays/',
+  '/explore/replays/:replaySlug/',
   '/explore/traces/',
   '/explore/traces/trace/:traceSlug/',
   '/issues/',


### PR DESCRIPTION
+ Register /explore/replays/ and /explore/replays/:replaySlug/ in STRUCTURED_CONTEXT_ROUTES so Seer receives structured JSON context instead of an ASCII screenshot fallback on these pages.

+ The replay list page provides search query, sort order, date range, and dead/rage click widget visibility. The replay detail page provides replay metadata including user, browser, OS, duration, error and click counts, environment, and platform.
