### PR TITLE
fix(dashboards): raise widget description limit to 350

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -539,9 +539,9 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
 
         description = data.get("description")
         description_length = len(description) if description else 0
-        if description_length > 255:
+        if description_length > 350:
             raise serializers.ValidationError(
-                {"description": "Ensure description has no more than 255 characters."}
+                {"description": "Ensure description has no more than 350 characters."}
             )
 
         if data.get("queries"):

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -1242,7 +1242,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                 {
                     "title": "Widget with long description",
                     "displayType": "line",
-                    "description": "x" * 256,
+                    "description": "x" * 351,
                     "interval": "5m",
                     "queries": [
                         {
@@ -1259,7 +1259,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         response = self.do_request("put", self.url(self.dashboard.id), data=data)
         assert response.status_code == 400, response.data
         assert response.data["widgets"][1]["description"] == [
-            "Ensure description has no more than 255 characters."
+            "Ensure description has no more than 350 characters."
         ]
 
     def test_add_text_widget_description_exceeds_max_length(self) -> None:


### PR DESCRIPTION
## Summary
- Bumps the widget `description` validator from 255 → 350 chars to fit the longest prebuilt widget description (271 chars, mobile vitals **App Starts**) plus buffer.
- The 255 cap was a legacy artifact of the old `CharField(max_length=255)`; the column is now `TextField`, so this is a serializer-only change.

DAIN-1693