### PR TITLE
fix(codecov): Require org:write for repository token regeneration

### DIFF
--- a/src/sentry/codecov/endpoints/repository_token_regenerate/repository_token_regenerate.py
+++ b/src/sentry/codecov/endpoints/repository_token_regenerate/repository_token_regenerate.py
@@ -17,13 +17,6 @@ from sentry.codecov.endpoints.repository_token_regenerate.serializers import (
 from sentry.integrations.services.integration.model import RpcIntegration
 
 
-class RepositoryTokenRegeneratePermission(OrganizationPermission):
-    scope_map = {
-        "GET": ["org:read", "org:write", "org:admin"],
-        "POST": ["org:read", "org:write", "org:admin"],
-    }
-
-
 @extend_schema(tags=["Prevent"])
 @cell_silo_endpoint
 class RepositoryTokenRegenerateEndpoint(CodecovEndpoint):
@@ -31,7 +24,7 @@ class RepositoryTokenRegenerateEndpoint(CodecovEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PUBLIC,
     }
-    permission_classes = (RepositoryTokenRegeneratePermission,)
+    permission_classes = (OrganizationPermission,)
 
     @extend_schema(
         operation_id="Regenerates a repository upload token and returns the new token",

--- a/tests/sentry/codecov/endpoints/test_repository_token_regenerate.py
+++ b/tests/sentry/codecov/endpoints/test_repository_token_regenerate.py
@@ -125,7 +125,7 @@ class RepositoryTokenRegenerateEndpointTest(APITestCase):
         self.create_member(
             user=user_with_write,
             organization=self.organization,
-            role="admin",  # admin role has org:write
+            role="manager",
         )
 
         # Create a user with no permissions
@@ -134,11 +134,10 @@ class RepositoryTokenRegenerateEndpointTest(APITestCase):
 
         url = self.reverse_url()
 
-        # Test that user with org:read can access the endpoint
+        # Test that user with only org:read cannot regenerate tokens
         self.login_as(user_with_read_only)
         response = self.client.post(url, data={})
-        # Should not be a 403 Forbidden (permission denied)
-        assert response.status_code == 200
+        assert response.status_code == 403
 
         # Test that user with org:write can access the endpoint
         self.login_as(user_with_write)


### PR DESCRIPTION
The custom RepositoryTokenRegeneratePermission allowed org:read for POST, letting any org member regenerate repository upload tokens. Use the base OrganizationPermission which correctly requires org:write.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
