### PR TITLE
fix(workflows): Filter out workflows from other organizations

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3662,6 +3662,13 @@ register(
     default=1000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Skip workflows that don't belong to the event's organization.
+register(
+    "workflow_engine.filter_cross_org_workflows",
+    type=Bool,
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Higher opt-in limit for workflows; intended for orgs we know are hitting limits legitimately,
 # generally set to 'as high as we think we can safely handle for a handful of orgs'.
 register(

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -688,6 +688,8 @@ class Fixtures:
         return Factories.create_dashboard_widget_query(*args, **kwargs)
 
     def create_workflow(self, *args, **kwargs) -> Workflow:
+        if "organization" not in kwargs:
+            kwargs["organization"] = self.organization
         return Factories.create_workflow(*args, **kwargs)
 
     def create_data_source(self, *args, **kwargs) -> DataSource:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -476,6 +476,19 @@ def process_workflows(
         log_context.set_verbose(True)
 
     workflows = get_workflows_by_detectors(event_detectors.detectors, environment)
+    wrong_org_workflows = {wf for wf in workflows if wf.organization_id != organization.id}
+    if wrong_org_workflows:
+        logger.warning(
+            "workflow_engine.process_workflows.wrong_organization",
+            extra={
+                "organization_id": organization.id,
+                "wrong_org_workflow_ids": sorted(wf.id for wf in wrong_org_workflows),
+                "wrong_org_organization_ids": sorted(
+                    wf.organization_id for wf in wrong_org_workflows
+                ),
+            },
+        )
+        workflows = workflows - wrong_org_workflows
 
     if workflows:
         metrics_incr("process_workflows", len(workflows))

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 import sentry_sdk
 from django.db.models import Q
 
-from sentry import features
+from sentry import features, options
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
@@ -488,7 +488,8 @@ def process_workflows(
                 ),
             },
         )
-        workflows = workflows - wrong_org_workflows
+        if options.get("workflow_engine.filter_cross_org_workflows"):
+            workflows = workflows - wrong_org_workflows
 
     if workflows:
         metrics_incr("process_workflows", len(workflows))

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -91,6 +91,30 @@ class TestProcessWorkflows(BaseWorkflowTest):
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert result.data.triggered_workflows == {self.error_workflow}
 
+    def test_filters_cross_org_workflows(self) -> None:
+        other_org = self.create_organization()
+        cross_org_triggers = self.create_data_condition_group()
+        self.create_data_condition(
+            condition_group=cross_org_triggers,
+            type=Condition.EVENT_SEEN_COUNT,
+            comparison=1,
+            condition_result=True,
+        )
+        cross_org_workflow = self.create_workflow(
+            name="cross_org_workflow",
+            organization=other_org,
+            when_condition_group=cross_org_triggers,
+        )
+        # Stale DetectorWorkflow left behind after project transfer
+        self.create_detector_workflow(
+            detector=self.error_detector,
+            workflow=cross_org_workflow,
+        )
+
+        result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
+        assert result.data.triggered_workflows == {self.error_workflow}
+        assert cross_org_workflow not in result.data.workflows
+
     def test_error_event(self) -> None:
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert result.data.triggered_workflows == {self.error_workflow}

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -113,6 +113,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert result.data.triggered_workflows == {self.error_workflow}
+        assert result.data.workflows is not None
         assert cross_org_workflow not in result.data.workflows
 
     def test_error_event(self) -> None:

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -111,7 +111,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
             workflow=cross_org_workflow,
         )
 
-        result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
+        with self.options({"workflow_engine.filter_cross_org_workflows": True}):
+            result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert result.data.triggered_workflows == {self.error_workflow}
         assert result.data.workflows is not None
         assert cross_org_workflow not in result.data.workflows


### PR DESCRIPTION
Added a simple check for workflows from other orgs; they _shouldn't_ be triggered, but the path to workflow lookup is a bit complex and we've gotten this wrong in the wild.
Also fix existing test helpers so we don't depend on cross-org workflow triggering in our existing tests.

Fixes ISWF-2691.