### PR TITLE
ref(spans): Use full web vitals attribute strings

### DIFF
--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -109,17 +109,18 @@ class Spans(rpc_dataset_common.RPCBase):
             "sdk.name",
             "measurements.time_to_initial_display",
             "measurements.time_to_full_display",
+            "measurements.lcp",
+            "measurements.score.ratio.lcp",
+            "measurements.fcp",
+            "measurements.score.ratio.fcp",
+            "measurements.inp",
+            "measurements.score.ratio.inp",
+            "measurements.cls",
+            "measurements.score.ratio.cls",
+            "measurements.ttfb",
+            "measurements.score.ratio.ttfb",
             *additional_attributes,
         ]
-        for key in {
-            "lcp",
-            "fcp",
-            "inp",
-            "cls",
-            "ttfb",
-        }:
-            trace_attributes.append(f"measurements.{key}")
-            trace_attributes.append(f"measurements.score.ratio.{key}")
         resolver = cls.get_resolver(params=params, config=SearchResolverConfig())
         columns, _ = resolver.resolve_attributes(trace_attributes)
         meta = resolver.resolve_meta(referrer=referrer)


### PR DESCRIPTION
Tiny nit, but:

Constructing the web vitals attribute names in a loop saves 1 line and ensures consistent formatting, _but_ it means that the references to these attributes are hidden from search/grep. "find if/where in the codebase this attribute is used" is useful/important enough (for development, debugging, checking whether attribute name conventions are safe to update, etc) to be worth the change IMO.

---

🤖: Not used.