### PR TITLE
fix(automations): fix validation error when selecting Tagged Event

### DIFF
--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -114,11 +114,11 @@ function KeyField() {
         }
       }}
       onBlur={() => {
-        if (typedValueRef.current) {
+        if (typedValueRef.current && !condition.comparison.key) {
           onUpdate({comparison: {...condition.comparison, key: typedValueRef.current}});
           removeError(condition.id);
-          typedValueRef.current = '';
         }
+        typedValueRef.current = '';
       }}
       onChange={(e: SelectValue<MatchType>) => {
         typedValueRef.current = '';

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useMemo, useRef} from 'react';
 
 import {useFetchOrganizationTags} from 'sentry/actionCreators/tags';
 import {AutomationBuilderInput} from 'sentry/components/workflowEngine/form/automationBuilderInput';
@@ -60,6 +60,7 @@ export function TaggedEventNode() {
 function KeyField() {
   const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
   const {removeError} = useAutomationBuilderErrorContext();
+  const typedValueRef = useRef('');
 
   // TODO - get form context, get the detector ids from the context.
   // if there are connected detectors / projects, then grab the project id list and use that. otherwise, -1.
@@ -105,7 +106,21 @@ function KeyField() {
       placeholder={isLoading ? t('Loading tags\u2026') : t('tag')}
       value={condition.comparison.key}
       options={sortedOptions}
+      onInputChange={(value: string, {action}: {action: string}) => {
+        // 'menu-close' and 'input-blur' fire with '' right before onBlur and would
+        // wipe the tracked value, so only track real typing actions
+        if (action === 'input-change') {
+          typedValueRef.current = value;
+        }
+      }}
+      onBlur={() => {
+        if (typedValueRef.current) {
+          onUpdate({comparison: {...condition.comparison, key: typedValueRef.current}});
+          removeError(condition.id);
+        }
+      }}
       onChange={(e: SelectValue<MatchType>) => {
+        typedValueRef.current = '';
         onUpdate({comparison: {...condition.comparison, key: e.value}});
         removeError(condition.id);
       }}
@@ -154,11 +169,14 @@ function ValueField() {
 export function validateTaggedEventCondition({
   condition,
 }: ValidateDataConditionProps): string | undefined {
-  if (!condition.comparison.key || !condition.comparison.match) {
-    return t('Ensure all fields are filled in.');
+  if (!condition.comparison.key) {
+    return t('Select a tag.');
+  }
+  if (!condition.comparison.match) {
+    return t('Select a match type.');
   }
   if (matchRequiresValue(condition.comparison.match) && !condition.comparison.value) {
-    return t('Ensure all fields are filled in.');
+    return t('Enter a value.');
   }
   return undefined;
 }

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -117,6 +117,7 @@ function KeyField() {
         if (typedValueRef.current) {
           onUpdate({comparison: {...condition.comparison, key: typedValueRef.current}});
           removeError(condition.id);
+          typedValueRef.current = '';
         }
       }}
       onChange={(e: SelectValue<MatchType>) => {


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

This PR fixes #115268 ; the bug that appears when creating Alert.

Testing scenario:

1. Click create Alert button
2. On the If section, chooses Tagged Event
3. The key will be automatically filled with 'Tag' string
4. Fill in manually the Match and Value field
5. When clicking Create Alert, the validation keeps appearing as a blocker.

[Screencast from 23-05-26 23:13:55.webm](https://github.com/user-attachments/assets/03350894-2563-4522-a2d1-2fc8462c6e69)

Analyze:

1. In function validateTaggedEventCondition, the key seems to always be falsy.
2. The hook onChange in KeyField's component seems to not fire anything, which causes the Key to not be saved.

Solution:
1. Use hook onBlur to manually commit whatever was typed - which will required useRef & onInputChange hook.

After implement:
[Screencast from 24-05-26 23:33:07.webm](https://github.com/user-attachments/assets/32f48a87-eec0-41df-9a27-f70d53c02318) 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
