### PR TITLE
fix(discover): Add missing check for DiscoverSavedQueryVisitEndpoint

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -181,6 +181,8 @@ class DiscoverSavedQueryVisitEndpoint(DiscoverSavedQueryBase):
         if not self.has_feature(organization, request):
             return self.respond(status=404)
 
+        self.check_object_permissions(request, query)
+
         query.visits = F("visits") + 1
         query.last_visited = timezone.now()
         query.save(update_fields=["visits", "last_visited"])

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -624,3 +624,20 @@ class OrganizationDiscoverQueryVisitTest(APITestCase, SnubaTestCase):
         query = DiscoverSavedQuery.objects.get(id=self.query.id)
         assert query.visits == 1
         assert query.last_visited == last_visited
+
+    def test_visit_disallow_when_no_project_access(self) -> None:
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+
+        user_no_team = self.create_user(is_superuser=False)
+        self.create_member(user=user_no_team, organization=self.org, role="member", teams=[])
+        self.login_as(user_no_team)
+
+        with self.feature("organizations:discover-query"):
+            response = self.client.post(self.url(self.query.id))
+
+        assert response.status_code == 403
+        assert response.data == {"detail": "You do not have permission to perform this action."}
+
+        query = DiscoverSavedQuery.objects.get(id=self.query.id)
+        assert query.visits == 1


### PR DESCRIPTION
This PR adds in a missing check in the `DiscoverSavedQueryVisitEndpoint` endpoint.

Closes BROWSE-518
