### PR TITLE
ref(seer): Remove seer-slack-workflows and seer-slack-explorer flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -292,6 +292,10 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:autofix-on-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable autofix introspection for early stopping of autofix runs
     manager.add("organizations:seer-autofix-introspection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable Seer Workflows in Slack (released, kept until overrides are removed)
+    manager.add("organizations:seer-slack-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable Seer Agent in Slack via @mentions (released, kept until overrides are removed)
+    manager.add("organizations:seer-slack-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Show Seer run ID in Slack notification footers
     manager.add("organizations:seer-run-id-in-slack", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Seer activity events in the issue activity timeline

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -292,10 +292,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:autofix-on-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable autofix introspection for early stopping of autofix runs
     manager.add("organizations:seer-autofix-introspection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable Seer Workflows in Slack
-    manager.add("organizations:seer-slack-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable Seer Agent in Slack via @mentions
-    manager.add("organizations:seer-slack-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Show Seer run ID in Slack notification footers
     manager.add("organizations:seer-run-id-in-slack", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Seer activity events in the issue activity timeline

--- a/src/sentry/integrations/slack/requests/event.py
+++ b/src/sentry/integrations/slack/requests/event.py
@@ -76,14 +76,9 @@ def _resolve_available_organizations(
             logger.info("_resolve_available_organizations.inactive_org", extra=logging_ctx)
             continue
 
-        # Since the getsentry FeatureHandler does _not_ add subscription context to CONTROL
-        # evaluations, we need to slim down the check to only cover the feature flag.
-        # This is actually fine, since after routing, this method is rerun at the CELL.
-        if SiloMode.get_current_mode() == SiloMode.CONTROL:
-            if not SlackAgentEntrypoint.has_feature_flag(ctx.organization):
-                logger.info("_resolve_available_organizations.no_feature_flag", extra=logging_ctx)
-                continue
-        else:
+        # In CONTROL silo the getsentry FeatureHandler does _not_ add subscription
+        # context, so we skip the full access check — it is re-evaluated at CELL.
+        if SiloMode.get_current_mode() != SiloMode.CONTROL:
             if not SlackAgentEntrypoint.has_access(ctx.organization):
                 logger.info("_resolve_available_organizations.no_access", extra=logging_ctx)
                 continue

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, TypedDict
 
-from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration.service import integration_service
 from sentry.locks import locks
@@ -198,7 +197,7 @@ class SlackAutofixEntrypoint(
 
     @staticmethod
     def has_access(organization: Organization) -> bool:
-        return features.has("organizations:seer-slack-workflows", organization)
+        return True
 
     @staticmethod
     def get_group_link(group: Group) -> str:
@@ -504,20 +503,16 @@ class SlackAgentEntrypoint(
         self.install = SlackIntegration(model=integration, organization_id=organization_id)
         self.slack_user_id = slack_user_id
 
-    @staticmethod
-    def has_feature_flag(organization: Organization | RpcOrganization) -> bool:
-        return features.has("organizations:seer-slack-explorer", organization)
-
+    # TODO(Leander): This should probably move to the SeerAgentOperator class, any future entrypoint will be checking the same flag, not just Slack.
     @staticmethod
     def has_access(organization: Organization | RpcOrganization) -> bool:
         """
         Determines access to Seer Agent, along with the Slack feature. Shouldn't be called from
         the CONTROL silo since `has_explorer_access_with_detail` will not get populated with the
-        subscription context, and will return False every time. For slim, CONTROL calls, use
-        the `has_feature_flag` method instead.
+        subscription context, and will return False every time.
         """
         has_agent_access, _ = has_seer_agent_access_with_detail(organization, None)
-        return SlackAgentEntrypoint.has_feature_flag(organization) and has_agent_access
+        return has_agent_access
 
     def on_trigger_agent_error(self, *, error: str) -> None:
         send_thread_update(

--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -77,10 +77,9 @@ def process_mention_for_slack(
     ``ts`` is the message's own timestamp (always present).
     ``thread_ts`` is the parent thread's timestamp (None for top-level messages).
 
-    Authorization: Access is gated by the org-level ``seer-slack-workflows``
-    feature flag and ``has_explorer_access()``.  The incoming webhook is
-    verified by ``SlackDMRequest.validate()``.  The Slack user must have a
-    linked Sentry identity; if not, an ephemeral prompt to link is sent.
+    Authorization: Access is gated by ``has_explorer_access()``.  The incoming
+    webhook is verified by ``SlackDMRequest.validate()``.  The Slack user must
+    have a linked Sentry identity; if not, an ephemeral prompt to link is sent.
     """
 
     with SlackEntrypointEventLifecycleMetric(

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -959,50 +959,21 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         return False
 
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @with_feature(
-        {
-            "organizations:gen-ai-features": True,
-            "organizations:seer-slack-workflows": True,
-        }
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_autofix_button_shown_when_all_conditions_met(self, mock_quota: MagicMock) -> None:
         group = self.create_group(project=self.project)
         blocks = SlackIssuesMessageBuilder(group).build()
         assert self._has_autofix_button(blocks)
 
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @with_feature(
-        {
-            "organizations:gen-ai-features": True,
-            "organizations:seer-slack-workflows": False,
-        }
-    )
-    def test_autofix_button_hidden_without_slack_workflows_flag(
-        self, mock_quota: MagicMock
-    ) -> None:
-        group = self.create_group(project=self.project)
-        blocks = SlackIssuesMessageBuilder(group).build()
-        assert not self._has_autofix_button(blocks)
-
-    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @with_feature(
-        {
-            "organizations:gen-ai-features": True,
-            "organizations:seer-slack-workflows": True,
-        }
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_autofix_button_hidden_on_unfurl(self, mock_quota: MagicMock) -> None:
         group = self.create_group(project=self.project)
         blocks = SlackIssuesMessageBuilder(group, is_unfurl=True).build()
         assert not self._has_autofix_button(blocks)
 
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @with_feature(
-        {
-            "organizations:gen-ai-features": True,
-            "organizations:seer-slack-workflows": True,
-        }
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_autofix_button_hidden_when_no_other_actions(self, mock_quota: MagicMock) -> None:
         group = self.create_group(project=self.project)
         blocks = SlackIssuesMessageBuilder(group, issue_details=True).build()

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -417,61 +417,29 @@ class SlackEventRequestSeerResolutionTest(TestCase):
         assert result.halt_reason is None
 
     @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_feature_flag",
-        return_value=True,
-    )
-    @patch(
         "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
         return_value=False,
     )
-    def test_control_silo_skips_subscription_gated_access_check(
-        self, mock_has_access, mock_has_feature_flag
-    ):
+    def test_control_silo_skips_access_check(self, mock_has_access):
         """
         In control silo, has_access is not consulted (it depends on subscription context
         that getsentry's FlagpoleFeatureHandler does not populate in control silo).
-        Only has_feature_flag gates the control-silo check; the full verdict is deferred
-        to the cell handler.
+        The full verdict is deferred to the cell handler.
         """
         with assume_test_silo_mode(SiloMode.CONTROL, can_be_monolith=False):
             result = self.slack_request.resolve_seer_organization()
 
         assert result.organization_id == self.organization.id
         assert result.halt_reason is None
-        mock_has_feature_flag.assert_called()
         mock_has_access.assert_not_called()
 
-    @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_feature_flag",
-        return_value=False,
-    )
     @patch(
         "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
         return_value=True,
     )
-    def test_control_silo_halts_when_feature_flag_disabled(
-        self, mock_has_access, mock_has_feature_flag
-    ):
-        with assume_test_silo_mode(SiloMode.CONTROL, can_be_monolith=False):
-            result = self.slack_request.resolve_seer_organization()
-
-        assert result.organization_id is None
-        assert result.halt_reason == SeerSlackHaltReason.NO_VALID_ORGANIZATION
-        mock_has_feature_flag.assert_called()
-        mock_has_access.assert_not_called()
-
-    @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_feature_flag",
-        return_value=True,
-    )
-    @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
-        return_value=True,
-    )
-    def test_cell_silo_uses_full_access_check(self, mock_has_access, mock_has_feature_flag):
+    def test_cell_silo_uses_full_access_check(self, mock_has_access):
         """
         In cell silo, has_access (the subscription-gated check) is the gate.
-        has_feature_flag is not consulted independently — it only runs inside has_access.
         """
         with assume_test_silo_mode(SiloMode.CELL, can_be_monolith=False):
             result = self.slack_request.resolve_seer_organization()
@@ -479,7 +447,6 @@ class SlackEventRequestSeerResolutionTest(TestCase):
         assert result.organization_id == self.organization.id
         assert result.halt_reason is None
         mock_has_access.assert_called()
-        mock_has_feature_flag.assert_not_called()
 
     @patch("sentry.integrations.slack.requests.event.get_thread_history")
     @patch(

--- a/tests/sentry/integrations/slack/webhooks/events/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/events/__init__.py
@@ -12,7 +12,6 @@ from sentry.users.models.user import User
 UNSET = object()
 
 SEER_EXPLORER_FEATURES = {
-    "organizations:seer-slack-explorer": True,
     "organizations:gen-ai-features": True,
     "organizations:seer-explorer": True,
 }

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -521,16 +521,12 @@ class TestSeerRpcMethods(APITestCase):
     @patch("sentry.seer.endpoints.seer_rpc.process_autofix_updates")
     @patch("sentry.sentry_apps.tasks.sentry_apps.broadcast_webhooks_for_organization.delay")
     def test_send_seer_webhook_operator(self, mock_broadcast, mock_process_autofix_updates) -> None:
-        """Slack workflows flag should not affect broadcasting the webhooks."""
         from sentry.seer.endpoints.seer_rpc import send_seer_webhook
 
         event_payload = {"run_id": 123}
         event_name = "root_cause_completed"
 
-        with (
-            self.feature("organizations:seer-slack-workflows"),
-            patch("sentry.seer.entrypoints.operator.has_seer_access", return_value=True),
-        ):
+        with patch("sentry.seer.entrypoints.operator.has_seer_access", return_value=True):
             result = send_seer_webhook(
                 event_name=event_name,
                 organization_id=self.organization.id,

--- a/tests/sentry/seer/entrypoints/slack/test_slack.py
+++ b/tests/sentry/seer/entrypoints/slack/test_slack.py
@@ -77,10 +77,7 @@ class SlackAutofixEntrypointTest(TestCase):
         )
 
     def test_has_access(self) -> None:
-        with self.feature({"organizations:seer-slack-workflows": False}):
-            assert not SlackAutofixEntrypoint.has_access(self.organization)
-        with self.feature("organizations:seer-slack-workflows"):
-            assert SlackAutofixEntrypoint.has_access(self.organization)
+        assert SlackAutofixEntrypoint.has_access(self.organization)
 
     @patch("sentry.integrations.slack.integration.SlackIntegration.send_threaded_ephemeral_message")
     def test_on_trigger_autofix_error(self, mock_send_threaded_ephemeral_message):
@@ -598,33 +595,12 @@ class SlackAgentEntrypointTest(TestCase):
             "organizations:gen-ai-features": True,
             "organizations:seer-explorer": True,
         }
-        with self.feature({"organizations:seer-slack-explorer": False, **explorer_flags}):
-            assert not SlackAgentEntrypoint.has_access(self.organization)
-        with self.feature({"organizations:seer-slack-explorer": True, **explorer_flags}):
+        with self.feature(explorer_flags):
             assert SlackAgentEntrypoint.has_access(self.organization)
             self.organization.update_option("sentry:hide_ai_features", True)
             assert not SlackAgentEntrypoint.has_access(self.organization)
             self.organization.update_option("sentry:hide_ai_features", False)
             assert SlackAgentEntrypoint.has_access(self.organization)
-
-    def test_has_feature_flag(self) -> None:
-        """
-        has_feature_flag is the cheap, control-silo-safe gate: it only checks the Slack
-        feature flag, not the subscription-gated Seer Agent access. Used by the
-        parser to avoid evaluating Flagpole rules that need subscription context
-        (which getsentry's FlagpoleFeatureHandler does not populate in control silo).
-        """
-        with self.feature({"organizations:seer-slack-explorer": False}):
-            assert not SlackAgentEntrypoint.has_feature_flag(self.organization)
-        with self.feature({"organizations:seer-slack-explorer": True}):
-            assert SlackAgentEntrypoint.has_feature_flag(self.organization)
-
-        # hide_ai_features and the other subscription-gated signals must NOT influence
-        # has_feature_flag — that's precisely what makes it safe to call from control.
-        with self.feature({"organizations:seer-slack-explorer": True}):
-            self.organization.update_option("sentry:hide_ai_features", True)
-            assert SlackAgentEntrypoint.has_feature_flag(self.organization)
-            self.organization.update_option("sentry:hide_ai_features", False)
 
     @patch("sentry.integrations.slack.integration.SlackIntegration.send_threaded_ephemeral_message")
     def test_on_trigger_agent_error(self, mock_send_ephemeral):

--- a/tests/sentry/seer/entrypoints/slack/test_tasks.py
+++ b/tests/sentry/seer/entrypoints/slack/test_tasks.py
@@ -42,8 +42,6 @@ _SEER_SLACK_FEATURES = {
     "organizations:gen-ai-features": True,
     "organizations:seer-explorer": True,
     "organizations:autofix-on-explorer": True,
-    "organizations:seer-slack-explorer": True,
-    "organizations:seer-slack-workflows": True,
 }
 
 


### PR DESCRIPTION
removes the `seer-slack-workflows` and `seer-slack-explorer` feature flags, releasing both to everyone. all gating logic, flag registrations, and related tests have been cleaned up.