### PR TITLE
fix(grouping): Mark Flutter runtime native frames as non-app

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
@@ -396,6 +396,11 @@ family:javascript module:**/packages/flutter/** -app
 family:native stack.abs_path:**/packages/flutter/** -app
 family:native stack.abs_path:lib/ui/hooks.dart -app
 family:native stack.abs_path:lib/ui/platform_dispatcher.dart -app
+family:native package:**/Frameworks/FlutterMacOS.framework/** -app
+family:native package:**/Frameworks/Flutter.framework/**      -app
+family:native stack.abs_path:third_party/dart/sdk/** -app
+family:native function:"stub InvokeDartCode" -app
+family:native function:"stub CallBootstrapNative" -app
 # sentry-dart SDK frames are not in app
 stack.abs_path:package:sentry/** -app -group
 stack.abs_path:package:sentry_flutter/** -app -group

--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
@@ -396,8 +396,8 @@ family:javascript module:**/packages/flutter/** -app
 family:native stack.abs_path:**/packages/flutter/** -app
 family:native stack.abs_path:lib/ui/hooks.dart -app
 family:native stack.abs_path:lib/ui/platform_dispatcher.dart -app
-family:native stack.abs_path:package:flutter/** -app -group
-family:native stack.abs_path:dart:** -app -group
+family:native stack.abs_path:package:flutter/** -app
+family:native stack.abs_path:dart:** -app
 family:native stack.abs_path:third_party/dart/sdk/** -app
 family:native package:**/Frameworks/FlutterMacOS.framework/** -app
 family:native package:**/Frameworks/Flutter.framework/** -app

--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
@@ -396,11 +396,14 @@ family:javascript module:**/packages/flutter/** -app
 family:native stack.abs_path:**/packages/flutter/** -app
 family:native stack.abs_path:lib/ui/hooks.dart -app
 family:native stack.abs_path:lib/ui/platform_dispatcher.dart -app
+family:native stack.abs_path:package:flutter/** -app -group
+family:native stack.abs_path:dart:** -app -group
+family:native stack.abs_path:third_party/dart/sdk/** -app
 family:native package:**/Frameworks/FlutterMacOS.framework/** -app
 family:native package:**/Frameworks/Flutter.framework/** -app
-family:native stack.abs_path:third_party/dart/sdk/** -app
 family:native function:"stub InvokeDartCode" -app
 family:native function:"stub CallBootstrapNative" -app
+
 # sentry-dart SDK frames are not in app
 stack.abs_path:package:sentry/** -app -group
 stack.abs_path:package:sentry_flutter/** -app -group

--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
@@ -397,7 +397,7 @@ family:native stack.abs_path:**/packages/flutter/** -app
 family:native stack.abs_path:lib/ui/hooks.dart -app
 family:native stack.abs_path:lib/ui/platform_dispatcher.dart -app
 family:native package:**/Frameworks/FlutterMacOS.framework/** -app
-family:native package:**/Frameworks/Flutter.framework/**      -app
+family:native package:**/Frameworks/Flutter.framework/** -app
 family:native stack.abs_path:third_party/dart/sdk/** -app
 family:native function:"stub InvokeDartCode" -app
 family:native function:"stub CallBootstrapNative" -app

--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
@@ -398,6 +398,7 @@ family:native stack.abs_path:lib/ui/hooks.dart -app
 family:native stack.abs_path:lib/ui/platform_dispatcher.dart -app
 family:native stack.abs_path:package:flutter/** -app
 family:native stack.abs_path:dart:** -app
+family:native stack.abs_path:dart:*/** -app
 family:native stack.abs_path:third_party/dart/sdk/** -app
 family:native package:**/Frameworks/FlutterMacOS.framework/** -app
 family:native package:**/Frameworks/Flutter.framework/** -app

--- a/tests/sentry/grouping/test_enhancer_dart_flutter_native.py
+++ b/tests/sentry/grouping/test_enhancer_dart_flutter_native.py
@@ -17,10 +17,10 @@ class _BaseNativeDartFlutterEnhancerTest(TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        # Load the default enhancement rules that include Dart/Flutter logic.
-        self.enhancements = ENHANCEMENT_BASES["all-platforms:2023-01-11"]
+        # Load the default enhancement base, which includes the Dart/Flutter logic.
+        self.enhancements = ENHANCEMENT_BASES["all-platforms:2026-01-20"]
 
-    def apply_rules(self, frame: dict[str, str]) -> dict[str, Any]:
+    def apply_rules(self, frame: dict[str, Any]) -> dict[str, Any]:
         """Apply enhancement rules to a single frame and return the processed frame."""
         frames = [frame]
         self.enhancements.apply_category_and_updated_in_app_to_frames(frames, self.PLATFORM, {})
@@ -173,3 +173,109 @@ class TestDartFlutterEnhancerNative(_BaseNativeDartFlutterEnhancerTest):
         }
         result = self.apply_rules(frame)
         assert result.get("in_app") is None
+
+    # ------------------------------------------------------------------
+    # Flutter/Dart runtime frames in native (Cocoa) crashes & app-hangs
+    #
+    # These frames must be out-of-app so they neither pollute in-app frame
+    # highlighting nor affect native grouping.
+    # ------------------------------------------------------------------
+
+    def test_flutter_engine_framework_frames_not_in_app(self) -> None:
+        """Flutter engine frames live in the Flutter.framework binary (iOS)."""
+        flutter_framework = (
+            "/private/var/containers/Bundle/Application/"
+            "00000000-0000-0000-0000-000000000000/Runner.app/"
+            "Frameworks/Flutter.framework/Flutter"
+        )
+        frames = [
+            {
+                "function": "flutter::Engine::DispatchPointerDataPacket",
+                "abs_path": "flutter/shell/common/engine.cc",
+                "package": flutter_framework,
+            },
+            {
+                "function": "dart::DartEntry::InvokeFunction",
+                "abs_path": "flutter/third_party/dart/runtime/vm/dart_entry.cc",
+                "package": flutter_framework,
+            },
+            {
+                "function": "dart::OS::GetCurrentMonotonicTicks",
+                "abs_path": "flutter/third_party/dart/runtime/vm/os_macos.cc",
+                "package": flutter_framework,
+            },
+        ]
+        for frame in frames:
+            result = self.apply_rules(frame)
+            assert result["in_app"] is False, f"{frame['function']} should be out-of-app"
+
+    def test_flutter_macos_engine_framework_frames_not_in_app(self) -> None:
+        """Flutter engine frames live in the FlutterMacOS.framework binary (macOS)."""
+        frame = {
+            "function": "flutter::Shell::OnPlatformViewDispatchPointerDataPacket",
+            "abs_path": "flutter/shell/common/shell.cc",
+            "package": (
+                "/Applications/MyApp.app/Contents/Frameworks/FlutterMacOS.framework/FlutterMacOS"
+            ),
+        }
+        result = self.apply_rules(frame)
+        assert result["in_app"] is False
+
+    def test_flutter_framework_dart_frames_not_in_app(self) -> None:
+        """`package:flutter/**` framework Dart frames are out-of-app."""
+        flutter_dart_paths = [
+            "package:flutter/src/gestures/binding.dart",
+            "package:flutter/src/gestures/pointer_router.dart",
+            "package:flutter/src/gestures/recognizer.dart",
+            "package:flutter/src/rendering/binding.dart",
+            "package:flutter/src/material/ink_well.dart",
+        ]
+        for path in flutter_dart_paths:
+            frame = {"abs_path": path}
+            result = self.apply_rules(frame)
+            assert result["in_app"] is False, f"{path} should be out-of-app"
+
+    def test_dart_sdk_frames_not_in_app(self) -> None:
+        """Dart SDK frames (`dart:...` and `third_party/dart/sdk/...`) are out-of-app."""
+        dart_sdk_paths = [
+            "dart:ui/hooks.dart",
+            "dart:ui/platform_dispatcher.dart",
+            "dart:core/stopwatch.dart",
+            "dart:core-patch/stopwatch_patch.dart",
+            "dart:_compact_hash",
+            "third_party/dart/sdk/lib/core/object.dart",
+        ]
+        for path in dart_sdk_paths:
+            frame = {"abs_path": path}
+            result = self.apply_rules(frame)
+            assert result["in_app"] is False, f"{path} should be out-of-app"
+
+    def test_dart_bootstrap_stub_frames_not_in_app(self) -> None:
+        """Dart VM bootstrap/invoke stub frames (no abs_path) are out-of-app.
+
+        Native frames carry `raw_function`, which makes the grouping matcher use
+        the untrimmed `function` value. Without it, `trim_native_function_name`
+        would strip the leading `stub ` token and the rule wouldn't match.
+        """
+        for stub_function in ("stub InvokeDartCode", "stub CallBootstrapNative"):
+            frame = {"function": stub_function, "raw_function": stub_function}
+            result = self.apply_rules(frame)
+            assert result["in_app"] is False, f"{stub_function} should be out-of-app"
+
+    def test_user_dart_frames_stay_in_app(self) -> None:
+        """User application Dart frames must remain in-app (regression guard).
+
+        The `package:flutter/**` rule must only match the exact `flutter` SDK
+        package, not user packages whose name merely starts with or contains
+        "flutter" (e.g. `flutter_app`, `my_flutter_app`, `flutterfire`).
+        """
+        frames = [
+            {"abs_path": "package:app_hang_test_app/main.dart", "in_app": True},
+            {"abs_path": "package:myapp/src/widgets/home_screen.dart", "in_app": True},
+            {"abs_path": "package:flutter_app/main.dart", "in_app": True},
+            {"abs_path": "package:my_flutter_app/main.dart", "in_app": True},
+            {"abs_path": "package:flutterfire/main.dart", "in_app": True},
+        ]
+        for frame in frames:
+            result = self.apply_rules(frame)
+            assert result["in_app"] is True, f"{frame['abs_path']} should stay in-app"


### PR DESCRIPTION
Treat Flutter framework, Dart SDK, and bootstrap stub frames as not in app frames

Example event of wrongly classified inApp: https://sentry-sdks.sentry.io/issues/7506985123/?project=5428562&query=is%3Aunresolved%20App%20Hang&referrer=issue-stream

Closes https://github.com/getsentry/sentry-dart/issues/3650