### PR TITLE
meta: Remove autopilot CODEOWNERS entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -583,8 +583,6 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 
 
 ## Telemetry Experience
-/src/sentry/autopilot/                                                           @getsentry/telemetry-experience
-/tests/sentry/autopilot/                                                         @getsentry/telemetry-experience
 /src/sentry/api/endpoints/organization_sessions.py                               @getsentry/telemetry-experience
 /tests/snuba/api/endpoints/test_organization_sessions.py                         @getsentry/telemetry-experience
 /src/sentry/api/endpoints/organization_sampling_project_span_counts.py           @getsentry/telemetry-experience


### PR DESCRIPTION
The autopilot project has been removed, so clean up its two CODEOWNERS entries from the Telemetry Experience section.