### PR TITLE
ref(conversations): Simplify conversation details endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -1,5 +1,7 @@
-from datetime import timedelta
+from dataclasses import replace
+from datetime import datetime, timedelta
 
+import sentry_sdk
 from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,14 +12,22 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.api.utils import handle_query_errors
+from sentry.api.utils import TimeoutException, handle_query_errors
 from sentry.models.organization import Organization
 from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
 from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
+from sentry.utils.dates import parse_stats_period
 
 MAX_RETENTION_DAYS = 30
+
+# Widening steps used when no explicit time range is provided.
+# We try progressively wider windows so that a recent conversation is found
+# quickly, while older ones can still be located without timing out on a
+# full 30-day scan every time.
+_WIDENING_STEPS = [timedelta(days=7), timedelta(days=MAX_RETENTION_DAYS)]
 
 # Base span fields always returned
 AI_CONVERSATION_ATTRIBUTES = [
@@ -58,6 +68,12 @@ AI_CONVERSATION_ATTRIBUTES = [
     "user.ip",
 ]
 
+_TIMEOUT_DETAIL = (
+    "The query timed out before finding this conversation. "
+    "Open the conversation from the Conversations list to get a direct link "
+    "with a precise time range."
+)
+
 
 @cell_silo_endpoint
 class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
@@ -68,7 +84,6 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):
             return Response(status=404)
 
-        # Check what date params were passed before calling get_snuba_params
         stats_period = request.GET.get("statsPeriod")
         has_explicit_range = request.GET.get("start") or request.GET.get("end")
 
@@ -77,17 +92,11 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         except NoProjects:
             return Response(status=404)
 
-        # Enforce 30-day retention limit
-        max_retention = timedelta(days=MAX_RETENTION_DAYS)
         now = timezone.now()
-        max_retention_cutoff = now - max_retention
+        max_retention_cutoff = now - timedelta(days=MAX_RETENTION_DAYS)
 
-        if stats_period or not has_explicit_range:
-            # Always use full 30d range when statsPeriod is passed or no date params
-            snuba_params.start = max_retention_cutoff
-            snuba_params.end = now
-        else:
-            # Validate explicit start/end aren't older than retention limit
+        if has_explicit_range:
+            # Caller supplied precise timestamps — validate retention and use as-is.
             if snuba_params.start and snuba_params.start < max_retention_cutoff:
                 return Response(
                     {"detail": f"start time cannot be older than {MAX_RETENTION_DAYS} days"},
@@ -98,38 +107,101 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                     {"detail": f"end time cannot be older than {MAX_RETENTION_DAYS} days"},
                     status=400,
                 )
+            data_fn = self._make_direct_data_fn(snuba_params, conversation_id)
+        else:
+            # No explicit range: respect the passed statsPeriod as the first
+            # attempt, then widen to 7d and 30d if the conversation is not found.
+            params_sequence = self._build_widening_sequence(snuba_params, stats_period, now)
+            data_fn = self._make_widening_data_fn(params_sequence, conversation_id)
 
-        selected_columns = AI_CONVERSATION_ATTRIBUTES
-
-        def data_fn(offset: int, limit: int):
-            return self._fetch_conversation_spans(
-                snuba_params=snuba_params,
-                conversation_id=conversation_id,
-                selected_columns=selected_columns,
-                offset=offset,
-                limit=limit,
+        try:
+            with handle_query_errors():
+                return self.paginate(
+                    request=request,
+                    paginator=GenericOffsetPaginator(data_fn=data_fn),
+                    default_per_page=100,
+                    max_per_page=1000,
+                )
+        except TimeoutException:
+            sentry_sdk.set_tag("ai_conversations.detail_timeout", True)
+            return Response(
+                {"detail": _TIMEOUT_DETAIL, "code": "query_timeout"},
+                status=504,
             )
 
-        with handle_query_errors():
-            return self.paginate(
-                request=request,
-                paginator=GenericOffsetPaginator(data_fn=data_fn),
-                default_per_page=100,
-                max_per_page=1000,
-            )
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
 
+    def _build_widening_sequence(
+        self, base_params: SnubaParams, stats_period: str | None, now: datetime
+    ) -> list[SnubaParams]:
+        """
+        Return a list of SnubaParams covering progressively wider time windows.
+
+        Starts from the requested statsPeriod (if any), then appends the
+        standard widening steps (7d, 30d) that are wider than the initial period.
+        """
+        requested_delta: timedelta | None = None
+        if stats_period:
+            requested_delta = parse_stats_period(stats_period)
+
+        steps: list[timedelta] = []
+        if requested_delta and requested_delta < timedelta(days=MAX_RETENTION_DAYS):
+            steps.append(requested_delta)
+
+        for step in _WIDENING_STEPS:
+            if not steps or step > steps[-1]:
+                steps.append(step)
+
+        return [replace(base_params, start=now - delta, end=now) for delta in steps]
+
+    def _make_direct_data_fn(self, snuba_params, conversation_id: str):
+        """data_fn for an explicit time range — no widening."""
+
+        def data_fn(offset: int, limit: int) -> list:
+            return self._fetch_conversation_spans(snuba_params, conversation_id, offset, limit)
+
+        return data_fn
+
+    def _make_widening_data_fn(self, params_sequence: list[SnubaParams], conversation_id: str):
+        """
+        data_fn that tries each set of params in order and memoises the first
+        one that returns results.  Subsequent pages reuse the winning params
+        directly, avoiding redundant narrower-window queries.
+        """
+        winning_params: SnubaParams | None = None
+
+        def data_fn(offset: int, limit: int) -> list:
+            nonlocal winning_params
+
+            if winning_params is not None:
+                return self._fetch_conversation_spans(
+                    winning_params, conversation_id, offset, limit
+                )
+
+            for params in params_sequence:
+                result = self._fetch_conversation_spans(params, conversation_id, offset, limit)
+                if result:
+                    winning_params = params
+                    return result
+
+            return []
+
+        return data_fn
+
+    @sentry_sdk.trace
     def _fetch_conversation_spans(
         self,
         snuba_params,
         conversation_id: str,
-        selected_columns: list[str],
         offset: int,
         limit: int,
-    ):
+    ) -> list:
         result = Spans.run_table_query(
             params=snuba_params,
             query_string=build_escaped_term_filter("gen_ai.conversation.id", [conversation_id]),
-            selected_columns=selected_columns,
+            selected_columns=AI_CONVERSATION_ATTRIBUTES,
             orderby=["precise.start_ts"],
             offset=offset,
             limit=limit,

--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -64,11 +64,7 @@ AI_CONVERSATION_ATTRIBUTES = [
     "user.ip",
 ]
 
-_TIMEOUT_DETAIL = (
-    "The query timed out before finding this conversation. "
-    "Open the conversation from the Conversations list to get a direct link "
-    "with a precise time range."
-)
+_TIMEOUT_DETAIL = "Query timed out. Try searching with a narrower time range."
 
 
 @cell_silo_endpoint

--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -11,8 +11,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
-from sentry.api.paginator import GenericOffsetPaginator
-from sentry.api.utils import TimeoutException, handle_query_errors
+from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
 from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
 from sentry.search.eap.types import SearchResolverConfig
@@ -22,9 +21,9 @@ from sentry.snuba.spans_rpc import Spans
 from sentry.utils.dates import parse_stats_period
 
 MAX_RETENTION_DAYS = 30
+MAX_SPANS = 1000
 
-# Try progressively wider windows before giving up.
-_WIDENING_STEPS = [timedelta(days=7), timedelta(days=MAX_RETENTION_DAYS)]
+_WIDENING_STEPS = [timedelta(days=7), timedelta(days=14), timedelta(days=MAX_RETENTION_DAYS)]
 
 AI_CONVERSATION_ATTRIBUTES = [
     "span_id",
@@ -64,8 +63,6 @@ AI_CONVERSATION_ATTRIBUTES = [
     "user.ip",
 ]
 
-_TIMEOUT_DETAIL = "Query timed out. Try searching with a narrower time range."
-
 
 @cell_silo_endpoint
 class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
@@ -76,9 +73,6 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):
             return Response(status=404)
 
-        stats_period = request.GET.get("statsPeriod")
-        has_explicit_range = request.GET.get("start") or request.GET.get("end")
-
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
@@ -86,6 +80,7 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
 
         now = timezone.now()
         max_retention_cutoff = now - timedelta(days=MAX_RETENTION_DAYS)
+        has_explicit_range = request.GET.get("start") or request.GET.get("end")
 
         if has_explicit_range:
             if snuba_params.start and snuba_params.start < max_retention_cutoff:
@@ -98,84 +93,44 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                     {"detail": f"end time cannot be older than {MAX_RETENTION_DAYS} days"},
                     status=400,
                 )
-            data_fn = self._make_direct_data_fn(snuba_params, conversation_id)
+            params_to_try = [snuba_params]
         else:
-            params_sequence = self._build_widening_sequence(snuba_params, stats_period, now)
-            data_fn = self._make_widening_data_fn(params_sequence, conversation_id)
-
-        try:
-            with handle_query_errors():
-                return self.paginate(
-                    request=request,
-                    paginator=GenericOffsetPaginator(data_fn=data_fn),
-                    default_per_page=100,
-                    max_per_page=1000,
-                )
-        except TimeoutException:
-            sentry_sdk.set_tag("ai_conversations.detail_timeout", True)
-            return Response(
-                {"detail": _TIMEOUT_DETAIL, "code": "query_timeout"},
-                status=504,
+            params_to_try = self._build_widening_params(
+                snuba_params, request.GET.get("statsPeriod"), now
             )
 
-    def _build_widening_sequence(
+        with handle_query_errors():
+            for params in params_to_try:
+                data = self._fetch_conversation_spans(params, conversation_id)
+                if data:
+                    return Response({"data": data})
+            return Response({"data": []})
+
+    def _build_widening_params(
         self, base_params: SnubaParams, stats_period: str | None, now: datetime
     ) -> list[SnubaParams]:
-        # parse_stats_period returns None for invalid input; skip to default steps
-        requested_delta = parse_stats_period(stats_period) if stats_period else None
+        requested_delta: timedelta | None = (
+            parse_stats_period(stats_period) if stats_period else None
+        )
 
         steps: list[timedelta] = []
-        if requested_delta and requested_delta < timedelta(days=MAX_RETENTION_DAYS):
+        if requested_delta:
             steps.append(requested_delta)
-
         for step in _WIDENING_STEPS:
             if not steps or step > steps[-1]:
                 steps.append(step)
 
         return [replace(base_params, start=now - delta, end=now) for delta in steps]
 
-    def _make_direct_data_fn(self, snuba_params: SnubaParams, conversation_id: str):
-        def data_fn(offset: int, limit: int) -> list:
-            return self._fetch_conversation_spans(snuba_params, conversation_id, offset, limit)
-
-        return data_fn
-
-    def _make_widening_data_fn(self, params_sequence: list[SnubaParams], conversation_id: str):
-        winning_params: SnubaParams | None = None
-
-        def data_fn(offset: int, limit: int) -> list:
-            nonlocal winning_params
-
-            if winning_params is not None:
-                return self._fetch_conversation_spans(
-                    winning_params, conversation_id, offset, limit
-                )
-
-            for params in params_sequence:
-                result = self._fetch_conversation_spans(params, conversation_id, offset, limit)
-                if result:
-                    winning_params = params
-                    return result
-
-            return []
-
-        return data_fn
-
     @sentry_sdk.trace
-    def _fetch_conversation_spans(
-        self,
-        snuba_params: SnubaParams,
-        conversation_id: str,
-        offset: int,
-        limit: int,
-    ) -> list:
+    def _fetch_conversation_spans(self, snuba_params: SnubaParams, conversation_id: str) -> list:
         result = Spans.run_table_query(
             params=snuba_params,
             query_string=build_escaped_term_filter("gen_ai.conversation.id", [conversation_id]),
             selected_columns=AI_CONVERSATION_ATTRIBUTES,
             orderby=["precise.start_ts"],
-            offset=offset,
-            limit=limit,
+            offset=0,
+            limit=MAX_SPANS,
             referrer=Referrer.API_AI_CONVERSATION_DETAILS.value,
             config=SearchResolverConfig(auto_fields=True),
             sampling_mode="HIGHEST_ACCURACY",

--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -11,6 +11,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
 from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
@@ -21,7 +22,6 @@ from sentry.snuba.spans_rpc import Spans
 from sentry.utils.dates import parse_stats_period
 
 MAX_RETENTION_DAYS = 30
-MAX_SPANS = 1000
 
 _WIDENING_STEPS = [timedelta(days=7), timedelta(days=14), timedelta(days=MAX_RETENTION_DAYS)]
 
@@ -93,28 +93,49 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                     {"detail": f"end time cannot be older than {MAX_RETENTION_DAYS} days"},
                     status=400,
                 )
-            params_to_try = [snuba_params]
-        else:
-            params_to_try = self._build_widening_params(
-                snuba_params, request.GET.get("statsPeriod"), now
-            )
 
         with handle_query_errors():
-            for params in params_to_try:
-                data = self._fetch_conversation_spans(params, conversation_id)
-                if data:
-                    return Response({"data": data})
-            return Response({"data": []})
+            if has_explicit_range:
+                resolved_params = snuba_params
+            else:
+                resolved_params = self._resolve_time_window(
+                    snuba_params, request.GET.get("statsPeriod"), now, conversation_id
+                )
+
+            def data_fn(offset: int, limit: int) -> list:
+                return self._fetch_spans(resolved_params, conversation_id, offset, limit)
+
+            return self.paginate(
+                request=request,
+                paginator=GenericOffsetPaginator(data_fn=data_fn),
+                default_per_page=100,
+                max_per_page=1000,
+            )
+
+    def _resolve_time_window(
+        self,
+        base_params: SnubaParams,
+        stats_period: str | None,
+        now: datetime,
+        conversation_id: str,
+    ) -> SnubaParams:
+        """Probe progressively wider windows to find which contains the conversation."""
+        candidates = self._build_widening_params(base_params, stats_period, now)
+        for params in candidates:
+            if self._fetch_spans(params, conversation_id, offset=0, limit=1):
+                return params
+        return candidates[-1]
 
     def _build_widening_params(
         self, base_params: SnubaParams, stats_period: str | None, now: datetime
     ) -> list[SnubaParams]:
+        max_retention = timedelta(days=MAX_RETENTION_DAYS)
         requested_delta: timedelta | None = (
             parse_stats_period(stats_period) if stats_period else None
         )
 
         steps: list[timedelta] = []
-        if requested_delta:
+        if requested_delta and requested_delta < max_retention:
             steps.append(requested_delta)
         for step in _WIDENING_STEPS:
             if not steps or step > steps[-1]:
@@ -123,14 +144,20 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         return [replace(base_params, start=now - delta, end=now) for delta in steps]
 
     @sentry_sdk.trace
-    def _fetch_conversation_spans(self, snuba_params: SnubaParams, conversation_id: str) -> list:
+    def _fetch_spans(
+        self,
+        snuba_params: SnubaParams,
+        conversation_id: str,
+        offset: int,
+        limit: int,
+    ) -> list:
         result = Spans.run_table_query(
             params=snuba_params,
             query_string=build_escaped_term_filter("gen_ai.conversation.id", [conversation_id]),
             selected_columns=AI_CONVERSATION_ATTRIBUTES,
             orderby=["precise.start_ts"],
-            offset=0,
-            limit=MAX_SPANS,
+            offset=offset,
+            limit=limit,
             referrer=Referrer.API_AI_CONVERSATION_DETAILS.value,
             config=SearchResolverConfig(auto_fields=True),
             sampling_mode="HIGHEST_ACCURACY",

--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -23,13 +23,9 @@ from sentry.utils.dates import parse_stats_period
 
 MAX_RETENTION_DAYS = 30
 
-# Widening steps used when no explicit time range is provided.
-# We try progressively wider windows so that a recent conversation is found
-# quickly, while older ones can still be located without timing out on a
-# full 30-day scan every time.
+# Try progressively wider windows before giving up.
 _WIDENING_STEPS = [timedelta(days=7), timedelta(days=MAX_RETENTION_DAYS)]
 
-# Base span fields always returned
 AI_CONVERSATION_ATTRIBUTES = [
     "span_id",
     "trace",
@@ -96,7 +92,6 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         max_retention_cutoff = now - timedelta(days=MAX_RETENTION_DAYS)
 
         if has_explicit_range:
-            # Caller supplied precise timestamps — validate retention and use as-is.
             if snuba_params.start and snuba_params.start < max_retention_cutoff:
                 return Response(
                     {"detail": f"start time cannot be older than {MAX_RETENTION_DAYS} days"},
@@ -109,8 +104,6 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                 )
             data_fn = self._make_direct_data_fn(snuba_params, conversation_id)
         else:
-            # No explicit range: respect the passed statsPeriod as the first
-            # attempt, then widen to 7d and 30d if the conversation is not found.
             params_sequence = self._build_widening_sequence(snuba_params, stats_period, now)
             data_fn = self._make_widening_data_fn(params_sequence, conversation_id)
 
@@ -129,22 +122,11 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                 status=504,
             )
 
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
     def _build_widening_sequence(
         self, base_params: SnubaParams, stats_period: str | None, now: datetime
     ) -> list[SnubaParams]:
-        """
-        Return a list of SnubaParams covering progressively wider time windows.
-
-        Starts from the requested statsPeriod (if any), then appends the
-        standard widening steps (7d, 30d) that are wider than the initial period.
-        """
-        requested_delta: timedelta | None = None
-        if stats_period:
-            requested_delta = parse_stats_period(stats_period)
+        # parse_stats_period returns None for invalid input; skip to default steps
+        requested_delta = parse_stats_period(stats_period) if stats_period else None
 
         steps: list[timedelta] = []
         if requested_delta and requested_delta < timedelta(days=MAX_RETENTION_DAYS):
@@ -156,20 +138,13 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
 
         return [replace(base_params, start=now - delta, end=now) for delta in steps]
 
-    def _make_direct_data_fn(self, snuba_params, conversation_id: str):
-        """data_fn for an explicit time range — no widening."""
-
+    def _make_direct_data_fn(self, snuba_params: SnubaParams, conversation_id: str):
         def data_fn(offset: int, limit: int) -> list:
             return self._fetch_conversation_spans(snuba_params, conversation_id, offset, limit)
 
         return data_fn
 
     def _make_widening_data_fn(self, params_sequence: list[SnubaParams], conversation_id: str):
-        """
-        data_fn that tries each set of params in order and memoises the first
-        one that returns results.  Subsequent pages reuse the winning params
-        directly, avoiding redundant narrower-window queries.
-        """
         winning_params: SnubaParams | None = None
 
         def data_fn(offset: int, limit: int) -> list:
@@ -193,7 +168,7 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
     @sentry_sdk.trace
     def _fetch_conversation_spans(
         self,
-        snuba_params,
+        snuba_params: SnubaParams,
         conversation_id: str,
         offset: int,
         limit: int,

--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -403,7 +403,7 @@ describe('useConversation', () => {
     expect(queryArg).not.toHaveProperty('statsPeriod');
   });
 
-  it('falls back to ALL_ACCESS_PROJECTS and 30d when no filters are set', async () => {
+  it('falls back to ALL_ACCESS_PROJECTS with no time params when no filters are set', async () => {
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
       body: [BASE_SPAN],
@@ -421,10 +421,14 @@ describe('useConversation', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           project: [-1],
-          statsPeriod: '30d',
         }),
       })
     );
+    // No statsPeriod sent — backend uses its 30d retention fallback
+    const queryArg = mockRequest.mock.calls[0]![1]!.query;
+    expect(queryArg).not.toHaveProperty('statsPeriod');
+    expect(queryArg).not.toHaveProperty('start');
+    expect(queryArg).not.toHaveProperty('end');
   });
 
   it('uses relative period from page filters when explicitly set', async () => {

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -202,7 +202,7 @@ export function useConversation(
       }
     : hasExplicitDatetime
       ? normalizeDateTimeParams(selection.datetime)
-      : {statsPeriod: '30d'};
+      : {};
 
   const project =
     selection.projects.length > 0 ? selection.projects : [ALL_ACCESS_PROJECTS];

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -125,7 +125,11 @@ export function ExploreSecondaryNavigation() {
             <Feature features="gen-ai-conversations">
               <SecondaryNavigation.ListItem>
                 <SecondaryNavigation.Link
-                  to={`${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`}
+                  // TODO: Remove once query performance is improved - defaults to 24h to avoid slow loads
+                  to={{
+                    pathname: `${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`,
+                    query: {statsPeriod: '24h'},
+                  }}
                   analyticsItemName="explore_conversations"
                   trailingItems={<FeatureBadge type="beta" />}
                 >

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -128,7 +128,7 @@ export function ExploreSecondaryNavigation() {
                   // TODO: Remove once query performance is improved - defaults to 24h to avoid slow loads
                   to={{
                     pathname: `${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`,
-                    query: {statsPeriod: '24h'},
+                    search: '?statsPeriod=24h',
                   }}
                   analyticsItemName="explore_conversations"
                   trailingItems={<FeatureBadge type="beta" />}

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -1,10 +1,12 @@
 from datetime import timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from django.urls import reverse
 from urllib3.exceptions import ReadTimeoutError
 
+from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.snuba_rpc import SnubaRPCTimeout
 
@@ -33,10 +35,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
                 format="json",
                 **kwargs,
             )
-
-    def get_spans(self, response):
-        """Extract the spans list from the response envelope."""
-        return response.data["data"]
 
     def test_no_feature(self) -> None:
         conversation_id = uuid4().hex
@@ -67,7 +65,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(self.get_spans(response)) == 0
+        assert len(response.data) == 0
 
     def test_single_trace_conversation(self) -> None:
         now = before_now(days=20).replace(microsecond=0)
@@ -106,13 +104,12 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        spans = self.get_spans(response)
-        assert len(spans) == 3
+        assert len(response.data) == 3
 
-        for span in spans:
+        for span in response.data:
             assert span["gen_ai.conversation.id"] == conversation_id
 
-        trace_ids = {span["trace"] for span in spans}
+        trace_ids = {span["trace"] for span in response.data}
         assert len(trace_ids) == 1
         assert trace_id in trace_ids
 
@@ -159,10 +156,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        spans = self.get_spans(response)
-        assert len(spans) == 4
+        assert len(response.data) == 4
 
-        trace_ids = {span["trace"] for span in spans}
+        trace_ids = {span["trace"] for span in response.data}
         assert trace_ids == {trace_id_1, trace_id_2}
 
     def test_returns_conversation_attributes(self) -> None:
@@ -192,10 +188,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        spans = self.get_spans(response)
-        assert len(spans) == 1
+        assert len(response.data) == 1
 
-        span = spans[0]
+        span = response.data[0]
         assert "span_id" in span
         assert span["trace"] == trace_id
         assert "precise.start_ts" in span
@@ -214,6 +209,47 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert span["gen_ai.cost.total_tokens"] == 0.0025
         assert span["user.id"] == "user-123"
         assert span["user.email"] == "test@example.com"
+
+    def test_pagination(self) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        trace_id = uuid4().hex
+
+        for i in range(5):
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=i),
+                op="gen_ai.chat",
+                trace_id=trace_id,
+            )
+
+        query: dict[str, Any] = {
+            "project": [self.project.id],
+            "per_page": "2",
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert len(response.data) == 2
+
+        links = parse_link_header(response.headers["Link"])
+        next_link = next(link for link in links.values() if link["rel"] == "next")
+        assert next_link["results"] == "true"
+        assert next_link["cursor"]
+
+        query["cursor"] = next_link["cursor"]
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert len(response.data) == 2
+
+        links = parse_link_header(response.headers["Link"])
+        next_link = next(link for link in links.values() if link["rel"] == "next")
+        query["cursor"] = next_link["cursor"]
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert len(response.data) == 1
 
     def test_span_ordering(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
@@ -242,10 +278,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        spans = self.get_spans(response)
-        assert len(spans) == 3
+        assert len(response.data) == 3
 
-        span_timestamps = [span["precise.start_ts"] for span in spans]
+        span_timestamps = [span["precise.start_ts"] for span in response.data]
         assert span_timestamps == sorted(span_timestamps)
 
     def test_only_returns_matching_conversation(self) -> None:
@@ -281,16 +316,14 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id_1, query)
         assert response.status_code == 200
-        spans = self.get_spans(response)
-        assert len(spans) == 2
-        for span in spans:
+        assert len(response.data) == 2
+        for span in response.data:
             assert span["gen_ai.conversation.id"] == conversation_id_1
 
         response = self.do_request(conversation_id_2, query)
         assert response.status_code == 200
-        spans = self.get_spans(response)
-        assert len(spans) == 1
-        assert spans[0]["gen_ai.conversation.id"] == conversation_id_2
+        assert len(response.data) == 1
+        assert response.data[0]["gen_ai.conversation.id"] == conversation_id_2
 
     def test_returns_tool_attributes(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
@@ -314,10 +347,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        spans = self.get_spans(response)
-        assert len(spans) == 1
+        assert len(response.data) == 1
 
-        span = spans[0]
+        span = response.data[0]
         assert span["span.op"] == "gen_ai.execute_tool"
         assert span["gen_ai.operation.type"] == "tool"
         assert span["gen_ai.tool.name"] == "search_database"
@@ -341,9 +373,8 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        spans = self.get_spans(response)
-        assert len(spans) == 1
-        assert spans[0]["gen_ai.conversation.id"] == conversation_id
+        assert len(response.data) == 1
+        assert response.data[0]["gen_ai.conversation.id"] == conversation_id
 
     def test_stats_period_recent_conversation_returned_without_widening(self) -> None:
         timestamp_1h = before_now(minutes=30).replace(microsecond=0)
@@ -364,7 +395,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(self.get_spans(response)) == 1
+        assert len(response.data) == 1
 
     def test_no_time_params_falls_back_to_30d(self) -> None:
         timestamp = before_now(days=15).replace(microsecond=0)
@@ -382,9 +413,8 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        spans = self.get_spans(response)
-        assert len(spans) == 1
-        assert spans[0]["gen_ai.conversation.id"] == conversation_id
+        assert len(response.data) == 1
+        assert response.data[0]["gen_ai.conversation.id"] == conversation_id
 
     def test_tokens_on_multiple_span_types(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
@@ -420,10 +450,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        spans = self.get_spans(response)
-        assert len(spans) == 2
+        assert len(response.data) == 2
 
-        spans = sorted(spans, key=lambda s: s["precise.start_ts"])
+        spans = sorted(response.data, key=lambda s: s["precise.start_ts"])
 
         agent_span = spans[0]
         assert agent_span["gen_ai.operation.type"] == "invoke_agent"

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -389,8 +389,56 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert span["gen_ai.operation.type"] == "tool"
         assert span["gen_ai.tool.name"] == "search_database"
 
-    def test_stats_period_overrides_to_30d(self) -> None:
-        """Test that statsPeriod is overridden to 30d so all recent data is returned"""
+    def test_stats_period_is_tried_first_then_widened(self) -> None:
+        """A passed statsPeriod is used as the first attempt; if the conversation
+        falls outside it the endpoint widens to 7d then 30d automatically."""
+        timestamp_15d = before_now(days=15).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=timestamp_15d,
+            op="gen_ai.chat",
+            trace_id=trace_id,
+        )
+
+        # statsPeriod=1h is too narrow; widening finds the 15-day-old span via 30d
+        query = {
+            "project": [self.project.id],
+            "statsPeriod": "1h",
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+        assert response.data[0]["gen_ai.conversation.id"] == conversation_id
+
+    def test_stats_period_recent_conversation_returned_without_widening(self) -> None:
+        """When the conversation falls within the requested statsPeriod it is
+        returned immediately without trying wider windows."""
+        timestamp_1h = before_now(minutes=30).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=timestamp_1h,
+            op="gen_ai.chat",
+            trace_id=trace_id,
+        )
+
+        query = {
+            "project": [self.project.id],
+            "statsPeriod": "1h",
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+
+    def test_no_time_params_falls_back_to_30d(self) -> None:
+        """Omitting all time params searches the full 30d retention window."""
         timestamp = before_now(days=15).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
@@ -402,12 +450,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             trace_id=trace_id,
         )
 
-        # statsPeriod=1h would normally restrict to last hour and exclude our 15-day-old span,
-        # but endpoint overrides to 30d
-        query = {
-            "project": [self.project.id],
-            "statsPeriod": "1h",
-        }
+        query = {"project": [self.project.id]}
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200, response.data

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from django.urls import reverse
@@ -526,7 +526,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         # Wrap in a ReadTimeoutError so handle_query_errors() converts it to
         # TimeoutException, which our endpoint then catches to return 504.
-        rpc_timeout = SnubaRPCTimeout(ReadTimeoutError(None, "/", "timed out"))
+        rpc_timeout = SnubaRPCTimeout(ReadTimeoutError(MagicMock(), "/", "timed out"))
 
         with patch(
             "sentry.snuba.spans_rpc.Spans.run_table_query",

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -1,11 +1,14 @@
 from datetime import timedelta
 from typing import Any
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.urls import reverse
+from urllib3.exceptions import ReadTimeoutError
 
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.snuba_rpc import SnubaRPCTimeout
 
 from .test_organization_ai_conversations_base import BaseAIConversationsTestCase
 
@@ -516,3 +519,21 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert ai_client_span["gen_ai.operation.type"] == "ai_client"
         assert ai_client_span["gen_ai.usage.total_tokens"] == 100
         assert ai_client_span["gen_ai.cost.total_tokens"] == 0.01
+
+    def test_timeout_returns_504_with_error_code(self) -> None:
+        """A Snuba RPC timeout surfaces as 504 with a machine-readable code."""
+        conversation_id = uuid4().hex
+
+        # Wrap in a ReadTimeoutError so handle_query_errors() converts it to
+        # TimeoutException, which our endpoint then catches to return 504.
+        rpc_timeout = SnubaRPCTimeout(ReadTimeoutError(None, "/", "timed out"))
+
+        with patch(
+            "sentry.snuba.spans_rpc.Spans.run_table_query",
+            side_effect=rpc_timeout,
+        ):
+            response = self.do_request(conversation_id, {"project": [self.project.id]})
+
+        assert response.status_code == 504
+        assert response.data["code"] == "query_timeout"
+        assert "detail" in response.data

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -1,12 +1,10 @@
 from datetime import timedelta
-from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from django.urls import reverse
 from urllib3.exceptions import ReadTimeoutError
 
-from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.snuba_rpc import SnubaRPCTimeout
 
@@ -36,6 +34,10 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
                 **kwargs,
             )
 
+    def get_spans(self, response):
+        """Extract the spans list from the response envelope."""
+        return response.data["data"]
+
     def test_no_feature(self) -> None:
         conversation_id = uuid4().hex
         response = self.do_request(conversation_id, features=[])
@@ -47,12 +49,10 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert response.status_code == 404
 
     def test_conversation_not_found(self) -> None:
-        """Test endpoint returns empty list when no spans match conversation ID"""
         now = before_now(days=10).replace(microsecond=0)
         conversation_id = uuid4().hex
         other_conversation_id = uuid4().hex
 
-        # Store a span with a different conversation ID
         self.store_ai_span(
             conversation_id=other_conversation_id,
             timestamp=now,
@@ -66,16 +66,14 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         }
 
         response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 0
+        assert response.status_code == 200
+        assert len(self.get_spans(response)) == 0
 
     def test_single_trace_conversation(self) -> None:
-        """Test returns all spans for a conversation in a single trace"""
         now = before_now(days=20).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
 
-        # Store multiple spans in the same conversation and trace
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=3),
@@ -84,7 +82,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             agent_name="Test Agent",
             trace_id=trace_id,
         )
-
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=2),
@@ -93,7 +90,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             tokens=100,
             trace_id=trace_id,
         )
-
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=1),
@@ -109,26 +105,23 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         }
 
         response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 3
+        assert response.status_code == 200
+        spans = self.get_spans(response)
+        assert len(spans) == 3
 
-        # Verify all spans belong to the same conversation
-        for span in response.data:
+        for span in spans:
             assert span["gen_ai.conversation.id"] == conversation_id
 
-        # Verify all spans have the same trace ID
-        trace_ids = {span["trace"] for span in response.data}
+        trace_ids = {span["trace"] for span in spans}
         assert len(trace_ids) == 1
         assert trace_id in trace_ids
 
     def test_multi_trace_conversation(self) -> None:
-        """Test returns all spans for a conversation across multiple traces"""
         now = before_now(days=10).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id_1 = uuid4().hex
         trace_id_2 = uuid4().hex
 
-        # Spans in first trace
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=4),
@@ -136,7 +129,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             operation_type="ai_client",
             trace_id=trace_id_1,
         )
-
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=3),
@@ -144,8 +136,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             operation_type="tool",
             trace_id=trace_id_1,
         )
-
-        # Spans in second trace
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=2),
@@ -153,7 +143,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             operation_type="ai_client",
             trace_id=trace_id_2,
         )
-
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=1),
@@ -169,15 +158,14 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         }
 
         response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 4
+        assert response.status_code == 200
+        spans = self.get_spans(response)
+        assert len(spans) == 4
 
-        # Verify spans come from both traces
-        trace_ids = {span["trace"] for span in response.data}
+        trace_ids = {span["trace"] for span in spans}
         assert trace_ids == {trace_id_1, trace_id_2}
 
     def test_returns_conversation_attributes(self) -> None:
-        """Test that the endpoint returns all AI conversation attributes"""
         now = before_now(days=5).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
@@ -203,11 +191,11 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         }
 
         response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 1
+        assert response.status_code == 200
+        spans = self.get_spans(response)
+        assert len(spans) == 1
 
-        span = response.data[0]
-        # Verify core span fields
+        span = spans[0]
         assert "span_id" in span
         assert span["trace"] == trace_id
         assert "precise.start_ts" in span
@@ -215,79 +203,27 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert span["span.op"] == "gen_ai.chat"
         assert "span.duration" in span
         assert span["gen_ai.conversation.id"] == conversation_id
-        # Verify project fields
         assert "project" in span
         assert span["project.id"] == self.project.id
-        # Verify transaction fields
         assert "transaction" in span
         assert "is_transaction" in span
-        # Verify AI conversation attributes are included
         assert span["gen_ai.operation.type"] == "ai_client"
         assert span["gen_ai.request.messages"] is not None
         assert span["gen_ai.response.text"] == "Hi there!"
         assert span["gen_ai.usage.total_tokens"] == 150
         assert span["gen_ai.cost.total_tokens"] == 0.0025
-        # Verify user attributes are included
         assert span["user.id"] == "user-123"
         assert span["user.email"] == "test@example.com"
 
-    def test_pagination(self) -> None:
-        """Test pagination works correctly"""
-        now = before_now(days=5).replace(microsecond=0)
-        conversation_id = uuid4().hex
-        trace_id = uuid4().hex
-
-        # Create 5 spans
-        for i in range(5):
-            self.store_ai_span(
-                conversation_id=conversation_id,
-                timestamp=now - timedelta(seconds=i),
-                op="gen_ai.chat",
-                trace_id=trace_id,
-            )
-
-        query: dict[str, Any] = {
-            "project": [self.project.id],
-            "per_page": "2",
-            "start": (now - timedelta(hours=1)).isoformat(),
-            "end": (now + timedelta(hours=1)).isoformat(),
-        }
-
-        # First page
-        response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 2
-
-        links = parse_link_header(response.headers["Link"])
-        next_link = next(link for link in links.values() if link["rel"] == "next")
-        assert next_link["results"] == "true"
-        assert next_link["cursor"]
-
-        # Second page
-        query["cursor"] = next_link["cursor"]
-        response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 2
-
-        # Third page (last)
-        links = parse_link_header(response.headers["Link"])
-        next_link = next(link for link in links.values() if link["rel"] == "next")
-        query["cursor"] = next_link["cursor"]
-        response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 1
-
     def test_span_ordering(self) -> None:
-        """Test spans are ordered by timestamp ascending"""
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
-        # Store spans in reverse chronological order
         timestamps = [
-            now - timedelta(seconds=1),  # newest
-            now - timedelta(seconds=3),  # middle
-            now - timedelta(seconds=5),  # oldest
+            now - timedelta(seconds=1),
+            now - timedelta(seconds=3),
+            now - timedelta(seconds=5),
         ]
 
         for ts in timestamps:
@@ -305,36 +241,31 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         }
 
         response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 3
+        assert response.status_code == 200
+        spans = self.get_spans(response)
+        assert len(spans) == 3
 
-        # Verify spans are ordered by timestamp ascending (oldest first)
-        span_timestamps = [span["precise.start_ts"] for span in response.data]
+        span_timestamps = [span["precise.start_ts"] for span in spans]
         assert span_timestamps == sorted(span_timestamps)
 
     def test_only_returns_matching_conversation(self) -> None:
-        """Test that only spans from the requested conversation are returned"""
         now = before_now(days=5).replace(microsecond=0)
         conversation_id_1 = uuid4().hex
         conversation_id_2 = uuid4().hex
         trace_id = uuid4().hex
 
-        # Spans in conversation 1
         self.store_ai_span(
             conversation_id=conversation_id_1,
             timestamp=now - timedelta(seconds=2),
             op="gen_ai.chat",
             trace_id=trace_id,
         )
-
         self.store_ai_span(
             conversation_id=conversation_id_1,
             timestamp=now - timedelta(seconds=1),
             op="gen_ai.chat",
             trace_id=trace_id,
         )
-
-        # Spans in conversation 2
         self.store_ai_span(
             conversation_id=conversation_id_2,
             timestamp=now,
@@ -348,22 +279,20 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             "end": (now + timedelta(hours=1)).isoformat(),
         }
 
-        # Request conversation 1
         response = self.do_request(conversation_id_1, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 2
-
-        for span in response.data:
+        assert response.status_code == 200
+        spans = self.get_spans(response)
+        assert len(spans) == 2
+        for span in spans:
             assert span["gen_ai.conversation.id"] == conversation_id_1
 
-        # Request conversation 2
         response = self.do_request(conversation_id_2, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 1
-        assert response.data[0]["gen_ai.conversation.id"] == conversation_id_2
+        assert response.status_code == 200
+        spans = self.get_spans(response)
+        assert len(spans) == 1
+        assert spans[0]["gen_ai.conversation.id"] == conversation_id_2
 
     def test_returns_tool_attributes(self) -> None:
-        """Test that tool spans include gen_ai.tool.name attribute"""
         now = before_now(days=5).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
@@ -384,17 +313,16 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         }
 
         response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 1
+        assert response.status_code == 200
+        spans = self.get_spans(response)
+        assert len(spans) == 1
 
-        span = response.data[0]
+        span = spans[0]
         assert span["span.op"] == "gen_ai.execute_tool"
         assert span["gen_ai.operation.type"] == "tool"
         assert span["gen_ai.tool.name"] == "search_database"
 
     def test_stats_period_is_tried_first_then_widened(self) -> None:
-        """A passed statsPeriod is used as the first attempt; if the conversation
-        falls outside it the endpoint widens to 7d then 30d automatically."""
         timestamp_15d = before_now(days=15).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
@@ -406,20 +334,18 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             trace_id=trace_id,
         )
 
-        # statsPeriod=1h is too narrow; widening finds the 15-day-old span via 30d
         query = {
             "project": [self.project.id],
             "statsPeriod": "1h",
         }
 
         response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 1
-        assert response.data[0]["gen_ai.conversation.id"] == conversation_id
+        assert response.status_code == 200
+        spans = self.get_spans(response)
+        assert len(spans) == 1
+        assert spans[0]["gen_ai.conversation.id"] == conversation_id
 
     def test_stats_period_recent_conversation_returned_without_widening(self) -> None:
-        """When the conversation falls within the requested statsPeriod it is
-        returned immediately without trying wider windows."""
         timestamp_1h = before_now(minutes=30).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
@@ -437,11 +363,10 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         }
 
         response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 1
+        assert response.status_code == 200
+        assert len(self.get_spans(response)) == 1
 
     def test_no_time_params_falls_back_to_30d(self) -> None:
-        """Omitting all time params searches the full 30d retention window."""
         timestamp = before_now(days=15).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
@@ -456,22 +381,16 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         query = {"project": [self.project.id]}
 
         response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 1
-        assert response.data[0]["gen_ai.conversation.id"] == conversation_id
+        assert response.status_code == 200
+        spans = self.get_spans(response)
+        assert len(spans) == 1
+        assert spans[0]["gen_ai.conversation.id"] == conversation_id
 
     def test_tokens_on_multiple_span_types(self) -> None:
-        """Test that raw spans are returned with their individual token/cost values.
-
-        This endpoint returns raw span data without aggregation. Consumers must
-        filter by gen_ai.operation.type:ai_client when summing tokens/costs
-        to avoid double counting from agent spans that may also have token data.
-        """
         now = before_now(days=5).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
 
-        # Agent span with tokens/cost
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=2),
@@ -483,8 +402,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             tokens=500,
             cost=0.05,
         )
-
-        # ai_client span with tokens/cost
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=1),
@@ -502,30 +419,25 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         }
 
         response = self.do_request(conversation_id, query)
-        assert response.status_code == 200, response.data
-        assert len(response.data) == 2
+        assert response.status_code == 200
+        spans = self.get_spans(response)
+        assert len(spans) == 2
 
-        # Sort by timestamp to ensure consistent order (oldest first)
-        spans = sorted(response.data, key=lambda s: s["precise.start_ts"])
+        spans = sorted(spans, key=lambda s: s["precise.start_ts"])
 
-        # First span is the agent span with its own token values
         agent_span = spans[0]
         assert agent_span["gen_ai.operation.type"] == "invoke_agent"
         assert agent_span["gen_ai.usage.total_tokens"] == 500
         assert agent_span["gen_ai.cost.total_tokens"] == 0.05
 
-        # Second span is the ai_client span with its own token values
         ai_client_span = spans[1]
         assert ai_client_span["gen_ai.operation.type"] == "ai_client"
         assert ai_client_span["gen_ai.usage.total_tokens"] == 100
         assert ai_client_span["gen_ai.cost.total_tokens"] == 0.01
 
-    def test_timeout_returns_504_with_error_code(self) -> None:
-        """A Snuba RPC timeout surfaces as 504 with a machine-readable code."""
+    def test_timeout_returns_504(self) -> None:
         conversation_id = uuid4().hex
 
-        # Wrap in a ReadTimeoutError so handle_query_errors() converts it to
-        # TimeoutException, which our endpoint then catches to return 504.
         rpc_timeout = SnubaRPCTimeout(ReadTimeoutError(MagicMock(), "/", "timed out"))
 
         with patch(
@@ -535,5 +447,3 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             response = self.do_request(conversation_id, {"project": [self.project.id]})
 
         assert response.status_code == 504
-        assert response.data["code"] == "query_timeout"
-        assert "detail" in response.data


### PR DESCRIPTION
When no explicit start/end is provided, the endpoint now probes progressively wider time windows to find the conversation before paginating. A cheap limit=1 query tries the requested statsPeriod (if < 30d), then 7d, 14d, and 30d and  returns the first match. The paginator then fetches full pages within that resolved window.

When explicit start/end are provided, nothing changes — the endpoint validates them against the 30-day retention limit and paginates directly.

statsPeriod values >= 30d are silently ignored to prevent unbounded Snuba queries.

Refs TET-2388