### PR TITLE
fix(cross-events): Correct styling based off date selection

### DIFF
--- a/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
@@ -1,6 +1,6 @@
 import {memo, useCallback, useMemo} from 'react';
 
-import {Grid} from '@sentry/scraps/layout';
+import {Container, Grid} from '@sentry/scraps/layout';
 
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {
@@ -143,19 +143,23 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
     });
 
     return (
-      <Grid columns="minmax(180px, 240px) 1fr" gap="md">
-        <MetricSelector traceMetric={metric} onChange={onMetricChange} />
-        <SearchQueryBuilderProvider
-          // Use the metric name as a key to force remount when it changes
-          // This prevents race conditions when switching between different metrics
-          key={metric.name}
-          {...searchQueryBuilderProps}
-        >
-          <TraceItemSearchQueryBuilder
-            itemType={TraceItemDataset.TRACEMETRICS}
-            {...eapSpanSearchQueryBuilderProps}
-          />
-        </SearchQueryBuilderProvider>
+      <Grid columns="minmax(0, 240px) minmax(0, 1fr)" gap="md" minWidth="0">
+        <Container minWidth="0">
+          <MetricSelector traceMetric={metric} onChange={onMetricChange} />
+        </Container>
+        <Container minWidth="0">
+          <SearchQueryBuilderProvider
+            // Use the metric name as a key to force remount when it changes
+            // This prevents race conditions when switching between different metrics
+            key={metric.name}
+            {...searchQueryBuilderProps}
+          >
+            <TraceItemSearchQueryBuilder
+              itemType={TraceItemDataset.TRACEMETRICS}
+              {...eapSpanSearchQueryBuilderProps}
+            />
+          </SearchQueryBuilderProvider>
+        </Container>
       </Grid>
     );
   }

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBars.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBars.tsx
@@ -2,7 +2,7 @@ import {Fragment, useEffect, useEffectEvent} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Container} from '@sentry/scraps/layout';
+import {Container, Grid} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -30,7 +30,13 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 
 const EMPTY_CROSS_EVENTS: CrossEvent[] = [];
 
-export function SpansTabCrossEventSearchBars() {
+interface SpansTabCrossEventSearchBarsProps {
+  hasIndependentDateColumn?: boolean;
+}
+
+export function SpansTabCrossEventSearchBars({
+  hasIndependentDateColumn = false,
+}: SpansTabCrossEventSearchBarsProps) {
   const organization = useOrganization();
   const crossEvents = useQueryParamsCrossEvents() ?? EMPTY_CROSS_EVENTS;
   const setCrossEvents = useSetQueryParamsCrossEvents();
@@ -71,7 +77,7 @@ export function SpansTabCrossEventSearchBars() {
     return null;
   }
 
-  return visibleCrossEvents.map(({crossEvent, index}, visibleIndex) => {
+  const crossEventRows = visibleCrossEvents.map(({crossEvent, index}, visibleIndex) => {
     let traceItemType = TraceItemDataset.SPANS;
     if (crossEvent.type === 'logs') {
       traceItemType = TraceItemDataset.LOGS;
@@ -176,4 +182,17 @@ export function SpansTabCrossEventSearchBars() {
       </Fragment>
     );
   });
+
+  if (!hasIndependentDateColumn) {
+    return <Fragment>{crossEventRows}</Fragment>;
+  }
+
+  return (
+    <Grid
+      gap="md"
+      columns={{sm: '1fr', md: 'minmax(300px, max-content) 1fr min-content'}}
+    >
+      {crossEventRows}
+    </Grid>
+  );
 }

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -9,6 +9,7 @@ import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter'
 import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/environmentPageFilter';
 import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useSpanSearchQueryBuilderProps} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {
   SearchQueryBuilderProvider,
@@ -73,6 +74,7 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
   const crossEvents = useQueryParamsCrossEvents();
   const setQueryParams = useSetQueryParams();
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
+  const {selection} = usePageFilters();
 
   const organization = useOrganization();
   const hasRawSearchReplacement = organization.features.includes(
@@ -80,6 +82,9 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
   );
 
   const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
+  const hasAbsoluteDateSelection = Boolean(
+    selection.datetime.start && selection.datetime.end && !selection.datetime.period
+  );
 
   const {attributes: numberAttributes, isLoading: numberAttributesLoading} =
     useSpanItemAttributes({}, 'number');
@@ -167,20 +172,30 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
         >
           {tourProps => (
             <div {...tourProps}>
-              <Grid
-                gap="md"
-                columns={{sm: '1fr', md: 'minmax(300px, auto) 1fr min-content'}}
-              >
-                <StyledPageFilterBar condensed>
-                  <ProjectPageFilter />
-                  <EnvironmentPageFilter />
-                  <DatePageFilter {...datePageFilterProps} />
-                </StyledPageFilterBar>
-                <SpansSearchBar
-                  spanSearchQueryBuilderProps={spanSearchQueryBuilderProps}
-                />
-                <CrossEventQueryingDropdown />
-                {hasCrossEvents ? <SpansTabCrossEventSearchBars /> : null}
+              <Grid gap="md">
+                <Grid
+                  gap="md"
+                  columns={{
+                    sm: '1fr',
+                    md: 'minmax(300px, auto) 1fr min-content',
+                  }}
+                >
+                  <StyledPageFilterBar condensed>
+                    <ProjectPageFilter />
+                    <EnvironmentPageFilter />
+                    <DatePageFilter {...datePageFilterProps} />
+                  </StyledPageFilterBar>
+                  <SpansSearchBar
+                    spanSearchQueryBuilderProps={spanSearchQueryBuilderProps}
+                  />
+                  <CrossEventQueryingDropdown />
+                  {hasCrossEvents && !hasAbsoluteDateSelection ? (
+                    <SpansTabCrossEventSearchBars />
+                  ) : null}
+                </Grid>
+                {hasCrossEvents && hasAbsoluteDateSelection ? (
+                  <SpansTabCrossEventSearchBars hasIndependentDateColumn />
+                ) : null}
               </Grid>
               {hasCrossEvents ? null : (
                 <ExploreSchemaHintsSection>


### PR DESCRIPTION
The goal of this PR is to tweak the styles for the cross-event query section based off of the period selection. There are a couple issues currently when selecting an exact date range so this PR tweaks the styles based off of that condition.

| | Before | After |
| - | - | - |
| Relative Date | <img width="1236" height="103" alt="Screenshot 2026-05-25 at 09 04 53" src="https://github.com/user-attachments/assets/8b46b311-2d7e-4141-81b4-e98bf6ed4b9b" /> | <img width="1240" height="103" alt="Screenshot 2026-05-25 at 09 05 20" src="https://github.com/user-attachments/assets/cf1782b3-edd1-4b92-8db3-5ec1e56d917a" /> |
| Absolute Date | <img width="1233" height="100" alt="Screenshot 2026-05-25 at 09 06 16" src="https://github.com/user-attachments/assets/595fa67c-201a-4159-8853-482ef37472c4" /> | <img width="1238" height="97" alt="Screenshot 2026-05-25 at 09 06 26" src="https://github.com/user-attachments/assets/60da8ea9-2408-466b-878a-e3ac2c083415" /> |
| Absolute Date w/time | <img width="1237" height="102" alt="Screenshot 2026-05-25 at 09 07 21" src="https://github.com/user-attachments/assets/eb8879e7-d5f6-475c-bbc5-e927f07b4d27" /> | <img width="1239" height="102" alt="Screenshot 2026-05-25 at 09 07 29" src="https://github.com/user-attachments/assets/88ae5d1e-e2fd-4981-9b4d-ce271a2c1ec6" /> |