### PR TITLE
chore(typing): Remove `tests.sentry.issues.test_utils` from mypy ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -398,7 +398,6 @@ module = [
     "sentry.snuba.metrics.query_builder",
     "sentry.testutils.cases",
     "tests.sentry.api.helpers.test_group_index",
-    "tests.sentry.issues.test_utils",
 ]
 disable_error_code = [
     "arg-type",

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from hashlib import md5
 from typing import Any, TypedDict
@@ -104,7 +104,7 @@ def process_occurrence_data(data: dict[str, Any]) -> None:
     data["fingerprint"] = hash_fingerprint(data["fingerprint"])
 
 
-def hash_fingerprint(fingerprint: list[str]) -> list[str]:
+def hash_fingerprint(fingerprint: Sequence[str]) -> list[str]:
     return [md5(part.encode("utf-8")).hexdigest() for part in fingerprint]
 
 

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from sentry.event_manager import GroupInfo
 from sentry.issues.escalating.escalating import GroupsCountResponse
 from sentry.issues.grouptype import ProfileFileIOGroupType
-from sentry.issues.ingest import process_occurrence_data, save_issue_occurrence
+from sentry.issues.ingest import hash_fingerprint, save_issue_occurrence
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence, IssueOccurrenceData
 from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.issues.status_change_message import StatusChangeMessage, StatusChangeMessageData
@@ -58,7 +58,7 @@ class OccurrenceTestMixin:
         }
         kwargs.update(overrides)  # type: ignore[typeddict-item]
 
-        process_occurrence_data(kwargs)
+        kwargs["fingerprint"] = hash_fingerprint(kwargs["fingerprint"])
         return kwargs
 
     def build_occurrence(self, **overrides: Any) -> IssueOccurrence:
@@ -99,7 +99,7 @@ class StatusChangeTestMixin:
         }
         kwargs.update(overrides)  # type: ignore[typeddict-item]
 
-        process_occurrence_data(kwargs)
+        kwargs["fingerprint"] = hash_fingerprint(kwargs["fingerprint"])
         return kwargs
 
     def build_statuschange(self, **overrides: Any) -> StatusChangeMessage:
@@ -107,6 +107,9 @@ class StatusChangeTestMixin:
 
 
 class SearchIssueTestMixin(OccurrenceTestMixin):
+    def store_event(self, data: dict[str, Any], project_id: int, **kwargs: Any) -> Event:
+        raise NotImplementedError
+
     def store_search_issue(
         self,
         project_id: int,


### PR DESCRIPTION
Resolves [ENG-6461](https://linear.app/getsentry/issue/ENG-6461/remove-testssentryissuestest-utils-from-ignore-list).

Fixes the `mypy` errors in `tests/sentry/issues/test_utils.py`.