### PR TITLE
fix(search): Prevent Ask AI from doubling pasted query text

### DIFF
--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -74,10 +74,12 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
     ?.join(' ')
     ?.trim();
 
-  // Use filteredCommittedQuery if it exists and has content, otherwise fall back to queryToUse
+  // Use filteredCommittedQuery if it has content.
+  // Only fall back to queryToUse when there's no inputValue to filter by.
+  // This prevents duplication when the entire query is free text matching inputValue.
   if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
     initialSeerQuery = filteredCommittedQuery;
-  } else if (queryDetails?.queryToUse) {
+  } else if (!inputValue && queryDetails?.queryToUse) {
     initialSeerQuery = queryDetails.queryToUse;
   }
 

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -85,10 +85,12 @@ export function LogsTabSeerComboBox() {
     ?.join(' ')
     ?.trim();
 
-  // Use filteredCommittedQuery if it exists and has content, otherwise fall back to queryToUse
+  // Use filteredCommittedQuery if it has content.
+  // Only fall back to queryToUse when there's no inputValue to filter by.
+  // This prevents duplication when the entire query is free text matching inputValue.
   if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
     initialSeerQuery = filteredCommittedQuery;
-  } else if (queryDetails?.queryToUse) {
+  } else if (!inputValue && queryDetails?.queryToUse) {
     initialSeerQuery = queryDetails.queryToUse;
   }
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -108,10 +108,12 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     .join(' ')
     .trim();
 
-  // Use filteredCommittedQuery if it exists and has content, otherwise fall back to queryToUse
+  // Use filteredCommittedQuery if it has content.
+  // Only fall back to queryToUse when there's no inputValue to filter by.
+  // This prevents duplication when the entire query is free text matching inputValue.
   if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
     initialSeerQuery = filteredCommittedQuery;
-  } else if (queryDetails.queryToUse) {
+  } else if (!inputValue && queryDetails.queryToUse) {
     initialSeerQuery = queryDetails.queryToUse;
   }
 

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -108,10 +108,12 @@ export function SpansTabSeerComboBox() {
     ?.join(' ')
     ?.trim();
 
-  // Use filteredCommittedQuery if it exists and has content, otherwise fall back to queryToUse
+  // Use filteredCommittedQuery if it has content.
+  // Only fall back to queryToUse when there's no inputValue to filter by.
+  // This prevents duplication when the entire query is free text matching inputValue.
   if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
     initialSeerQuery = filteredCommittedQuery;
-  } else if (queryDetails?.queryToUse) {
+  } else if (!inputValue && queryDetails?.queryToUse) {
     initialSeerQuery = queryDetails.queryToUse;
   }
 


### PR DESCRIPTION
## Summary
- Fixes a bug where pasting text into the search bar and clicking "Ask AI" would double the query text (e.g. "show me errors" → "show me errors show me errors")
- Root cause: when the entire query is free text, the `initialSeerQuery` builder filters it out, falls back to the unfiltered query, then appends `inputValue` again
- Adds `!inputValue` guard to the fallback branch in 4 strategy wrappers (Logs, Spans, Metrics, Discover Issues), matching the fix already present in `issueList/issueListSeerComboBox.tsx`

Fixes AIML-2875

## Test plan
- [x] Existing `askSeerComboBox.spec.tsx` tests pass
- [x] Lint passes on all changed files
- [x] Manual: paste a natural language query into Logs/Spans/Metrics search bar → click Ask AI → query text should appear once, not doubled
- [x] Manual: existing filter + pasted free text (e.g. `browser.name:Firefox` + paste "show me errors") → Ask AI shows `browser.name:Firefox show me errors`