### PR TITLE
ref(pipeline): Use Button busy prop for advancing state

### DIFF
--- a/static/app/components/core/form/scrapsForm.tsx
+++ b/static/app/components/core/form/scrapsForm.tsx
@@ -81,7 +81,7 @@ function SubmitButton(props: ButtonProps) {
           variant="primary"
           type="submit"
           form={form.formId}
-          busy={isSubmitting}
+          busy={isSubmitting || props.busy}
           disabled={isSubmitting || props.disabled}
         />
       )}

--- a/static/app/components/pipeline/pipelineIntegrationAwsLambda.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationAwsLambda.spec.tsx
@@ -50,12 +50,15 @@ describe('ProjectSelectStep', () => {
     });
   });
 
-  it('shows submitting state when isAdvancing', () => {
+  it('shows busy state when isAdvancing', () => {
     ProjectsStore.loadInitialData([ProjectFixture()]);
 
     render(<ProjectSelectStep {...makeStepProps({stepData: {}, isAdvancing: true})} />);
 
-    expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables submit button when isInitializing', () => {
@@ -159,10 +162,13 @@ describe('CloudFormationStep', () => {
     });
   });
 
-  it('shows verifying state when isAdvancing', () => {
+  it('shows busy state when isAdvancing', () => {
     render(<CloudFormationStep {...makeStepProps({stepData, isAdvancing: true})} />);
 
-    expect(screen.getByRole('button', {name: 'Verifying...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 });
 

--- a/static/app/components/pipeline/pipelineIntegrationAwsLambda.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationAwsLambda.tsx
@@ -101,8 +101,8 @@ function ProjectSelectStep({
           {t('Currently only supports Node and Python Lambda functions.')}
         </Text>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing || isInitializing}>
-            {isAdvancing ? t('Submitting...') : t('Continue')}
+          <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
+            {t('Continue')}
           </form.SubmitButton>
         </Flex>
       </Stack>
@@ -292,9 +292,7 @@ function CloudFormationStep({
           </div>
         )}
         <Flex>
-          <form.SubmitButton disabled={isAdvancing}>
-            {isAdvancing ? t('Verifying...') : t('Continue')}
-          </form.SubmitButton>
+          <form.SubmitButton busy={isAdvancing}>{t('Continue')}</form.SubmitButton>
         </Flex>
       </Stack>
     </form.AppForm>
@@ -436,7 +434,8 @@ function InstrumentationStep({
         <Button
           variant="primary"
           size="sm"
-          disabled={isAdvancing || enabledCount === 0}
+          busy={isAdvancing}
+          disabled={enabledCount === 0}
           onClick={() => {
             const enabledFunctions = Object.entries(enabled)
               .filter(([_, v]) => v)
@@ -444,7 +443,7 @@ function InstrumentationStep({
             advance({enabledFunctions});
           }}
         >
-          {isAdvancing ? t('Instrumenting...') : t('Instrument Functions')}
+          {t('Instrument Functions')}
         </Button>
         {failedNames.size > 0 && (
           <Text size="sm">

--- a/static/app/components/pipeline/pipelineIntegrationBitbucket.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationBitbucket.spec.tsx
@@ -81,7 +81,7 @@ describe('BitbucketAuthorizeStep', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows loading state when isAdvancing is true', () => {
+  it('shows busy state when isAdvancing is true', () => {
     render(
       <BitbucketAuthorizeStep
         {...makeStepProps({
@@ -94,7 +94,10 @@ describe('BitbucketAuthorizeStep', () => {
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Authorizing...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Authorize Bitbucket'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables authorize button when authorizeUrl is not provided', () => {

--- a/static/app/components/pipeline/pipelineIntegrationBitbucket.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationBitbucket.tsx
@@ -59,11 +59,7 @@ function BitbucketAuthorizeStep({
           </Text>
         )}
       </Stack>
-      {isAdvancing ? (
-        <Button size="sm" disabled>
-          {t('Authorizing...')}
-        </Button>
-      ) : isWaitingForCallback ? (
+      {isWaitingForCallback && !isAdvancing ? (
         <Button size="sm" onClick={openPopup}>
           {t('Reopen authorization window')}
         </Button>
@@ -72,6 +68,7 @@ function BitbucketAuthorizeStep({
           size="sm"
           variant="primary"
           onClick={openPopup}
+          busy={isAdvancing}
           disabled={!stepData?.authorizeUrl}
         >
           {t('Authorize Bitbucket')}

--- a/static/app/components/pipeline/pipelineIntegrationClaudeCode.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationClaudeCode.spec.tsx
@@ -27,12 +27,15 @@ describe('ClaudeCodeApiKeyStep', () => {
     });
   });
 
-  it('shows loading state when isAdvancing', () => {
+  it('shows busy state when isAdvancing', () => {
     render(
       <ClaudeCodeApiKeyStep {...makeStepProps({stepData: {}, isAdvancing: true})} />
     );
 
-    expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables submit button when isInitializing', () => {

--- a/static/app/components/pipeline/pipelineIntegrationClaudeCode.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationClaudeCode.tsx
@@ -55,8 +55,8 @@ function ClaudeCodeApiKeyStep({
           )}
         </form.AppField>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing || isInitializing}>
-            {isAdvancing ? t('Submitting...') : t('Continue')}
+          <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
+            {t('Continue')}
           </form.SubmitButton>
         </Flex>
       </Stack>

--- a/static/app/components/pipeline/pipelineIntegrationCursor.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationCursor.spec.tsx
@@ -27,10 +27,13 @@ describe('CursorApiKeyStep', () => {
     });
   });
 
-  it('shows loading state when isAdvancing', () => {
+  it('shows busy state when isAdvancing', () => {
     render(<CursorApiKeyStep {...makeStepProps({stepData: {}, isAdvancing: true})} />);
 
-    expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables submit button when isInitializing', () => {

--- a/static/app/components/pipeline/pipelineIntegrationCursor.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationCursor.tsx
@@ -55,8 +55,8 @@ function CursorApiKeyStep({
           )}
         </form.AppField>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing || isInitializing}>
-            {isAdvancing ? t('Submitting...') : t('Continue')}
+          <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
+            {t('Continue')}
           </form.SubmitButton>
         </Flex>
       </Stack>

--- a/static/app/components/pipeline/pipelineIntegrationDiscord.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationDiscord.spec.tsx
@@ -60,7 +60,7 @@ describe('DiscordOAuthLoginStep', () => {
     });
   });
 
-  it('shows loading state when isAdvancing is true', () => {
+  it('shows busy state when isAdvancing is true', () => {
     render(
       <DiscordOAuthLoginStep
         {...makeStepProps({
@@ -70,7 +70,10 @@ describe('DiscordOAuthLoginStep', () => {
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Authorizing...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Authorize Discord'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables authorize button when oauthUrl is not provided', () => {

--- a/static/app/components/pipeline/pipelineIntegrationGitHub.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHub.spec.tsx
@@ -61,7 +61,7 @@ describe('GitHubOAuthLoginStep', () => {
     });
   });
 
-  it('shows loading state when isAdvancing is true', () => {
+  it('shows busy state when isAdvancing is true', () => {
     render(
       <GitHubOAuthLoginStep
         {...makeStepProps({
@@ -71,7 +71,10 @@ describe('GitHubOAuthLoginStep', () => {
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Authorizing...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Authorize GitHub'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables authorize button when isInitializing', () => {
@@ -276,7 +279,7 @@ describe('OrgSelectionStep', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows completing state when isAdvancing in fresh install view', () => {
+  it('shows busy state when isAdvancing in fresh install view', () => {
     render(
       <OrgSelectionStep
         {...makeStepProps({
@@ -289,6 +292,8 @@ describe('OrgSelectionStep', () => {
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Completing...'})).toBeDisabled();
+    expect(
+      screen.getByRole('button', {name: 'Reopen installation window'})
+    ).toHaveAttribute('aria-busy', 'true');
   });
 });

--- a/static/app/components/pipeline/pipelineIntegrationGitHub.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHub.tsx
@@ -207,7 +207,7 @@ function FreshInstallSteps({
   onInstall: () => void;
   popupBlockedNotice?: React.ReactNode;
 }) {
-  if (isAdvancing) {
+  if (isWaitingForCallback || isAdvancing) {
     return (
       <Stack gap="lg" align="start">
         <Text>
@@ -215,22 +215,7 @@ function FreshInstallSteps({
             'Complete the installation in the popup window. Once finished, this page will update automatically.'
           )}
         </Text>
-        <Button size="sm" disabled>
-          {t('Completing...')}
-        </Button>
-      </Stack>
-    );
-  }
-
-  if (isWaitingForCallback) {
-    return (
-      <Stack gap="lg" align="start">
-        <Text>
-          {t(
-            'Complete the installation in the popup window. Once finished, this page will update automatically.'
-          )}
-        </Text>
-        <Button size="sm" onClick={onInstall}>
+        <Button size="sm" onClick={onInstall} busy={isAdvancing}>
           {t('Reopen installation window')}
         </Button>
       </Stack>

--- a/static/app/components/pipeline/pipelineIntegrationGitLab.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitLab.spec.tsx
@@ -246,7 +246,7 @@ describe('InstallationConfigStep', () => {
     });
   });
 
-  it('shows submitting state when isAdvancing is true', async () => {
+  it('shows busy state when isAdvancing is true', async () => {
     render(
       <InstallationConfigStep
         {...makeStepProps({
@@ -259,7 +259,10 @@ describe('InstallationConfigStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
 
-    expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables submit button when isInitializing', async () => {
@@ -317,7 +320,7 @@ describe('GitLabOAuthLoginStep', () => {
     });
   });
 
-  it('shows loading state when isAdvancing is true', () => {
+  it('shows busy state when isAdvancing is true', () => {
     render(
       <GitLabOAuthLoginStep
         {...makeStepProps({
@@ -327,7 +330,10 @@ describe('GitLabOAuthLoginStep', () => {
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Authorizing...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Authorize GitLab'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables authorize button when oauthUrl is not provided', () => {

--- a/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
@@ -202,8 +202,8 @@ function InstallationConfigStep({
           }
         </form.Subscribe>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing || isInitializing}>
-            {isAdvancing ? t('Submitting...') : t('Continue')}
+          <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
+            {t('Continue')}
           </form.SubmitButton>
         </Flex>
       </Stack>

--- a/static/app/components/pipeline/pipelineIntegrationOpsgenie.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationOpsgenie.spec.tsx
@@ -69,14 +69,17 @@ describe('OpsgenieInstallationConfigStep', () => {
     });
   });
 
-  it('shows loading state when isAdvancing', () => {
+  it('shows busy state when isAdvancing', () => {
     render(
       <OpsgenieInstallationConfigStep
         {...makeStepProps({stepData: {baseUrlChoices}, isAdvancing: true})}
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables submit button when isInitializing', () => {

--- a/static/app/components/pipeline/pipelineIntegrationOpsgenie.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationOpsgenie.tsx
@@ -115,8 +115,8 @@ function OpsgenieInstallationConfigStep({
           )}
         </form.AppField>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing || isInitializing}>
-            {isAdvancing ? t('Submitting...') : t('Continue')}
+          <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
+            {t('Continue')}
           </form.SubmitButton>
         </Flex>
       </Stack>

--- a/static/app/components/pipeline/pipelineIntegrationPagerDuty.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPagerDuty.spec.tsx
@@ -58,7 +58,7 @@ describe('PagerDutyInstallStep', () => {
     });
   });
 
-  it('shows loading state when isAdvancing is true', () => {
+  it('shows busy state when isAdvancing is true', () => {
     render(
       <PagerDutyInstallStep
         {...makeStepProps({
@@ -68,7 +68,10 @@ describe('PagerDutyInstallStep', () => {
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Installing...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Install PagerDuty App'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables install button when installUrl is not provided', () => {

--- a/static/app/components/pipeline/pipelineIntegrationPagerDuty.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPagerDuty.tsx
@@ -50,11 +50,7 @@ function PagerDutyInstallStep({
           </Text>
         )}
       </Stack>
-      {isAdvancing ? (
-        <Button size="sm" disabled>
-          {t('Installing...')}
-        </Button>
-      ) : popupStatus === 'popup-open' ? (
+      {popupStatus === 'popup-open' && !isAdvancing ? (
         <Button size="sm" onClick={openPopup}>
           {t('Reopen installation window')}
         </Button>
@@ -63,6 +59,7 @@ function PagerDutyInstallStep({
           size="sm"
           variant="primary"
           onClick={openPopup}
+          busy={isAdvancing}
           disabled={!stepData?.installUrl}
         >
           {t('Install PagerDuty App')}

--- a/static/app/components/pipeline/pipelineIntegrationPerforce.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPerforce.spec.tsx
@@ -116,14 +116,17 @@ describe('PerforceInstallationConfigStep', () => {
     });
   });
 
-  it('shows loading state when isAdvancing', () => {
+  it('shows busy state when isAdvancing', () => {
     render(
       <PerforceInstallationConfigStep
         {...makeStepProps({stepData: {}, isAdvancing: true})}
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Connecting...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Connect'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables submit button when isInitializing', () => {

--- a/static/app/components/pipeline/pipelineIntegrationPerforce.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPerforce.tsx
@@ -194,8 +194,8 @@ function PerforceInstallationConfigStep({
           )}
         </form.AppField>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing || isInitializing}>
-            {isAdvancing ? t('Connecting...') : t('Connect')}
+          <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
+            {t('Connect')}
           </form.SubmitButton>
         </Flex>
       </Stack>

--- a/static/app/components/pipeline/pipelineIntegrationSlack.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationSlack.spec.tsx
@@ -58,7 +58,7 @@ describe('SlackOAuthLoginStep', () => {
     });
   });
 
-  it('shows loading state when isAdvancing is true', () => {
+  it('shows busy state when isAdvancing is true', () => {
     render(
       <SlackOAuthLoginStep
         {...makeStepProps({
@@ -68,7 +68,10 @@ describe('SlackOAuthLoginStep', () => {
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Authorizing...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Authorize Slack'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables authorize button when oauthUrl is not provided', () => {

--- a/static/app/components/pipeline/pipelineIntegrationVercel.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationVercel.spec.tsx
@@ -58,7 +58,7 @@ describe('VercelOAuthLoginStep', () => {
     });
   });
 
-  it('shows loading state when isAdvancing is true', () => {
+  it('shows busy state when isAdvancing is true', () => {
     render(
       <VercelOAuthLoginStep
         {...makeStepProps({
@@ -68,7 +68,10 @@ describe('VercelOAuthLoginStep', () => {
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Authorizing...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Authorize Vercel'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('disables authorize button when oauthUrl is not provided', () => {

--- a/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
+++ b/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
@@ -197,7 +197,7 @@ describe('OAuthLoginStep', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows loading state when isLoading is true', () => {
+  it('shows busy state when isLoading is true', () => {
     render(
       <OAuthLoginStep
         serviceName="GitLab"
@@ -207,6 +207,9 @@ describe('OAuthLoginStep', () => {
       />
     );
 
-    expect(screen.getByRole('button', {name: 'Authorizing...'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Authorize GitLab'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 });

--- a/static/app/components/pipeline/shared/oauthLoginStep.tsx
+++ b/static/app/components/pipeline/shared/oauthLoginStep.tsx
@@ -67,16 +67,18 @@ export function OAuthLoginStep({
           </Text>
         )}
       </Stack>
-      {isLoading ? (
-        <Button size="sm" disabled>
-          {t('Authorizing...')}
-        </Button>
-      ) : popupStatus === 'popup-open' ? (
+      {popupStatus === 'popup-open' && !isLoading ? (
         <Button size="sm" onClick={openPopup}>
           {t('Reopen authorization window')}
         </Button>
       ) : (
-        <Button size="sm" variant="primary" onClick={openPopup} disabled={!oauthUrl}>
+        <Button
+          size="sm"
+          variant="primary"
+          onClick={openPopup}
+          busy={isLoading}
+          disabled={!oauthUrl}
+        >
           {tct('Authorize [service]', {service: serviceName})}
         </Button>
       )}


### PR DESCRIPTION
Switches the pipeline integration buttons from the label-swap / disabled pattern (`Submitting...`, `Authorizing...`, `Installing...`) to the `busy` prop on `Button`. The steady-state label stays visible, the spinner overlay communicates progress, and consumers get `aria-busy="true"` for assistive tech.

`form.SubmitButton` is updated to OR `busy` from props with its internal `isSubmitting` state, matching how `disabled` is already merged. This lets pipeline steps drive the busy state from `isAdvancing` while still respecting normal form submission.

Excludes the GitHub Enterprise and Vercel backend pipelines, which are still pending in unmerged PRs.