### PR TITLE
feat(flagpole): Register onboarding-scm-project-creation-experiment feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -180,6 +180,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding-scm-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Experiment: SCM onboarding project details A/B test
     manager.add("organizations:onboarding-scm-project-details-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Experiment: SCM-first project creation wizard A/B test (project creation flow, not new-org onboarding)
+    manager.add("organizations:onboarding-scm-project-creation-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable large ownership rule file size limit
     manager.add("organizations:ownership-size-limit-large", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable xlarge ownership rule file size limit


### PR DESCRIPTION
## Summary
- Registers `organizations:onboarding-scm-project-creation-experiment` in `temporary.py` for the SCM-first project creation wizard A/B test.
- Uses `FLAGPOLE` handler with `api_expose=True` so the frontend can read it via `useExperiment()` to gate the new wizard against the legacy `createProject.tsx` form.

Companion PR in sentry-options-automator: https://github.com/getsentry/sentry-options-automator/pull/7930

Refs VDY-73

## Test plan
- [ ] Verify flag is accessible via the org serializer
- [ ] Confirm experiment assignment works with `useExperiment()` hook once the wizard scaffold (VDY-73 follow-up) lands