### PR TITLE
ref(mypy): Rename sort_stronger_modules to sort_weaklist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         types: [python]
       - id: sort-mypy-weaklist
         name: sort mypy weaklist
-        entry: python3 -m tools.mypy_helpers.sort_stronger_modules
+        entry: python3 -m tools.mypy_helpers.sort_weaklist
         files: ^pyproject\.toml$
         language: python
       - id: check-mypy-weaklist

--- a/tests/tools/mypy_helpers/test_sort_weaklist.py
+++ b/tests/tools/mypy_helpers/test_sort_weaklist.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
-from tools.mypy_helpers.sort_stronger_modules import main
+from tools.mypy_helpers.sort_weaklist import main
 
 
-def test_sort_stronger_modules(tmp_path: Path) -> None:
+def test_sort_weaklist(tmp_path: Path) -> None:
     src = """\
 # before
 

--- a/tools/mypy_helpers/sort_stronger_modules.py
+++ b/tools/mypy_helpers/sort_stronger_modules.py
@@ -1,35 +1,6 @@
 from __future__ import annotations
 
-import argparse
-from collections.abc import Sequence
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("filenames", nargs="*")
-    args = parser.parse_args(argv)
-
-    ret = 0
-    for filename in args.filenames:
-        with open(filename) as f:
-            contents = f.read()
-
-        rest = contents
-        b1, m1, rest = rest.partition("# begin: not yet strongly typed\n")
-        b2, m2, rest = rest.partition("module = [\n")
-        b3, m3, rest = rest.partition("]\n")
-        b4, m4, rest = rest.partition("# end: not yet strongly typed\n")
-
-        b3 = "".join(sorted(frozenset(b3.splitlines(True))))
-
-        new_contents = b1 + m1 + b2 + m2 + b3 + m3 + b4 + m4 + rest
-        if new_contents != contents:
-            with open(filename, "w") as f:
-                f.write(new_contents)
-            ret = 1
-
-    return ret
-
+from tools.mypy_helpers.sort_weaklist import main
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/tools/mypy_helpers/sort_weaklist.py
+++ b/tools/mypy_helpers/sort_weaklist.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filenames", nargs="*")
+    args = parser.parse_args(argv)
+
+    ret = 0
+    for filename in args.filenames:
+        with open(filename) as f:
+            contents = f.read()
+
+        rest = contents
+        b1, m1, rest = rest.partition("# begin: not yet strongly typed\n")
+        b2, m2, rest = rest.partition("module = [\n")
+        b3, m3, rest = rest.partition("]\n")
+        b4, m4, rest = rest.partition("# end: not yet strongly typed\n")
+
+        b3 = "".join(sorted(frozenset(b3.splitlines(True))))
+
+        new_contents = b1 + m1 + b2 + m2 + b3 + m3 + b4 + m4 + rest
+        if new_contents != contents:
+            with open(filename, "w") as f:
+                f.write(new_contents)
+            ret = 1
+
+    return ret
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Rename `tools.mypy_helpers.sort_stronger_modules` to `tools.mypy_helpers.sort_weaklist` so the module name matches the pre-commit hook id (`sort-mypy-weaklist`) and the rest of the weaklist tooling (`check_stronglist`, `prevent_weaklist_additions`).

**Backwards-compatible shim**

The old module path stays as a 4-line re-export so getsentry's [`.pre-commit-config.yaml`](https://github.com/getsentry/getsentry/blob/master/.pre-commit-config.yaml), which still calls `python3 -m tools.mypy_helpers.sort_stronger_modules`, keeps working. A follow-up PR will delete the shim once getsentry has been updated to call `sort_weaklist`.

Made with [Cursor](https://cursor.com)