### PR TITLE
ref(api): type nullable fields in the base group serializer

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -111,7 +111,7 @@ class BaseGroupResponseOptional(TypedDict, total=False):
 
 class BaseGroupSerializerResponse(BaseGroupResponseOptional):
     id: str
-    shareId: str
+    shareId: str | None
     shortId: str
     title: str
     culprit: str | None
@@ -134,7 +134,7 @@ class BaseGroupSerializerResponse(BaseGroupResponseOptional):
     issueCategory: str
     metadata: dict[str, Any]
     numComments: int
-    assignedTo: ActorSerializerResponse
+    assignedTo: ActorSerializerResponse | None
     isBookmarked: bool
     isSubscribed: bool
     subscriptionDetails: SubscriptionDetails | None

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -281,7 +281,7 @@ class _Filtered(TypedDict):
 class StreamGroupSerializerSnubaResponse(TypedDict):
     id: str
     # from base response
-    shareId: NotRequired[str]
+    shareId: NotRequired[str | None]
     shortId: NotRequired[str]
     title: NotRequired[str]
     culprit: NotRequired[str | None]
@@ -304,7 +304,7 @@ class StreamGroupSerializerSnubaResponse(TypedDict):
     issueCategory: NotRequired[str]
     metadata: NotRequired[dict[str, Any]]
     numComments: NotRequired[int]
-    assignedTo: NotRequired[ActorSerializerResponse]
+    assignedTo: NotRequired[ActorSerializerResponse | None]
     isBookmarked: NotRequired[bool]
     isSubscribed: NotRequired[bool]
     subscriptionDetails: NotRequired[SubscriptionDetails | None]


### PR DESCRIPTION
For unshared / unassigned issues, the actual response from the API for endpoints using the BaseGroupSerializerResponse was null. Type that correctly in the serializer
