### PR TITLE
feat(attributes): Hide internal attributes from responses

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -30,6 +30,8 @@ from sentry.apidocs.parameters import (
     VisibilityParams,
 )
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.organization import Organization
@@ -57,7 +59,12 @@ from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.types import DatasetQuery
-from sentry.snuba.utils import RPC_DATASETS, dataset_split_decision_inferred_from_query, get_dataset
+from sentry.snuba.utils import (
+    RPC_DATASETS,
+    dataset_split_decision_inferred_from_query,
+    get_dataset,
+    get_rpc_dataset_attribute_visibility_item_type,
+)
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.cursors import Cursor, EAPPageTokenCursor
@@ -512,6 +519,16 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                     organization,
                     actor=request.user,
                 )
+                api_item_type = get_rpc_dataset_attribute_visibility_item_type(scoped_dataset)
+                attribute_visibility_kwargs = (
+                    {
+                        "api_attribute_visibility_item_type": api_item_type.value,
+                        "api_attribute_visibility_include_internal": is_active_superuser(request)
+                        or is_active_staff(request),
+                    }
+                    if api_item_type is not None
+                    else {}
+                )
 
                 if scoped_dataset == Spans:
                     return SearchResolverConfig(
@@ -521,6 +538,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == OurLogs:
                     # ourlogs doesn't have use aggregate conditions
@@ -529,6 +547,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == TraceMetrics:
                     # tracemetrics uses aggregate conditions
@@ -541,6 +560,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == ProfileFunctions:
                     # profile_functions uses aggregate conditions
@@ -550,6 +570,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == uptime_results.UptimeResults:
                     return SearchResolverConfig(
@@ -558,6 +579,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == ProcessingErrors:
                     return SearchResolverConfig(
@@ -566,6 +588,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == PreprodSize:
                     return PreprodSizeSearchResolverConfig(
@@ -573,6 +596,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 else:
                     return SearchResolverConfig(
@@ -580,6 +604,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
 
             if snuba_params.sampling_mode == "HIGHEST_ACCURACY_FLEX_TIME":

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -520,15 +520,12 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                     actor=request.user,
                 )
                 api_item_type = get_rpc_dataset_attribute_visibility_item_type(scoped_dataset)
-                attribute_visibility_kwargs = (
-                    {
-                        "api_attribute_visibility_item_type": api_item_type.value,
-                        "api_attribute_visibility_include_internal": is_active_superuser(request)
-                        or is_active_staff(request),
-                    }
-                    if api_item_type is not None
-                    else {}
+                api_attribute_visibility_item_type = (
+                    api_item_type.value if api_item_type is not None else None
                 )
+                api_attribute_visibility_include_internal = is_active_superuser(
+                    request
+                ) or is_active_staff(request)
 
                 if scoped_dataset == Spans:
                     return SearchResolverConfig(
@@ -538,7 +535,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == OurLogs:
                     # ourlogs doesn't have use aggregate conditions
@@ -547,7 +545,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == TraceMetrics:
                     # tracemetrics uses aggregate conditions
@@ -560,7 +559,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == ProfileFunctions:
                     # profile_functions uses aggregate conditions
@@ -570,7 +570,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == uptime_results.UptimeResults:
                     return SearchResolverConfig(
@@ -579,7 +580,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == ProcessingErrors:
                     return SearchResolverConfig(
@@ -588,7 +590,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == PreprodSize:
                     return PreprodSizeSearchResolverConfig(
@@ -596,7 +599,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 else:
                     return SearchResolverConfig(
@@ -604,7 +608,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
 
             if snuba_params.sampling_mode == "HIGHEST_ACCURACY_FLEX_TIME":

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -28,6 +28,8 @@ from sentry.apidocs import constants as api_constants
 from sentry.apidocs.examples.discover_performance_examples import DiscoverAndPerformanceExamples
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams, VisibilityParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
 from sentry.constants import MAX_TOP_EVENTS
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
@@ -53,7 +55,11 @@ from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
-from sentry.snuba.utils import DATASET_LABELS, RPC_DATASETS
+from sentry.snuba.utils import (
+    DATASET_LABELS,
+    RPC_DATASETS,
+    get_rpc_dataset_attribute_visibility_item_type,
+)
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.snuba import SnubaTSResult
 
@@ -230,6 +236,16 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
             organization,
             actor=request.user,
         )
+        api_item_type = get_rpc_dataset_attribute_visibility_item_type(dataset)
+        attribute_visibility_kwargs = (
+            {
+                "api_attribute_visibility_item_type": api_item_type.value,
+                "api_attribute_visibility_include_internal": is_active_superuser(request)
+                or is_active_staff(request),
+            }
+            if api_item_type is not None
+            else {}
+        )
 
         if dataset == TraceMetrics:
             # tracemetrics uses aggregate conditions
@@ -240,6 +256,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
+                **attribute_visibility_kwargs,
             )
         elif dataset == PreprodSize:
             return PreprodSizeSearchResolverConfig(
@@ -248,6 +265,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
+                **attribute_visibility_kwargs,
             )
         else:
             return SearchResolverConfig(
@@ -256,6 +274,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
+                **attribute_visibility_kwargs,
             )
 
     def get_event_stats(

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -237,14 +237,11 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
             actor=request.user,
         )
         api_item_type = get_rpc_dataset_attribute_visibility_item_type(dataset)
-        attribute_visibility_kwargs = (
-            {
-                "api_attribute_visibility_item_type": api_item_type.value,
-                "api_attribute_visibility_include_internal": is_active_superuser(request)
-                or is_active_staff(request),
-            }
-            if api_item_type is not None
-            else {}
+        api_attribute_visibility_item_type = (
+            api_item_type.value if api_item_type is not None else None
+        )
+        api_attribute_visibility_include_internal = is_active_superuser(request) or is_active_staff(
+            request
         )
 
         if dataset == TraceMetrics:
@@ -256,7 +253,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
-                **attribute_visibility_kwargs,
+                api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
             )
         elif dataset == PreprodSize:
             return PreprodSizeSearchResolverConfig(
@@ -265,7 +263,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
-                **attribute_visibility_kwargs,
+                api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
             )
         else:
             return SearchResolverConfig(
@@ -274,7 +273,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
-                **attribute_visibility_kwargs,
+                api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
             )
 
     def get_event_stats(

--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -29,7 +29,7 @@ from sentry.search.eap import constants
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
-from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
+from sentry.search.eap.utils import can_expose_attribute_to_api, translate_internal_to_public_alias
 from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.tagstore.types import TagValue
@@ -125,7 +125,7 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
                     as_tag_key(attribute.name, serialized["type"])
                     for attribute in rpc_response.attributes
                     if attribute.name
-                    and can_expose_attribute(
+                    and can_expose_attribute_to_api(
                         attribute.name,
                         SupportedTraceItemType.SPANS,
                         include_internal=include_internal,
@@ -164,15 +164,25 @@ class OrganizationSpansFieldValuesEndpoint(OrganizationSpansFieldsEndpointBase):
 
         max_span_tag_values = options.get("performance.spans-tags-values.max")
 
-        executor = EAPSpanFieldValuesAutocompletionExecutor(
-            organization=organization,
-            snuba_params=snuba_params,
-            key=key,
-            query=request.GET.get("query"),
-            max_span_tag_values=max_span_tag_values,
-        )
-
         with handle_query_errors():
+            executor = EAPSpanFieldValuesAutocompletionExecutor(
+                organization=organization,
+                snuba_params=snuba_params,
+                key=key,
+                query=request.GET.get("query"),
+                max_span_tag_values=max_span_tag_values,
+                include_internal=is_active_superuser(request) or is_active_staff(request),
+            )
+
+            if not executor.can_expose_attribute_to_api():
+                return self.paginate(
+                    request=request,
+                    paginator=ChainPaginator([]),
+                    on_results=lambda results: serialize(results, request.user),
+                    default_per_page=max_span_tag_values,
+                    max_per_page=max_span_tag_values,
+                )
+
             tag_values = executor.execute()
 
         tag_values.sort(key=lambda tag: tag.value or "")
@@ -245,8 +255,10 @@ class EAPSpanFieldValuesAutocompletionExecutor(BaseSpanFieldValuesAutocompletion
         key: str,
         query: str | None,
         max_span_tag_values: int,
+        include_internal: bool,
     ):
         super().__init__(organization, snuba_params, key, query, max_span_tag_values)
+        self.include_internal = include_internal
         self.resolver = SearchResolver(
             params=snuba_params, config=SearchResolverConfig(), definitions=SPAN_DEFINITIONS
         )
@@ -257,6 +269,23 @@ class EAPSpanFieldValuesAutocompletionExecutor(BaseSpanFieldValuesAutocompletion
     ) -> tuple[constants.SearchType, AttributeKey]:
         resolved, _ = self.resolver.resolve_attribute(key)
         return resolved.search_type, resolved.proto_definition
+
+    def can_expose_attribute_to_api(self) -> bool:
+        is_public_defined_attribute = (
+            self.key in SPAN_DEFINITIONS.columns or self.key in SPAN_DEFINITIONS.contexts
+        )
+        return can_expose_attribute_to_api(
+            self.key,
+            SupportedTraceItemType.SPANS,
+            include_internal=self.include_internal,
+        ) and (
+            is_public_defined_attribute
+            or can_expose_attribute_to_api(
+                self.attribute_key.name,
+                SupportedTraceItemType.SPANS,
+                include_internal=self.include_internal,
+            )
+        )
 
     def execute(self) -> list[TagValue]:
         if self.key in self.PROJECT_ID_KEYS:

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -64,7 +64,7 @@ from sentry.search.eap.types import (
     SupportedTraceItemType,
 )
 from sentry.search.eap.utils import (
-    can_expose_attribute,
+    can_expose_attribute_to_api,
     get_secondary_aliases,
     is_sentry_convention_replacement_attribute,
     translate_internal_to_public_alias,
@@ -321,12 +321,21 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         trace_item_type = SupportedTraceItemType(dataset)
         referrer = resolve_attribute_referrer(trace_item_type)
         column_definitions = get_column_definitions(trace_item_type)
+        include_internal = is_active_superuser(request) or is_active_staff(request)
         resolver = SearchResolver(
             params=snuba_params,
-            config=SearchResolverConfig(),
+            config=SearchResolverConfig(
+                api_attribute_visibility_item_type=trace_item_type.value,
+                api_attribute_visibility_include_internal=include_internal,
+            ),
             definitions=column_definitions,
         )
         query_filter, _, _ = resolver.resolve_query(query_string)
+        if resolver.has_hidden_api_attributes():
+            return self.paginate(
+                request=request,
+                paginator=ChainPaginator([]),
+            )
         meta = resolver.resolve_meta(referrer=referrer.value)
         meta.trace_item_type = constants.SUPPORTED_TRACE_ITEM_TYPE_MAP.get(
             trace_item_type, ProtoTraceItemType.TRACE_ITEM_TYPE_SPAN
@@ -337,8 +346,6 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         )
         snuba_params.start = adjusted_start_date
         snuba_params.end = adjusted_end_date
-
-        include_internal = is_active_superuser(request) or is_active_staff(request)
 
         def data_fn(offset: int, limit: int) -> list[TraceItemAttributeKey]:
             futures = []
@@ -404,6 +411,11 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                             and substring_match in column.public_alias
                             and not column.secondary_alias
                             and not column.private
+                            and can_expose_attribute_to_api(
+                                column.public_alias,
+                                trace_item_type,
+                                include_internal=include_internal,
+                            )
                         ):
                             all_aliased_attributes.append(column)
                     for (
@@ -415,6 +427,11 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                             and virtual_context.search_type is not None
                             and not virtual_context.secondary_alias
                             and constants.TYPE_MAP[virtual_context.search_type] == attr_type
+                            and can_expose_attribute_to_api(
+                                public_label,
+                                trace_item_type,
+                                include_internal=include_internal,
+                            )
                         ):
                             all_aliased_attributes.append(
                                 ProxyResolvedAttribute(
@@ -433,6 +450,11 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                             and virtual_context.search_type is not None
                             and not virtual_context.secondary_alias
                             and constants.TYPE_MAP[virtual_context.search_type] == attr_type
+                            and can_expose_attribute_to_api(
+                                public_label,
+                                trace_item_type,
+                                include_internal=include_internal,
+                            )
                         ):
                             all_aliased_attributes.append(
                                 ProxyResolvedAttribute(
@@ -493,7 +515,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
     ) -> list[TraceItemAttributeKey]:
         attribute_keys = {}
         for attribute in rpc_response.attributes:
-            if attribute.name and can_expose_attribute(
+            if attribute.name and can_expose_attribute_to_api(
                 attribute.name,
                 trace_item_type,
                 include_internal=include_internal,
@@ -523,6 +545,14 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
             if attr_key["name"] in attribute_keys:
                 del attribute_keys[attr_key["name"]]
         for aliased_attr in aliased_attributes:
+            if not (
+                can_expose_attribute_to_api(
+                    aliased_attr.public_alias,
+                    trace_item_type,
+                    include_internal=include_internal,
+                )
+            ):
+                continue
             attr_key = as_attribute_key(
                 aliased_attr.internal_name,
                 attribute_type,
@@ -547,7 +577,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
     ) -> list[TraceItemAttributeKey]:
         attribute_keys = {}
         for attribute in rpc_response.attributes:
-            if attribute.name and can_expose_attribute(
+            if attribute.name and can_expose_attribute_to_api(
                 attribute.name,
                 trace_item_type,
                 include_internal=include_internal,
@@ -579,18 +609,21 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
             if attr_key["name"] in attribute_keys:
                 del attribute_keys[attr_key["name"]]
         for aliased_attr in aliased_attributes:
-            if can_expose_attribute(
-                aliased_attr.public_alias,
-                trace_item_type,
-                include_internal=include_internal,
-            ):
-                attr_key = as_attribute_key(
-                    aliased_attr.internal_name,
-                    attribute_type,
+            if not (
+                can_expose_attribute_to_api(
+                    aliased_attr.public_alias,
                     trace_item_type,
-                    is_proxy=isinstance(aliased_attr, ProxyResolvedAttribute),
+                    include_internal=include_internal,
                 )
-                attribute_keys[attr_key["key"]] = attr_key
+            ):
+                continue
+            attr_key = as_attribute_key(
+                aliased_attr.internal_name,
+                attribute_type,
+                trace_item_type,
+                is_proxy=isinstance(aliased_attr, ProxyResolvedAttribute),
+            )
+            attribute_keys[attr_key["key"]] = attr_key
         attributes = list(attribute_keys.values())
         sentry_sdk.set_context("api_response", {"attributes": attributes})
         return attributes
@@ -628,19 +661,25 @@ class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttribut
         max_attribute_values = options.get("explore.trace-items.values.max")
 
         definitions = get_column_definitions(SupportedTraceItemType(dataset))
+        include_internal = is_active_superuser(request) or is_active_staff(request)
 
         def data_fn(offset: int, limit: int):
-            executor = TraceItemAttributeValuesAutocompletionExecutor(
-                organization=organization,
-                snuba_params=snuba_params,
-                key=key,
-                query=substring_match,
-                limit=limit,
-                offset=offset,
-                definitions=definitions,
-            )
-
             with handle_query_errors():
+                executor = TraceItemAttributeValuesAutocompletionExecutor(
+                    organization=organization,
+                    snuba_params=snuba_params,
+                    key=key,
+                    query=substring_match,
+                    limit=limit,
+                    offset=offset,
+                    definitions=definitions,
+                    item_type=SupportedTraceItemType(dataset),
+                    include_internal=include_internal,
+                )
+
+                if not executor.can_expose_attribute_to_api():
+                    return []
+
                 tag_values = executor.execute()
             tag_values.sort(key=lambda tag: tag.value or "")
             return tag_values
@@ -664,10 +703,15 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
         limit: int,
         offset: int,
         definitions: ColumnDefinitions,
+        item_type: SupportedTraceItemType,
+        include_internal: bool,
     ):
         super().__init__(organization, snuba_params, key, query, limit)
         self.limit = limit
         self.offset = offset
+        self.item_type = item_type
+        self.include_internal = include_internal
+        self.definitions = definitions
         self.resolver = SearchResolver(
             params=snuba_params, config=SearchResolverConfig(), definitions=definitions
         )
@@ -696,6 +740,23 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
             resolved_attr.search_type,
             resolved_attr.proto_definition,
             context_definition,
+        )
+
+    def can_expose_attribute_to_api(self) -> bool:
+        is_public_defined_attribute = (
+            self.key in self.definitions.columns or self.key in self.definitions.contexts
+        )
+        return can_expose_attribute_to_api(
+            self.key,
+            self.item_type,
+            include_internal=self.include_internal,
+        ) and (
+            is_public_defined_attribute
+            or can_expose_attribute_to_api(
+                self.attribute_key.name,
+                self.item_type,
+                include_internal=self.include_internal,
+            )
         )
 
     def execute(self) -> list[TagValue]:
@@ -1033,6 +1094,7 @@ class OrganizationTraceItemAttributeValidateEndpoint(OrganizationTraceItemAttrib
 
         item_type = SupportedTraceItemType(query_serializer.validated_data["item_type"])
         attribute_names: list[str] = serializer.validated_data["attributes"]
+        include_internal = is_active_superuser(request) or is_active_staff(request)
 
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -1045,7 +1107,10 @@ class OrganizationTraceItemAttributeValidateEndpoint(OrganizationTraceItemAttrib
             return Response({"detail": f"Unsupported item type: {item_type.value}"}, status=400)
         resolver = SearchResolver(
             params=snuba_params,
-            config=SearchResolverConfig(),
+            config=SearchResolverConfig(
+                api_attribute_visibility_item_type=item_type.value,
+                api_attribute_visibility_include_internal=include_internal,
+            ),
             definitions=definitions,
         )
 
@@ -1056,6 +1121,12 @@ class OrganizationTraceItemAttributeValidateEndpoint(OrganizationTraceItemAttrib
         for attr_name in attribute_names:
             try:
                 resolved, _context = resolver.resolve_attribute(attr_name)
+                if resolver.is_hidden_api_attribute(attr_name):
+                    results[attr_name] = {
+                        "valid": False,
+                        "error": f"Unknown attribute: {attr_name}",
+                    }
+                    continue
                 if attr_name in definitions.contexts or attr_name in definitions.columns:
                     # Known column or virtual context — always valid
                     results[attr_name] = {

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -20,13 +20,15 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_trace_item_attributes import adjust_start_end_window
 from sentry.api.utils import handle_query_errors
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.attributes import SPANS_STATS_EXCLUDED_ATTRIBUTES
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
-from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
+from sentry.search.eap.utils import can_expose_attribute_to_api, translate_internal_to_public_alias
 from sentry.search.events import fields
 from sentry.seer.endpoints.compare import compare_distributions
 from sentry.seer.signed_seer_api import SeerViewerContext
@@ -58,6 +60,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsEndpointB
         above = request.GET.get("above") == "1"
         query_1 = request.GET.get("query_1", "")  # Suspect query
         query_2 = request.GET.get("query_2", "")  # Query for all the spans with the base query
+        include_internal = is_active_superuser(request) or is_active_staff(request)
 
         if query_1 == query_2:
             return Response({"rankedAttributes": []})
@@ -68,6 +71,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsEndpointB
             above=above,
             query_1=query_1,
             query_2=query_2,
+            include_internal=include_internal,
         )
 
         cohort_2_distribution = distributions_result["cohort_2_distribution"]
@@ -131,7 +135,19 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsEndpointB
             if public_alias is None:
                 public_alias = attr
 
-            if not public_alias.startswith("tags[") and (
+            if (
+                can_expose_attribute_to_api(
+                    attr,
+                    SupportedTraceItemType.SPANS,
+                    include_internal=include_internal,
+                )
+                and can_expose_attribute_to_api(
+                    public_alias,
+                    SupportedTraceItemType.SPANS,
+                    include_internal=include_internal,
+                )
+                and not public_alias.startswith("tags[")
+            ) and (
                 not public_alias.startswith("sentry.")
                 or public_alias == "sentry.normalized_description"
             ):
@@ -175,6 +191,7 @@ def query_attribute_distributions(
     above: bool,
     query_1: str,
     query_2: str,
+    include_internal: bool = False,
 ) -> AttributeDistributionsResponse:
     """
     Query for and compute span attribute distributions for outlier (query_1) and baseline (query_2) cohorts.
@@ -190,7 +207,9 @@ def query_attribute_distributions(
         AttributeDistributionsResponse with distribution data and total counts for both cohorts
     """
     resolver_config = SearchResolverConfig(
-        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE
+        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+        api_attribute_visibility_item_type=SupportedTraceItemType.SPANS.value,
+        api_attribute_visibility_include_internal=include_internal,
     )
 
     resolver = SearchResolver(
@@ -261,6 +280,16 @@ def query_attribute_distributions(
 
     cohort_1, _, _ = resolver.resolve_query(query_1)
     cohort_2, _, _ = resolver.resolve_query(query_2)
+    if resolver.has_hidden_api_attributes():
+        return AttributeDistributionsResponse(
+            cohort_2_distribution=[],
+            cohort_2_distribution_map={},
+            total_cohort_2=0,
+            cohort_1_distribution=[],
+            cohort_1_distribution_map={},
+            total_cohort_1=0,
+            cohort_1_function_value=function_value,
+        )
 
     # Fetch attribute names for parallelization
     adjusted_start_date, adjusted_end_date = adjust_start_end_window(
@@ -290,6 +319,12 @@ def query_attribute_distributions(
     chunked_attributes: defaultdict[int, list[AttributeKey]] = defaultdict(list)
     for i, attr_proto in enumerate(attrs_response.attributes):
         if attr_proto.name in SPANS_STATS_EXCLUDED_ATTRIBUTES:
+            continue
+        if not can_expose_attribute_to_api(
+            attr_proto.name,
+            SupportedTraceItemType.SPANS,
+            include_internal=include_internal,
+        ):
             continue
 
         chunked_attributes[i % PARALLELIZATION_FACTOR].append(
@@ -367,7 +402,11 @@ def query_attribute_distributions(
     processed_cohort_2_buckets = set()
 
     for attribute in cohort_2_data:
-        if not can_expose_attribute(attribute.attribute_name, SupportedTraceItemType.SPANS):
+        if not can_expose_attribute_to_api(
+            attribute.attribute_name,
+            SupportedTraceItemType.SPANS,
+            include_internal=include_internal,
+        ):
             continue
 
         for bucket in attribute.buckets:
@@ -376,7 +415,11 @@ def query_attribute_distributions(
             )
 
     for attribute in cohort_1_data:
-        if not can_expose_attribute(attribute.attribute_name, SupportedTraceItemType.SPANS):
+        if not can_expose_attribute_to_api(
+            attribute.attribute_name,
+            SupportedTraceItemType.SPANS,
+            include_internal=include_internal,
+        ):
             continue
         for bucket in attribute.buckets:
             cohort_1_distribution.append((attribute.attribute_name, bucket.label, bucket.value))

--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -17,6 +17,8 @@ from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.event_search import translate_escape_sequences
 from sentry.api.serializers.base import serialize
 from sentry.api.utils import handle_query_errors
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
 from sentry.models.organization import Organization
 from sentry.search.eap.columns import ColumnDefinitions
 from sentry.search.eap.constants import SUPPORTED_STATS_TYPES
@@ -31,7 +33,8 @@ from sentry.search.eap.spans.attributes import (
     SPANS_STATS_EXCLUDED_ATTRIBUTES_PUBLIC_ALIAS,
 )
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
+from sentry.search.eap.utils import can_expose_attribute_to_api
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.occurrences_rpc import Occurrences
 from sentry.snuba.referrer import Referrer
@@ -143,9 +146,15 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
             return Response(serializer.errors, status=400)
         serialized = serializer.validated_data
 
-        stats_config = get_trace_item_stats_config(serialized.get("itemType", "spans"))
+        item_type = serialized.get("itemType", "spans")
+        stats_config = get_trace_item_stats_config(item_type)
+        api_item_type = SupportedTraceItemType(item_type)
+        include_internal = is_active_superuser(request) or is_active_staff(request)
 
-        resolver_config = SearchResolverConfig()
+        resolver_config = SearchResolverConfig(
+            api_attribute_visibility_item_type=api_item_type.value,
+            api_attribute_visibility_include_internal=include_internal,
+        )
         resolver = SearchResolver(
             params=snuba_params, config=resolver_config, definitions=stats_config.definitions
         )
@@ -159,7 +168,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
             with handle_query_errors():
                 return stats_config.rpc_class.run_table_query(
                     params=snuba_params,
-                    config=SearchResolverConfig(),
+                    config=resolver_config,
                     offset=0,
                     limit=serialized.get("traceItemsLimit", 1000),
                     sampling_mode=snuba_params.sampling_mode,
@@ -180,6 +189,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                     search_resolver=resolver,
                     max_buckets=1,
                     skip_translate_internal_to_public_alias=True,
+                    include_internal=include_internal,
                 )
 
         def run_stats_query_with_error_handling(attributes):
@@ -192,6 +202,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                     config=resolver_config,
                     search_resolver=resolver,
                     attributes=attributes,
+                    include_internal=include_internal,
                 )
 
         def data_fn(offset: int, limit: int):
@@ -217,6 +228,20 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                 )
 
                 if public_alias in stats_config.excluded_attributes:
+                    continue
+
+                if not (
+                    can_expose_attribute_to_api(
+                        internal_name,
+                        api_item_type,
+                        include_internal=include_internal,
+                    )
+                    and can_expose_attribute_to_api(
+                        public_alias,
+                        api_item_type,
+                        include_internal=include_internal,
+                    )
+                ):
                     continue
 
                 if value_substring_match:

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -29,7 +29,7 @@ from sentry.search.eap.types import (
     TraceItemAttribute,
 )
 from sentry.search.eap.utils import (
-    can_expose_attribute,
+    can_expose_attribute_to_api,
     get_deprecated_source_internal_names,
     is_sentry_convention_replacement_attribute,
     translate_internal_to_public_alias,
@@ -118,7 +118,7 @@ def convert_rpc_attribute_to_json(
     for attribute in attributes:
         internal_name = attribute["name"]
 
-        if not can_expose_attribute(
+        if not can_expose_attribute_to_api(
             internal_name, trace_item_type, include_internal=include_internal
         ):
             continue
@@ -209,6 +209,7 @@ def convert_rpc_attribute_to_json(
 def serialize_meta(
     attributes: list[dict],
     trace_item_type: SupportedTraceItemType,
+    include_internal: bool = False,
 ) -> dict:
     internal_name = ""
     attribute = {}
@@ -243,6 +244,12 @@ def serialize_meta(
             result = json.loads(attribute["value"]["valStr"])
             # Map the internal field key name back to its public name
             if field_key in attribute_map:
+                if not can_expose_attribute_to_api(
+                    field_key,
+                    trace_item_type,
+                    include_internal=include_internal,
+                ):
+                    continue
                 item_type: Literal["string", "number", "boolean"]
                 if (
                     "valInt" in attribute_map[field_key]
@@ -270,7 +277,11 @@ def serialize_meta(
     return meta_result
 
 
-def serialize_links(attributes: list[dict]) -> list[dict] | None:
+def serialize_links(
+    attributes: list[dict],
+    trace_item_type: SupportedTraceItemType,
+    include_internal: bool = False,
+) -> list[dict] | None:
     """Links are temporarily stored in `sentry.links` so lets parse that back out and return separately"""
     link_attribute = None
     for attribute in attributes:
@@ -285,7 +296,14 @@ def serialize_links(attributes: list[dict]) -> list[dict] | None:
         value = link_attribute.get("value", {}).get("valStr", None)
         if value is not None:
             links = json.loads(value)
-            return [serialize_link(link) for link in links]
+            return [
+                serialize_link(
+                    link,
+                    trace_item_type=trace_item_type,
+                    include_internal=include_internal,
+                )
+                for link in links
+            ]
         else:
             return None
     except Exception as e:
@@ -293,7 +311,11 @@ def serialize_links(attributes: list[dict]) -> list[dict] | None:
         return None
 
 
-def serialize_link(link: dict) -> dict:
+def serialize_link(
+    link: dict,
+    trace_item_type: SupportedTraceItemType,
+    include_internal: bool = False,
+) -> dict:
     clean_link = {
         "itemId": link["span_id"],
         "traceId": link["trace_id"],
@@ -307,6 +329,11 @@ def serialize_link(link: dict) -> dict:
             {"name": k, "value": v, "type": infer_type(v)}
             for k, v in attributes.items()
             if infer_type(v) is not None
+            and can_expose_attribute_to_api(
+                k,
+                trace_item_type,
+                include_internal=include_internal,
+            )
         ]
 
     return clean_link
@@ -428,8 +455,12 @@ class ProjectTraceItemDetailsEndpoint(ProjectEndpoint):
                 include_internal=include_internal,
                 include_arrays=include_arrays,
             ),
-            "meta": serialize_meta(resp["attributes"], item_type),
-            "links": serialize_links(resp["attributes"]),
+            "meta": serialize_meta(
+                resp["attributes"], item_type, include_internal=include_internal
+            ),
+            "links": serialize_links(
+                resp["attributes"], item_type, include_internal=include_internal
+            ),
         }
 
         return Response(resp_dict)

--- a/src/sentry/data_export/utils.py
+++ b/src/sentry/data_export/utils.py
@@ -13,7 +13,7 @@ from sentry.data_export.base import ExportError
 from sentry.search.eap.constants import PROTOBUF_TYPE_TO_SEARCH_TYPE
 from sentry.search.eap.rpc_utils import anyvalue_to_python
 from sentry.search.eap.types import SupportedTraceItemType
-from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
+from sentry.search.eap.utils import can_expose_attribute_to_api, translate_internal_to_public_alias
 from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
 from sentry.snuba import discover
 from sentry.utils import metrics, snuba
@@ -146,7 +146,7 @@ def trace_item_to_row(
     _merge_trace_export_cell(row, "id", item.item_id.hex() if item.item_id else None)
 
     for internal_key, av in item.attributes.items():
-        if not can_expose_attribute(internal_key, item_type, include_internal=False):
+        if not can_expose_attribute_to_api(internal_key, item_type, include_internal=False):
             continue
         which = av.WhichOneof("value")
         value = anyvalue_to_python(av)

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -121,6 +121,18 @@ class SearchResolver:
     def add_hidden_api_attributes(self, columns: set[str]) -> None:
         self._hidden_api_attributes.update(columns)
 
+    def get_api_attribute_visibility_item_type(self) -> SupportedTraceItemType | None:
+        if self.config.api_attribute_visibility_item_type is None:
+            return None
+
+        configured_item_type = SupportedTraceItemType(
+            self.config.api_attribute_visibility_item_type
+        )
+        for item_type, trace_item_type in constants.SUPPORTED_TRACE_ITEM_TYPE_MAP.items():
+            if trace_item_type == self.definitions.trace_item_type:
+                return item_type
+        return configured_item_type
+
     def _find_column_by_internal_name(self, internal_name: str) -> ResolvedAttribute | None:
         """Look up a column definition by its internal name (e.g. 'sentry.item_id' -> 'id' column).
 
@@ -1127,10 +1139,10 @@ class SearchResolver:
             column_context = None
 
         if column_definition:
-            if self.config.api_attribute_visibility_item_type is not None:
+            item_type = self.get_api_attribute_visibility_item_type()
+            if item_type is not None:
                 from sentry.search.eap.utils import can_expose_attribute_to_api
 
-                item_type = SupportedTraceItemType(self.config.api_attribute_visibility_item_type)
                 visibility_attribute = (
                     column_definition.public_alias
                     if is_public_defined_attribute

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -60,7 +60,7 @@ from sentry.search.eap.columns import (
 from sentry.search.eap.rpc_utils import and_trace_item_filters
 from sentry.search.eap.sampling import validate_sampling
 from sentry.search.eap.spans.attributes import SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS
-from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import EAPResponse, SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events import constants as qb_constants
 from sentry.search.events import fields
 from sentry.search.events import filter as event_filter
@@ -105,8 +105,15 @@ class SearchResolver:
             VirtualColumnDefinition | None,
         ],
     ] = field(default_factory=dict)
+    _hidden_api_attributes: set[str] = field(default_factory=set, repr=False)
     qualified_short_id_to_group_id_cache: dict[int, dict[str, int]] = field(default_factory=dict)
     _internal_name_to_column: dict[str, ResolvedAttribute] = field(default_factory=dict, repr=False)
+
+    def has_hidden_api_attributes(self) -> bool:
+        return bool(self._hidden_api_attributes)
+
+    def is_hidden_api_attribute(self, column: str) -> bool:
+        return column in self._hidden_api_attributes
 
     def _find_column_by_internal_name(self, internal_name: str) -> ResolvedAttribute | None:
         """Look up a column definition by its internal name (e.g. 'sentry.item_id' -> 'id' column).
@@ -1043,7 +1050,9 @@ class SearchResolver:
         if public_alias_override is not None:
             alias = public_alias_override
 
+        is_public_defined_attribute = False
         if column in self.definitions.contexts:
+            is_public_defined_attribute = True
             column_context = self.definitions.contexts[column]
             column_definition = ResolvedAttribute(
                 public_alias=alias,
@@ -1052,6 +1061,7 @@ class SearchResolver:
                 processor=column_context.processor,
             )
         elif column in self.definitions.columns:
+            is_public_defined_attribute = True
             column_context = None
             column_definition = self.definitions.columns[column]
             if column_definition.private and column not in self.config.fields_acl.attributes:
@@ -1111,6 +1121,21 @@ class SearchResolver:
             column_context = None
 
         if column_definition:
+            if self.config.api_attribute_visibility_item_type is not None:
+                from sentry.search.eap.utils import can_expose_attribute_to_api
+
+                item_type = SupportedTraceItemType(self.config.api_attribute_visibility_item_type)
+                visibility_attribute = (
+                    column_definition.public_alias
+                    if is_public_defined_attribute
+                    else column_definition.internal_name
+                )
+                if not can_expose_attribute_to_api(
+                    visibility_attribute,
+                    item_type,
+                    include_internal=self.config.api_attribute_visibility_include_internal,
+                ):
+                    self._hidden_api_attributes.add(column)
             self._resolved_attribute_cache[column] = (column_definition, column_context)
             return self._resolved_attribute_cache[column]
         else:

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -115,6 +115,12 @@ class SearchResolver:
     def is_hidden_api_attribute(self, column: str) -> bool:
         return column in self._hidden_api_attributes
 
+    def get_hidden_api_attributes(self) -> set[str]:
+        return set(self._hidden_api_attributes)
+
+    def add_hidden_api_attributes(self, columns: set[str]) -> None:
+        self._hidden_api_attributes.update(columns)
+
     def _find_column_by_internal_name(self, internal_name: str) -> ResolvedAttribute | None:
         """Look up a column definition by its internal name (e.g. 'sentry.item_id' -> 'id' column).
 

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -39,6 +39,10 @@ class SearchResolverConfig:
     # When True, ResolvedAttributes whose internal_type is ARRAY are silently dropped based on
     # feature flag organizations:trace-item-details-array-fields
     disable_array_attributes: bool = True
+    # API-only visibility enforcement. Non-API callers should leave this as None
+    # so backend resolution semantics remain unchanged.
+    api_attribute_visibility_item_type: str | None = None
+    api_attribute_visibility_include_internal: bool = False
 
     def extra_conditions(
         self,

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Literal
 
 from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_conventions.attributes import ATTRIBUTE_METADATA
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 
 from sentry.search.eap.columns import ColumnDefinitions, ResolvedAttribute
@@ -235,6 +236,77 @@ def can_expose_attribute(
         return include_internal
 
     return True
+
+
+def _has_internal_convention_visibility(attribute: str) -> bool:
+    metadata = ATTRIBUTE_METADATA.get(attribute)
+    if metadata is None:
+        return False
+
+    visibility = metadata.visibility
+    return getattr(visibility, "value", visibility) == "internal"
+
+
+def _get_sentry_convention_visibility_candidates(
+    attribute: str, item_type: SupportedTraceItemType
+) -> set[str]:
+    candidates = {attribute}
+
+    if item_type == SupportedTraceItemType.SPANS and attribute.startswith(("dsc.", "_internal.")):
+        candidates.add(f"sentry.{attribute}")
+
+    resolved_attribute = PUBLIC_ALIAS_TO_INTERNAL_MAPPING.get(item_type, {}).get(attribute)
+    if resolved_attribute is not None:
+        candidates.add(resolved_attribute.public_alias)
+        candidates.add(resolved_attribute.internal_name)
+        if resolved_attribute.replacement:
+            candidates.add(resolved_attribute.replacement)
+
+    for mapping in INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).values():
+        public_alias = mapping.get(attribute)
+        if public_alias is not None:
+            candidates.add(public_alias)
+
+    replacement_map = SENTRY_CONVENTIONS_REPLACEMENT_MAPPINGS.get(item_type, {})
+    seen: set[str] = set()
+    pending = list(candidates)
+    while pending:
+        candidate = pending.pop()
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        replacement = replacement_map.get(candidate)
+        if replacement is not None and replacement not in candidates:
+            candidates.add(replacement)
+            pending.append(replacement)
+
+    return candidates
+
+
+def is_internal_sentry_convention_attribute(
+    attribute: str, item_type: SupportedTraceItemType
+) -> bool:
+    return any(
+        _has_internal_convention_visibility(candidate)
+        for candidate in _get_sentry_convention_visibility_candidates(attribute, item_type)
+    )
+
+
+def can_expose_attribute_to_api(
+    attribute: str, item_type: SupportedTraceItemType, include_internal: bool = False
+) -> bool:
+    candidates = _get_sentry_convention_visibility_candidates(attribute, item_type)
+
+    for candidate in candidates:
+        if not can_expose_attribute(candidate, item_type, include_internal=include_internal):
+            return False
+
+    if include_internal:
+        return True
+
+    return not any(
+        is_internal_sentry_convention_attribute(candidate, item_type) for candidate in candidates
+    )
 
 
 def is_sentry_convention_replacement_attribute(

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Literal
 
 from google.protobuf.timestamp_pb2 import Timestamp
-from sentry_conventions.attributes import ATTRIBUTE_METADATA
+from sentry_conventions.attributes import ATTRIBUTE_METADATA as ATTRIBUTE_METADATA
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 
 from sentry.search.eap.columns import ColumnDefinitions, ResolvedAttribute

--- a/src/sentry/snuba/occurrences_rpc.py
+++ b/src/sentry/snuba/occurrences_rpc.py
@@ -281,9 +281,14 @@ class Occurrences(rpc_dataset_common.RPCBase):
         max_buckets: int = 75,
         skip_translate_internal_to_public_alias: bool = False,
         occurrence_category: OccurrenceCategory | None = None,
+        include_internal: bool = False,
     ) -> list[dict[str, Any]]:
         search_resolver = search_resolver or cls.get_resolver(params, config)
         stats_filter, _, _ = search_resolver.resolve_query(query_string)
+        if search_resolver.has_hidden_api_attributes():
+            # Hidden attributes here came from the query filter. Dropping them would
+            # broaden the query and return results for different search semantics.
+            return []
 
         stats_filter = and_trace_item_filters(
             stats_filter, cls._build_category_filter(occurrence_category)
@@ -315,7 +320,10 @@ class Occurrences(rpc_dataset_common.RPCBase):
         response = snuba_rpc.trace_item_stats_rpc(stats_request)
         stats = []
 
-        from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
+        from sentry.search.eap.utils import (
+            can_expose_attribute_to_api,
+            translate_internal_to_public_alias,
+        )
 
         for result in response.results:
             if "attributeDistributions" in stats_types and result.HasField(
@@ -323,8 +331,10 @@ class Occurrences(rpc_dataset_common.RPCBase):
             ):
                 attrs: dict[str, list[dict[str, Any]]] = defaultdict(list)
                 for attribute in result.attribute_distributions.attributes:
-                    if not can_expose_attribute(
-                        attribute.attribute_name, SupportedTraceItemType.OCCURRENCES
+                    if not can_expose_attribute_to_api(
+                        attribute.attribute_name,
+                        SupportedTraceItemType.OCCURRENCES,
+                        include_internal=include_internal,
                     ):
                         continue
 

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -809,11 +809,11 @@ class RPCBase:
         )
         result = ProcessedTimeseries()
         if search_resolver.has_hidden_api_attributes():
-            final_meta: EventsMeta = {"fields": {}}
+            hidden_meta: EventsMeta = {"fields": {}}
             for resolved_field in aggregates + groupbys:
-                final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
+                hidden_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
             return SnubaTSResult(
-                {"data": [], "processed_timeseries": result, "meta": final_meta},
+                {"data": [], "processed_timeseries": result, "meta": hidden_meta},
                 params.start,
                 params.end,
                 params.granularity_secs,

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -390,6 +390,8 @@ class RPCBase:
     ) -> EAPResponse:
         """Run the query"""
         table_request = cls.get_table_rpc_request(query)
+        if query.resolver.has_hidden_api_attributes():
+            return {"data": [], "meta": {"fields": {}}, "confidence": []}
         rpc_request = table_request.rpc_request
         try:
             rpc_response = snuba_rpc.table_rpc([rpc_request])[0]

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -807,12 +807,22 @@ class RPCBase:
             sampling_mode=sampling_mode,
             additional_queries=additional_queries,
         )
+        result = ProcessedTimeseries()
+        if search_resolver.has_hidden_api_attributes():
+            final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_request.meta)
+            for resolved_field in aggregates + groupbys:
+                final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
+            return SnubaTSResult(
+                {"data": [], "processed_timeseries": result, "meta": final_meta},
+                params.start,
+                params.end,
+                params.granularity_secs,
+            )
 
         """Run the query"""
         rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
 
         """Process the results"""
-        result = ProcessedTimeseries()
         final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_response.meta)
         if params.debug:
             set_debug_meta(final_meta, rpc_response.meta, rpc_request)

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -809,7 +809,7 @@ class RPCBase:
         )
         result = ProcessedTimeseries()
         if search_resolver.has_hidden_api_attributes():
-            final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_request.meta)
+            final_meta: EventsMeta = {"fields": {}}
             for resolved_field in aggregates + groupbys:
                 final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
             return SnubaTSResult(
@@ -1148,6 +1148,7 @@ class RPCBase:
         attributes: list[AttributeKey] | None = None,
         max_buckets: int = 75,
         skip_translate_internal_to_public_alias: bool = False,
+        include_internal: bool = False,
     ) -> list[dict[str, Any]]:
         raise NotImplementedError()
 

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -58,6 +58,7 @@ from sentry.search.eap.types import (
     ConfidenceData,
     EAPResponse,
     SearchResolverConfig,
+    SupportedTraceItemType,
 )
 from sentry.search.events.fields import get_function_alias, is_function
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaData, SnubaParams
@@ -177,8 +178,7 @@ class RPCBase:
     def get_cross_trace_queries(
         cls,
         additional_queries: AdditionalQueries | None,
-        config: SearchResolverConfig,
-        query_params: SnubaParams,
+        resolver: SearchResolver,
     ) -> list[TraceItemFilterWithType]:
         from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
         from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
@@ -190,32 +190,48 @@ class RPCBase:
 
         # resolve cross trace queries
         # Copy the existing resolver, but we don't allow aggregate conditions for cross trace filters
-        cross_trace_config = replace(config, use_aggregate_conditions=False)
+        cross_trace_config = replace(resolver.config, use_aggregate_conditions=False)
 
         cross_trace_queries = []
-        for queries, definitions, item_type in [
+        for queries, definitions, item_type, api_item_type in [
             (
                 additional_queries.log,
                 OURLOG_DEFINITIONS,
                 TraceItemType.TRACE_ITEM_TYPE_LOG,
+                SupportedTraceItemType.LOGS,
             ),
-            (additional_queries.span, SPAN_DEFINITIONS, TraceItemType.TRACE_ITEM_TYPE_SPAN),
+            (
+                additional_queries.span,
+                SPAN_DEFINITIONS,
+                TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                SupportedTraceItemType.SPANS,
+            ),
             (
                 additional_queries.metric,
                 TRACE_METRICS_DEFINITIONS,
                 TraceItemType.TRACE_ITEM_TYPE_METRIC,
+                SupportedTraceItemType.TRACEMETRICS,
             ),
             (
                 additional_queries.occurrences,
                 OCCURRENCE_DEFINITIONS,
                 TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE,
+                SupportedTraceItemType.OCCURRENCES,
             ),
         ]:
             if queries is not None:
                 # Create a resolver for the subqueries
+                query_config = replace(
+                    cross_trace_config,
+                    api_attribute_visibility_item_type=(
+                        api_item_type.value
+                        if cross_trace_config.api_attribute_visibility_item_type is not None
+                        else None
+                    ),
+                )
                 cross_resolver = SearchResolver(
-                    params=query_params,
-                    config=cross_trace_config,
+                    params=resolver.params,
+                    config=query_config,
                     definitions=definitions,
                 )
                 for query_string in queries:
@@ -228,6 +244,8 @@ class RPCBase:
                                 item_type=item_type,
                             )
                         )
+                if cross_resolver.has_hidden_api_attributes():
+                    resolver.add_hidden_api_attributes(cross_resolver.get_hidden_api_attributes())
         return cross_trace_queries
 
     @classmethod
@@ -262,9 +280,7 @@ class RPCBase:
         # if there are additional conditions to be added, make sure to merge them with the
         where = and_trace_item_filters(where, query.extra_conditions)
 
-        cross_trace_queries = cls.get_cross_trace_queries(
-            query.additional_queries, query.resolver.config, query.resolver.params
-        )
+        cross_trace_queries = cls.get_cross_trace_queries(query.additional_queries, query.resolver)
 
         trace_column, _ = resolver.resolve_column("trace")
         if (
@@ -441,19 +457,28 @@ class RPCBase:
             names.add(query.name)
 
         request_context_pairs: list[tuple[str, TableRequest, dict[str, Any]]] = []
+        results: dict[str, EAPResponse] = {}
         for query in queries:
             assert query.name is not None
             table_request = cls.get_table_rpc_request(query)
+            if query.resolver.has_hidden_api_attributes():
+                results[query.name] = {"data": [], "meta": {"fields": {}}, "confidence": []}
+                continue
             request_context_pairs.append(
                 (query.name, table_request, cls.build_rpc_table_row_context(query))
             )
-        responses = snuba_rpc.table_rpc(
-            [request.rpc_request for _, request, _ in request_context_pairs]
-        )
-        results = {
-            name: cls.process_table_response(response, request, context=process_context)
-            for (name, request, process_context), response in zip(request_context_pairs, responses)
-        }
+        if request_context_pairs:
+            responses = snuba_rpc.table_rpc(
+                [request.rpc_request for _, request, _ in request_context_pairs]
+            )
+            results.update(
+                {
+                    name: cls.process_table_response(response, request, context=process_context)
+                    for (name, request, process_context), response in zip(
+                        request_context_pairs, responses
+                    )
+                }
+            )
         return results
 
     @classmethod
@@ -726,9 +751,7 @@ class RPCBase:
             selected_equations,
         )
 
-        cross_trace_queries = cls.get_cross_trace_queries(
-            additional_queries, search_resolver.config, search_resolver.params
-        )
+        cross_trace_queries = cls.get_cross_trace_queries(additional_queries, search_resolver)
 
         trace_column, _ = search_resolver.resolve_column("trace")
         if (

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -25,7 +25,7 @@ from sentry.search.eap.types import (
     SearchResolverConfig,
     SupportedTraceItemType,
 )
-from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
+from sentry.search.eap.utils import can_expose_attribute_to_api, translate_internal_to_public_alias
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.utils import json, snuba_rpc
@@ -222,9 +222,12 @@ class Spans(rpc_dataset_common.RPCBase):
         attributes: list[AttributeKey] | None = None,
         max_buckets: int = 75,
         skip_translate_internal_to_public_alias: bool = False,
+        include_internal: bool = False,
     ) -> list[dict[str, Any]]:
         search_resolver = search_resolver or cls.get_resolver(params, config)
         stats_filter, _, _ = search_resolver.resolve_query(query_string)
+        if search_resolver.has_hidden_api_attributes():
+            return []
         meta = search_resolver.resolve_meta(
             referrer=referrer,
             sampling_mode=params.sampling_mode,
@@ -257,8 +260,10 @@ class Spans(rpc_dataset_common.RPCBase):
             ):
                 attrs = defaultdict(list)
                 for attribute in result.attribute_distributions.attributes:
-                    if not can_expose_attribute(
-                        attribute.attribute_name, SupportedTraceItemType.SPANS
+                    if not can_expose_attribute_to_api(
+                        attribute.attribute_name,
+                        SupportedTraceItemType.SPANS,
+                        include_internal=include_internal,
                     ):
                         continue
 

--- a/src/sentry/snuba/utils.py
+++ b/src/sentry/snuba/utils.py
@@ -77,9 +77,24 @@ RPC_DATASETS = {
     TraceMetrics,
     UptimeResults,
 }
+RPC_DATASET_ATTRIBUTE_VISIBILITY_ITEM_TYPES = {
+    Occurrences: SupportedTraceItemType.OCCURRENCES,
+    OurLogs: SupportedTraceItemType.LOGS,
+    PreprodSize: SupportedTraceItemType.PREPROD,
+    ProcessingErrors: SupportedTraceItemType.PROCESSING_ERRORS,
+    ProfileFunctions: SupportedTraceItemType.PROFILE_FUNCTIONS,
+    Replays: SupportedTraceItemType.REPLAYS,
+    Spans: SupportedTraceItemType.SPANS,
+    TraceMetrics: SupportedTraceItemType.TRACEMETRICS,
+    UptimeResults: SupportedTraceItemType.UPTIME_RESULTS,
+}
 DATASET_LABELS = {
     value: key for key, value in DATASET_OPTIONS.items() if key not in DEPRECATED_LABELS
 }
+
+
+def get_rpc_dataset_attribute_visibility_item_type(dataset: Any) -> SupportedTraceItemType | None:
+    return RPC_DATASET_ATTRIBUTE_VISIBILITY_ITEM_TYPES.get(dataset)
 
 
 TRANSACTION_ONLY_FIELDS = [

--- a/tests/sentry/api/endpoints/test_organization_spans_fields.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields.py
@@ -163,6 +163,32 @@ class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, SpanTestCase, APITest
         assert "tags[is_debug,boolean]" in keys
         assert "tags[is_production,boolean]" in keys
 
+    def test_internal_convention_attributes_are_staff_only(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"tags": {"normal_attr": "normal_value", "sentry.dsc.trace_id": "abc123"}},
+                    start_ts=before_now(days=0, minutes=10),
+                ),
+            ],
+        )
+
+        response = self.do_request(query={"dataset": "spans", "type": "string", "process": 1})
+        assert response.status_code == 200, response.data
+        attribute_names = {attr["name"] for attr in response.data}
+        assert "normal_attr" in attribute_names
+        assert "sentry.dsc.trace_id" not in attribute_names
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.do_request(query={"dataset": "spans", "type": "string", "process": 1})
+        assert response.status_code == 200, response.data
+        attribute_names = {attr["name"] for attr in response.data}
+        assert "normal_attr" in attribute_names
+        assert "sentry.dsc.trace_id" in attribute_names
+
 
 class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
     view = "sentry-api-0-organization-spans-fields-values"
@@ -248,6 +274,33 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 "lastSeen": mock.ANY,
             },
         ]
+
+    def test_internal_convention_attribute_values_are_staff_only(self) -> None:
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            span_id=uuid4().hex[:16],
+            organization_id=self.organization.id,
+            parent_span_id=None,
+            timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+            transaction="foo",
+            duration=100,
+            exclusive_time=100,
+            tags={"sentry.dsc.trace_id": "abc123"},
+        )
+
+        response = self.do_request("sentry.dsc.trace_id")
+        assert response.status_code == 200, response.data
+        assert response.data == []
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.do_request("sentry.dsc.trace_id")
+        assert response.status_code == 200, response.data
+        assert [item["value"] for item in response.data] == ["abc123"]
 
     def test_transaction_keys_autocomplete(self) -> None:
         timestamp = before_now(days=0, minutes=10).replace(microsecond=0)

--- a/tests/sentry/search/eap/test_ourlogs.py
+++ b/tests/sentry/search/eap/test_ourlogs.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
@@ -17,9 +17,10 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     TraceItemFilter,
 )
 
+from sentry.search.eap import utils as eap_utils
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events.types import SnubaParams
 
 
@@ -50,6 +51,26 @@ class SearchResolverQueryTest(TestCase):
             )
         )
         assert having is None
+
+    def test_visibility_uses_definitions_item_type(self) -> None:
+        resolver = SearchResolver(
+            params=SnubaParams(),
+            config=SearchResolverConfig(
+                api_attribute_visibility_item_type=SupportedTraceItemType.SPANS.value
+            ),
+            definitions=OURLOG_DEFINITIONS,
+        )
+
+        with mock.patch.dict(
+            eap_utils.PRIVATE_ATTRIBUTES,
+            {
+                SupportedTraceItemType.SPANS: set(),
+                SupportedTraceItemType.LOGS: {"log.internal.only"},
+            },
+        ):
+            resolver.resolve_attribute("log.internal.only")
+
+        assert resolver.has_hidden_api_attributes()
 
     def test_negation(self) -> None:
         where, having, _ = self.resolver.resolve_query("!message:foo")

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -1,5 +1,7 @@
 import os
 from datetime import datetime
+from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
@@ -28,6 +30,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 )
 
 from sentry.exceptions import InvalidSearchQuery
+from sentry.search.eap import utils as eap_utils
 from sentry.search.eap.columns import ResolvedAttribute
 from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
@@ -40,11 +43,92 @@ from sentry.search.eap.spans.attributes import (
 )
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.spans.sentry_conventions import SENTRY_CONVENTIONS_DIRECTORY
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
+from sentry.search.eap.utils import can_expose_attribute_to_api
 from sentry.search.events.types import SnubaParams
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
+
+
+class AttributeVisibilityTest(TestCase):
+    def test_public_convention_attribute_visible_to_everyone(self) -> None:
+        with mock.patch.dict(
+            eap_utils.ATTRIBUTE_METADATA,
+            {"public.attr": SimpleNamespace(visibility="public")},
+        ):
+            assert can_expose_attribute_to_api("public.attr", SupportedTraceItemType.SPANS)
+
+    def test_internal_convention_attribute_hidden_unless_included(self) -> None:
+        with mock.patch.dict(
+            eap_utils.ATTRIBUTE_METADATA,
+            {"internal.attr": SimpleNamespace(visibility="internal")},
+        ):
+            assert not can_expose_attribute_to_api("internal.attr", SupportedTraceItemType.SPANS)
+            assert can_expose_attribute_to_api(
+                "internal.attr", SupportedTraceItemType.SPANS, include_internal=True
+            )
+
+    def test_internal_convention_public_alias_is_hidden(self) -> None:
+        with (
+            mock.patch.dict(
+                eap_utils.ATTRIBUTE_METADATA,
+                {"internal.attr": SimpleNamespace(visibility="internal")},
+            ),
+            mock.patch.dict(
+                eap_utils.PUBLIC_ALIAS_TO_INTERNAL_MAPPING[SupportedTraceItemType.SPANS],
+                {
+                    "public.alias": ResolvedAttribute(
+                        public_alias="public.alias",
+                        internal_name="internal.attr",
+                        search_type="string",
+                    )
+                },
+            ),
+        ):
+            assert not can_expose_attribute_to_api("public.alias", SupportedTraceItemType.SPANS)
+
+    def test_internal_convention_translated_public_alias_is_hidden(self) -> None:
+        with (
+            mock.patch.dict(
+                eap_utils.ATTRIBUTE_METADATA,
+                {"public.alias": SimpleNamespace(visibility="internal")},
+            ),
+            mock.patch.dict(
+                eap_utils.INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS[SupportedTraceItemType.SPANS]["string"],
+                {"internal.attr": "public.alias"},
+            ),
+        ):
+            assert not can_expose_attribute_to_api("internal.attr", SupportedTraceItemType.SPANS)
+
+    def test_internal_convention_replacement_is_hidden(self) -> None:
+        with (
+            mock.patch.dict(
+                eap_utils.ATTRIBUTE_METADATA,
+                {"replacement.attr": SimpleNamespace(visibility="internal")},
+            ),
+            mock.patch.dict(
+                eap_utils.SENTRY_CONVENTIONS_REPLACEMENT_MAPPINGS[SupportedTraceItemType.SPANS],
+                {"deprecated.attr": "replacement.attr"},
+            ),
+        ):
+            assert not can_expose_attribute_to_api("deprecated.attr", SupportedTraceItemType.SPANS)
+
+    def test_stripped_internal_prefix_alias_is_hidden(self) -> None:
+        assert not can_expose_attribute_to_api(
+            "_internal.normalized_description", SupportedTraceItemType.SPANS
+        )
+        assert can_expose_attribute_to_api(
+            "_internal.normalized_description",
+            SupportedTraceItemType.SPANS,
+            include_internal=True,
+        )
+
+    def test_stripped_dsc_convention_alias_is_hidden(self) -> None:
+        assert not can_expose_attribute_to_api("dsc.trace_id", SupportedTraceItemType.SPANS)
+        assert can_expose_attribute_to_api(
+            "dsc.trace_id", SupportedTraceItemType.SPANS, include_internal=True
+        )
 
 
 class SearchResolverQueryTest(TestCase):

--- a/tests/sentry/snuba/test_rpc_dataset_common.py
+++ b/tests/sentry/snuba/test_rpc_dataset_common.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from unittest import mock
 
 import pytest
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
@@ -17,7 +18,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 class TestBulkTableQueries(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.snuba_params = SnubaParams()
+        self.snuba_params = SnubaParams(projects=[self.project], stats_period="1h")
         self.config = SearchResolverConfig()
         self.resolver = Spans.get_resolver(self.snuba_params, self.config)
 
@@ -68,6 +69,29 @@ class TestBulkTableQueries(TestCase):
                     ),
                 ]
             )
+
+    def test_hidden_attribute_query_returns_empty_without_rpc(self) -> None:
+        self.resolver.add_hidden_api_attributes({"__sentry_internal_test"})
+
+        with mock.patch("sentry.snuba.rpc_dataset_common.snuba_rpc.table_rpc") as mock_table_rpc:
+            results = RPCBase.run_bulk_table_queries(
+                [
+                    TableQuery(
+                        "",
+                        ["count()"],
+                        None,
+                        0,
+                        1,
+                        "TestReferrer",
+                        None,
+                        self.resolver,
+                        name="hidden",
+                    )
+                ]
+            )
+
+        assert results == {"hidden": {"data": [], "meta": {"fields": {}}, "confidence": []}}
+        mock_table_rpc.assert_not_called()
 
 
 trace_id_test_cases = (

--- a/tests/sentry/snuba/test_rpc_dataset_common.py
+++ b/tests/sentry/snuba/test_rpc_dataset_common.py
@@ -3,8 +3,10 @@ from unittest import mock
 
 import pytest
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.resolver import SearchResolver
+from sentry.search.eap.types import AdditionalQueries, SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events.types import SnubaParams
 from sentry.snuba.occurrences_rpc import Occurrences
 from sentry.snuba.ourlogs import OurLogs
@@ -92,6 +94,36 @@ class TestBulkTableQueries(TestCase):
 
         assert results == {"hidden": {"data": [], "meta": {"fields": {}}, "confidence": []}}
         mock_table_rpc.assert_not_called()
+
+    def test_cross_trace_queries_pass_subquery_item_type_for_visibility(self) -> None:
+        resolver = Spans.get_resolver(
+            self.snuba_params,
+            SearchResolverConfig(
+                api_attribute_visibility_item_type=SupportedTraceItemType.SPANS.value
+            ),
+        )
+
+        def resolve_query(search_resolver: SearchResolver, query_string: str):
+            if (
+                search_resolver.config.api_attribute_visibility_item_type
+                == SupportedTraceItemType.OCCURRENCES.value
+            ):
+                search_resolver.add_hidden_api_attributes({query_string})
+            return TraceItemFilter(), None, []
+
+        with mock.patch.object(SearchResolver, "resolve_query", autospec=True) as mock_resolve:
+            mock_resolve.side_effect = resolve_query
+            RPCBase.get_cross_trace_queries(
+                AdditionalQueries(
+                    span=None,
+                    log=None,
+                    metric=None,
+                    occurrences=["occurrence.internal.only:value"],
+                ),
+                resolver,
+            )
+
+        assert resolver.has_hidden_api_attributes()
 
 
 trace_id_test_cases = (

--- a/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
@@ -108,6 +108,106 @@ class OrganizationEventsCrossTraceEndpointTest(OrganizationEventsEndpointTestBas
         assert len(response.data["data"]) == 1
         assert response.data["data"][0]["tags[foo]"] == "five"
 
+    def test_cross_trace_query_with_internal_span_attribute_is_staff_only(self) -> None:
+        trace_id = uuid.uuid4().hex
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "tags": {"foo": "five"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "hidden-filter-span",
+                        "tags": {"__sentry_internal_test": "internal_value"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+        )
+
+        query = {
+            "field": ["tags[foo]", "count()"],
+            "query": "description:baz",
+            "orderby": "count()",
+            "project": self.project.id,
+            "dataset": "spans",
+            "spanQuery": ["__sentry_internal_test:internal_value"],
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == []
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+        with self.feature({"organizations:discover-basic": True}):
+            response = self.client_get(self.reverse_url(), query, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "tags[foo]": "five",
+                "count()": 1,
+            }
+        ]
+
+    def test_cross_trace_query_with_internal_log_attribute_is_staff_only(self) -> None:
+        trace_id = uuid.uuid4().hex
+        logs = [
+            self.create_ourlog(
+                {"body": "foo", "trace_id": trace_id},
+                timestamp=self.ten_mins_ago,
+                attributes={"__sentry_internal_test": "internal_value"},
+            ),
+        ]
+        self.store_eap_items(logs)
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "tags": {"foo": "five"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+        )
+
+        query = {
+            "field": ["tags[foo]", "count()"],
+            "query": "description:baz",
+            "orderby": "count()",
+            "project": self.project.id,
+            "dataset": "spans",
+            "logQuery": ["__sentry_internal_test:internal_value"],
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == []
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+        with self.feature({"organizations:discover-basic": True}):
+            response = self.client_get(self.reverse_url(), query, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "tags[foo]": "five",
+                "count()": 1,
+            }
+        ]
+
     def test_cross_trace_query_with_spans_and_logs(self) -> None:
         trace_id = uuid.uuid4().hex
         excluded_trace_id = uuid.uuid4().hex

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -4551,6 +4551,47 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
 
             assert response.status_code == 400, response.content
 
+    def test_sentry_internal_field_values_are_staff_only(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "tags": {
+                            "normal_attr": "normal_value",
+                            "__sentry_internal_test": "internal_value",
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+        )
+        query = {
+            "field": ["__sentry_internal_test", "count()"],
+            "query": "",
+            "orderby": "__sentry_internal_test",
+            "project": self.project.id,
+            "dataset": "spans",
+            "statsPeriod": "1h",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == []
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+        with self.feature({"organizations:discover-basic": True}):
+            response = self.client_get(self.reverse_url(), query, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "__sentry_internal_test": "internal_value",
+                "count()": 1,
+            }
+        ]
+
     def test_transaction_profile_attributes(self) -> None:
         span_with_profile = self.create_span(start_ts=before_now(minutes=10))
         span_without_profile = self.create_span(

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -141,6 +141,50 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "interval": 3_600_000,
         }
 
+    def test_sentry_internal_groupby_values_are_staff_only(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"tags": {"__sentry_internal_test": "internal_value"}},
+                    start_ts=self.start,
+                ),
+            ],
+        )
+        query = {
+            "start": self.start,
+            "end": self.end,
+            "interval": "1h",
+            "yAxis": "count()",
+            "groupBy": "__sentry_internal_test",
+            "orderby": "-count()",
+            "topEvents": 1,
+            "project": self.project.id,
+            "dataset": "spans",
+            "excludeOther": 1,
+        }
+
+        response = self._do_request(data=query)
+        assert response.status_code == 200, response.content
+        assert response.data["timeSeries"] == []
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self._do_request(data=query)
+        assert response.status_code == 200, response.content
+        assert len(response.data["timeSeries"]) == 1
+        timeseries = response.data["timeSeries"][0]
+        assert timeseries["groupBy"] == [
+            {"key": "__sentry_internal_test", "value": "internal_value"}
+        ]
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start,
+            3_600_000,
+            [1, 0, 0, 0, 0, 0],
+            ignore_accuracy=True,
+        )
+
     def test_handle_nans_from_snuba(self) -> None:
         self.store_spans(
             [self.create_span({"description": "foo"}, start_ts=self.start)],

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -953,6 +953,32 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert "__sentry_internal_span_buffer_outcome" in attribute_names
         assert "__sentry_internal_test" in attribute_names
 
+    def test_internal_convention_attributes_are_staff_only(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"tags": {"normal_attr": "normal_value", "sentry.dsc.trace_id": "abc123"}},
+                    start_ts=before_now(days=0, minutes=10),
+                ),
+            ],
+        )
+
+        response = self.do_request(query={"attributeType": "string", "substringMatch": ""})
+        assert response.status_code == 200
+        attribute_names = {attr["name"] for attr in response.data}
+        assert "normal_attr" in attribute_names
+        assert "sentry.dsc.trace_id" not in attribute_names
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.do_request(query={"attributeType": "string", "substringMatch": ""})
+        assert response.status_code == 200
+        attribute_names = {attr["name"] for attr in response.data}
+        assert "normal_attr" in attribute_names
+        assert "sentry.dsc.trace_id" in attribute_names
+
     def test_boolean_attributes(self) -> None:
         span1 = self.create_span(start_ts=before_now(days=0, minutes=10))
         span1["data"] = {
@@ -1491,6 +1517,28 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
                 "lastSeen": mock.ANY,
             },
         ]
+
+    def test_internal_convention_attribute_values_are_staff_only(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"tags": {"sentry.dsc.trace_id": "abc123"}},
+                    start_ts=before_now(days=0, minutes=10),
+                ),
+            ],
+        )
+
+        response = self.do_request(key="sentry.dsc.trace_id")
+        assert response.status_code == 200, response.content
+        assert response.data == []
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.do_request(key="sentry.dsc.trace_id")
+        assert response.status_code == 200, response.content
+        assert [item["value"] for item in response.data] == ["abc123"]
 
     def test_transaction_keys_autocomplete(self) -> None:
         timestamp = before_now(days=0, minutes=10).replace(microsecond=0)
@@ -2442,6 +2490,40 @@ class OrganizationTraceItemAttributeValidateEndpointTest(
         attr = response.data["attributes"]["span.duration"]
         assert attr["valid"] is True
         assert attr["type"] == "number"
+
+    def test_internal_convention_attribute_validation_is_staff_only(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"tags": {"sentry.dsc.trace_id": "abc123"}},
+                    start_ts=before_now(days=0, minutes=10),
+                ),
+            ],
+        )
+
+        response = self.do_request(
+            payload={"attributes": ["sentry.dsc.trace_id"]},
+            query_params={"itemType": "spans"},
+        )
+        assert response.status_code == 200
+        attr = response.data["attributes"]["sentry.dsc.trace_id"]
+        assert attr == {
+            "valid": False,
+            "error": "Unknown attribute: sentry.dsc.trace_id",
+        }
+
+        with mock.patch(
+            "sentry.api.endpoints.organization_trace_item_attributes.is_active_staff",
+            return_value=True,
+        ):
+            response = self.do_request(
+                payload={"attributes": ["sentry.dsc.trace_id"]},
+                query_params={"itemType": "spans"},
+            )
+        assert response.status_code == 200
+        attr = response.data["attributes"]["sentry.dsc.trace_id"]
+        assert attr["valid"] is True
+        assert attr["type"] == "string"
 
     def test_virtual_context_attributes(self):
         response = self.do_request(

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes_ranked.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes_ranked.py
@@ -66,6 +66,11 @@ class OrganizationTraceItemsAttributesRankedEndpointTest(
         assert response.status_code == 200, response.data
         assert response.data == {"rankedAttributes": []}
 
+    def test_internal_convention_attribute_query_returns_empty_for_non_staff(self) -> None:
+        response = self.do_request(query={"query_1": "sentry.dsc.trace_id:abc123"})
+        assert response.status_code == 200, response.data
+        assert response.data == {"rankedAttributes": []}
+
     @patch("sentry.api.endpoints.organization_trace_item_attributes_ranked.compare_distributions")
     def test_distribution_values(self, mock_compare_distributions) -> None:
         mock_compare_distributions.return_value = {

--- a/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
@@ -182,6 +182,38 @@ class OrganizationTraceItemsStatsEndpointTest(
         assert "custom_attr" not in attribute_distribution
         assert "other_attr" not in attribute_distribution
 
+    def test_internal_convention_attributes_are_staff_only(self) -> None:
+        self.store_span(
+            self.create_span(
+                {"sentry_tags": {"dsc.trace_id": "abc123"}},
+                start_ts=self.ten_mins_ago,
+            ),
+        )
+
+        response = self.do_request(
+            query={
+                "statsType": ["attributeDistributions"],
+                "substringMatch": "dsc",
+            }
+        )
+        assert response.status_code == 200, response.data
+        assert response.data == {"data": []}
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.do_request(
+            query={
+                "statsType": ["attributeDistributions"],
+                "substringMatch": "dsc",
+            }
+        )
+        assert response.status_code == 200, response.data
+        assert len(response.data["data"]) == 1
+        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        assert attribute_distribution["sentry.dsc.trace_id"] == [{"label": "abc123", "value": 1.0}]
+
     def test_query_filters_spans_before_stats(self) -> None:
         tags = [
             ({"browser": "chrome", "device": "desktop"}, 100),

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -309,6 +309,80 @@ class ProjectTraceItemDetailsEndpointTest(
             == self.one_min_ago.replace(microsecond=0, tzinfo=None).isoformat() + "Z"
         )
 
+    def test_internal_convention_span_attributes_are_staff_only(self) -> None:
+        span = self.create_span(
+            {
+                "tags": {
+                    "sentry._meta.fields.attributes.sentry.dsc.trace_id": '{"reason": "internal"}'
+                },
+                "sentry_tags": {"dsc.trace_id": "abc123"},
+            },
+            start_ts=self.one_min_ago,
+        )
+        span["trace_id"] = self.trace_uuid
+        item_id = span["span_id"]
+        self.store_span(span)
+
+        response = self.do_request("spans", item_id)
+        assert response.status_code == 200, response.content
+        attribute_names = {attr["name"] for attr in response.data["attributes"]}
+        assert "dsc.trace_id" not in attribute_names
+        assert "sentry.dsc.trace_id" not in response.data["meta"]
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.do_request("spans", item_id)
+        assert response.status_code == 200, response.content
+        attributes = {attr["name"]: attr for attr in response.data["attributes"]}
+        assert attributes["dsc.trace_id"] == {
+            "name": "dsc.trace_id",
+            "type": "str",
+            "value": "abc123",
+        }
+        assert response.data["meta"]["sentry.dsc.trace_id"] == {"reason": "internal"}
+
+    def test_stripped_internal_convention_span_attributes_are_staff_only(self) -> None:
+        span = self.create_span(
+            {
+                "description": "test span",
+                "tags": {
+                    "dsc.trace_id": "abc123",
+                    "_internal.normalized_description": "normalized",
+                },
+            },
+            start_ts=self.one_min_ago,
+        )
+        span["trace_id"] = self.trace_uuid
+        item_id = span["span_id"]
+
+        self.store_span(span)
+
+        response = self.do_request("spans", item_id)
+        assert response.status_code == 200, response.content
+        attribute_names = {attr["name"] for attr in response.data["attributes"]}
+        assert "dsc.trace_id" not in attribute_names
+        assert "_internal.normalized_description" not in attribute_names
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.do_request("spans", item_id)
+        assert response.status_code == 200, response.content
+        attributes = {attr["name"]: attr for attr in response.data["attributes"]}
+        assert attributes["dsc.trace_id"] == {
+            "name": "dsc.trace_id",
+            "type": "str",
+            "value": "abc123",
+        }
+        assert attributes["_internal.normalized_description"] == {
+            "name": "_internal.normalized_description",
+            "type": "str",
+            "value": "normalized",
+        }
+
     def test_simple_using_spans_item_type_with_sentry_conventions(self) -> None:
         span_1 = self.create_span(
             {"description": "foo", "sentry_tags": {"status": "success"}},
@@ -496,7 +570,7 @@ class ProjectTraceItemDetailsEndpointTest(
             {
                 "description": "foo",
                 "sentry_tags": {
-                    "links": '[{"trace_id":"d099bf9ad5a143cf8f83a98081d0ed3b","span_id":"8873a98879faf06d","sampled":true,"attributes":{"sentry.link.type":"parent","sentry.dropped_attributes_count":1}}]',
+                    "links": '[{"trace_id":"d099bf9ad5a143cf8f83a98081d0ed3b","span_id":"8873a98879faf06d","sampled":true,"attributes":{"sentry.link.type":"parent","sentry.dropped_attributes_count":1,"dsc.trace_id":"abc123","_internal.normalized_description":"normalized"}}]',
                 },
             },
             start_ts=self.one_min_ago,


### PR DESCRIPTION
The goal of this PR is to hide internal attributes from API responses to non-staff users. This visibility is controlled via the `visibility` field from the conventions package.

TODO

Closes EXP-966