### PR TITLE
fix(discover): Add org id to project filter

### DIFF
--- a/src/sentry/data_export/processors/discover.py
+++ b/src/sentry/data_export/processors/discover.py
@@ -57,7 +57,11 @@ class DiscoverProcessor:
 
     @staticmethod
     def get_projects(organization_id: int, query: dict[str, Any]) -> list[Project]:
-        projects = list(Project.objects.filter(id__in=query.get("project")))
+        projects = list(
+            Project.objects.filter(
+                id__in=query.get("project") or [], organization_id=organization_id
+            )
+        )
         if len(projects) == 0:
             raise ExportError("Requested project does not exist")
         return projects

--- a/tests/sentry/data_export/processors/test_discover.py
+++ b/tests/sentry/data_export/processors/test_discover.py
@@ -35,6 +35,14 @@ class DiscoverProcessorTest(TestCase, SnubaTestCase):
         with pytest.raises(ExportError):
             DiscoverProcessor.get_projects(organization_id=self.org.id, query={"project": [-1]})
 
+    def test_get_projects_rejects_cross_org_project(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        with pytest.raises(ExportError):
+            DiscoverProcessor.get_projects(
+                organization_id=self.org.id, query={"project": [other_project.id]}
+            )
+
     def test_handle_issue_id_fields(self) -> None:
         processor = DiscoverProcessor(organization=self.org, discover_query=self.discover_query)
         assert processor.header_fields == ["count_id", "fake_field", "issue"]

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -633,7 +633,7 @@ class AssembleDownloadLargeTest(TestCase, SnubaTestCase):
         super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization()
-        self.project = self.create_project()
+        self.project = self.create_project(organization=self.org)
         self.data = load_data("transaction")
 
     @patch("sentry.data_export.tasks.MAX_BATCH_SIZE", 200)


### PR DESCRIPTION
Add in org id to projects filter, and add a regression test.

Closes BROWSE-519