### PR TITLE
fix(issue-detection): Add plural KBLayouts_iPhone.dat to FileIO ignore list

### DIFF
--- a/src/sentry/issue_detection/detectors/io_main_thread_detector.py
+++ b/src/sentry/issue_detection/detectors/io_main_thread_detector.py
@@ -119,7 +119,7 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
     Checks for a file io span on the main thread
     """
 
-    IGNORED_SUFFIXES = [".nib", ".plist", "kblayout_iphone.dat"]
+    IGNORED_SUFFIXES = [".nib", ".plist", "kblayout_iphone.dat", "kblayouts_iphone.dat"]
     SPAN_PREFIX = "file"
     type = DetectorType.FILE_IO_MAIN_THREAD
     settings_key = DetectorType.FILE_IO_MAIN_THREAD

--- a/tests/sentry/issue_detection/test_file_io_on_main_thread_detector.py
+++ b/tests/sentry/issue_detection/test_file_io_on_main_thread_detector.py
@@ -112,6 +112,11 @@ class FileIOMainThreadDetectorTest(TestCase):
         event["spans"][0]["data"]["file.path"] = "somethins/stuff/blah/yup/KBLayout_iPhone.dat"
         assert self.find_problems(event) == []
 
+    def test_ignores_keyboard_files_plural(self) -> None:
+        event = get_event("file-io-on-main-thread/file-io-on-main-thread")
+        event["spans"][0]["data"]["file.path"] = "somethins/stuff/blah/yup/KBLayouts_iPhone.dat"
+        assert self.find_problems(event) == []
+
     def test_gives_problem_correct_title(self) -> None:
         event = get_event("file-io-on-main-thread/file-io-on-main-thread")
         event["spans"][0]["data"]["blocked_main_thread"] = True


### PR DESCRIPTION
Adds `kblayouts_iphone.dat` to `FileIOMainThreadDetector.IGNORED_SUFFIXES` to suppress false File IO on Main Thread issues from the plural `KBLayouts_iPhone.dat` keyboard cache file used on newer iOS versions

fixes ID-1564
