### PR TITLE
fix(metrics): default to largest interval when using heatmaps visualization

### DIFF
--- a/static/app/utils/useChartInterval.spec.tsx
+++ b/static/app/utils/useChartInterval.spec.tsx
@@ -3,7 +3,11 @@ import {act, render} from 'sentry-test/reactTestingLibrary';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 
-import {getIntervalOptionsForPageFilter, useChartInterval} from './useChartInterval';
+import {
+  ChartIntervalUnspecifiedStrategy,
+  getIntervalOptionsForPageFilter,
+  useChartInterval,
+} from './useChartInterval';
 
 describe('useChartInterval', () => {
   beforeEach(() => {
@@ -52,6 +56,83 @@ describe('useChartInterval', () => {
       setChartInterval('5m');
     });
     expect(chartInterval).toBe('5m');
+  });
+
+  it('defaults to the smallest interval with USE_SMALLEST strategy', () => {
+    // Default 14d period produces ladder-derived options ['1h', '3h', '6h']
+    let chartInterval!: ReturnType<typeof useChartInterval>[0];
+
+    function TestPage() {
+      [chartInterval] = useChartInterval({
+        unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_SMALLEST,
+      });
+      return null;
+    }
+
+    render(<TestPage />);
+    expect(chartInterval).toBe('1h');
+  });
+
+  it('defaults to the largest ladder-derived interval with USE_BIGGEST strategy', () => {
+    // Default 14d period produces ladder-derived options ['1h', '3h', '6h'].
+    // The '1d' option is appended after the default is computed, so it is not
+    // considered when selecting the biggest default.
+    let chartInterval!: ReturnType<typeof useChartInterval>[0];
+    let intervalOptions!: ReturnType<typeof useChartInterval>[2];
+
+    function TestPage() {
+      [chartInterval, , intervalOptions] = useChartInterval({
+        unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_BIGGEST,
+      });
+      return null;
+    }
+
+    render(<TestPage />);
+    expect(chartInterval).toBe('6h');
+    // '1d' is still present as a selectable option even though it was not the default
+    expect(intervalOptions.map(o => o.value)).toContain('1d');
+  });
+
+  it('defaults to the second-largest interval with USE_SECOND_BIGGEST strategy', () => {
+    // Default 14d period produces ladder-derived options ['1h', '3h', '6h'],
+    // so the second-biggest is '3h'.
+    let chartInterval!: ReturnType<typeof useChartInterval>[0];
+
+    function TestPage() {
+      [chartInterval] = useChartInterval({
+        unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_SECOND_BIGGEST,
+      });
+      return null;
+    }
+
+    render(<TestPage />);
+    expect(chartInterval).toBe('3h');
+  });
+
+  it('falls back to the only option when USE_SECOND_BIGGEST is used with a single-option period', () => {
+    // A 1-minute period produces only ['1m'] as the valid interval option.
+    // options[length-2] is undefined, so the fallback is options[length-1] = '1m'.
+    let chartInterval!: ReturnType<typeof useChartInterval>[0];
+
+    function TestPage() {
+      [chartInterval] = useChartInterval({
+        unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_SECOND_BIGGEST,
+      });
+      return null;
+    }
+
+    render(<TestPage />);
+
+    act(() =>
+      PageFiltersStore.updateDateTime({
+        period: '1m',
+        start: null,
+        end: null,
+        utc: true,
+      })
+    );
+
+    expect(chartInterval).toBe('1m');
   });
 });
 

--- a/static/app/utils/useChartInterval.tsx
+++ b/static/app/utils/useChartInterval.tsx
@@ -26,6 +26,8 @@ export enum ChartIntervalUnspecifiedStrategy {
   USE_SECOND_BIGGEST = 'use_second_biggest',
   /** Use the smallest possible interval (e.g., the smallest possible buckets) */
   USE_SMALLEST = 'use_smallest',
+  /** Use the biggest possible interval (e.g., the biggest possible buckets) */
+  USE_BIGGEST = 'use_biggest',
 }
 
 interface Options {
@@ -74,7 +76,9 @@ function useChartIntervalImpl({
     const fallback =
       unspecifiedStrategy === ChartIntervalUnspecifiedStrategy.USE_SMALLEST
         ? options[0]!.value
-        : (options[options.length - 2]?.value ?? options[options.length - 1]!.value);
+        : unspecifiedStrategy === ChartIntervalUnspecifiedStrategy.USE_BIGGEST
+          ? options[options.length - 1]!.value
+          : (options[options.length - 2]?.value ?? options[options.length - 1]!.value);
 
     if (diffInMinutes >= MINIMUM_DURATION_FOR_ONE_DAY_INTERVAL) {
       options.push(ONE_DAY_OPTION);

--- a/static/app/utils/useChartInterval.tsx
+++ b/static/app/utils/useChartInterval.tsx
@@ -73,12 +73,20 @@ function useChartIntervalImpl({
     const options = getIntervalOptionsForPageFilter(datetime);
 
     // Compute the default from the ladder-derived options, before appending extras
-    const fallback =
-      unspecifiedStrategy === ChartIntervalUnspecifiedStrategy.USE_SMALLEST
-        ? options[0]!.value
-        : unspecifiedStrategy === ChartIntervalUnspecifiedStrategy.USE_BIGGEST
-          ? options[options.length - 1]!.value
-          : (options[options.length - 2]?.value ?? options[options.length - 1]!.value);
+    let fallback: string;
+    switch (unspecifiedStrategy) {
+      case ChartIntervalUnspecifiedStrategy.USE_SMALLEST:
+        fallback = options[0]!.value;
+        break;
+      case ChartIntervalUnspecifiedStrategy.USE_BIGGEST:
+        fallback = options[options.length - 1]!.value;
+        break;
+      case ChartIntervalUnspecifiedStrategy.USE_SECOND_BIGGEST:
+      default:
+        fallback =
+          options[options.length - 2]?.value ?? options[options.length - 1]!.value;
+        break;
+    }
 
     if (diffInMinutes >= MINIMUM_DURATION_FOR_ONE_DAY_INTERVAL) {
       options.push(ONE_DAY_OPTION);

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -18,7 +18,10 @@ import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {DataUnit} from 'sentry/utils/discover/fields';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
-import {useChartInterval} from 'sentry/utils/useChartInterval';
+import {
+  ChartIntervalUnspecifiedStrategy,
+  useChartInterval,
+} from 'sentry/utils/useChartInterval';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
@@ -120,11 +123,17 @@ export function MetricPanel({
   const aggregateSortBys = useQueryParamsAggregateSortBys();
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();
-  const [interval, setInterval, intervalOptions] = useChartInterval();
   const topEvents = useTopEvents();
   const visualize = useMetricVisualize();
   const visualizes = useMetricVisualizes();
   const setVisualizes = useSetMetricVisualizes();
+  // use the biggest interval for the heat map as this produces better patterns
+  const [interval, setInterval, intervalOptions] = useChartInterval({
+    unspecifiedStrategy:
+      visualize.chartType === ChartType.HEATMAP
+        ? ChartIntervalUnspecifiedStrategy.USE_BIGGEST
+        : ChartIntervalUnspecifiedStrategy.USE_SMALLEST,
+  });
 
   const [title, setTitle] = useState<string | undefined>(() => {
     if (isVisualizeEquation(visualize)) {


### PR DESCRIPTION
Couple of things to note here. For heat maps we want to default to the largest interval because it shows the most patterns and then users can adjust how they'd like. There wasn't an option to use the largest interval so i added it in. I've also added tests for the `useChartInterval` hook.

Test by changing the chart type in metrics to heat map and see the default interval change 🤩 