### PR TITLE
fix(search): Short ID lookup works when query contains filters

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -19,7 +19,7 @@ from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.issue_search import convert_query_values, parse_search_query
 from sentry.models.environment import Environment
-from sentry.models.group import Group, looks_like_short_id
+from sentry.models.group import Group, looks_like_short_id, parse_short_id
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.release import Release
@@ -175,11 +175,21 @@ def get_by_short_id(
     is_short_id_lookup: str,
     query: str,
 ) -> Group | None:
-    if is_short_id_lookup == "1" and looks_like_short_id(query):
+    if is_short_id_lookup != "1":
+        return None
+    if looks_like_short_id(query):
         try:
             return Group.objects.by_qualified_short_id(organization_id, query)
         except Group.DoesNotExist:
             pass
+    # When the query contains filters (e.g. "is:unresolved SEER-7D1"),
+    # the full string won't match as a short ID. Try individual tokens.
+    for token in query.split():
+        if parse_short_id(token) is not None:
+            try:
+                return Group.objects.by_qualified_short_id(organization_id, token)
+            except Group.DoesNotExist:
+                pass
     return None
 
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -660,6 +660,15 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert len(response.data) == 1
         assert response["X-Sentry-Direct-Hit"] == "1"
 
+    def test_lookup_by_short_id_with_filters(self) -> None:
+        group = self.group
+        short_id = group.qualified_short_id
+
+        self.login_as(user=self.user)
+        response = self.get_success_response(query=f"is:unresolved {short_id}", shortIdLookup=1)
+        assert len(response.data) == 1
+        assert response["X-Sentry-Direct-Hit"] == "1"
+
     def test_lookup_by_short_id_alias(self) -> None:
         event_id = "f" * 32
         group = self.store_event(


### PR DESCRIPTION
When searching for a short ID (e.g. `SEER-7D1`) in the issue stream alongside
filters like `is:unresolved`, the direct hit lookup failed because
`get_by_short_id()` tried to parse the entire query string `"is:unresolved SEER-7D1"`
as a short ID.

Now falls back to checking individual space-separated tokens using `parse_short_id()`
(stricter validation than `looks_like_short_id()`) when the full query doesn't match.

Fixes https://linear.app/getsentry/issue/ID-1565