### PR TITLE
feat(tracing): Add debug endpoint for raw trace item response

### DIFF
--- a/src/sentry/api/endpoints/project_trace_item_details_raw.py
+++ b/src/sentry/api/endpoints/project_trace_item_details_raw.py
@@ -1,0 +1,85 @@
+import time
+import uuid
+
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.timestamp_pb2 import Timestamp as ProtoTimestamp
+from rest_framework.request import Request
+from rest_framework.response import Response
+from sentry_protos.snuba.v1.endpoint_trace_item_details_pb2 import TraceItemDetailsRequest
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.exceptions import BadRequest
+from sentry.auth.superuser import superuser_has_permission
+from sentry.models.project import Project
+from sentry.search.eap import constants
+from sentry.search.eap.types import SupportedTraceItemType
+from sentry.snuba.referrer import Referrer
+from sentry.utils import snuba_rpc
+
+from .project_trace_item_details import ProjectTraceItemDetailsEndpointSerializer
+
+
+@cell_silo_endpoint
+class ProjectTraceItemDetailsRawEndpoint(ProjectEndpoint):
+    owner = ApiOwner.DATA_BROWSING
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    @staticmethod
+    def get(request: Request, project: Project, item_id: str) -> Response:
+        """
+        Like ProjectTraceItemDetailsEndpoint, but returns the raw
+        TraceItemDetailsResponse without post-processing so superusers can
+        inspect underlying EAP data.
+        """
+        if not superuser_has_permission(request):
+            return Response(status=403)
+
+        serializer = ProjectTraceItemDetailsEndpointSerializer(data=request.GET)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        serialized = serializer.validated_data
+        item_type = serialized.get("item_type")
+
+        trace_item_type = None
+        if item_type is not None:
+            trace_item_type = constants.SUPPORTED_TRACE_ITEM_TYPE_MAP.get(
+                SupportedTraceItemType(item_type), None
+            )
+
+        if trace_item_type is None:
+            raise BadRequest(detail=f"Unknown trace item type: {item_type}")
+
+        start_timestamp_proto = ProtoTimestamp()
+        start_timestamp_proto.FromSeconds(0)
+
+        end_timestamp_proto = ProtoTimestamp()
+        end_timestamp_proto.FromSeconds(int(time.time()) + 60 * 60 * 24 * 7)
+
+        trace_id = request.GET.get("trace_id")
+        if not trace_id:
+            raise BadRequest(detail="Missing required query parameter 'trace_id'")
+
+        req = TraceItemDetailsRequest(
+            item_id=item_id,
+            meta=RequestMeta(
+                organization_id=project.organization.id,
+                cogs_category="events_analytics_platform",
+                referrer=Referrer.API_ORGANIZATION_TRACE_ITEM_DETAILS_RAW.value,
+                project_ids=[project.id],
+                start_timestamp=start_timestamp_proto,
+                end_timestamp=end_timestamp_proto,
+                trace_item_type=trace_item_type,
+                request_id=str(uuid.uuid4()),
+            ),
+            trace_id=trace_id,
+        )
+
+        resp = MessageToDict(snuba_rpc.trace_item_details_rpc(req))
+        return Response(resp)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -849,6 +849,7 @@ from .endpoints.project_tagkey_details import ProjectTagKeyDetailsEndpoint
 from .endpoints.project_tagkey_values import ProjectTagKeyValuesEndpoint
 from .endpoints.project_tags import ProjectTagsEndpoint
 from .endpoints.project_trace_item_details import ProjectTraceItemDetailsEndpoint
+from .endpoints.project_trace_item_details_raw import ProjectTraceItemDetailsRawEndpoint
 from .endpoints.project_transaction_names import ProjectTransactionNamesCluster
 from .endpoints.project_transaction_threshold import ProjectTransactionThresholdEndpoint
 from .endpoints.project_transaction_threshold_override import (
@@ -2797,6 +2798,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/trace-items/(?P<item_id>(?:[A-Fa-f0-9]+))/$",
         ProjectTraceItemDetailsEndpoint.as_view(),
         name="sentry-api-0-project-trace-item-details",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/trace-items/(?P<item_id>(?:[A-Fa-f0-9]+))/raw/$",
+        ProjectTraceItemDetailsRawEndpoint.as_view(),
+        name="sentry-api-0-project-trace-item-details-raw",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/events/$",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -436,6 +436,7 @@ class Referrer(StrEnum):
     API_METRICS_SERIES_SECOND_QUERY = "api.metrics.series.second_query"
 
     API_ORGANIZATION_TRACE_ITEM_DETAILS = "api.organization-trace-item-details"
+    API_ORGANIZATION_TRACE_ITEM_DETAILS_RAW = "api.organization-trace-item-details-raw"
     API_ORGANIZATION_EVENT_STATS_FIND_TOPN = "api.organization-event-stats.find-topn"
     API_ORGANIZATION_EVENT_STATS_METRICS_ENHANCED = "api.organization-event-stats.metrics-enhanced"
     API_ORGANIZATION_EVENT_STATS = "api.organization-event-stats"

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -740,6 +740,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/tombstones/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/tombstones/$tombstoneId/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/trace-items/$itemId/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/trace-items/$itemId/raw/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/transaction-threshold/configure/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/transfer/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/'

--- a/tests/snuba/api/endpoints/test_project_trace_item_details_raw.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details_raw.py
@@ -1,0 +1,69 @@
+import uuid
+
+from django import urls
+
+from sentry.testutils.cases import APITestCase, OurLogTestCase, SnubaTestCase, SpanTestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+class ProjectTraceItemDetailsRawEndpointTest(
+    APITestCase,
+    SnubaTestCase,
+    OurLogTestCase,
+    SpanTestCase,
+):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.one_min_ago = before_now(minutes=1)
+        self.trace_uuid = str(uuid.uuid4()).replace("-", "")
+
+    def do_request(self, event_type: str, item_id: str):
+        url = urls.reverse(
+            "sentry-api-0-project-trace-item-details-raw",
+            kwargs={
+                "item_id": item_id,
+                "project_id_or_slug": self.project.slug,
+                "organization_id_or_slug": self.project.organization.slug,
+            },
+        )
+        return self.client.get(
+            url,
+            {
+                "item_type": event_type,
+                "trace_id": self.trace_uuid,
+            },
+        )
+
+    def test_requires_superuser(self) -> None:
+        log = self.create_ourlog(
+            {"body": "foo", "trace_id": self.trace_uuid},
+            attributes={"str_attr": {"string_value": "1"}},
+            timestamp=self.one_min_ago,
+        )
+        self.store_eap_items([log])
+        item_id = log.item_id.hex()
+
+        response = self.do_request("logs", item_id)
+        assert response.status_code == 403
+
+    def test_superuser_gets_raw_response(self) -> None:
+        superuser = self.create_user(is_superuser=True)
+        self.create_member(user=superuser, organization=self.organization)
+        self.login_as(user=superuser, superuser=True)
+
+        log = self.create_ourlog(
+            {"body": "foo", "trace_id": self.trace_uuid},
+            attributes={"str_attr": {"string_value": "1"}},
+            timestamp=self.one_min_ago,
+        )
+        self.store_eap_items([log])
+        item_id = log.item_id.hex()
+
+        response = self.do_request("logs", item_id)
+        assert response.status_code == 200
+
+        assert "itemId" in response.data
+        assert "attributes" in response.data
+        attrs_by_name = {attr["name"]: attr["value"] for attr in response.data["attributes"]}
+        assert attrs_by_name["str_attr"] == {"valStr": "1"}


### PR DESCRIPTION
In general, but especially during our span streaming rollout, it's useful for debugging to be able to see the underlying data for a particular span before it is transformed by the Sentry API and frontend. This PR adds a **superuser-only** endpoint that returns the **raw** result from EAP's `TraceItemDetails` RPC.

This will be hooked up to a superuser-only button on the span details pane in the trace waterfall, similar to how we have the link to see raw transaction JSON for transactions (except the audience for this will be superusers only).

---

🤖: Claude Code (Opus 4.6) used to generate the code, with human editing + review. All words my own.