### PR TITLE
chore(workflow-engine): Edit flag with the correct prefix

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -404,7 +404,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable seer activities to be evaluated in workflow engine
-    manager.add("organization:workflow-engine-evaluate-seer-activities", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-evaluate-seer-activities", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable our logs product (known internally as ourlogs) in UI and backend
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -63,7 +63,7 @@ def workflow_status_update_handler(
 
     organization = Organization.objects.get_from_cache(pk=activity.project.organization_id)
     can_process_seer_activities = features.has(
-        "organization:workflow-engine-evaluate-seer-activities", organization
+        "organizations:workflow-engine-evaluate-seer-activities", organization
     )
 
     if activity.type in SEER_ACTIVITIES and not can_process_seer_activities:

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -164,7 +164,7 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
         )
 
         with (
-            self.feature("organization:workflow-engine-evaluate-seer-activities"),
+            self.feature("organizations:workflow-engine-evaluate-seer-activities"),
             mock.patch(
                 "sentry.workflow_engine.tasks.workflows.process_workflow_activity.delay"
             ) as mock_delay,


### PR DESCRIPTION
Just a typo fix, i'll be using this flag for the new activity registry

Fixes SENTRY-5P40