### PR TITLE
ref(api): move `GroupEventDetailsResponse` to event serializer module

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -198,6 +198,11 @@ class IssueEventSerializerResponse(SqlFormatEventSerializerResponse):
     resolvedWith: list[str]
 
 
+class GroupEventDetailsResponse(IssueEventSerializerResponse):
+    nextEventID: str | None
+    previousEventID: str | None
+
+
 @register(GroupEvent)
 @register(Event)
 class EventSerializer(Serializer):

--- a/src/sentry/apidocs/examples/event_examples.py
+++ b/src/sentry/apidocs/examples/event_examples.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from drf_spectacular.utils import OpenApiExample
 
-from sentry.issues.endpoints.project_event_details import GroupEventDetailsResponse
+from sentry.api.serializers.models.event import GroupEventDetailsResponse
 
 SIMPLE_EVENT = {
     "eventID": "9fac2ceed9344f2bbfdd1fdacb0ed9b1",

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -21,6 +21,7 @@ from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.group_index import parse_and_convert_issue_search_query
 from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.serializers import EventSerializer, serialize
+from sentry.api.serializers.models.event import GroupEventDetailsResponse
 from sentry.api.utils import get_date_range_from_params
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -34,10 +35,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.endpoints.bases.group import GroupEndpoint
-from sentry.issues.endpoints.project_event_details import (
-    GroupEventDetailsResponse,
-    wrap_event_response,
-)
+from sentry.issues.endpoints.project_event_details import wrap_event_response
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
 from sentry.models.group import Group

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -13,7 +13,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import IssueEventSerializer, serialize
-from sentry.api.serializers.models.event import IssueEventSerializerResponse
+from sentry.api.serializers.models.event import GroupEventDetailsResponse
 from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
@@ -21,11 +21,6 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-
-
-class GroupEventDetailsResponse(IssueEventSerializerResponse):
-    nextEventID: str | None
-    previousEventID: str | None
 
 
 def wrap_event_response(


### PR DESCRIPTION
Move `GroupEventDetailsResponse` closer to its parent. This prevents a circular import in the follow up PR (https://github.com/getsentry/sentry/pull/116059), where we use that serializer to document the API endpoint