### PR TITLE
ref(spans): split load_segment_data into helper steps

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -102,7 +102,7 @@ import logging
 import math
 import time
 import uuid
-from collections.abc import Generator, MutableMapping, Sequence
+from collections.abc import Generator, Mapping, MutableMapping, Sequence
 from hashlib import blake2b
 from typing import Any, NamedTuple, cast
 
@@ -120,13 +120,18 @@ from sentry.processing.backpressure.memory import ServiceMemory, iter_cluster_me
 from sentry.spans.buffer_logger import (
     BufferLogger,
     DeadlineUpdateLog,
-    FlusherLogEntry,
     FlusherLogger,
     FlushSegmentLog,
     InsertSpansMetrics,
     SubsegmentDebugLog,
 )
-from sentry.spans.buffer_types import EvalshaResult, InsertedSubsegment, Span, Subsegment
+from sentry.spans.buffer_types import (
+    EvalshaResult,
+    InsertedSubsegment,
+    LoadedSegmentData,
+    Span,
+    Subsegment,
+)
 from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.spans.debug_trace_logger import DebugTraceLogger
 from sentry.spans.segment_key import (
@@ -223,7 +228,6 @@ class SpansBuffer:
         self.slice_id = slice_id
         self.add_buffer_sha: str | None = None
         self.any_shard_at_limit = False
-        self._last_decompress_latency_ms = 0
         self._current_compression_level = None
         self._zstd_compressor: zstandard.ZstdCompressor | None = None
         self._zstd_decompressor = zstandard.ZstdDecompressor()
@@ -657,7 +661,6 @@ class SpansBuffer:
         queue_keys = []
         shard_factor = max(1, len(self.assigned_shards))
         max_flush_segments = options.get("spans.buffer.max-flush-segments")
-        flusher_logger_enabled = options.get("spans.buffer.flusher-cumulative-logger-enabled")
         max_segments_per_shard = math.ceil(max_flush_segments / shard_factor)
 
         ids_start = time.monotonic()
@@ -680,6 +683,7 @@ class SpansBuffer:
 
         acquired_locks = self._acquire_flush_locks([k for _, _, k, _ in segment_keys])
         segment_keys = [entry for entry in segment_keys if entry[2] in acquired_locks]
+        segment_key_values = [k for _, _, k, _ in segment_keys]
 
         data_start = time.monotonic()
         with metrics.timer("spans.buffer.flush_segments.load_segment_data"):
@@ -687,21 +691,23 @@ class SpansBuffer:
             segment_to_queue = {
                 segment_key: queue_key for _, queue_key, segment_key, _ in segment_keys
             }
-            segments, payload_keys_map = self._load_segment_data(
-                [k for _, _, k, _ in segment_keys],
-                segment_to_queue,
-                now,
-            )
+            loaded_segment_data, decompress_latency_ms = self._load_segment_data(segment_key_values)
         load_data_latency_ms = int((time.monotonic() - data_start) * 1000)
+
+        self._record_segment_loss_metrics(
+            segment_key_values,
+            segment_to_queue,
+            now,
+            loaded_segment_data.payloads,
+        )
 
         return_segments = {}
         num_has_root_spans = 0
         any_shard_at_limit = False
-        flusher_log_entries: list[FlusherLogEntry] = []
 
         for shard, queue_key, segment_key, score in segment_keys:
             segment_span_id = segment_key_to_span_id(segment_key).decode("ascii")
-            segment = segments.get(segment_key, [])
+            segment = loaded_segment_data.payloads.get(segment_key, [])
             project_id, _, _ = parse_segment_key(segment_key)
             if len(segment) >= max_segments_per_shard:
                 any_shard_at_limit = True
@@ -737,7 +743,7 @@ class SpansBuffer:
                 queue_key=queue_key,
                 spans=output_spans,
                 project_id=int(project_id.decode("ascii")),
-                payload_keys=payload_keys_map.get(segment_key, []),
+                payload_keys=loaded_segment_data.payload_keys.get(segment_key, []),
             )
             num_has_root_spans += int(has_root_span)
 
@@ -751,24 +757,13 @@ class SpansBuffer:
                 timestamp=now,
             ).emit(self._get_debug_trace_logger)
 
-            if flusher_logger_enabled and segment:
-                project_id, trace_id, _ = parse_segment_key(segment_key)
-                project_and_trace = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
-                flusher_log_entries.append(
-                    FlusherLogEntry(
-                        project_and_trace,
-                        len(segment),
-                        sum(len(s) for s in segment),
-                    )
-                )
-
-        if flusher_logger_enabled and flusher_log_entries:
-            self._flusher_logger.log(
-                flusher_log_entries,
-                load_ids_latency_ms,
-                load_data_latency_ms,
-                self._last_decompress_latency_ms,
-            )
+        self._flusher_logger.log_loaded_segments(
+            segment_key_values,
+            loaded_segment_data.payloads,
+            load_ids_latency_ms=load_ids_latency_ms,
+            load_data_latency_ms=load_data_latency_ms,
+            decompress_latency_ms=decompress_latency_ms,
+        )
 
         metrics.timing("spans.buffer.flush_segments.num_segments", len(return_segments))
         metrics.timing("spans.buffer.flush_segments.has_root_span", num_has_root_spans)
@@ -779,29 +774,31 @@ class SpansBuffer:
     def _load_segment_data(
         self,
         segment_keys: list[SegmentKey],
-        segment_to_queue: dict[SegmentKey, QueueKey],
-        now: int,
-    ) -> tuple[dict[SegmentKey, list[bytes]], dict[SegmentKey, list[PayloadKey]]]:
+    ) -> tuple[LoadedSegmentData, int]:
         """
         Loads the segments from Redis, given a list of segment keys.
 
         :param segment_keys: List of segment keys to load.
-        :param segment_to_queue: Mapping of segment keys to their queue keys for TTL checking.
-        :param now: Current timestamp for age calculation.
-        :return: payloads mapping segment keys to lists of span payloads.
+        :return: Loaded payloads and payload keys, plus decompression latency.
         """
 
         page_size = options.get("spans.buffer.segment-page-size")
+        payload_keys = self._load_payload_keys(segment_keys)
+        payloads, decompress_latency_ms = self._load_payloads_from_keys(
+            segment_keys,
+            payload_keys,
+            page_size,
+        )
 
-        payloads: dict[SegmentKey, list[bytes]] = {key: [] for key in segment_keys}
-        payload_keys_map: dict[SegmentKey, list[PayloadKey]] = {key: [] for key in segment_keys}
-        self._last_decompress_latency_ms = 0
-        decompress_latency_ms = 0.0
+        return (
+            LoadedSegmentData(payloads, payload_keys),
+            decompress_latency_ms,
+        )
 
-        # Maps each payload key back to the segment it belongs to.
-        # Multiple distributed payload keys map to one segment.
-        scan_key_to_segment: dict[SegmentKey | PayloadKey, SegmentKey] = {}
-        cursors: dict[bytes, int] = {}
+    def _load_payload_keys(
+        self, segment_keys: Sequence[SegmentKey]
+    ) -> dict[SegmentKey, list[PayloadKey]]:
+        payload_keys: dict[SegmentKey, list[PayloadKey]] = {key: [] for key in segment_keys}
 
         with self.client.pipeline(transaction=False) as p:
             for key in segment_keys:
@@ -811,17 +808,30 @@ class SpansBuffer:
         for key, payload_key_span_ids in zip(segment_keys, mk_results):
             project_id, trace_id, _ = parse_segment_key(key)
             project_and_trace = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
-            segment_payload_keys: list[PayloadKey] = []
             for payload_key_span_id in payload_key_span_ids:
                 payload_key = self._get_payload_key(
                     project_and_trace, payload_key_span_id.decode("ascii")
                 )
-                segment_payload_keys.append(payload_key)
-                scan_key_to_segment[payload_key] = key
-                cursors[payload_key] = 0
-            payload_keys_map[key] = segment_payload_keys
+                payload_keys[key].append(payload_key)
 
-        def _add_spans(key: SegmentKey, raw_data: bytes):
+        return payload_keys
+
+    def _load_payloads_from_keys(
+        self,
+        segment_keys: Sequence[SegmentKey],
+        payload_keys: Mapping[SegmentKey, Sequence[PayloadKey]],
+        page_size: int,
+    ) -> tuple[dict[SegmentKey, list[bytes]], int]:
+        payloads: dict[SegmentKey, list[bytes]] = {key: [] for key in segment_keys}
+        decompress_latency_ms = 0.0
+        segment_by_payload_key = {
+            payload_key: segment_key
+            for segment_key, segment_payload_keys in payload_keys.items()
+            for payload_key in segment_payload_keys
+        }
+        cursors = {payload_key: 0 for payload_key in segment_by_payload_key}
+
+        def _add_spans(key: SegmentKey, raw_data: bytes) -> None:
             """
             Decompress and add spans to the segment.
             """
@@ -842,7 +852,7 @@ class SpansBuffer:
                 scan_results = p.execute()
 
             for key, (cursor, scan_values) in zip(current_keys, scan_results):
-                segment_key = scan_key_to_segment[key]
+                segment_key = segment_by_payload_key[key]
                 for scan_value in scan_values:
                     if segment_key in payloads:
                         _add_spans(segment_key, scan_value)
@@ -852,6 +862,15 @@ class SpansBuffer:
                 else:
                     cursors[key] = cursor
 
+        return payloads, int(decompress_latency_ms)
+
+    def _record_segment_loss_metrics(
+        self,
+        segment_keys: Sequence[SegmentKey],
+        segment_to_queue: dict[SegmentKey, QueueKey],
+        now: int,
+        payloads: dict[SegmentKey, list[bytes]],
+    ) -> None:
         # Fetch ingested counts for all segments to calculate dropped spans
         with self.client.pipeline(transaction=False) as p:
             for key in segment_keys:
@@ -931,10 +950,6 @@ class SpansBuffer:
                 # over each other. The consequence is duplicated segments,
                 # worst-case.
                 metrics.incr("spans.buffer.empty_segments")
-
-        self._last_decompress_latency_ms = int(decompress_latency_ms)
-
-        return payloads, payload_keys_map
 
     def done_flush_segments(self, segment_keys: dict[SegmentKey, FlushedSegment]):
         metrics.timing("spans.buffer.done_flush_segments.num_segments", len(segment_keys))

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -798,6 +798,12 @@ class SpansBuffer:
     def _load_payload_keys(
         self, segment_keys: Sequence[SegmentKey]
     ) -> dict[SegmentKey, list[PayloadKey]]:
+        """
+        Load the payload keys indexed under each segment key.
+
+        Segment keys point to member-key indexes; those indexes contain salts
+        used to build the distributed Redis keys that store compressed payload batches.
+        """
         payload_keys: dict[SegmentKey, list[PayloadKey]] = {key: [] for key in segment_keys}
 
         with self.client.pipeline(transaction=False) as p:
@@ -822,6 +828,9 @@ class SpansBuffer:
         payload_keys: Mapping[SegmentKey, Sequence[PayloadKey]],
         page_size: int,
     ) -> tuple[dict[SegmentKey, list[bytes]], int]:
+        """
+        Scan payload keys and return decompressed payloads grouped by segment key.
+        """
         payloads: dict[SegmentKey, list[bytes]] = {key: [] for key in segment_keys}
         decompress_latency_ms = 0.0
         segment_by_payload_key = {

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -801,8 +801,8 @@ class SpansBuffer:
         """
         Load the payload keys indexed under each segment key.
 
-        Segment keys point to member-key indexes; those indexes contain salts
-        used to build the distributed Redis keys that store compressed payload batches.
+        Segment keys point to member-key indexes; indexes contain payload keys
+        that point to spans payloads for the segment.
         """
         payload_keys: dict[SegmentKey, list[PayloadKey]] = {key: [] for key in segment_keys}
 

--- a/src/sentry/spans/buffer_logger.py
+++ b/src/sentry/spans/buffer_logger.py
@@ -175,6 +175,10 @@ class FlusherLogger:
         load_data_latency_ms: int,
         decompress_latency_ms: int,
     ) -> None:
+        """
+        Record loaded segments and periodically log the top traces sorted by
+        cumulative bytes flushed.
+        """
         if not options.get("spans.buffer.flusher-cumulative-logger-enabled"):
             return
 

--- a/src/sentry/spans/buffer_logger.py
+++ b/src/sentry/spans/buffer_logger.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, NamedTuple, TypeVar
 
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
@@ -10,7 +10,7 @@ from sentry_redis_tools.clients import RedisCluster, StrictRedis
 from sentry import options
 from sentry.spans.buffer_types import EvalshaData, EvalshaResult, InsertedSubsegment, Span
 from sentry.spans.debug_trace_logger import DebugTraceLogger
-from sentry.spans.segment_key import SegmentKey
+from sentry.spans.segment_key import SegmentKey, parse_segment_key
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -166,21 +166,50 @@ class FlusherLogger:
         self._cumulative_decompress_latency_ms: int = 0
         self._last_log_time: float | None = None
 
-    def log(
+    def log_loaded_segments(
+        self,
+        segment_keys: Sequence[SegmentKey],
+        payloads: Mapping[SegmentKey, Sequence[bytes]],
+        *,
+        load_ids_latency_ms: int,
+        load_data_latency_ms: int,
+        decompress_latency_ms: int,
+    ) -> None:
+        if not options.get("spans.buffer.flusher-cumulative-logger-enabled"):
+            return
+
+        entries: list[FlusherLogEntry] = []
+        for segment_key in segment_keys:
+            segment = payloads.get(segment_key, [])
+            if not segment:
+                continue
+
+            project_id, trace_id, _ = parse_segment_key(segment_key)
+            entries.append(
+                FlusherLogEntry(
+                    f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}",
+                    len(segment),
+                    sum(len(payload) for payload in segment),
+                )
+            )
+
+        if not entries:
+            return
+
+        self._log_entries(
+            entries,
+            load_ids_latency_ms,
+            load_data_latency_ms,
+            decompress_latency_ms,
+        )
+
+    def _log_entries(
         self,
         entries: list[FlusherLogEntry],
         load_ids_latency_ms: int,
         load_data_latency_ms: int,
         decompress_latency_ms: int,
     ) -> None:
-        """
-        Record a batch of flush operations and periodically log the top traces sorted by
-        cumulative bytes flushed.
-        """
-
-        if not options.get("spans.buffer.flusher-cumulative-logger-enabled"):
-            return
-
         self._cumulative_load_ids_latency_ms += load_ids_latency_ms
         self._cumulative_load_data_latency_ms += load_data_latency_ms
         self._cumulative_decompress_latency_ms += decompress_latency_ms

--- a/src/sentry/spans/buffer_types.py
+++ b/src/sentry/spans/buffer_types.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, NamedTuple
 
-from sentry.spans.segment_key import SegmentKey
+from sentry.spans.segment_key import PayloadKey, SegmentKey
 
 type DataPoint = tuple[bytes, float]
 type EvalshaData = list[DataPoint]
@@ -102,3 +102,8 @@ class InsertedSubsegment(NamedTuple):
     @property
     def is_detached_segment(self) -> bool:
         return self.result.segment_key.endswith(self.subsegment.salt.encode("ascii"))
+
+
+class LoadedSegmentData(NamedTuple):
+    payloads: dict[SegmentKey, list[bytes]]
+    payload_keys: dict[SegmentKey, list[PayloadKey]]

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -20,7 +20,12 @@ from sentry.spans.buffer import (
     OutputSpan,
     SpansBuffer,
 )
-from sentry.spans.buffer_types import EvalshaResult, InsertedSubsegment, Span, Subsegment
+from sentry.spans.buffer_types import (
+    EvalshaResult,
+    InsertedSubsegment,
+    Span,
+    Subsegment,
+)
 from sentry.spans.consumers.process.factory import SPANS_CODEC, validate_span_event
 from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.spans.segment_key import SegmentKey
@@ -2010,6 +2015,48 @@ def load_segment_buffer() -> Iterator[SpansBuffer]:
         yield buffer
 
 
+def test_load_payload_keys_from_distributed_keys(
+    load_segment_buffer: SpansBuffer,
+) -> None:
+    buffer = load_segment_buffer
+    trace_id = "a" * 32
+    segment_key = _segment_id(1, trace_id, "b" * 16)
+    first_salt = "1" * 32
+    second_salt = "2" * 32
+    first_payload_key = _payload_key(1, trace_id, first_salt)
+    second_payload_key = _payload_key(1, trace_id, second_salt)
+    buffer.client.sadd(buffer._get_payload_key_index(segment_key), first_salt, second_salt)
+
+    payload_keys = buffer._load_payload_keys([segment_key])
+
+    assert set(payload_keys[segment_key]) == {
+        first_payload_key,
+        second_payload_key,
+    }
+
+
+def test_load_payloads_from_keys_decompresses_payload_batches(
+    load_segment_buffer: SpansBuffer,
+) -> None:
+    buffer = load_segment_buffer
+    trace_id = "a" * 32
+    segment_key = _segment_id(1, trace_id, "b" * 16)
+    payload_key = _payload_key(1, trace_id, "1" * 32)
+    span_a = _payload("a" * 16)
+    span_b = _payload("b" * 16)
+    compressed = zstandard.ZstdCompressor(level=0).compress(b"\x00".join([span_a, span_b]))
+    buffer.client.sadd(payload_key, compressed)
+
+    payloads, decompress_latency_ms = buffer._load_payloads_from_keys(
+        [segment_key],
+        {segment_key: [payload_key]},
+        page_size=1,
+    )
+
+    assert set(payloads[segment_key]) == {span_a, span_b}
+    assert decompress_latency_ms >= 0
+
+
 def test_load_segment_data_reads_payloads_from_distributed_keys(
     load_segment_buffer: SpansBuffer,
 ) -> None:
@@ -2030,10 +2077,13 @@ def test_load_segment_data_reads_payloads_from_distributed_keys(
     buffer.client.set(b"span-buf:ic:" + segment_key, 3)
     buffer.client.set(b"span-buf:ibc:" + segment_key, len(span_a) + len(span_b) + len(span_c))
 
-    payloads, payload_keys_map = buffer._load_segment_data([segment_key], {}, now=0)
+    loaded_segment_data, _ = buffer._load_segment_data([segment_key])
 
-    assert set(payloads[segment_key]) == {span_a, span_b, span_c}
-    assert set(payload_keys_map[segment_key]) == {first_payload_key, second_payload_key}
+    assert set(loaded_segment_data.payloads[segment_key]) == {span_a, span_b, span_c}
+    assert set(loaded_segment_data.payload_keys[segment_key]) == {
+        first_payload_key,
+        second_payload_key,
+    }
 
 
 def test_load_segment_data_decompresses_payload_batches(
@@ -2052,13 +2102,16 @@ def test_load_segment_data_decompresses_payload_batches(
     buffer.client.sadd(payload_key, compressed)
     buffer.client.set(b"span-buf:ic:" + segment_key, 2)
 
-    payloads, payload_keys_map = buffer._load_segment_data([segment_key], {}, now=0)
+    loaded_segment_data, decompress_latency_ms = buffer._load_segment_data([segment_key])
 
-    assert set(payloads[segment_key]) == {span_a, span_b}
-    assert payload_keys_map[segment_key] == [payload_key]
+    assert set(loaded_segment_data.payloads[segment_key]) == {span_a, span_b}
+    assert loaded_segment_data.payload_keys[segment_key] == [payload_key]
+    assert decompress_latency_ms >= 0
 
 
-def test_load_segment_data_records_dropped_spans(load_segment_buffer: SpansBuffer) -> None:
+def test_record_segment_loss_metrics_records_dropped_spans(
+    load_segment_buffer: SpansBuffer,
+) -> None:
     buffer = load_segment_buffer
     trace_id = "a" * 32
     segment_key = _segment_id(1, trace_id, "b" * 16)
@@ -2077,10 +2130,16 @@ def test_load_segment_data_records_dropped_spans(load_segment_buffer: SpansBuffe
         mock.patch("sentry.spans.buffer.track_outcome") as track_outcome,
     ):
         project_model.objects.get_from_cache.return_value = mock_project
-        payloads, payload_keys_map = buffer._load_segment_data([segment_key], {}, now=0)
+        loaded_segment_data, _ = buffer._load_segment_data([segment_key])
+        buffer._record_segment_loss_metrics(
+            [segment_key],
+            {},
+            now=0,
+            payloads=loaded_segment_data.payloads,
+        )
 
-    assert payloads[segment_key] == [span_a]
-    assert payload_keys_map[segment_key] == [payload_key]
+    assert loaded_segment_data.payloads[segment_key] == [span_a]
+    assert loaded_segment_data.payload_keys[segment_key] == [payload_key]
     track_outcome.assert_called_once()
     outcome_kwargs = track_outcome.call_args.kwargs
     assert outcome_kwargs["org_id"] == 100
@@ -2109,7 +2168,7 @@ def test_load_segment_data_records_dropped_spans(load_segment_buffer: SpansBuffe
         ),
     ],
 )
-def test_load_segment_data_records_empty_expired_segments(
+def test_record_segment_loss_metrics_records_empty_expired_segments(
     load_segment_buffer: SpansBuffer, deadline: int, now: int, expected_expired: bool
 ) -> None:
     buffer = load_segment_buffer
@@ -2119,12 +2178,16 @@ def test_load_segment_data_records_empty_expired_segments(
     buffer.client.zadd(queue_key, {segment_key: deadline})
 
     with mock.patch("sentry.spans.buffer.metrics.incr") as metrics_incr:
-        payloads, payload_keys_map = buffer._load_segment_data(
-            [segment_key], {segment_key: queue_key}, now=now
+        loaded_segment_data, _ = buffer._load_segment_data([segment_key])
+        buffer._record_segment_loss_metrics(
+            [segment_key],
+            {segment_key: queue_key},
+            now=now,
+            payloads=loaded_segment_data.payloads,
         )
 
-    assert payloads[segment_key] == []
-    assert payload_keys_map[segment_key] == []
+    assert loaded_segment_data.payloads[segment_key] == []
+    assert loaded_segment_data.payload_keys[segment_key] == []
     incr_names = [call.args[0] for call in metrics_incr.call_args_list]
     assert ("spans.buffer.segment_expired_before_flush" in incr_names) is expected_expired
     assert "spans.buffer.empty_segments" in incr_names

--- a/tests/sentry/spans/test_buffer_logger.py
+++ b/tests/sentry/spans/test_buffer_logger.py
@@ -6,6 +6,7 @@ from unittest.mock import call
 from sentry.spans.buffer_logger import (
     BufferLogger,
     DeadlineUpdateLog,
+    FlusherAggregate,
     FlusherLogEntry,
     FlusherLogger,
     FlushSegmentLog,
@@ -301,7 +302,7 @@ def test_flusher_logger_accumulates_segments_and_spans(mock_time):
 
         flusher_logger = FlusherLogger()
 
-        flusher_logger.log(
+        flusher_logger._log_entries(
             [
                 FlusherLogEntry("project1:trace1", 10, 500),
                 FlusherLogEntry("project1:trace1", 20, 800),
@@ -324,7 +325,7 @@ def test_flusher_logger_accumulates_segments_and_spans(mock_time):
         assert flusher_logger._cumulative_load_data_latency_ms == 10
         assert flusher_logger._cumulative_decompress_latency_ms == 3
 
-        flusher_logger.log(
+        flusher_logger._log_entries(
             [FlusherLogEntry("project1:trace1", 15, 600)],
             load_ids_latency_ms=3,
             load_data_latency_ms=7,
@@ -341,6 +342,37 @@ def test_flusher_logger_accumulates_segments_and_spans(mock_time):
 
 
 @mock.patch("sentry.spans.buffer_logger.time")
+def test_flusher_logger_records_loaded_segments(mock_time):
+    with override_options({"spans.buffer.flusher-cumulative-logger-enabled": True}):
+        mock_time.time.return_value = 1000.0
+        flusher_logger = FlusherLogger()
+        first_segment_key = _segment_id(1, "a" * 32, "b" * 16)
+        second_segment_key = _segment_id(2, "c" * 32, "d" * 16)
+        empty_segment_key = _segment_id(3, "e" * 32, "f" * 16)
+
+        flusher_logger.log_loaded_segments(
+            [first_segment_key, empty_segment_key, second_segment_key],
+            {
+                first_segment_key: [b"first", b"second"],
+                empty_segment_key: [],
+                second_segment_key: [b"third"],
+            },
+            load_ids_latency_ms=5,
+            load_data_latency_ms=10,
+            decompress_latency_ms=3,
+        )
+
+        first_trace = flusher_logger._metrics_per_trace[f"1:{'a' * 32}"]
+        second_trace = flusher_logger._metrics_per_trace[f"2:{'c' * 32}"]
+        assert first_trace == FlusherAggregate(1, 2, len(b"first") + len(b"second"))
+        assert second_trace == FlusherAggregate(1, 1, len(b"third"))
+        assert f"3:{'e' * 32}" not in flusher_logger._metrics_per_trace
+        assert flusher_logger._cumulative_load_ids_latency_ms == 5
+        assert flusher_logger._cumulative_load_data_latency_ms == 10
+        assert flusher_logger._cumulative_decompress_latency_ms == 3
+
+
+@mock.patch("sentry.spans.buffer_logger.time")
 def test_flusher_logger_prunes_to_top_50_by_bytes(mock_time):
     """
     Test that FlusherLogger prunes to top 50 entries by cumulative bytes
@@ -352,7 +384,7 @@ def test_flusher_logger_prunes_to_top_50_by_bytes(mock_time):
         flusher_logger = FlusherLogger()
 
         entries = [FlusherLogEntry(f"project{i}:trace{i}", 10, 1000 - i) for i in range(500)]
-        flusher_logger.log(
+        flusher_logger._log_entries(
             entries, load_ids_latency_ms=20, load_data_latency_ms=30, decompress_latency_ms=10
         )
 
@@ -379,7 +411,7 @@ def test_flusher_logger_logs_and_resets_after_interval(mock_time, mock_logger):
 
         flusher_logger = FlusherLogger()
 
-        flusher_logger.log(
+        flusher_logger._log_entries(
             [
                 FlusherLogEntry("project1:trace1", 10, 500),
                 FlusherLogEntry("project2:trace2", 5, 200),
@@ -391,7 +423,7 @@ def test_flusher_logger_logs_and_resets_after_interval(mock_time, mock_logger):
 
         assert mock_logger.info.call_count == 0
 
-        flusher_logger.log(
+        flusher_logger._log_entries(
             [FlusherLogEntry("project1:trace1", 8, 400)],
             load_ids_latency_ms=10,
             load_data_latency_ms=20,

--- a/tests/sentry/spans/test_buffer_types.py
+++ b/tests/sentry/spans/test_buffer_types.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 import orjson
 
-from sentry.spans.buffer_types import EvalshaResult, InsertedSubsegment, Span, Subsegment
-from sentry.spans.segment_key import SegmentKey
+from sentry.spans.buffer_types import (
+    EvalshaResult,
+    InsertedSubsegment,
+    LoadedSegmentData,
+    Span,
+    Subsegment,
+)
+from sentry.spans.segment_key import PayloadKey, SegmentKey
 
 
 def _segment_id(project_id: int, trace_id: str, span_id: str) -> SegmentKey:
@@ -127,3 +133,17 @@ def test_inserted_subsegment_exposes_queue_and_cleanup_metadata() -> None:
     assert inserted.queue_shard == 3
     assert not inserted.is_detached_segment
     assert detached.is_detached_segment
+
+
+def test_loaded_segment_data_exposes_payloads() -> None:
+    segment_key = _segment_id(1, "a" * 32, "b" * 16)
+    payload_key = PayloadKey(b"span-buf:s:{1:%s:salted}:salted" % (b"a" * 32))
+    payload = _payload("a" * 16)
+
+    loaded_segment_data = LoadedSegmentData(
+        payloads={segment_key: [payload]},
+        payload_keys={segment_key: [payload_key]},
+    )
+
+    assert loaded_segment_data.payloads[segment_key] == [payload]
+    assert loaded_segment_data.payload_keys[segment_key] == [payload_key]


### PR DESCRIPTION
Refs STREAM-1001

Refactors `_load_segment_data` into an orchestration function with unit testable helpers:

- load payload keys for each segment
- scan/decompress payload batches from those payload keys, return loaded payloads and cleanup keys as `LoadedSegmentData`

Also updates the cumulative flusher logger to accept loaded segment payloads and build its own `FlusherLogEntry` values, removing the bookkeeping from `flush_segments`.

Segment-loss accounting is also split into `_record_segment_loss_metrics`, so `_load_segment_data` only loads data.

