### PR TITLE
chore(seer): Use `elif` instead of `if` in actionability filter logic for clarity

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -264,7 +264,7 @@ def seer_actionability_filter(trigger_values: list[float]) -> Q:
                 seer_fixability_score__gte=0.0,
                 seer_fixability_score__lte=FixabilityScoreThresholds.LOW.value,
             )
-        if val == FixabilityScoreThresholds.LOW.value:
+        elif val == FixabilityScoreThresholds.LOW.value:
             query |= Q(
                 seer_fixability_score__gt=FixabilityScoreThresholds.LOW.value,
                 seer_fixability_score__lte=FixabilityScoreThresholds.MEDIUM.value,


### PR DESCRIPTION
Using `elif` in place of `if` for clarity - no change in behavior.