### PR TITLE
fix(api): allow read-only tokens to list org access requests

### DIFF
--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -80,7 +80,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
         Get a list of requests to join org/team.
         If any requests are redundant (user already joined the team), they are not returned.
         """
-        if request.access.has_scope("org:write"):
+        if request.access.has_scope("org:read"):
             access_requests = list(
                 OrganizationAccessRequest.objects.filter(
                     team__organization=organization,
@@ -89,7 +89,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
                 ).select_related("team", "member")
             )
 
-        elif request.access.has_scope("team:write") and request.access.team_ids_with_membership:
+        elif request.access.has_scope("team:read") and request.access.team_ids_with_membership:
             access_requests = list(
                 OrganizationAccessRequest.objects.filter(
                     member__user_is_active=True,

--- a/tests/sentry/api/endpoints/test_organization_access_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_access_request_details.py
@@ -3,7 +3,9 @@ from django.urls import reverse
 from sentry.models.apitoken import ApiToken
 from sentry.models.organizationaccessrequest import OrganizationAccessRequest
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode
 
 
 class GetOrganizationAccessRequestTest(APITestCase):
@@ -58,7 +60,8 @@ class GetOrganizationAccessRequestTest(APITestCase):
         )
         access_request = OrganizationAccessRequest.objects.create(member=member, team=team)
 
-        token = ApiToken.objects.create(user=owner_user, scope_list=["org:read"])
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=owner_user, scope_list=["org:read"])
 
         resp = self.client.get(
             reverse("sentry-api-0-organization-access-requests", args=[organization.slug]),
@@ -101,7 +104,8 @@ class GetOrganizationAccessRequestTest(APITestCase):
         access_request_a = OrganizationAccessRequest.objects.create(member=member_a, team=team_a)
         OrganizationAccessRequest.objects.create(member=member_b, team=team_b)
 
-        token = ApiToken.objects.create(user=token_user, scope_list=["team:read"])
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=token_user, scope_list=["team:read"])
 
         resp = self.client.get(
             reverse("sentry-api-0-organization-access-requests", args=[organization.slug]),

--- a/tests/sentry/api/endpoints/test_organization_access_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_access_request_details.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 
+from sentry.models.apitoken import ApiToken
 from sentry.models.organizationaccessrequest import OrganizationAccessRequest
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.testutils.cases import APITestCase
@@ -44,6 +45,73 @@ class GetOrganizationAccessRequestTest(APITestCase):
         assert resp.data[0]["id"] == str(not_joined_request.id)
         assert resp.data[0]["member"]["id"] == str(not_joined_request.member.id)
         assert resp.data[0]["team"]["id"] == str(not_joined_request.team.id)
+
+    def test_read_only_token_can_list_requests(self) -> None:
+        owner_user = self.create_user("owner2@example.com")
+        organization = self.create_organization(owner=owner_user)
+        team = self.create_team(organization=organization)
+        requesting_user = self.create_user("requester@example.com")
+        member = self.create_member(
+            organization=organization,
+            role="member",
+            user=requesting_user,
+        )
+        access_request = OrganizationAccessRequest.objects.create(member=member, team=team)
+
+        token = ApiToken.objects.create(user=owner_user, scope_list=["org:read"])
+
+        resp = self.client.get(
+            reverse("sentry-api-0-organization-access-requests", args=[organization.slug]),
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert resp.status_code == 200
+        assert len(resp.data) == 1
+        assert resp.data[0]["id"] == str(access_request.id)
+
+    def test_team_read_token_sees_own_team_requests(self) -> None:
+        owner_user = self.create_user("owner3@example.com")
+        organization = self.create_organization(owner=owner_user)
+        team_a = self.create_team(organization=organization)
+        team_b = self.create_team(organization=organization)
+
+        # token_user is a member of team_a but NOT team_b
+        token_user = self.create_user("token-user@example.com")
+        self.create_member(
+            organization=organization,
+            role="member",
+            user=token_user,
+            teams=[team_a],
+        )
+
+        # Two different users request to join team_a and team_b respectively
+        requester_a = self.create_user("requester-a@example.com")
+        member_a = self.create_member(
+            organization=organization,
+            role="member",
+            user=requester_a,
+        )
+        requester_b = self.create_user("requester-b@example.com")
+        member_b = self.create_member(
+            organization=organization,
+            role="member",
+            user=requester_b,
+        )
+
+        access_request_a = OrganizationAccessRequest.objects.create(member=member_a, team=team_a)
+        OrganizationAccessRequest.objects.create(member=member_b, team=team_b)
+
+        token = ApiToken.objects.create(user=token_user, scope_list=["team:read"])
+
+        resp = self.client.get(
+            reverse("sentry-api-0-organization-access-requests", args=[organization.slug]),
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert resp.status_code == 200
+        # Should only see team_a's request (the team token_user belongs to)
+        assert len(resp.data) == 1
+        assert resp.data[0]["id"] == str(access_request_a.id)
 
 
 class UpdateOrganizationAccessRequestTest(APITestCase):


### PR DESCRIPTION
_original PR closed by bot: https://github.com/getsentry/sentry/pull/111935_

---

The GET /api/0/organizations/{org}/access-requests/ endpoint declared read scopes (org:read, team:read) as sufficient in its permission class

https://github.com/getsentry/sentry/blob/0702428b2464dd70abaacad6c2194cbe570e7548/src/sentry/api/endpoints/organization_access_request_details.py#L24-L35

but the view implementation checked for write scopes (org:write, team:write), silently returning `[]` for any read-only Integration Token.

This PR replaces the internal has_scope checks with their read equivalents so that tokens following the principle of least privilege receive actual data. PUT (approve/deny) is unaffected — write scopes remain required there.

How to reproduce the issue: 
1. Create Integration Token with `org:read, team:read, member:read`
2. Fetch access requests with this token:
```bash
 curl -s -H "Authorization: Bearer $SENTRY_TOKEN" \
    "https://<domain>/api/0/organizations/<org-slug>/access-requests/"
```
3. You'll get empty json list as a result.

P.S: I generated a few tests, if you think that they are unnecessary - I can remove/refactor them

<img width="1667" height="238" alt="image" src="https://github.com/user-attachments/assets/9736d482-8c1c-4849-b7dd-8533f50e1749" />


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
