### PR TITLE
fix(supergroups): move to post process task

### DIFF
--- a/src/sentry/tasks/seer/lightweight_rca_cluster.py
+++ b/src/sentry/tasks/seer/lightweight_rca_cluster.py
@@ -3,14 +3,15 @@ import logging
 from sentry.models.group import Group
 from sentry.seer.supergroups.lightweight_rca_cluster import trigger_lightweight_rca_cluster
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import ingest_errors_tasks
+from sentry.taskworker.namespaces import ingest_errors_postprocess_tasks, ingest_errors_tasks
 
 logger = logging.getLogger(__name__)
 
 
 @instrumented_task(
     name="sentry.tasks.seer.lightweight_rca_cluster.trigger_lightweight_rca_cluster_task",
-    namespace=ingest_errors_tasks,
+    namespace=ingest_errors_postprocess_tasks,
+    alias_namespace=ingest_errors_tasks,
 )
 def trigger_lightweight_rca_cluster_task(group_id: int, **kwargs) -> None:
     try:


### PR DESCRIPTION
We were previously using the ingest-errors queue by mistake — switch to post process