### PR TITLE
fix(dashboards): Anchor Editors dropdown to the right edge of the trigger

### DIFF
--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -361,6 +361,7 @@ export function EditAccessSelector({
           />
         </Flex>
       }
+      position="bottom-end"
       strategy="fixed"
       preventOverflowOptions={{mainAxis: false}}
       disabled={disabled}


### PR DESCRIPTION
Fix editor dropdown placement, so the apply button is visible

Before

<img width="424" height="393" alt="image" src="https://github.com/user-attachments/assets/36cb7f3a-aac3-45eb-91d5-8ea623d61a54" />


After

<img width="424" height="393" alt="image" src="https://github.com/user-attachments/assets/a92f0e97-a62b-41e4-bd0f-d54f57671453" />



Fixes DAIN-1677