### PR TITLE
fix(ui): Increase dropdown z-index to appear above sidebar

### DIFF
--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -196,7 +196,6 @@ const commonTheme = {
     truncationFullValue: 10,
 
     header: 1000,
-    dropdown: 1001,
 
     // dashboard widget builder backdrop sits behind the sidebar
     // because it renders on the right next to the sidebar
@@ -204,6 +203,7 @@ const commonTheme = {
     widgetBuilderDrawer: 1016,
 
     sidebarPanel: 1019,
+    dropdown: 1020,
     sidebar: 1020,
 
     // Sentry user feedback modal


### PR DESCRIPTION
Fixes DAIN-1690

## Problem
Widget context menus (triggered by clicking the '...' buttons on dashboard widgets) were appearing behind the dashboard navigation sidebar because `theme.zIndex.dropdown` (1001) was lower than `theme.zIndex.sidebarPanel` (1019).

Before
<img width="297" alt="Screenshot 2026-05-25 at 1 06 18 PM" src="https://github.com/user-attachments/assets/814181dd-572a-4f2d-9679-3bdb57ed101d" />
After
<img width="297" height="280" alt="Monosnap General Template copy 35 — sentry — Sentry 2026-05-25 13-53-18" src="https://github.com/user-attachments/assets/119b3eb7-3681-4aec-8e95-7063ea4d6641" />

## Solution
Updated `theme.zIndex.dropdown` from 1001 to 1020 (sidebarPanel + 1) in the theme definition. This ensures all dropdown menus across the application appear above the sidebar panel.

Linear Issue: [DAIN-1690](https://linear.app/getsentry/issue/DAIN-1690/menu-appears-behind-dashboard-widget-actions)
