### PR TITLE
feat(scm): add github_enterprise support to SCM Platform RPC dispatch

### DIFF
--- a/src/sentry/scm/private/helpers.py
+++ b/src/sentry/scm/private/helpers.py
@@ -77,6 +77,19 @@ def fetch_repository(organization_id: int, repository_id: RepositoryId) -> Repos
     if not isinstance(repo.provider, str):
         return None
 
+    provider_name = repo.provider.removeprefix("integrations:")
+    web_base_url: str | None = None
+    if provider_name == "github_enterprise":
+        integration = integration_service.get_integration(
+            integration_id=repo.integration_id,
+            organization_id=organization_id,
+        )
+        if integration:
+            domain_name = integration.metadata.get("domain_name")
+            if domain_name:
+                base_host = domain_name.split("/", 1)[0]
+                web_base_url = f"https://{base_host}"
+
     return cast(
         Repository,
         {
@@ -86,8 +99,8 @@ def fetch_repository(organization_id: int, repository_id: RepositoryId) -> Repos
             "is_active": repo.status == ObjectStatus.ACTIVE,
             "name": repo.name,
             "organization_id": repo.organization_id,
-            "provider_name": repo.provider.removeprefix("integrations:"),
-            "web_base_url": None,
+            "provider_name": provider_name,
+            "web_base_url": web_base_url,
         },
     )
 

--- a/tests/sentry/scm/integration/test_helpers_integration.py
+++ b/tests/sentry/scm/integration/test_helpers_integration.py
@@ -181,3 +181,83 @@ class TestFetchServiceProvider(TestCase):
         }
         result = fetch_service_provider(self.organization.id, repository)
         assert result is None
+
+    def test_github_enterprise_returns_github_provider(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github_enterprise",
+            name="GHE Acme",
+            external_id="ghe-dispatch-1",
+            metadata={
+                "domain_name": "github.acme.com",
+                "installation_id": "1",
+                "installation": {"id": "1", "private_key": "x", "verify_ssl": True},
+            },
+        )
+
+        repository: Repository = {
+            "id": 1,
+            "integration_id": integration.id,
+            "name": "acme/widget",
+            "organization_id": self.organization.id,
+            "is_active": True,
+            "external_id": "9001",
+            "provider_name": "github_enterprise",
+            "web_base_url": "https://github.acme.com",
+        }
+        provider = fetch_service_provider(self.organization.id, repository)
+
+        assert isinstance(provider, GitHubProvider)
+
+    def test_github_enterprise_without_integration_returns_none(self) -> None:
+        repository: Repository = {
+            "id": 1,
+            "integration_id": 99999,
+            "name": "acme/widget",
+            "organization_id": self.organization.id,
+            "is_active": True,
+            "external_id": "9001",
+            "provider_name": "github_enterprise",
+            "web_base_url": "https://github.acme.com",
+        }
+        assert fetch_service_provider(self.organization.id, repository) is None
+
+    def test_github_enterprise_client_error_returns_none(self) -> None:
+        from unittest.mock import patch
+
+        from sentry.shared_integrations.exceptions import IntegrationError
+
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github_enterprise",
+            name="GHE Acme",
+            external_id="ghe-clienterror-1",
+            metadata={
+                "domain_name": "github.acme.com",
+                "installation_id": "1",
+                "installation": {"id": "1", "private_key": "x", "verify_ssl": True},
+            },
+        )
+        repository: Repository = {
+            "id": 1,
+            "integration_id": integration.id,
+            "name": "acme/widget",
+            "organization_id": self.organization.id,
+            "is_active": True,
+            "external_id": "9001",
+            "provider_name": "github_enterprise",
+            "web_base_url": "https://github.acme.com",
+        }
+
+        with (
+            patch(
+                "sentry.scm.private.helpers.integration_service.get_integration",
+                return_value=integration,
+            ),
+            patch.object(
+                type(integration.get_installation(organization_id=self.organization.id)),
+                "get_client",
+                side_effect=IntegrationError("boom"),
+            ),
+        ):
+            assert fetch_service_provider(self.organization.id, repository) is None

--- a/tests/sentry/scm/integration/test_helpers_integration.py
+++ b/tests/sentry/scm/integration/test_helpers_integration.py
@@ -73,6 +73,74 @@ class TestFetchRepository(TestCase):
     def test_fetch_by_provider_and_external_id_returns_none_for_nonexistent(self) -> None:
         assert fetch_repository(self.organization.id, ("github", "nonexistent")) is None
 
+    def test_fetch_ghe_repo_populates_web_base_url(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github_enterprise",
+            name="GHE Acme",
+            external_id="ghe-acme-1",
+            metadata={
+                "domain_name": "github.acme.com/installations/1",
+                "installation_id": "1",
+                "installation": {"id": "1", "private_key": "x", "verify_ssl": True},
+            },
+        )
+        repo = RepositoryModel.objects.create(
+            organization_id=self.organization.id,
+            name="acme/widget",
+            provider="integrations:github_enterprise",
+            external_id="9001",
+            status=ObjectStatus.ACTIVE,
+            integration_id=integration.id,
+        )
+
+        result = fetch_repository(self.organization.id, ("github_enterprise", repo.external_id))
+
+        assert result is not None
+        assert result["provider_name"] == "github_enterprise"
+        assert result["web_base_url"] == "https://github.acme.com"
+
+    def test_fetch_ghe_cloud_repo_populates_web_base_url(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github_enterprise",
+            name="GHE Cloud Acme",
+            external_id="ghe-cloud-acme-1",
+            metadata={
+                "domain_name": "acme-corp.ghe.com",
+                "installation_id": "2",
+                "installation": {"id": "2", "private_key": "x", "verify_ssl": True},
+            },
+        )
+        repo = RepositoryModel.objects.create(
+            organization_id=self.organization.id,
+            name="acme/widget",
+            provider="integrations:github_enterprise",
+            external_id="9002",
+            status=ObjectStatus.ACTIVE,
+            integration_id=integration.id,
+        )
+
+        result = fetch_repository(self.organization.id, ("github_enterprise", repo.external_id))
+
+        assert result is not None
+        assert result["web_base_url"] == "https://acme-corp.ghe.com"
+
+    def test_fetch_non_ghe_repo_web_base_url_is_none(self) -> None:
+        repo = RepositoryModel.objects.create(
+            organization_id=self.organization.id,
+            name="test-org/test-repo",
+            provider="integrations:github",
+            external_id="11111",
+            status=ObjectStatus.ACTIVE,
+            integration_id=1,
+        )
+
+        result = fetch_repository(self.organization.id, repo.id)
+
+        assert result is not None
+        assert result["web_base_url"] is None
+
 
 class TestFetchServiceProvider(TestCase):
     def test_returns_provider_from_map_to_provider(self) -> None:

--- a/tests/sentry/scm/integration/test_helpers_integration.py
+++ b/tests/sentry/scm/integration/test_helpers_integration.py
@@ -85,7 +85,7 @@ class TestFetchRepository(TestCase):
                 "installation": {"id": "1", "private_key": "x", "verify_ssl": True},
             },
         )
-        repo = RepositoryModel.objects.create(
+        RepositoryModel.objects.create(
             organization_id=self.organization.id,
             name="acme/widget",
             provider="integrations:github_enterprise",
@@ -94,7 +94,7 @@ class TestFetchRepository(TestCase):
             integration_id=integration.id,
         )
 
-        result = fetch_repository(self.organization.id, ("github_enterprise", repo.external_id))
+        result = fetch_repository(self.organization.id, ("github_enterprise", "9001"))
 
         assert result is not None
         assert result["provider_name"] == "github_enterprise"
@@ -112,7 +112,7 @@ class TestFetchRepository(TestCase):
                 "installation": {"id": "2", "private_key": "x", "verify_ssl": True},
             },
         )
-        repo = RepositoryModel.objects.create(
+        RepositoryModel.objects.create(
             organization_id=self.organization.id,
             name="acme/widget",
             provider="integrations:github_enterprise",
@@ -121,7 +121,7 @@ class TestFetchRepository(TestCase):
             integration_id=integration.id,
         )
 
-        result = fetch_repository(self.organization.id, ("github_enterprise", repo.external_id))
+        result = fetch_repository(self.organization.id, ("github_enterprise", "9002"))
 
         assert result is not None
         assert result["web_base_url"] == "https://acme-corp.ghe.com"


### PR DESCRIPTION
Closes [SCM-112](https://linear.app/getsentry/issue/SCM-112).

Adds GitHub Enterprise support to Sentry's SCM Platform RPC server so seer's \`ScmRepoClient\` proxy path can construct a working \`GitHubProvider\` for \`github_enterprise\` integrations.


