### PR TITLE
ref(issueDetails): collapse ParticipantList wrapper div to a Flex

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import {AvatarList, TeamAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 
 import {DateTime} from 'sentry/components/dateTime';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
@@ -30,7 +31,7 @@ export function ParticipantList({users, teams, hideTimestamp}: DropdownListProps
   const showHeaders = users.length > 0 && teams && teams.length > 0;
 
   return (
-    <div>
+    <Flex>
       <Button variant="transparent" size="zero" {...triggerProps}>
         <StyledAvatarList
           teams={teams}
@@ -87,7 +88,7 @@ export function ParticipantList({users, teams, hideTimestamp}: DropdownListProps
           </StyledOverlay>
         </PositionWrapper>
       )}
-    </div>
+    </Flex>
   );
 }
 

--- a/static/app/views/issueDetails/streamline/sidebar/peopleSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/peopleSection.tsx
@@ -26,22 +26,24 @@ export function PeopleSection({
       title={<Title>{t('People')}</Title>}
       sectionKey={SectionKey.PEOPLE}
     >
-      {hasParticipants && (
-        <Flex gap="xs" align="center">
-          <ParticipantList
-            users={userParticipants}
-            teams={teamParticipants}
-            hideTimestamp
-          />
-          {t('participating')}
-        </Flex>
-      )}
-      {hasViewers && (
-        <Flex gap="xs" align="center">
-          <ParticipantList users={viewers} />
-          {t('viewed')}
-        </Flex>
-      )}
+      <Flex direction="column" gap="md">
+        {hasParticipants && (
+          <Flex gap="xs" align="center">
+            <ParticipantList
+              users={userParticipants}
+              teams={teamParticipants}
+              hideTimestamp
+            />
+            {t('participating')}
+          </Flex>
+        )}
+        {hasViewers && (
+          <Flex gap="xs" align="center">
+            <ParticipantList users={viewers} />
+            {t('viewed')}
+          </Flex>
+        )}
+      </Flex>
     </SidebarFoldSection>
   );
 }


### PR DESCRIPTION
Two small tweaks to the People section in issue details:

**`ParticipantList` wrapper.** The wrapper `<div>` around the avatar trigger established an inline formatting context, which reserves descender space below the inline-block `Button`. That made the trigger element a few pixels taller than the visible avatars, pushing the "participating" / "viewed" label below the visual center of the avatar row. Swapping the wrapper to a `<Flex>` removes the inline formatting context, so the trigger collapses to the Button's actual height and the labels sit vertically centered with the avatars.

**Row spacing.** The participating and viewed rows were rendered as bare siblings with no spacing between them. Wrapped them in a `Flex direction="column"` with a gap so they get a bit of breathing room.