### PR TITLE
ref(seer): Move agent access check from entrypoint to operator

### DIFF
--- a/src/sentry/integrations/slack/requests/event.py
+++ b/src/sentry/integrations/slack/requests/event.py
@@ -21,8 +21,9 @@ from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmember import InviteStatus
 from sentry.organizations.services.organization.model import RpcUserOrganizationContext
 from sentry.organizations.services.organization.service import organization_service
-from sentry.seer.entrypoints.slack.entrypoint import SlackAgentEntrypoint
+from sentry.seer.entrypoints.operator import SeerAgentOperator
 from sentry.seer.entrypoints.slack.mention import _SLACK_URL_RE, build_thread_context
+from sentry.seer.entrypoints.types import SeerEntrypointKey
 from sentry.silo.base import SiloMode, all_silo_function
 from sentry.users.services.user.service import user_service
 
@@ -79,7 +80,9 @@ def _resolve_available_organizations(
         # In CONTROL silo the getsentry FeatureHandler does _not_ add subscription
         # context, so we skip the full access check — it is re-evaluated at CELL.
         if SiloMode.get_current_mode() != SiloMode.CONTROL:
-            if not SlackAgentEntrypoint.has_access(ctx.organization):
+            if not SeerAgentOperator.has_access(
+                organization=ctx.organization, entrypoint_key=SeerEntrypointKey.SLACK
+            ):
                 logger.info("_resolve_available_organizations.no_access", extra=logging_ctx)
                 continue
 

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -8,6 +8,7 @@ from sentry.constants import DataCategory
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.organization import Organization
+from sentry.organizations.services.organization import RpcOrganization
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import CodingAgentState, SeerRunState
 from sentry.seer.agent.client_utils import fetch_run_status
@@ -579,6 +580,45 @@ class SeerAutofixOperator[CachePayloadT]:
             )
 
 
+def has_seer_agent_entrypoint_access(
+    *,
+    organization: Organization | RpcOrganization,
+    entrypoint_key: SeerEntrypointKey | None = None,
+) -> bool:
+    """
+    Checks if the organization has access to Seer Agent and at least one agent entrypoint.
+    If an entrypoint_key is provided, ensures the organization has access to that specific
+    agent entrypoint.
+
+    Should not be called from the CONTROL silo since ``has_seer_agent_access_with_detail``
+    depends on subscription context that getsentry's FlagpoleFeatureHandler does not
+    populate in control silo.
+    """
+    from sentry.seer.agent.client_utils import has_seer_agent_access_with_detail
+
+    has_access, _ = has_seer_agent_access_with_detail(organization, None)
+    if not has_access:
+        return False
+
+    if entrypoint_key:
+        if entrypoint_key not in agent_entrypoint_registry.registrations:
+            logger.error(
+                "seer.operator.invalid_agent_entrypoint_key",
+                extra={
+                    "entrypoint_key": str(entrypoint_key),
+                    "organization_id": organization.id,
+                },
+            )
+            return False
+        entrypoint_cls = agent_entrypoint_registry.registrations[entrypoint_key]
+        return entrypoint_cls.has_access(organization)
+
+    return any(
+        entrypoint_cls.has_access(organization=organization)
+        for entrypoint_cls in agent_entrypoint_registry.registrations.values()
+    )
+
+
 class SeerAgentOperator[CachePayloadT]:
     """
     A class that connects to entrypoint implementations and runs Seer Agent operations.
@@ -587,6 +627,17 @@ class SeerAgentOperator[CachePayloadT]:
 
     def __init__(self, entrypoint: SeerAgentEntrypoint[CachePayloadT]):
         self.entrypoint = entrypoint
+
+    @classmethod
+    def has_access(
+        cls,
+        *,
+        organization: Organization | RpcOrganization,
+        entrypoint_key: SeerEntrypointKey | None = None,
+    ) -> bool:
+        return has_seer_agent_entrypoint_access(
+            organization=organization, entrypoint_key=entrypoint_key
+        )
 
     def trigger_agent(
         self,
@@ -969,6 +1020,10 @@ class SeerOperatorCompletionHook(AgentOnCompletionHook):
                     "organization_id": organization.id,
                 }
             )
+
+            if not SeerAgentOperator.has_access(organization=organization):
+                lifecycle.record_halt(halt_reason="no_operator_access")
+                return
 
             summary: str | None = None
             try:

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -16,7 +16,6 @@ from sentry.notifications.platform.templates.seer import (
 )
 from sentry.notifications.utils.actions import BlockKitMessageAction
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.seer.agent.client_utils import has_seer_agent_access_with_detail
 from sentry.seer.autofix.utils import AutofixStoppingPoint, CodingAgentProviderType
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.registry import (
@@ -503,16 +502,9 @@ class SlackAgentEntrypoint(
         self.install = SlackIntegration(model=integration, organization_id=organization_id)
         self.slack_user_id = slack_user_id
 
-    # TODO(Leander): This should probably move to the SeerAgentOperator class, any future entrypoint will be checking the same flag, not just Slack.
     @staticmethod
     def has_access(organization: Organization | RpcOrganization) -> bool:
-        """
-        Determines access to Seer Agent, along with the Slack feature. Shouldn't be called from
-        the CONTROL silo since `has_explorer_access_with_detail` will not get populated with the
-        subscription context, and will return False every time.
-        """
-        has_agent_access, _ = has_seer_agent_access_with_detail(organization, None)
-        return has_agent_access
+        return True
 
     def on_trigger_agent_error(self, *, error: str) -> None:
         send_thread_update(

--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -102,7 +102,9 @@ def process_mention_for_slack(
             lifecycle.record_failure(failure_reason=ProcessMentionFailureReason.ORG_NOT_FOUND)
             return
 
-        if not SlackAgentEntrypoint.has_access(organization):
+        if not SeerAgentOperator.has_access(
+            organization=organization, entrypoint_key=SeerEntrypointKey.SLACK
+        ):
             lifecycle.record_failure(failure_reason=ProcessMentionFailureReason.NO_AGENT_ACCESS)
             return
 
@@ -514,7 +516,9 @@ def process_reaction_for_slack(
             lifecycle.record_failure(failure_reason=ProcessReactionFailureReason.ORG_NOT_FOUND)
             return
 
-        if not SlackAgentEntrypoint.has_access(organization):
+        if not SeerAgentOperator.has_access(
+            organization=organization, entrypoint_key=SeerEntrypointKey.SLACK
+        ):
             lifecycle.record_halt(halt_reason=ProcessReactionHaltReason.NO_AGENT_ACCESS)
             return
 

--- a/src/sentry/seer/entrypoints/types.py
+++ b/src/sentry/seer/entrypoints/types.py
@@ -2,6 +2,7 @@ from enum import StrEnum
 from typing import Any, Literal, Protocol, TypedDict
 
 from sentry.models.organization import Organization
+from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.seer.autofix.utils import CodingAgentProviderType
 from sentry.sentry_apps.metrics import SentryAppEventType
 
@@ -112,11 +113,11 @@ class SeerAgentEntrypoint[CachePayloadT](Protocol):
     key: SeerEntrypointKey
 
     @staticmethod
-    def has_access(organization: Organization) -> bool:
+    def has_access(organization: Organization | RpcOrganization) -> bool:
         """
-        Used to gate access unless the organization has access to at least one entrypoint.
-        The caller will check for seer-access prior to this check, so no need to repeat
-        that check on the entrypoint.
+        Entrypoint-specific access gate. The operator checks general Seer Agent access
+        (``has_seer_agent_access_with_detail``) prior to this, so only entrypoint-specific
+        conditions belong here.
         """
         ...
 

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -383,7 +383,7 @@ class SlackEventRequestSeerResolutionTest(TestCase):
         assert result.halt_reason == SeerSlackHaltReason.NO_VALID_ORGANIZATION
 
     @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
+        "sentry.integrations.slack.requests.event.SeerAgentOperator.has_access",
         return_value=False,
     )
     def test_org_no_seer_access(self, mock_access):
@@ -408,7 +408,7 @@ class SlackEventRequestSeerResolutionTest(TestCase):
         assert result.halt_reason == SeerSlackHaltReason.NO_VALID_ORGANIZATION
 
     @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
+        "sentry.integrations.slack.requests.event.SeerAgentOperator.has_access",
         return_value=True,
     )
     def test_resolves_valid_organization(self, mock_access):
@@ -417,7 +417,7 @@ class SlackEventRequestSeerResolutionTest(TestCase):
         assert result.halt_reason is None
 
     @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
+        "sentry.integrations.slack.requests.event.SeerAgentOperator.has_access",
         return_value=False,
     )
     def test_control_silo_skips_access_check(self, mock_has_access):
@@ -434,7 +434,7 @@ class SlackEventRequestSeerResolutionTest(TestCase):
         mock_has_access.assert_not_called()
 
     @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
+        "sentry.integrations.slack.requests.event.SeerAgentOperator.has_access",
         return_value=True,
     )
     def test_cell_silo_uses_full_access_check(self, mock_has_access):
@@ -450,7 +450,7 @@ class SlackEventRequestSeerResolutionTest(TestCase):
 
     @patch("sentry.integrations.slack.requests.event.get_thread_history")
     @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
+        "sentry.integrations.slack.requests.event.SeerAgentOperator.has_access",
         return_value=True,
     )
     def test_multi_org_resolves_from_message_link(self, mock_access, mock_get_thread_history):
@@ -466,7 +466,7 @@ class SlackEventRequestSeerResolutionTest(TestCase):
 
     @patch("sentry.integrations.slack.requests.event.get_thread_history")
     @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
+        "sentry.integrations.slack.requests.event.SeerAgentOperator.has_access",
         return_value=True,
     )
     def test_multi_org_resolves_from_thread(self, mock_access, mock_get_thread_history):
@@ -481,7 +481,7 @@ class SlackEventRequestSeerResolutionTest(TestCase):
         assert result.halt_reason is None
 
     @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
+        "sentry.integrations.slack.requests.event.SeerAgentOperator.has_access",
         return_value=True,
     )
     def test_multi_org_ignores_link_for_unavailable_org(self, mock_access):
@@ -495,7 +495,7 @@ class SlackEventRequestSeerResolutionTest(TestCase):
 
     @patch("sentry.integrations.slack.requests.event.get_thread_history", return_value=[])
     @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
+        "sentry.integrations.slack.requests.event.SeerAgentOperator.has_access",
         return_value=True,
     )
     def test_multi_org_resolves_from_preference(self, mock_access, mock_get_thread_history):
@@ -510,7 +510,7 @@ class SlackEventRequestSeerResolutionTest(TestCase):
 
     @patch("sentry.integrations.slack.requests.event.get_thread_history", return_value=[])
     @patch(
-        "sentry.integrations.slack.requests.event.SlackAgentEntrypoint.has_access",
+        "sentry.integrations.slack.requests.event.SeerAgentOperator.has_access",
         return_value=True,
     )
     def test_multi_org_ignores_stale_preference(self, mock_access, mock_get_thread_history):

--- a/tests/sentry/seer/entrypoints/slack/test_slack.py
+++ b/tests/sentry/seer/entrypoints/slack/test_slack.py
@@ -591,16 +591,7 @@ class SlackAgentEntrypointTest(TestCase):
             )
 
     def test_has_access(self) -> None:
-        explorer_flags = {
-            "organizations:gen-ai-features": True,
-            "organizations:seer-explorer": True,
-        }
-        with self.feature(explorer_flags):
-            assert SlackAgentEntrypoint.has_access(self.organization)
-            self.organization.update_option("sentry:hide_ai_features", True)
-            assert not SlackAgentEntrypoint.has_access(self.organization)
-            self.organization.update_option("sentry:hide_ai_features", False)
-            assert SlackAgentEntrypoint.has_access(self.organization)
+        assert SlackAgentEntrypoint.has_access(self.organization)
 
     @patch("sentry.integrations.slack.integration.SlackIntegration.send_threaded_ephemeral_message")
     def test_on_trigger_agent_error(self, mock_send_ephemeral):

--- a/tests/sentry/seer/entrypoints/slack/test_tasks.py
+++ b/tests/sentry/seer/entrypoints/slack/test_tasks.py
@@ -70,7 +70,7 @@ class ProcessMentionForSlackTest(TestCase):
         mock_user = MagicMock(id=self.user.id, username="alice")
         mock_resolve_user.return_value = mock_user
 
-        mock_agent_cls.has_access.return_value = True
+        mock_operator_cls.has_access.return_value = True
         mock_entrypoint = MagicMock()
         mock_entrypoint.thread_ts = "1234567890.123456"
         mock_entrypoint.install.get_thread_history.return_value = []
@@ -118,7 +118,7 @@ class ProcessMentionForSlackTest(TestCase):
     def test_org_not_found(self, mock_agent_cls, mock_operator_cls, mock_record):
         self._run_task(organization_id=999999999)
 
-        mock_agent_cls.has_access.assert_not_called()
+        mock_operator_cls.has_access.assert_not_called()
         mock_agent_cls.assert_not_called()
         mock_operator_cls.assert_not_called()
         assert_failure_metric(mock_record, ProcessMentionFailureReason.ORG_NOT_FOUND)
@@ -127,7 +127,7 @@ class ProcessMentionForSlackTest(TestCase):
     @patch("sentry.seer.entrypoints.slack.tasks.SeerAgentOperator")
     @patch("sentry.seer.entrypoints.slack.tasks.SlackAgentEntrypoint")
     def test_no_agent_access(self, mock_agent_cls, mock_operator_cls, mock_record):
-        mock_agent_cls.has_access.return_value = False
+        mock_operator_cls.has_access.return_value = False
 
         self._run_task()
 
@@ -139,7 +139,7 @@ class ProcessMentionForSlackTest(TestCase):
     @patch("sentry.seer.entrypoints.slack.tasks.SeerAgentOperator")
     @patch("sentry.seer.entrypoints.slack.tasks.SlackAgentEntrypoint")
     def test_integration_not_found(self, mock_agent_cls, mock_operator_cls, mock_record):
-        mock_agent_cls.has_access.return_value = True
+        mock_operator_cls.has_access.return_value = True
         mock_agent_cls.side_effect = EntrypointSetupError("not found")
 
         self._run_task()
@@ -162,7 +162,7 @@ class ProcessMentionForSlackTest(TestCase):
     ):
         mock_resolve_user.return_value = None
 
-        mock_agent_cls.has_access.return_value = True
+        mock_operator_cls.has_access.return_value = True
         mock_entrypoint = MagicMock()
         mock_entrypoint.thread_ts = "1234567890.123456"
         mock_agent_cls.return_value = mock_entrypoint
@@ -196,7 +196,7 @@ class ProcessMentionForSlackTest(TestCase):
         mock_user = MagicMock(id=self.create_user().id)
         mock_resolve_user.return_value = mock_user
 
-        mock_agent_cls.has_access.return_value = True
+        mock_operator_cls.has_access.return_value = True
         mock_entrypoint = MagicMock()
         mock_agent_cls.return_value = mock_entrypoint
 
@@ -230,7 +230,7 @@ class ProcessMentionForSlackTest(TestCase):
     ):
         mock_resolve_user.return_value = MagicMock(id=self.user.id, username="alice")
 
-        mock_agent_cls.has_access.return_value = True
+        mock_operator_cls.has_access.return_value = True
         mock_entrypoint = MagicMock()
         mock_entrypoint.thread_ts = "1234567890.000001"
         mock_entrypoint.install.get_thread_history.return_value = [
@@ -294,7 +294,7 @@ class ProcessMentionForSlackTest(TestCase):
     def test_without_thread_context(self, mock_resolve_user, mock_agent_cls, mock_operator_cls):
         mock_resolve_user.return_value = MagicMock(id=self.user.id)
 
-        mock_agent_cls.has_access.return_value = True
+        mock_operator_cls.has_access.return_value = True
         mock_entrypoint = MagicMock()
         mock_entrypoint.thread_ts = "1234567890.123456"
         mock_agent_cls.return_value = mock_entrypoint
@@ -324,7 +324,7 @@ class ProcessMentionForSlackTest(TestCase):
     ):
         mock_resolve_user.return_value = MagicMock(id=self.user.id, username="alice")
 
-        mock_agent_cls.has_access.return_value = True
+        mock_operator_cls.has_access.return_value = True
         mock_entrypoint = MagicMock()
         mock_entrypoint.thread_ts = "1234567890.654321"
         mock_agent_cls.return_value = mock_entrypoint
@@ -368,7 +368,7 @@ class ProcessMentionForSlackTest(TestCase):
     ):
         mock_resolve_user.return_value = MagicMock(id=self.user.id)
 
-        mock_agent_cls.has_access.return_value = True
+        mock_operator_cls.has_access.return_value = True
         mock_entrypoint = MagicMock()
         mock_entrypoint.thread_ts = "1234567890.123456"
         mock_agent_cls.return_value = mock_entrypoint
@@ -440,7 +440,7 @@ class LinkedMessagesContextTest(TestCase):
         self.mock_operator.trigger_agent.return_value = 42
 
         self.mock_resolve_user.return_value = self.mock_user
-        self.mock_agent_cls.has_access.return_value = True
+        self.mock_operator_cls.has_access.return_value = True
         self.mock_agent_cls.return_value = self.mock_entrypoint
         self.mock_operator_cls.return_value = self.mock_operator
 

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from fixtures.seer.webhooks import MOCK_RUN_ID
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
+from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.seer.agent.client_models import (
     CodingAgentState,
     MemoryBlock,
@@ -1062,7 +1063,7 @@ class MockAgentEntrypoint(SeerAgentEntrypoint[MockCachePayload]):
         self.agent_run_ids: list[int] = []
 
     @staticmethod
-    def has_access(organization: Organization) -> bool:
+    def has_access(organization: Organization | RpcOrganization) -> bool:
         return True
 
     def on_trigger_agent_error(self, *, error: str) -> None:
@@ -1077,6 +1078,46 @@ class MockAgentEntrypoint(SeerAgentEntrypoint[MockCachePayload]):
     @staticmethod
     def on_agent_update(cache_payload: MockCachePayload, summary: str | None, run_id: int) -> None:
         return None
+
+
+class TestSeerAgentOperatorAccess(TestCase):
+    def setUp(self) -> None:
+        self.entrypoint = MockAgentEntrypoint()
+        self.operator = SeerAgentOperator(self.entrypoint)
+
+    def test_has_access_with_seer_agent(self):
+        MockNoAccessEntrypoint = Mock(spec=SeerAgentEntrypoint)
+        MockNoAccessEntrypoint.key = cast(SeerEntrypointKey, "MOCK_NO_ACCESS")
+        MockNoAccessEntrypoint.has_access.return_value = False
+        with (
+            self.feature(
+                {
+                    "organizations:gen-ai-features": True,
+                    "organizations:seer-explorer": True,
+                }
+            ),
+            patch.dict(
+                "sentry.seer.entrypoints.operator.agent_entrypoint_registry.registrations",
+                {
+                    MockAgentEntrypoint.key: MockAgentEntrypoint,
+                    MockNoAccessEntrypoint.key: MockNoAccessEntrypoint,
+                },
+                clear=True,
+            ),
+        ):
+            assert SeerAgentOperator.has_access(organization=self.organization)
+            assert SeerAgentOperator.has_access(
+                organization=self.organization,
+                entrypoint_key=MockAgentEntrypoint.key,
+            )
+            assert not SeerAgentOperator.has_access(
+                organization=self.organization,
+                entrypoint_key=MockNoAccessEntrypoint.key,
+            )
+
+    def test_has_access_without_seer_agent(self):
+        with self.feature({"organizations:gen-ai-features": False}):
+            assert not SeerAgentOperator.has_access(organization=self.organization)
 
 
 class TestSeerOperatorCompletionHook(TestCase):
@@ -1121,6 +1162,10 @@ class TestSeerOperatorCompletionHook(TestCase):
             patch(
                 "sentry.seer.entrypoints.operator.SeerOperatorAgentCache.get",
                 return_value=cache_return_value,
+            ),
+            patch(
+                "sentry.seer.entrypoints.operator.SeerAgentOperator.has_access",
+                return_value=True,
             ),
         ):
             SeerOperatorCompletionHook.execute(self.organization, MOCK_RUN_ID)
@@ -1180,8 +1225,9 @@ class TestSeerOperatorCompletionHook(TestCase):
             run_id=MOCK_RUN_ID,
         )
 
+    @patch("sentry.seer.entrypoints.operator.SeerAgentOperator.has_access", return_value=True)
     @patch("sentry.seer.entrypoints.operator.fetch_run_status")
-    def test_execute_returns_early_on_fetch_error(self, mock_fetch):
+    def test_execute_returns_early_on_fetch_error(self, mock_fetch, _mock_access):
         mock_fetch.side_effect = Exception("Seer is down")
         mock_entrypoint_cls = Mock(spec=SeerAgentEntrypoint)
 
@@ -1194,8 +1240,9 @@ class TestSeerOperatorCompletionHook(TestCase):
 
         mock_entrypoint_cls.on_agent_update.assert_not_called()
 
+    @patch("sentry.seer.entrypoints.operator.SeerAgentOperator.has_access", return_value=True)
     @patch("sentry.seer.entrypoints.operator.fetch_run_status")
-    def test_execute_skips_entrypoint_without_access(self, mock_fetch):
+    def test_execute_skips_entrypoint_without_access(self, mock_fetch, _mock_access):
         state = self._make_state(
             blocks=[
                 MemoryBlock(


### PR DESCRIPTION
moves the general seer agent access check from `SlackAgentEntrypoint.has_access` to `SeerAgentOperator.has_access`, mirroring the existing autofix operator pattern. callers now pass `entrypoint_key=SeerEntrypointKey.SLACK` so the operator gates on both general and entrypoint-level access.