### PR TITLE
feat(search): Add recommended sort option to issue stream dropdown

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -4,7 +4,7 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import type {DropdownButtonProps} from 'sentry/components/dropdownButton';
 import {IconSort} from 'sentry/icons/iconSort';
 import {t} from 'sentry/locale';
-import useOrganization from 'sentry/utils/useOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   FOR_REVIEW_QUERIES,
   getSortLabel,

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -4,6 +4,7 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import type {DropdownButtonProps} from 'sentry/components/dropdownButton';
 import {IconSort} from 'sentry/icons/iconSort';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
   FOR_REVIEW_QUERIES,
   getSortLabel,
@@ -47,6 +48,10 @@ export function IssueListSortOptions({
   triggerSize = 'xs',
   showIcon = true,
 }: Props) {
+  const organization = useOrganization();
+  const hasRecommendedSort =
+    organization.features.includes('issue-stream-recommended-sort') ||
+    sort === IssueSortOptions.RECOMMENDED;
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
     ...(FOR_REVIEW_QUERIES.includes(query || '') ? [IssueSortOptions.INBOX] : []),
@@ -55,7 +60,7 @@ export function IssueListSortOptions({
     IssueSortOptions.TRENDS,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
-    ...(sort === IssueSortOptions.RECOMMENDED ? [IssueSortOptions.RECOMMENDED] : []),
+    ...(hasRecommendedSort ? [IssueSortOptions.RECOMMENDED] : []),
   ];
 
   return (


### PR DESCRIPTION
Gate the experimental recommended sort (#111043) behind the
`organizations:issue-stream-recommended-sort` feature flag (#116191) so orgs
with the flag enabled see "Recommended" in the issue stream sort dropdown.

The option also appears when `?sort=recommended` is already in the URL, so it
can still be tested manually without the flag.

fixes https://linear.app/getsentry/issue/ID-1568/add-recommended-sort-to-ui-for-feature-flagged-users