### PR TITLE
fix(api): Filter internal trace attributes from results

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -20,13 +20,15 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_trace_item_attributes import adjust_start_end_window
 from sentry.api.utils import handle_query_errors
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.attributes import SPANS_STATS_EXCLUDED_ATTRIBUTES
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
-from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
+from sentry.search.eap.utils import can_expose_attribute_to_api, translate_internal_to_public_alias
 from sentry.search.events import fields
 from sentry.seer.endpoints.compare import compare_distributions
 from sentry.seer.signed_seer_api import SeerViewerContext
@@ -58,6 +60,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsEndpointB
         above = request.GET.get("above") == "1"
         query_1 = request.GET.get("query_1", "")  # Suspect query
         query_2 = request.GET.get("query_2", "")  # Query for all the spans with the base query
+        include_internal = is_active_superuser(request) or is_active_staff(request)
 
         if query_1 == query_2:
             return Response({"rankedAttributes": []})
@@ -68,6 +71,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsEndpointB
             above=above,
             query_1=query_1,
             query_2=query_2,
+            include_internal=include_internal,
         )
 
         cohort_2_distribution = distributions_result["cohort_2_distribution"]
@@ -131,7 +135,19 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsEndpointB
             if public_alias is None:
                 public_alias = attr
 
-            if not public_alias.startswith("tags[") and (
+            if (
+                can_expose_attribute_to_api(
+                    attr,
+                    SupportedTraceItemType.SPANS,
+                    include_internal=include_internal,
+                )
+                and can_expose_attribute_to_api(
+                    public_alias,
+                    SupportedTraceItemType.SPANS,
+                    include_internal=include_internal,
+                )
+                and not public_alias.startswith("tags[")
+            ) and (
                 not public_alias.startswith("sentry.")
                 or public_alias == "sentry.normalized_description"
             ):
@@ -175,6 +191,7 @@ def query_attribute_distributions(
     above: bool,
     query_1: str,
     query_2: str,
+    include_internal: bool = False,
 ) -> AttributeDistributionsResponse:
     """
     Query for and compute span attribute distributions for outlier (query_1) and baseline (query_2) cohorts.
@@ -190,7 +207,9 @@ def query_attribute_distributions(
         AttributeDistributionsResponse with distribution data and total counts for both cohorts
     """
     resolver_config = SearchResolverConfig(
-        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE
+        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+        api_attribute_visibility_item_type=SupportedTraceItemType.SPANS.value,
+        api_attribute_visibility_include_internal=include_internal,
     )
 
     resolver = SearchResolver(
@@ -261,6 +280,16 @@ def query_attribute_distributions(
 
     cohort_1, _, _ = resolver.resolve_query(query_1)
     cohort_2, _, _ = resolver.resolve_query(query_2)
+    if resolver.has_hidden_api_attributes():
+        return AttributeDistributionsResponse(
+            cohort_2_distribution=[],
+            cohort_2_distribution_map={},
+            total_cohort_2=0,
+            cohort_1_distribution=[],
+            cohort_1_distribution_map={},
+            total_cohort_1=0,
+            cohort_1_function_value=function_value,
+        )
 
     # Fetch attribute names for parallelization
     adjusted_start_date, adjusted_end_date = adjust_start_end_window(
@@ -290,6 +319,12 @@ def query_attribute_distributions(
     chunked_attributes: defaultdict[int, list[AttributeKey]] = defaultdict(list)
     for i, attr_proto in enumerate(attrs_response.attributes):
         if attr_proto.name in SPANS_STATS_EXCLUDED_ATTRIBUTES:
+            continue
+        if not can_expose_attribute_to_api(
+            attr_proto.name,
+            SupportedTraceItemType.SPANS,
+            include_internal=include_internal,
+        ):
             continue
 
         chunked_attributes[i % PARALLELIZATION_FACTOR].append(
@@ -367,7 +402,11 @@ def query_attribute_distributions(
     processed_cohort_2_buckets = set()
 
     for attribute in cohort_2_data:
-        if not can_expose_attribute(attribute.attribute_name, SupportedTraceItemType.SPANS):
+        if not can_expose_attribute_to_api(
+            attribute.attribute_name,
+            SupportedTraceItemType.SPANS,
+            include_internal=include_internal,
+        ):
             continue
 
         for bucket in attribute.buckets:
@@ -376,7 +415,11 @@ def query_attribute_distributions(
             )
 
     for attribute in cohort_1_data:
-        if not can_expose_attribute(attribute.attribute_name, SupportedTraceItemType.SPANS):
+        if not can_expose_attribute_to_api(
+            attribute.attribute_name,
+            SupportedTraceItemType.SPANS,
+            include_internal=include_internal,
+        ):
             continue
         for bucket in attribute.buckets:
             cohort_1_distribution.append((attribute.attribute_name, bucket.label, bucket.value))

--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -17,6 +17,8 @@ from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.event_search import translate_escape_sequences
 from sentry.api.serializers.base import serialize
 from sentry.api.utils import handle_query_errors
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
 from sentry.models.organization import Organization
 from sentry.search.eap.columns import ColumnDefinitions
 from sentry.search.eap.constants import SUPPORTED_STATS_TYPES
@@ -31,7 +33,8 @@ from sentry.search.eap.spans.attributes import (
     SPANS_STATS_EXCLUDED_ATTRIBUTES_PUBLIC_ALIAS,
 )
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
+from sentry.search.eap.utils import can_expose_attribute_to_api
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.occurrences_rpc import Occurrences
 from sentry.snuba.referrer import Referrer
@@ -143,9 +146,15 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
             return Response(serializer.errors, status=400)
         serialized = serializer.validated_data
 
-        stats_config = get_trace_item_stats_config(serialized.get("itemType", "spans"))
+        item_type = serialized.get("itemType", "spans")
+        stats_config = get_trace_item_stats_config(item_type)
+        api_item_type = SupportedTraceItemType(item_type)
+        include_internal = is_active_superuser(request) or is_active_staff(request)
 
-        resolver_config = SearchResolverConfig()
+        resolver_config = SearchResolverConfig(
+            api_attribute_visibility_item_type=api_item_type.value,
+            api_attribute_visibility_include_internal=include_internal,
+        )
         resolver = SearchResolver(
             params=snuba_params, config=resolver_config, definitions=stats_config.definitions
         )
@@ -159,7 +168,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
             with handle_query_errors():
                 return stats_config.rpc_class.run_table_query(
                     params=snuba_params,
-                    config=SearchResolverConfig(),
+                    config=resolver_config,
                     offset=0,
                     limit=serialized.get("traceItemsLimit", 1000),
                     sampling_mode=snuba_params.sampling_mode,
@@ -180,6 +189,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                     search_resolver=resolver,
                     max_buckets=1,
                     skip_translate_internal_to_public_alias=True,
+                    include_internal=include_internal,
                 )
 
         def run_stats_query_with_error_handling(attributes):
@@ -192,6 +202,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                     config=resolver_config,
                     search_resolver=resolver,
                     attributes=attributes,
+                    include_internal=include_internal,
                 )
 
         def data_fn(offset: int, limit: int):
@@ -217,6 +228,20 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                 )
 
                 if public_alias in stats_config.excluded_attributes:
+                    continue
+
+                if not (
+                    can_expose_attribute_to_api(
+                        internal_name,
+                        api_item_type,
+                        include_internal=include_internal,
+                    )
+                    and can_expose_attribute_to_api(
+                        public_alias,
+                        api_item_type,
+                        include_internal=include_internal,
+                    )
+                ):
                     continue
 
                 if value_substring_match:

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -29,7 +29,7 @@ from sentry.search.eap.types import (
     TraceItemAttribute,
 )
 from sentry.search.eap.utils import (
-    can_expose_attribute,
+    can_expose_attribute_to_api,
     get_deprecated_source_internal_names,
     is_sentry_convention_replacement_attribute,
     translate_internal_to_public_alias,
@@ -118,7 +118,7 @@ def convert_rpc_attribute_to_json(
     for attribute in attributes:
         internal_name = attribute["name"]
 
-        if not can_expose_attribute(
+        if not can_expose_attribute_to_api(
             internal_name, trace_item_type, include_internal=include_internal
         ):
             continue
@@ -209,6 +209,7 @@ def convert_rpc_attribute_to_json(
 def serialize_meta(
     attributes: list[dict],
     trace_item_type: SupportedTraceItemType,
+    include_internal: bool = False,
 ) -> dict:
     internal_name = ""
     attribute = {}
@@ -243,6 +244,12 @@ def serialize_meta(
             result = json.loads(attribute["value"]["valStr"])
             # Map the internal field key name back to its public name
             if field_key in attribute_map:
+                if not can_expose_attribute_to_api(
+                    field_key,
+                    trace_item_type,
+                    include_internal=include_internal,
+                ):
+                    continue
                 item_type: Literal["string", "number", "boolean"]
                 if (
                     "valInt" in attribute_map[field_key]
@@ -270,7 +277,11 @@ def serialize_meta(
     return meta_result
 
 
-def serialize_links(attributes: list[dict]) -> list[dict] | None:
+def serialize_links(
+    attributes: list[dict],
+    trace_item_type: SupportedTraceItemType,
+    include_internal: bool = False,
+) -> list[dict] | None:
     """Links are temporarily stored in `sentry.links` so lets parse that back out and return separately"""
     link_attribute = None
     for attribute in attributes:
@@ -285,7 +296,14 @@ def serialize_links(attributes: list[dict]) -> list[dict] | None:
         value = link_attribute.get("value", {}).get("valStr", None)
         if value is not None:
             links = json.loads(value)
-            return [serialize_link(link) for link in links]
+            return [
+                serialize_link(
+                    link,
+                    trace_item_type=trace_item_type,
+                    include_internal=include_internal,
+                )
+                for link in links
+            ]
         else:
             return None
     except Exception as e:
@@ -293,7 +311,11 @@ def serialize_links(attributes: list[dict]) -> list[dict] | None:
         return None
 
 
-def serialize_link(link: dict) -> dict:
+def serialize_link(
+    link: dict,
+    trace_item_type: SupportedTraceItemType,
+    include_internal: bool = False,
+) -> dict:
     clean_link = {
         "itemId": link["span_id"],
         "traceId": link["trace_id"],
@@ -307,6 +329,11 @@ def serialize_link(link: dict) -> dict:
             {"name": k, "value": v, "type": infer_type(v)}
             for k, v in attributes.items()
             if infer_type(v) is not None
+            and can_expose_attribute_to_api(
+                k,
+                trace_item_type,
+                include_internal=include_internal,
+            )
         ]
 
     return clean_link
@@ -428,8 +455,12 @@ class ProjectTraceItemDetailsEndpoint(ProjectEndpoint):
                 include_internal=include_internal,
                 include_arrays=include_arrays,
             ),
-            "meta": serialize_meta(resp["attributes"], item_type),
-            "links": serialize_links(resp["attributes"]),
+            "meta": serialize_meta(
+                resp["attributes"], item_type, include_internal=include_internal
+            ),
+            "links": serialize_links(
+                resp["attributes"], item_type, include_internal=include_internal
+            ),
         }
 
         return Response(resp_dict)

--- a/src/sentry/data_export/utils.py
+++ b/src/sentry/data_export/utils.py
@@ -13,7 +13,7 @@ from sentry.data_export.base import ExportError
 from sentry.search.eap.constants import PROTOBUF_TYPE_TO_SEARCH_TYPE
 from sentry.search.eap.rpc_utils import anyvalue_to_python
 from sentry.search.eap.types import SupportedTraceItemType
-from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
+from sentry.search.eap.utils import can_expose_attribute_to_api, translate_internal_to_public_alias
 from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
 from sentry.snuba import discover
 from sentry.utils import metrics, snuba
@@ -146,7 +146,7 @@ def trace_item_to_row(
     _merge_trace_export_cell(row, "id", item.item_id.hex() if item.item_id else None)
 
     for internal_key, av in item.attributes.items():
-        if not can_expose_attribute(internal_key, item_type, include_internal=False):
+        if not can_expose_attribute_to_api(internal_key, item_type, include_internal=False):
             continue
         which = av.WhichOneof("value")
         value = anyvalue_to_python(av)

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -60,7 +60,7 @@ from sentry.search.eap.columns import (
 from sentry.search.eap.rpc_utils import and_trace_item_filters
 from sentry.search.eap.sampling import validate_sampling
 from sentry.search.eap.spans.attributes import SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS
-from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import EAPResponse, SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events import constants as qb_constants
 from sentry.search.events import fields
 from sentry.search.events import filter as event_filter
@@ -105,8 +105,15 @@ class SearchResolver:
             VirtualColumnDefinition | None,
         ],
     ] = field(default_factory=dict)
+    _hidden_api_attributes: set[str] = field(default_factory=set, repr=False)
     qualified_short_id_to_group_id_cache: dict[int, dict[str, int]] = field(default_factory=dict)
     _internal_name_to_column: dict[str, ResolvedAttribute] = field(default_factory=dict, repr=False)
+
+    def has_hidden_api_attributes(self) -> bool:
+        return bool(self._hidden_api_attributes)
+
+    def is_hidden_api_attribute(self, column: str) -> bool:
+        return column in self._hidden_api_attributes
 
     def _find_column_by_internal_name(self, internal_name: str) -> ResolvedAttribute | None:
         """Look up a column definition by its internal name (e.g. 'sentry.item_id' -> 'id' column).
@@ -1043,7 +1050,9 @@ class SearchResolver:
         if public_alias_override is not None:
             alias = public_alias_override
 
+        is_public_defined_attribute = False
         if column in self.definitions.contexts:
+            is_public_defined_attribute = True
             column_context = self.definitions.contexts[column]
             column_definition = ResolvedAttribute(
                 public_alias=alias,
@@ -1052,6 +1061,7 @@ class SearchResolver:
                 processor=column_context.processor,
             )
         elif column in self.definitions.columns:
+            is_public_defined_attribute = True
             column_context = None
             column_definition = self.definitions.columns[column]
             if column_definition.private and column not in self.config.fields_acl.attributes:
@@ -1111,6 +1121,21 @@ class SearchResolver:
             column_context = None
 
         if column_definition:
+            if self.config.api_attribute_visibility_item_type is not None:
+                from sentry.search.eap.utils import can_expose_attribute_to_api
+
+                item_type = SupportedTraceItemType(self.config.api_attribute_visibility_item_type)
+                visibility_attribute = (
+                    column_definition.public_alias
+                    if is_public_defined_attribute
+                    else column_definition.internal_name
+                )
+                if not can_expose_attribute_to_api(
+                    visibility_attribute,
+                    item_type,
+                    include_internal=self.config.api_attribute_visibility_include_internal,
+                ):
+                    self._hidden_api_attributes.add(column)
             self._resolved_attribute_cache[column] = (column_definition, column_context)
             return self._resolved_attribute_cache[column]
         else:

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -39,6 +39,10 @@ class SearchResolverConfig:
     # When True, ResolvedAttributes whose internal_type is ARRAY are silently dropped based on
     # feature flag organizations:trace-item-details-array-fields
     disable_array_attributes: bool = True
+    # API-only visibility enforcement. Non-API callers should leave this as None
+    # so backend resolution semantics remain unchanged.
+    api_attribute_visibility_item_type: str | None = None
+    api_attribute_visibility_include_internal: bool = False
 
     def extra_conditions(
         self,

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Literal
 
 from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_conventions.attributes import ATTRIBUTE_METADATA
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 
 from sentry.search.eap.columns import ColumnDefinitions, ResolvedAttribute
@@ -235,6 +236,77 @@ def can_expose_attribute(
         return include_internal
 
     return True
+
+
+def _has_internal_convention_visibility(attribute: str) -> bool:
+    metadata = ATTRIBUTE_METADATA.get(attribute)
+    if metadata is None:
+        return False
+
+    visibility = metadata.visibility
+    return getattr(visibility, "value", visibility) == "internal"
+
+
+def _get_sentry_convention_visibility_candidates(
+    attribute: str, item_type: SupportedTraceItemType
+) -> set[str]:
+    candidates = {attribute}
+
+    if item_type == SupportedTraceItemType.SPANS and attribute.startswith(("dsc.", "_internal.")):
+        candidates.add(f"sentry.{attribute}")
+
+    resolved_attribute = PUBLIC_ALIAS_TO_INTERNAL_MAPPING.get(item_type, {}).get(attribute)
+    if resolved_attribute is not None:
+        candidates.add(resolved_attribute.public_alias)
+        candidates.add(resolved_attribute.internal_name)
+        if resolved_attribute.replacement:
+            candidates.add(resolved_attribute.replacement)
+
+    for mapping in INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).values():
+        public_alias = mapping.get(attribute)
+        if public_alias is not None:
+            candidates.add(public_alias)
+
+    replacement_map = SENTRY_CONVENTIONS_REPLACEMENT_MAPPINGS.get(item_type, {})
+    seen: set[str] = set()
+    pending = list(candidates)
+    while pending:
+        candidate = pending.pop()
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        replacement = replacement_map.get(candidate)
+        if replacement is not None and replacement not in candidates:
+            candidates.add(replacement)
+            pending.append(replacement)
+
+    return candidates
+
+
+def is_internal_sentry_convention_attribute(
+    attribute: str, item_type: SupportedTraceItemType
+) -> bool:
+    return any(
+        _has_internal_convention_visibility(candidate)
+        for candidate in _get_sentry_convention_visibility_candidates(attribute, item_type)
+    )
+
+
+def can_expose_attribute_to_api(
+    attribute: str, item_type: SupportedTraceItemType, include_internal: bool = False
+) -> bool:
+    candidates = _get_sentry_convention_visibility_candidates(attribute, item_type)
+
+    for candidate in candidates:
+        if not can_expose_attribute(candidate, item_type, include_internal=include_internal):
+            return False
+
+    if include_internal:
+        return True
+
+    return not any(
+        is_internal_sentry_convention_attribute(candidate, item_type) for candidate in candidates
+    )
 
 
 def is_sentry_convention_replacement_attribute(

--- a/src/sentry/snuba/occurrences_rpc.py
+++ b/src/sentry/snuba/occurrences_rpc.py
@@ -281,9 +281,14 @@ class Occurrences(rpc_dataset_common.RPCBase):
         max_buckets: int = 75,
         skip_translate_internal_to_public_alias: bool = False,
         occurrence_category: OccurrenceCategory | None = None,
+        include_internal: bool = False,
     ) -> list[dict[str, Any]]:
         search_resolver = search_resolver or cls.get_resolver(params, config)
         stats_filter, _, _ = search_resolver.resolve_query(query_string)
+        if search_resolver.has_hidden_api_attributes():
+            # Hidden attributes here came from the query filter. Dropping them would
+            # broaden the query and return results for different search semantics.
+            return []
 
         stats_filter = and_trace_item_filters(
             stats_filter, cls._build_category_filter(occurrence_category)
@@ -315,7 +320,10 @@ class Occurrences(rpc_dataset_common.RPCBase):
         response = snuba_rpc.trace_item_stats_rpc(stats_request)
         stats = []
 
-        from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
+        from sentry.search.eap.utils import (
+            can_expose_attribute_to_api,
+            translate_internal_to_public_alias,
+        )
 
         for result in response.results:
             if "attributeDistributions" in stats_types and result.HasField(
@@ -323,8 +331,10 @@ class Occurrences(rpc_dataset_common.RPCBase):
             ):
                 attrs: dict[str, list[dict[str, Any]]] = defaultdict(list)
                 for attribute in result.attribute_distributions.attributes:
-                    if not can_expose_attribute(
-                        attribute.attribute_name, SupportedTraceItemType.OCCURRENCES
+                    if not can_expose_attribute_to_api(
+                        attribute.attribute_name,
+                        SupportedTraceItemType.OCCURRENCES,
+                        include_internal=include_internal,
                     ):
                         continue
 

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -390,6 +390,8 @@ class RPCBase:
     ) -> EAPResponse:
         """Run the query"""
         table_request = cls.get_table_rpc_request(query)
+        if query.resolver.has_hidden_api_attributes():
+            return {"data": [], "meta": {"fields": {}}, "confidence": []}
         rpc_request = table_request.rpc_request
         try:
             rpc_response = snuba_rpc.table_rpc([rpc_request])[0]

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -25,7 +25,7 @@ from sentry.search.eap.types import (
     SearchResolverConfig,
     SupportedTraceItemType,
 )
-from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
+from sentry.search.eap.utils import can_expose_attribute_to_api, translate_internal_to_public_alias
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.utils import json, snuba_rpc
@@ -222,9 +222,12 @@ class Spans(rpc_dataset_common.RPCBase):
         attributes: list[AttributeKey] | None = None,
         max_buckets: int = 75,
         skip_translate_internal_to_public_alias: bool = False,
+        include_internal: bool = False,
     ) -> list[dict[str, Any]]:
         search_resolver = search_resolver or cls.get_resolver(params, config)
         stats_filter, _, _ = search_resolver.resolve_query(query_string)
+        if search_resolver.has_hidden_api_attributes():
+            return []
         meta = search_resolver.resolve_meta(
             referrer=referrer,
             sampling_mode=params.sampling_mode,
@@ -257,8 +260,10 @@ class Spans(rpc_dataset_common.RPCBase):
             ):
                 attrs = defaultdict(list)
                 for attribute in result.attribute_distributions.attributes:
-                    if not can_expose_attribute(
-                        attribute.attribute_name, SupportedTraceItemType.SPANS
+                    if not can_expose_attribute_to_api(
+                        attribute.attribute_name,
+                        SupportedTraceItemType.SPANS,
+                        include_internal=include_internal,
                     ):
                         continue
 

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -1,5 +1,7 @@
 import os
 from datetime import datetime
+from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
@@ -28,6 +30,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 )
 
 from sentry.exceptions import InvalidSearchQuery
+from sentry.search.eap import utils as eap_utils
 from sentry.search.eap.columns import ResolvedAttribute
 from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
@@ -40,11 +43,92 @@ from sentry.search.eap.spans.attributes import (
 )
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.spans.sentry_conventions import SENTRY_CONVENTIONS_DIRECTORY
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
+from sentry.search.eap.utils import can_expose_attribute_to_api
 from sentry.search.events.types import SnubaParams
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
+
+
+class AttributeVisibilityTest(TestCase):
+    def test_public_convention_attribute_visible_to_everyone(self) -> None:
+        with mock.patch.dict(
+            eap_utils.ATTRIBUTE_METADATA,
+            {"public.attr": SimpleNamespace(visibility="public")},
+        ):
+            assert can_expose_attribute_to_api("public.attr", SupportedTraceItemType.SPANS)
+
+    def test_internal_convention_attribute_hidden_unless_included(self) -> None:
+        with mock.patch.dict(
+            eap_utils.ATTRIBUTE_METADATA,
+            {"internal.attr": SimpleNamespace(visibility="internal")},
+        ):
+            assert not can_expose_attribute_to_api("internal.attr", SupportedTraceItemType.SPANS)
+            assert can_expose_attribute_to_api(
+                "internal.attr", SupportedTraceItemType.SPANS, include_internal=True
+            )
+
+    def test_internal_convention_public_alias_is_hidden(self) -> None:
+        with (
+            mock.patch.dict(
+                eap_utils.ATTRIBUTE_METADATA,
+                {"internal.attr": SimpleNamespace(visibility="internal")},
+            ),
+            mock.patch.dict(
+                eap_utils.PUBLIC_ALIAS_TO_INTERNAL_MAPPING[SupportedTraceItemType.SPANS],
+                {
+                    "public.alias": ResolvedAttribute(
+                        public_alias="public.alias",
+                        internal_name="internal.attr",
+                        search_type="string",
+                    )
+                },
+            ),
+        ):
+            assert not can_expose_attribute_to_api("public.alias", SupportedTraceItemType.SPANS)
+
+    def test_internal_convention_translated_public_alias_is_hidden(self) -> None:
+        with (
+            mock.patch.dict(
+                eap_utils.ATTRIBUTE_METADATA,
+                {"public.alias": SimpleNamespace(visibility="internal")},
+            ),
+            mock.patch.dict(
+                eap_utils.INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS[SupportedTraceItemType.SPANS]["string"],
+                {"internal.attr": "public.alias"},
+            ),
+        ):
+            assert not can_expose_attribute_to_api("internal.attr", SupportedTraceItemType.SPANS)
+
+    def test_internal_convention_replacement_is_hidden(self) -> None:
+        with (
+            mock.patch.dict(
+                eap_utils.ATTRIBUTE_METADATA,
+                {"replacement.attr": SimpleNamespace(visibility="internal")},
+            ),
+            mock.patch.dict(
+                eap_utils.SENTRY_CONVENTIONS_REPLACEMENT_MAPPINGS[SupportedTraceItemType.SPANS],
+                {"deprecated.attr": "replacement.attr"},
+            ),
+        ):
+            assert not can_expose_attribute_to_api("deprecated.attr", SupportedTraceItemType.SPANS)
+
+    def test_stripped_internal_prefix_alias_is_hidden(self) -> None:
+        assert not can_expose_attribute_to_api(
+            "_internal.normalized_description", SupportedTraceItemType.SPANS
+        )
+        assert can_expose_attribute_to_api(
+            "_internal.normalized_description",
+            SupportedTraceItemType.SPANS,
+            include_internal=True,
+        )
+
+    def test_stripped_dsc_convention_alias_is_hidden(self) -> None:
+        assert not can_expose_attribute_to_api("dsc.trace_id", SupportedTraceItemType.SPANS)
+        assert can_expose_attribute_to_api(
+            "dsc.trace_id", SupportedTraceItemType.SPANS, include_internal=True
+        )
 
 
 class SearchResolverQueryTest(TestCase):

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes_ranked.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes_ranked.py
@@ -66,6 +66,11 @@ class OrganizationTraceItemsAttributesRankedEndpointTest(
         assert response.status_code == 200, response.data
         assert response.data == {"rankedAttributes": []}
 
+    def test_internal_convention_attribute_query_returns_empty_for_non_staff(self) -> None:
+        response = self.do_request(query={"query_1": "sentry.dsc.trace_id:abc123"})
+        assert response.status_code == 200, response.data
+        assert response.data == {"rankedAttributes": []}
+
     @patch("sentry.api.endpoints.organization_trace_item_attributes_ranked.compare_distributions")
     def test_distribution_values(self, mock_compare_distributions) -> None:
         mock_compare_distributions.return_value = {

--- a/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
@@ -182,6 +182,38 @@ class OrganizationTraceItemsStatsEndpointTest(
         assert "custom_attr" not in attribute_distribution
         assert "other_attr" not in attribute_distribution
 
+    def test_internal_convention_attributes_are_staff_only(self) -> None:
+        self.store_span(
+            self.create_span(
+                {"sentry_tags": {"dsc.trace_id": "abc123"}},
+                start_ts=self.ten_mins_ago,
+            ),
+        )
+
+        response = self.do_request(
+            query={
+                "statsType": ["attributeDistributions"],
+                "substringMatch": "dsc",
+            }
+        )
+        assert response.status_code == 200, response.data
+        assert response.data == {"data": []}
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.do_request(
+            query={
+                "statsType": ["attributeDistributions"],
+                "substringMatch": "dsc",
+            }
+        )
+        assert response.status_code == 200, response.data
+        assert len(response.data["data"]) == 1
+        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        assert attribute_distribution["sentry.dsc.trace_id"] == [{"label": "abc123", "value": 1.0}]
+
     def test_query_filters_spans_before_stats(self) -> None:
         tags = [
             ({"browser": "chrome", "device": "desktop"}, 100),

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -309,6 +309,80 @@ class ProjectTraceItemDetailsEndpointTest(
             == self.one_min_ago.replace(microsecond=0, tzinfo=None).isoformat() + "Z"
         )
 
+    def test_internal_convention_span_attributes_are_staff_only(self) -> None:
+        span = self.create_span(
+            {
+                "tags": {
+                    "sentry._meta.fields.attributes.sentry.dsc.trace_id": '{"reason": "internal"}'
+                },
+                "sentry_tags": {"dsc.trace_id": "abc123"},
+            },
+            start_ts=self.one_min_ago,
+        )
+        span["trace_id"] = self.trace_uuid
+        item_id = span["span_id"]
+        self.store_span(span)
+
+        response = self.do_request("spans", item_id)
+        assert response.status_code == 200, response.content
+        attribute_names = {attr["name"] for attr in response.data["attributes"]}
+        assert "dsc.trace_id" not in attribute_names
+        assert "sentry.dsc.trace_id" not in response.data["meta"]
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.do_request("spans", item_id)
+        assert response.status_code == 200, response.content
+        attributes = {attr["name"]: attr for attr in response.data["attributes"]}
+        assert attributes["dsc.trace_id"] == {
+            "name": "dsc.trace_id",
+            "type": "str",
+            "value": "abc123",
+        }
+        assert response.data["meta"]["sentry.dsc.trace_id"] == {"reason": "internal"}
+
+    def test_stripped_internal_convention_span_attributes_are_staff_only(self) -> None:
+        span = self.create_span(
+            {
+                "description": "test span",
+                "tags": {
+                    "dsc.trace_id": "abc123",
+                    "_internal.normalized_description": "normalized",
+                },
+            },
+            start_ts=self.one_min_ago,
+        )
+        span["trace_id"] = self.trace_uuid
+        item_id = span["span_id"]
+
+        self.store_span(span)
+
+        response = self.do_request("spans", item_id)
+        assert response.status_code == 200, response.content
+        attribute_names = {attr["name"] for attr in response.data["attributes"]}
+        assert "dsc.trace_id" not in attribute_names
+        assert "_internal.normalized_description" not in attribute_names
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.do_request("spans", item_id)
+        assert response.status_code == 200, response.content
+        attributes = {attr["name"]: attr for attr in response.data["attributes"]}
+        assert attributes["dsc.trace_id"] == {
+            "name": "dsc.trace_id",
+            "type": "str",
+            "value": "abc123",
+        }
+        assert attributes["_internal.normalized_description"] == {
+            "name": "_internal.normalized_description",
+            "type": "str",
+            "value": "normalized",
+        }
+
     def test_simple_using_spans_item_type_with_sentry_conventions(self) -> None:
         span_1 = self.create_span(
             {"description": "foo", "sentry_tags": {"status": "success"}},
@@ -496,7 +570,7 @@ class ProjectTraceItemDetailsEndpointTest(
             {
                 "description": "foo",
                 "sentry_tags": {
-                    "links": '[{"trace_id":"d099bf9ad5a143cf8f83a98081d0ed3b","span_id":"8873a98879faf06d","sampled":true,"attributes":{"sentry.link.type":"parent","sentry.dropped_attributes_count":1}}]',
+                    "links": '[{"trace_id":"d099bf9ad5a143cf8f83a98081d0ed3b","span_id":"8873a98879faf06d","sampled":true,"attributes":{"sentry.link.type":"parent","sentry.dropped_attributes_count":1,"dsc.trace_id":"abc123","_internal.normalized_description":"normalized"}}]',
                 },
             },
             start_ts=self.one_min_ago,


### PR DESCRIPTION
## Summary
- Apply visibility checks to trace item detail, stats, and ranked attribute endpoints — queries referencing hidden internal attributes return empty results instead of leaking internal data
- Thread `include_internal` parameter through `spans_rpc`, `occurrences_rpc`, and `data_export` callers
- Add `has_hidden_api_attributes()` short-circuit in `RPCBase.run_table_query()` to avoid dispatching RPCs when the query is guaranteed to return nothing useful

Depends on #116091

## Test plan
- New tests in `test_project_trace_item_details.py`, `test_organization_trace_item_stats.py`, and `test_organization_trace_item_attributes_ranked.py`

Closes TODO