### PR TITLE
fix(security): Add project-level access check to GroupEventJsonView

### DIFF
--- a/src/sentry/web/frontend/group_event_json.py
+++ b/src/sentry/web/frontend/group_event_json.py
@@ -20,6 +20,9 @@ class GroupEventJsonView(OrganizationView):
         except Group.DoesNotExist:
             raise Http404
 
+        if not request.access.has_project_access(group.project):
+            raise Http404
+
         event: Event | GroupEvent | None
         if event_id_or_latest == "latest":
             event = group.get_latest_event()

--- a/tests/sentry/web/frontend/test_group_event_json.py
+++ b/tests/sentry/web/frontend/test_group_event_json.py
@@ -22,6 +22,58 @@ class GroupEventJsonTest(TestCase):
         data = json.loads(resp.content.decode("utf-8"))
         assert data["event_id"] == self.event.event_id
 
+    def test_cross_project_access_denied(self) -> None:
+        """User on team A cannot read event JSON from a project they lack access to."""
+        org = self.create_organization(flags=0)
+        team_b = self.create_team(organization=org, name="team-b")
+        project_b = self.create_project(organization=org, teams=[team_b])
+        min_ago = before_now(minutes=1).isoformat()
+        event_b = self.store_event(
+            data={"fingerprint": ["group-b"], "timestamp": min_ago},
+            project_id=project_b.id,
+        )
+
+        team_a = self.create_team(organization=org, name="team-a")
+        restricted_user = self.create_user()
+        self.create_member(
+            user=restricted_user,
+            organization=org,
+            role="member",
+            teams=[team_a],
+        )
+
+        self.login_as(restricted_user)
+        path = (
+            f"/organizations/{org.slug}/issues/{event_b.group_id}/events/{event_b.event_id}/json/"
+        )
+        resp = self.client.get(path)
+        assert resp.status_code == 404
+
+    def test_cross_project_access_denied_latest(self) -> None:
+        """User on team A cannot read latest event JSON from a project they lack access to."""
+        org = self.create_organization(flags=0)
+        team_b = self.create_team(organization=org, name="team-b")
+        project_b = self.create_project(organization=org, teams=[team_b])
+        min_ago = before_now(minutes=1).isoformat()
+        event_b = self.store_event(
+            data={"fingerprint": ["group-b"], "timestamp": min_ago},
+            project_id=project_b.id,
+        )
+
+        team_a = self.create_team(organization=org, name="team-a")
+        restricted_user = self.create_user()
+        self.create_member(
+            user=restricted_user,
+            organization=org,
+            role="member",
+            teams=[team_a],
+        )
+
+        self.login_as(restricted_user)
+        path = f"/organizations/{org.slug}/issues/{event_b.group_id}/events/latest/json/"
+        resp = self.client.get(path)
+        assert resp.status_code == 404
+
     def test_cross_organization_access_denied(self) -> None:
         """Ensures users cannot access event data from other organizations."""
         victim_org = self.create_organization(name="victim-org")


### PR DESCRIPTION
`GroupEventJsonView` checked org-level `event:read` scope via `OrganizationView` but did not verify the user has access to the resolved group's project. In orgs with closed membership (team-based access), a user on team A could read raw event JSON (PII, stacktraces, request bodies) from any project by guessing group IDs. Added `request.access.has_project_access(group.project)` check after resolving the group, returning 404 on denial (consistent with the existing cross-org pattern)

Fixes ID-1563
