### PR TITLE
fix(issues): Make GroupSearchViewPermission fail closed for unknown object types

### DIFF
--- a/src/sentry/issues/endpoints/bases/group_search_view.py
+++ b/src/sentry/issues/endpoints/bases/group_search_view.py
@@ -35,4 +35,4 @@ class GroupSearchViewPermission(OrganizationPermission):
 
             return False
 
-        return True
+        return False

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -606,3 +606,12 @@ class GroupSearchViewPermissionTest(TestCase):
         view = MagicMock()
 
         assert permission.has_object_permission(request, view, object()) is False
+
+    def test_denies_related_model_types(self) -> None:
+        permission = GroupSearchViewPermission()
+        request = MagicMock()
+        request.method = "GET"
+        view = MagicMock()
+
+        starred = MagicMock(spec=GroupSearchViewStarred)
+        assert permission.has_object_permission(request, view, starred) is False

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -1,10 +1,13 @@
+from unittest.mock import MagicMock
+
 from django.urls import reverse
 from django.utils import timezone
 
+from sentry.issues.endpoints.bases.group_search_view import GroupSearchViewPermission
 from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers import with_feature
 
 
@@ -593,3 +596,13 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
         response = self.client.put(self.url, data=data)
         assert response.status_code == 404
+
+
+class GroupSearchViewPermissionTest(TestCase):
+    def test_denies_unknown_object_types(self) -> None:
+        permission = GroupSearchViewPermission()
+        request = MagicMock()
+        request.method = "PUT"
+        view = MagicMock()
+
+        assert permission.has_object_permission(request, view, object()) is False


### PR DESCRIPTION
`GroupSearchViewPermission.has_object_permission` returned `True` for unrecognized object types (the fallback at the end of the method), granting access by default. Changed the fallback to return `False` so unknown object types are denied

Fixes ID-1562
