### PR TITLE
fix(dashboards): propagate global filters in Open in Issues link

### DIFF
--- a/static/app/views/dashboards/utils.spec.tsx
+++ b/static/app/views/dashboards/utils.spec.tsx
@@ -194,6 +194,30 @@ describe('Dashboards util', () => {
       const urlParams = new URLSearchParams(queryString);
       expect(urlParams.get('query')).toBe('(is:unresolved) release:["1.0.0","2.0.0"] ');
     });
+    it('applies global filters scoped to the issue dataset', () => {
+      const url = getWidgetIssueUrl(
+        widget,
+        {
+          globalFilter: [
+            {
+              dataset: WidgetType.ISSUE,
+              tag: {key: 'transaction', name: 'transaction'},
+              value: 'transaction:/api/foo',
+            },
+            {
+              dataset: WidgetType.DISCOVER,
+              tag: {key: 'transaction', name: 'transaction'},
+              value: 'transaction:/api/bar',
+            },
+          ],
+        },
+        selection,
+        OrganizationFixture()
+      );
+      const queryString = url.split('?')[1];
+      const urlParams = new URLSearchParams(queryString);
+      expect(urlParams.get('query')).toBe('(is:unresolved) transaction:/api/foo');
+    });
   });
 
   describe('flattenErrors', () => {

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -278,7 +278,11 @@ export function getWidgetIssueUrl(
       ? {start: getUtcDateString(start), end: getUtcDateString(end), utc}
       : {statsPeriod: period};
   const issuesLocation = `/organizations/${organization.slug}/issues/?${qs.stringify({
-    query: applyDashboardFilters(widget.queries?.[0]?.conditions, dashboardFilters),
+    query: applyDashboardFilters(
+      widget.queries?.[0]?.conditions,
+      dashboardFilters,
+      widget.widgetType
+    ),
     sort: widget.queries?.[0]?.orderby,
     ...datetime,
     // Pass empty string when projects is empty to preserve "My Projects" selection in URL


### PR DESCRIPTION
propogate global filters in open in issues link

For example:
1. If i have a transaction filter on the issues dataset
<img width="854" height="411" alt="image" src="https://github.com/user-attachments/assets/9f58c282-53be-4ca5-a597-db3aa8f05795" />
2. Clicking `open in issues` actually populates the query now
<img width="1177" height="191" alt="image" src="https://github.com/user-attachments/assets/af79cc4c-7471-4ab3-b5df-0c58089f6bb0" />
