### PR TITLE
fix(kafkapublisher): leaks memory: rdkafka stats grow without poll()

### DIFF
--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -8,11 +8,14 @@ from datetime import datetime, timedelta
 from enum import IntEnum
 from threading import Lock
 
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.types import Topic as ArroyoTopic
+
 from sentry.conf.types.kafka_definition import Topic
 from sentry.constants import DataCategory
 from sentry.utils import json, kafka_config, metrics
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.dates import to_datetime
-from sentry.utils.pubsub import KafkaPublisher
 
 # Aggregation key for grouping outcomes
 OutcomeKey = namedtuple(
@@ -156,8 +159,22 @@ class Outcome(IntEnum):
         return self in (Outcome.ACCEPTED, Outcome.RATE_LIMITED)
 
 
-outcomes_publisher: KafkaPublisher | None = None
-billing_publisher: KafkaPublisher | None = None
+def _get_outcomes_producer() -> KafkaProducer:
+    return get_arroyo_producer(
+        "sentry.utils.outcomes",
+        Topic.OUTCOMES,
+    )
+
+
+def _get_billing_producer() -> KafkaProducer:
+    return get_arroyo_producer(
+        "sentry.utils.outcomes.billing",
+        Topic.OUTCOMES_BILLING,
+    )
+
+
+outcomes_producer = SingletonProducer(_get_outcomes_producer)
+billing_producer = SingletonProducer(_get_billing_producer)
 
 LATE_OUTCOME_THRESHOLD = timedelta(days=1)
 
@@ -183,9 +200,6 @@ def track_outcome(
     data for SnubaTSDB and RedisSnubaTSDB, such as # of rate-limited/filtered
     events.
     """
-    global outcomes_publisher
-    global billing_publisher
-
     if quantity is None:
         quantity = 1
 
@@ -205,20 +219,9 @@ def track_outcome(
     # Create a second producer instance only if the cluster differs. Otherwise,
     # reuse the same producer and just send to the other topic.
     if use_billing and billing_config["cluster"] != outcomes_config["cluster"]:
-        if billing_publisher is None:
-            cluster_name = billing_config["cluster"]
-            billing_publisher = KafkaPublisher(
-                kafka_config.get_kafka_producer_cluster_options(cluster_name)
-            )
-        publisher = billing_publisher
-
+        producer = billing_producer
     else:
-        if outcomes_publisher is None:
-            cluster_name = outcomes_config["cluster"]
-            outcomes_publisher = KafkaPublisher(
-                kafka_config.get_kafka_producer_cluster_options(cluster_name)
-            )
-        publisher = outcomes_publisher
+        producer = outcomes_producer
 
     now = to_datetime(time.time())
     timestamp = timestamp or now
@@ -228,21 +231,24 @@ def track_outcome(
         billing_config["real_topic_name"] if use_billing else outcomes_config["real_topic_name"]
     )
 
-    # Send a snuba metrics payload.
-    publisher.publish(
-        topic_name,
-        json.dumps(
-            {
-                "timestamp": timestamp,
-                "org_id": org_id,
-                "project_id": project_id,
-                "key_id": key_id,
-                "outcome": outcome.value,
-                "reason": reason,
-                "event_id": event_id,
-                "category": category,
-                "quantity": quantity,
-            }
+    producer.produce(
+        ArroyoTopic(topic_name),
+        KafkaPayload(
+            None,
+            json.dumps(
+                {
+                    "timestamp": timestamp,
+                    "org_id": org_id,
+                    "project_id": project_id,
+                    "key_id": key_id,
+                    "outcome": outcome.value,
+                    "reason": reason,
+                    "event_id": event_id,
+                    "category": category,
+                    "quantity": quantity,
+                }
+            ).encode("utf-8"),
+            [],
         ),
     )
 

--- a/src/sentry/utils/pubsub.py
+++ b/src/sentry/utils/pubsub.py
@@ -16,7 +16,6 @@ class KafkaPublisher:
             build_kafka_producer_configuration(default_config=connection)
         )
         self.asynchronous = asynchronous
-        self._shutdown = threading.Event()
         self._poll_thread = threading.Thread(
             target=self.__worker,
             name="KafkaPublisher.poll",
@@ -34,7 +33,7 @@ class KafkaPublisher:
 
         Similar to https://github.com/getsentry/arroyo/blob/a4bd9a7ef5e9a23a7862e278d9881d0a7a7e18e5/arroyo/backends/kafka/consumer.py#L774-L784
         """
-        while not self._shutdown.is_set():
+        while True:
             self.producer.poll(0.1)
 
     def publish(self, channel: str, value: str, key: str | None = None) -> None:

--- a/src/sentry/utils/pubsub.py
+++ b/src/sentry/utils/pubsub.py
@@ -16,6 +16,7 @@ class KafkaPublisher:
             build_kafka_producer_configuration(default_config=connection)
         )
         self.asynchronous = asynchronous
+        self._shutdown = threading.Event()
         self._poll_thread = threading.Thread(
             target=self.__worker,
             name="KafkaPublisher.poll",
@@ -33,7 +34,7 @@ class KafkaPublisher:
 
         Similar to https://github.com/getsentry/arroyo/blob/a4bd9a7ef5e9a23a7862e278d9881d0a7a7e18e5/arroyo/backends/kafka/consumer.py#L774-L784
         """
-        while True:
+        while not self._shutdown.is_set():
             self.producer.poll(0.1)
 
     def publish(self, channel: str, value: str, key: str | None = None) -> None:

--- a/src/sentry/utils/pubsub.py
+++ b/src/sentry/utils/pubsub.py
@@ -1,3 +1,4 @@
+import threading
 from typing import Any
 
 from arroyo.backends.kafka import build_kafka_producer_configuration
@@ -15,6 +16,26 @@ class KafkaPublisher:
             build_kafka_producer_configuration(default_config=connection)
         )
         self.asynchronous = asynchronous
+        self._shutdown = threading.Event()
+        self._poll_thread = threading.Thread(
+            target=self.__worker,
+            name="KafkaPublisher.poll",
+            daemon=True,
+        )
+        self._poll_thread.start()
+
+    def __worker(self) -> None:
+        """
+        Drain rdkafka's internal queue continuously so stats ops (generated
+        by statistics.interval.ms=1000 that arroyo sets on all producers)
+        don't accumulate when the publisher is idle between publish() calls.
+        Without this, each stats op holds a JSON blob that is never freed,
+        causing RSS growth and OOMKill when no attachments for a long period.
+
+        Similar to https://github.com/getsentry/arroyo/blob/a4bd9a7ef5e9a23a7862e278d9881d0a7a7e18e5/arroyo/backends/kafka/consumer.py#L774-L784
+        """
+        while not self._shutdown.is_set():
+            self.producer.poll(0.1)
 
     def publish(self, channel: str, value: str, key: str | None = None) -> None:
         self.producer.produce(topic=channel, value=value, key=key)

--- a/src/sentry/utils/pubsub.py
+++ b/src/sentry/utils/pubsub.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Any
 
 from arroyo.backends.kafka import build_kafka_producer_configuration
@@ -16,26 +15,6 @@ class KafkaPublisher:
             build_kafka_producer_configuration(default_config=connection)
         )
         self.asynchronous = asynchronous
-        self._shutdown = threading.Event()
-        self._poll_thread = threading.Thread(
-            target=self.__worker,
-            name="KafkaPublisher.poll",
-            daemon=True,
-        )
-        self._poll_thread.start()
-
-    def __worker(self) -> None:
-        """
-        Drain rdkafka's internal queue continuously so stats ops (generated
-        by statistics.interval.ms=1000 that arroyo sets on all producers)
-        don't accumulate when the publisher is idle between publish() calls.
-        Without this, each stats op holds a JSON blob that is never freed,
-        causing RSS growth and OOMKill when no attachments for a long period.
-
-        Similar to https://github.com/getsentry/arroyo/blob/a4bd9a7ef5e9a23a7862e278d9881d0a7a7e18e5/arroyo/backends/kafka/consumer.py#L774-L784
-        """
-        while not self._shutdown.is_set():
-            self.producer.poll(0.1)
 
     def publish(self, channel: str, value: str, key: str | None = None) -> None:
         self.producer.produce(topic=channel, value=value, key=key)

--- a/tests/sentry/utils/test_outcome_aggregator.py
+++ b/tests/sentry/utils/test_outcome_aggregator.py
@@ -1,19 +1,18 @@
+import types
 from unittest import mock
 
 import pytest
 
 from sentry.constants import DataCategory
-from sentry.utils import json
+from sentry.utils import json, outcomes
 from sentry.utils.outcomes import Outcome, OutcomeAggregator
 
 
 @pytest.fixture(autouse=True)
 def setup():
-    with mock.patch("sentry.utils.kafka_config.get_kafka_producer_cluster_options"):
-        with mock.patch("sentry.utils.outcomes.KafkaPublisher") as mck_publisher:
-            with mock.patch("sentry.utils.outcomes.outcomes_publisher", None):
-                with mock.patch("sentry.utils.outcomes.billing_publisher", None):
-                    yield mck_publisher
+    with mock.patch.object(outcomes.outcomes_producer, "produce") as mck_outcomes:
+        with mock.patch.object(outcomes.billing_producer, "produce") as mck_billing:
+            yield types.SimpleNamespace(outcomes=mck_outcomes, billing=mck_billing)
 
 
 def test_basic_aggregation(setup):
@@ -40,9 +39,9 @@ def test_basic_aggregation(setup):
 
     aggregator.flush(force=True)
 
-    assert setup.return_value.publish.call_count == 1
-    (_, payload), _ = setup.return_value.publish.call_args
-    data = json.loads(payload)
+    assert setup.outcomes.call_count == 1
+    (_, kafka_payload), _ = setup.outcomes.call_args
+    data = json.loads(kafka_payload.value)
     assert data["quantity"] == 8
 
 
@@ -70,7 +69,7 @@ def test_different_keys_not_aggregated(setup):
 
     aggregator.flush(force=True)
 
-    assert setup.return_value.publish.call_count == 2
+    assert setup.outcomes.call_count == 2
 
 
 def test_flush_on_buffer_size(setup):
@@ -95,7 +94,7 @@ def test_flush_on_buffer_size(setup):
         quantity=1,
     )
 
-    assert setup.return_value.publish.call_count == 2
+    assert setup.outcomes.call_count == 2
 
 
 def test_flush_on_time_interval(setup):
@@ -115,7 +114,7 @@ def test_flush_on_time_interval(setup):
             quantity=1,
         )
 
-    assert setup.return_value.publish.call_count == 0
+    assert setup.outcomes.call_count == 0
 
     with mock.patch("time.time", return_value=base_time + 3):
         aggregator.track_outcome_aggregated(
@@ -127,7 +126,7 @@ def test_flush_on_time_interval(setup):
             quantity=1,
         )
 
-    assert setup.return_value.publish.call_count >= 1
+    assert setup.outcomes.call_count >= 1
 
 
 def test_jitter_applied(setup):

--- a/tests/sentry/utils/test_outcomes.py
+++ b/tests/sentry/utils/test_outcomes.py
@@ -4,25 +4,20 @@ from unittest import mock
 
 import pytest
 
-from sentry.conf.types.kafka_definition import Topic
 from sentry.constants import DataCategory
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.utils import json, kafka_config, outcomes
+from sentry.utils import json, outcomes
 from sentry.utils.outcomes import Outcome, track_outcome
 
 
 @pytest.fixture(autouse=True)
 def setup():
-    # Rely on the fact that the publisher is initialized lazily
-    with mock.patch.object(kafka_config, "get_kafka_producer_cluster_options") as mck_get_options:
-        with mock.patch.object(outcomes, "KafkaPublisher") as mck_publisher:
-            # Reset internals of the outcomes module
-            with mock.patch.object(outcomes, "outcomes_publisher", None):
-                with mock.patch.object(outcomes, "billing_publisher", None):
-                    yield types.SimpleNamespace(
-                        mock_get_kafka_producer_cluster_options=mck_get_options,
-                        mock_publisher=mck_publisher,
-                    )
+    with mock.patch.object(outcomes.outcomes_producer, "produce") as mck_outcomes:
+        with mock.patch.object(outcomes.billing_producer, "produce") as mck_billing:
+            yield types.SimpleNamespace(
+                mock_outcomes_produce=mck_outcomes,
+                mock_billing_produce=mck_billing,
+            )
 
 
 @pytest.mark.parametrize(
@@ -81,16 +76,13 @@ def test_track_outcome_default(setup) -> None:
         reason="project_id",
     )
 
-    cluster_args, _ = setup.mock_get_kafka_producer_cluster_options.call_args
-    assert cluster_args == (kafka_config.get_topic_definition(Topic.OUTCOMES)["cluster"],)
-
-    assert outcomes.outcomes_publisher
-    (topic_name, payload), _ = setup.mock_publisher.return_value.publish.call_args
+    setup.mock_billing_produce.assert_not_called()
+    (arroyo_topic, kafka_payload), _ = setup.mock_outcomes_produce.call_args
 
     # not billing because it's not accepted/rate limited
-    assert topic_name == "outcomes"
+    assert arroyo_topic.name == "outcomes"
 
-    data = json.loads(payload)
+    data = json.loads(kafka_payload.value)
     del data["timestamp"]
     assert data == {
         "org_id": 1,
@@ -102,8 +94,6 @@ def test_track_outcome_default(setup) -> None:
         "category": None,
         "quantity": 1,
     }
-
-    assert outcomes.billing_publisher is None
 
 
 def test_track_outcome_billing(setup) -> None:
@@ -119,14 +109,9 @@ def test_track_outcome_billing(setup) -> None:
         outcome=Outcome.ACCEPTED,
     )
 
-    cluster_args, _ = setup.mock_get_kafka_producer_cluster_options.call_args
-    assert cluster_args == (kafka_config.get_topic_definition(Topic.OUTCOMES)["cluster"],)
-
-    assert outcomes.outcomes_publisher
-    (topic_name, _), _ = setup.mock_publisher.return_value.publish.call_args
-    assert topic_name == "outcomes-billing"
-
-    assert outcomes.billing_publisher is None
+    setup.mock_billing_produce.assert_not_called()
+    (arroyo_topic, _), _ = setup.mock_outcomes_produce.call_args
+    assert arroyo_topic.name == "outcomes-billing"
 
 
 def test_track_outcome_billing_topic(setup) -> None:
@@ -141,14 +126,9 @@ def test_track_outcome_billing_topic(setup) -> None:
         outcome=Outcome.ACCEPTED,
     )
 
-    cluster_args, _ = setup.mock_get_kafka_producer_cluster_options.call_args
-    assert cluster_args == (kafka_config.get_topic_definition(Topic.OUTCOMES)["cluster"],)
-
-    assert outcomes.outcomes_publisher
-    (topic_name, _), _ = setup.mock_publisher.return_value.publish.call_args
-    assert topic_name == "outcomes-billing"
-
-    assert outcomes.billing_publisher is None
+    setup.mock_billing_produce.assert_not_called()
+    (arroyo_topic, _), _ = setup.mock_outcomes_produce.call_args
+    assert arroyo_topic.name == "outcomes-billing"
 
 
 def test_track_outcome_billing_cluster(settings, setup) -> None:
@@ -164,14 +144,9 @@ def test_track_outcome_billing_cluster(settings, setup) -> None:
             outcome=Outcome.ACCEPTED,
         )
 
-        cluster_args, _ = setup.mock_get_kafka_producer_cluster_options.call_args
-        assert cluster_args == ("different",)
-
-        assert outcomes.billing_publisher
-        (topic_name, _), _ = setup.mock_publisher.return_value.publish.call_args
-        assert topic_name == "outcomes-billing"
-
-        assert outcomes.outcomes_publisher is None
+        setup.mock_outcomes_produce.assert_not_called()
+        (arroyo_topic, _), _ = setup.mock_billing_produce.call_args
+        assert arroyo_topic.name == "outcomes-billing"
 
 
 def test_outcome_api_name() -> None:
@@ -196,9 +171,9 @@ def test_track_outcome_with_quantity(setup) -> None:
         quantity=5,
     )
 
-    (topic_name, payload), _ = setup.mock_publisher.return_value.publish.call_args
+    (_, kafka_payload), _ = setup.mock_outcomes_produce.call_args
 
-    data = json.loads(payload)
+    data = json.loads(kafka_payload.value)
     assert data["quantity"] == 5
 
 
@@ -215,9 +190,9 @@ def test_track_outcome_with_event_id(setup) -> None:
         event_id="abcdef1234567890abcdef1234567890",
     )
 
-    (topic_name, payload), _ = setup.mock_publisher.return_value.publish.call_args
+    (_, kafka_payload), _ = setup.mock_outcomes_produce.call_args
 
-    data = json.loads(payload)
+    data = json.loads(kafka_payload.value)
     assert data["event_id"] == "abcdef1234567890abcdef1234567890"
 
 
@@ -244,9 +219,9 @@ def test_track_outcome_with_category(setup, category: DataCategory) -> None:
         category=category,
     )
 
-    (topic_name, payload), _ = setup.mock_publisher.return_value.publish.call_args
+    (_, kafka_payload), _ = setup.mock_outcomes_produce.call_args
 
-    data = json.loads(payload)
+    data = json.loads(kafka_payload.value)
     assert data["category"] == category.value
 
 
@@ -297,8 +272,8 @@ def test_track_outcome_with_provided_timestamp(setup) -> None:
         timestamp=provided_timestamp,
     )
 
-    (topic_name, payload), _ = setup.mock_publisher.return_value.publish.call_args
-    data = json.loads(payload)
+    (_, kafka_payload), _ = setup.mock_outcomes_produce.call_args
+    data = json.loads(kafka_payload.value)
     assert data["timestamp"] == "2021-01-01T12:00:00.000000Z"
 
 
@@ -353,8 +328,8 @@ def test_track_outcome_with_none_key_id(setup) -> None:
         outcome=Outcome.FILTERED,
     )
 
-    (topic_name, payload), _ = setup.mock_publisher.return_value.publish.call_args
-    data = json.loads(payload)
+    (_, kafka_payload), _ = setup.mock_outcomes_produce.call_args
+    data = json.loads(kafka_payload.value)
     assert data["key_id"] is None
 
 
@@ -370,8 +345,8 @@ def test_track_outcome_with_none_reason(setup) -> None:
         reason=None,
     )
 
-    (topic_name, payload), _ = setup.mock_publisher.return_value.publish.call_args
-    data = json.loads(payload)
+    (_, kafka_payload), _ = setup.mock_outcomes_produce.call_args
+    data = json.loads(kafka_payload.value)
     assert data["reason"] is None
 
 
@@ -387,8 +362,8 @@ def test_track_outcome_with_none_category(setup) -> None:
         category=None,
     )
 
-    (topic_name, payload), _ = setup.mock_publisher.return_value.publish.call_args
-    data = json.loads(payload)
+    (_, kafka_payload), _ = setup.mock_outcomes_produce.call_args
+    data = json.loads(kafka_payload.value)
     assert data["category"] is None
 
 
@@ -405,8 +380,8 @@ def test_track_outcome_with_non_positive_quantity(setup, quantity: int) -> None:
         quantity=quantity,
     )
 
-    (topic_name, payload), _ = setup.mock_publisher.return_value.publish.call_args
-    data = json.loads(payload)
+    (_, kafka_payload), _ = setup.mock_outcomes_produce.call_args
+    data = json.loads(kafka_payload.value)
     assert data["quantity"] == quantity
 
 
@@ -436,15 +411,11 @@ def test_metrics_incr_called_with_correct_tags(setup) -> None:
         )
 
 
-def test_track_outcome_publisher_initialization(setup) -> None:
+def test_track_outcome_routes_to_outcomes_producer(setup) -> None:
     """
-    Tests that the publisher is correctly initialized when clusters are the same.
+    When the billing and outcomes topics share a cluster, billing outcomes
+    are routed through the outcomes producer (to the billing topic name).
     """
-    # Ensure publishers are None
-    outcomes.outcomes_publisher = None
-    outcomes.billing_publisher = None
-
-    # Trigger track_outcome to initialize the publisher
     track_outcome(
         org_id=1,
         project_id=1,
@@ -452,23 +423,18 @@ def test_track_outcome_publisher_initialization(setup) -> None:
         outcome=Outcome.ACCEPTED,
     )
 
-    # Since outcome is billing but clusters are the same, outcomes_publisher should be initialized
-    assert outcomes.billing_publisher is None
-    assert outcomes.outcomes_publisher is not None
+    setup.mock_outcomes_produce.assert_called_once()
+    setup.mock_billing_produce.assert_not_called()
 
 
-def test_track_outcome_publisher_initialization_different_cluster(settings, setup) -> None:
+def test_track_outcome_routes_to_billing_producer_when_clusters_differ(settings, setup) -> None:
     """
-    Tests that the publisher is correctly initialized when clusters are different.
+    When the billing topic lives on a different cluster from the outcomes
+    topic, billing outcomes use the billing producer and non-billing outcomes
+    continue to use the outcomes producer.
     """
-    # Ensure publishers are None
-    outcomes.outcomes_publisher = None
-    outcomes.billing_publisher = None
-
-    # Simulate different clusters for 'outcomes' and 'outcomes-billing' topics
     cluster_patch = {"outcomes-billing": "different_cluster", "outcomes": "default_cluster"}
     with mock.patch.dict(settings.KAFKA_TOPIC_TO_CLUSTER, cluster_patch):
-        # Trigger track_outcome to initialize the publisher
         track_outcome(
             org_id=1,
             project_id=1,
@@ -476,15 +442,12 @@ def test_track_outcome_publisher_initialization_different_cluster(settings, setu
             outcome=Outcome.ACCEPTED,
         )
 
-        # Since outcome is billing and clusters are different, billing_publisher should be initialized
-        assert outcomes.billing_publisher is not None
-        assert outcomes.outcomes_publisher is None  # type: ignore[unreachable]
+        setup.mock_billing_produce.assert_called_once()
+        setup.mock_outcomes_produce.assert_not_called()
 
-        # Reset publishers
-        outcomes.outcomes_publisher = None
-        outcomes.billing_publisher = None
+        setup.mock_billing_produce.reset_mock()
+        setup.mock_outcomes_produce.reset_mock()
 
-        # Trigger track_outcome to initialize the publisher for non-billing outcomes
         track_outcome(
             org_id=1,
             project_id=1,
@@ -492,5 +455,5 @@ def test_track_outcome_publisher_initialization_different_cluster(settings, setu
             outcome=Outcome.FILTERED,
         )
 
-        assert outcomes.billing_publisher is None
-        assert outcomes.outcomes_publisher is not None
+        setup.mock_outcomes_produce.assert_called_once()
+        setup.mock_billing_produce.assert_not_called()


### PR DESCRIPTION
note: original PR was closed by bot - https://github.com/getsentry/sentry/pull/113028

## Summary

`KafkaPublisher` (used by `track_outcome()`) wraps a raw `ConfluentProducer` with no background poll thread. Arroyo's `build_kafka_producer_configuration()` sets `statistics.interval.ms=1000` on all producers, causing librdkafka to generate a stats op every second. These ops are only drained by `producer.poll()` — which only runs inside `KafkaPublisher.publish()`. When the consumer topic goes idle, stats ops accumulate indefinitely in rdkafka's internal queue.

We hit this problem, because we have small rate of attachments in `ingest-attachments` topic - once a day or less. So most of the time `ingest-consumer-attachments` which uses `KafkaPublisher` is idle.

In our case it looked like:
1. `ingest-consumer-attachments` receives one attachment from topic `ingest-attachments`
2. It publishes to `outcomes`, memory drops down then memory starts growing gradually
3. If there are no messages for a long period - memory hits the limit and Pod goes OOM

<img height="700" alt="image" src="https://github.com/user-attachments/assets/136525ea-23a8-4014-95b7-355dd5e3f19a" />

librdkafka stats op holds a JSON blob. In our production this is ~23-50 kB per op, leaking 2.9MB/min until OOMKill. More info on librdkafka statistics: https://docs.confluent.io/platform/current/clients/librdkafka/html/md_STATISTICS.html

## More details

I've compared `KafkaPublisher` with Arroyo's `KafkaProducer`. And the latter has a background poll thread:

https://github.com/getsentry/arroyo/blob/a4bd9a7ef5e9a23a7862e278d9881d0a7a7e18e5/arroyo/backends/kafka/consumer.py#L774-L784 

So `KafkaProducer` has no issues with draining stats queue, because of continuous polling.

## Reproduction

I create a small dockerfile with Kafka Broker and producer to simulate the environment where poll is called only in the beggining and then no poll calls executed and stats enabled. 

Everything in a docker compose: https://github.com/moleus/sentry-kafkapublisher-oom-repro

## What I did 

Replaced confluent producer with `sentry.utils.arroyo_producer.get_arroyo_producer` which has the background thread. 

This approach was recommended by Evan here - https://github.com/getsentry/sentry/pull/113028#issuecomment-4268501270

I touched only outcomes producer and test files

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
