### PR TITLE
feat(routes): Add redirect from /snapshots/ to explore releases

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1703,9 +1703,16 @@ function buildRoutes(): RouteObject[] {
   };
 
   const snapshotsRedirect: SentryRouteObject = {
-    path: '/snapshots/',
-    redirectTo: '/explore/releases/?tab=snapshots',
-    withOrgPath: true,
+    children: [
+      {
+        path: '/snapshots/',
+        redirectTo: '/explore/releases/?tab=snapshots',
+      },
+      {
+        path: '/organizations/:orgId/snapshots/',
+        redirectTo: '/organizations/:orgId/explore/releases/?tab=snapshots',
+      },
+    ],
   };
 
   const discoverChildren: SentryRouteObject[] = [

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1702,6 +1702,12 @@ function buildRoutes(): RouteObject[] {
     ],
   };
 
+  const snapshotsRedirect: SentryRouteObject = {
+    path: '/snapshots/',
+    redirectTo: '/explore/releases/?tab=snapshots',
+    withOrgPath: true,
+  };
+
   const discoverChildren: SentryRouteObject[] = [
     {
       index: true,
@@ -2775,6 +2781,7 @@ function buildRoutes(): RouteObject[] {
       preprodRoutes,
       replayRoutes,
       releasesRoutes,
+      snapshotsRedirect,
       statsRoutes,
       discoverRoutes,
       errorsRoutes,


### PR DESCRIPTION
Adds a client-side redirect so that visiting `/snapshots/` (e.g. `sentry.sentry.io/snapshots`) takes users to `/explore/releases/?tab=snapshots`.

Uses the existing `redirectTo` + `withOrgPath` route pattern, so it works on both customer domain URLs and org-prefixed paths.