### PR TITLE
ref(autofix): Remove legacy autofix path from GroupAutofixEndpoint

### DIFF
--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -24,14 +24,9 @@ from sentry.apidocs.examples.autofix_examples import AutofixExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
-from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
-from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
-from sentry.models.organization import Organization
-from sentry.models.repository import Repository
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.seer.autofix.autofix import trigger_legacy_autofix
 from sentry.seer.autofix.autofix_agent import (
     UNKNOWN_RUN_ID_FOR_GROUP,
     AutofixStep,
@@ -50,13 +45,10 @@ from sentry.seer.autofix.types import AutofixPostResponse, AutofixStateResponse
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     CodingAgentProviderType,
-    get_autofix_state,
     has_project_connected_repos,
 )
 from sentry.seer.models import SeerPermissionError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.users.services.user.service import user_service
-from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
 
@@ -75,30 +67,6 @@ def _parse_autofix_referrer(raw: str | None) -> AutofixReferrer:
     except ValueError:
         logger.warning("group_ai_autofix.unknown_referrer", extra={"referrer": raw})
         return AutofixReferrer.UNKNOWN
-
-
-class AutofixRequestSerializer(CamelSnakeSerializer):
-    event_id = serializers.CharField(
-        required=False,
-        help_text="Run issue fix on a specific event. If not provided, the recommended event for the issue will be used.",
-    )
-    instruction = serializers.CharField(
-        required=False,
-        help_text="Optional custom instruction to guide the issue fix process.",
-        allow_blank=True,
-    )
-    pr_to_comment_on_url = serializers.URLField(
-        required=False, help_text="URL of a pull request where the issue fix should add comments."
-    )
-    stopping_point = serializers.ChoiceField(
-        required=False,
-        choices=["root_cause", "solution", "code_changes", "open_pr"],
-        help_text="Where the issue fix process should stop. If not provided, will run to root cause.",
-    )
-    referrer = serializers.CharField(
-        required=False,
-        help_text="Referrer identifying where the issue fix was triggered from.",
-    )
 
 
 class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
@@ -184,9 +152,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         }
     )
 
-    def _should_use_agent(self, request: Request, organization: Organization) -> bool:
-        return True
-
     @extend_schema(
         operation_id="Start Seer Issue Fix",
         parameters=[
@@ -194,7 +159,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             IssueParams.ISSUES_OR_GROUPS,
             IssueParams.ISSUE_ID,
         ],
-        request=AutofixRequestSerializer,
+        request=ExplorerAutofixRequestSerializer,
         responses={
             202: inline_sentry_response_serializer("AutofixPostResponse", AutofixPostResponse),
             400: RESPONSE_BAD_REQUEST,
@@ -217,12 +182,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
 
         The process runs asynchronously, and you can get the state using the GET endpoint.
         """
-        if self._should_use_agent(request, group.organization):
-            return self._post_agent(request, group)
-        return self._post_legacy(request, group)
-
-    def _post_agent(self, request: Request, group: Group) -> Response:
-        """Handle POST for the agent-based autofix."""
         if not has_project_connected_repos(group.organization, group.project):
             return Response(
                 {"detail": "SCM integration is not configured for this project."},
@@ -308,28 +267,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 return Response(status=status.HTTP_404_NOT_FOUND)
             raise PermissionDenied(SEER_PERMISSION_DENIED)
 
-    def _post_legacy(self, request: Request, group: Group) -> Response:
-        """Handle POST for legacy autofix."""
-        serializer = AutofixRequestSerializer(data=request.data)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        data = serializer.validated_data
-
-        stopping_point = data.get("stopping_point")
-        stopping_point = AutofixStoppingPoint(stopping_point) if stopping_point else None
-
-        return trigger_legacy_autofix(
-            group=group,
-            # This event_id is the event that the user is looking at when they click the "Fix" button
-            event_id=data.get("event_id"),
-            user=request.user,
-            referrer=_parse_autofix_referrer(data.get("referrer")),
-            instruction=data.get("instruction"),
-            pr_to_comment_on_url=data.get("pr_to_comment_on_url"),
-            stopping_point=stopping_point,
-        )
-
     @extend_schema(
         operation_id="Retrieve Seer Issue Fix State",
         parameters=[
@@ -359,12 +296,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
 
         This endpoint although documented is still experimental and the payload may change in the future.
         """
-        if self._should_use_agent(request, group.organization):
-            return self._get_agent(request, group)
-        return self._get_legacy(request, group)
-
-    def _get_agent(self, request: Request, group: Group) -> Response:
-        """Handle GET for the agent-based autofix."""
         try:
             state = get_autofix_agent_state(group.organization, group.id)
         except SeerPermissionError as e:
@@ -385,7 +316,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                     organization_id=group.organization.id,
                 )
 
-        # Return the agent state directly - frontend will handle the format
         return Response(
             {
                 "autofix": {
@@ -405,101 +335,3 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 }
             }
         )
-
-    def _get_legacy(self, request: Request, group: Group) -> Response:
-        """Handle GET for legacy autofix."""
-        access_check_cache_key = f"autofix_access_check:{group.id}"
-        access_check_cache_value = cache.get(access_check_cache_key)
-
-        check_repo_access = False
-        if not access_check_cache_value:
-            check_repo_access = True
-
-        is_user_watching = request.GET.get("isUserWatching", False)
-
-        try:
-            autofix_state = get_autofix_state(
-                group_id=group.id,
-                organization_id=group.organization.id,
-                check_repo_access=check_repo_access,
-                is_user_fetching=bool(is_user_watching),
-            )
-        except SeerPermissionError:
-            logger.exception(
-                "group_ai_autofix.get.seer_permission_error",
-                extra={"group_id": group.id, "organization_id": group.organization.id},
-            )
-
-            raise PermissionDenied("You are not authorized to access this autofix state")
-
-        if autofix_state and autofix_state.coding_agents and request.user.id:
-            agent_providers = {a.provider for a in autofix_state.coding_agents.values()}
-            if CodingAgentProviderType.GITHUB_COPILOT_AGENT in agent_providers:
-                poll_github_copilot_agents(autofix_state, user_id=request.user.id)
-            if CodingAgentProviderType.CLAUDE_CODE_AGENT in agent_providers:
-                poll_claude_code_agents(autofix_state=autofix_state)
-
-        if check_repo_access:
-            cache.set(access_check_cache_key, True, timeout=60)  # 1 minute timeout
-
-        response_state: dict[str, Any] | None = None
-
-        if autofix_state:
-            response_state = autofix_state.dict()
-            user_ids = autofix_state.actor_ids
-            if user_ids:
-                users = user_service.serialize_many(
-                    filter={"user_ids": user_ids, "organization_id": request.organization.id},
-                    as_user=request.user,
-                )
-
-                users_map = {user["id"]: user for user in users}
-
-                response_state["users"] = users_map
-
-            project = group.project
-            repositories = []
-
-            autofix_codebase_state = response_state.get("codebases", {})
-
-            repo_code_mappings: dict[str, RepositoryProjectPathConfig] = {}
-            if project:
-                code_mappings = get_sorted_code_mapping_configs(project=project)
-                for mapping in code_mappings:
-                    repo = mapping.project_repository.repository
-                    if repo.external_id:
-                        repo_code_mappings[repo.external_id] = mapping
-
-            for repo_external_id, repo_state in autofix_codebase_state.items():
-                retrieved_mapping: RepositoryProjectPathConfig | None = repo_code_mappings.get(
-                    repo_external_id, None
-                )
-
-                if not retrieved_mapping:
-                    continue
-
-                mapping_repo: Repository = retrieved_mapping.project_repository.repository
-
-                repositories.append(
-                    {
-                        "integration_id": mapping_repo.integration_id,
-                        "url": mapping_repo.url,
-                        "external_id": repo_external_id,
-                        "name": mapping_repo.name,
-                        "provider": mapping_repo.provider,
-                        "default_branch": retrieved_mapping.default_branch,
-                        "is_readable": repo_state.get("is_readable", None),
-                        "is_writeable": repo_state.get("is_writeable", None),
-                    }
-                )
-
-            response_state["repositories"] = repositories
-
-            # Remove unnecessary or sensitive data to reduce returned payload size
-            for key in ["usage", "signals"]:
-                response_state.pop(key, None)
-            for request_key in ["issue", "trace_tree", "profile", "issue_summary", "logs"]:
-                if "request" in response_state and request_key in response_state["request"]:
-                    del response_state["request"][request_key]
-
-        return Response({"autofix": response_state})

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -16,21 +16,10 @@ from sentry.testutils.skips import requires_snuba
 pytestmark = [requires_snuba]
 
 
-EXPLORER_FLAGS = [
-    "organizations:seer-explorer",
-    "organizations:autofix-on-explorer",
-]
-
-
 @with_feature("organizations:gen-ai-features")
-class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
-    """Tests for feature flag routing to the agent-based autofix."""
-
-    def _get_url(self, group_id: int, mode: str | None = None) -> str:
-        url = f"/api/0/organizations/{self.organization.slug}/issues/{group_id}/autofix/"
-        if mode is not None:
-            url = f"{url}?mode={mode}"
-        return url
+class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
+    def _get_url(self, group_id: int) -> str:
+        return f"/api/0/organizations/{self.organization.slug}/issues/{group_id}/autofix/"
 
     def setUp(self) -> None:
         super().setUp()
@@ -39,205 +28,175 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         self.organization.save()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
-    def test_get_routes_to_explorer_with_explorer_flag(self, mock_get_explorer_state):
-        """GET routes to explorer when any individual explorer flag is enabled."""
-        for flag in EXPLORER_FLAGS:
-            mock_get_explorer_state.reset_mock()
-            group = self.create_group()
-            mock_get_explorer_state.return_value = None
+    def test_get_returns_state(self, mock_get_explorer_state):
+        group = self.create_group()
+        mock_get_explorer_state.return_value = None
 
-            self.login_as(user=self.user)
-            with self.feature(flag):
-                response = self.client.get(self._get_url(group.id, mode="explorer"), format="json")
+        self.login_as(user=self.user)
+        response = self.client.get(self._get_url(group.id), format="json")
 
-            assert response.status_code == 200, f"Failed for {flag}: {response.data}"
-            mock_get_explorer_state.assert_called_once_with(group.organization, group.id)
+        assert response.status_code == 200, response.data
+        mock_get_explorer_state.assert_called_once_with(group.organization, group.id)
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
-    def test_post_routes_to_explorer_with_explorer_flag(self, mock_trigger_explorer, _):
-        """POST routes to explorer when any individual explorer flag is enabled."""
-        for flag in EXPLORER_FLAGS:
-            mock_trigger_explorer.reset_mock()
-            group = self.create_group()
-            mock_trigger_explorer.return_value = 123
+    def test_post_triggers_autofix_agent(self, mock_trigger_explorer, _):
+        group = self.create_group()
+        mock_trigger_explorer.return_value = 123
 
-            self.login_as(user=self.user)
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={"step": "root_cause"},
-                    format="json",
-                )
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "root_cause"},
+            format="json",
+        )
 
-            assert response.status_code == 202, f"Failed for {flag}: {response.data}"
-            assert response.data["run_id"] == 123
-            mock_trigger_explorer.assert_called_once()
+        assert response.status_code == 202, response.data
+        assert response.data["run_id"] == 123
+        mock_trigger_explorer.assert_called_once()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=False)
     def test_post_returns_409_without_connected_repos(self, _):
-        """POST returns 409 when project has no connected repositories."""
-        for flag in EXPLORER_FLAGS:
-            group = self.create_group()
+        group = self.create_group()
 
-            self.login_as(user=self.user)
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={"step": "root_cause"},
-                    format="json",
-                )
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "root_cause"},
+            format="json",
+        )
 
-            assert response.status_code == 409, f"Failed for {flag}: {response.data}"
-            assert response.data["detail"] == "SCM integration is not configured for this project."
+        assert response.status_code == 409, response.data
+        assert response.data["detail"] == "SCM integration is not configured for this project."
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_stopping_point(self, mock_trigger_explorer, _):
-        """POST routes to explorer and stopping point forces the step to be root_cause"""
-        for flag in EXPLORER_FLAGS:
-            mock_trigger_explorer.reset_mock()
-            group = self.create_group()
-            mock_trigger_explorer.return_value = 123
+        """Stopping point forces the step to be root_cause"""
+        group = self.create_group()
+        mock_trigger_explorer.return_value = 123
 
-            self.login_as(user=self.user)
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={"step": "coding_agent_handoff", "stopping_point": "code_changes"},
-                    format="json",
-                )
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "coding_agent_handoff", "stopping_point": "code_changes"},
+            format="json",
+        )
 
-            assert response.status_code == 202, f"Failed for {flag}: {response.data}"
-            assert response.data["run_id"] == 123
-            mock_trigger_explorer.assert_called_once_with(
-                group=group,
-                step=AutofixStep.ROOT_CAUSE,
-                referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
-                stopping_point=AutofixStoppingPoint.CODE_CHANGES,
-                run_id=None,
-                intelligence_level="medium",
-                user_context=None,
-                insert_index=None,
-            )
+        assert response.status_code == 202, response.data
+        assert response.data["run_id"] == 123
+        mock_trigger_explorer.assert_called_once_with(
+            group=group,
+            step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
+            stopping_point=AutofixStoppingPoint.CODE_CHANGES,
+            run_id=None,
+            intelligence_level="medium",
+            user_context=None,
+            insert_index=None,
+        )
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_insert_index_passed_through(self, mock_trigger_explorer, _):
         """POST passes insert_index to trigger_autofix_agent for retry-from-step."""
-        for flag in EXPLORER_FLAGS:
-            mock_trigger_explorer.reset_mock()
-            group = self.create_group()
-            mock_trigger_explorer.return_value = 123
+        group = self.create_group()
+        mock_trigger_explorer.return_value = 123
 
-            self.login_as(user=self.user)
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={"step": "solution", "run_id": 42, "insert_index": 3},
-                    format="json",
-                )
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "solution", "run_id": 42, "insert_index": 3},
+            format="json",
+        )
 
-            assert response.status_code == 202, f"Failed for {flag}: {response.data}"
-            mock_trigger_explorer.assert_called_once_with(
-                group=group,
-                step=AutofixStep.SOLUTION,
-                referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
-                stopping_point=None,
-                run_id=42,
-                intelligence_level="medium",
-                user_context=None,
-                insert_index=3,
-            )
+        assert response.status_code == 202, response.data
+        mock_trigger_explorer.assert_called_once_with(
+            group=group,
+            step=AutofixStep.SOLUTION,
+            referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
+            stopping_point=None,
+            run_id=42,
+            intelligence_level="medium",
+            user_context=None,
+            insert_index=3,
+        )
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_post_continue_unknown_run_returns_404(self, mock_trigger_explorer, _):
-        for flag in EXPLORER_FLAGS:
-            mock_trigger_explorer.reset_mock()
-            mock_trigger_explorer.side_effect = SeerPermissionError("Unknown run id for group")
-            group = self.create_group()
+        mock_trigger_explorer.side_effect = SeerPermissionError("Unknown run id for group")
+        group = self.create_group()
 
-            self.login_as(user=self.user)
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={"step": "solution", "run_id": 123},
-                    format="json",
-                )
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "solution", "run_id": 123},
+            format="json",
+        )
 
-            assert response.status_code == 404, f"Failed for {flag}: {response.data}"
-            mock_trigger_explorer.assert_called_once()
+        assert response.status_code == 404, response.data
+        mock_trigger_explorer.assert_called_once()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_post_returns_402_when_no_seer_quota(self, mock_trigger_explorer, _):
         """POST returns 402 Payment Required when quota check fails."""
-        for flag in EXPLORER_FLAGS:
-            mock_trigger_explorer.reset_mock()
-            mock_trigger_explorer.side_effect = NoSeerQuotaException()
-            group = self.create_group()
+        mock_trigger_explorer.side_effect = NoSeerQuotaException()
+        group = self.create_group()
 
-            self.login_as(user=self.user)
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={"step": "root_cause"},
-                    format="json",
-                )
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "root_cause"},
+            format="json",
+        )
 
-            assert response.status_code == 402, f"Failed for {flag}: {response.data}"
-            assert response.data == "No budget for Seer Autofix."
+        assert response.status_code == 402, response.data
+        assert response.data == "No budget for Seer Autofix."
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     def test_post_coding_agent_handoff_errors_with_both_provider_and_integration_id(
         self, _
     ) -> None:
         """POST returns 400 when both provider and integration_id are specified for coding_agent_handoff."""
-        for flag in EXPLORER_FLAGS:
-            group = self.create_group()
+        group = self.create_group()
 
-            self.login_as(user=self.user)
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={
-                        "step": "coding_agent_handoff",
-                        "run_id": 123,
-                        "integration_id": 456,
-                        "provider": "github_copilot",
-                    },
-                    format="json",
-                )
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "coding_agent_handoff",
+                "run_id": 123,
+                "integration_id": 456,
+                "provider": "github_copilot",
+            },
+            format="json",
+        )
 
-            assert response.status_code == 400, f"Failed for {flag}: {response.data}"
-            assert response.data["detail"] == "Cannot specify both integration_id and provider"
+        assert response.status_code == 400, response.data
+        assert response.data["detail"] == "Cannot specify both integration_id and provider"
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_coding_agent_handoff")
     def test_post_coding_agent_handoff_unknown_run_returns_404(self, mock_handoff, _):
-        for flag in EXPLORER_FLAGS:
-            mock_handoff.reset_mock()
-            mock_handoff.side_effect = SeerPermissionError("Unknown run id for group")
-            group = self.create_group()
+        mock_handoff.side_effect = SeerPermissionError("Unknown run id for group")
+        group = self.create_group()
 
-            self.login_as(user=self.user)
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={
-                        "step": "coding_agent_handoff",
-                        "run_id": 123,
-                        "integration_id": 456,
-                    },
-                    format="json",
-                )
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "coding_agent_handoff",
+                "run_id": 123,
+                "integration_id": 456,
+            },
+            format="json",
+        )
 
-            assert response.status_code == 404, f"Failed for {flag}: {response.data}"
-            mock_handoff.assert_called_once()
-            assert (
-                mock_handoff.call_args.kwargs["referrer"] == AutofixReferrer.GROUP_AUTOFIX_ENDPOINT
-            )
+        assert response.status_code == 404, response.data
+        mock_handoff.assert_called_once()
+        assert mock_handoff.call_args.kwargs["referrer"] == AutofixReferrer.GROUP_AUTOFIX_ENDPOINT
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_coding_agent_handoff")
@@ -246,16 +205,15 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         group = self.create_group()
 
         self.login_as(user=self.user)
-        with self.feature(EXPLORER_FLAGS[0]):
-            response = self.client.post(
-                self._get_url(group.id, mode="explorer"),
-                data={
-                    "step": "coding_agent_handoff",
-                    "run_id": 123,
-                    "integration_id": 456,
-                },
-                format="json",
-            )
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "coding_agent_handoff",
+                "run_id": 123,
+                "integration_id": 456,
+            },
+            format="json",
+        )
 
         assert response.status_code == 202, response.data
         mock_handoff.assert_called_once_with(
@@ -296,19 +254,17 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         )
         mock_explorer_state_request.return_value = mock_explorer_state_response
 
-        for flag in EXPLORER_FLAGS:
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={
-                        "step": "open_pr",
-                        "run_id": 123,
-                    },
-                    format="json",
-                )
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "open_pr",
+                "run_id": 123,
+            },
+            format="json",
+        )
 
-            assert response.status_code == 202, f"Failed for {flag}: {response.data}"
-            assert response.data == {"run_id": 123}
+        assert response.status_code == 202, response.data
+        assert response.data == {"run_id": 123}
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     @patch("sentry.seer.agent.client_utils.make_agent_state_request")
@@ -340,22 +296,20 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         )
         mock_explorer_state_request.return_value = mock_explorer_state_response
 
-        for flag in EXPLORER_FLAGS:
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={
-                        "step": "open_pr",
-                        "run_id": 123,
-                        "repo_name": "my-org/my-repo",
-                    },
-                    format="json",
-                )
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "open_pr",
+                "run_id": 123,
+                "repo_name": "my-org/my-repo",
+            },
+            format="json",
+        )
 
-            assert response.status_code == 202, f"Failed for {flag}: {response.data}"
-            call_body = mock_explorer_update_request.call_args[0][0]
-            assert call_body["payload"]["type"] == "create_pr"
-            assert call_body["payload"]["repo_name"] == "my-org/my-repo"
+        assert response.status_code == 202, response.data
+        call_body = mock_explorer_update_request.call_args[0][0]
+        assert call_body["payload"]["type"] == "create_pr"
+        assert call_body["payload"]["repo_name"] == "my-org/my-repo"
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     @patch("sentry.seer.agent.client_utils.make_agent_state_request")
@@ -387,37 +341,33 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         )
         mock_explorer_state_request.return_value = mock_explorer_state_response
 
-        for flag in EXPLORER_FLAGS:
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={
-                        "step": "open_pr",
-                        "run_id": 123,
-                    },
-                    format="json",
-                )
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "open_pr",
+                "run_id": 123,
+            },
+            format="json",
+        )
 
-            assert response.status_code == 202, f"Failed for {flag}: {response.data}"
-            call_body = mock_explorer_update_request.call_args[0][0]
-            assert call_body["payload"]["type"] == "create_pr"
-            assert "repo_name" not in call_body["payload"]
+        assert response.status_code == 202, response.data
+        call_body = mock_explorer_update_request.call_args[0][0]
+        assert call_body["payload"]["type"] == "create_pr"
+        assert "repo_name" not in call_body["payload"]
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     def test_open_pr_no_run_id(self, _) -> None:
         self.login_as(user=self.user)
+        group = self.create_group()
 
-        for flag in EXPLORER_FLAGS:
-            group = self.create_group()
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={"step": "open_pr"},
-                    format="json",
-                )
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "open_pr"},
+            format="json",
+        )
 
-            assert response.status_code == 400, f"Failed for {flag}: {response.data}"
-            assert response.data["detail"] == "run_id is required for open_pr"
+        assert response.status_code == 400, response.data
+        assert response.data["detail"] == "run_id is required for open_pr"
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     @patch("sentry.seer.agent.client_utils.make_agent_state_request")
@@ -439,18 +389,16 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         )
         mock_explorer_state_request.return_value = mock_explorer_state_response
 
-        for flag in EXPLORER_FLAGS:
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={
-                        "step": "open_pr",
-                        "run_id": 123,
-                    },
-                    format="json",
-                )
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "open_pr",
+                "run_id": 123,
+            },
+            format="json",
+        )
 
-            assert response.status_code == 404, f"Failed for {flag}: {response.data}"
+        assert response.status_code == 404, response.data
 
     @patch("sentry.seer.endpoints.group_ai_autofix.has_project_connected_repos", return_value=True)
     def test_open_pr_coding_disabled(self, _):
@@ -458,15 +406,13 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         group = self.create_group()
         self.organization.update_option("sentry:enable_seer_coding", False)
 
-        for flag in EXPLORER_FLAGS:
-            with self.feature(flag):
-                response = self.client.post(
-                    self._get_url(group.id, mode="explorer"),
-                    data={
-                        "step": "open_pr",
-                        "run_id": 123,
-                    },
-                    format="json",
-                )
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "open_pr",
+                "run_id": 123,
+            },
+            format="json",
+        )
 
-            assert response.status_code == 403, f"Failed for {flag}: {response.data}"
+        assert response.status_code == 403, response.data


### PR DESCRIPTION
## Summary

Follow-up to #116162. Now that `_should_use_agent` always returns `True`, the legacy autofix code path is unreachable. This PR removes it.

- Drop the `_should_use_agent` routing method, `_post_legacy`, `_get_legacy`, and `AutofixRequestSerializer`.
- Inline `_post_agent` / `_get_agent` into the now-single-caller `post` / `get` methods.
- Remove imports that were only used by the legacy path (`trigger_legacy_autofix`, `get_autofix_state`, `Organization`, `RepositoryProjectPathConfig`, `Repository`, `get_sorted_code_mapping_configs`, `user_service`, `cache`).
- Delete the legacy and explorer-vs-legacy routing test classes; simplify the remaining explorer tests to drop the no-longer-meaningful `mode=explorer` URL param and feature-flag loops.

Net: 2 files changed, 173 insertions, 1306 deletions.


Agent transcript: https://claudescope.sentry.dev/share/SqDAC8UBY8YUaDzBnlmada7CGxiZ8RuLvMQmcFxfks4