### PR TITLE
fix(dashboards): Stop widget header action clicks from bubbling

### DIFF
--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -145,6 +145,7 @@ export function SortableWidget(props: Props) {
     onWidgetTableSort,
     onWidgetTableResizeColumn,
     widgetInterval: props.widgetInterval,
+    disableFullscreen: hasSlideout,
   };
 
   return (

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -145,7 +145,6 @@ export function SortableWidget(props: Props) {
     onWidgetTableSort,
     onWidgetTableResizeColumn,
     widgetInterval: props.widgetInterval,
-    disableFullscreen: hasSlideout,
   };
 
   return (

--- a/static/app/views/dashboards/widgetCard/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetFrame.tsx
@@ -108,7 +108,10 @@ export function WidgetFrame(props: WidgetFrameProps) {
                   <LinkButton
                     size="xs"
                     disabled={props.actionsDisabled}
-                    onClick={actions[0]!.onAction}
+                    onClick={e => {
+                      e.stopPropagation();
+                      actions[0]!.onAction?.();
+                    }}
                     to={actions[0]!.to}
                   >
                     {actions[0]!.label}
@@ -117,7 +120,10 @@ export function WidgetFrame(props: WidgetFrameProps) {
                   <Button
                     size="xs"
                     disabled={props.actionsDisabled}
-                    onClick={actions[0]!.onAction}
+                    onClick={e => {
+                      e.stopPropagation();
+                      actions[0]!.onAction?.();
+                    }}
                   >
                     {actions[0]!.label}
                   </Button>
@@ -148,7 +154,8 @@ export function WidgetFrame(props: WidgetFrameProps) {
                 aria-label={t('Copy Widget URL')}
                 variant="transparent"
                 icon={<IconCopy />}
-                onClick={() => {
+                onClick={e => {
+                  e.stopPropagation();
                   props.onCopyUrlClick?.();
                 }}
               />
@@ -161,7 +168,8 @@ export function WidgetFrame(props: WidgetFrameProps) {
               aria-label={t('Open Full-Screen View')}
               variant="transparent"
               icon={<IconExpand />}
-              onClick={() => {
+              onClick={e => {
+                e.stopPropagation();
                 props.onFullScreenViewClick?.();
               }}
             />


### PR DESCRIPTION
Stop click events from bubbling out of widget header action buttons (full-screen view, copy URL). 

On prebuilt dashboards like Web Vitals that wire a slideout drawer to the wrapper's `onClick`, the bubble caused the full-screen modal and the slideout drawer to open from a single click and overlap.

**Root cause**

The header buttons in `widgetFrame.tsx` didn't `e.stopPropagation()`, so a click on the expand icon fired the button's `onFullScreenViewClick` *and* bubbled up to `GridWidgetWrapper`'s `onClick` in `sortableWidget.tsx`, which opens the slideout. Same bubble exists for the Copy URL button and any single custom action.

**Fix**

Each header action button now stops propagation before invoking its handler. The wrapper's click target stays the widget body, so the slideout only opens when the user actually clicks into the widget body — not when they interact with a header button.

Fixes DAIN-1684