### PR TITLE
fix(issues): match short id when combined with filters

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -175,11 +175,16 @@ def get_by_short_id(
     is_short_id_lookup: str,
     query: str,
 ) -> Group | None:
-    if is_short_id_lookup == "1" and looks_like_short_id(query):
-        try:
-            return Group.objects.by_qualified_short_id(organization_id, query)
-        except Group.DoesNotExist:
-            pass
+    if is_short_id_lookup != "1":
+        return None
+    # A short id token anywhere in the query is treated as a direct hit,
+    # so it composes with filters.
+    for token in query.split():
+        if looks_like_short_id(token):
+            try:
+                return Group.objects.by_qualified_short_id(organization_id, token)
+            except Group.DoesNotExist:
+                continue
     return None
 
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -732,6 +732,29 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert len(response.data) == 0
         assert response.get("X-Sentry-Direct-Hit") != "1"
 
+    def test_lookup_by_short_id_with_filter(self) -> None:
+        group = self.group
+        short_id = group.qualified_short_id
+
+        self.login_as(user=self.user)
+        response = self.get_success_response(query=f"is:unresolved {short_id}", shortIdLookup=1)
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(group.id)
+        assert response["X-Sentry-Direct-Hit"] == "1"
+
+    def test_lookup_by_short_id_with_filter_resolved(self) -> None:
+        group = self.group
+        group.status = GroupStatus.RESOLVED
+        group.substatus = None
+        group.save()
+        short_id = group.qualified_short_id
+
+        self.login_as(user=self.user)
+        response = self.get_success_response(query=f"is:unresolved {short_id}", shortIdLookup=1)
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(group.id)
+        assert response["X-Sentry-Direct-Hit"] == "1"
+
     def test_lookup_by_group_id(self) -> None:
         self.login_as(user=self.user)
         response = self.get_success_response(group=self.group.id)


### PR DESCRIPTION
If a user searches an issue short-id directly, we move them to the issue details page. However, if the user inputted the short id + any filters, we wouldn't match on that. Match short ids in those cases by scanning every query parameter.