### PR TITLE
feat(ourlogs): reduce modal export rows limit to 10k

### DIFF
--- a/static/app/views/explore/logs/exports/generateLogExportRowCountOptions.ts
+++ b/static/app/views/explore/logs/exports/generateLogExportRowCountOptions.ts
@@ -16,8 +16,6 @@ const ROW_COUNT_VALUES = [
   ROW_COUNT_VALUE_DEFAULT,
   ROW_COUNT_VALUE_SYNC_LIMIT,
   10_000,
-  50_000,
-  100_000,
 ];
 
 export function generateLogExportRowCountOptions(estimatedRowCount: number) {


### PR DESCRIPTION
Corresponds to #116048.

Closes LOGS-823.