### PR TITLE
feat: flags and rpc for frontend code search tool

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -273,7 +273,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable code editing tools in Seer Agent chat
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable sentry source code search tool
-    manager.add("organizations:seer-agent-source-code-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:seer-agent-source-code-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable code mode tools (sentry_api_search/execute) in Seer Agent
     manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code mode tools for Slack-initiated Explorer sessions

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -272,6 +272,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-context-engine-fe-override-ui-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code editing tools in Seer Agent chat
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable sentry source code search tool
+    manager.add("organizations:seer-agent-source-code-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code mode tools (sentry_api_search/execute) in Seer Agent
     manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code mode tools for Slack-initiated Explorer sessions

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -273,7 +273,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable code editing tools in Seer Agent chat
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable sentry source code search tool
-    manager.add("organizations:seer-agent-source-code-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:seer-agent-source-code-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code mode tools (sentry_api_search/execute) in Seer Agent
     manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code mode tools for Slack-initiated Explorer sessions

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -364,6 +364,13 @@ class SeerAgentClient:
         ):
             chat_body["is_context_engine_enabled"] = override_ce_enable
 
+        if features.has(
+            "organizations:seer-agent-source-code-search",
+            self.organization,
+            actor=self.user,
+        ):
+            chat_body["enable_frontend_code_search"] = True
+
         if features.has("organizations:seer-run-mirror-explorer", self.organization):
             user_id = (
                 self.user.id

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -549,6 +549,13 @@ class SeerAgentClient:
         if _has_context_engine(self.organization, self.user):
             chat_body["is_context_engine_enabled"] = True
 
+        if features.has(
+            "organizations:seer-agent-source-code-search",
+            self.organization,
+            actor=self.user,
+        ):
+            chat_body["enable_frontend_code_search"] = True
+
         response = make_agent_chat_request(chat_body, viewer_context=self.viewer_context)
 
         if response.status >= 400:

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -73,6 +73,7 @@ class AgentChatRequest(TypedDict):
     category_value: NotRequired[str]
     metadata: NotRequired[dict[str, Any]]
     is_context_engine_enabled: NotRequired[bool]
+    enable_frontend_code_search: NotRequired[bool]
     max_iterations: NotRequired[int]
     proxy_headers: NotRequired[dict[str, str] | None]
     ui_tools: NotRequired[str | None]

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -22,6 +22,7 @@ from urllib3 import BaseHTTPResponse, HTTPConnectionPool
 
 from sentry import features
 from sentry.constants import ObjectStatus
+from sentry.features.base import OrganizationFeature
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
@@ -245,19 +246,17 @@ def _get_org_feature_flags(
     organization: Organization, user: SentryUser | RpcUser | AnonymousUser | None
 ) -> list[str]:
     """Return the list of active org feature flag names (without the 'organizations:' prefix)."""
-    from sentry.features.base import OrganizationFeature
-
-    features_to_check = [
+    features_to_check = {
         feature
         for feature in features.all(feature_type=OrganizationFeature, api_expose_only=True).keys()
         if feature.startswith(_ORGANIZATION_SCOPE_PREFIX)
-    ]
+    }
 
     feature_set: set[str] = set()
 
     with sentry_sdk.start_span(op="features.check", name="check batch features"):
         batch = features.batch_has(
-            features_to_check,
+            list(features_to_check),
             actor=user,
             organization=organization,
             skip_experiment_exposure=True,
@@ -267,7 +266,7 @@ def _get_org_feature_flags(
             for name, active in batch.get(f"organization:{organization.id}", {}).items():
                 if active:
                     feature_set.add(name[len(_ORGANIZATION_SCOPE_PREFIX) :])
-                features_to_check.remove(name)
+                features_to_check.discard(name)
 
     with sentry_sdk.start_span(op="features.check", name="check individual features"):
         for name in features_to_check:

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -14,7 +14,6 @@ from datetime import datetime
 from typing import Any, NotRequired, TypedDict
 
 import orjson
-import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
@@ -22,7 +21,6 @@ from urllib3 import BaseHTTPResponse, HTTPConnectionPool
 
 from sentry import features
 from sentry.constants import ObjectStatus
-from sentry.features.base import OrganizationFeature
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
@@ -239,43 +237,6 @@ def has_seer_agent_access_with_detail(
     return True, None
 
 
-_ORGANIZATION_SCOPE_PREFIX = "organizations:"
-
-
-def _get_org_feature_flags(
-    organization: Organization, user: SentryUser | RpcUser | AnonymousUser | None
-) -> list[str]:
-    """Return the list of active org feature flag names (without the 'organizations:' prefix)."""
-    features_to_check = {
-        feature
-        for feature in features.all(feature_type=OrganizationFeature, api_expose_only=True).keys()
-        if feature.startswith(_ORGANIZATION_SCOPE_PREFIX)
-    }
-
-    feature_set: set[str] = set()
-
-    with sentry_sdk.start_span(op="features.check", name="check batch features"):
-        batch = features.batch_has(
-            list(features_to_check),
-            actor=user,
-            organization=organization,
-            skip_experiment_exposure=True,
-        )
-
-        if batch:
-            for name, active in batch.get(f"organization:{organization.id}", {}).items():
-                if active:
-                    feature_set.add(name[len(_ORGANIZATION_SCOPE_PREFIX) :])
-                features_to_check.discard(name)
-
-    with sentry_sdk.start_span(op="features.check", name="check individual features"):
-        for name in features_to_check:
-            if features.has(name, organization, actor=user, skip_entity=True):
-                feature_set.add(name[len(_ORGANIZATION_SCOPE_PREFIX) :])
-
-    return sorted(feature_set)
-
-
 def collect_user_org_context(
     user: SentryUser | RpcUser | AnonymousUser | None,
     organization: Organization,
@@ -298,13 +259,10 @@ def collect_user_org_context(
         for p in all_projects
     ]
 
-    org_features = _get_org_feature_flags(organization, user)
-
     if user is None or isinstance(user, AnonymousUser):
         return {
             "org_slug": organization.slug,
             "all_org_projects": all_org_projects,
-            "org_features": org_features,
         }
 
     try:
@@ -322,7 +280,6 @@ def collect_user_org_context(
         return {
             "org_slug": organization.slug,
             "all_org_projects": all_org_projects,
-            "org_features": org_features,
         }
     user_teams = [{"id": t.id, "slug": t.slug} for t in member.get_teams()]
     my_projects = (
@@ -361,7 +318,6 @@ def collect_user_org_context(
         "user_teams": user_teams,
         "user_projects": user_projects,
         "all_org_projects": all_org_projects,
-        "org_features": org_features,
     }
 
 

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from typing import Any, NotRequired, TypedDict
 
 import orjson
+import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
@@ -237,6 +238,45 @@ def has_seer_agent_access_with_detail(
     return True, None
 
 
+_ORGANIZATION_SCOPE_PREFIX = "organizations:"
+
+
+def _get_org_feature_flags(
+    organization: Organization, user: SentryUser | RpcUser | AnonymousUser | None
+) -> list[str]:
+    """Return the list of active org feature flag names (without the 'organizations:' prefix)."""
+    from sentry.features.base import OrganizationFeature
+
+    features_to_check = [
+        feature
+        for feature in features.all(feature_type=OrganizationFeature, api_expose_only=True).keys()
+        if feature.startswith(_ORGANIZATION_SCOPE_PREFIX)
+    ]
+
+    feature_set: set[str] = set()
+
+    with sentry_sdk.start_span(op="features.check", name="check batch features"):
+        batch = features.batch_has(
+            features_to_check,
+            actor=user,
+            organization=organization,
+            skip_experiment_exposure=True,
+        )
+
+        if batch:
+            for name, active in batch.get(f"organization:{organization.id}", {}).items():
+                if active:
+                    feature_set.add(name[len(_ORGANIZATION_SCOPE_PREFIX) :])
+                features_to_check.remove(name)
+
+    with sentry_sdk.start_span(op="features.check", name="check individual features"):
+        for name in features_to_check:
+            if features.has(name, organization, actor=user, skip_entity=True):
+                feature_set.add(name[len(_ORGANIZATION_SCOPE_PREFIX) :])
+
+    return sorted(feature_set)
+
+
 def collect_user_org_context(
     user: SentryUser | RpcUser | AnonymousUser | None,
     organization: Organization,
@@ -259,10 +299,13 @@ def collect_user_org_context(
         for p in all_projects
     ]
 
+    org_features = _get_org_feature_flags(organization, user)
+
     if user is None or isinstance(user, AnonymousUser):
         return {
             "org_slug": organization.slug,
             "all_org_projects": all_org_projects,
+            "org_features": org_features,
         }
 
     try:
@@ -280,6 +323,7 @@ def collect_user_org_context(
         return {
             "org_slug": organization.slug,
             "all_org_projects": all_org_projects,
+            "org_features": org_features,
         }
     user_teams = [{"id": t.id, "slug": t.slug} for t in member.get_teams()]
     my_projects = (
@@ -318,6 +362,7 @@ def collect_user_org_context(
         "user_teams": user_teams,
         "user_projects": user_projects,
         "all_org_projects": all_org_projects,
+        "org_features": org_features,
     }
 
 

--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -64,6 +64,7 @@ from sentry.seer.endpoints.seer_rpc import (
     get_attributes_and_values,
     get_attributes_for_span,
     get_github_enterprise_integration_config,
+    get_organization_features,
     get_organization_project_ids,
     get_organization_slug,
     has_repo_code_mappings,
@@ -87,6 +88,7 @@ public_org_seer_method_registry: dict[str, Callable] = {
     # Common to Seer features
     "get_organization_project_ids": map_org_id_param(get_organization_project_ids),
     "get_organization_slug": map_org_id_param(get_organization_slug),
+    "get_organization_features": map_org_id_param(get_organization_features),
     "validate_repo": validate_repo,
     "get_github_enterprise_integration_config": get_github_enterprise_integration_config,
     #

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -126,6 +126,7 @@ from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
 from sentry.silo.base import SiloMode
 from sentry.snuba.referrer import Referrer
+from sentry.users.services.user.service import user_service
 from sentry.utils import snuba_rpc
 from sentry.utils.env import in_test_environment
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
@@ -322,11 +323,13 @@ def get_organization_project_ids(*, org_id: int) -> dict:
 _ORGANIZATION_SCOPE_PREFIX = "organizations:"
 
 
-def get_organization_features(*, org_id: int) -> dict[str, list[str]]:
+def get_organization_features(*, org_id: int, user_id: int | None = None) -> dict[str, list[str]]:
     try:
         organization = Organization.objects.get(id=org_id)
     except Organization.DoesNotExist:
         return {"features": []}
+
+    actor = user_service.get_user(user_id=user_id) if user_id is not None else None
 
     features_to_check = {
         feature
@@ -339,6 +342,7 @@ def get_organization_features(*, org_id: int) -> dict[str, list[str]]:
     with sentry_sdk.start_span(op="features.check", name="check batch features"):
         batch = features.batch_has(
             list(features_to_check),
+            actor=actor,
             organization=organization,
             skip_experiment_exposure=True,
         )
@@ -351,7 +355,7 @@ def get_organization_features(*, org_id: int) -> dict[str, list[str]]:
 
     with sentry_sdk.start_span(op="features.check", name="check individual features"):
         for name in features_to_check:
-            if features.has(name, organization, skip_entity=True):
+            if features.has(name, organization, actor=actor, skip_entity=True):
                 feature_set.add(name[len(_ORGANIZATION_SCOPE_PREFIX) :])
 
     return {"features": list(sorted(feature_set))}

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -957,6 +957,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     # Common to Seer features
     "get_github_enterprise_integration_config": get_github_enterprise_integration_config,
     "get_organization_project_ids": get_organization_project_ids,
+    "get_organization_features": get_organization_features,
     "check_repository_integrations_status": check_repository_integrations_status,
     "validate_repo": validate_repo,
     "get_repo_installation_id": get_repo_installation_id,

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -36,6 +36,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue, StrArray
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentication
@@ -44,6 +45,7 @@ from sentry.api.endpoints.project_trace_item_details import convert_rpc_attribut
 from sentry.api.utils import get_date_range_from_params
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidSearchQuery
+from sentry.features.base import OrganizationFeature
 from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException, RpcResolutionException
 from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
 from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
@@ -315,6 +317,44 @@ def get_organization_project_ids(*, org_id: int) -> dict:
     )
 
     return {"projects": projects}
+
+
+_ORGANIZATION_SCOPE_PREFIX = "organizations:"
+
+
+def get_organization_features(*, org_id: int) -> dict[str, list[str]]:
+    try:
+        organization = Organization.objects.get(id=org_id)
+    except Organization.DoesNotExist:
+        return {"features": []}
+
+    features_to_check = {
+        feature
+        for feature in features.all(feature_type=OrganizationFeature, api_expose_only=True).keys()
+        if feature.startswith(_ORGANIZATION_SCOPE_PREFIX)
+    }
+
+    feature_set: set[str] = set()
+
+    with sentry_sdk.start_span(op="features.check", name="check batch features"):
+        batch = features.batch_has(
+            list(features_to_check),
+            organization=organization,
+            skip_experiment_exposure=True,
+        )
+
+        if batch:
+            for name, active in batch.get(f"organization:{organization.id}", {}).items():
+                if active:
+                    feature_set.add(name[len(_ORGANIZATION_SCOPE_PREFIX) :])
+                features_to_check.discard(name)
+
+    with sentry_sdk.start_span(op="features.check", name="check individual features"):
+        for name in features_to_check:
+            if features.has(name, organization, skip_entity=True):
+                feature_set.add(name[len(_ORGANIZATION_SCOPE_PREFIX) :])
+
+    return {"features": list(sorted(feature_set))}
 
 
 class SentryOrganizaionIdsAndSlugs(TypedDict):

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -278,6 +278,8 @@ class TestSeerAgentClient(TestCase):
 
         assert run_id == 456
         assert mock_post.called
+        body = mock_post.call_args[0][0]
+        assert "enable_frontend_code_search" not in body
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.make_agent_chat_request")
@@ -290,11 +292,14 @@ class TestSeerAgentClient(TestCase):
         mock_post.return_value = mock_response
 
         client = SeerAgentClient(self.organization, self.user)
-        run_id = client.continue_run(789, "Follow up", insert_index=2, on_page_context="context")
+        with self.feature("organizations:seer-agent-source-code-search"):
+            run_id = client.continue_run(
+                789, "Follow up", insert_index=2, on_page_context="context"
+            )
 
         assert run_id == 789
-        call_args = mock_post.call_args
-        assert call_args is not None
+        body = mock_post.call_args[0][0]
+        assert body["enable_frontend_code_search"] is True
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.make_agent_chat_request")

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -75,6 +75,8 @@ class TestSeerAgentClient(TestCase):
         assert run_id == 123
         mock_collect_context.assert_called_once_with(self.user, self.organization, request=None)
         assert mock_post.called
+        body = mock_post.call_args[0][0]
+        assert "enable_frontend_code_search" not in body
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.make_agent_chat_request")
@@ -139,12 +141,14 @@ class TestSeerAgentClient(TestCase):
         client = SeerAgentClient(
             self.organization, self.user, category_key="bug-fixer", category_value="issue-123"
         )
-        run_id = client.start_run("Fix bug")
+        with self.feature("organizations:seer-agent-source-code-search"):
+            run_id = client.start_run("Fix bug")
 
         assert run_id == 999
         body = mock_post.call_args[0][0]
         assert body["category_key"] == "bug-fixer"
         assert body["category_value"] == "issue-123"
+        assert body["enable_frontend_code_search"] is True
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     def test_init_category_key_only_raises_error(self, mock_access):
@@ -258,47 +262,6 @@ class TestSeerAgentClient(TestCase):
         assert run_id == 445
         body = mock_post.call_args[0][0]
         assert "max_iterations" not in body
-
-    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
-    @patch("sentry.seer.agent.client.collect_user_org_context")
-    def test_start_run_sets_enable_frontend_code_search_when_flag_active(
-        self, mock_collect_context, mock_post, mock_access
-    ):
-        mock_access.return_value = (True, None)
-        mock_collect_context.return_value = {"user_id": self.user.id}
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"run_id": 446}
-        mock_response.status = 200
-        mock_post.return_value = mock_response
-
-        with self.feature("organizations:seer-agent-source-code-search"):
-            client = SeerAgentClient(self.organization, self.user)
-            run_id = client.start_run("Test query")
-
-        assert run_id == 446
-        body = mock_post.call_args[0][0]
-        assert body["enable_frontend_code_search"] is True
-
-    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
-    @patch("sentry.seer.agent.client.collect_user_org_context")
-    def test_start_run_omits_enable_frontend_code_search_when_flag_inactive(
-        self, mock_collect_context, mock_post, mock_access
-    ):
-        mock_access.return_value = (True, None)
-        mock_collect_context.return_value = {"user_id": self.user.id}
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"run_id": 447}
-        mock_response.status = 200
-        mock_post.return_value = mock_response
-
-        client = SeerAgentClient(self.organization, self.user)
-        run_id = client.start_run("Test query")
-
-        assert run_id == 447
-        body = mock_post.call_args[0][0]
-        assert "enable_frontend_code_search" not in body
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.make_agent_chat_request")

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -261,6 +261,47 @@ class TestSeerAgentClient(TestCase):
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    def test_start_run_sets_enable_frontend_code_search_when_flag_active(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 446}
+        mock_response.status = 200
+        mock_post.return_value = mock_response
+
+        with self.feature("organizations:seer-agent-source-code-search"):
+            client = SeerAgentClient(self.organization, self.user)
+            run_id = client.start_run("Test query")
+
+        assert run_id == 446
+        body = mock_post.call_args[0][0]
+        assert body["enable_frontend_code_search"] is True
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    def test_start_run_omits_enable_frontend_code_search_when_flag_inactive(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 447}
+        mock_response.status = 200
+        mock_post.return_value = mock_response
+
+        client = SeerAgentClient(self.organization, self.user)
+        run_id = client.start_run("Test query")
+
+        assert run_id == 447
+        body = mock_post.call_args[0][0]
+        assert "enable_frontend_code_search" not in body
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.seer.agent.client.make_agent_chat_request")
     def test_continue_run_basic(self, mock_post, mock_access):
         """Test continuing an existing run"""
         mock_access.return_value = (True, None)

--- a/tests/sentry/seer/agent/test_client_utils.py
+++ b/tests/sentry/seer/agent/test_client_utils.py
@@ -1,8 +1,11 @@
+from unittest.mock import MagicMock, patch
+
 import jwt
 from django.test import override_settings
 
 from sentry.models.organizationmember import OrganizationMember
 from sentry.seer.agent.client_utils import (
+    _get_org_feature_flags,
     _normalize_wildcard_operators,
     collect_user_org_context,
     get_proxy_headers,
@@ -165,10 +168,10 @@ class CollectUserOrgContextTest(TestCase):
         context = collect_user_org_context(other_user, self.organization)
 
         all_project_slugs = {p["slug"] for p in context["all_org_projects"]}
-        assert context == {
-            "org_slug": self.organization.slug,
-            "all_org_projects": context["all_org_projects"],
-        }
+        # Non-member path returns only org-level keys — no user-specific keys.
+        assert set(context.keys()) == {"org_slug", "all_org_projects", "org_features"}
+        assert context["org_slug"] == self.organization.slug
+        assert isinstance(context["org_features"], list)
         assert all_project_slugs == {"project-1", "project-2", "other-project"}
 
     def test_collect_context_with_timezone(self) -> None:
@@ -221,6 +224,52 @@ class CollectUserOrgContextTest(TestCase):
         user_by_id = {p["id"]: p for p in context["user_projects"]}
         assert [r["external_id"] for r in user_by_id[self.project1.id]["repos"]] == ["ext-1"]
         assert [r["external_id"] for r in user_by_id[self.project2.id]["repos"]] == ["ext-2"]
+
+    @patch(
+        "sentry.seer.agent.client_utils._get_org_feature_flags",
+        return_value=["seer-agent-source-code-search"],
+    )
+    def test_collect_context_member_includes_org_features(self, _mock_flags: MagicMock) -> None:
+        context = collect_user_org_context(self.user, self.organization)
+        assert context["org_features"] == ["seer-agent-source-code-search"]
+
+
+# Two real flags registered with api_expose=True used to exercise _get_org_feature_flags
+# in isolation. Mocking features.all to exactly this set keeps each test fast and
+# deterministic (otherwise all 100+ api-exposed features are checked).
+_TEST_FEATURE_SET = {
+    "organizations:seer-agent-source-code-search": MagicMock(),
+    "organizations:seer-explorer-chat-coding": MagicMock(),
+}
+
+
+class GetOrgFeatureFlagsTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.org = self.create_organization(owner=self.user)
+
+    @patch("sentry.seer.agent.client_utils.features.all", return_value=_TEST_FEATURE_SET)
+    def test_returns_active_flag_without_prefix(self, _mock_all: MagicMock) -> None:
+        with self.feature("organizations:seer-agent-source-code-search"):
+            result = _get_org_feature_flags(self.org, self.user)
+        assert result == ["seer-agent-source-code-search"]
+
+    @patch("sentry.seer.agent.client_utils.features.all", return_value=_TEST_FEATURE_SET)
+    def test_excludes_inactive_flags(self, _mock_all: MagicMock) -> None:
+        result = _get_org_feature_flags(self.org, self.user)
+        assert result == []
+
+    @patch("sentry.seer.agent.client_utils.features.all", return_value=_TEST_FEATURE_SET)
+    def test_returns_sorted_list(self, _mock_all: MagicMock) -> None:
+        with self.feature(
+            {
+                "organizations:seer-agent-source-code-search": True,
+                "organizations:seer-explorer-chat-coding": True,
+            }
+        ):
+            result = _get_org_feature_flags(self.org, self.user)
+        # "seer-agent-..." < "seer-explorer-..." alphabetically
+        assert result == ["seer-agent-source-code-search", "seer-explorer-chat-coding"]
 
 
 class SnapshotToMarkdownTest(TestCase):

--- a/tests/sentry/seer/agent/test_client_utils.py
+++ b/tests/sentry/seer/agent/test_client_utils.py
@@ -165,9 +165,10 @@ class CollectUserOrgContextTest(TestCase):
         context = collect_user_org_context(other_user, self.organization)
 
         all_project_slugs = {p["slug"] for p in context["all_org_projects"]}
-        # Non-member path returns only org-level keys — no user-specific keys.
-        assert set(context.keys()) == {"org_slug", "all_org_projects"}
-        assert context["org_slug"] == self.organization.slug
+        assert context == {
+            "org_slug": self.organization.slug,
+            "all_org_projects": context["all_org_projects"],
+        }
         assert all_project_slugs == {"project-1", "project-2", "other-project"}
 
     def test_collect_context_with_timezone(self) -> None:

--- a/tests/sentry/seer/agent/test_client_utils.py
+++ b/tests/sentry/seer/agent/test_client_utils.py
@@ -1,11 +1,8 @@
-from unittest.mock import MagicMock, patch
-
 import jwt
 from django.test import override_settings
 
 from sentry.models.organizationmember import OrganizationMember
 from sentry.seer.agent.client_utils import (
-    _get_org_feature_flags,
     _normalize_wildcard_operators,
     collect_user_org_context,
     get_proxy_headers,
@@ -169,9 +166,8 @@ class CollectUserOrgContextTest(TestCase):
 
         all_project_slugs = {p["slug"] for p in context["all_org_projects"]}
         # Non-member path returns only org-level keys — no user-specific keys.
-        assert set(context.keys()) == {"org_slug", "all_org_projects", "org_features"}
+        assert set(context.keys()) == {"org_slug", "all_org_projects"}
         assert context["org_slug"] == self.organization.slug
-        assert isinstance(context["org_features"], list)
         assert all_project_slugs == {"project-1", "project-2", "other-project"}
 
     def test_collect_context_with_timezone(self) -> None:
@@ -224,52 +220,6 @@ class CollectUserOrgContextTest(TestCase):
         user_by_id = {p["id"]: p for p in context["user_projects"]}
         assert [r["external_id"] for r in user_by_id[self.project1.id]["repos"]] == ["ext-1"]
         assert [r["external_id"] for r in user_by_id[self.project2.id]["repos"]] == ["ext-2"]
-
-    @patch(
-        "sentry.seer.agent.client_utils._get_org_feature_flags",
-        return_value=["seer-agent-source-code-search"],
-    )
-    def test_collect_context_member_includes_org_features(self, _mock_flags: MagicMock) -> None:
-        context = collect_user_org_context(self.user, self.organization)
-        assert context["org_features"] == ["seer-agent-source-code-search"]
-
-
-# Two real flags registered with api_expose=True used to exercise _get_org_feature_flags
-# in isolation. Mocking features.all to exactly this set keeps each test fast and
-# deterministic (otherwise all 100+ api-exposed features are checked).
-_TEST_FEATURE_SET = {
-    "organizations:seer-agent-source-code-search": MagicMock(),
-    "organizations:seer-explorer-chat-coding": MagicMock(),
-}
-
-
-class GetOrgFeatureFlagsTest(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.org = self.create_organization(owner=self.user)
-
-    @patch("sentry.seer.agent.client_utils.features.all", return_value=_TEST_FEATURE_SET)
-    def test_returns_active_flag_without_prefix(self, _mock_all: MagicMock) -> None:
-        with self.feature("organizations:seer-agent-source-code-search"):
-            result = _get_org_feature_flags(self.org, self.user)
-        assert result == ["seer-agent-source-code-search"]
-
-    @patch("sentry.seer.agent.client_utils.features.all", return_value=_TEST_FEATURE_SET)
-    def test_excludes_inactive_flags(self, _mock_all: MagicMock) -> None:
-        result = _get_org_feature_flags(self.org, self.user)
-        assert result == []
-
-    @patch("sentry.seer.agent.client_utils.features.all", return_value=_TEST_FEATURE_SET)
-    def test_returns_sorted_list(self, _mock_all: MagicMock) -> None:
-        with self.feature(
-            {
-                "organizations:seer-agent-source-code-search": True,
-                "organizations:seer-explorer-chat-coding": True,
-            }
-        ):
-            result = _get_org_feature_flags(self.org, self.user)
-        # "seer-agent-..." < "seer-explorer-..." alphabetically
-        assert result == ["seer-agent-source-code-search", "seer-explorer-chat-coding"]
 
 
 class SnapshotToMarkdownTest(TestCase):

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -64,6 +64,16 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
         assert self.project.id in project_ids
 
     @with_feature("organizations:seer-public-rpc")
+    def test_org_level_method_get_organization_features(self) -> None:
+        """Test that get_organization_features returns the features key"""
+        path = self._get_path("get_organization_features")
+        response = self.client.post(path, data={"args": {}}, format="json")
+
+        assert response.status_code == 200
+        assert "features" in response.data
+        assert isinstance(response.data["features"], list)
+
+    @with_feature("organizations:seer-public-rpc")
     def test_org_level_method_get_dsn(self) -> None:
         project = self.create_project(organization=self.organization, slug="wordcraft")
         path = self._get_path("get_dsn")

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1671,6 +1671,18 @@ class TestGetOrganizationFeatures(APITestCase):
         result = get_organization_features(org_id=0)
         assert result == {"features": []}
 
+    @patch("sentry.seer.endpoints.seer_rpc.features.all", return_value=_ORG_FEATURES_TEST_SET)
+    def test_uses_user_as_actor_when_provided(self, _mock_all: object) -> None:
+        with self.feature("organizations:seer-agent-source-code-search"):
+            result = get_organization_features(org_id=self.organization.id, user_id=self.user.id)
+        assert result == {"features": ["seer-agent-source-code-search"]}
+
+    @patch("sentry.seer.endpoints.seer_rpc.features.all", return_value=_ORG_FEATURES_TEST_SET)
+    def test_unknown_user_id_falls_back_to_no_actor(self, _mock_all: object) -> None:
+        with self.feature("organizations:seer-agent-source-code-search"):
+            result = get_organization_features(org_id=self.organization.id, user_id=0)
+        assert result == {"features": ["seer-agent-source-code-search"]}
+
 
 class TestTriggerCodingAgentLaunch:
     @patch("sentry.seer.endpoints.seer_rpc.launch_coding_agents_for_run")

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -70,6 +70,17 @@ class TestSeerRpc(APITestCase):
         )
         assert response.status_code == 404
 
+    def test_get_organization_features_registered_on_internal_rpc(self) -> None:
+        org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path, data=data, HTTP_AUTHORIZATION=self.auth_header(path, data)
+        )
+        assert response.status_code == 200
+        assert "features" in response.data
+        assert isinstance(response.data["features"], list)
+
     def test_snuba_rate_limit_returns_429(self) -> None:
         """Test that SnubaRPCRateLimitExceeded returns 429 to Seer for retry."""
         path = self._get_path("get_trace_waterfall")

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -25,6 +25,7 @@ from sentry.seer.endpoints.seer_rpc import (
     generate_request_signature,
     get_attributes_for_span,
     get_github_enterprise_integration_config,
+    get_organization_features,
     get_project_preferences,
     get_repo_installation_id,
     has_repo_code_mappings,
@@ -1614,6 +1615,50 @@ class TestSeerRpcMethods(APITestCase):
             project_ids=[],
         )
         assert result == {}
+
+
+# Two real api_expose=True flags used as a controlled feature set for
+# get_organization_features tests. Mocking features.all to this subset keeps
+# each test deterministic instead of iterating all 100+ registered flags.
+_ORG_FEATURES_TEST_SET = {
+    "organizations:seer-agent-source-code-search": object(),
+    "organizations:seer-explorer-chat-coding": object(),
+}
+
+
+class TestGetOrganizationFeatures(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+
+    @patch("sentry.seer.endpoints.seer_rpc.features.all", return_value=_ORG_FEATURES_TEST_SET)
+    def test_returns_active_flags_without_prefix(self, _mock_all: object) -> None:
+        with self.feature("organizations:seer-agent-source-code-search"):
+            result = get_organization_features(org_id=self.organization.id)
+        assert result == {"features": ["seer-agent-source-code-search"]}
+
+    @patch("sentry.seer.endpoints.seer_rpc.features.all", return_value=_ORG_FEATURES_TEST_SET)
+    def test_excludes_inactive_flags(self, _mock_all: object) -> None:
+        result = get_organization_features(org_id=self.organization.id)
+        assert result == {"features": []}
+
+    @patch("sentry.seer.endpoints.seer_rpc.features.all", return_value=_ORG_FEATURES_TEST_SET)
+    def test_returns_sorted_list(self, _mock_all: object) -> None:
+        with self.feature(
+            {
+                "organizations:seer-agent-source-code-search": True,
+                "organizations:seer-explorer-chat-coding": True,
+            }
+        ):
+            result = get_organization_features(org_id=self.organization.id)
+        # "seer-agent-..." < "seer-explorer-..." alphabetically
+        assert result == {
+            "features": ["seer-agent-source-code-search", "seer-explorer-chat-coding"]
+        }
+
+    def test_org_not_found_returns_empty(self) -> None:
+        result = get_organization_features(org_id=0)
+        assert result == {"features": []}
 
 
 class TestTriggerCodingAgentLaunch:


### PR DESCRIPTION
  - When the flag is enabled, sets enable_frontend_code_search: true in seer chat request
  - The frontend code search needs to know the feature flags enabled for an org - so this PR adds a get_organization_features RPC endpoint that returns all active api_expose=True flags. Seer can call this on demand to validate what features are enabled in the user's Sentry frontend