### PR TITLE
feat(preprod): Display images_skipped in snapshot table

### DIFF
--- a/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
@@ -69,6 +69,7 @@ function makeBuild(
       images_removed: 0,
       images_changed: 3,
       images_unchanged: 19,
+      images_skipped: 0,
     },
     ...overrides,
   };
@@ -117,6 +118,7 @@ describe('PreprodBuildsSnapshotTable', () => {
               images_removed: 0,
               images_changed: 3,
               images_unchanged: 19,
+              images_skipped: 0,
             },
           })
         ),
@@ -137,6 +139,7 @@ describe('PreprodBuildsSnapshotTable', () => {
               images_removed: 0,
               images_changed: 0,
               images_unchanged: 0,
+              images_skipped: 0,
             },
           })
         ),
@@ -168,6 +171,7 @@ describe('PreprodBuildsSnapshotTable', () => {
               images_removed: 0,
               images_changed: 0,
               images_unchanged: 20,
+              images_skipped: 0,
             },
           })
         ),

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -31,18 +31,20 @@ function ChangeCounts({
   removed,
   changed,
   unchanged,
+  skipped,
   comparisonState,
 }: {
   added: number;
   changed: number;
   comparisonState: SnapshotComparisonState | null | undefined;
   removed: number;
+  skipped: number;
   unchanged: number;
 }) {
   if (comparisonState !== 'success') {
     return <Text variant="muted">{'–'}</Text>;
   }
-  if (added === 0 && removed === 0 && changed === 0) {
+  if (added === 0 && removed === 0 && changed === 0 && skipped === 0) {
     return (
       <Text size="sm" variant="muted">
         {t('No changes')}
@@ -61,6 +63,9 @@ function ChangeCounts({
   }
   if (unchanged > 0) {
     parts.push(t('%s unchanged', unchanged));
+  }
+  if (skipped > 0) {
+    parts.push(t('%s skipped', skipped));
   }
   return (
     <Text size="sm" variant="muted">
@@ -113,6 +118,7 @@ export function PreprodBuildsSnapshotTable({
               removed={info?.images_removed ?? 0}
               changed={info?.images_changed ?? 0}
               unchanged={info?.images_unchanged ?? 0}
+              skipped={info?.images_skipped ?? 0}
               comparisonState={info?.comparison_state}
             />
           </SimpleTable.RowCell>

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -211,5 +211,6 @@ interface SnapshotComparisonInfo {
   images_added: number;
   images_changed: number;
   images_removed: number;
+  images_skipped: number;
   images_unchanged: number;
 }


### PR DESCRIPTION
Wire `images_skipped` into the frontend `ChangeCounts` component so the snapshots table displays skipped image counts when present (e.g., "5 skipped").

Also fixes a bug in the "No changes" early return: previously, a selective snapshot run with 0 added/removed/changed but >0 skipped images would show "No changes" instead of "N skipped". The condition now checks `skipped === 0` as well, matching the backend behavior in VCS status check templates.

Depends on #116073.