### PR TITLE
perf(preprod): Optimize snapshot download with connection reuse and progressive streaming

### DIFF
--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -87,8 +87,8 @@ def create_client() -> Client:
         timeout_ms=options.get("timeout_ms", None),
         connection_kwargs=options.get(
             "connection_kwargs",
-            # Workaround for 0.0.14's default read timeout. Can be removed with 0.0.15
-            {"timeout": urllib3.Timeout(connect=0.1)},
+            # timeout is a workaround for 0.0.14's default read timeout, can be removed with 0.0.15
+            {"timeout": urllib3.Timeout(connect=0.1), "maxsize": 32},
         ),
         token=token_generator,
     )

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_download.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_download.py
@@ -4,6 +4,7 @@ import logging
 import zipfile
 from collections import defaultdict
 from collections.abc import Generator
+from concurrent.futures import as_completed
 from io import BytesIO
 
 import orjson
@@ -32,7 +33,6 @@ from sentry.utils.zip import is_unsafe_path
 
 logger = logging.getLogger(__name__)
 
-FETCH_BATCH_SIZE = 200
 FETCH_MAX_WORKERS = 32
 
 
@@ -151,19 +151,20 @@ class OrganizationPreprodSnapshotDownloadEndpoint(OrganizationEndpoint):
                     return (image_hash, None)
 
             try:
+                # as_completed() streams results as they finish rather than in
+                # submission order, so zip bytes flow to the client progressively
+                # instead of waiting for the slowest image in each batch.
                 with ContextPropagatingThreadPoolExecutor(
                     max_workers=FETCH_MAX_WORKERS
                 ) as executor:
-                    for batch_start in range(0, len(unique_hashes), FETCH_BATCH_SIZE):
-                        batch = unique_hashes[batch_start : batch_start + FETCH_BATCH_SIZE]
-
-                        for image_hash, data in executor.map(fetch_image, batch):
-                            if data is None:
-                                failed_count += 1
-                                continue
-                            for filename in hash_to_filenames[image_hash]:
-                                zf.writestr(filename, data)
-
+                    futures = [executor.submit(fetch_image, h) for h in unique_hashes]
+                    for future in as_completed(futures):
+                        image_hash, data = future.result()
+                        if data is None:
+                            failed_count += 1
+                            continue
+                        for filename in hash_to_filenames[image_hash]:
+                            zf.writestr(filename, data)
                         chunk = buf.drain()
                         if chunk:
                             yield chunk


### PR DESCRIPTION
Optimizes the bulk snapshot image download endpoint in two ways:

**Connection pool sizing** — The global objectstore `Client` was using
`urllib3.HTTPConnectionPool(maxsize=1, block=False)`. With 32 concurrent
worker threads, 31 of them created ephemeral TCP connections that were
discarded after each request. Increasing `maxsize` to 32 lets the pool
cache idle connections for reuse, eliminating unnecessary connection
setup/teardown overhead.

**Progressive streaming** — Replaced the batched `executor.map()` pattern
with `executor.submit()` + `as_completed()`. Previously, results were
returned in submission order (head-of-line blocking) and the zip buffer
only drained after each 200-image batch completed. Now zip bytes flow to
the client as each image finishes, reducing time-to-first-byte and peak
memory.