### PR TITLE
chore(activity): Remove duplicate call to calculate initial priority from group metadata

### DIFF
--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -44,11 +44,7 @@ class ActivityManager(BaseManager["Activity"]):
         activities = []
         activity_qs = self.filter(group=group).order_by("-datetime")
 
-        # Check if 'initial_priority' is available
-        initial_priority_value = group.get_event_metadata().get(
-            "initial_priority", None
-        ) or group.get_event_metadata().get("initial_priority", None)
-
+        initial_priority_value = group.get_event_metadata().get("initial_priority")
         initial_priority = (
             PriorityLevel(initial_priority_value).to_str() if initial_priority_value else None
         )


### PR DESCRIPTION
Removing an unnecessary duplicate call here to calculate priority from group metadata.