### PR TITLE
fix(settings): List all projects in context picker instead of default 1st page

### DIFF
--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -125,7 +125,7 @@ function ContextPickerContent({
         selectedOrgSlug && needProject
           ? {organizationIdOrSlug: selectedOrgSlug}
           : skipToken,
-      query: {collapse: ['latestDeploys', 'unusedFeatures']},
+      query: {all_projects: '1', collapse: ['latestDeploys', 'unusedFeatures']},
       staleTime: Infinity,
     })
   );


### PR DESCRIPTION
A quick fix for something I noticed: when linked to a generic settings page from our documentation:
https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/:projectId/security-and-privacy/

I was presented with a "Select a project to continue" modal that clearly listed a limited set of Sentry projects: they're alphabetically sorted and end at "I", so the main `sentry` project was missing.

Instead of accepting the default page size on
/organizations/{orgSlug}/projects/ we should pass `?allprojects=1` to ensure we get all projects at once.

Tested with dev-ui locally.

Before:
<img width="964" height="845" alt="Screenshot 2026-05-21 at 4 24 48 PM" src="https://github.com/user-attachments/assets/cdb5b43b-1571-4869-9548-f611a0279e46" />

After:
<img width="1033" height="904" alt="Screenshot 2026-05-21 at 4 24 59 PM" src="https://github.com/user-attachments/assets/d8e057ed-7582-4fad-bdb8-2dd553ba08db" />
