### PR TITLE
fix(api): Hide internal attributes in events and cross-trace queries

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -30,6 +30,8 @@ from sentry.apidocs.parameters import (
     VisibilityParams,
 )
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.organization import Organization
@@ -57,7 +59,12 @@ from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.types import DatasetQuery
-from sentry.snuba.utils import RPC_DATASETS, dataset_split_decision_inferred_from_query, get_dataset
+from sentry.snuba.utils import (
+    RPC_DATASETS,
+    dataset_split_decision_inferred_from_query,
+    get_dataset,
+    get_rpc_dataset_attribute_visibility_item_type,
+)
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.cursors import Cursor, EAPPageTokenCursor
@@ -512,6 +519,16 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                     organization,
                     actor=request.user,
                 )
+                api_item_type = get_rpc_dataset_attribute_visibility_item_type(scoped_dataset)
+                attribute_visibility_kwargs = (
+                    {
+                        "api_attribute_visibility_item_type": api_item_type.value,
+                        "api_attribute_visibility_include_internal": is_active_superuser(request)
+                        or is_active_staff(request),
+                    }
+                    if api_item_type is not None
+                    else {}
+                )
 
                 if scoped_dataset == Spans:
                     return SearchResolverConfig(
@@ -521,6 +538,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == OurLogs:
                     # ourlogs doesn't have use aggregate conditions
@@ -529,6 +547,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == TraceMetrics:
                     # tracemetrics uses aggregate conditions
@@ -541,6 +560,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == ProfileFunctions:
                     # profile_functions uses aggregate conditions
@@ -550,6 +570,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == uptime_results.UptimeResults:
                     return SearchResolverConfig(
@@ -558,6 +579,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == ProcessingErrors:
                     return SearchResolverConfig(
@@ -566,6 +588,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 elif scoped_dataset == PreprodSize:
                     return PreprodSizeSearchResolverConfig(
@@ -573,6 +596,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
                 else:
                     return SearchResolverConfig(
@@ -580,6 +604,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
+                        **attribute_visibility_kwargs,
                     )
 
             if snuba_params.sampling_mode == "HIGHEST_ACCURACY_FLEX_TIME":

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -520,15 +520,12 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                     actor=request.user,
                 )
                 api_item_type = get_rpc_dataset_attribute_visibility_item_type(scoped_dataset)
-                attribute_visibility_kwargs = (
-                    {
-                        "api_attribute_visibility_item_type": api_item_type.value,
-                        "api_attribute_visibility_include_internal": is_active_superuser(request)
-                        or is_active_staff(request),
-                    }
-                    if api_item_type is not None
-                    else {}
+                api_attribute_visibility_item_type = (
+                    api_item_type.value if api_item_type is not None else None
                 )
+                api_attribute_visibility_include_internal = is_active_superuser(
+                    request
+                ) or is_active_staff(request)
 
                 if scoped_dataset == Spans:
                     return SearchResolverConfig(
@@ -538,7 +535,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == OurLogs:
                     # ourlogs doesn't have use aggregate conditions
@@ -547,7 +545,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == TraceMetrics:
                     # tracemetrics uses aggregate conditions
@@ -560,7 +559,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == ProfileFunctions:
                     # profile_functions uses aggregate conditions
@@ -570,7 +570,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == uptime_results.UptimeResults:
                     return SearchResolverConfig(
@@ -579,7 +580,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == ProcessingErrors:
                     return SearchResolverConfig(
@@ -588,7 +590,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 elif scoped_dataset == PreprodSize:
                     return PreprodSizeSearchResolverConfig(
@@ -596,7 +599,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
                 else:
                     return SearchResolverConfig(
@@ -604,7 +608,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,
                         disable_array_attributes=disable_array_attributes,
-                        **attribute_visibility_kwargs,
+                        api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                        api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
                     )
 
             if snuba_params.sampling_mode == "HIGHEST_ACCURACY_FLEX_TIME":

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -28,6 +28,8 @@ from sentry.apidocs import constants as api_constants
 from sentry.apidocs.examples.discover_performance_examples import DiscoverAndPerformanceExamples
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams, VisibilityParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
 from sentry.constants import MAX_TOP_EVENTS
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
@@ -53,7 +55,11 @@ from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
-from sentry.snuba.utils import DATASET_LABELS, RPC_DATASETS
+from sentry.snuba.utils import (
+    DATASET_LABELS,
+    RPC_DATASETS,
+    get_rpc_dataset_attribute_visibility_item_type,
+)
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.snuba import SnubaTSResult
 
@@ -230,6 +236,16 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
             organization,
             actor=request.user,
         )
+        api_item_type = get_rpc_dataset_attribute_visibility_item_type(dataset)
+        attribute_visibility_kwargs = (
+            {
+                "api_attribute_visibility_item_type": api_item_type.value,
+                "api_attribute_visibility_include_internal": is_active_superuser(request)
+                or is_active_staff(request),
+            }
+            if api_item_type is not None
+            else {}
+        )
 
         if dataset == TraceMetrics:
             # tracemetrics uses aggregate conditions
@@ -240,6 +256,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
+                **attribute_visibility_kwargs,
             )
         elif dataset == PreprodSize:
             return PreprodSizeSearchResolverConfig(
@@ -248,6 +265,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
+                **attribute_visibility_kwargs,
             )
         else:
             return SearchResolverConfig(
@@ -256,6 +274,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
+                **attribute_visibility_kwargs,
             )
 
     def get_event_stats(

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -237,14 +237,11 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
             actor=request.user,
         )
         api_item_type = get_rpc_dataset_attribute_visibility_item_type(dataset)
-        attribute_visibility_kwargs = (
-            {
-                "api_attribute_visibility_item_type": api_item_type.value,
-                "api_attribute_visibility_include_internal": is_active_superuser(request)
-                or is_active_staff(request),
-            }
-            if api_item_type is not None
-            else {}
+        api_attribute_visibility_item_type = (
+            api_item_type.value if api_item_type is not None else None
+        )
+        api_attribute_visibility_include_internal = is_active_superuser(request) or is_active_staff(
+            request
         )
 
         if dataset == TraceMetrics:
@@ -256,7 +253,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
-                **attribute_visibility_kwargs,
+                api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
             )
         elif dataset == PreprodSize:
             return PreprodSizeSearchResolverConfig(
@@ -265,7 +263,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
-                **attribute_visibility_kwargs,
+                api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
             )
         else:
             return SearchResolverConfig(
@@ -274,7 +273,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                 extrapolation_mode=extrapolation_mode,
                 disable_array_attributes=disable_array_attributes,
-                **attribute_visibility_kwargs,
+                api_attribute_visibility_item_type=api_attribute_visibility_item_type,
+                api_attribute_visibility_include_internal=api_attribute_visibility_include_internal,
             )
 
     def get_event_stats(

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -121,6 +121,18 @@ class SearchResolver:
     def add_hidden_api_attributes(self, columns: set[str]) -> None:
         self._hidden_api_attributes.update(columns)
 
+    def get_api_attribute_visibility_item_type(self) -> SupportedTraceItemType | None:
+        if self.config.api_attribute_visibility_item_type is None:
+            return None
+
+        configured_item_type = SupportedTraceItemType(
+            self.config.api_attribute_visibility_item_type
+        )
+        for item_type, trace_item_type in constants.SUPPORTED_TRACE_ITEM_TYPE_MAP.items():
+            if trace_item_type == self.definitions.trace_item_type:
+                return item_type
+        return configured_item_type
+
     def _find_column_by_internal_name(self, internal_name: str) -> ResolvedAttribute | None:
         """Look up a column definition by its internal name (e.g. 'sentry.item_id' -> 'id' column).
 
@@ -1127,10 +1139,10 @@ class SearchResolver:
             column_context = None
 
         if column_definition:
-            if self.config.api_attribute_visibility_item_type is not None:
+            item_type = self.get_api_attribute_visibility_item_type()
+            if item_type is not None:
                 from sentry.search.eap.utils import can_expose_attribute_to_api
 
-                item_type = SupportedTraceItemType(self.config.api_attribute_visibility_item_type)
                 visibility_attribute = (
                     column_definition.public_alias
                     if is_public_defined_attribute

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -60,7 +60,7 @@ from sentry.search.eap.columns import (
 from sentry.search.eap.rpc_utils import and_trace_item_filters
 from sentry.search.eap.sampling import validate_sampling
 from sentry.search.eap.spans.attributes import SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS
-from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import EAPResponse, SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events import constants as qb_constants
 from sentry.search.events import fields
 from sentry.search.events import filter as event_filter
@@ -105,8 +105,15 @@ class SearchResolver:
             VirtualColumnDefinition | None,
         ],
     ] = field(default_factory=dict)
+    _hidden_api_attributes: set[str] = field(default_factory=set, repr=False)
     qualified_short_id_to_group_id_cache: dict[int, dict[str, int]] = field(default_factory=dict)
     _internal_name_to_column: dict[str, ResolvedAttribute] = field(default_factory=dict, repr=False)
+
+    def has_hidden_api_attributes(self) -> bool:
+        return bool(self._hidden_api_attributes)
+
+    def is_hidden_api_attribute(self, column: str) -> bool:
+        return column in self._hidden_api_attributes
 
     def _find_column_by_internal_name(self, internal_name: str) -> ResolvedAttribute | None:
         """Look up a column definition by its internal name (e.g. 'sentry.item_id' -> 'id' column).
@@ -1043,7 +1050,9 @@ class SearchResolver:
         if public_alias_override is not None:
             alias = public_alias_override
 
+        is_public_defined_attribute = False
         if column in self.definitions.contexts:
+            is_public_defined_attribute = True
             column_context = self.definitions.contexts[column]
             column_definition = ResolvedAttribute(
                 public_alias=alias,
@@ -1052,6 +1061,7 @@ class SearchResolver:
                 processor=column_context.processor,
             )
         elif column in self.definitions.columns:
+            is_public_defined_attribute = True
             column_context = None
             column_definition = self.definitions.columns[column]
             if column_definition.private and column not in self.config.fields_acl.attributes:
@@ -1111,6 +1121,21 @@ class SearchResolver:
             column_context = None
 
         if column_definition:
+            if self.config.api_attribute_visibility_item_type is not None:
+                from sentry.search.eap.utils import can_expose_attribute_to_api
+
+                item_type = SupportedTraceItemType(self.config.api_attribute_visibility_item_type)
+                visibility_attribute = (
+                    column_definition.public_alias
+                    if is_public_defined_attribute
+                    else column_definition.internal_name
+                )
+                if not can_expose_attribute_to_api(
+                    visibility_attribute,
+                    item_type,
+                    include_internal=self.config.api_attribute_visibility_include_internal,
+                ):
+                    self._hidden_api_attributes.add(column)
             self._resolved_attribute_cache[column] = (column_definition, column_context)
             return self._resolved_attribute_cache[column]
         else:

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -115,6 +115,12 @@ class SearchResolver:
     def is_hidden_api_attribute(self, column: str) -> bool:
         return column in self._hidden_api_attributes
 
+    def get_hidden_api_attributes(self) -> set[str]:
+        return set(self._hidden_api_attributes)
+
+    def add_hidden_api_attributes(self, columns: set[str]) -> None:
+        self._hidden_api_attributes.update(columns)
+
     def _find_column_by_internal_name(self, internal_name: str) -> ResolvedAttribute | None:
         """Look up a column definition by its internal name (e.g. 'sentry.item_id' -> 'id' column).
 

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -39,6 +39,10 @@ class SearchResolverConfig:
     # When True, ResolvedAttributes whose internal_type is ARRAY are silently dropped based on
     # feature flag organizations:trace-item-details-array-fields
     disable_array_attributes: bool = True
+    # API-only visibility enforcement. Non-API callers should leave this as None
+    # so backend resolution semantics remain unchanged.
+    api_attribute_visibility_item_type: str | None = None
+    api_attribute_visibility_include_internal: bool = False
 
     def extra_conditions(
         self,

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Literal
 
 from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_conventions.attributes import ATTRIBUTE_METADATA
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 
 from sentry.search.eap.columns import ColumnDefinitions, ResolvedAttribute
@@ -235,6 +236,77 @@ def can_expose_attribute(
         return include_internal
 
     return True
+
+
+def _has_internal_convention_visibility(attribute: str) -> bool:
+    metadata = ATTRIBUTE_METADATA.get(attribute)
+    if metadata is None:
+        return False
+
+    visibility = metadata.visibility
+    return getattr(visibility, "value", visibility) == "internal"
+
+
+def _get_sentry_convention_visibility_candidates(
+    attribute: str, item_type: SupportedTraceItemType
+) -> set[str]:
+    candidates = {attribute}
+
+    if item_type == SupportedTraceItemType.SPANS and attribute.startswith(("dsc.", "_internal.")):
+        candidates.add(f"sentry.{attribute}")
+
+    resolved_attribute = PUBLIC_ALIAS_TO_INTERNAL_MAPPING.get(item_type, {}).get(attribute)
+    if resolved_attribute is not None:
+        candidates.add(resolved_attribute.public_alias)
+        candidates.add(resolved_attribute.internal_name)
+        if resolved_attribute.replacement:
+            candidates.add(resolved_attribute.replacement)
+
+    for mapping in INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).values():
+        public_alias = mapping.get(attribute)
+        if public_alias is not None:
+            candidates.add(public_alias)
+
+    replacement_map = SENTRY_CONVENTIONS_REPLACEMENT_MAPPINGS.get(item_type, {})
+    seen: set[str] = set()
+    pending = list(candidates)
+    while pending:
+        candidate = pending.pop()
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        replacement = replacement_map.get(candidate)
+        if replacement is not None and replacement not in candidates:
+            candidates.add(replacement)
+            pending.append(replacement)
+
+    return candidates
+
+
+def is_internal_sentry_convention_attribute(
+    attribute: str, item_type: SupportedTraceItemType
+) -> bool:
+    return any(
+        _has_internal_convention_visibility(candidate)
+        for candidate in _get_sentry_convention_visibility_candidates(attribute, item_type)
+    )
+
+
+def can_expose_attribute_to_api(
+    attribute: str, item_type: SupportedTraceItemType, include_internal: bool = False
+) -> bool:
+    candidates = _get_sentry_convention_visibility_candidates(attribute, item_type)
+
+    for candidate in candidates:
+        if not can_expose_attribute(candidate, item_type, include_internal=include_internal):
+            return False
+
+    if include_internal:
+        return True
+
+    return not any(
+        is_internal_sentry_convention_attribute(candidate, item_type) for candidate in candidates
+    )
 
 
 def is_sentry_convention_replacement_attribute(

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Literal
 
 from google.protobuf.timestamp_pb2 import Timestamp
-from sentry_conventions.attributes import ATTRIBUTE_METADATA
+from sentry_conventions.attributes import ATTRIBUTE_METADATA as ATTRIBUTE_METADATA
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 
 from sentry.search.eap.columns import ColumnDefinitions, ResolvedAttribute

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -805,12 +805,22 @@ class RPCBase:
             sampling_mode=sampling_mode,
             additional_queries=additional_queries,
         )
+        result = ProcessedTimeseries()
+        if search_resolver.has_hidden_api_attributes():
+            final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_request.meta)
+            for resolved_field in aggregates + groupbys:
+                final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
+            return SnubaTSResult(
+                {"data": [], "processed_timeseries": result, "meta": final_meta},
+                params.start,
+                params.end,
+                params.granularity_secs,
+            )
 
         """Run the query"""
         rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
 
         """Process the results"""
-        result = ProcessedTimeseries()
         final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_response.meta)
         if params.debug:
             set_debug_meta(final_meta, rpc_response.meta, rpc_request)

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -807,7 +807,7 @@ class RPCBase:
         )
         result = ProcessedTimeseries()
         if search_resolver.has_hidden_api_attributes():
-            final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_request.meta)
+            final_meta: EventsMeta = {"fields": {}}
             for resolved_field in aggregates + groupbys:
                 final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
             return SnubaTSResult(
@@ -1146,6 +1146,7 @@ class RPCBase:
         attributes: list[AttributeKey] | None = None,
         max_buckets: int = 75,
         skip_translate_internal_to_public_alias: bool = False,
+        include_internal: bool = False,
     ) -> list[dict[str, Any]]:
         raise NotImplementedError()
 

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -807,11 +807,11 @@ class RPCBase:
         )
         result = ProcessedTimeseries()
         if search_resolver.has_hidden_api_attributes():
-            final_meta: EventsMeta = {"fields": {}}
+            hidden_meta: EventsMeta = {"fields": {}}
             for resolved_field in aggregates + groupbys:
-                final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
+                hidden_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
             return SnubaTSResult(
-                {"data": [], "processed_timeseries": result, "meta": final_meta},
+                {"data": [], "processed_timeseries": result, "meta": hidden_meta},
                 params.start,
                 params.end,
                 params.granularity_secs,

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -58,6 +58,7 @@ from sentry.search.eap.types import (
     ConfidenceData,
     EAPResponse,
     SearchResolverConfig,
+    SupportedTraceItemType,
 )
 from sentry.search.events.fields import get_function_alias, is_function
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaData, SnubaParams
@@ -177,8 +178,7 @@ class RPCBase:
     def get_cross_trace_queries(
         cls,
         additional_queries: AdditionalQueries | None,
-        config: SearchResolverConfig,
-        query_params: SnubaParams,
+        resolver: SearchResolver,
     ) -> list[TraceItemFilterWithType]:
         from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
         from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
@@ -190,32 +190,48 @@ class RPCBase:
 
         # resolve cross trace queries
         # Copy the existing resolver, but we don't allow aggregate conditions for cross trace filters
-        cross_trace_config = replace(config, use_aggregate_conditions=False)
+        cross_trace_config = replace(resolver.config, use_aggregate_conditions=False)
 
         cross_trace_queries = []
-        for queries, definitions, item_type in [
+        for queries, definitions, item_type, api_item_type in [
             (
                 additional_queries.log,
                 OURLOG_DEFINITIONS,
                 TraceItemType.TRACE_ITEM_TYPE_LOG,
+                SupportedTraceItemType.LOGS,
             ),
-            (additional_queries.span, SPAN_DEFINITIONS, TraceItemType.TRACE_ITEM_TYPE_SPAN),
+            (
+                additional_queries.span,
+                SPAN_DEFINITIONS,
+                TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                SupportedTraceItemType.SPANS,
+            ),
             (
                 additional_queries.metric,
                 TRACE_METRICS_DEFINITIONS,
                 TraceItemType.TRACE_ITEM_TYPE_METRIC,
+                SupportedTraceItemType.TRACEMETRICS,
             ),
             (
                 additional_queries.occurrences,
                 OCCURRENCE_DEFINITIONS,
                 TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE,
+                SupportedTraceItemType.OCCURRENCES,
             ),
         ]:
             if queries is not None:
                 # Create a resolver for the subqueries
+                query_config = replace(
+                    cross_trace_config,
+                    api_attribute_visibility_item_type=(
+                        api_item_type.value
+                        if cross_trace_config.api_attribute_visibility_item_type is not None
+                        else None
+                    ),
+                )
                 cross_resolver = SearchResolver(
-                    params=query_params,
-                    config=cross_trace_config,
+                    params=resolver.params,
+                    config=query_config,
                     definitions=definitions,
                 )
                 for query_string in queries:
@@ -228,6 +244,8 @@ class RPCBase:
                                 item_type=item_type,
                             )
                         )
+                if cross_resolver.has_hidden_api_attributes():
+                    resolver.add_hidden_api_attributes(cross_resolver.get_hidden_api_attributes())
         return cross_trace_queries
 
     @classmethod
@@ -262,9 +280,7 @@ class RPCBase:
         # if there are additional conditions to be added, make sure to merge them with the
         where = and_trace_item_filters(where, query.extra_conditions)
 
-        cross_trace_queries = cls.get_cross_trace_queries(
-            query.additional_queries, query.resolver.config, query.resolver.params
-        )
+        cross_trace_queries = cls.get_cross_trace_queries(query.additional_queries, query.resolver)
 
         trace_column, _ = resolver.resolve_column("trace")
         if (
@@ -439,19 +455,28 @@ class RPCBase:
             names.add(query.name)
 
         request_context_pairs: list[tuple[str, TableRequest, dict[str, Any]]] = []
+        results: dict[str, EAPResponse] = {}
         for query in queries:
             assert query.name is not None
             table_request = cls.get_table_rpc_request(query)
+            if query.resolver.has_hidden_api_attributes():
+                results[query.name] = {"data": [], "meta": {"fields": {}}, "confidence": []}
+                continue
             request_context_pairs.append(
                 (query.name, table_request, cls.build_rpc_table_row_context(query))
             )
-        responses = snuba_rpc.table_rpc(
-            [request.rpc_request for _, request, _ in request_context_pairs]
-        )
-        results = {
-            name: cls.process_table_response(response, request, context=process_context)
-            for (name, request, process_context), response in zip(request_context_pairs, responses)
-        }
+        if request_context_pairs:
+            responses = snuba_rpc.table_rpc(
+                [request.rpc_request for _, request, _ in request_context_pairs]
+            )
+            results.update(
+                {
+                    name: cls.process_table_response(response, request, context=process_context)
+                    for (name, request, process_context), response in zip(
+                        request_context_pairs, responses
+                    )
+                }
+            )
         return results
 
     @classmethod
@@ -724,9 +749,7 @@ class RPCBase:
             selected_equations,
         )
 
-        cross_trace_queries = cls.get_cross_trace_queries(
-            additional_queries, search_resolver.config, search_resolver.params
-        )
+        cross_trace_queries = cls.get_cross_trace_queries(additional_queries, search_resolver)
 
         trace_column, _ = search_resolver.resolve_column("trace")
         if (

--- a/src/sentry/snuba/utils.py
+++ b/src/sentry/snuba/utils.py
@@ -77,9 +77,24 @@ RPC_DATASETS = {
     TraceMetrics,
     UptimeResults,
 }
+RPC_DATASET_ATTRIBUTE_VISIBILITY_ITEM_TYPES = {
+    Occurrences: SupportedTraceItemType.OCCURRENCES,
+    OurLogs: SupportedTraceItemType.LOGS,
+    PreprodSize: SupportedTraceItemType.PREPROD,
+    ProcessingErrors: SupportedTraceItemType.PROCESSING_ERRORS,
+    ProfileFunctions: SupportedTraceItemType.PROFILE_FUNCTIONS,
+    Replays: SupportedTraceItemType.REPLAYS,
+    Spans: SupportedTraceItemType.SPANS,
+    TraceMetrics: SupportedTraceItemType.TRACEMETRICS,
+    UptimeResults: SupportedTraceItemType.UPTIME_RESULTS,
+}
 DATASET_LABELS = {
     value: key for key, value in DATASET_OPTIONS.items() if key not in DEPRECATED_LABELS
 }
+
+
+def get_rpc_dataset_attribute_visibility_item_type(dataset: Any) -> SupportedTraceItemType | None:
+    return RPC_DATASET_ATTRIBUTE_VISIBILITY_ITEM_TYPES.get(dataset)
 
 
 TRANSACTION_ONLY_FIELDS = [

--- a/tests/sentry/search/eap/test_ourlogs.py
+++ b/tests/sentry/search/eap/test_ourlogs.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
@@ -17,9 +17,10 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     TraceItemFilter,
 )
 
+from sentry.search.eap import utils as eap_utils
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events.types import SnubaParams
 
 
@@ -50,6 +51,26 @@ class SearchResolverQueryTest(TestCase):
             )
         )
         assert having is None
+
+    def test_visibility_uses_definitions_item_type(self) -> None:
+        resolver = SearchResolver(
+            params=SnubaParams(),
+            config=SearchResolverConfig(
+                api_attribute_visibility_item_type=SupportedTraceItemType.SPANS.value
+            ),
+            definitions=OURLOG_DEFINITIONS,
+        )
+
+        with mock.patch.dict(
+            eap_utils.PRIVATE_ATTRIBUTES,
+            {
+                SupportedTraceItemType.SPANS: set(),
+                SupportedTraceItemType.LOGS: {"log.internal.only"},
+            },
+        ):
+            resolver.resolve_attribute("log.internal.only")
+
+        assert resolver.has_hidden_api_attributes()
 
     def test_negation(self) -> None:
         where, having, _ = self.resolver.resolve_query("!message:foo")

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -1,5 +1,7 @@
 import os
 from datetime import datetime
+from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
@@ -28,6 +30,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 )
 
 from sentry.exceptions import InvalidSearchQuery
+from sentry.search.eap import utils as eap_utils
 from sentry.search.eap.columns import ResolvedAttribute
 from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
@@ -40,11 +43,92 @@ from sentry.search.eap.spans.attributes import (
 )
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.spans.sentry_conventions import SENTRY_CONVENTIONS_DIRECTORY
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
+from sentry.search.eap.utils import can_expose_attribute_to_api
 from sentry.search.events.types import SnubaParams
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
+
+
+class AttributeVisibilityTest(TestCase):
+    def test_public_convention_attribute_visible_to_everyone(self) -> None:
+        with mock.patch.dict(
+            eap_utils.ATTRIBUTE_METADATA,
+            {"public.attr": SimpleNamespace(visibility="public")},
+        ):
+            assert can_expose_attribute_to_api("public.attr", SupportedTraceItemType.SPANS)
+
+    def test_internal_convention_attribute_hidden_unless_included(self) -> None:
+        with mock.patch.dict(
+            eap_utils.ATTRIBUTE_METADATA,
+            {"internal.attr": SimpleNamespace(visibility="internal")},
+        ):
+            assert not can_expose_attribute_to_api("internal.attr", SupportedTraceItemType.SPANS)
+            assert can_expose_attribute_to_api(
+                "internal.attr", SupportedTraceItemType.SPANS, include_internal=True
+            )
+
+    def test_internal_convention_public_alias_is_hidden(self) -> None:
+        with (
+            mock.patch.dict(
+                eap_utils.ATTRIBUTE_METADATA,
+                {"internal.attr": SimpleNamespace(visibility="internal")},
+            ),
+            mock.patch.dict(
+                eap_utils.PUBLIC_ALIAS_TO_INTERNAL_MAPPING[SupportedTraceItemType.SPANS],
+                {
+                    "public.alias": ResolvedAttribute(
+                        public_alias="public.alias",
+                        internal_name="internal.attr",
+                        search_type="string",
+                    )
+                },
+            ),
+        ):
+            assert not can_expose_attribute_to_api("public.alias", SupportedTraceItemType.SPANS)
+
+    def test_internal_convention_translated_public_alias_is_hidden(self) -> None:
+        with (
+            mock.patch.dict(
+                eap_utils.ATTRIBUTE_METADATA,
+                {"public.alias": SimpleNamespace(visibility="internal")},
+            ),
+            mock.patch.dict(
+                eap_utils.INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS[SupportedTraceItemType.SPANS]["string"],
+                {"internal.attr": "public.alias"},
+            ),
+        ):
+            assert not can_expose_attribute_to_api("internal.attr", SupportedTraceItemType.SPANS)
+
+    def test_internal_convention_replacement_is_hidden(self) -> None:
+        with (
+            mock.patch.dict(
+                eap_utils.ATTRIBUTE_METADATA,
+                {"replacement.attr": SimpleNamespace(visibility="internal")},
+            ),
+            mock.patch.dict(
+                eap_utils.SENTRY_CONVENTIONS_REPLACEMENT_MAPPINGS[SupportedTraceItemType.SPANS],
+                {"deprecated.attr": "replacement.attr"},
+            ),
+        ):
+            assert not can_expose_attribute_to_api("deprecated.attr", SupportedTraceItemType.SPANS)
+
+    def test_stripped_internal_prefix_alias_is_hidden(self) -> None:
+        assert not can_expose_attribute_to_api(
+            "_internal.normalized_description", SupportedTraceItemType.SPANS
+        )
+        assert can_expose_attribute_to_api(
+            "_internal.normalized_description",
+            SupportedTraceItemType.SPANS,
+            include_internal=True,
+        )
+
+    def test_stripped_dsc_convention_alias_is_hidden(self) -> None:
+        assert not can_expose_attribute_to_api("dsc.trace_id", SupportedTraceItemType.SPANS)
+        assert can_expose_attribute_to_api(
+            "dsc.trace_id", SupportedTraceItemType.SPANS, include_internal=True
+        )
 
 
 class SearchResolverQueryTest(TestCase):

--- a/tests/sentry/snuba/test_rpc_dataset_common.py
+++ b/tests/sentry/snuba/test_rpc_dataset_common.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from unittest import mock
 
 import pytest
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
@@ -17,7 +18,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 class TestBulkTableQueries(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.snuba_params = SnubaParams()
+        self.snuba_params = SnubaParams(projects=[self.project], stats_period="1h")
         self.config = SearchResolverConfig()
         self.resolver = Spans.get_resolver(self.snuba_params, self.config)
 
@@ -68,6 +69,29 @@ class TestBulkTableQueries(TestCase):
                     ),
                 ]
             )
+
+    def test_hidden_attribute_query_returns_empty_without_rpc(self) -> None:
+        self.resolver.add_hidden_api_attributes({"__sentry_internal_test"})
+
+        with mock.patch("sentry.snuba.rpc_dataset_common.snuba_rpc.table_rpc") as mock_table_rpc:
+            results = RPCBase.run_bulk_table_queries(
+                [
+                    TableQuery(
+                        "",
+                        ["count()"],
+                        None,
+                        0,
+                        1,
+                        "TestReferrer",
+                        None,
+                        self.resolver,
+                        name="hidden",
+                    )
+                ]
+            )
+
+        assert results == {"hidden": {"data": [], "meta": {"fields": {}}, "confidence": []}}
+        mock_table_rpc.assert_not_called()
 
 
 trace_id_test_cases = (

--- a/tests/sentry/snuba/test_rpc_dataset_common.py
+++ b/tests/sentry/snuba/test_rpc_dataset_common.py
@@ -3,8 +3,10 @@ from unittest import mock
 
 import pytest
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.resolver import SearchResolver
+from sentry.search.eap.types import AdditionalQueries, SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events.types import SnubaParams
 from sentry.snuba.occurrences_rpc import Occurrences
 from sentry.snuba.ourlogs import OurLogs
@@ -92,6 +94,36 @@ class TestBulkTableQueries(TestCase):
 
         assert results == {"hidden": {"data": [], "meta": {"fields": {}}, "confidence": []}}
         mock_table_rpc.assert_not_called()
+
+    def test_cross_trace_queries_pass_subquery_item_type_for_visibility(self) -> None:
+        resolver = Spans.get_resolver(
+            self.snuba_params,
+            SearchResolverConfig(
+                api_attribute_visibility_item_type=SupportedTraceItemType.SPANS.value
+            ),
+        )
+
+        def resolve_query(search_resolver: SearchResolver, query_string: str):
+            if (
+                search_resolver.config.api_attribute_visibility_item_type
+                == SupportedTraceItemType.OCCURRENCES.value
+            ):
+                search_resolver.add_hidden_api_attributes({query_string})
+            return TraceItemFilter(), None, []
+
+        with mock.patch.object(SearchResolver, "resolve_query", autospec=True) as mock_resolve:
+            mock_resolve.side_effect = resolve_query
+            RPCBase.get_cross_trace_queries(
+                AdditionalQueries(
+                    span=None,
+                    log=None,
+                    metric=None,
+                    occurrences=["occurrence.internal.only:value"],
+                ),
+                resolver,
+            )
+
+        assert resolver.has_hidden_api_attributes()
 
 
 trace_id_test_cases = (

--- a/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
@@ -108,6 +108,106 @@ class OrganizationEventsCrossTraceEndpointTest(OrganizationEventsEndpointTestBas
         assert len(response.data["data"]) == 1
         assert response.data["data"][0]["tags[foo]"] == "five"
 
+    def test_cross_trace_query_with_internal_span_attribute_is_staff_only(self) -> None:
+        trace_id = uuid.uuid4().hex
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "tags": {"foo": "five"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "hidden-filter-span",
+                        "tags": {"__sentry_internal_test": "internal_value"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+        )
+
+        query = {
+            "field": ["tags[foo]", "count()"],
+            "query": "description:baz",
+            "orderby": "count()",
+            "project": self.project.id,
+            "dataset": "spans",
+            "spanQuery": ["__sentry_internal_test:internal_value"],
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == []
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+        with self.feature({"organizations:discover-basic": True}):
+            response = self.client_get(self.reverse_url(), query, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "tags[foo]": "five",
+                "count()": 1,
+            }
+        ]
+
+    def test_cross_trace_query_with_internal_log_attribute_is_staff_only(self) -> None:
+        trace_id = uuid.uuid4().hex
+        logs = [
+            self.create_ourlog(
+                {"body": "foo", "trace_id": trace_id},
+                timestamp=self.ten_mins_ago,
+                attributes={"__sentry_internal_test": "internal_value"},
+            ),
+        ]
+        self.store_eap_items(logs)
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "tags": {"foo": "five"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+        )
+
+        query = {
+            "field": ["tags[foo]", "count()"],
+            "query": "description:baz",
+            "orderby": "count()",
+            "project": self.project.id,
+            "dataset": "spans",
+            "logQuery": ["__sentry_internal_test:internal_value"],
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == []
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+        with self.feature({"organizations:discover-basic": True}):
+            response = self.client_get(self.reverse_url(), query, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "tags[foo]": "five",
+                "count()": 1,
+            }
+        ]
+
     def test_cross_trace_query_with_spans_and_logs(self) -> None:
         trace_id = uuid.uuid4().hex
         excluded_trace_id = uuid.uuid4().hex

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -4551,6 +4551,47 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
 
             assert response.status_code == 400, response.content
 
+    def test_sentry_internal_field_values_are_staff_only(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "tags": {
+                            "normal_attr": "normal_value",
+                            "__sentry_internal_test": "internal_value",
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+        )
+        query = {
+            "field": ["__sentry_internal_test", "count()"],
+            "query": "",
+            "orderby": "__sentry_internal_test",
+            "project": self.project.id,
+            "dataset": "spans",
+            "statsPeriod": "1h",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == []
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+        with self.feature({"organizations:discover-basic": True}):
+            response = self.client_get(self.reverse_url(), query, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "__sentry_internal_test": "internal_value",
+                "count()": 1,
+            }
+        ]
+
     def test_transaction_profile_attributes(self) -> None:
         span_with_profile = self.create_span(start_ts=before_now(minutes=10))
         span_without_profile = self.create_span(

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -141,6 +141,50 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "interval": 3_600_000,
         }
 
+    def test_sentry_internal_groupby_values_are_staff_only(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"tags": {"__sentry_internal_test": "internal_value"}},
+                    start_ts=self.start,
+                ),
+            ],
+        )
+        query = {
+            "start": self.start,
+            "end": self.end,
+            "interval": "1h",
+            "yAxis": "count()",
+            "groupBy": "__sentry_internal_test",
+            "orderby": "-count()",
+            "topEvents": 1,
+            "project": self.project.id,
+            "dataset": "spans",
+            "excludeOther": 1,
+        }
+
+        response = self._do_request(data=query)
+        assert response.status_code == 200, response.content
+        assert response.data["timeSeries"] == []
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self._do_request(data=query)
+        assert response.status_code == 200, response.content
+        assert len(response.data["timeSeries"]) == 1
+        timeseries = response.data["timeSeries"][0]
+        assert timeseries["groupBy"] == [
+            {"key": "__sentry_internal_test", "value": "internal_value"}
+        ]
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start,
+            3_600_000,
+            [1, 0, 0, 0, 0, 0],
+            ignore_accuracy=True,
+        )
+
     def test_handle_nans_from_snuba(self) -> None:
         self.store_spans(
             [self.create_span({"description": "foo"}, start_ts=self.start)],


### PR DESCRIPTION
## Summary
- Apply visibility checks to `organization_events` and `organization_events_timeseries` endpoints — queries on hidden internal attributes return empty results for non-staff users
- Refactor `get_cross_trace_queries` to accept the full `SearchResolver` instead of config + params, propagating hidden attribute markers from cross-trace sub-resolvers back to the primary resolver
- Add `has_hidden_api_attributes()` short-circuit in both `run_table_query` and `run_bulk_table_query` to avoid dispatching RPCs
- Derive the visibility item type from the resolver's column definitions rather than the primary request type, so cross-trace sub-resolvers use the correct item type
- Return properly structured empty timeseries responses (with field metadata) when attributes are hidden

Depends on #116091

## Test plan
- New tests in `test_organization_events_span_indexed.py`, `test_organization_events_timeseries_spans.py`, `test_organization_events_cross_trace.py`, and `test_rpc_dataset_common.py`
- Coverage for log resolvers receiving a spans visibility config in `test_ourlogs.py`

Closes TODO