### PR TITLE
feat(workflow-engine): Add Seer activity trigger for workflow automations

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -420,7 +420,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable seer activities to be evaluated in workflow engine
-    manager.add("organization:workflow-engine-evaluate-seer-activities", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-evaluate-seer-activities", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable our logs product (known internally as ourlogs) in UI and backend
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.

--- a/src/sentry/issues/activity_registry.py
+++ b/src/sentry/issues/activity_registry.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.utils.registry import Registry
+
+GroupActivityHandler = Callable[[Group, Activity], None]
+group_activity_registry = Registry[GroupActivityHandler](enable_reverse_lookup=False)
+
+
+def invoke_activity_handlers(group: Group, activity: Activity) -> None:
+    for handler in group_activity_registry.registrations.values():
+        handler(group, activity)

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -31,8 +31,13 @@ from sentry.shared_integrations.exceptions import (
     IntegrationConfigurationError,
     IntegrationFormError,
 )
-from sentry.types.activity import ActivityType
 from sentry.types.rules import RuleFuture
+from sentry.workflow_engine.handlers.workflow.workflow_activity_handler import (
+    SUPPORTED_WORKFLOW_ACTIVITIES,
+)
+from sentry.workflow_engine.handlers.workflow.workflow_status_update_handler import (
+    SUPPORTED_ACTIVITIES,
+)
 from sentry.workflow_engine.models import Action, AlertRuleWorkflow, Detector, Workflow
 from sentry.workflow_engine.types import (
     ActionInvocation,
@@ -425,7 +430,7 @@ class TicketingIssueAlertHandler(BaseIssueAlertHandler):
 
 
 class BaseMetricAlertHandler(ABC):
-    ACTIVITIES_TO_INVOKE_ON = [ActivityType.SET_RESOLVED.value]
+    ACTIVITIES_TO_INVOKE_ON = [*SUPPORTED_ACTIVITIES, *SUPPORTED_WORKFLOW_ACTIVITIES]
 
     @classmethod
     def send_alert(

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.constants import DataCategory
+from sentry.issues.activity_registry import invoke_activity_handlers
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -55,11 +56,11 @@ SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
     SentryAppEventType.SEER_SOLUTION_COMPLETED: ActivityType.SEER_SOLUTION_COMPLETED,
     SentryAppEventType.SEER_CODING_STARTED: ActivityType.SEER_CODING_STARTED,
     SentryAppEventType.SEER_CODING_COMPLETED: ActivityType.SEER_CODING_COMPLETED,
+    SentryAppEventType.SEER_PR_CREATED: ActivityType.SEER_PR_CREATED,
 }
 
 SEER_OPERATOR_AUTOFIX_UPDATE_EVENTS: set[SentryAppEventType] = {
     *SEER_EVENT_TO_ACTIVITY_TYPE.keys(),
-    SentryAppEventType.SEER_PR_CREATED,
 }
 
 logger = logging.getLogger(__name__)
@@ -724,12 +725,13 @@ def _create_seer_activity(
         if solution:
             activity_data["summary"] = solution.get("one_line_summary")
 
-    Activity.objects.create_group_activity(
+    activity = Activity.objects.create_group_activity(
         group,
         activity_type,
         data=activity_data if activity_data else None,
         send_notification=False,
     )
+    invoke_activity_handlers(group=group, activity=activity)
 
 
 @instrumented_task(

--- a/src/sentry/workflow_engine/endpoints/organization_data_condition_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_data_condition_index.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -22,7 +23,7 @@ from sentry.workflow_engine.endpoints.serializers.data_condition_handler_seriali
     DataConditionHandlerResponse,
     DataConditionHandlerSerializer,
 )
-from sentry.workflow_engine.models.data_condition import LEGACY_CONDITIONS
+from sentry.workflow_engine.models.data_condition import LEGACY_CONDITIONS, Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler
 
@@ -63,7 +64,13 @@ class OrganizationDataConditionIndexEndpoint(OrganizationEndpoint):
 
         data_conditions = []
 
+        has_seer_triggers = features.has(
+            "organizations:workflow-engine-evaluate-seer-activities", organization
+        )
+
         for condition_type, handler in condition_handler_registry.registrations.items():
+            if condition_type == Condition.SEER_ACTIVITY_TRIGGER and not has_seer_triggers:
+                continue
             if condition_type not in LEGACY_CONDITIONS and handler.group == group:
                 serialized = serialize(
                     handler,

--- a/src/sentry/workflow_engine/handlers/condition/__init__.py
+++ b/src/sentry/workflow_engine/handlers/condition/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "PercentSessionsPercentHandler",
     "ReappearedEventConditionHandler",
     "RegressionEventConditionHandler",
+    "SeerActivityTriggerCondition",
     "TaggedEventConditionHandler",
 ]
 
@@ -51,4 +52,5 @@ from .level_handler import LevelConditionHandler
 from .new_high_priority_issue_handler import NewHighPriorityIssueConditionHandler
 from .reappeared_event_handler import ReappearedEventConditionHandler
 from .regression_event_handler import RegressionEventConditionHandler
+from .seer_activity_trigger_conditions import SeerActivityTriggerCondition
 from .tagged_event_handler import TaggedEventConditionHandler

--- a/src/sentry/workflow_engine/handlers/condition/seer_activity_trigger_conditions.py
+++ b/src/sentry/workflow_engine/handlers/condition/seer_activity_trigger_conditions.py
@@ -1,0 +1,65 @@
+from typing import Any
+
+from sentry.models.activity import Activity
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.registry import condition_handler_registry
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
+
+
+class SeerActivityStage:
+    RCA_STARTED = "rca_started"
+    RCA_COMPLETED = "rca_completed"
+    SOLUTION_STARTED = "solution_started"
+    SOLUTION_COMPLETED = "solution_completed"
+    CODING_STARTED = "coding_started"
+    CODING_COMPLETED = "coding_completed"
+    PR_CREATED = "pr_created"
+
+
+SEER_ACTIVITY_STAGES = [
+    SeerActivityStage.RCA_STARTED,
+    SeerActivityStage.RCA_COMPLETED,
+    SeerActivityStage.SOLUTION_STARTED,
+    SeerActivityStage.SOLUTION_COMPLETED,
+    SeerActivityStage.CODING_STARTED,
+    SeerActivityStage.CODING_COMPLETED,
+    SeerActivityStage.PR_CREATED,
+]
+
+SEER_STAGE_TO_ACTIVITY_TYPE: dict[str, int] = {
+    SeerActivityStage.RCA_STARTED: ActivityType.SEER_RCA_STARTED.value,
+    SeerActivityStage.RCA_COMPLETED: ActivityType.SEER_RCA_COMPLETED.value,
+    SeerActivityStage.SOLUTION_STARTED: ActivityType.SEER_SOLUTION_STARTED.value,
+    SeerActivityStage.SOLUTION_COMPLETED: ActivityType.SEER_SOLUTION_COMPLETED.value,
+    SeerActivityStage.CODING_STARTED: ActivityType.SEER_CODING_STARTED.value,
+    SeerActivityStage.CODING_COMPLETED: ActivityType.SEER_CODING_COMPLETED.value,
+    SeerActivityStage.PR_CREATED: ActivityType.SEER_PR_CREATED.value,
+}
+
+
+@condition_handler_registry.register(Condition.SEER_ACTIVITY_TRIGGER)
+class SeerActivityTriggerCondition(DataConditionHandler[WorkflowEventData]):
+    group = DataConditionHandler.Group.WORKFLOW_TRIGGER
+    comparison_json_schema = {
+        "type": "array",
+        "items": {"type": "string", "enum": SEER_ACTIVITY_STAGES},
+        "minItems": 1,
+        "uniqueItems": True,
+    }
+
+    @staticmethod
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        event = event_data.event
+        if not isinstance(event, Activity):
+            return False
+
+        if not isinstance(comparison, list):
+            return False
+
+        expected_activity_types = {
+            SEER_STAGE_TO_ACTIVITY_TYPE[stage]
+            for stage in comparison
+            if stage in SEER_STAGE_TO_ACTIVITY_TYPE
+        }
+        return event.type in expected_activity_types

--- a/src/sentry/workflow_engine/handlers/workflow/__init__.py
+++ b/src/sentry/workflow_engine/handlers/workflow/__init__.py
@@ -1,3 +1,4 @@
+from .workflow_activity_handler import workflow_activity_handler
 from .workflow_status_update_handler import workflow_status_update_handler
 
-__all__ = ["workflow_status_update_handler"]
+__all__ = ["workflow_activity_handler", "workflow_status_update_handler"]

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handler.py
@@ -1,0 +1,55 @@
+import logging
+
+from sentry import features
+from sentry.issues.activity_registry import group_activity_registry
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.types.activity import ActivityType
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_WORKFLOW_ACTIVITIES = [
+    ActivityType.SEER_RCA_STARTED.value,
+    ActivityType.SEER_RCA_COMPLETED.value,
+    ActivityType.SEER_SOLUTION_STARTED.value,
+    ActivityType.SEER_SOLUTION_COMPLETED.value,
+    ActivityType.SEER_CODING_STARTED.value,
+    ActivityType.SEER_CODING_COMPLETED.value,
+    ActivityType.SEER_PR_CREATED.value,
+]
+
+
+@group_activity_registry.register("workflow_activity")
+def workflow_activity_handler(group: Group, activity: Activity) -> None:
+    from sentry.workflow_engine.models import Detector
+    from sentry.workflow_engine.tasks.workflows import process_workflow_activity
+
+    metrics.incr(
+        "workflow_engine.tasks.process_workflows.activity_created",
+        tags={"activity_type": activity.type},
+    )
+
+    if activity.type not in SUPPORTED_WORKFLOW_ACTIVITIES:
+        return
+
+    if not features.has(
+        "organizations:workflow-engine-evaluate-seer-activities", group.organization
+    ):
+        return
+
+    try:
+        detector = Detector.get_issue_stream_detector_for_project(group.project_id)
+    except Detector.DoesNotExist:
+        metrics.incr("workflow_engine.tasks.error.no_issue_stream_detector")
+        logger.error(
+            "Issue stream detector not found for project",
+            extra={"project_id": group.project_id, "group_id": group.id},
+        )
+        return
+
+    process_workflow_activity.delay(
+        activity_id=activity.id,
+        group_id=group.id,
+        detector_id=detector.id,
+    )

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -63,7 +63,7 @@ def workflow_status_update_handler(
 
     organization = Organization.objects.get_from_cache(pk=activity.project.organization_id)
     can_process_seer_activities = features.has(
-        "organization:workflow-engine-evaluate-seer-activities", organization
+        "organizations:workflow-engine-evaluate-seer-activities", organization
     )
 
     if activity.type in SEER_ACTIVITIES and not can_process_seer_activities:

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -56,6 +56,7 @@ class Condition(StrEnum):
     REAPPEARED_EVENT = "reappeared_event"
     REGRESSION_EVENT = "regression_event"
     TAGGED_EVENT = "tagged_event"
+    SEER_ACTIVITY_TRIGGER = "seer_activity_trigger"
 
     # Event frequency conditions
     EVENT_FREQUENCY_COUNT = "event_frequency_count"
@@ -74,6 +75,7 @@ TRIGGER_CONDITIONS = [
     Condition.ISSUE_RESOLVED_TRIGGER,
     Condition.REAPPEARED_EVENT,
     Condition.REGRESSION_EVENT,
+    Condition.SEER_ACTIVITY_TRIGGER,
 ]
 
 CONDITION_OPS = {

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -10,15 +10,11 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.services.eventstore.models import Event, GroupEvent
-from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context, scopedstats
-
-SUPPORTED_ACTIVITIES = [ActivityType.SET_RESOLVED.value]
-
 
 logger = log_context.get_logger(__name__)
 

--- a/static/app/components/workflowEngine/form/automationBuilderSelect.tsx
+++ b/static/app/components/workflowEngine/form/automationBuilderSelect.tsx
@@ -8,7 +8,7 @@ export function AutomationBuilderSelect(props: ComponentProps<typeof Select>) {
 }
 
 const StyledSelect = styled(Select)`
-  width: 180px;
+  min-width: 180px;
   padding: 0;
   > div {
     padding-left: 0;
@@ -20,7 +20,6 @@ export const selectControlStyles = {
   control: (provided: any) => ({
     ...provided,
     minHeight: '32px',
-    height: '32px',
     padding: 0,
   }),
 };

--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -34,6 +34,7 @@ export enum DataConditionType {
   REAPPEARED_EVENT = 'reappeared_event',
   ISSUE_RESOLVED_TRIGGER = 'issue_resolved_trigger',
   TAGGED_EVENT = 'tagged_event',
+  SEER_ACTIVITY_TRIGGER = 'seer_activity_trigger',
   ISSUE_PRIORITY_EQUALS = 'issue_priority_equals',
   ISSUE_PRIORITY_GREATER_OR_EQUAL = 'issue_priority_greater_or_equal',
   ISSUE_PRIORITY_DEESCALATING = 'issue_priority_deescalating',

--- a/static/app/views/automations/components/actionFilters/seerActivityTrigger.tsx
+++ b/static/app/views/automations/components/actionFilters/seerActivityTrigger.tsx
@@ -1,0 +1,67 @@
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
+import {t} from 'sentry/locale';
+import type {SelectValue} from 'sentry/types/core';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
+import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
+import type {ValidateDataConditionProps} from 'sentry/views/automations/components/automationFormData';
+import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+const SEER_ACTIVITY_STAGE_CHOICES: Array<{label: string; value: string}> = [
+  {value: 'rca_started', label: t('Root cause analysis started')},
+  {value: 'rca_completed', label: t('Root cause analysis completed')},
+  {value: 'solution_started', label: t('Solution search started')},
+  {value: 'solution_completed', label: t('Solution search completed')},
+  {value: 'coding_started', label: t('Coding started')},
+  {value: 'coding_completed', label: t('Coding completed')},
+  {value: 'pr_created', label: t('Pull request created')},
+];
+
+export function SeerActivityTriggerDetails({condition}: {condition: DataCondition}) {
+  const stages: string[] = Array.isArray(condition.comparison)
+    ? condition.comparison
+    : [];
+  const labels = stages
+    .map(s => SEER_ACTIVITY_STAGE_CHOICES.find(c => c.value === s)?.label)
+    .filter(Boolean);
+  if (labels.length === 1) {
+    return <span>{t("Seer reaches the '%s' stage", labels[0])}</span>;
+  }
+  return <span>{t('Seer reaches any of these stages: %s', labels.join(', '))}</span>;
+}
+
+export function SeerActivityTriggerNode() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  const {removeError} = useAutomationBuilderErrorContext();
+
+  const value: string[] = Array.isArray(condition.comparison) ? condition.comparison : [];
+
+  return (
+    <Flex direction="column" gap="sm">
+      <Text>{t('Seer runs on an issue and reaches the stage...')}</Text>
+      <AutomationBuilderSelect
+        multiple
+        name={`${condition_id}.comparison`}
+        aria-label={t('Seer activity stages')}
+        placeholder={t('Select a stage...')}
+        value={value}
+        options={SEER_ACTIVITY_STAGE_CHOICES}
+        onChange={(options: Array<SelectValue<string>>) => {
+          onUpdate({comparison: options.map(o => o.value)});
+          removeError(condition.id);
+        }}
+      />
+    </Flex>
+  );
+}
+
+export function validateSeerActivityTriggerCondition({
+  condition,
+}: ValidateDataConditionProps): string | undefined {
+  if (!Array.isArray(condition.comparison) || condition.comparison.length === 0) {
+    return t('You must select at least one Seer stage.');
+  }
+  return undefined;
+}

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -86,6 +86,11 @@ import {
   validatePercentSessionsCondition,
 } from 'sentry/views/automations/components/actionFilters/percentSessions';
 import {
+  SeerActivityTriggerDetails,
+  SeerActivityTriggerNode,
+  validateSeerActivityTriggerCondition,
+} from 'sentry/views/automations/components/actionFilters/seerActivityTrigger';
+import {
   TaggedEventDetails,
   TaggedEventNode,
   validateTaggedEventCondition,
@@ -162,6 +167,16 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Sentry marks an existing issue as high priority'),
       validate: undefined,
+    },
+  ],
+  [
+    DataConditionType.SEER_ACTIVITY_TRIGGER,
+    {
+      label: t('Seer runs on an issue and reaches the stage...'),
+      dataCondition: SeerActivityTriggerNode,
+      details: SeerActivityTriggerDetails,
+      defaultComparison: [],
+      validate: validateSeerActivityTriggerCondition,
     },
   ],
   [

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -164,7 +164,7 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
         )
 
         with (
-            self.feature("organization:workflow-engine-evaluate-seer-activities"),
+            self.feature("organizations:workflow-engine-evaluate-seer-activities"),
             mock.patch(
                 "sentry.workflow_engine.tasks.workflows.process_workflow_activity.delay"
             ) as mock_delay,


### PR DESCRIPTION
- Fix `organization:` → `organizations:` prefix for the `workflow-engine-evaluate-seer-activities` feature flag
- Add a single `SEER_ACTIVITY_TRIGGER` condition type with multiselect comparison value, replacing the need for 7 separate condition types per Seer pipeline stage
- Add activity registry (`group_activity_registry`) so Seer activity creation in the operator can invoke workflow handlers
- Add `workflow_activity_handler` to route supported Seer activities into the workflow engine
- Gate Seer trigger visibility in the data condition index endpoint behind the feature flag
- Frontend: multiselect `AutomationBuilderSelect` for picking Seer stages (RCA, solution, coding, PR creation)
- Allow `AutomationBuilderSelect` to grow for multiselect usage (`min-width` instead of fixed `width`, remove fixed `height`)