### PR TITLE
ref(api-docs): add GroupDetailsResponse type, params, and example

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -142,6 +142,31 @@ class BaseGroupSerializerResponse(BaseGroupResponseOptional):
     annotations: list[GroupAnnotation]
 
 
+class GroupDetailsResponseOptional(TypedDict, total=False):
+    # Included by default; removable via `?collapse=release|tags|stats`
+    firstRelease: dict[str, Any] | None
+    lastRelease: dict[str, Any] | None
+    tags: list[dict[str, Any]]
+    stats: dict[str, list[list[float]]]
+    # Opt-in via `?expand=...`
+    inbox: dict[str, Any] | None
+    owners: list[dict[str, Any]] | None
+    forecast: dict[str, Any]
+    integrationIssues: list[dict[str, Any]]
+    sentryAppIssues: list[dict[str, Any]]
+    latestEventHasAttachments: bool
+
+
+class GroupDetailsResponse(BaseGroupSerializerResponse, GroupDetailsResponseOptional):
+    activity: list[dict[str, Any]]
+    seenBy: list[dict[str, Any]]
+    pluginActions: list[Any]
+    pluginIssues: list[dict[str, Any]]
+    pluginContexts: list[dict[str, Any]]
+    userReportCount: int
+    participants: list[dict[str, Any]]
+
+
 class SeenStats(TypedDict):
     times_seen: int
     first_seen: datetime | None

--- a/src/sentry/apidocs/examples/issue_examples.py
+++ b/src/sentry/apidocs/examples/issue_examples.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from drf_spectacular.utils import OpenApiExample
 
 from sentry.api.helpers.group_index.types import MutateIssueResponse
+from sentry.api.serializers.models.group import GroupDetailsResponse
 from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnubaResponse
 
 SIMPLE_ISSUE: StreamGroupSerializerSnubaResponse = {
@@ -130,6 +131,78 @@ MUTATE_ISSUE_RESULT: MutateIssueResponse = {
 }
 
 
+GROUP_DETAILS: GroupDetailsResponse = {
+    "id": "1",
+    "shareId": "123def456abc",
+    "shortId": "PUMP-STATION-1",
+    "title": "This is an example Python exception",
+    "culprit": "raven.scripts.runner in main",
+    "permalink": "https://sentry.io/the-interstellar-jurisdiction/pump-station/issues/1/",
+    "logger": None,
+    "level": "error",
+    "status": "unresolved",
+    "statusDetails": {},
+    "substatus": "ongoing",
+    "isPublic": False,
+    "platform": "python",
+    "priority": "medium",
+    "priorityLockedAt": None,
+    "seerFixabilityScore": None,
+    "seerAutofixLastTriggered": None,
+    "seerExplorerAutofixLastTriggered": None,
+    "project": {"id": "2", "name": "Pump Station", "slug": "pump-station", "platform": "python"},
+    "type": "default",
+    "issueType": "error",
+    "issueCategory": "error",
+    "metadata": {"title": "This is an example Python exception"},
+    "numComments": 0,
+    "assignedTo": {"type": "user", "id": "1", "name": "John Doe", "email": "john.doe@example.com"},
+    "isBookmarked": False,
+    "isSubscribed": True,
+    "subscriptionDetails": None,
+    "hasSeen": False,
+    "annotations": [],
+    "count": "150",
+    "userCount": 12,
+    "firstSeen": datetime.fromisoformat("2018-11-06T21:19:55Z"),
+    "lastSeen": datetime.fromisoformat("2018-12-06T21:19:55Z"),
+    # Always added by the detail view
+    "activity": [
+        {
+            "data": {},
+            "dateCreated": "2018-11-06T21:19:55Z",
+            "id": "0",
+            "type": "first_seen",
+            "user": None,
+        }
+    ],
+    "seenBy": [],
+    "pluginActions": [],
+    "pluginIssues": [],
+    "pluginContexts": [],
+    "userReportCount": 0,
+    "participants": [],
+    # Default-included unless suppressed via `?collapse=...`
+    "firstRelease": {
+        "version": "17642328ead24b51867165985996d04b29310337",
+        "shortVersion": "1764232",
+        "dateCreated": "2018-11-06T21:19:55.146Z",
+        "dateReleased": None,
+        "ref": None,
+        "url": None,
+    },
+    "lastRelease": None,
+    "tags": [
+        {"key": "browser", "name": "Browser", "totalValues": 150},
+        {"key": "level", "name": "Level", "totalValues": 150},
+    ],
+    "stats": {
+        "24h": [[1541451600.0, 557], [1541455200.0, 473]],
+        "30d": [[1538870400.0, 565], [1538956800.0, 12862]],
+    },
+}
+
+
 class IssueExamples:
     ORGANIZATION_GROUP_INDEX_GET = [
         OpenApiExample(
@@ -143,6 +216,14 @@ class IssueExamples:
         OpenApiExample(
             "Return the update results for issues in an organization",
             value=MUTATE_ISSUE_RESULT,
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]
+    GROUP_DETAILS = [
+        OpenApiExample(
+            "Return an issue",
+            value=GROUP_DETAILS,
             response_only=True,
             status_codes=["200"],
         )

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -401,6 +401,33 @@ class IssueParams:
         required=False,
         many=True,
     )
+
+    GROUP_DETAILS_EXPAND = OpenApiParameter(
+        name="expand",
+        description="Additional data to include in the response.",
+        enum=[
+            "inbox",
+            "owners",
+            "forecast",
+            "integrationIssues",
+            "sentryAppIssues",
+            "latestEventHasAttachments",
+        ],
+        location=OpenApiParameter.QUERY,
+        type=OpenApiTypes.STR,
+        required=False,
+        many=True,
+    )
+
+    GROUP_DETAILS_COLLAPSE = OpenApiParameter(
+        name="collapse",
+        description="Fields to remove from the response to improve query performance.",
+        enum=["release", "tags", "stats"],
+        location=OpenApiParameter.QUERY,
+        type=OpenApiTypes.STR,
+        required=False,
+        many=True,
+    )
     MUTATE_ISSUE_ID_LIST = OpenApiParameter(
         name="id",
         description="The list of issue IDs to mutate. It is optional for status updates, in which an implicit `update all` is assumed.",


### PR DESCRIPTION
Preparation for publishing the group details endpoint. Specifies optional fields that are collapsable / expandable on the endpoint and creates `GroupDetailsResponse` to specify the full typed response, and adds an example + additional OpenAPI parameters that will be used by https://github.com/getsentry/sentry/pull/116119