### PR TITLE
feat(replays): Add EAP `spans` dataset support to replay counts endpoint

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -34,6 +34,7 @@ class ReplayCountQueryParamsValidator(serializers.Serializer):
             Dataset.Events.value,
             Dataset.Transactions.value,
             Dataset.IssuePlatform.value,
+            "spans",
         ),
         default=Dataset.Discover.value,
     )

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -22,6 +22,7 @@ from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.replays.permissions import has_replay_permission
 from sentry.replays.usecases.replay_counts import get_replay_counts
+from sentry.search.eap.types import SupportedTraceItemType
 from sentry.snuba.dataset import Dataset
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -34,7 +35,7 @@ class ReplayCountQueryParamsValidator(serializers.Serializer):
             Dataset.Events.value,
             Dataset.Transactions.value,
             Dataset.IssuePlatform.value,
-            "spans",
+            SupportedTraceItemType.SPANS.value,
         ),
         default=Dataset.Discover.value,
     )

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -9,7 +9,7 @@ from typing import Any, Literal, Protocol, overload
 from sentry.api.event_search import ParenExpression, QueryToken, SearchFilter, parse_search_query
 from sentry.models.group import Group
 from sentry.replays.query import query_replays_count
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events.types import EventsResponse, SnubaParams
 from sentry.snuba import discover, errors, issue_platform, transactions
 from sentry.snuba.dataset import Dataset
@@ -73,7 +73,7 @@ def get_replay_counts(
         raise ValueError("Must provide start and end")
 
     if not isinstance(data_source, Dataset):
-        if data_source == "spans":
+        if data_source == SupportedTraceItemType.SPANS.value:
             data_source = Dataset.EventsAnalyticsPlatform
         else:
             data_source = Dataset(data_source)

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -9,9 +9,11 @@ from typing import Any, Literal, Protocol, overload
 from sentry.api.event_search import ParenExpression, QueryToken, SearchFilter, parse_search_query
 from sentry.models.group import Group
 from sentry.replays.query import query_replays_count
+from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import EventsResponse, SnubaParams
 from sentry.snuba import discover, errors, issue_platform, transactions
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.spans_rpc import Spans
 
 MAX_REPLAY_COUNT = 51
 MAX_VALS_PROVIDED = {
@@ -71,7 +73,10 @@ def get_replay_counts(
         raise ValueError("Must provide start and end")
 
     if not isinstance(data_source, Dataset):
-        data_source = Dataset(data_source)
+        if data_source == "spans":
+            data_source = Dataset.EventsAnalyticsPlatform
+        else:
+            data_source = Dataset(data_source)
 
     replay_ids_mapping = _get_replay_id_mappings(query, snuba_params, data_source)
 
@@ -105,13 +110,7 @@ def _get_replay_id_mappings(
     If select_column is replay_id, return an identity map of replay_id -> [replay_id].
     The keys of the returned dict are UUIDs, represented as 32 char hex strings (all '-'s stripped)
     """
-    if data_source not in _DATASET_QUERY_FUNCS:
-        raise ValueError("Invalid data source")
-    search_query_func = _DATASET_QUERY_FUNCS[data_source]
-
     select_column, column_value = _get_select_column(query)
-    if data_source != Dataset.IssuePlatform:
-        query = query + FILTER_HAS_A_REPLAY
 
     if select_column == "replay_id":
         # just return a mapping of replay_id:replay_id instead of hitting the dataset.
@@ -145,6 +144,20 @@ def _get_replay_id_mappings(
         if not snuba_params.projects:
             return {}
 
+    if data_source == Dataset.EventsAnalyticsPlatform:
+        if len(column_value) != 1:
+            raise ValueError("The spans data source only supports a single value")
+        return _query_eap_spans_for_replay_ids(
+            query + FILTER_HAS_A_REPLAY, snuba_params, column_value[0]
+        )
+
+    if data_source not in _DATASET_QUERY_FUNCS:
+        raise ValueError("Invalid data source")
+    search_query_func = _DATASET_QUERY_FUNCS[data_source]
+
+    if data_source != Dataset.IssuePlatform:
+        query = query + FILTER_HAS_A_REPLAY
+
     results = search_query_func(
         snuba_params=snuba_params,
         selected_columns=["group_uniq_array(100,replay.id)", select_column],
@@ -166,6 +179,36 @@ def _get_replay_id_mappings(
                 replay_id_to_issue_map[replay_id].append(row[select_column])
 
     return replay_id_to_issue_map
+
+
+def _query_eap_spans_for_replay_ids(
+    query: str,
+    snuba_params: SnubaParams,
+    identifier: Any,
+) -> dict[str, list[Any]]:
+    """Query EAP spans for unique replay IDs matching the given identifier."""
+    result = Spans.run_table_query(
+        params=snuba_params,
+        query_string=query,
+        # We don't care about the count(), but it forces grouping by the other
+        # columns (so `replay.id`s will be unique).
+        selected_columns=["replay.id", "count()"],
+        orderby=None,
+        offset=0,
+        limit=2500,
+        referrer="api.organization-issue-replay-count",
+        config=SearchResolverConfig(),
+        sampling_mode="HIGHEST_ACCURACY",
+    )
+
+    replay_id_to_identifier_map = defaultdict(list)
+    for row in result["data"]:
+        replay_id = row.get("replay.id", "")
+        if replay_id:
+            replay_id = replay_id.replace("-", "")
+            replay_id_to_identifier_map[replay_id].append(identifier)
+
+    return replay_id_to_identifier_map
 
 
 def _get_counts(replay_results: Any, replay_ids_mapping: dict[str, list[int]]) -> dict[int, int]:

--- a/tests/sentry/replays/endpoints/test_organization_replay_count.py
+++ b/tests/sentry/replays/endpoints/test_organization_replay_count.py
@@ -18,6 +18,7 @@ from sentry.testutils.cases import (
     PerformanceIssueTestCase,
     ReplaysSnubaTestCase,
     SnubaTestCase,
+    SpanTestCase,
 )
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
@@ -26,7 +27,7 @@ pytestmark = pytest.mark.sentry_metrics
 
 
 class OrganizationReplayCountEndpointTest(
-    APITestCase, SnubaTestCase, ReplaysSnubaTestCase, PerformanceIssueTestCase
+    APITestCase, SnubaTestCase, ReplaysSnubaTestCase, PerformanceIssueTestCase, SpanTestCase
 ):
     def setUp(self) -> None:
         super().setUp()
@@ -730,3 +731,77 @@ class OrganizationReplayCountEndpointTest(
         # The restricted user must not receive data for project_b's group.
         assert response.status_code == 200, response.content
         assert response.data == {}
+
+    def test_eap_spans_transaction(self) -> None:
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
+        nonexistent_replay_id = uuid.uuid4().hex
+
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay1_id,
+            )
+        )
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay2_id,
+            )
+        )
+
+        ten_mins_ago = before_now(minutes=10)
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "sentry_tags": {
+                            "replay_id": replay1_id,
+                            "transaction": "/api/foo/",
+                        },
+                    },
+                    start_ts=ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "sentry_tags": {
+                            "replay_id": replay2_id,
+                            "transaction": "/api/foo/",
+                        },
+                    },
+                    start_ts=ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "sentry_tags": {
+                            "replay_id": nonexistent_replay_id,
+                            "transaction": "/api/foo/",
+                        },
+                    },
+                    start_ts=ten_mins_ago,
+                ),
+            ],
+        )
+
+        query = {
+            "query": 'transaction:["/api/foo/"]',
+            "data_source": "spans",
+        }
+        with self.feature(self.features):
+            response = self.client.get(self.url, query, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data == {"/api/foo/": 2}
+
+    def test_eap_spans_multiple_values_rejected(self) -> None:
+        query = {
+            "query": 'transaction:["/api/foo/","/api/bar/"]',
+            "data_source": "spans",
+        }
+        with self.feature(self.features):
+            response = self.client.get(self.url, query, format="json")
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "The spans data source only supports a single value"


### PR DESCRIPTION
## History

- this `/replay-counts/` endpoint has three modes, basically:
1. get replay count for each given issue ID
2. get replay count for each given transaction name
3. check if the given replay IDs exist
- the transaction details screen needs to get the replay count for a particular transaction name, and historically did so using mode 2 above
- but, that uses the deprecated `transactions` dataset behind the scenes and won't work for span streaming
- so, we [replaced the FE implementation]() to instead first get a list of replay IDs by querying spans, then passing that to mode 3 above
- that relied on the semantics that the `replayId` attribute was only set when a replay was actually going to be sent to sentry
- but, that semantic is no longer available in span streaming when recording replays in `buffer` mode (only send when there's an error), because most spans will finish before we know if the replay is going to be sent or not
- you are here

## This PR

The new semantics for `replay.id` (the replacement for `replayId`) mean that we can't tell whether or not the replay actually exists just because an ID exists. That means even if the count display caps at `50+`, we might have to query hundreds or thousands of replays to find 51 existing replays. We can only request 100 rows at a time from the frontend, so we have to make calls in a loop. Doing API calls in loops via effects in React is miserable. Forget it.

Instead, update `/replay-counts/` to support EAP spans dataset. That means we can query way more rows at once, if we have to loop we can do so easily (note: this PR does not), and we only pay the latency cost to the Sentry API once.

The big caveat:

This new `spans` data source is **capped to a single transaction name**. There is no way with EAP to construct a single query to get the replay IDs for multiple transaction names at once in a way that will return enough data to get a reasonable count, and we don't want to make a separate query per given transaction name. I argue this is okay because:
- the frontend only needs to look up one transaction name at a time
- this only applies to the new `spans` data source, which has no existing callers, so no backwards compat concerns

This is a public API, but the data source param isn't even documented as part of it. If it was, we'd document the limitation of `spans` there.

---

🤖: Claude Code (Opus 4.6) helped with the code. Edited + carefully reviewed by me. All words mine.