### PR TITLE
ref(spans): Extract flush_segment pipeline helpers

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -101,10 +101,9 @@ import itertools
 import logging
 import math
 import time
-import uuid
 from collections.abc import Generator, Mapping, MutableMapping, Sequence
 from hashlib import blake2b
-from typing import Any, NamedTuple, cast
+from typing import Any, cast
 
 import orjson
 import zstandard
@@ -127,8 +126,12 @@ from sentry.spans.buffer_logger import (
 )
 from sentry.spans.buffer_types import (
     EvalshaResult,
+    FlushCandidate,
+    FlushedSegment,
     InsertedSubsegment,
     LoadedSegmentData,
+    OutputSpan,
+    QueueKey,
     Span,
     Subsegment,
 )
@@ -143,8 +146,6 @@ from sentry.spans.segment_key import (
 from sentry.utils import metrics, redis
 from sentry.utils.outcomes import Outcome, track_outcome
 
-QueueKey = bytes
-
 logger = logging.getLogger(__name__)
 
 
@@ -155,71 +156,11 @@ def get_redis_client() -> RedisCluster[bytes] | StrictRedis[bytes]:
 add_buffer_script = redis.load_redis_script("spans/add-buffer.lua")
 
 
-type SpanPayload = dict[str, Any]
-
-
 def _compute_salt(spans: Sequence[Span]) -> str:
     return blake2b(
         b"".join(s.span_id.encode("ascii") for s in spans),
         digest_size=16,
     ).hexdigest()
-
-
-class OutputSpan(NamedTuple):
-    payload: SpanPayload
-
-
-class FlushedSegment(NamedTuple):
-    queue_key: QueueKey
-    spans: list[OutputSpan]
-    project_id: int  # Used to track outcomes
-    payload_keys: list[PayloadKey] = []  # For cleanup
-
-    def to_messages(self) -> list[dict[str, Any]]:
-        """
-        Build producer messages for this segment.
-
-        If the segment size exceeds `spans.buffer.max_segment_bytes`, the segment is split
-        into multiple messages with skip_enrichment=True. Otherwise, returns a single message.
-
-        Each message gets a unique flush_id generated at call time, ensuring duplicate
-        flushes from Redis produce distinct IDs.
-        """
-        max_segment_bytes = options.get("spans.buffer.max-segment-bytes")
-
-        spans: list[SpanPayload] = [span.payload for span in self.spans]
-
-        sizes = [len(orjson.dumps(s)) for s in spans]
-        if sum(sizes) <= max_segment_bytes:
-            return [{"flush_id": uuid.uuid4().hex, "spans": spans}]
-
-        messages: list[dict[str, Any]] = []
-        current: list[SpanPayload] = []
-        current_size = 0
-
-        for span, size in zip(spans, sizes):
-            if current and current_size + size > max_segment_bytes:
-                messages.append(
-                    {"flush_id": uuid.uuid4().hex, "spans": current, "skip_enrichment": True}
-                )
-                current = []
-                current_size = 0
-            current.append(span)
-            current_size += size
-
-        if current:
-            messages.append(
-                {"flush_id": uuid.uuid4().hex, "spans": current, "skip_enrichment": True}
-            )
-
-        if len(messages) > 1:
-            metrics.timing(
-                "spans.buffer.oversized_segments_chunked",
-                len(messages),
-            )
-            metrics.timing("spans.buffer.oversized_segments_size", sum(sizes))
-
-        return messages
 
 
 class SpansBuffer:
@@ -656,12 +597,70 @@ class SpansBuffer:
         return locks_acquired
 
     def flush_segments(self, now: int) -> dict[SegmentKey, FlushedSegment]:
-        cutoff = now
+        """
+        Select queued segments and prepare them for Kafka production.
 
-        queue_keys = []
+        This orchestrates the flush path: load ready queue entries, acquire
+        per-segment locks, load payload data, emit loss/flush observability, and
+        return producer-ready FlushedSegment objects. SpanFlusher produces those
+        objects to Kafka and calls done_flush_segments after successful delivery.
+        """
         shard_factor = max(1, len(self.assigned_shards))
         max_flush_segments = options.get("spans.buffer.max-flush-segments")
         max_segments_per_shard = math.ceil(max_flush_segments / shard_factor)
+
+        flush_candidates, load_ids_latency_ms = self._load_flush_candidates(
+            cutoff=now,
+            max_segments_per_shard=max_segments_per_shard,
+        )
+
+        flush_candidates = self._acquire_locks_for_flush_candidates(flush_candidates)
+        segment_keys = [candidate.segment_key for candidate in flush_candidates]
+
+        loaded_segment_data, load_data_latency_ms, decompress_latency_ms = self._load_segment_data(
+            segment_keys
+        )
+
+        segment_to_queue = {
+            candidate.segment_key: candidate.queue_key for candidate in flush_candidates
+        }
+        self._record_segment_loss_metrics(
+            segment_keys,
+            segment_to_queue,
+            now,
+            loaded_segment_data.payloads,
+        )
+
+        flushed_segments, num_has_root_spans, any_shard_at_limit = self._build_flushed_segments(
+            flush_candidates,
+            loaded_segment_data,
+            max_segments_per_shard,
+            now,
+        )
+
+        self._flusher_logger.log_loaded_segments(
+            segment_keys,
+            loaded_segment_data.payloads,
+            load_ids_latency_ms=load_ids_latency_ms,
+            load_data_latency_ms=load_data_latency_ms,
+            decompress_latency_ms=decompress_latency_ms,
+        )
+
+        metrics.timing("spans.buffer.flush_segments.num_segments", len(flushed_segments))
+        metrics.timing("spans.buffer.flush_segments.has_root_span", num_has_root_spans)
+
+        self.any_shard_at_limit = any_shard_at_limit
+        return flushed_segments
+
+    def _load_flush_candidates(
+        self,
+        cutoff: int,
+        max_segments_per_shard: int,
+    ) -> tuple[list[FlushCandidate], int]:
+        """
+        Read ready segment keys from the assigned queue shards.
+        """
+        queue_keys = []
 
         ids_start = time.monotonic()
         with metrics.timer("spans.buffer.flush_segments.load_segment_ids"):
@@ -676,43 +675,52 @@ class SpansBuffer:
                 result = p.execute()
         load_ids_latency_ms = int((time.monotonic() - ids_start) * 1000)
 
-        segment_keys: list[tuple[int, QueueKey, SegmentKey, float]] = []
+        flush_candidates: list[FlushCandidate] = []
         for shard, queue_key, keys_with_scores in zip(self.assigned_shards, queue_keys, result):
             for segment_key, score in keys_with_scores:
-                segment_keys.append((shard, queue_key, segment_key, score))
+                flush_candidates.append(FlushCandidate(shard, queue_key, segment_key, score))
 
-        acquired_locks = self._acquire_flush_locks([k for _, _, k, _ in segment_keys])
-        segment_keys = [entry for entry in segment_keys if entry[2] in acquired_locks]
-        segment_key_values = [k for _, _, k, _ in segment_keys]
+        return flush_candidates, load_ids_latency_ms
 
-        data_start = time.monotonic()
-        with metrics.timer("spans.buffer.flush_segments.load_segment_data"):
-            # Pass queue mapping to enable TTL expiration detection
-            segment_to_queue = {
-                segment_key: queue_key for _, queue_key, segment_key, _ in segment_keys
-            }
-            loaded_segment_data, decompress_latency_ms = self._load_segment_data(segment_key_values)
-        load_data_latency_ms = int((time.monotonic() - data_start) * 1000)
-
-        self._record_segment_loss_metrics(
-            segment_key_values,
-            segment_to_queue,
-            now,
-            loaded_segment_data.payloads,
+    def _acquire_locks_for_flush_candidates(
+        self, flush_candidates: Sequence[FlushCandidate]
+    ) -> list[FlushCandidate]:
+        """
+        Acquire per-segment flush locks and keep the candidates that won.
+        """
+        acquired_locks = self._acquire_flush_locks(
+            [candidate.segment_key for candidate in flush_candidates]
         )
+        return [
+            flush_candidate
+            for flush_candidate in flush_candidates
+            if flush_candidate.segment_key in acquired_locks
+        ]
 
-        return_segments = {}
+    def _build_flushed_segments(
+        self,
+        flush_candidates: Sequence[FlushCandidate],
+        loaded_segment_data: LoadedSegmentData,
+        max_segments_per_shard: int,
+        now: int,
+    ) -> tuple[dict[SegmentKey, FlushedSegment], int, bool]:
+        """
+        Convert loaded payload bytes into FlushedSegment objects that contain
+        the segment metadata and span payloads.
+        """
+        return_segments: dict[SegmentKey, FlushedSegment] = {}
         num_has_root_spans = 0
         any_shard_at_limit = False
 
-        for shard, queue_key, segment_key, score in segment_keys:
+        for flush_candidate in flush_candidates:
+            segment_key = flush_candidate.segment_key
             segment_span_id = segment_key_to_span_id(segment_key).decode("ascii")
             segment = loaded_segment_data.payloads.get(segment_key, [])
             project_id, _, _ = parse_segment_key(segment_key)
             if len(segment) >= max_segments_per_shard:
                 any_shard_at_limit = True
 
-            output_spans = []
+            output_spans: list[OutputSpan] = []
             has_root_span = False
             metrics.timing("spans.buffer.flush_segments.num_spans_per_segment", len(segment))
             # This incr metric is needed to get a rate overall.
@@ -737,10 +745,11 @@ class SpansBuffer:
                 output_spans.append(OutputSpan(payload=cast(dict[str, Any], span)))
 
             metrics.incr(
-                "spans.buffer.flush_segments.num_segments_per_shard", tags={"shard_i": shard}
+                "spans.buffer.flush_segments.num_segments_per_shard",
+                tags={"shard_i": flush_candidate.shard},
             )
             return_segments[segment_key] = FlushedSegment(
-                queue_key=queue_key,
+                queue_key=flush_candidate.queue_key,
                 spans=output_spans,
                 project_id=int(project_id.decode("ascii")),
                 payload_keys=loaded_segment_data.payload_keys.get(segment_key, []),
@@ -752,46 +761,38 @@ class SpansBuffer:
                 segment_span_id=segment_span_id,
                 has_root_span=has_root_span,
                 num_spans=len(segment),
-                shard=shard,
-                queue_key=queue_key,
+                shard=flush_candidate.shard,
+                queue_key=flush_candidate.queue_key,
                 timestamp=now,
             ).emit(self._get_debug_trace_logger)
 
-        self._flusher_logger.log_loaded_segments(
-            segment_key_values,
-            loaded_segment_data.payloads,
-            load_ids_latency_ms=load_ids_latency_ms,
-            load_data_latency_ms=load_data_latency_ms,
-            decompress_latency_ms=decompress_latency_ms,
-        )
-
-        metrics.timing("spans.buffer.flush_segments.num_segments", len(return_segments))
-        metrics.timing("spans.buffer.flush_segments.has_root_span", num_has_root_spans)
-
-        self.any_shard_at_limit = any_shard_at_limit
-        return return_segments
+        return return_segments, num_has_root_spans, any_shard_at_limit
 
     def _load_segment_data(
         self,
         segment_keys: list[SegmentKey],
-    ) -> tuple[LoadedSegmentData, int]:
+    ) -> tuple[LoadedSegmentData, int, int]:
         """
-        Loads the segments from Redis, given a list of segment keys.
+        Load payload keys and span payload bytes for segment keys.
 
-        :param segment_keys: List of segment keys to load.
-        :return: Loaded payloads and payload keys, plus decompression latency.
+        This is the load-data orchestration step for flushing. It returns the
+        loaded payload data plus phase latencies for cumulative flusher logging.
         """
 
-        page_size = options.get("spans.buffer.segment-page-size")
-        payload_keys = self._load_payload_keys(segment_keys)
-        payloads, decompress_latency_ms = self._load_payloads_from_keys(
-            segment_keys,
-            payload_keys,
-            page_size,
-        )
+        data_start = time.monotonic()
+        with metrics.timer("spans.buffer.flush_segments.load_segment_data"):
+            page_size = options.get("spans.buffer.segment-page-size")
+            payload_keys = self._load_payload_keys(segment_keys)
+            payloads, decompress_latency_ms = self._load_payloads_from_keys(
+                segment_keys,
+                payload_keys,
+                page_size,
+            )
+        load_data_latency_ms = int((time.monotonic() - data_start) * 1000)
 
         return (
             LoadedSegmentData(payloads, payload_keys),
+            load_data_latency_ms,
             decompress_latency_ms,
         )
 
@@ -880,6 +881,9 @@ class SpansBuffer:
         now: int,
         payloads: dict[SegmentKey, list[bytes]],
     ) -> None:
+        """
+        Emit loss and expiration metrics for loaded segments.
+        """
         # Fetch ingested counts for all segments to calculate dropped spans
         with self.client.pipeline(transaction=False) as p:
             for key in segment_keys:

--- a/src/sentry/spans/buffer_types.py
+++ b/src/sentry/spans/buffer_types.py
@@ -1,19 +1,27 @@
 """
-Shared value types for the span buffer.
+Shared span buffer data structures.
 
-These types describe data passed between buffer pipeline steps. They do not
-own Redis operations, logging behavior, or Django model state.
+These types describe data passed between buffer pipeline steps. Some include
+small representation helpers, but Redis operations and Django model state stay
+outside this module.
 """
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Sequence
 from typing import Any, NamedTuple
 
+import orjson
+
+from sentry import options
 from sentry.spans.segment_key import PayloadKey, SegmentKey
+from sentry.utils import metrics
 
 type DataPoint = tuple[bytes, float]
 type EvalshaData = list[DataPoint]
+type QueueKey = bytes
+type SpanPayload = dict[str, Any]
 
 
 # NamedTuples are faster to construct than dataclasses
@@ -105,5 +113,92 @@ class InsertedSubsegment(NamedTuple):
 
 
 class LoadedSegmentData(NamedTuple):
+    """
+    Raw payload data loaded for flush candidates.
+    """
+
     payloads: dict[SegmentKey, list[bytes]]
     payload_keys: dict[SegmentKey, list[PayloadKey]]
+
+
+class OutputSpan(NamedTuple):
+    """
+    A span payload after flush-time segment metadata has been attached.
+    """
+
+    payload: SpanPayload
+
+
+class FlushCandidate(NamedTuple):
+    """
+    A queued segment that is ready to be considered for flushing.
+
+    At this stage only queue metadata is known; payload keys and span payloads
+    are loaded after the flush lock is acquired.
+    """
+
+    shard: int
+    queue_key: QueueKey
+    segment_key: SegmentKey
+    score: float
+
+
+class FlushedSegment(NamedTuple):
+    """
+    A buffered segment selected, loaded, and prepared for Kafka production.
+
+    The segment has not been produced to Kafka yet. SpanFlusher calls
+    `to_messages()` and produces those messages, then cleanup happens through
+    done_flush_segments.
+    """
+
+    queue_key: QueueKey
+    spans: list[OutputSpan]
+    project_id: int  # Used to track outcomes
+    payload_keys: list[PayloadKey] = []  # For cleanup
+
+    def to_messages(self) -> list[dict[str, Any]]:
+        """
+        Build producer messages for this segment.
+
+        If the segment size exceeds `spans.buffer.max_segment_bytes`, the segment is split
+        into multiple messages with skip_enrichment=True. Otherwise, returns a single message.
+
+        Each message gets a unique flush_id generated at call time, ensuring duplicate
+        flushes from Redis produce distinct IDs.
+        """
+        max_segment_bytes = options.get("spans.buffer.max-segment-bytes")
+
+        spans: list[SpanPayload] = [span.payload for span in self.spans]
+
+        sizes = [len(orjson.dumps(s)) for s in spans]
+        if sum(sizes) <= max_segment_bytes:
+            return [{"flush_id": uuid.uuid4().hex, "spans": spans}]
+
+        messages: list[dict[str, Any]] = []
+        current: list[SpanPayload] = []
+        current_size = 0
+
+        for span, size in zip(spans, sizes):
+            if current and current_size + size > max_segment_bytes:
+                messages.append(
+                    {"flush_id": uuid.uuid4().hex, "spans": current, "skip_enrichment": True}
+                )
+                current = []
+                current_size = 0
+            current.append(span)
+            current_size += size
+
+        if current:
+            messages.append(
+                {"flush_id": uuid.uuid4().hex, "spans": current, "skip_enrichment": True}
+            )
+
+        if len(messages) > 1:
+            metrics.timing(
+                "spans.buffer.oversized_segments_chunked",
+                len(messages),
+            )
+            metrics.timing("spans.buffer.oversized_segments_size", sum(sizes))
+
+        return messages

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -10,8 +10,8 @@ from arroyo.processing.strategies.noop import Noop
 from django.test import override_settings
 
 from sentry.conf.types.kafka_definition import Topic
-from sentry.spans.buffer import FlushedSegment, OutputSpan, SpansBuffer
-from sentry.spans.buffer_types import Span
+from sentry.spans.buffer import SpansBuffer
+from sentry.spans.buffer_types import FlushedSegment, OutputSpan, Span
 from sentry.spans.consumers.process.flusher import MultiProducer, SpanFlusher
 from sentry.testutils.helpers.options import override_options
 from tests.sentry.spans.test_buffer import DEFAULT_OPTIONS

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -15,14 +15,14 @@ from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.constants import DataCategory
-from sentry.spans.buffer import (
-    FlushedSegment,
-    OutputSpan,
-    SpansBuffer,
-)
+from sentry.spans.buffer import SpansBuffer
 from sentry.spans.buffer_types import (
     EvalshaResult,
+    FlushCandidate,
+    FlushedSegment,
     InsertedSubsegment,
+    LoadedSegmentData,
+    OutputSpan,
     Span,
     Subsegment,
 )
@@ -1967,6 +1967,30 @@ class _LoadSegmentDataRedis:
     def zscore(self, key: bytes, value: bytes) -> float | None:
         return self.zsets.get(key, {}).get(value)
 
+    def zrangebyscore(
+        self,
+        key: bytes,
+        min_score: int,
+        max_score: int,
+        start: int = 0,
+        num: int | None = None,
+        withscores: bool = False,
+    ):
+        values = [
+            (value, score)
+            for value, score in self.zsets.get(key, {}).items()
+            if min_score <= score <= max_score
+        ]
+        values.sort(key=lambda item: item[1])
+        if num is not None:
+            values = values[start : start + num]
+        else:
+            values = values[start:]
+
+        if withscores:
+            return values
+        return [value for value, _ in values]
+
 
 class _LoadSegmentDataPipeline:
     def __init__(self, client: _LoadSegmentDataRedis) -> None:
@@ -1987,6 +2011,17 @@ class _LoadSegmentDataPipeline:
 
     def get(self, key: bytes) -> None:
         self.commands.append(("get", (key,)))
+
+    def zrangebyscore(
+        self,
+        key: bytes,
+        min_score: int,
+        max_score: int,
+        start: int = 0,
+        num: int | None = None,
+        withscores: bool = False,
+    ) -> None:
+        self.commands.append(("zrangebyscore", (key, min_score, max_score, start, num, withscores)))
 
     def execute(self):
         results = []
@@ -2013,6 +2048,73 @@ def load_segment_buffer() -> Iterator[SpansBuffer]:
         buffer = SpansBuffer(assigned_shards=[0])
         buffer.__dict__["client"] = _LoadSegmentDataRedis()
         yield buffer
+
+
+def test_load_flush_candidates_reads_ready_segments(load_segment_buffer: SpansBuffer) -> None:
+    buffer = load_segment_buffer
+    queue_key = buffer._get_queue_key(0)
+    ready_segment_key = _segment_id(1, "a" * 32, "b" * 16)
+    later_segment_key = _segment_id(1, "a" * 32, "c" * 16)
+    buffer.client.zadd(queue_key, {ready_segment_key: 5, later_segment_key: 15})
+
+    flush_candidates, load_ids_latency_ms = buffer._load_flush_candidates(
+        cutoff=10,
+        max_segments_per_shard=10,
+    )
+
+    assert flush_candidates == [FlushCandidate(0, queue_key, ready_segment_key, 5)]
+    assert load_ids_latency_ms >= 0
+
+
+def test_acquire_locks_for_flush_candidates_keeps_acquired_locks() -> None:
+    buffer = SpansBuffer(assigned_shards=[0])
+    first_segment_key = _segment_id(1, "a" * 32, "b" * 16)
+    second_segment_key = _segment_id(1, "a" * 32, "c" * 16)
+    first_candidate = FlushCandidate(0, b"queue", first_segment_key, 5)
+    second_candidate = FlushCandidate(0, b"queue", second_segment_key, 10)
+
+    with mock.patch.object(
+        buffer, "_acquire_flush_locks", return_value={second_segment_key}
+    ) as acquire_flush_locks:
+        flush_candidates = buffer._acquire_locks_for_flush_candidates(
+            [first_candidate, second_candidate]
+        )
+
+    assert flush_candidates == [second_candidate]
+    acquire_flush_locks.assert_called_once_with([first_segment_key, second_segment_key])
+
+
+def test_build_flushed_segments_adds_segment_metadata() -> None:
+    buffer = SpansBuffer(assigned_shards=[0])
+    trace_id = "a" * 32
+    segment_span_id = "b" * 16
+    child_span_id = "c" * 16
+    segment_key = _segment_id(1, trace_id, segment_span_id)
+    queue_key = buffer._get_queue_key(0)
+    payload_key = _payload_key(1, trace_id, "1" * 32)
+
+    flushed_segments, num_has_root_spans, _ = buffer._build_flushed_segments(
+        [FlushCandidate(0, queue_key, segment_key, 5)],
+        LoadedSegmentData(
+            payloads={segment_key: [_payload(segment_span_id), _payload(child_span_id)]},
+            payload_keys={segment_key: [payload_key]},
+        ),
+        max_segments_per_shard=2,
+        now=10,
+    )
+
+    flushed_segment = flushed_segments[segment_key]
+    output_payloads = {span.payload["span_id"]: span.payload for span in flushed_segment.spans}
+    assert flushed_segment.queue_key == queue_key
+    assert flushed_segment.project_id == 1
+    assert flushed_segment.payload_keys == [payload_key]
+    assert output_payloads[segment_span_id]["is_segment"] is True
+    assert output_payloads[child_span_id]["is_segment"] is False
+    assert (
+        output_payloads[child_span_id]["attributes"]["sentry.segment.id"]["value"]
+        == segment_span_id
+    )
+    assert num_has_root_spans == 1
 
 
 def test_load_payload_keys_from_distributed_keys(
@@ -2077,7 +2179,7 @@ def test_load_segment_data_reads_payloads_from_distributed_keys(
     buffer.client.set(b"span-buf:ic:" + segment_key, 3)
     buffer.client.set(b"span-buf:ibc:" + segment_key, len(span_a) + len(span_b) + len(span_c))
 
-    loaded_segment_data, _ = buffer._load_segment_data([segment_key])
+    loaded_segment_data, _, _ = buffer._load_segment_data([segment_key])
 
     assert set(loaded_segment_data.payloads[segment_key]) == {span_a, span_b, span_c}
     assert set(loaded_segment_data.payload_keys[segment_key]) == {
@@ -2102,10 +2204,13 @@ def test_load_segment_data_decompresses_payload_batches(
     buffer.client.sadd(payload_key, compressed)
     buffer.client.set(b"span-buf:ic:" + segment_key, 2)
 
-    loaded_segment_data, decompress_latency_ms = buffer._load_segment_data([segment_key])
+    loaded_segment_data, load_data_latency_ms, decompress_latency_ms = buffer._load_segment_data(
+        [segment_key]
+    )
 
     assert set(loaded_segment_data.payloads[segment_key]) == {span_a, span_b}
     assert loaded_segment_data.payload_keys[segment_key] == [payload_key]
+    assert load_data_latency_ms >= 0
     assert decompress_latency_ms >= 0
 
 
@@ -2130,7 +2235,7 @@ def test_record_segment_loss_metrics_records_dropped_spans(
         mock.patch("sentry.spans.buffer.track_outcome") as track_outcome,
     ):
         project_model.objects.get_from_cache.return_value = mock_project
-        loaded_segment_data, _ = buffer._load_segment_data([segment_key])
+        loaded_segment_data, _, _ = buffer._load_segment_data([segment_key])
         buffer._record_segment_loss_metrics(
             [segment_key],
             {},
@@ -2178,7 +2283,7 @@ def test_record_segment_loss_metrics_records_empty_expired_segments(
     buffer.client.zadd(queue_key, {segment_key: deadline})
 
     with mock.patch("sentry.spans.buffer.metrics.incr") as metrics_incr:
-        loaded_segment_data, _ = buffer._load_segment_data([segment_key])
+        loaded_segment_data, _, _ = buffer._load_segment_data([segment_key])
         buffer._record_segment_loss_metrics(
             [segment_key],
             {segment_key: queue_key},


### PR DESCRIPTION
Refs STREAM-1001

Refactors the `flush_segments` to be an orchestration function with unit testable helpers:

- `_load_flush_candidates`: loading ready flush candidates from queue shards
- `_acquire_locks_for_flush_candidates`: acquiring per-segment flush locks
- `_load_segment_data`: loading payload keys and payload bytes
- `_build_flushed_segments`: building producer-ready `FlushedSegment` objects
- `_record_segment_loss_metrics`: recording segment loss / expiration metrics

Also adds/moves datamodels (`FlushCandidate`, `FlushedSegment`, `OutputSpan`) into `buffer_types.py` alongside the existing span buffer value types.