### PR TITLE
 ref(dynamic-sampling): directly compute release boost factoring the latest releases factor

### DIFF
--- a/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
@@ -20,6 +20,7 @@ class BoostLatestReleasesBias(Bias):
         # If the base sample rate is 100%, the factor will be 1.0
         # If the base sample rate is close to 0%, the factor will be 1.5
         # Between these two extremes, the factor will be a decaying value between 1.0 and 1.5
+        # Why is it quadratic? I don't know, legacy code.
         factor = float(LATEST_RELEASES_BOOST_FACTOR ** (1 - base_sample_rate))
         boosted_releases = ProjectBoostedReleases(project).get_extended_boosted_releases()
 

--- a/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
@@ -9,7 +9,6 @@ from sentry.dynamic_sampling.rules.utils import (
     RESERVED_IDS,
     PolymorphicRule,
     RuleType,
-    apply_dynamic_factor,
 )
 from sentry.models.project import Project
 
@@ -18,7 +17,10 @@ class BoostLatestReleasesBias(Bias):
     datetime_format = "%Y-%m-%dT%H:%M:%SZ"
 
     def generate_rules(self, project: Project, base_sample_rate: float) -> list[PolymorphicRule]:
-        factor = apply_dynamic_factor(base_sample_rate, LATEST_RELEASES_BOOST_FACTOR)
+        # If the base sample rate is 100%, the factor will be 1.0
+        # If the base sample rate is close to 0%, the factor will be 1.5
+        # Between these two extremes, the factor will be a decaying value between 1.0 and 1.5
+        factor = float(LATEST_RELEASES_BOOST_FACTOR ** (1 - base_sample_rate))
         boosted_releases = ProjectBoostedReleases(project).get_extended_boosted_releases()
 
         return cast(

--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -137,25 +137,6 @@ def get_supported_biases_ids() -> list[str]:
     return sorted({bias["id"] for bias in DEFAULT_BIASES})
 
 
-def apply_dynamic_factor(base_sample_rate: float, x: float) -> float:
-    """
-    This function known as dynamic factor function is used during the rules generation in order to determine the factor
-    for each rule based on the base_sample_rate of the project.
-
-    The high-level idea is that we want to reduce the factor the bigger the base_sample_rate becomes, this is done
-    because multiplication will exceed 1 very quickly in case we don't reduce the factor.
-    """
-    if x == 0:
-        raise Exception("A dynamic factor of 0 cannot be set.")
-
-    if base_sample_rate < 0.0 or base_sample_rate > 1.0:
-        raise Exception(
-            "The dynamic factor function requires a sample rate in the interval [0.0, 1.0]."
-        )
-
-    return float(x / x**base_sample_rate)
-
-
 def get_redis_client_for_ds() -> StrictRedis[str]:
     cluster_key = settings.SENTRY_DYNAMIC_SAMPLING_RULES_REDIS_CLUSTER
     return redis.redis_clusters.get(cluster_key)

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from sentry_relay.processing import normalize_project_config
@@ -11,7 +11,6 @@ from sentry.dynamic_sampling import ENVIRONMENT_GLOBS, generate_rules, get_redis
 from sentry.dynamic_sampling.rules.base import NEW_MODEL_THRESHOLD_IN_MINUTES
 from sentry.dynamic_sampling.rules.utils import (
     LATEST_RELEASES_BOOST_DECAYED_FACTOR,
-    LATEST_RELEASES_BOOST_FACTOR,
     RESERVED_IDS,
     RuleType,
 )
@@ -225,7 +224,6 @@ def test_generate_rules_return_uniform_rule_with_100_rate_and_without_env_rule(
 
 
 @freeze_time("2022-10-21T18:50:25Z")
-@patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
 @patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 @django_db_all
 @pytest.mark.parametrize(
@@ -240,7 +238,6 @@ def test_generate_rules_return_uniform_rule_with_100_rate_and_without_env_rule(
 )
 def test_generate_rules_with_different_project_platforms(
     get_blended_sample_rate,
-    apply_dynamic_factor,
     version,
     platform,
     end,
@@ -250,7 +247,6 @@ def test_generate_rules_with_different_project_platforms(
     default_old_project = _apply_old_date_to_project_and_org(default_project)
 
     get_blended_sample_rate.return_value = 0.1
-    apply_dynamic_factor.return_value = LATEST_RELEASES_BOOST_FACTOR
 
     redis_client = get_redis_client_for_ds()
 
@@ -266,7 +262,7 @@ def test_generate_rules_with_different_project_platforms(
 
     assert generate_rules(default_old_project) == [
         {
-            "samplingValue": {"type": "factor", "value": LATEST_RELEASES_BOOST_FACTOR},
+            "samplingValue": {"type": "factor", "value": ANY},
             "type": "trace",
             "condition": {
                 "op": "and",
@@ -298,15 +294,13 @@ def test_generate_rules_with_different_project_platforms(
 
 @django_db_all
 @freeze_time("2022-10-21T18:50:25Z")
-@patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
 @patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rules_and_latest_release_rule(
-    get_blended_sample_rate, apply_dynamic_factor, default_project, latest_release_only
+    get_blended_sample_rate, default_project, latest_release_only
 ):
     default_old_project = _apply_old_date_to_project_and_org(default_project)
 
     get_blended_sample_rate.return_value = 0.1
-    apply_dynamic_factor.return_value = LATEST_RELEASES_BOOST_FACTOR
 
     redis_client = get_redis_client_for_ds()
 
@@ -326,7 +320,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
 
     assert generate_rules(default_old_project) == [
         {
-            "samplingValue": {"type": "factor", "value": LATEST_RELEASES_BOOST_FACTOR},
+            "samplingValue": {"type": "factor", "value": ANY},
             "type": "trace",
             "condition": {
                 "op": "and",
@@ -340,7 +334,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
             "decayingFn": {"type": "linear", "decayedValue": LATEST_RELEASES_BOOST_DECAYED_FACTOR},
         },
         {
-            "samplingValue": {"type": "factor", "value": LATEST_RELEASES_BOOST_FACTOR},
+            "samplingValue": {"type": "factor", "value": ANY},
             "type": "trace",
             "condition": {
                 "op": "and",
@@ -354,7 +348,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
             "decayingFn": {"type": "linear", "decayedValue": LATEST_RELEASES_BOOST_DECAYED_FACTOR},
         },
         {
-            "samplingValue": {"type": "factor", "value": LATEST_RELEASES_BOOST_FACTOR},
+            "samplingValue": {"type": "factor", "value": ANY},
             "type": "trace",
             "condition": {
                 "op": "and",
@@ -379,15 +373,13 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
 
 @django_db_all
 @freeze_time("2022-10-21T18:50:25Z")
-@patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
 @patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_does_not_return_rule_with_deleted_release(
-    get_blended_sample_rate, apply_dynamic_factor, default_project, latest_release_only
+    get_blended_sample_rate, default_project, latest_release_only
 ):
     default_old_project = _apply_old_date_to_project_and_org(default_project)
 
     get_blended_sample_rate.return_value = 0.1
-    apply_dynamic_factor.return_value = LATEST_RELEASES_BOOST_FACTOR
 
     redis_client = get_redis_client_for_ds()
 
@@ -410,7 +402,7 @@ def test_generate_rules_does_not_return_rule_with_deleted_release(
 
     assert generate_rules(default_old_project) == [
         {
-            "samplingValue": {"type": "factor", "value": LATEST_RELEASES_BOOST_FACTOR},
+            "samplingValue": {"type": "factor", "value": ANY},
             "type": "trace",
             "condition": {
                 "op": "and",

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime, timedelta, timezone
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sentry_relay.processing import normalize_project_config
@@ -262,7 +262,7 @@ def test_generate_rules_with_different_project_platforms(
 
     assert generate_rules(default_old_project) == [
         {
-            "samplingValue": {"type": "factor", "value": ANY},
+            "samplingValue": {"type": "factor", "value": 1.5},
             "type": "trace",
             "condition": {
                 "op": "and",
@@ -320,7 +320,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
 
     assert generate_rules(default_old_project) == [
         {
-            "samplingValue": {"type": "factor", "value": ANY},
+            "samplingValue": {"type": "factor", "value": 1.5},
             "type": "trace",
             "condition": {
                 "op": "and",
@@ -334,7 +334,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
             "decayingFn": {"type": "linear", "decayedValue": LATEST_RELEASES_BOOST_DECAYED_FACTOR},
         },
         {
-            "samplingValue": {"type": "factor", "value": ANY},
+            "samplingValue": {"type": "factor", "value": 1.5},
             "type": "trace",
             "condition": {
                 "op": "and",
@@ -348,7 +348,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
             "decayingFn": {"type": "linear", "decayedValue": LATEST_RELEASES_BOOST_DECAYED_FACTOR},
         },
         {
-            "samplingValue": {"type": "factor", "value": ANY},
+            "samplingValue": {"type": "factor", "value": 1.5},
             "type": "trace",
             "condition": {
                 "op": "and",
@@ -402,7 +402,7 @@ def test_generate_rules_does_not_return_rule_with_deleted_release(
 
     assert generate_rules(default_old_project) == [
         {
-            "samplingValue": {"type": "factor", "value": ANY},
+            "samplingValue": {"type": "factor", "value": 1.5},
             "type": "trace",
             "condition": {
                 "op": "and",

--- a/tests/sentry/dynamic_sampling/test_utils.py
+++ b/tests/sentry/dynamic_sampling/test_utils.py
@@ -1,6 +1,3 @@
-import pytest
-
-from sentry.dynamic_sampling.rules.utils import apply_dynamic_factor
 from sentry.dynamic_sampling.types import DynamicSamplingMode
 from sentry.dynamic_sampling.utils import (
     has_custom_dynamic_sampling,
@@ -8,25 +5,6 @@ from sentry.dynamic_sampling.utils import (
     is_project_mode_sampling,
 )
 from sentry.testutils.cases import TestCase
-
-
-@pytest.mark.parametrize(
-    ["base_sample_rate", "x", "expected"],
-    [
-        (0.0, 2.0, 2.0),
-        (0.1, 2.0, 1.8660659830736148),
-        (0.5, 3.0, 1.7320508075688774),
-        (1.0, 4.0, 1.0),
-    ],
-)
-def test_apply_dynamic_factor_with_valid_params(base_sample_rate, x, expected) -> None:
-    assert apply_dynamic_factor(base_sample_rate, x) == pytest.approx(expected)
-
-
-@pytest.mark.parametrize(["base_sample_rate", "x"], [(-0.1, 1.5), (1.1, 2.5), (0.5, 0)])
-def test_apply_dynamic_factor_with_invalid_params(base_sample_rate, x) -> None:
-    with pytest.raises(Exception):
-        apply_dynamic_factor(base_sample_rate, x)
 
 
 class HasDynamicSamplingTestCase(TestCase):

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -248,16 +248,11 @@ def test_project_config_exposed_features_raise_exc(default_project: MagicMock) -
 
 @django_db_all
 @cell_silo_test
-@patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
 @freeze_time("2022-10-21 18:50:25.000000+00:00")
-def test_project_config_with_all_biases_enabled(
-    eval_dynamic_factor_lr, default_project, default_team
-):
+def test_project_config_with_all_biases_enabled(default_project, default_team):
     """
     Tests that dynamic sampling information return correct uniform rules
     """
-    eval_dynamic_factor_lr.return_value = 1.5
-
     redis_client = get_redis_client_for_ds()
     ts = time.time()
 
@@ -380,7 +375,7 @@ def test_project_config_with_all_biases_enabled(
                 "type": "trace",
             },
             {
-                "samplingValue": {"type": "factor", "value": 1.5},
+                "samplingValue": {"type": "factor", "value": ANY},
                 "type": "trace",
                 "condition": {
                     "op": "and",
@@ -401,7 +396,7 @@ def test_project_config_with_all_biases_enabled(
                 "decayingFn": {"type": "linear", "decayedValue": 1.0},
             },
             {
-                "samplingValue": {"type": "factor", "value": 1.5},
+                "samplingValue": {"type": "factor", "value": ANY},
                 "type": "trace",
                 "condition": {
                     "op": "and",
@@ -433,13 +428,8 @@ def test_project_config_with_all_biases_enabled(
 
 @django_db_all
 @cell_silo_test
-@patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
 @freeze_time("2022-10-21 18:50:25.000000+00:00")
-def test_project_config_with_trace_health_checks_enabled(
-    eval_dynamic_factor_lr, default_project, default_team
-):
-    eval_dynamic_factor_lr.return_value = 1.5
-
+def test_project_config_with_trace_health_checks_enabled(default_project, default_team):
     default_project.update_option(
         "sentry:dynamic_sampling_biases",
         [

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -375,7 +375,7 @@ def test_project_config_with_all_biases_enabled(default_project, default_team):
                 "type": "trace",
             },
             {
-                "samplingValue": {"type": "factor", "value": ANY},
+                "samplingValue": {"type": "factor", "value": 1.5},
                 "type": "trace",
                 "condition": {
                     "op": "and",
@@ -396,7 +396,7 @@ def test_project_config_with_all_biases_enabled(default_project, default_team):
                 "decayingFn": {"type": "linear", "decayedValue": 1.0},
             },
             {
-                "samplingValue": {"type": "factor", "value": ANY},
+                "samplingValue": {"type": "factor", "value": 1.5},
                 "type": "trace",
                 "condition": {
                     "op": "and",


### PR DESCRIPTION
- Remove some code that can be static, but is currently somewhat dynamic to make things simpler