### PR TITLE
ref(db): Add strong typing to postgres DatabaseWrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -388,7 +388,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "sentry.api.endpoints.organization_releases",
-    "sentry.db.postgres.base",
     "sentry.middleware.ratelimit",
     "sentry.release_health.metrics_sessions_v2",
     "sentry.search.events.builder.errors",

--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from typing import Any
 
 import psycopg2
+import psycopg2.extensions
 from django.db.backends.postgresql.base import DatabaseWrapper as DjangoDatabaseWrapper
 from django.db.backends.postgresql.operations import DatabaseOperations
+from django.db.backends.utils import CursorWrapper as DjangoCursorWrapper
 
 from sentry.utils.strings import strip_lone_surrogates
 
@@ -79,24 +81,35 @@ class CursorWrapper:
     from cursors, such as auto reconnects and lazy time zone evaluation.
     """
 
-    def __init__(self, db, cursor):
+    db: DatabaseWrapper
+    cursor: psycopg2.extensions.cursor
+
+    def __init__(self, db: DatabaseWrapper, cursor: psycopg2.extensions.cursor) -> None:
         self.db = db
         self.cursor = cursor
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Any:
         return getattr(self.cursor, attr)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[Any, ...]]:
         return iter(self.cursor)
 
     @auto_reconnect_cursor
-    def execute(self, sql, params=None):
+    def execute(
+        self,
+        sql: str,
+        params: Sequence[object] | Mapping[str, object] | None = None,
+    ) -> None:
         if params is not None:
             return self.cursor.execute(sql, params)
         return self.cursor.execute(sql)
 
     @auto_reconnect_cursor
-    def executemany(self, sql, paramlist=()):
+    def executemany(
+        self,
+        sql: str,
+        paramlist: Iterable[Sequence[object] | Mapping[str, object] | None] = (),
+    ) -> None:
         return self.cursor.executemany(sql, paramlist)
 
 
@@ -104,13 +117,13 @@ class DatabaseWrapper(DjangoDatabaseWrapper):
     SchemaEditorClass = DatabaseSchemaEditorProxy
     queries_limit = 15000
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, settings_dict: dict[str, object], alias: str = "default") -> None:
+        super().__init__(settings_dict, alias)
         self.ops = DatabaseOperations(self)
         self.execute_wrappers.extend((_execute__include_sql_in_error, _execute__clean_params))
 
     @auto_reconnect_connection
-    def _cursor(self, *args, **kwargs):
+    def _cursor(self, name: str | None = None) -> DjangoCursorWrapper:
         return super()._cursor()
 
     # We're overriding this internal method that's present in Django 1.11+, because
@@ -118,11 +131,10 @@ class DatabaseWrapper(DjangoDatabaseWrapper):
     # with our CursorWrapper. We need to be passing our wrapped cursor to their wrapped cursor,
     # not the other way around since then we'll lose things like __enter__ due to the way this
     # wrapper is working (getattr on self.cursor).
-    def _prepare_cursor(self, cursor):
-        cursor = super()._prepare_cursor(CursorWrapper(self, cursor))
-        return cursor
+    def _prepare_cursor(self, cursor: psycopg2.extensions.cursor) -> DjangoCursorWrapper:
+        return super()._prepare_cursor(CursorWrapper(self, cursor))
 
-    def close(self, reconnect=False):
+    def close(self, reconnect: bool = False) -> None:
         """
         This ensures we don't error if the connection has already been closed.
         """


### PR DESCRIPTION
Add concrete type annotations to `CursorWrapper` and `DatabaseWrapper` in
`sentry.db.postgres.base`, replacing untyped parameters with specific types
from psycopg2 and Django stubs.

`Any` is retained only where Django's `_ExecuteWrapper` protocol or the
`__getattr__` proxy pattern requires it. SQL params use
`Sequence[object] | Mapping[str, object] | None` instead of `Any`.

Removes `sentry.db.postgres.base` from the mypy typing-issues ignore list
(the block that disables `arg-type`, `assignment`, `attr-defined`, etc.).