### PR TITLE
feat(search): Register feature flag for recommended issue sort

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -331,6 +331,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-feed.eap-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Remove trace and breadcrumbs from issue summary input
     manager.add("organizations:issue-summary-experimental", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable the experimental "recommended" sort option in the issue stream
+    manager.add("organizations:issue-stream-recommended-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # Lets organizations manage grouping configs
     manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)


### PR DESCRIPTION
Register `organizations:issue-stream-recommended-sort` as a temporary feature
flag with `api_expose=True` so the frontend can check it.

This enables per-org enablement via FlagPole for the experimental recommended
sort added in #111043. The flag will be used to gate showing "Recommended" in
the issue stream sort dropdown for orgs that opt in.

No behavioral changes — just the flag registration.

fixes https://linear.app/getsentry/issue/ID-1566/add-feature-flag-for-sort-option