### PR TITLE
fix(alerts): Sanitize legacy React-element labels in TicketRuleModal

### DIFF
--- a/static/app/components/externalIssues/ticketRuleModal.spec.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.spec.tsx
@@ -330,6 +330,60 @@ describe('ProjectAlerts -> TicketRuleModal', () => {
       expect(formData.reporter).toBe('saved-user-id');
     });
 
+    it('should not crash when saved choices have non-string labels (legacy data)', async () => {
+      // Automations saved by the pre-#112094 form persisted React-element
+      // labels on dynamic_form_fields[].choices. JSON-serialized, those
+      // collapse to {key, ref, props}. React 19 throws when those leak into
+      // option rendering — see https://sentry.sentry.io/issues/JAVASCRIPT-3921
+      const reporterField: IssueConfigField = {
+        label: 'Reporter',
+        required: false,
+        url: 'http://example.com',
+        type: 'select',
+        name: 'reporter',
+        choices: [],
+      };
+
+      addMockConfigsAPICall(reporterField);
+
+      render(
+        <TicketRuleModal
+          Body={ModalBody}
+          Header={makeClosableHeader(closeModal)}
+          Footer={ModalFooter}
+          CloseButton={makeCloseButton(closeModal)}
+          closeModal={closeModal}
+          link=""
+          ticketType=""
+          instance={{
+            integration: '1',
+            reporter: 'saved-user-id',
+            dynamic_form_fields: [
+              ...defaultIssueConfig,
+              {
+                ...reporterField,
+                choices: [
+                  [
+                    'saved-user-id',
+                    // Shape left behind by JSON-stringifying a React element.
+                    {key: null, ref: null, props: {children: 'Joe Smith'}} as any,
+                  ],
+                ],
+              },
+            ],
+          }}
+          onSubmitAction={onSubmitAction}
+        />,
+        {organization}
+      );
+
+      // Falls back to the value string instead of crashing.
+      expect(await screen.findByText('saved-user-id')).toBeInTheDocument();
+
+      await submitSuccess();
+      expect(onSubmitAction.mock.calls[0][0].reporter).toBe('saved-user-id');
+    });
+
     it('should get async options from URL', async () => {
       await renderTicketRuleModal();
 

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -30,20 +30,21 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 const IGNORED_FIELDS = ['Sprint'];
 
-// Older saved automations may have `dynamic_form_fields[i].choices` whose
-// labels were React elements (the pre-#112094 code wrapped the current
-// option's label in a <Fragment><QuestionTooltip />…</Fragment>). When the
-// rule was JSON-serialized to the backend, $$typeof (Symbol) and type
-// (function) were dropped, leaving {key, ref, props} on the wire. React 19
-// throws "Objects are not valid as a React child" when those leak into the
-// option list. Coerce any non-string label to String(value) at the read
-// boundary so the form can render and so we don't re-persist the bad shape.
+// The new form adapter requires string labels — see `JsonFormAdapterSelect`
+// in backendJsonFormAdapter/types.ts. Older saved automations may have
+// `dynamic_form_fields[i].choices` whose labels were React elements (the
+// pre-#112094 code wrapped the current option's label in a
+// <Fragment><QuestionTooltip />…</Fragment>). When the rule was
+// JSON-serialized to the backend, $$typeof (Symbol) and type (function)
+// were dropped, leaving {key, ref, props} on the wire. React 19 throws
+// "Objects are not valid as a React child" when those leak into the option
+// list. Enforce stringness at the read boundary so the form can render and
+// so we don't re-persist the bad shape.
 function sanitizeSavedChoices(choices: Choices): Choices {
-  return choices.map(([value, label]) =>
-    typeof label === 'string' || typeof label === 'number'
-      ? [value, label]
-      : [value, String(value)]
-  );
+  return choices.map(([value, label]) => [
+    value,
+    typeof label === 'string' ? label : String(value),
+  ]);
 }
 
 function sanitizeSavedFields(fields: IssueConfigField[]): IssueConfigField[] {

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -30,6 +30,30 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 const IGNORED_FIELDS = ['Sprint'];
 
+// Older saved automations may have `dynamic_form_fields[i].choices` whose
+// labels were React elements (the pre-#112094 code wrapped the current
+// option's label in a <Fragment><QuestionTooltip />…</Fragment>). When the
+// rule was JSON-serialized to the backend, $$typeof (Symbol) and type
+// (function) were dropped, leaving {key, ref, props} on the wire. React 19
+// throws "Objects are not valid as a React child" when those leak into the
+// option list. Coerce any non-string label to String(value) at the read
+// boundary so the form can render and so we don't re-persist the bad shape.
+function sanitizeSavedChoices(choices: Choices): Choices {
+  return choices.map(([value, label]) =>
+    typeof label === 'string' || typeof label === 'number'
+      ? [value, label]
+      : [value, String(value)]
+  );
+}
+
+function sanitizeSavedFields(fields: IssueConfigField[]): IssueConfigField[] {
+  return fields.map(field =>
+    Array.isArray(field.choices)
+      ? {...field, choices: sanitizeSavedChoices(field.choices)}
+      : field
+  );
+}
+
 interface TicketRuleModalProps extends ModalRenderProps {
   instance: TicketActionData;
   link: string | null;
@@ -83,7 +107,7 @@ export function TicketRuleModal({
   const [issueConfigFieldsCache, setIssueConfigFieldsCache] = useState<
     IssueConfigField[]
   >(() => {
-    return Object.values(instance?.dynamic_form_fields || {});
+    return sanitizeSavedFields(Object.values(instance?.dynamic_form_fields || {}));
   });
 
   const [isDynamicallyRefetching, setIsDynamicallyRefetching] = useState(false);
@@ -320,7 +344,7 @@ export function TicketRuleModal({
             Array.isArray(f.choices) &&
             f.choices.length > 0
         )
-        .map(f => [f.name, f.choices as Choices])
+        .map(f => [f.name, sanitizeSavedChoices(f.choices as Choices)])
     );
 
     const configFields = (integrationDetails?.[getConfigName(action)] ||


### PR DESCRIPTION
Fix a React 19 crash on the automations edit page when opening the Ticket Action Settings for older saved automations.

Automations saved by the pre-#112094 external-issues form persisted React-element labels on `dynamic_form_fields[*].choices`. The legacy `ensureCurrentOption` (in `static/app/components/externalIssues/utils.tsx`) wrapped the current option's label in a `<Fragment><QuestionTooltip />…</Fragment>`, and that wrapped option flowed through `useAsyncOptionsCache.updateCache` → `onSubmitAction(cache)` → `ruleNode.tsx:updateParentFromTicketRule` → `field.choices = fetchedFieldOptionsCache[field.name]`, then JSON-serialized to the backend. `JSON.stringify` drops `$$typeof` (Symbol) and `type` (function), leaving `{key, ref, props}` on the wire.

The scrapsForm migration (#112094) stopped re-wrapping on every render, so the broken inner shape that used to be masked by a fresh wrapper now reaches react-select directly. `MenuListItem` renders `<StyledLabel>{label}</StyledLabel>`, React 19's `throwOnInvalidObjectTypeImpl` sees an object missing `$$typeof`, and throws "Objects are not valid as a React child (found: object with keys {key, ref, props})".

Coerce any non-primitive label to `String(value)` at the read boundary in `TicketRuleModal` — both for the initial `issueConfigFieldsCache` (which `cleanData` writes back, so future saves stop re-persisting the bad shape) and for the `savedChoicesMap` consulted while building `cleanFields`. This stops the crash and lets the data self-heal as users edit and re-save automations.

This **does not** backfill the corrupt rows already in the DB. If we want eager cleanup, a one-shot script that walks `Workflow.action_filters[*].actions[*].data.dynamic_form_fields[*].choices` and coerces non-string labels would do it — happy to add if reviewers want.

Fixes JAVASCRIPT-3921