### PR TITLE
fix(issues): Provide correct value for `search.sort` SDK tag

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -126,7 +126,7 @@ def build_query_params_from_request(
             query = saved_search.query
 
     sentry_sdk.set_tag("search.query", query)
-    sentry_sdk.set_tag("search.sort", query)
+    sentry_sdk.set_tag("search.sort", query_kwargs["sort_by"])
     if projects:
         sentry_sdk.set_tag("search.projects", len(projects) if len(projects) <= 5 else ">5")
     if environments:


### PR DESCRIPTION
This SDK tag is getting the wrong value - correcting to `query_kwargs["sort_by"]`.