### PR TITLE
feat(seer): always show action buttons in explorer chat blocks

### DIFF
--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -696,11 +696,6 @@ const ActionButtonBar = styled(Flex)`
   white-space: nowrap;
   font-size: ${p => p.theme.font.size.sm};
   background: ${p => p.theme.tokens.background.primary};
-  visibility: hidden;
-
-  ${Block}:hover & {
-    visibility: visible;
-  }
 `;
 
 const TodoListContent = styled(MarkedText)`


### PR DESCRIPTION
## Summary

- Removed `visibility: hidden` and the `Block:hover` CSS rule from `ActionButtonBar` in `blockComponents.tsx`
- The thumbs up/down feedback buttons and copy button in the Seer Explorer chat are now always visible instead of only appearing on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)