### PR TITLE
fix(replay): Remove extra padding on replay details page

### DIFF
--- a/static/app/views/explore/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/explore/replays/detail/layout/replayLayout.tsx
@@ -169,7 +169,6 @@ const BodyGrid = styled('div')`
   display: grid;
   grid-template-rows: 1fr auto;
   gap: ${p => p.theme.space.xl};
-  padding: ${p => p.theme.space.xl};
   flex: 1;
 
   /*


### PR DESCRIPTION
**Before**
Notice how the tabs on the right, "Trace" sticks out closer to the window edge compared to the table below it.

<img width="1064" height="729" alt="SCR-20260525-sdow" src="https://github.com/user-attachments/assets/ee9cf77d-c3ac-4f7d-839c-c71b55f1e9b3" />

**After**
This is consistent with the Issue Feed and other pages. Pages should not wrap their stuff with their own padding.
<img width="1064" height="729" alt="SCR-20260525-sdpr" src="https://github.com/user-attachments/assets/c1f71f48-ddc5-4fa0-b781-fb3afb114831" />
