### PR TITLE
chore(workflow-engine): Build out new registry for activities

### DIFF
--- a/src/sentry/workflow_engine/apps.py
+++ b/src/sentry/workflow_engine/apps.py
@@ -8,4 +8,5 @@ class Config(AppConfig):
         # Import items that use registries or respond to events
         import sentry.workflow_engine.handlers  # NOQA
         import sentry.workflow_engine.receivers  # NOQA
+        import sentry.workflow_engine.handlers.workflow.workflow_activity_handlers  # NOQA
         from sentry.workflow_engine.endpoints import serializers  # NOQA

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -1,0 +1,9 @@
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.workflow_engine.registry import workflow_activity_registry
+
+
+@workflow_activity_registry.register("seer_activity")
+def seer_activity_handler(group: Group, activity: Activity) -> None:
+    # TODO(Leander): Implement this handler
+    pass

--- a/src/sentry/workflow_engine/registry.py
+++ b/src/sentry/workflow_engine/registry.py
@@ -1,8 +1,21 @@
 from typing import Any
 
+from sentry.models.activity import Activity
+from sentry.models.group import Group
 from sentry.utils.registry import Registry
-from sentry.workflow_engine.types import ActionHandler, DataConditionHandler, DataSourceTypeHandler
+from sentry.workflow_engine.types import (
+    ActionHandler,
+    DataConditionHandler,
+    DataSourceTypeHandler,
+    WorkflowActivityHandler,
+)
 
 data_source_type_registry = Registry[type[DataSourceTypeHandler[Any]]]()
 condition_handler_registry = Registry[type[DataConditionHandler[Any]]](enable_reverse_lookup=False)
 action_handler_registry = Registry[type[ActionHandler]](enable_reverse_lookup=False)
+workflow_activity_registry = Registry[WorkflowActivityHandler](enable_reverse_lookup=False)
+
+
+def invoke_workflow_activity_handlers(group: Group, activity: Activity) -> None:
+    for handler in workflow_activity_registry.registrations.values():
+        handler(group, activity)

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import random
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
 from logging import Logger
@@ -423,3 +424,6 @@ class DetectorSettings:
     validator: type[BaseDetectorTypeValidator] | None = None
     config_schema: dict[str, Any] = field(default_factory=dict)
     filter: Q | None = None
+
+
+WorkflowActivityHandler: TypeAlias = Callable[["Group", "Activity"], None]

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -1,0 +1,38 @@
+from unittest import mock
+
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.registry import (
+    invoke_workflow_activity_handlers,
+    workflow_activity_registry,
+)
+
+
+class WorkflowActivityRegistryTest(TestCase):
+    def setUp(self) -> None:
+        self.group = self.create_group()
+        self.activity = self.create_group_activity(
+            group=self.group, type=ActivityType.SEER_PR_CREATED.value
+        )
+
+    def test_registrants(self) -> None:
+        assert "seer_activity" in workflow_activity_registry.registrations
+        assert len(workflow_activity_registry.registrations) == 1
+
+    def test_invoke_handlers(self) -> None:
+        handler_a = mock.Mock()
+        handler_b = mock.Mock()
+
+        with mock.patch.dict(
+            workflow_activity_registry.registrations,
+            {"handler_a": handler_a, "handler_b": handler_b},
+            clear=True,
+        ):
+            invoke_workflow_activity_handlers(self.group, self.activity)
+
+        handler_a.assert_called_once_with(self.group, self.activity)
+        handler_b.assert_called_once_with(self.group, self.activity)
+
+    def test_invoke_handlers_no_registrants(self) -> None:
+        with mock.patch.dict(workflow_activity_registry.registrations, {}, clear=True):
+            invoke_workflow_activity_handlers(self.group, self.activity)


### PR DESCRIPTION
Called it `WorkflowActivityRegistry` instead of `GroupActivityRegistry`, not sure if the other is preferred, let me know.

Added some basic tests and a todo for the member I'll add later.