### PR TITLE
feat(preprod): Add images_skipped to builds API response and snapshot table

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -106,6 +106,7 @@ class SnapshotComparisonInfo(BaseModel):
     images_removed: int = 0
     images_changed: int = 0
     images_unchanged: int = 0
+    images_skipped: int = 0
     approval_status: ApprovalStatusLiteral | None = None
 
 
@@ -344,11 +345,13 @@ def to_snapshot_comparison_info(head_artifact: PreprodArtifact) -> SnapshotCompa
     images_removed = 0
     images_changed = 0
     images_unchanged = 0
+    images_skipped = 0
     if comparison is not None and comparison.state == PreprodSnapshotComparison.State.SUCCESS:
         images_added = comparison.images_added
         images_removed = comparison.images_removed
         images_changed = comparison.images_changed
         images_unchanged = comparison.images_unchanged
+        images_skipped = comparison.images_skipped
 
     return SnapshotComparisonInfo(
         image_count=snapshot_metrics.image_count,
@@ -358,6 +361,7 @@ def to_snapshot_comparison_info(head_artifact: PreprodArtifact) -> SnapshotCompa
         images_removed=images_removed,
         images_changed=images_changed,
         images_unchanged=images_unchanged,
+        images_skipped=images_skipped,
         approval_status=derived.approval_status,
     )
 

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
@@ -69,6 +69,7 @@ function makeBuild(
       images_removed: 0,
       images_changed: 3,
       images_unchanged: 19,
+      images_skipped: 0,
     },
     ...overrides,
   };
@@ -117,6 +118,7 @@ describe('PreprodBuildsSnapshotTable', () => {
               images_removed: 0,
               images_changed: 3,
               images_unchanged: 19,
+              images_skipped: 0,
             },
           })
         ),
@@ -137,6 +139,7 @@ describe('PreprodBuildsSnapshotTable', () => {
               images_removed: 0,
               images_changed: 0,
               images_unchanged: 0,
+              images_skipped: 0,
             },
           })
         ),
@@ -168,6 +171,7 @@ describe('PreprodBuildsSnapshotTable', () => {
               images_removed: 0,
               images_changed: 0,
               images_unchanged: 20,
+              images_skipped: 0,
             },
           })
         ),

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -31,18 +31,20 @@ function ChangeCounts({
   removed,
   changed,
   unchanged,
+  skipped,
   comparisonState,
 }: {
   added: number;
   changed: number;
   comparisonState: SnapshotComparisonState | null | undefined;
   removed: number;
+  skipped: number;
   unchanged: number;
 }) {
   if (comparisonState !== 'success') {
     return <Text variant="muted">{'–'}</Text>;
   }
-  if (added === 0 && removed === 0 && changed === 0) {
+  if (added === 0 && removed === 0 && changed === 0 && skipped === 0) {
     return (
       <Text size="sm" variant="muted">
         {t('No changes')}
@@ -61,6 +63,9 @@ function ChangeCounts({
   }
   if (unchanged > 0) {
     parts.push(t('%s unchanged', unchanged));
+  }
+  if (skipped > 0) {
+    parts.push(t('%s skipped', skipped));
   }
   return (
     <Text size="sm" variant="muted">
@@ -113,6 +118,7 @@ export function PreprodBuildsSnapshotTable({
               removed={info?.images_removed ?? 0}
               changed={info?.images_changed ?? 0}
               unchanged={info?.images_unchanged ?? 0}
+              skipped={info?.images_skipped ?? 0}
               comparisonState={info?.comparison_state}
             />
           </SimpleTable.RowCell>

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -211,5 +211,6 @@ interface SnapshotComparisonInfo {
   images_added: number;
   images_changed: number;
   images_removed: number;
+  images_skipped: number;
   images_unchanged: number;
 }


### PR DESCRIPTION
The `images_skipped` count was already computed during the snapshot diff task and stored on the `PreprodSnapshotComparison` DB model, but it was omitted from the builds API `snapshot_comparison_info` response and the frontend snapshot table.

This adds `images_skipped` to:
- The `SnapshotComparisonInfo` Pydantic model and its factory function (`to_snapshot_comparison_info`)
- The `SnapshotComparisonInfo` TypeScript interface
- The `ChangeCounts` component in the snapshots table, so it displays "N skipped" when applicable

Also fixes a bug in the `ChangeCounts` early return: previously, a selective run with 0 added/removed/changed but >0 skipped images would show "No changes" instead of "N skipped". The condition now checks `skipped === 0` as well.