### PR TITLE
fix(snapshots): Add timeout override for snapshot download in emmett gateway

### DIFF
--- a/src/apigw/proxy.py
+++ b/src/apigw/proxy.py
@@ -31,6 +31,7 @@ TIMEOUT_OVERRIDES = [
     (["/files/dsyms/"], 90.0),
     (["/installablepreprodartifact/"], 90.0),
     (["/objectstore/"], 90.0),
+    (["/preprodartifacts/snapshots/", "/download/"], 90.0),
 ]
 
 


### PR DESCRIPTION
## Summary

The emmett API gateway (`src/apigw/proxy.py`) has its own path-based `TIMEOUT_OVERRIDES` dict, separate from the Django gateway's URL-name-based overrides that were added in #116076. Without this entry, snapshot downloads fall back to the httpx client default of `read=60s`, causing HTTP/2 stream errors on large snapshots (40K+ images).

Adds `(["/preprodartifacts/snapshots/", "/download/"], 90.0)` to match the path pattern.

## Test plan

- [ ] Download a large snapshot (40K images) via `sentry-cli snapshots download` and confirm it no longer fails with HTTP/2 stream errors after ~60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)