### PR TITLE
fix: add catch-all path to explore route and redirect to index

### DIFF
--- a/static/app/router/routes.spec.tsx
+++ b/static/app/router/routes.spec.tsx
@@ -1,4 +1,4 @@
-import type {RouteObject} from 'react-router-dom';
+import {matchRoutes, type RouteObject} from 'react-router-dom';
 
 import * as constants from 'sentry/constants';
 import {buildRoutes} from 'sentry/router/routes';
@@ -65,6 +65,17 @@ function extractRoutes(rootRoute: RouteObject[]): Set<string> {
   return routes;
 }
 
+/**
+ * Returns the paths of all matched route segments for a given URL.
+ */
+function getMatchedPaths(routes: RouteObject[], url: string): string[] {
+  const matches = matchRoutes(routes, url);
+  if (!matches) {
+    return [];
+  }
+  return matches.map(m => m.route.path ?? '(layout)');
+}
+
 describe('buildRoutes()', () => {
   // Until customer-domains is enabled for single-tenant, self-hosted and path
   // based slug routes are removed we need to ensure
@@ -108,5 +119,20 @@ describe('buildRoutes()', () => {
           'If you need help with this drop by #proj-hybrid-cloud.'
       );
     }
+  });
+
+  describe('explore route catch-all', () => {
+    it('catches unknown subpaths under /explore/', () => {
+      const routes = buildRoutes();
+
+      let matchedPaths = getMatchedPaths(routes, '/explore/nonexistent-page/');
+      expect(matchedPaths).toContain('*');
+
+      matchedPaths = getMatchedPaths(
+        routes,
+        '/organizations/test-org/explore/nonexistent-page/also-nonexistent-page/'
+      );
+      expect(matchedPaths).toContain('*');
+    });
   });
 });

--- a/static/app/router/routes.spec.tsx
+++ b/static/app/router/routes.spec.tsx
@@ -123,16 +123,20 @@ describe('buildRoutes()', () => {
 
   describe('explore route catch-all', () => {
     it('catches unknown subpaths under /explore/', () => {
-      const routes = buildRoutes();
+      const spy = jest.spyOn(constants, 'USING_CUSTOMER_DOMAIN', 'get');
 
+      spy.mockReturnValue(true);
+      let routes = buildRoutes();
       let matchedPaths = getMatchedPaths(routes, '/explore/nonexistent-page/');
-      expect(matchedPaths).toContain('*');
+      expect(matchedPaths).toContain(':catchAll/');
 
+      spy.mockReturnValue(false);
+      routes = buildRoutes();
       matchedPaths = getMatchedPaths(
         routes,
         '/organizations/test-org/explore/nonexistent-page/also-nonexistent-page/'
       );
-      expect(matchedPaths).toContain('*');
+      expect(matchedPaths).toContain(':catchAll/*');
     });
   });
 });

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2336,9 +2336,13 @@ function buildRoutes(): RouteObject[] {
       path: 'saved-queries/',
       component: make(() => import('sentry/views/explore/savedQueries')),
     },
+    {
+      path: '*',
+      component: make(() => import('sentry/views/explore/indexRedirect')),
+    },
   ];
   const exploreRoutes: SentryRouteObject = {
-    path: '/explore/',
+    path: '/explore/*',
     withOrgPath: true,
     children: exploreChildren,
   };

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2336,6 +2336,8 @@ function buildRoutes(): RouteObject[] {
       path: 'saved-queries/',
       component: make(() => import('sentry/views/explore/savedQueries')),
     },
+    // These two routes have to be placed at the end of the exploreChildren
+    // array to avoid being overridden by the other routes.
     {
       path: ':catchAll/',
       component: make(() => import('sentry/views/explore/indexRedirect')),

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2337,12 +2337,16 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/explore/savedQueries')),
     },
     {
-      path: '*',
+      path: ':catchAll/',
+      component: make(() => import('sentry/views/explore/indexRedirect')),
+    },
+    {
+      path: ':catchAll/*',
       component: make(() => import('sentry/views/explore/indexRedirect')),
     },
   ];
   const exploreRoutes: SentryRouteObject = {
-    path: '/explore/*',
+    path: '/explore/',
     withOrgPath: true,
     children: exploreChildren,
   };


### PR DESCRIPTION
When a customer goes to explore/<random-path>, the user sees a “The project you were looking for was not found.” error, which is a wrong behavior and error to show. This is because it tries to match an explore/* path, which isn't defined, and eventually matches the **legacyOrgRedirects** route, treating both params as :orgId/:projectId. 

This ticket adds a splat (*) path to the explore path and redirects users to the index explore component. 

Fixes EXP-959