### PR TITLE
ref(slack): remove widget unfurl feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -66,8 +66,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-basic", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
     # Enables custom editable dashboards
     manager.add("organizations:dashboards-edit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
-    # Enable unfurling of dashboard widgets in Slack
-    manager.add("organizations:dashboards-widget-unfurl", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable metrics enhanced performance for AM2+ customers as they transition from AM2 to AM3
     manager.add("organizations:dashboards-metrics-transition", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable drilldown flow for dashboards
@@ -348,8 +346,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:insights-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable data browsing heat map widget
     manager.add("organizations:data-browsing-heat-map-widget", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable data browsing widget unfurl
-    manager.add("organizations:data-browsing-widget-unfurl", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable public RPC endpoint for local seer development
     manager.add("organizations:seer-public-rpc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Organizations on the old usage-based (v0) Seer plan

--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from django.db.models import Prefetch
 from django.http.request import QueryDict
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api import client
 from sentry.api.endpoints.timeseries import TimeSeries
 from sentry.api.serializers import serialize
@@ -126,12 +126,7 @@ def _unfurl_dashboards(
     )
     orgs_by_slug = {org.slug: org for org in organizations}
 
-    enabled_orgs = {
-        slug: org
-        for slug, org in orgs_by_slug.items()
-        if features.has("organizations:dashboards-widget-unfurl", org, actor=user)
-    }
-    if not enabled_orgs:
+    if not orgs_by_slug:
         return {}
 
     unfurls = {}
@@ -139,7 +134,7 @@ def _unfurl_dashboards(
     for link in links:
         args = cast(DashboardsUnfurlArgs, link.args)
         org_slug = args["org_slug"]
-        org = enabled_orgs.get(org_slug)
+        org = orgs_by_slug.get(org_slug)
 
         if not org:
             continue

--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from django.db.models import Prefetch
 from django.http.request import QueryDict
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.api import client
 from sentry.api.endpoints.timeseries import TimeSeries
 from sentry.api.serializers import serialize
@@ -126,7 +126,12 @@ def _unfurl_dashboards(
     )
     orgs_by_slug = {org.slug: org for org in organizations}
 
-    if not orgs_by_slug:
+    enabled_orgs = {
+        slug: org
+        for slug, org in orgs_by_slug.items()
+        if features.has("organizations:dashboards-basic", org, actor=user)
+    }
+    if not enabled_orgs:
         return {}
 
     unfurls = {}
@@ -134,7 +139,7 @@ def _unfurl_dashboards(
     for link in links:
         args = cast(DashboardsUnfurlArgs, link.args)
         org_slug = args["org_slug"]
-        org = orgs_by_slug.get(org_slug)
+        org = enabled_orgs.get(org_slug)
 
         if not org:
             continue

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 from django.http.request import QueryDict
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api import client
 from sentry.charts import backend as charts
 from sentry.charts.types import ChartSize, ChartType
@@ -375,20 +375,14 @@ def _unfurl_explore(
     )
     orgs_by_slug = {org.slug: org for org in organizations}
 
-    # Check if any org has the feature flag enabled before doing any work
-    enabled_orgs = {
-        slug: org
-        for slug, org in orgs_by_slug.items()
-        if features.has("organizations:data-browsing-widget-unfurl", org, actor=user)
-    }
-    if not enabled_orgs:
+    if not orgs_by_slug:
         return {}
 
     unfurls = {}
 
     for link in links:
         org_slug = link.args["org_slug"]
-        org = enabled_orgs.get(org_slug)
+        org = orgs_by_slug.get(org_slug)
 
         if not org:
             continue

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 from django.http.request import QueryDict
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.api import client
 from sentry.charts import backend as charts
 from sentry.charts.types import ChartSize, ChartType
@@ -375,14 +375,19 @@ def _unfurl_explore(
     )
     orgs_by_slug = {org.slug: org for org in organizations}
 
-    if not orgs_by_slug:
+    enabled_orgs = {
+        slug: org
+        for slug, org in orgs_by_slug.items()
+        if features.has("organizations:visibility-explore-view", org, actor=user)
+    }
+    if not enabled_orgs:
         return {}
 
     unfurls = {}
 
     for link in links:
         org_slug = link.args["org_slug"]
-        org = orgs_by_slug.get(org_slug)
+        org = enabled_orgs.get(org_slug)
 
         if not org:
             continue

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -229,15 +229,21 @@ class SlackEventEndpoint(SlackDMEndpoint):
 
                 feature_flag = {
                     LinkType.DISCOVER: "organizations:discover-basic",
-                    LinkType.EXPLORE: "organizations:data-browsing-widget-unfurl",
-                    LinkType.DASHBOARDS: "organizations:dashboards-widget-unfurl",
                 }.get(link_type)
+                requires_identity = link_type in (
+                    LinkType.DISCOVER,
+                    LinkType.EXPLORE,
+                    LinkType.DASHBOARDS,
+                )
 
                 if (
                     organization
-                    and feature_flag
+                    and requires_identity
                     and not slack_request.has_identity
-                    and features.has(feature_flag, organization, actor=request.user)
+                    and (
+                        feature_flag is None
+                        or features.has(feature_flag, organization, actor=request.user)
+                    )
                 ):
                     try:
                         analytics.record(

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -229,21 +229,15 @@ class SlackEventEndpoint(SlackDMEndpoint):
 
                 feature_flag = {
                     LinkType.DISCOVER: "organizations:discover-basic",
+                    LinkType.EXPLORE: "organizations:visibility-explore-view",
+                    LinkType.DASHBOARDS: "organizations:dashboards-basic",
                 }.get(link_type)
-                requires_identity = link_type in (
-                    LinkType.DISCOVER,
-                    LinkType.EXPLORE,
-                    LinkType.DASHBOARDS,
-                )
 
                 if (
                     organization
-                    and requires_identity
+                    and feature_flag
                     and not slack_request.has_identity
-                    and (
-                        feature_flag is None
-                        or features.has(feature_flag, organization, actor=request.user)
-                    )
+                    and features.has(feature_flag, organization, actor=request.user)
                 ):
                     try:
                         analytics.record(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -23,6 +23,7 @@ from sentry.snuba import discover, errors, transactions
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
@@ -196,6 +197,7 @@ def test_match_link(url, expected) -> None:
     assert match_link(url) == expected
 
 
+@with_feature("organizations:visibility-explore-view")
 class UnfurlTest(TestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1135,8 +1135,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert (
             unfurls[url]
@@ -1148,28 +1147,6 @@ class UnfurlTest(TestCase):
         assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_TIMESERIES
         chart_data = mock_generate_chart.call_args[0][1]
         assert "timeSeries" in chart_data
-
-    @patch(
-        "sentry.integrations.slack.unfurl.explore.client.get",
-    )
-    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
-    def test_unfurl_explore_no_feature_flag(
-        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
-    ) -> None:
-        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
-        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D&project={self.project.id}&statsPeriod=24h"
-        link_type, args = match_link(url)
-
-        if not args or not link_type:
-            raise AssertionError("Missing link_type/args")
-
-        links = [
-            UnfurlableUrl(url=url, args=args),
-        ]
-
-        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
-        assert len(unfurls) == 0
-        assert len(mock_generate_chart.mock_calls) == 0
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",
@@ -1189,8 +1166,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         assert len(mock_generate_chart.mock_calls) == 1
@@ -1221,8 +1197,7 @@ class UnfurlTest(TestCase):
             raise AssertionError("Missing link_type/args")
 
         links = [UnfurlableUrl(url=url, args=args)]
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            link_handlers[link_type].fn(self.integration, links, self.user)
+        link_handlers[link_type].fn(self.integration, links, self.user)
 
         mock_view.assert_called_once()
         request = mock_view.call_args[0][0]
@@ -1248,8 +1223,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
 
@@ -1277,8 +1251,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         assert len(mock_generate_chart.mock_calls) == 1
@@ -1305,8 +1278,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         # Should still unfurl with default yAxis
         assert len(unfurls) == 1
@@ -1341,8 +1313,7 @@ class UnfurlTest(TestCase):
 
         # Step 2: Run handler
         links = [UnfurlableUrl(url=url, args=args)]
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         # Step 3: Verify events-timeseries was called with correct args
         assert mock_client_get.call_count == 1
@@ -1402,8 +1373,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         assert len(mock_generate_chart.mock_calls) == 1
@@ -1429,8 +1399,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
@@ -1456,8 +1425,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert unfurls == {}
         # Skip happens before the events-timeseries call, so neither the API
@@ -1486,8 +1454,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
@@ -1729,8 +1696,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         call_kwargs = mock_client_get.call_args[1]
@@ -1880,8 +1846,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert (
             unfurls[url]
@@ -2002,8 +1967,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         call_kwargs = mock_client_get.call_args[1]
@@ -2030,8 +1994,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert (
             unfurls[url]
@@ -2075,8 +2038,7 @@ class UnfurlTest(TestCase):
 
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert (
             unfurls[url]
@@ -2112,8 +2074,7 @@ class UnfurlTest(TestCase):
 
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert unfurls == {}
         assert mock_generate_chart.call_count == 0
@@ -2171,8 +2132,7 @@ class UnfurlTest(TestCase):
 
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature(["organizations:dashboards-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert (
             unfurls[url]
@@ -2213,35 +2173,10 @@ class UnfurlTest(TestCase):
         assert args is not None
 
         links = [UnfurlableUrl(url=url, args=args)]
-        with self.feature(["organizations:dashboards-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         assert mock_generate_chart.call_count == 1
-
-    @patch("sentry.integrations.slack.unfurl.dashboards.client.get")
-    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
-    def test_unfurl_dashboards_no_feature_flag(
-        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
-    ) -> None:
-        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
-        dashboard, _ = self._create_spans_widget()
-
-        url = (
-            f"https://sentry.io/organizations/{self.organization.slug}"
-            f"/dashboard/{dashboard.id}/widget/0/?statsPeriod=7d"
-        )
-        link_type, args = match_link(url)
-
-        assert link_type == LinkType.DASHBOARDS
-        assert args is not None
-
-        links = [UnfurlableUrl(url=url, args=args)]
-        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
-
-        assert len(unfurls) == 0
-        assert mock_generate_chart.call_count == 0
-        assert mock_client_get.call_count == 0
 
     @patch("sentry.integrations.slack.unfurl.dashboards.client.get")
     @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
@@ -2273,8 +2208,7 @@ class UnfurlTest(TestCase):
         assert link_type is not None and args is not None
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature(["organizations:dashboards-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 0
         assert mock_client_get.call_count == 0
@@ -2298,8 +2232,7 @@ class UnfurlTest(TestCase):
         assert link_type is not None and args is not None
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature(["organizations:dashboards-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 0
         assert mock_client_get.call_count == 0
@@ -2320,8 +2253,7 @@ class UnfurlTest(TestCase):
         assert link_type is not None and args is not None
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature(["organizations:dashboards-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 0
         assert mock_client_get.call_count == 0
@@ -2372,8 +2304,7 @@ class UnfurlTest(TestCase):
         assert link_type is not None and args is not None
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature(["organizations:dashboards-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         assert mock_client_get.call_count == 2
@@ -2430,8 +2361,7 @@ class UnfurlTest(TestCase):
         assert link_type is not None and args is not None
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature(["organizations:dashboards-widget-unfurl"]):
-            link_handlers[link_type].fn(self.integration, links, self.user)
+        link_handlers[link_type].fn(self.integration, links, self.user)
 
         chart_data = mock_generate_chart.call_args[0][1]
         pairs = chart_data["timeSeries"]
@@ -2489,8 +2419,7 @@ class UnfurlTest(TestCase):
         assert link_type is not None and args is not None
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature(["organizations:dashboards-widget-unfurl"]):
-            link_handlers[link_type].fn(self.integration, links, self.user)
+        link_handlers[link_type].fn(self.integration, links, self.user)
 
         chart_data = mock_generate_chart.call_args[0][1]
         pairs = chart_data["timeSeries"]
@@ -2518,8 +2447,7 @@ class UnfurlTest(TestCase):
         assert link_type is not None and args is not None
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature(["organizations:dashboards-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         chart_data = mock_generate_chart.call_args[0][1]

--- a/tests/sentry/integrations/slack/webhooks/events/test_explore_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_explore_link_shared.py
@@ -93,7 +93,8 @@ class ExploreLinkSharedEvent(BaseEventTest):
         return self.mock_post.call_args[1]
 
     def test_share_explore_links_unlinked_user(self) -> None:
-        data = self.share_explore_links_ephemeral_sdk()
+        with self.feature("organizations:visibility-explore-view"):
+            data = self.share_explore_links_ephemeral_sdk()
 
         blocks = orjson.loads(data["blocks"])
 

--- a/tests/sentry/integrations/slack/webhooks/events/test_explore_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_explore_link_shared.py
@@ -93,8 +93,7 @@ class ExploreLinkSharedEvent(BaseEventTest):
         return self.mock_post.call_args[1]
 
     def test_share_explore_links_unlinked_user(self) -> None:
-        with self.feature("organizations:data-browsing-widget-unfurl"):
-            data = self.share_explore_links_ephemeral_sdk()
+        data = self.share_explore_links_ephemeral_sdk()
 
         blocks = orjson.loads(data["blocks"])
 


### PR DESCRIPTION
## Summary

- Removes the `organizations:data-browsing-widget-unfurl` and `organizations:dashboards-widget-unfurl` registrations from `src/sentry/features/temporary.py`.
- Switches the Slack unfurl flag gates over to the base feature flags for each product (`organizations:visibility-explore-view` for explore, `organizations:dashboards-basic` for dashboards) in `explore.py`, `dashboards.py`, and `webhooks/event.py`. This keeps the existing "only unfurl when the org has the underlying product" guard while removing the unfurl-specific flags.