### PR TITLE
fix(settings): Fix CI permission checkbox not reflecting state

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.spec.tsx
@@ -1,38 +1,30 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
-import {Form} from 'sentry/components/forms/form';
-import {FormModel} from 'sentry/components/forms/model';
+import type {Permissions} from 'sentry/types/integrations';
 import {PermissionSelection} from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
 
+const defaultPermissions: Permissions = {
+  Event: 'no-access',
+  Team: 'no-access',
+  Member: 'no-access',
+  Project: 'write',
+  Release: 'admin',
+  Organization: 'admin',
+};
+
+const noop = () => {};
+
 describe('PermissionSelection', () => {
-  let onChange: jest.Mock;
-  let model: FormModel;
-
-  function renderForm() {
-    model = new FormModel();
-    onChange = jest.fn();
-    render(
-      <Form model={model}>
-        <PermissionSelection
-          appPublished={false}
-          hasContinuousIntegration
-          permissions={{
-            Event: 'no-access',
-            Team: 'no-access',
-            Member: 'no-access',
-            Project: 'write',
-            Release: 'admin',
-            Organization: 'admin',
-          }}
-          onChange={onChange}
-        />
-      </Form>
-    );
-  }
-
   it('renders a row for each resource', async () => {
-    renderForm();
+    render(
+      <PermissionSelection
+        appPublished={false}
+        hasContinuousIntegration
+        permissions={defaultPermissions}
+        onChange={noop}
+      />
+    );
     expect(await screen.findByRole('textbox', {name: 'Project'})).toBeInTheDocument();
     expect(screen.getByRole('textbox', {name: 'Team'})).toBeInTheDocument();
     expect(screen.getByRole('textbox', {name: 'Release'})).toBeInTheDocument();
@@ -45,7 +37,14 @@ describe('PermissionSelection', () => {
   });
 
   it('lists human readable permissions', async () => {
-    renderForm();
+    render(
+      <PermissionSelection
+        appPublished={false}
+        hasContinuousIntegration
+        permissions={defaultPermissions}
+        onChange={noop}
+      />
+    );
     await screen.findByRole('textbox', {name: 'Project'});
     const expectOptions = async (name: string, options: string[]) => {
       for (const option of options) {
@@ -62,7 +61,15 @@ describe('PermissionSelection', () => {
   });
 
   it('stores the permissions the User has selected', async () => {
-    renderForm();
+    const onChange = jest.fn();
+    render(
+      <PermissionSelection
+        appPublished={false}
+        hasContinuousIntegration
+        permissions={defaultPermissions}
+        onChange={onChange}
+      />
+    );
     await screen.findByRole('textbox', {name: 'Project'});
     const selectByValue = (name: string, value: string) =>
       selectEvent.select(screen.getByRole('textbox', {name}), value);
@@ -74,24 +81,157 @@ describe('PermissionSelection', () => {
     await selectByValue('Organization', 'Read');
     await selectByValue('Member', 'No Access');
 
-    expect(model.getValue('Project--permission')).toBe('write');
-    expect(model.getValue('Team--permission')).toBe('read');
-    expect(model.getValue('Release--permission')).toBe('admin');
-    expect(model.getValue('Event--permission')).toBe('admin');
-    expect(model.getValue('Organization--permission')).toBe('read');
-    expect(model.getValue('Member--permission')).toBe('no-access');
+    expect(onChange).toHaveBeenLastCalledWith(
+      {
+        Project: 'write',
+        Team: 'read',
+        Release: 'admin',
+        Event: 'admin',
+        Organization: 'read',
+        Member: 'no-access',
+      },
+      true
+    );
   });
 
-  it('stores the Continuous Integration permission', async () => {
-    renderForm();
-    const ciCheckbox = await screen.findByRole('checkbox', {
+  it('reflects the initial CI checkbox state', () => {
+    render(
+      <PermissionSelection
+        appPublished={false}
+        hasContinuousIntegration
+        permissions={defaultPermissions}
+        onChange={noop}
+      />
+    );
+    expect(
+      screen.getByRole('checkbox', {name: 'Continuous Integration (CI)'})
+    ).toBeChecked();
+  });
+
+  it('reflects initial unchecked CI checkbox state', () => {
+    render(
+      <PermissionSelection
+        appPublished={false}
+        hasContinuousIntegration={false}
+        permissions={defaultPermissions}
+        onChange={noop}
+      />
+    );
+    expect(
+      screen.getByRole('checkbox', {name: 'Continuous Integration (CI)'})
+    ).not.toBeChecked();
+  });
+
+  it('unchecks the Continuous Integration permission', async () => {
+    const onChange = jest.fn();
+    render(
+      <PermissionSelection
+        appPublished={false}
+        hasContinuousIntegration
+        permissions={defaultPermissions}
+        onChange={onChange}
+      />
+    );
+    const ciCheckbox = screen.getByRole('checkbox', {
       name: 'Continuous Integration (CI)',
     });
 
     expect(ciCheckbox).toBeChecked();
     await userEvent.click(ciCheckbox);
 
-    expect(model.getValue('ContinuousIntegration--permission')).toBe(false);
-    expect(model.getValue('scopes')).not.toContain('org:ci');
+    expect(ciCheckbox).not.toBeChecked();
+    expect(onChange).toHaveBeenLastCalledWith(expect.any(Object), false);
+  });
+
+  it('disables all controls when the app is published', () => {
+    render(
+      <PermissionSelection
+        appPublished
+        hasContinuousIntegration
+        permissions={defaultPermissions}
+        onChange={noop}
+      />
+    );
+    expect(screen.getByRole('textbox', {name: 'Project'})).toBeDisabled();
+    expect(screen.getByRole('textbox', {name: 'Team'})).toBeDisabled();
+    expect(screen.getByRole('textbox', {name: 'Release'})).toBeDisabled();
+    expect(screen.getByRole('textbox', {name: 'Issue & Event'})).toBeDisabled();
+    expect(screen.getByRole('textbox', {name: 'Organization'})).toBeDisabled();
+    expect(screen.getByRole('textbox', {name: 'Member'})).toBeDisabled();
+    expect(
+      screen.getByRole('checkbox', {name: 'Continuous Integration (CI)'})
+    ).toBeDisabled();
+  });
+
+  it('hides the CI checkbox when displaySpecialPermissions is false', () => {
+    render(
+      <PermissionSelection
+        appPublished={false}
+        hasContinuousIntegration
+        permissions={defaultPermissions}
+        onChange={noop}
+        displaySpecialPermissions={false}
+      />
+    );
+    expect(
+      screen.queryByRole('checkbox', {name: 'Continuous Integration (CI)'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders only the provided displayedPermissions', () => {
+    render(
+      <PermissionSelection
+        appPublished={false}
+        hasContinuousIntegration
+        permissions={defaultPermissions}
+        onChange={noop}
+        displayedPermissions={[
+          {
+            resource: 'Project',
+            help: 'Projects',
+            choices: {
+              'no-access': {label: 'No Access', scopes: []},
+              read: {label: 'Read', scopes: ['project:read']},
+            },
+          },
+        ]}
+      />
+    );
+    expect(screen.getByRole('textbox', {name: 'Project'})).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', {name: 'Team'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox', {name: 'Organization'})).not.toBeInTheDocument();
+  });
+
+  it('renders permission errors', () => {
+    render(
+      <PermissionSelection
+        appPublished={false}
+        hasContinuousIntegration
+        permissions={defaultPermissions}
+        onChange={noop}
+        errors={{
+          Project:
+            "Requested permission of project:write exceeds requester's permission.",
+        }}
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      "Requested permission of project:write exceeds requester's permission."
+    );
+  });
+
+  it('renders continuous integration error', () => {
+    render(
+      <PermissionSelection
+        appPublished={false}
+        hasContinuousIntegration
+        permissions={defaultPermissions}
+        onChange={noop}
+        continuousIntegrationError="Requested permission of org:ci exceeds requester's permission."
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      "Requested permission of org:ci exceeds requester's permission."
+    );
   });
 });

--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -148,7 +148,7 @@ function SpecialPermissionField({
         onChange: formOnChange,
       }: {
         id: string;
-        onChange: (...args: any[]) => void;
+        onChange: (value: boolean, event: ChangeEvent<HTMLInputElement>) => void;
       }) => {
         const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
           formOnChange(event.target.checked, event);

--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -143,7 +143,13 @@ function SpecialPermissionField({
       name={name}
       onChange={onChange}
     >
-      {({id, onChange: formOnChange, value: checked}: any) => {
+      {({
+        id,
+        onChange: formOnChange,
+      }: {
+        id: string;
+        onChange: (...args: any[]) => void;
+      }) => {
         const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
           formOnChange(event.target.checked, event);
         };
@@ -156,7 +162,7 @@ function SpecialPermissionField({
                   id={id}
                   name={name}
                   disabled={disabled}
-                  checked={checked === true}
+                  checked={value}
                   onChange={handleChange}
                 />
               </Flex>

--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
@@ -1,53 +1,75 @@
-import {render} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Form} from 'sentry/components/forms/form';
-import {FormModel} from 'sentry/components/forms/model';
 import {PermissionsObserver} from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
 
+const noop = () => {};
+
 describe('PermissionsObserver', () => {
-  let model: FormModel;
-
-  function renderForm() {
-    model = new FormModel();
-
+  it('defaults to no-access for resources not in scopes', () => {
+    const onScopesChange = jest.fn();
     render(
-      <Form model={model}>
-        <PermissionsObserver
-          scopes={[
-            'project:read',
-            'project:write',
-            'project:releases',
-            'org:admin',
-            'org:ci',
-          ]}
-          events={['issue']}
-          newApp={false}
-        />
-      </Form>
+      <PermissionsObserver
+        scopes={['project:read', 'project:write', 'project:releases', 'org:admin']}
+        events={['issue']}
+        newApp={false}
+        onScopesChange={onScopesChange}
+        onEventsChange={noop}
+      />
     );
-  }
-
-  it('defaults to no-access for all resources not passed', () => {
-    renderForm();
-    expect(model.getValue('Team--permission')).toBe('no-access');
-    expect(model.getValue('Event--permission')).toBe('no-access');
-    expect(model.getValue('Member--permission')).toBe('no-access');
+    expect(screen.getByRole('textbox', {name: 'Team'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Issue & Event'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Member'})).toBeInTheDocument();
   });
 
-  it('converts a raw list of scopes into permissions', () => {
-    renderForm();
-    expect(model.getValue('Project--permission')).toBe('write');
-    expect(model.getValue('Release--permission')).toBe('admin');
-    expect(model.getValue('Organization--permission')).toBe('admin');
+  it('converts scopes into permissions and passes them through on change', () => {
+    const onScopesChange = jest.fn();
+    render(
+      <PermissionsObserver
+        scopes={[
+          'project:read',
+          'project:write',
+          'project:releases',
+          'org:admin',
+          'org:ci',
+        ]}
+        events={['issue']}
+        newApp={false}
+        onScopesChange={onScopesChange}
+        onEventsChange={noop}
+      />
+    );
+    expect(screen.getByRole('textbox', {name: 'Project'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Release'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Organization'})).toBeInTheDocument();
   });
 
-  it('selects the highest ranking scope to convert to permission', () => {
-    renderForm();
-    expect(model.getValue('Project--permission')).toBe('write');
+  it('checks the CI checkbox when org:ci is in scopes', () => {
+    render(
+      <PermissionsObserver
+        scopes={['org:ci']}
+        events={[]}
+        newApp={false}
+        onScopesChange={noop}
+        onEventsChange={noop}
+      />
+    );
+    expect(
+      screen.getByRole('checkbox', {name: 'Continuous Integration (CI)'})
+    ).toBeChecked();
   });
 
-  it('stores the Continuous Integration scope separately', () => {
-    renderForm();
-    expect(model.getValue('ContinuousIntegration--permission')).toBe(true);
+  it('does not check the CI checkbox when org:ci is not in scopes', () => {
+    render(
+      <PermissionsObserver
+        scopes={['project:read']}
+        events={[]}
+        newApp={false}
+        onScopesChange={noop}
+        onEventsChange={noop}
+      />
+    );
+    expect(
+      screen.getByRole('checkbox', {name: 'Continuous Integration (CI)'})
+    ).not.toBeChecked();
   });
 });


### PR DESCRIPTION
was impossible to check this box on [new internal integrations ](https://sentry.sentry.io/settings/developer-settings/new-internal/)

<img width="797" height="138" alt="image" src="https://github.com/user-attachments/assets/f340a09f-bb19-482f-89cc-a83ea05497fc" />


The scraps form migration in #114138 removed the legacy `Form` wrapper that provided `FormContext` with a real `FormModel`. The `SpecialPermissionField` still uses `FormField`, which falls back to `MockModel` without that context. `MockModel.getValue()` reads `props.value` but the field passes `defaultValue`, so the checkbox value was always undefined

Reads checked state from the parent prop instead of the model.

Also rewrites the `permissionSelection` tests to render without the legacy `Form` wrapper, matching real usage, and adds coverage for errors, `appPublished`, `displaySpecialPermissions`, and `displayedPermissions`.