### PR TITLE
ref(explore): port toolTags to scraps layout primitives

### DIFF
--- a/static/app/views/explore/conversations/components/toolTags.tsx
+++ b/static/app/views/explore/conversations/components/toolTags.tsx
@@ -1,9 +1,8 @@
 import {useEffect, useRef, useState} from 'react';
-import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
 
@@ -59,7 +58,16 @@ export function ToolTags({toolNames}: ToolTagsProps) {
   }, [toolNames, expanded, hiddenCount]);
 
   return (
-    <ToolTagsContainer ref={containerRef} expanded={expanded}>
+    <Flex
+      ref={containerRef}
+      align="center"
+      gap="sm"
+      wrap="wrap"
+      overflow="hidden"
+      position="relative"
+      maxHeight={expanded ? '500px' : `${TWO_ROW_HEIGHT}px`}
+      style={{transition: 'max-height 0.2s ease-in-out'}}
+    >
       {toolNames.map((toolName, index) => (
         <Tag
           key={toolName}
@@ -77,47 +85,28 @@ export function ToolTags({toolNames}: ToolTagsProps) {
         </Tag>
       ))}
       {hiddenCount > 0 && !expanded && (
-        <ToggleButtonWrapper ref={toggleButtonRef}>
-          <ToggleButton
-            variant="link"
-            size="xs"
-            onClick={() => setExpanded(prev => !prev)}
-          >
+        <Flex
+          ref={toggleButtonRef}
+          align="center"
+          position="absolute"
+          right="0"
+          bottom="4px"
+          height="22px"
+          background="primary"
+          paddingLeft="sm"
+        >
+          <Button variant="link" size="xs" onClick={() => setExpanded(prev => !prev)}>
             {t('+%s more', hiddenCount)}
-          </ToggleButton>
-        </ToggleButtonWrapper>
+          </Button>
+        </Flex>
       )}
       {expanded && (
-        <ToggleButton variant="link" size="xs" onClick={() => setExpanded(prev => !prev)}>
-          {t('Show less')}
-        </ToggleButton>
+        <Container flexShrink={0}>
+          <Button variant="link" size="xs" onClick={() => setExpanded(prev => !prev)}>
+            {t('Show less')}
+          </Button>
+        </Container>
       )}
-    </ToolTagsContainer>
+    </Flex>
   );
 }
-
-const ToolTagsContainer = styled(Flex)<{expanded: boolean}>`
-  align-items: center;
-  flex-direction: row;
-  gap: ${p => p.theme.space.sm};
-  flex-wrap: wrap;
-  overflow: hidden;
-  position: relative;
-  max-height: ${p => (p.expanded ? '500px' : `${TWO_ROW_HEIGHT}px`)};
-  transition: max-height 0.2s ease-in-out;
-`;
-
-const ToggleButtonWrapper = styled('div')`
-  position: absolute;
-  right: 0;
-  bottom: 4px;
-  display: flex;
-  align-items: center;
-  height: 22px;
-  background: ${p => p.theme.tokens.background.primary};
-  padding-left: ${p => p.theme.space.sm};
-`;
-
-const ToggleButton = styled(Button)`
-  flex-shrink: 0;
-`;


### PR DESCRIPTION
## Summary

- Replace the emotion `styled` wrappers (`ToolTagsContainer`, `ToggleButtonWrapper`, `ToggleButton`) in `toolTags.tsx` with `Flex` and `Container` from `@sentry/scraps/layout`, moving the layout props onto the JSX.