### PR TITLE
ref(search): Deduplicate SeerComboBox components with shared hooks

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
@@ -8,7 +8,7 @@ export interface SeerRawResponseItem {
   sort: string;
   start: string | null;
   stats_period: string;
-  visualization?: Array<{chart_type: number; y_axes: string[]}>;
+  visualization?: Array<{chart_type?: number; y_axes?: string[]}>;
 }
 
 export interface SeerRawResponse {
@@ -34,7 +34,7 @@ export interface QueryTokensProps {
   sort?: string;
   start?: string | null;
   statsPeriod?: string;
-  visualizations?: Array<{chartType: ChartType; yAxes: string[]}>;
+  visualizations?: Array<{yAxes: string[]; chartType?: ChartType}>;
 }
 
 export interface AskSeerSearchQuery extends QueryTokensProps {
@@ -45,7 +45,7 @@ export interface AskSeerSearchQuery extends QueryTokensProps {
   sort: string;
   start: string | null;
   statsPeriod: string;
-  visualizations: Array<{chartType: ChartType; yAxes: string[]}>;
+  visualizations: Array<{yAxes: string[]; chartType?: ChartType}>;
 }
 
 /**

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
@@ -1,5 +1,21 @@
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
 
+export interface SeerRawResponseItem {
+  end: string | null;
+  group_by: string[];
+  mode: string;
+  query: string;
+  sort: string;
+  start: string | null;
+  stats_period: string;
+  visualization?: Array<{chart_type: number; y_axes: string[]}>;
+}
+
+export interface SeerRawResponse {
+  responses: SeerRawResponseItem[];
+  unsupported_reason: string | null;
+}
+
 export interface NoneOfTheseItem {
   key: 'none-of-these';
   label: string;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
@@ -6,9 +6,11 @@ import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 import {
   buildSeerDateTimeSelection,
+  mapSeerResponseItem,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
@@ -126,6 +128,59 @@ describe('transformSeerResponse', () => {
         visualizations: [{chartType: 1, yAxes: ['count()']}],
       },
     ]);
+  });
+});
+
+describe('mapSeerResponseItem', () => {
+  it('maps Seer response fields into the shared query shape', () => {
+    expect(
+      mapSeerResponseItem({
+        query: 'span.op:db',
+        sort: '-timestamp',
+        group_by: ['project'],
+        stats_period: '24h',
+        start: null,
+        end: null,
+        mode: 'aggregates',
+        visualization: [{chart_type: ChartType.BAR, y_axes: ['count()']}],
+      })
+    ).toEqual({
+      query: 'span.op:db',
+      sort: '-timestamp',
+      groupBys: ['project'],
+      statsPeriod: '24h',
+      start: null,
+      end: null,
+      mode: 'aggregates',
+      visualizations: [{chartType: ChartType.BAR, yAxes: ['count()']}],
+    });
+  });
+
+  it('leaves missing or invalid chart types undefined', () => {
+    expect(
+      mapSeerResponseItem(
+        {
+          query: 'is:unresolved',
+          sort: '',
+          group_by: [],
+          stats_period: '',
+          start: null,
+          end: null,
+          mode: '',
+          visualization: [{y_axes: []}, {chart_type: 999, y_axes: ['count()']}],
+        },
+        'issues'
+      )
+    ).toEqual({
+      query: 'is:unresolved',
+      sort: '',
+      groupBys: [],
+      statsPeriod: '',
+      start: null,
+      end: null,
+      mode: 'issues',
+      visualizations: [{yAxes: ['count()']}],
+    });
   });
 });
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
@@ -1,0 +1,282 @@
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+
+import {
+  buildSeerDateTimeSelection,
+  transformSeerResponse,
+  useInitialSeerQuery,
+  useSelectedProjectIds,
+  useSelectedProjectIdsForMutation,
+} from './useSeerComboBoxSetup';
+
+const defaultProviderProps = {
+  enableAISearch: true,
+  filterKeys: {},
+  getTagValues: () => Promise.resolve([]),
+  initialQuery: '',
+  searchSource: 'test' as const,
+};
+
+function makeWrapper(providerProps = {}) {
+  return function Wrapper({children}: {children: React.ReactNode}) {
+    return (
+      <SearchQueryBuilderProvider {...defaultProviderProps} {...providerProps}>
+        {children}
+      </SearchQueryBuilderProvider>
+    );
+  };
+}
+
+describe('transformSeerResponse', () => {
+  const mapItem = (r: any) => ({
+    query: r?.query ?? '',
+    sort: r?.sort ?? '',
+    groupBys: r?.group_by ?? [],
+    statsPeriod: r?.stats_period ?? '',
+    start: r?.start ?? null,
+    end: r?.end ?? null,
+  });
+
+  it('transforms a response with responses array', () => {
+    const rawResponse = {
+      responses: [
+        {
+          query: 'is:unresolved',
+          sort: '-count',
+          group_by: ['project'],
+          stats_period: '24h',
+          start: null,
+          end: null,
+          mode: 'samples',
+        },
+      ],
+    };
+
+    const result = transformSeerResponse(rawResponse as any, mapItem);
+
+    expect(result).toEqual([
+      {
+        query: 'is:unresolved',
+        sort: '-count',
+        groupBys: ['project'],
+        statsPeriod: '24h',
+        start: null,
+        end: null,
+      },
+    ]);
+  });
+
+  it('wraps a single response without responses array', () => {
+    const singleResponse = {
+      query: 'is:unresolved',
+      sort: '',
+      groupBys: [],
+      statsPeriod: '24h',
+      start: null,
+      end: null,
+    };
+
+    const result = transformSeerResponse(singleResponse, mapItem);
+
+    expect(result).toEqual([singleResponse]);
+  });
+
+  it('handles empty responses array', () => {
+    const rawResponse = {responses: []};
+    const result = transformSeerResponse(rawResponse as any, mapItem);
+    expect(result).toEqual([]);
+  });
+
+  it('maps visualization fields when present', () => {
+    const rawResponse = {
+      responses: [
+        {
+          query: 'span.op:db',
+          sort: '',
+          group_by: [],
+          stats_period: '1h',
+          start: null,
+          end: null,
+          mode: 'spans',
+          visualization: [{chart_type: 1, y_axes: ['count()']}],
+        },
+      ],
+    };
+
+    const mapWithViz = (r: any) => ({
+      query: r?.query ?? '',
+      visualizations:
+        r?.visualization?.map((v: any) => ({
+          chartType: v.chart_type,
+          yAxes: v.y_axes ?? [],
+        })) ?? [],
+    });
+
+    const result = transformSeerResponse(rawResponse as any, mapWithViz);
+
+    expect(result).toEqual([
+      {
+        query: 'span.op:db',
+        visualizations: [{chartType: 1, yAxes: ['count()']}],
+      },
+    ]);
+  });
+});
+
+describe('buildSeerDateTimeSelection', () => {
+  const pageFiltersDatetime = {
+    start: '2024-01-01T00:00:00',
+    end: '2024-01-02T00:00:00',
+    period: '24h',
+    utc: true,
+  };
+
+  it('strips Z suffix and converts to ISO when both start and end provided', () => {
+    const result = buildSeerDateTimeSelection(
+      '2024-06-01T00:00:00Z',
+      '2024-06-02T00:00:00Z',
+      '',
+      pageFiltersDatetime
+    );
+
+    expect(result.start).toBe(new Date('2024-06-01T00:00:00').toISOString());
+    expect(result.end).toBe(new Date('2024-06-02T00:00:00').toISOString());
+    expect(result.period).toBeNull();
+    expect(result.utc).toBe(true);
+  });
+
+  it('falls back to pageFilters datetime when no start/end', () => {
+    const result = buildSeerDateTimeSelection(null, null, '', pageFiltersDatetime);
+
+    expect(result.start).toBe('2024-01-01T00:00:00');
+    expect(result.end).toBe('2024-01-02T00:00:00');
+    expect(result.period).toBe('24h');
+    expect(result.utc).toBe(true);
+  });
+
+  it('uses statsPeriod when no start/end', () => {
+    const result = buildSeerDateTimeSelection(null, null, '7d', pageFiltersDatetime);
+
+    expect(result.start).toBe('2024-01-01T00:00:00');
+    expect(result.end).toBe('2024-01-02T00:00:00');
+    expect(result.period).toBe('7d');
+  });
+
+  it('sets period to null when start and end are provided', () => {
+    const result = buildSeerDateTimeSelection(
+      '2024-06-01T00:00:00',
+      '2024-06-02T00:00:00',
+      '7d',
+      pageFiltersDatetime
+    );
+
+    expect(result.period).toBeNull();
+  });
+
+  it('handles dates without Z suffix', () => {
+    const result = buildSeerDateTimeSelection(
+      '2024-06-01T12:00:00',
+      '2024-06-02T12:00:00',
+      '',
+      pageFiltersDatetime
+    );
+
+    expect(result.start).toBe(new Date('2024-06-01T12:00:00').toISOString());
+    expect(result.end).toBe(new Date('2024-06-02T12:00:00').toISOString());
+  });
+});
+
+describe('useInitialSeerQuery', () => {
+  it('returns empty string when no query or input', () => {
+    const {result} = renderHookWithProviders(() => useInitialSeerQuery(), {
+      additionalWrapper: makeWrapper({initialQuery: ''}),
+    });
+
+    expect(result.current).toBe('');
+  });
+
+  it('uses committed query when available', () => {
+    const {result} = renderHookWithProviders(() => useInitialSeerQuery(), {
+      additionalWrapper: makeWrapper({initialQuery: 'is:unresolved'}),
+    });
+
+    expect(result.current).toBe('is:unresolved');
+  });
+});
+
+describe('useSelectedProjectIds', () => {
+  beforeEach(() => {
+    ProjectsStore.loadInitialData([
+      ProjectFixture({id: '1', isMember: true}),
+      ProjectFixture({id: '2', isMember: true}),
+      ProjectFixture({id: '3', isMember: false}),
+    ]);
+  });
+
+  it('returns pageFilters projects when specified', () => {
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({projects: [1, 2]}),
+      false
+    );
+
+    const {result} = renderHookWithProviders(() => useSelectedProjectIds());
+
+    expect(result.current).toEqual([1, 2]);
+  });
+
+  it('falls back to member projects when pageFilters has all projects', () => {
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({projects: [-1]}),
+      false
+    );
+
+    const {result} = renderHookWithProviders(() => useSelectedProjectIds());
+
+    expect(result.current).toEqual([1, 2]);
+  });
+
+  it('falls back to member projects when pageFilters has no projects', () => {
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: []}), false);
+
+    const {result} = renderHookWithProviders(() => useSelectedProjectIds());
+
+    expect(result.current).toEqual([1, 2]);
+  });
+});
+
+describe('useSelectedProjectIdsForMutation', () => {
+  beforeEach(() => {
+    ProjectsStore.loadInitialData([
+      ProjectFixture({id: '10', isMember: true}),
+      ProjectFixture({id: '20', isMember: false}),
+    ]);
+  });
+
+  it('returns string IDs for member projects', () => {
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({projects: [-1]}),
+      false
+    );
+
+    const {result} = renderHookWithProviders(() => useSelectedProjectIdsForMutation());
+
+    expect(result.current).toEqual(['10']);
+  });
+
+  it('returns pageFilters projects when specified', () => {
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({projects: [10, 20]}),
+      false
+    );
+
+    const {result} = renderHookWithProviders(() => useSelectedProjectIdsForMutation());
+
+    expect(result.current).toEqual([10, 20]);
+  });
+});

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
@@ -220,10 +220,7 @@ describe('useSelectedProjectIds', () => {
   });
 
   it('returns pageFilters projects when specified', () => {
-    PageFiltersStore.onInitializeUrlState(
-      PageFiltersFixture({projects: [1, 2]}),
-      false
-    );
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1, 2]}), false);
 
     const {result} = renderHookWithProviders(() => useSelectedProjectIds());
 
@@ -231,10 +228,7 @@ describe('useSelectedProjectIds', () => {
   });
 
   it('falls back to member projects when pageFilters has all projects', () => {
-    PageFiltersStore.onInitializeUrlState(
-      PageFiltersFixture({projects: [-1]}),
-      false
-    );
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [-1]}), false);
 
     const {result} = renderHookWithProviders(() => useSelectedProjectIds());
 
@@ -259,10 +253,7 @@ describe('useSelectedProjectIdsForMutation', () => {
   });
 
   it('returns string IDs for member projects', () => {
-    PageFiltersStore.onInitializeUrlState(
-      PageFiltersFixture({projects: [-1]}),
-      false
-    );
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [-1]}), false);
 
     const {result} = renderHookWithProviders(() => useSelectedProjectIdsForMutation());
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -10,8 +10,9 @@ import {stringifyToken} from 'sentry/components/searchSyntax/utils';
 import type {DateString} from 'sentry/types/core';
 import type {PageFilters} from 'sentry/types/core';
 import {useProjects} from 'sentry/utils/useProjects';
+import {isChartType} from 'sentry/views/insights/common/components/chart';
 
-import type {SeerRawResponseItem} from './types';
+import type {AskSeerSearchQuery, SeerRawResponseItem} from './types';
 
 export function useInitialSeerQuery(): string {
   const {query, committedQuery, parseQuery} = useSearchQueryBuilderState();
@@ -95,7 +96,31 @@ export function transformSeerResponse<T>(
   return [response];
 }
 
-interface SeerDateTimeSelection {
+export function mapSeerResponseItem(
+  item: SeerRawResponseItem,
+  defaultMode = 'samples'
+): AskSeerSearchQuery {
+  return {
+    visualizations:
+      item.visualization
+        ?.map(visualization => ({
+          ...(isChartType(visualization.chart_type)
+            ? {chartType: visualization.chart_type}
+            : {}),
+          yAxes: visualization.y_axes ?? [],
+        }))
+        .filter(visualization => visualization.yAxes.length > 0) ?? [],
+    query: item.query ?? '',
+    sort: item.sort ?? '',
+    groupBys: item.group_by ?? [],
+    statsPeriod: item.stats_period ?? '',
+    start: item.start ?? null,
+    end: item.end ?? null,
+    mode: item.mode || defaultMode,
+  };
+}
+
+export interface SeerDateTimeSelection {
   end: DateString;
   period: string | null;
   start: DateString;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -1,0 +1,130 @@
+import {useMemo} from 'react';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {
+  useSearchQueryBuilderLayout,
+  useSearchQueryBuilderState,
+} from 'sentry/components/searchQueryBuilder/context';
+import {Token} from 'sentry/components/searchSyntax/parser';
+import {stringifyToken} from 'sentry/components/searchSyntax/utils';
+import type {DateString} from 'sentry/types/core';
+import type {PageFilters} from 'sentry/types/core';
+import {useProjects} from 'sentry/utils/useProjects';
+
+import type {SeerRawResponseItem} from './types';
+
+export function useInitialSeerQuery(): string {
+  const {query, committedQuery, parseQuery} = useSearchQueryBuilderState();
+  const {currentInputValueRef} = useSearchQueryBuilderLayout();
+
+  const queryDetails = useMemo(() => {
+    const queryToUse = committedQuery.length > 0 ? committedQuery : query;
+    const parsedQuery = parseQuery(queryToUse);
+    return {parsedQuery, queryToUse};
+  }, [committedQuery, query, parseQuery]);
+
+  const inputValue = currentInputValueRef.current.trim();
+
+  const filteredCommittedQuery = queryDetails?.parsedQuery
+    ?.filter(
+      token =>
+        !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
+    )
+    ?.map(token => stringifyToken(token))
+    ?.join(' ')
+    ?.trim();
+
+  let initialSeerQuery = '';
+
+  if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
+    initialSeerQuery = filteredCommittedQuery;
+  } else if (!inputValue && queryDetails?.queryToUse) {
+    initialSeerQuery = queryDetails.queryToUse;
+  }
+
+  if (inputValue) {
+    initialSeerQuery =
+      initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
+  }
+
+  return initialSeerQuery;
+}
+
+export function useSelectedProjectIds(): number[] {
+  const pageFilters = usePageFilters();
+  const {projects} = useProjects();
+
+  return useMemo(() => {
+    if (
+      pageFilters.selection.projects?.length > 0 &&
+      pageFilters.selection.projects?.[0] !== -1
+    ) {
+      return pageFilters.selection.projects;
+    }
+    return projects.filter(p => p.isMember).map(p => parseInt(p.id, 10));
+  }, [pageFilters.selection.projects, projects]);
+}
+
+export function useSelectedProjectIdsForMutation(): Array<number | string> {
+  const pageFilters = usePageFilters();
+  const {projects} = useProjects();
+
+  return useMemo(() => {
+    if (
+      pageFilters.selection.projects?.length > 0 &&
+      pageFilters.selection.projects?.[0] !== -1
+    ) {
+      return pageFilters.selection.projects;
+    }
+    return projects.filter(p => p.isMember).map(p => p.id);
+  }, [pageFilters.selection.projects, projects]);
+}
+
+export function transformSeerResponse<T>(
+  response: T,
+  mapItem: (item: SeerRawResponseItem) => T
+): T[] {
+  const seerResponse = response as unknown as {
+    responses?: SeerRawResponseItem[];
+  };
+
+  if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
+    return seerResponse.responses.map(mapItem);
+  }
+
+  return [response];
+}
+
+interface SeerDateTimeSelection {
+  end: DateString;
+  period: string | null;
+  start: DateString;
+  utc: boolean | null;
+}
+
+export function buildSeerDateTimeSelection(
+  resultStart: string | null,
+  resultEnd: string | null,
+  statsPeriod: string,
+  pageFiltersDatetime: PageFilters['datetime']
+): SeerDateTimeSelection {
+  let start: DateString = null;
+  let end: DateString = null;
+
+  if (resultStart && resultEnd) {
+    const startLocal = resultStart.endsWith('Z') ? resultStart.slice(0, -1) : resultStart;
+    const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
+    start = new Date(startLocal).toISOString();
+    end = new Date(endLocal).toISOString();
+  } else {
+    start = pageFiltersDatetime.start;
+    end = pageFiltersDatetime.end;
+  }
+
+  return {
+    start,
+    end,
+    utc: pageFiltersDatetime.utc,
+    period: resultStart && resultEnd ? null : statsPeriod || pageFiltersDatetime.period,
+  };
+}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -26,6 +26,7 @@ export function useInitialSeerQuery(): string {
 
   const inputValue = currentInputValueRef.current.trim();
 
+  // Only filter out FREE_TEXT tokens if there's actual input value to filter by
   const filteredCommittedQuery = queryDetails?.parsedQuery
     ?.filter(
       token =>
@@ -37,6 +38,9 @@ export function useInitialSeerQuery(): string {
 
   let initialSeerQuery = '';
 
+  // Use filteredCommittedQuery if it has content.
+  // Only fall back to queryToUse when there's no inputValue to filter by.
+  // This prevents duplication when the entire query is free text matching inputValue.
   if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
     initialSeerQuery = filteredCommittedQuery;
   } else if (!inputValue && queryDetails?.queryToUse) {
@@ -137,6 +141,7 @@ export function buildSeerDateTimeSelection(
   let end: DateString = null;
 
   if (resultStart && resultEnd) {
+    // Strip 'Z' suffix to treat UTC dates as local time
     const startLocal = resultStart.endsWith('Z') ? resultStart.slice(0, -1) : resultStart;
     const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
     start = new Date(startLocal).toISOString();

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -5,13 +5,13 @@ import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
-import type {AskSeerSearchQuery} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import type {
+  AskSeerSearchQuery,
   SeerRawResponse,
-  SeerRawResponseItem,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
   buildSeerDateTimeSelection,
+  mapSeerResponseItem,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
@@ -25,27 +25,9 @@ import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import type {ChartType} from 'sentry/views/insights/common/components/chart';
 
 interface IssueListSeerComboBoxProps {
   onSearch: (query: string) => void;
-}
-
-function mapResponseItem(r: SeerRawResponseItem): AskSeerSearchQuery {
-  return {
-    query: r?.query ?? '',
-    sort: r?.sort ?? '',
-    groupBys: r?.group_by ?? [],
-    statsPeriod: r?.stats_period ?? '',
-    start: r?.start ?? null,
-    end: r?.end ?? null,
-    mode: r?.mode ?? 'samples',
-    visualizations:
-      r?.visualization?.map(v => ({
-        chartType: v.chart_type as ChartType,
-        yAxes: v.y_axes ?? [],
-      })) ?? [],
-  };
 }
 
 export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
@@ -63,7 +45,7 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
 
   const transformResponse = useCallback(
     (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, mapResponseItem),
+      transformSeerResponse(response, responseItem => mapSeerResponseItem(responseItem)),
     []
   );
 
@@ -86,7 +68,7 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(mapResponseItem),
+        queries: data.responses.map(response => mapSeerResponseItem(response)),
       };
     },
   });

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -136,6 +136,7 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         query: queryToUse,
       };
 
+      // Convert to aliased format for Discover (e.g., "-count()" -> "-count")
       if (sort) {
         const isDescending = sort.startsWith('-');
         const sortField = isDescending ? sort.substring(1) : sort;

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 import {mutationOptions} from '@tanstack/react-query';
 
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
@@ -6,153 +6,78 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
 import type {AskSeerSearchQuery} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
+import type {
+  SeerRawResponse,
+  SeerRawResponseItem,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
-  useSearchQueryBuilderAI,
-  useSearchQueryBuilderLayout,
-  useSearchQueryBuilderState,
-} from 'sentry/components/searchQueryBuilder/context';
-import {Token} from 'sentry/components/searchSyntax/parser';
-import {stringifyToken} from 'sentry/components/searchSyntax/utils';
+  buildSeerDateTimeSelection,
+  transformSeerResponse,
+  useInitialSeerQuery,
+  useSelectedProjectIds,
+  useSelectedProjectIdsForMutation,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {ConfigStore} from 'sentry/stores/configStore';
-import type {DateString} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
-
-interface IssuesAskSeerTranslateResponse {
-  responses: Array<{
-    end: string | null;
-    group_by: string[];
-    mode: string;
-    query: string;
-    sort: string;
-    start: string | null;
-    stats_period: string;
-    visualization: Array<{chart_type: number; y_axes: string[]}>;
-  }>;
-  unsupported_reason: string | null;
-}
 
 interface IssueListSeerComboBoxProps {
   onSearch: (query: string) => void;
 }
 
+function mapResponseItem(r: SeerRawResponseItem): AskSeerSearchQuery {
+  return {
+    query: r?.query ?? '',
+    sort: r?.sort ?? '',
+    groupBys: r?.group_by ?? [],
+    statsPeriod: r?.stats_period ?? '',
+    start: r?.start ?? null,
+    end: r?.end ?? null,
+    mode: r?.mode ?? 'samples',
+    visualizations:
+      r?.visualization?.map(v => ({
+        chartType: v.chart_type as ChartType,
+        yAxes: v.y_axes ?? [],
+      })) ?? [],
+  };
+}
+
 export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
   const navigate = useNavigate();
   const location = useLocation();
-  const {projects} = useProjects();
   const pageFilters = usePageFilters();
   const organization = useOrganization();
   const analyticsArea = useAnalyticsArea();
   const {setRunId} = useAiQueryContext();
-  const {query, committedQuery, parseQuery} = useSearchQueryBuilderState();
-  const {currentInputValueRef} = useSearchQueryBuilderLayout();
   const {askSeerSuggestedQueryRef, enableAISearch} = useSearchQueryBuilderAI();
 
-  let initialSeerQuery = '';
-  const queryDetails = useMemo(() => {
-    const queryToUse = committedQuery.length > 0 ? committedQuery : query;
-    const parsedQuery = parseQuery(queryToUse);
-    return {parsedQuery, queryToUse};
-  }, [committedQuery, query, parseQuery]);
+  const initialSeerQuery = useInitialSeerQuery();
+  const selectedProjectIds = useSelectedProjectIds();
+  const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
 
-  const inputValue = currentInputValueRef.current.trim();
-
-  // Only filter out FREE_TEXT tokens if there's actual input value to filter by
-  const filteredCommittedQuery = queryDetails?.parsedQuery
-    ?.filter(
-      token =>
-        !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
-    )
-    ?.map(token => stringifyToken(token))
-    ?.join(' ')
-    ?.trim();
-
-  // Use filteredCommittedQuery if it has content.
-  // Only fall back to queryToUse when there's no inputValue to filter by.
-  // This prevents duplication when the entire query is free text matching inputValue.
-  if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
-    initialSeerQuery = filteredCommittedQuery;
-  } else if (!inputValue && queryDetails?.queryToUse) {
-    initialSeerQuery = queryDetails.queryToUse;
-  }
-
-  if (inputValue) {
-    initialSeerQuery =
-      initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
-  }
-
-  // Get selected project IDs for the polling variant
-  const selectedProjectIds = useMemo(() => {
-    if (
-      pageFilters.selection.projects?.length > 0 &&
-      pageFilters.selection.projects?.[0] !== -1
-    ) {
-      return pageFilters.selection.projects;
-    }
-    return projects.filter(p => p.isMember).map(p => parseInt(p.id, 10));
-  }, [pageFilters.selection.projects, projects]);
-
-  // Transform the final_response from Seer to match the expected format
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
-      const seerResponse = response as unknown as {
-        responses?: Array<{
-          end: string | null;
-          group_by: string[];
-          mode: string;
-          query: string;
-          sort: string;
-          start: string | null;
-          stats_period: string;
-          visualization: Array<{chart_type: number; y_axes: string[]}>;
-        }>;
-      };
-
-      if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
-        return seerResponse.responses.map(r => ({
-          query: r?.query ?? '',
-          sort: r?.sort ?? '',
-          groupBys: r?.group_by ?? [],
-          statsPeriod: r?.stats_period ?? '',
-          start: r?.start ?? null,
-          end: r?.end ?? null,
-          mode: r?.mode ?? 'samples',
-          visualizations:
-            r?.visualization?.map(v => ({
-              chartType: v.chart_type,
-              yAxes: v.y_axes ?? [],
-            })) ?? [],
-        }));
-      }
-
-      return [response];
-    },
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
+      transformSeerResponse(response, mapResponseItem),
     []
   );
 
   const issueListAskSeerMutationOptions = mutationOptions({
     mutationFn: async (queryToSubmit: string) => {
-      const selectedProjects =
-        pageFilters.selection.projects?.length > 0 &&
-        pageFilters.selection.projects?.[0] !== -1
-          ? pageFilters.selection.projects
-          : projects.filter(p => p.isMember).map(p => p.id);
-
       const user = ConfigStore.get('user');
-      const data = await fetchMutation<IssuesAskSeerTranslateResponse>({
+      const data = await fetchMutation<SeerRawResponse>({
         url: `/organizations/${organization.slug}/search-agent/translate/`,
         method: 'POST',
         data: {
           org_id: organization.id,
           org_slug: organization.slug,
           natural_language_query: queryToSubmit,
-          project_ids: selectedProjects,
+          project_ids: selectedProjectIdsForMutation,
           strategy: 'Errors',
           user_email: user?.email,
         },
@@ -161,20 +86,7 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(r => ({
-          query: r?.query ?? '',
-          sort: r?.sort ?? '',
-          groupBys: r?.group_by ?? [],
-          statsPeriod: r?.stats_period ?? '',
-          start: r?.start ?? null,
-          end: r?.end ?? null,
-          mode: r?.mode ?? 'samples',
-          visualizations:
-            r?.visualization?.map(v => ({
-              chartType: v.chart_type as ChartType,
-              yAxes: v.y_axes ?? [],
-            })) ?? [],
-        })),
+        queries: data.responses.map(mapResponseItem),
       };
     },
   });
@@ -194,28 +106,19 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         visualizations,
       } = result;
 
-      let start: DateString = null;
-      let end: DateString = null;
+      const dt = buildSeerDateTimeSelection(
+        resultStart,
+        resultEnd,
+        statsPeriod,
+        pageFilters.selection.datetime
+      );
 
-      if (resultStart && resultEnd) {
-        // Strip 'Z' suffix to treat UTC dates as local time
-        const startLocal = resultStart.endsWith('Z')
-          ? resultStart.slice(0, -1)
-          : resultStart;
-        const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
-        start = new Date(startLocal).toISOString();
-        end = new Date(endLocal).toISOString();
-      } else {
-        start = pageFilters.selection.datetime.start;
-        end = pageFilters.selection.datetime.end;
-      }
+      const start = dt.start;
+      const end = dt.end;
 
-      // Get yAxis from visualizations
       const yAxis =
         visualizations?.length > 0 ? visualizations[0]?.yAxes?.[0] : undefined;
 
-      // Build columns (field) from groupBys and visualizations
-      // Columns should be [groupBy fields..., visualization yAxes...]
       const columns: string[] = [];
       if (groupBys && groupBys.length > 0) {
         columns.push(...groupBys);
@@ -244,17 +147,13 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         query: queryToUse,
       });
 
-      // Apply the search query
       onSearch(queryToUse);
 
-      // Build the new query params
       const newQueryParams: Record<string, string | string[] | null | undefined> = {
         ...location.query,
         query: queryToUse,
       };
 
-      // Apply sort if provided - convert to aliased format for Discover
-      // e.g., "-count()" -> "-count"
       if (sort) {
         const isDescending = sort.startsWith('-');
         const sortField = isDescending ? sort.substring(1) : sort;
@@ -262,17 +161,14 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         newQueryParams.sort = isDescending ? `-${aliasedSortField}` : aliasedSortField;
       }
 
-      // Apply yAxis if provided
       if (yAxis) {
         newQueryParams.yAxis = yAxis;
       }
 
-      // Apply columns (field) if we have groupBys or visualizations
       if (columns.length > 0) {
         newQueryParams.field = columns;
       }
 
-      // Apply date range
       if (resultStart && resultEnd) {
         newQueryParams.start = typeof start === 'string' ? start : start?.toISOString();
         newQueryParams.end = typeof end === 'string' ? end : end?.toISOString();
@@ -287,7 +183,6 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         setRunId(runId);
       }
 
-      // Navigate with all params
       navigate(
         {...location, query: newQueryParams},
         {replace: true, preventScrollReset: true}

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -1,27 +1,25 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 import {mutationOptions} from '@tanstack/react-query';
 
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
+import type {SeerRawResponse} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
-  useSearchQueryBuilderAI,
-  useSearchQueryBuilderLayout,
-  useSearchQueryBuilderState,
-} from 'sentry/components/searchQueryBuilder/context';
-import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
-import {Token} from 'sentry/components/searchSyntax/parser';
-import {stringifyToken} from 'sentry/components/searchSyntax/utils';
+  buildSeerDateTimeSelection,
+  transformSeerResponse,
+  useInitialSeerQuery,
+  useSelectedProjectIds,
+  useSelectedProjectIdsForMutation,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {ConfigStore} from 'sentry/stores/configStore';
-import type {DateString} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {getFieldDefinition} from 'sentry/utils/fields';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
 import {LOGS_QUERY_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_AGGREGATE_FIELD_KEY} from 'sentry/views/explore/logs/logsQueryParams';
 import type {WritableAggregateField} from 'sentry/views/explore/queryParams/aggregateField';
@@ -40,82 +38,31 @@ interface AskSeerSearchQuery {
   statsPeriod: string;
 }
 
-interface LogsAskSeerTranslateResponse {
-  responses: Array<{
-    end: string | null;
-    group_by: string[];
-    mode: string;
-    query: string;
-    sort: string;
-    start: string | null;
-    stats_period: string;
-  }>;
-  unsupported_reason: string | null;
-}
-
 export function LogsTabSeerComboBox() {
   const navigate = useNavigate();
   const location = useLocation();
-  const {projects} = useProjects();
   const pageFilters = usePageFilters();
   const organization = useOrganization();
   const queryParams = useQueryParams();
   const analyticsArea = useAnalyticsArea();
   const {setRunId} = useAiQueryContext();
-  const {query, committedQuery} = useSearchQueryBuilderState();
-  const {currentInputValueRef} = useSearchQueryBuilderLayout();
   const {askSeerSuggestedQueryRef, enableAISearch} = useSearchQueryBuilderAI();
 
-  let initialSeerQuery = '';
-  const queryDetails = useMemo(() => {
-    const queryToUse = committedQuery.length > 0 ? committedQuery : query;
-    const parsedQuery = parseQueryBuilderValue(queryToUse, getFieldDefinition);
-    return {parsedQuery, queryToUse};
-  }, [committedQuery, query]);
-
-  const inputValue = currentInputValueRef.current.trim();
-
-  // Only filter out FREE_TEXT tokens if there's actual input value to filter by
-  const filteredCommittedQuery = queryDetails?.parsedQuery
-    ?.filter(
-      token =>
-        !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
-    )
-    ?.map(token => stringifyToken(token))
-    ?.join(' ')
-    ?.trim();
-
-  // Use filteredCommittedQuery if it has content.
-  // Only fall back to queryToUse when there's no inputValue to filter by.
-  // This prevents duplication when the entire query is free text matching inputValue.
-  if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
-    initialSeerQuery = filteredCommittedQuery;
-  } else if (!inputValue && queryDetails?.queryToUse) {
-    initialSeerQuery = queryDetails.queryToUse;
-  }
-
-  if (inputValue) {
-    initialSeerQuery =
-      initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
-  }
+  const initialSeerQuery = useInitialSeerQuery();
+  const selectedProjectIds = useSelectedProjectIds();
+  const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
 
   const logsTabAskSeerMutationOptions = mutationOptions({
     mutationFn: async (queryToSubmit: string) => {
-      const selectedProjects =
-        pageFilters.selection.projects?.length > 0 &&
-        pageFilters.selection.projects?.[0] !== -1
-          ? pageFilters.selection.projects
-          : projects.filter(p => p.isMember).map(p => p.id);
-
       const user = ConfigStore.get('user');
-      const data = await fetchMutation<LogsAskSeerTranslateResponse>({
+      const data = await fetchMutation<SeerRawResponse>({
         url: `/organizations/${organization.slug}/search-agent/translate/`,
         method: 'POST',
         data: {
           org_id: organization.id,
           org_slug: organization.slug,
           natural_language_query: queryToSubmit,
-          project_ids: selectedProjects,
+          project_ids: selectedProjectIdsForMutation,
           strategy: 'Logs',
           user_email: user?.email,
         },
@@ -150,23 +97,16 @@ export function LogsTabSeerComboBox() {
         end: resultEnd,
       } = result;
 
-      let start: DateString = null;
-      let end: DateString = null;
+      const dt = buildSeerDateTimeSelection(
+        resultStart,
+        resultEnd,
+        statsPeriod,
+        pageFilters.selection.datetime
+      );
 
-      if (resultStart && resultEnd) {
-        // Strip 'Z' suffix to treat UTC dates as local time
-        const startLocal = resultStart.endsWith('Z')
-          ? resultStart.slice(0, -1)
-          : resultStart;
-        const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
-        start = new Date(startLocal).toISOString();
-        end = new Date(endLocal).toISOString();
-      } else {
-        start = pageFilters.selection.datetime.start;
-        end = pageFilters.selection.datetime.end;
-      }
+      const start = dt.start;
+      const end = dt.end;
 
-      // Update mode based on groupBys or response mode (matches Trace Explorer logic)
       const mode =
         groupBys.length > 0
           ? Mode.AGGREGATE
@@ -174,8 +114,6 @@ export function LogsTabSeerComboBox() {
             ? Mode.AGGREGATE
             : Mode.SAMPLES;
 
-      // Build aggregateFields array (similar to useSetQueryParamsGroupBys logic)
-      // This combines groupBys with existing visualizations
       let seenVisualizes = false;
       let groupByAfterVisualizes = false;
 
@@ -194,7 +132,6 @@ export function LogsTabSeerComboBox() {
       for (const aggregateField of queryParams.aggregateFields) {
         if (isVisualize(aggregateField)) {
           if (!groupByAfterVisualizes) {
-            // Insert group bys before visualizes
             for (const groupBy of iter) {
               aggregateFields.push({groupBy});
             }
@@ -208,33 +145,20 @@ export function LogsTabSeerComboBox() {
         }
       }
 
-      // Add any remaining group bys
       for (const groupBy of iter) {
         aggregateFields.push({groupBy});
       }
 
-      // Build datetime selection similar to Trace Explorer
       const selection = {
         ...pageFilters.selection,
-        datetime: {
-          start,
-          end,
-          utc: pageFilters.selection.datetime.utc,
-          period:
-            resultStart && resultEnd
-              ? null
-              : statsPeriod || pageFilters.selection.datetime.period,
-        },
+        datetime: {start, end, utc: dt.utc, period: dt.period},
       };
 
-      // Build complete URL with all params (query, mode, aggregateFields, datetime)
-      // This matches the Trace Explorer pattern of single navigation
       const newQuery = {
         ...location.query,
         [LOGS_QUERY_KEY]: queryToUse,
         mode,
         [LOGS_AGGREGATE_FIELD_KEY]: aggregateFields.map(field => JSON.stringify(field)),
-        // Datetime params from selection
         start: selection.datetime.start,
         end: selection.datetime.end,
         statsPeriod: selection.datetime.period,
@@ -259,7 +183,6 @@ export function LogsTabSeerComboBox() {
         setRunId(runId);
       }
 
-      // Single navigation with all params (matches Trace Explorer pattern)
       navigate({...location, query: newQuery}, {replace: true, preventScrollReset: true});
     },
     [
@@ -274,46 +197,17 @@ export function LogsTabSeerComboBox() {
     ]
   );
 
-  // Get selected project IDs for the polling variant
-  const selectedProjectIds = useMemo(() => {
-    if (
-      pageFilters.selection.projects?.length > 0 &&
-      pageFilters.selection.projects?.[0] !== -1
-    ) {
-      return pageFilters.selection.projects;
-    }
-    return projects.filter(p => p.isMember).map(p => parseInt(p.id, 10));
-  }, [pageFilters.selection.projects, projects]);
-
-  // Transform the final_response from Seer to match the expected format
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
-      const seerResponse = response as unknown as {
-        responses?: Array<{
-          end: string | null;
-          group_by: string[];
-          mode: string;
-          query: string;
-          sort: string;
-          start: string | null;
-          stats_period: string;
-        }>;
-      };
-
-      if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
-        return seerResponse.responses.map(r => ({
-          query: r?.query ?? '',
-          sort: r?.sort ?? '',
-          groupBys: r?.group_by ?? [],
-          statsPeriod: r?.stats_period ?? '',
-          start: r?.start ?? null,
-          end: r?.end ?? null,
-          mode: r?.mode ?? 'samples',
-        }));
-      }
-
-      return [response];
-    },
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
+      transformSeerResponse(response, r => ({
+        query: r?.query ?? '',
+        sort: r?.sort ?? '',
+        groupBys: r?.group_by ?? [],
+        statsPeriod: r?.stats_period ?? '',
+        start: r?.start ?? null,
+        end: r?.end ?? null,
+        mode: r?.mode ?? 'samples',
+      })),
     []
   );
 

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -114,6 +114,9 @@ export function LogsTabSeerComboBox() {
             ? Mode.AGGREGATE
             : Mode.SAMPLES;
 
+      // Build aggregateFields: combines groupBys with existing visualizations,
+      // preserving the existing field ordering (groupBy-before-visualize vs
+      // visualize-before-groupBy layout).
       let seenVisualizes = false;
       let groupByAfterVisualizes = false;
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 import {mutationOptions} from '@tanstack/react-query';
 
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
@@ -6,25 +6,26 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
 import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
+import type {
+  SeerRawResponse,
+  SeerRawResponseItem,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
-  useSearchQueryBuilderAI,
-  useSearchQueryBuilderLayout,
-  useSearchQueryBuilderState,
-} from 'sentry/components/searchQueryBuilder/context';
-import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
+  buildSeerDateTimeSelection,
+  transformSeerResponse,
+  useInitialSeerQuery,
+  useSelectedProjectIds,
+  useSelectedProjectIdsForMutation,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
-import {Token} from 'sentry/components/searchSyntax/parser';
-import {stringifyToken} from 'sentry/components/searchSyntax/utils';
 import {ConfigStore} from 'sentry/stores/configStore';
-import type {DateString} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {Sort} from 'sentry/utils/discover/fields';
-import {getFieldDefinition} from 'sentry/utils/fields';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
 import {DEFAULT_YAXIS_BY_TYPE, NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import {
   defaultAggregateSortBys,
@@ -65,87 +66,49 @@ interface AskSeerSearchQuery {
   visualizations: Visualization[];
 }
 
-interface MetricsAskSeerTranslateResponse {
-  responses: Array<{
-    end: string | null;
-    group_by: string[];
-    mode: string;
-    query: string;
-    sort: string;
-    start: string | null;
-    stats_period: string;
-    visualization: Array<{
-      chart_type: number;
-      y_axes: string[];
-    }>;
-  }>;
-  unsupported_reason: string | null;
+function mapResponseItem(r: SeerRawResponseItem): AskSeerSearchQuery {
+  return {
+    visualizations:
+      r.visualization?.map(v => ({
+        chartType: v.chart_type as ChartType,
+        yAxes: v.y_axes ?? [],
+      })) ?? [],
+    query: r.query,
+    sort: r.sort,
+    groupBys: r.group_by ?? [],
+    statsPeriod: r.stats_period,
+    start: r.start,
+    end: r.end,
+    mode: r.mode,
+  };
 }
 
 export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProps) {
   const navigate = useNavigate();
   const location = useLocation();
-  const {projects} = useProjects();
   const pageFilters = usePageFilters();
   const {setRunId} = useAiQueryContext();
   const organization = useOrganization();
   const queryParams = useQueryParams();
   const metricQueries = useMultiMetricsQueryParams();
   const analyticsArea = useAnalyticsArea();
-  const {query, committedQuery} = useSearchQueryBuilderState();
-  const {currentInputValueRef} = useSearchQueryBuilderLayout();
   const {askSeerSuggestedQueryRef, enableAISearch} = useSearchQueryBuilderAI();
 
-  let initialSeerQuery = '';
-  const queryDetails = useMemo(() => {
-    const queryToUse = committedQuery.length > 0 ? committedQuery : query;
-    const parsedQuery = parseQueryBuilderValue(queryToUse, getFieldDefinition);
-    return {parsedQuery, queryToUse};
-  }, [committedQuery, query]);
-
-  const inputValue = currentInputValueRef.current.trim();
-
-  // Only filter out FREE_TEXT tokens if there's actual input value to filter by
-  const filteredCommittedQuery = queryDetails.parsedQuery
-    ?.filter(
-      token =>
-        !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
-    )
-    .map(token => stringifyToken(token))
-    .join(' ')
-    .trim();
-
-  // Use filteredCommittedQuery if it has content.
-  // Only fall back to queryToUse when there's no inputValue to filter by.
-  // This prevents duplication when the entire query is free text matching inputValue.
-  if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
-    initialSeerQuery = filteredCommittedQuery;
-  } else if (!inputValue && queryDetails.queryToUse) {
-    initialSeerQuery = queryDetails.queryToUse;
-  }
-
-  if (inputValue) {
-    initialSeerQuery =
-      initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
-  }
+  const initialSeerQuery = useInitialSeerQuery();
+  const selectedProjectIds = useSelectedProjectIds();
+  const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
 
   const metricsTabAskSeerMutationOptions = mutationOptions({
     mutationFn: async (queryToSubmit: string) => {
-      const selectedProjects =
-        pageFilters.selection.projects?.length > 0 &&
-        pageFilters.selection.projects?.[0] !== -1
-          ? pageFilters.selection.projects
-          : projects.filter(p => p.isMember).map(p => p.id);
-
       const user = ConfigStore.get('user');
-      const data = await fetchMutation<MetricsAskSeerTranslateResponse>({
+      const data = await fetchMutation<SeerRawResponse>({
         url: `/organizations/${organization.slug}/search-agent/translate/`,
         method: 'POST',
         data: {
           org_id: organization.id,
           org_slug: organization.slug,
           natural_language_query: queryToSubmit,
-          project_ids: selectedProjects,
+          project_ids: selectedProjectIdsForMutation,
           strategy: 'Metrics',
           user_email: user?.email,
           options: {
@@ -161,20 +124,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(r => ({
-          visualizations:
-            r.visualization?.map(v => ({
-              chartType: v.chart_type,
-              yAxes: v.y_axes,
-            })) ?? [],
-          query: r.query,
-          sort: r.sort,
-          groupBys: r.group_by ?? [],
-          statsPeriod: r.stats_period,
-          start: r.start,
-          end: r.end,
-          mode: r.mode,
-        })),
+        queries: data.responses.map(mapResponseItem),
       };
     },
   });
@@ -193,23 +143,16 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         visualizations,
       } = result;
 
-      let start: DateString = null;
-      let end: DateString = null;
+      const dt = buildSeerDateTimeSelection(
+        resultStart,
+        resultEnd,
+        statsPeriod,
+        pageFilters.selection.datetime
+      );
 
-      if (resultStart && resultEnd) {
-        // Strip 'Z' suffix to treat UTC dates as local time
-        const startLocal = resultStart.endsWith('Z')
-          ? resultStart.slice(0, -1)
-          : resultStart;
-        const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
-        start = new Date(startLocal).toISOString();
-        end = new Date(endLocal).toISOString();
-      } else {
-        start = pageFilters.selection.datetime.start;
-        end = pageFilters.selection.datetime.end;
-      }
+      const start = dt.start;
+      const end = dt.end;
 
-      // Update mode based on groupBys or response mode
       const mode =
         groupBys.length > 0
           ? Mode.AGGREGATE
@@ -217,7 +160,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
             ? Mode.AGGREGATE
             : Mode.SAMPLES;
 
-      // Convert Seer visualizations to VisualizeFunction objects
       const seerVisualizes = visualizations.flatMap(viz =>
         viz.yAxes.map(yAxis => new VisualizeFunction(yAxis, {chartType: viz.chartType}))
       );
@@ -285,7 +227,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         cleanedQuery = search.formatString();
       }
 
-      // Build aggregateFields: groupBys first, then visualizes
       const aggregateFields: AggregateField[] = [];
 
       for (const groupBy of groupBys) {
@@ -343,7 +284,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         }
       }
 
-      // Parse and apply sort from Seer response
       const parseSeerSort = (sortStr: string): Sort => {
         if (sortStr.startsWith('-')) {
           return {field: sortStr.slice(1), kind: 'desc'};
@@ -359,7 +299,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       const sortBys =
         mode === Mode.SAMPLES && seerSort ? [seerSort] : queryParams.sortBys;
 
-      // Build updated ReadableQueryParams for this metric
       const newQueryParams = queryParams.replace({
         query: cleanedQuery,
         aggregateFields,
@@ -386,15 +325,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
       const selection = {
         ...pageFilters.selection,
-        datetime: {
-          start,
-          end,
-          utc: pageFilters.selection.datetime.utc,
-          period:
-            resultStart && resultEnd
-              ? null
-              : statsPeriod || pageFilters.selection.datetime.period,
-        },
+        datetime: {start, end, utc: dt.utc, period: dt.period},
       };
 
       askSeerSuggestedQueryRef.current = JSON.stringify({
@@ -416,9 +347,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         setRunId(runId);
       }
 
-      // Single navigate with both metric params and datetime
-      // (Previously, setQueryParams and navigate were called separately,
-      // causing the second navigate to overwrite the first with stale location)
       navigate(
         {
           ...location,
@@ -452,55 +380,9 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     organization.features.includes('gen-ai-search-agent-translate') &&
     organization.features.includes('gen-ai-explore-metrics-search');
 
-  // Get selected project IDs for the polling variant
-  const selectedProjectIds = useMemo(() => {
-    if (
-      pageFilters.selection.projects?.length > 0 &&
-      pageFilters.selection.projects?.[0] !== -1
-    ) {
-      return pageFilters.selection.projects;
-    }
-    return projects.filter(p => p.isMember).map(p => parseInt(p.id, 10));
-  }, [pageFilters.selection.projects, projects]);
-
-  // Transform the final_response from Seer to match the expected format
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
-      const seerResponse = response as unknown as {
-        responses?: Array<{
-          end: string | null;
-          group_by: string[];
-          mode: string;
-          query: string;
-          sort: string;
-          start: string | null;
-          stats_period: string;
-          visualization: Array<{
-            chart_type: number;
-            y_axes: string[];
-          }>;
-        }>;
-      };
-
-      if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
-        return seerResponse.responses.map(r => ({
-          visualizations:
-            r.visualization?.map(v => ({
-              chartType: v.chart_type,
-              yAxes: v.y_axes,
-            })) ?? [],
-          query: r.query,
-          sort: r.sort,
-          groupBys: r.group_by ?? [],
-          statsPeriod: r.stats_period,
-          start: r.start,
-          end: r.end,
-          mode: r.mode,
-        }));
-      }
-
-      return [response];
-    },
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
+      transformSeerResponse(response, mapResponseItem),
     []
   );
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -286,6 +286,9 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         setRunId(runId);
       }
 
+      // Single navigate with both metric params and datetime — previously
+      // setQueryParams and navigate were separate calls, and the second
+      // navigate overwrote the first with stale location.
       navigate(
         {
           ...location,

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -7,11 +7,11 @@ import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCom
 import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
 import type {
+  AskSeerSearchQuery,
   SeerRawResponse,
-  SeerRawResponseItem,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
-  buildSeerDateTimeSelection,
+  mapSeerResponseItem,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
@@ -21,7 +21,6 @@ import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/cont
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type {Sort} from 'sentry/utils/discover/fields';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -44,43 +43,10 @@ import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateFie
 import {useQueryParams} from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {isVisualize, VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
-import type {ChartType} from 'sentry/views/insights/common/components/chart';
+import {getSeerExploreQuery, getSeerSort} from 'sentry/views/explore/seerQuery';
 
 interface MetricsTabSeerComboBoxProps {
   traceMetric: TraceMetric;
-}
-
-interface Visualization {
-  chartType: ChartType;
-  yAxes: string[];
-}
-
-interface AskSeerSearchQuery {
-  end: string | null;
-  groupBys: string[];
-  mode: string;
-  query: string;
-  sort: string;
-  start: string | null;
-  statsPeriod: string;
-  visualizations: Visualization[];
-}
-
-function mapResponseItem(r: SeerRawResponseItem): AskSeerSearchQuery {
-  return {
-    visualizations:
-      r.visualization?.map(v => ({
-        chartType: v.chart_type as ChartType,
-        yAxes: v.y_axes ?? [],
-      })) ?? [],
-    query: r.query,
-    sort: r.sort,
-    groupBys: r.group_by ?? [],
-    statsPeriod: r.stats_period,
-    start: r.start,
-    end: r.end,
-    mode: r.mode,
-  };
 }
 
 export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProps) {
@@ -124,7 +90,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(mapResponseItem),
+        queries: data.responses.map(response => mapSeerResponseItem(response)),
       };
     },
   });
@@ -134,33 +100,13 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       if (!result) {
         return;
       }
-      const {
-        query: queryToUse,
-        groupBys,
-        statsPeriod,
-        start: resultStart,
-        end: resultEnd,
-        visualizations,
-      } = result;
 
-      const dt = buildSeerDateTimeSelection(
-        resultStart,
-        resultEnd,
-        statsPeriod,
-        pageFilters.selection.datetime
-      );
+      const seerQuery = getSeerExploreQuery({
+        result,
+        pageDatetime: pageFilters.selection.datetime,
+      });
 
-      const start = dt.start;
-      const end = dt.end;
-
-      const mode =
-        groupBys.length > 0
-          ? Mode.AGGREGATE
-          : result.mode === 'aggregates'
-            ? Mode.AGGREGATE
-            : Mode.SAMPLES;
-
-      const seerVisualizes = visualizations.flatMap(viz =>
+      const seerVisualizes = (result.visualizations ?? []).flatMap(viz =>
         viz.yAxes.map(yAxis => new VisualizeFunction(yAxis, {chartType: viz.chartType}))
       );
 
@@ -169,9 +115,9 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       // p75(value, metric.name, distribution, millisecond)); if it's not there
       // we read metric.name/type/unit filters from the query (typically only
       // present in samples mode).
-      const search = new MutableSearch(queryToUse);
+      const search = new MutableSearch(seerQuery.query);
 
-      const visualizationTraceMetric = visualizations
+      const visualizationTraceMetric = (result.visualizations ?? [])
         .flatMap(viz => viz.yAxes)
         .map(yAxis => parseMetricAggregate(yAxis).traceMetric)
         .find(
@@ -219,7 +165,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       // metric (it's then tracked on the panel, not the query). If we couldn't
       // resolve one, leave the query untouched so it stays consistent with the
       // unchanged panel metric.
-      let cleanedQuery = queryToUse;
+      let cleanedQuery = seerQuery.query;
       if (resolvedMetric) {
         search.removeFilter(TraceMetricKnownFieldKey.METRIC_NAME);
         search.removeFilter(TraceMetricKnownFieldKey.METRIC_TYPE);
@@ -229,7 +175,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
       const aggregateFields: AggregateField[] = [];
 
-      for (const groupBy of groupBys) {
+      for (const groupBy of seerQuery.groupBys) {
         aggregateFields.push({groupBy});
       }
 
@@ -284,27 +230,20 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         }
       }
 
-      const parseSeerSort = (sortStr: string): Sort => {
-        if (sortStr.startsWith('-')) {
-          return {field: sortStr.slice(1), kind: 'desc'};
-        }
-        return {field: sortStr, kind: 'asc'};
-      };
-
-      const seerSort = result.sort ? parseSeerSort(result.sort) : undefined;
+      const seerSort = getSeerSort(seerQuery.sort);
       const aggregateSortBys =
-        mode === Mode.AGGREGATE && seerSort
+        seerQuery.mode === Mode.AGGREGATE && seerSort
           ? [seerSort]
           : defaultAggregateSortBys(aggregateFields);
       const sortBys =
-        mode === Mode.SAMPLES && seerSort ? [seerSort] : queryParams.sortBys;
+        seerQuery.mode === Mode.SAMPLES && seerSort ? [seerSort] : queryParams.sortBys;
 
       const newQueryParams = queryParams.replace({
         query: cleanedQuery,
         aggregateFields,
         aggregateSortBys,
         sortBys,
-        mode,
+        mode: seerQuery.mode,
       });
 
       // Build encoded metric queries, updating the current metric's query params
@@ -325,22 +264,22 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
       const selection = {
         ...pageFilters.selection,
-        datetime: {start, end, utc: dt.utc, period: dt.period},
+        datetime: seerQuery.datetime,
       };
 
       askSeerSuggestedQueryRef.current = JSON.stringify({
         selection,
         query: cleanedQuery,
-        groupBys,
-        mode,
+        groupBys: seerQuery.groupBys,
+        mode: seerQuery.mode,
       });
 
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
         query: cleanedQuery,
-        group_by_count: groupBys.length,
-        visualize_count: visualizations?.length ?? 0,
+        group_by_count: seerQuery.groupBys.length,
+        visualize_count: seerQuery.visualizes.length,
       });
 
       if (runId !== undefined) {
@@ -353,10 +292,10 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           query: {
             ...location.query,
             metric: newEncodedMetrics,
-            start: selection.datetime.start,
-            end: selection.datetime.end,
-            statsPeriod: selection.datetime.period,
-            utc: selection.datetime.utc,
+            start: seerQuery.datetime.start,
+            end: seerQuery.datetime.end,
+            statsPeriod: seerQuery.datetime.period,
+            utc: seerQuery.datetime.utc,
           },
         },
         {replace: true, preventScrollReset: true}
@@ -382,7 +321,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
   const transformResponse = useCallback(
     (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, mapResponseItem),
+      transformSeerResponse(response, responseItem => mapSeerResponseItem(responseItem)),
     []
   );
 

--- a/static/app/views/explore/seerQuery.spec.tsx
+++ b/static/app/views/explore/seerQuery.spec.tsx
@@ -1,0 +1,155 @@
+import type {AskSeerSearchQuery} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {
+  getSeerAggregateFields,
+  getSeerExploreQuery,
+  getSeerSort,
+  getSeerWritableAggregateFields,
+} from 'sentry/views/explore/seerQuery';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+const pageDatetime = {
+  start: null,
+  end: null,
+  period: '7d',
+  utc: null,
+};
+
+function seerResult(overrides: Partial<AskSeerSearchQuery>): AskSeerSearchQuery {
+  return {
+    query: '',
+    sort: '',
+    groupBys: [],
+    statsPeriod: '',
+    start: null,
+    end: null,
+    mode: 'samples',
+    visualizations: [],
+    ...overrides,
+  };
+}
+
+describe('getSeerExploreQuery', () => {
+  it('normalizes mode, datetime, and visualizes', () => {
+    const result = getSeerExploreQuery({
+      pageDatetime,
+      result: seerResult({
+        query: 'span.op:db',
+        sort: '-timestamp',
+        groupBys: ['project'],
+        mode: 'samples',
+        statsPeriod: '24h',
+        visualizations: [{chartType: ChartType.BAR, yAxes: ['count()']}],
+      }),
+    });
+
+    expect(result).toMatchObject({
+      query: 'span.op:db',
+      sort: '-timestamp',
+      groupBys: ['project'],
+      mode: 'aggregate',
+      datetime: {period: '24h'},
+      visualizes: [{chartType: ChartType.BAR, yAxes: ['count()']}],
+    });
+  });
+});
+
+describe('getSeerSort', () => {
+  it('parses descending and ascending sorts', () => {
+    expect(getSeerSort('-count()')).toEqual({field: 'count()', kind: 'desc'});
+    expect(getSeerSort('timestamp')).toEqual({field: 'timestamp', kind: 'asc'});
+    expect(getSeerSort('')).toBeUndefined();
+  });
+});
+
+describe('getSeerWritableAggregateFields', () => {
+  it('uses Seer groupBys and visualizes when present', () => {
+    expect(
+      getSeerWritableAggregateFields({
+        currentAggregateFields: [new VisualizeFunction('count(message)')],
+        groupBys: ['service.name'],
+        visualizes: [{chartType: ChartType.AREA, yAxes: ['p95(payload_size)']}],
+      })
+    ).toEqual([
+      {groupBy: 'service.name'},
+      {chartType: ChartType.AREA, yAxes: ['p95(payload_size)']},
+    ]);
+  });
+
+  it('preserves visualize-first aggregate field order', () => {
+    expect(
+      getSeerWritableAggregateFields({
+        currentAggregateFields: [
+          new VisualizeFunction('count(message)'),
+          {groupBy: 'severity'},
+        ],
+        groupBys: ['service.name', 'environment'],
+        visualizes: [{chartType: ChartType.AREA, yAxes: ['p95(payload_size)']}],
+      })
+    ).toEqual([
+      {chartType: ChartType.AREA, yAxes: ['p95(payload_size)']},
+      {groupBy: 'service.name'},
+      {groupBy: 'environment'},
+    ]);
+  });
+
+  it('preserves mixed aggregate field order when groupBys straddle visualizes', () => {
+    expect(
+      getSeerWritableAggregateFields({
+        currentAggregateFields: [
+          {groupBy: 'severity'},
+          new VisualizeFunction('count(message)'),
+          {groupBy: 'project'},
+        ],
+        groupBys: ['service.name', 'environment'],
+        visualizes: [{chartType: ChartType.AREA, yAxes: ['p95(payload_size)']}],
+      })
+    ).toEqual([
+      {groupBy: 'service.name'},
+      {chartType: ChartType.AREA, yAxes: ['p95(payload_size)']},
+      {groupBy: 'environment'},
+    ]);
+  });
+
+  it('falls back to existing visualizes, then default visualizes', () => {
+    expect(
+      getSeerWritableAggregateFields({
+        currentAggregateFields: [
+          {groupBy: 'severity'},
+          new VisualizeFunction('count(message)', {chartType: ChartType.LINE}),
+        ],
+        groupBys: ['service.name'],
+        visualizes: [],
+      })
+    ).toEqual([
+      {groupBy: 'service.name'},
+      {chartType: ChartType.LINE, yAxes: ['count(message)']},
+    ]);
+
+    expect(
+      getSeerWritableAggregateFields({
+        currentAggregateFields: [],
+        fallbackVisualizes: [{yAxes: ['count(message)']}],
+        groupBys: [],
+        visualizes: [],
+      })
+    ).toEqual([{yAxes: ['count(message)']}]);
+  });
+});
+
+describe('getSeerAggregateFields', () => {
+  it('converts writable visualizes into query param aggregate fields', () => {
+    const fields = getSeerAggregateFields({
+      currentAggregateFields: [],
+      groupBys: ['service.name'],
+      visualizes: [{chartType: ChartType.BAR, yAxes: ['count(message)']}],
+    });
+
+    expect(fields[0]).toEqual({groupBy: 'service.name'});
+    expect(fields[1]).toBeInstanceOf(VisualizeFunction);
+    expect((fields[1] as VisualizeFunction).serialize()).toEqual({
+      chartType: ChartType.BAR,
+      yAxes: ['count(message)'],
+    });
+  });
+});

--- a/static/app/views/explore/seerQuery.spec.tsx
+++ b/static/app/views/explore/seerQuery.spec.tsx
@@ -1,11 +1,5 @@
 import type {AskSeerSearchQuery} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
-import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
-import {
-  getSeerAggregateFields,
-  getSeerExploreQuery,
-  getSeerSort,
-  getSeerWritableAggregateFields,
-} from 'sentry/views/explore/seerQuery';
+import {getSeerExploreQuery, getSeerSort} from 'sentry/views/explore/seerQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 const pageDatetime = {
@@ -59,97 +53,5 @@ describe('getSeerSort', () => {
     expect(getSeerSort('-count()')).toEqual({field: 'count()', kind: 'desc'});
     expect(getSeerSort('timestamp')).toEqual({field: 'timestamp', kind: 'asc'});
     expect(getSeerSort('')).toBeUndefined();
-  });
-});
-
-describe('getSeerWritableAggregateFields', () => {
-  it('uses Seer groupBys and visualizes when present', () => {
-    expect(
-      getSeerWritableAggregateFields({
-        currentAggregateFields: [new VisualizeFunction('count(message)')],
-        groupBys: ['service.name'],
-        visualizes: [{chartType: ChartType.AREA, yAxes: ['p95(payload_size)']}],
-      })
-    ).toEqual([
-      {groupBy: 'service.name'},
-      {chartType: ChartType.AREA, yAxes: ['p95(payload_size)']},
-    ]);
-  });
-
-  it('preserves visualize-first aggregate field order', () => {
-    expect(
-      getSeerWritableAggregateFields({
-        currentAggregateFields: [
-          new VisualizeFunction('count(message)'),
-          {groupBy: 'severity'},
-        ],
-        groupBys: ['service.name', 'environment'],
-        visualizes: [{chartType: ChartType.AREA, yAxes: ['p95(payload_size)']}],
-      })
-    ).toEqual([
-      {chartType: ChartType.AREA, yAxes: ['p95(payload_size)']},
-      {groupBy: 'service.name'},
-      {groupBy: 'environment'},
-    ]);
-  });
-
-  it('preserves mixed aggregate field order when groupBys straddle visualizes', () => {
-    expect(
-      getSeerWritableAggregateFields({
-        currentAggregateFields: [
-          {groupBy: 'severity'},
-          new VisualizeFunction('count(message)'),
-          {groupBy: 'project'},
-        ],
-        groupBys: ['service.name', 'environment'],
-        visualizes: [{chartType: ChartType.AREA, yAxes: ['p95(payload_size)']}],
-      })
-    ).toEqual([
-      {groupBy: 'service.name'},
-      {chartType: ChartType.AREA, yAxes: ['p95(payload_size)']},
-      {groupBy: 'environment'},
-    ]);
-  });
-
-  it('falls back to existing visualizes, then default visualizes', () => {
-    expect(
-      getSeerWritableAggregateFields({
-        currentAggregateFields: [
-          {groupBy: 'severity'},
-          new VisualizeFunction('count(message)', {chartType: ChartType.LINE}),
-        ],
-        groupBys: ['service.name'],
-        visualizes: [],
-      })
-    ).toEqual([
-      {groupBy: 'service.name'},
-      {chartType: ChartType.LINE, yAxes: ['count(message)']},
-    ]);
-
-    expect(
-      getSeerWritableAggregateFields({
-        currentAggregateFields: [],
-        fallbackVisualizes: [{yAxes: ['count(message)']}],
-        groupBys: [],
-        visualizes: [],
-      })
-    ).toEqual([{yAxes: ['count(message)']}]);
-  });
-});
-
-describe('getSeerAggregateFields', () => {
-  it('converts writable visualizes into query param aggregate fields', () => {
-    const fields = getSeerAggregateFields({
-      currentAggregateFields: [],
-      groupBys: ['service.name'],
-      visualizes: [{chartType: ChartType.BAR, yAxes: ['count(message)']}],
-    });
-
-    expect(fields[0]).toEqual({groupBy: 'service.name'});
-    expect(fields[1]).toBeInstanceOf(VisualizeFunction);
-    expect((fields[1] as VisualizeFunction).serialize()).toEqual({
-      chartType: ChartType.BAR,
-      yAxes: ['count(message)'],
-    });
   });
 });

--- a/static/app/views/explore/seerQuery.ts
+++ b/static/app/views/explore/seerQuery.ts
@@ -5,17 +5,8 @@ import {
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
 import type {PageFilters} from 'sentry/types/core';
 import type {Sort} from 'sentry/utils/discover/fields';
-import type {
-  AggregateField,
-  WritableAggregateField,
-} from 'sentry/views/explore/queryParams/aggregateField';
-import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
-import {
-  type BaseVisualize,
-  isVisualize,
-  Visualize,
-} from 'sentry/views/explore/queryParams/visualize';
+import type {BaseVisualize} from 'sentry/views/explore/queryParams/visualize';
 
 type SeerVisualization = AskSeerSearchQuery['visualizations'][number];
 
@@ -79,109 +70,4 @@ export function getSeerSort(sort: string): Sort | undefined {
   }
 
   return {field: sort, kind: 'asc'};
-}
-
-export function getSeerWritableAggregateFields({
-  currentAggregateFields,
-  fallbackVisualizes = [],
-  groupBys,
-  visualizes,
-}: {
-  currentAggregateFields: readonly AggregateField[];
-  groupBys: readonly string[];
-  visualizes: readonly BaseVisualize[];
-  fallbackVisualizes?: readonly BaseVisualize[];
-}): WritableAggregateField[] {
-  const existingVisualizes = currentAggregateFields
-    .filter(isVisualize)
-    .map(visualize => visualize.serialize());
-  const visualizesToUse = visualizes.length
-    ? visualizes
-    : existingVisualizes.length
-      ? existingVisualizes
-      : fallbackVisualizes;
-
-  let seenVisualizes = false;
-  let groupByAfterVisualizes = false;
-
-  for (const aggregateField of currentAggregateFields) {
-    if (isGroupBy(aggregateField) && seenVisualizes) {
-      groupByAfterVisualizes = true;
-      break;
-    } else if (isVisualize(aggregateField)) {
-      seenVisualizes = true;
-    }
-  }
-
-  const aggregateFields: WritableAggregateField[] = [];
-  const groupByIter = groupBys[Symbol.iterator]();
-  const visualizeIter = visualizesToUse[Symbol.iterator]();
-  let hasVisualizeSlot = false;
-
-  for (const aggregateField of currentAggregateFields) {
-    if (isVisualize(aggregateField)) {
-      hasVisualizeSlot = true;
-      if (!groupByAfterVisualizes) {
-        for (const groupBy of groupByIter) {
-          aggregateFields.push({groupBy});
-        }
-      }
-
-      const {value: visualize, done} = visualizeIter.next();
-      if (!done) {
-        aggregateFields.push(visualize);
-      }
-    } else if (isGroupBy(aggregateField)) {
-      const {value: groupBy, done} = groupByIter.next();
-      if (!done) {
-        aggregateFields.push({groupBy});
-      }
-    }
-  }
-
-  if (!hasVisualizeSlot) {
-    for (const groupBy of groupByIter) {
-      aggregateFields.push({groupBy});
-    }
-  }
-
-  for (const visualize of visualizeIter) {
-    aggregateFields.push(visualize);
-  }
-
-  for (const groupBy of groupByIter) {
-    aggregateFields.push({groupBy});
-  }
-
-  return aggregateFields;
-}
-
-export function getSeerAggregateFields({
-  currentAggregateFields,
-  fallbackVisualizes,
-  groupBys,
-  visualizes,
-}: {
-  currentAggregateFields: readonly AggregateField[];
-  groupBys: readonly string[];
-  visualizes: readonly BaseVisualize[];
-  fallbackVisualizes?: readonly BaseVisualize[];
-}): AggregateField[] {
-  const aggregateFields: AggregateField[] = [];
-  const writableFields = getSeerWritableAggregateFields({
-    currentAggregateFields,
-    fallbackVisualizes,
-    groupBys,
-    visualizes,
-  });
-
-  for (const field of writableFields) {
-    if ('groupBy' in field) {
-      aggregateFields.push(field);
-    } else {
-      aggregateFields.push(...Visualize.fromJSON(field));
-    }
-  }
-
-  return aggregateFields;
 }

--- a/static/app/views/explore/seerQuery.ts
+++ b/static/app/views/explore/seerQuery.ts
@@ -19,7 +19,7 @@ import {
 
 type SeerVisualization = AskSeerSearchQuery['visualizations'][number];
 
-export interface SeerExploreQuery {
+interface SeerExploreQuery {
   datetime: SeerDateTimeSelection;
   groupBys: string[];
   mode: Mode;

--- a/static/app/views/explore/seerQuery.ts
+++ b/static/app/views/explore/seerQuery.ts
@@ -1,0 +1,187 @@
+import type {AskSeerSearchQuery} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
+import {
+  buildSeerDateTimeSelection,
+  type SeerDateTimeSelection,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import type {PageFilters} from 'sentry/types/core';
+import type {Sort} from 'sentry/utils/discover/fields';
+import type {
+  AggregateField,
+  WritableAggregateField,
+} from 'sentry/views/explore/queryParams/aggregateField';
+import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {
+  type BaseVisualize,
+  isVisualize,
+  Visualize,
+} from 'sentry/views/explore/queryParams/visualize';
+
+type SeerVisualization = AskSeerSearchQuery['visualizations'][number];
+
+export interface SeerExploreQuery {
+  datetime: SeerDateTimeSelection;
+  groupBys: string[];
+  mode: Mode;
+  query: string;
+  sort: string;
+  visualizes: BaseVisualize[];
+}
+
+function getSeerExploreMode(result: AskSeerSearchQuery): Mode {
+  if ((result.groupBys?.length ?? 0) > 0 || result.mode === 'aggregates') {
+    return Mode.AGGREGATE;
+  }
+
+  return Mode.SAMPLES;
+}
+
+function getSeerVisualizes(
+  visualizations: readonly SeerVisualization[]
+): BaseVisualize[] {
+  return visualizations.map(({chartType, yAxes}) => ({
+    chartType,
+    yAxes,
+  }));
+}
+
+export function getSeerExploreQuery({
+  pageDatetime,
+  result,
+}: {
+  pageDatetime: PageFilters['datetime'];
+  result: AskSeerSearchQuery;
+}): SeerExploreQuery {
+  const datetime = buildSeerDateTimeSelection(
+    result.start,
+    result.end,
+    result.statsPeriod,
+    pageDatetime
+  );
+
+  return {
+    datetime,
+    groupBys: result.groupBys,
+    mode: getSeerExploreMode(result),
+    query: result.query,
+    sort: result.sort,
+    visualizes: getSeerVisualizes(result.visualizations),
+  };
+}
+
+export function getSeerSort(sort: string): Sort | undefined {
+  if (!sort) {
+    return undefined;
+  }
+
+  if (sort.startsWith('-')) {
+    return {field: sort.slice(1), kind: 'desc'};
+  }
+
+  return {field: sort, kind: 'asc'};
+}
+
+export function getSeerWritableAggregateFields({
+  currentAggregateFields,
+  fallbackVisualizes = [],
+  groupBys,
+  visualizes,
+}: {
+  currentAggregateFields: readonly AggregateField[];
+  groupBys: readonly string[];
+  visualizes: readonly BaseVisualize[];
+  fallbackVisualizes?: readonly BaseVisualize[];
+}): WritableAggregateField[] {
+  const existingVisualizes = currentAggregateFields
+    .filter(isVisualize)
+    .map(visualize => visualize.serialize());
+  const visualizesToUse = visualizes.length
+    ? visualizes
+    : existingVisualizes.length
+      ? existingVisualizes
+      : fallbackVisualizes;
+
+  let seenVisualizes = false;
+  let groupByAfterVisualizes = false;
+
+  for (const aggregateField of currentAggregateFields) {
+    if (isGroupBy(aggregateField) && seenVisualizes) {
+      groupByAfterVisualizes = true;
+      break;
+    } else if (isVisualize(aggregateField)) {
+      seenVisualizes = true;
+    }
+  }
+
+  const aggregateFields: WritableAggregateField[] = [];
+  const groupByIter = groupBys[Symbol.iterator]();
+  const visualizeIter = visualizesToUse[Symbol.iterator]();
+  let hasVisualizeSlot = false;
+
+  for (const aggregateField of currentAggregateFields) {
+    if (isVisualize(aggregateField)) {
+      hasVisualizeSlot = true;
+      if (!groupByAfterVisualizes) {
+        for (const groupBy of groupByIter) {
+          aggregateFields.push({groupBy});
+        }
+      }
+
+      const {value: visualize, done} = visualizeIter.next();
+      if (!done) {
+        aggregateFields.push(visualize);
+      }
+    } else if (isGroupBy(aggregateField)) {
+      const {value: groupBy, done} = groupByIter.next();
+      if (!done) {
+        aggregateFields.push({groupBy});
+      }
+    }
+  }
+
+  if (!hasVisualizeSlot) {
+    for (const groupBy of groupByIter) {
+      aggregateFields.push({groupBy});
+    }
+  }
+
+  for (const visualize of visualizeIter) {
+    aggregateFields.push(visualize);
+  }
+
+  for (const groupBy of groupByIter) {
+    aggregateFields.push({groupBy});
+  }
+
+  return aggregateFields;
+}
+
+export function getSeerAggregateFields({
+  currentAggregateFields,
+  fallbackVisualizes,
+  groupBys,
+  visualizes,
+}: {
+  currentAggregateFields: readonly AggregateField[];
+  groupBys: readonly string[];
+  visualizes: readonly BaseVisualize[];
+  fallbackVisualizes?: readonly BaseVisualize[];
+}): AggregateField[] {
+  const aggregateFields: AggregateField[] = [];
+  const writableFields = getSeerWritableAggregateFields({
+    currentAggregateFields,
+    fallbackVisualizes,
+    groupBys,
+    visualizes,
+  });
+
+  for (const field of writableFields) {
+    if ('groupBy' in field) {
+      aggregateFields.push(field);
+    } else {
+      aggregateFields.push(...Visualize.fromJSON(field));
+    }
+  }
+
+  return aggregateFields;
+}

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -124,6 +124,7 @@ export function SpansTabSeerComboBox() {
         datetime: seerQuery.datetime,
       };
 
+      // TODO: Include traces mode once we can switch the table in getExploreUrl
       const url = getExploreUrl({
         organization,
         selection,

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 import {mutationOptions} from '@tanstack/react-query';
 
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
@@ -6,21 +6,22 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
 import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
+import type {
+  SeerRawResponse,
+  SeerRawResponseItem,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
-  useSearchQueryBuilderAI,
-  useSearchQueryBuilderLayout,
-  useSearchQueryBuilderState,
-} from 'sentry/components/searchQueryBuilder/context';
-import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
-import {Token} from 'sentry/components/searchSyntax/parser';
-import {stringifyToken} from 'sentry/components/searchSyntax/utils';
-import type {DateString} from 'sentry/types/core';
+  buildSeerDateTimeSelection,
+  transformSeerResponse,
+  useInitialSeerQuery,
+  useSelectedProjectIds,
+  useSelectedProjectIdsForMutation,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {getFieldDefinition} from 'sentry/utils/fields';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
 import {useTraceExploreAiQuerySetup} from 'sentry/views/explore/hooks/useTraceExploreAiQuerySetup';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -58,105 +59,55 @@ interface TraceAskSeerSearchResponse {
   unsupported_reason: string | null;
 }
 
-interface TraceAskSeerTranslateResponse {
-  responses: Array<{
-    end: string | null;
-    group_by: string[];
-    mode: string;
-    query: string;
-    sort: string;
-    start: string | null;
-    stats_period: string;
-    visualization: Array<{
-      chart_type: number;
-      y_axes: string[];
-    }>;
-  }>;
-  unsupported_reason: string | null;
+function mapResponseItemWithVisualizations(r: SeerRawResponseItem): AskSeerSearchQuery {
+  return {
+    visualizations:
+      r?.visualization?.map(v => ({
+        chartType: v?.chart_type as ChartType,
+        yAxes: v?.y_axes ?? [],
+      })) ?? [],
+    query: r?.query ?? '',
+    sort: r?.sort ?? '',
+    groupBys: r?.group_by ?? [],
+    statsPeriod: r?.stats_period ?? '',
+    start: r?.start ?? null,
+    end: r?.end ?? null,
+    mode: r?.mode ?? 'spans',
+  };
 }
 
 export function SpansTabSeerComboBox() {
   const navigate = useNavigate();
-  const {projects} = useProjects();
   const pageFilters = usePageFilters();
   const organization = useOrganization();
   const analyticsArea = useAnalyticsArea();
   const {setRunId} = useAiQueryContext();
-  const {query, committedQuery} = useSearchQueryBuilderState();
-  const {currentInputValueRef} = useSearchQueryBuilderLayout();
   const {askSeerSuggestedQueryRef, enableAISearch} = useSearchQueryBuilderAI();
+
+  const initialSeerQuery = useInitialSeerQuery();
+  const selectedProjectIds = useSelectedProjectIds();
+  const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
 
   const useTranslateEndpoint = organization.features.includes(
     'gen-ai-search-agent-translate'
   );
-  let initialSeerQuery = '';
-  const queryDetails = useMemo(() => {
-    const queryToUse = committedQuery.length > 0 ? committedQuery : query;
-    const parsedQuery = parseQueryBuilderValue(queryToUse, getFieldDefinition);
-    return {parsedQuery, queryToUse};
-  }, [committedQuery, query]);
-
-  const inputValue = currentInputValueRef.current.trim();
-
-  // Only filter out FREE_TEXT tokens if there's actual input value to filter by
-  const filteredCommittedQuery = queryDetails?.parsedQuery
-    ?.filter(
-      token =>
-        !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
-    )
-    ?.map(token => stringifyToken(token))
-    ?.join(' ')
-    ?.trim();
-
-  // Use filteredCommittedQuery if it has content.
-  // Only fall back to queryToUse when there's no inputValue to filter by.
-  // This prevents duplication when the entire query is free text matching inputValue.
-  if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
-    initialSeerQuery = filteredCommittedQuery;
-  } else if (!inputValue && queryDetails?.queryToUse) {
-    initialSeerQuery = queryDetails.queryToUse;
-  }
-
-  if (inputValue) {
-    initialSeerQuery =
-      initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
-  }
 
   const spansTabAskSeerMutationOptions = mutationOptions({
     mutationFn: async (queryToSubmit: string) => {
-      const selectedProjects =
-        pageFilters.selection.projects?.length > 0 &&
-        pageFilters.selection.projects?.[0] !== -1
-          ? pageFilters.selection.projects
-          : projects.filter(p => p.isMember).map(p => p.id);
-
       if (useTranslateEndpoint) {
-        const data = await fetchMutation<TraceAskSeerTranslateResponse>({
+        const data = await fetchMutation<SeerRawResponse>({
           url: `/organizations/${organization.slug}/search-agent/translate/`,
           method: 'POST',
           data: {
             natural_language_query: queryToSubmit,
-            project_ids: selectedProjects,
+            project_ids: selectedProjectIdsForMutation,
           },
         });
 
         return {
           status: 'ok',
           unsupported_reason: data.unsupported_reason,
-          queries: data.responses.map(r => ({
-            visualizations:
-              r?.visualization?.map(v => ({
-                chartType: v?.chart_type,
-                yAxes: v?.y_axes ?? [],
-              })) ?? [],
-            query: r?.query ?? '',
-            sort: r?.sort ?? '',
-            groupBys: r?.group_by ?? [],
-            statsPeriod: r?.stats_period ?? '',
-            start: r?.start ?? null,
-            end: r?.end ?? null,
-            mode: r?.mode ?? 'spans',
-          })),
+          queries: data.responses.map(mapResponseItemWithVisualizations),
         };
       }
 
@@ -165,7 +116,7 @@ export function SpansTabSeerComboBox() {
         method: 'POST',
         data: {
           natural_language_query: queryToSubmit,
-          project_ids: selectedProjects,
+          project_ids: selectedProjectIdsForMutation,
           use_flyout: false,
           limit: 3,
         },
@@ -206,36 +157,21 @@ export function SpansTabSeerComboBox() {
         end: resultEnd,
       } = result;
 
-      let start: DateString = null;
-      let end: DateString = null;
+      const dt = buildSeerDateTimeSelection(
+        resultStart,
+        resultEnd,
+        statsPeriod,
+        pageFilters.selection.datetime
+      );
 
-      if (resultStart && resultEnd) {
-        // Strip 'Z' suffix to treat UTC dates as local time
-        const startLocal = resultStart.endsWith('Z')
-          ? resultStart.slice(0, -1)
-          : resultStart;
-        const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
-        start = new Date(startLocal).toISOString();
-        end = new Date(endLocal).toISOString();
-      } else {
-        start = pageFilters.selection.datetime.start;
-        end = pageFilters.selection.datetime.end;
-      }
+      const start = dt.start;
+      const end = dt.end;
 
       const selection = {
         ...pageFilters.selection,
-        datetime: {
-          start,
-          end,
-          utc: pageFilters.selection.datetime.utc,
-          period:
-            resultStart && resultEnd
-              ? null
-              : statsPeriod || pageFilters.selection.datetime.period,
-        },
+        datetime: {start, end, utc: dt.utc, period: dt.period},
       };
 
-      // TODO: Include traces mode once we can switch the table in getExploreUrl
       const mode =
         groupBys.length > 0
           ? Mode.AGGREGATE
@@ -292,62 +228,12 @@ export function SpansTabSeerComboBox() {
     enableAISearch: enableAISearch && !useTranslateEndpoint,
   });
 
-  // Get selected project IDs for the polling variant
-  const selectedProjectIds = useMemo(() => {
-    if (
-      pageFilters.selection.projects?.length > 0 &&
-      pageFilters.selection.projects?.[0] !== -1
-    ) {
-      return pageFilters.selection.projects;
-    }
-    return projects.filter(p => p.isMember).map(p => parseInt(p.id, 10));
-  }, [pageFilters.selection.projects, projects]);
-
-  // Transform the final_response from Seer to match the expected format
-  // The final_response contains a list of query suggestions in Seer's format
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
-      // If response has a 'responses' array (from Seer), transform each one
-      const seerResponse = response as unknown as {
-        responses?: Array<{
-          end: string | null;
-          group_by: string[];
-          mode: string;
-          query: string;
-          sort: string;
-          start: string | null;
-          stats_period: string;
-          visualization: Array<{
-            chart_type: number;
-            y_axes: string[];
-          }>;
-        }>;
-      };
-
-      if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
-        return seerResponse.responses.map(r => ({
-          visualizations:
-            r?.visualization?.map(v => ({
-              chartType: v?.chart_type,
-              yAxes: v?.y_axes ?? [],
-            })) ?? [],
-          query: r?.query ?? '',
-          sort: r?.sort ?? '',
-          groupBys: r?.group_by ?? [],
-          statsPeriod: r?.stats_period ?? '',
-          start: r?.start ?? null,
-          end: r?.end ?? null,
-          mode: r?.mode ?? 'spans',
-        }));
-      }
-
-      // If it's already in the expected format, wrap in array
-      return [response];
-    },
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
+      transformSeerResponse(response, mapResponseItemWithVisualizations),
     []
   );
 
-  // Use polling variant when the feature flag is enabled
   if (useTranslateEndpoint) {
     return (
       <AskSeerPollingComboBox<AskSeerSearchQuery>

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -7,11 +7,11 @@ import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCom
 import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
 import type {
+  AskSeerSearchQuery,
   SeerRawResponse,
-  SeerRawResponseItem,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
-  buildSeerDateTimeSelection,
+  mapSeerResponseItem,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
@@ -23,25 +23,8 @@ import {fetchMutation} from 'sentry/utils/queryClient';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTraceExploreAiQuerySetup} from 'sentry/views/explore/hooks/useTraceExploreAiQuerySetup';
-import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {getSeerExploreQuery} from 'sentry/views/explore/seerQuery';
 import {getExploreUrl} from 'sentry/views/explore/utils';
-import type {ChartType} from 'sentry/views/insights/common/components/chart';
-
-interface Visualization {
-  chartType: ChartType;
-  yAxes: string[];
-}
-
-interface AskSeerSearchQuery {
-  end: string | null;
-  groupBys: string[];
-  mode: string;
-  query: string;
-  sort: string;
-  start: string | null;
-  statsPeriod: string;
-  visualizations: Visualization[];
-}
 
 interface TraceAskSeerSearchResponse {
   queries: Array<{
@@ -51,29 +34,12 @@ interface TraceAskSeerSearchResponse {
     sort: string;
     stats_period: string;
     visualization: Array<{
-      chart_type: number;
-      y_axes: string[];
+      chart_type?: number;
+      y_axes?: string[];
     }>;
   }>;
   status: string;
   unsupported_reason: string | null;
-}
-
-function mapResponseItemWithVisualizations(r: SeerRawResponseItem): AskSeerSearchQuery {
-  return {
-    visualizations:
-      r?.visualization?.map(v => ({
-        chartType: v?.chart_type as ChartType,
-        yAxes: v?.y_axes ?? [],
-      })) ?? [],
-    query: r?.query ?? '',
-    sort: r?.sort ?? '',
-    groupBys: r?.group_by ?? [],
-    statsPeriod: r?.stats_period ?? '',
-    start: r?.start ?? null,
-    end: r?.end ?? null,
-    mode: r?.mode ?? 'spans',
-  };
 }
 
 export function SpansTabSeerComboBox() {
@@ -107,7 +73,7 @@ export function SpansTabSeerComboBox() {
         return {
           status: 'ok',
           unsupported_reason: data.unsupported_reason,
-          queries: data.responses.map(mapResponseItemWithVisualizations),
+          queries: data.responses.map(response => mapSeerResponseItem(response, 'spans')),
         };
       }
 
@@ -124,20 +90,21 @@ export function SpansTabSeerComboBox() {
 
       return {
         ...data,
-        queries: data.queries.map(q => ({
-          visualizations:
-            q?.visualization?.map((v: any) => ({
-              chartType: v?.chart_type,
-              yAxes: v?.y_axes ?? [],
-            })) ?? [],
-          query: q?.query,
-          sort: q?.sort ?? '',
-          groupBys: q?.group_by ?? [],
-          statsPeriod: q?.stats_period ?? '',
-          start: null,
-          end: null,
-          mode: q?.mode ?? 'spans',
-        })),
+        queries: data.queries.map(q =>
+          mapSeerResponseItem(
+            {
+              query: q.query,
+              sort: q.sort ?? '',
+              group_by: q.group_by ?? [],
+              stats_period: q.stats_period ?? '',
+              start: null,
+              end: null,
+              mode: q.mode ?? 'spans',
+              visualization: q.visualization,
+            },
+            'spans'
+          )
+        ),
       };
     },
   });
@@ -147,67 +114,40 @@ export function SpansTabSeerComboBox() {
       if (!result) {
         return;
       }
-      const {
-        query: queryToUse,
-        visualizations,
-        groupBys,
-        sort,
-        statsPeriod,
-        start: resultStart,
-        end: resultEnd,
-      } = result;
-
-      const dt = buildSeerDateTimeSelection(
-        resultStart,
-        resultEnd,
-        statsPeriod,
-        pageFilters.selection.datetime
-      );
-
-      const start = dt.start;
-      const end = dt.end;
+      const seerQuery = getSeerExploreQuery({
+        result,
+        pageDatetime: pageFilters.selection.datetime,
+      });
 
       const selection = {
         ...pageFilters.selection,
-        datetime: {start, end, utc: dt.utc, period: dt.period},
+        datetime: seerQuery.datetime,
       };
-
-      const mode =
-        groupBys.length > 0
-          ? Mode.AGGREGATE
-          : result.mode === 'aggregates'
-            ? Mode.AGGREGATE
-            : Mode.SAMPLES;
-      const visualize =
-        visualizations?.map((v: Visualization) => ({
-          chartType: v.chartType,
-          yAxes: v.yAxes,
-        })) ?? [];
 
       const url = getExploreUrl({
         organization,
         selection,
-        query: queryToUse,
-        visualize,
-        groupBy: groupBys,
-        sort,
-        mode,
+        query: seerQuery.query,
+        visualize: seerQuery.visualizes,
+        groupBy: seerQuery.groupBys,
+        sort: seerQuery.sort,
+        mode: seerQuery.mode,
       });
 
       askSeerSuggestedQueryRef.current = JSON.stringify({
         selection,
-        query: queryToUse,
-        visualize,
-        groupBy: groupBys,
-        sort,
-        mode,
+        query: seerQuery.query,
+        visualize: seerQuery.visualizes,
+        groupBy: seerQuery.groupBys,
+        sort: seerQuery.sort,
+        mode: seerQuery.mode,
       });
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
-        query: queryToUse,
-        group_by_count: groupBys.length,
-        visualize_count: visualizations.length,
+        query: seerQuery.query,
+        group_by_count: seerQuery.groupBys.length,
+        visualize_count: seerQuery.visualizes.length,
       });
       if (runId !== undefined) {
         setRunId(runId);
@@ -230,7 +170,9 @@ export function SpansTabSeerComboBox() {
 
   const transformResponse = useCallback(
     (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, mapResponseItemWithVisualizations),
+      transformSeerResponse(response, responseItem =>
+        mapSeerResponseItem(responseItem, 'spans')
+      ),
     []
   );
 

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -1,24 +1,23 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 import {mutationOptions} from '@tanstack/react-query';
 import omit from 'lodash/omit';
 
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
+import type {SeerRawResponse} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
-  useSearchQueryBuilderAI,
-  useSearchQueryBuilderLayout,
-  useSearchQueryBuilderState,
-} from 'sentry/components/searchQueryBuilder/context';
-import {Token} from 'sentry/components/searchSyntax/parser';
-import {stringifyToken} from 'sentry/components/searchSyntax/utils';
+  transformSeerResponse,
+  useInitialSeerQuery,
+  useSelectedProjectIds,
+  useSelectedProjectIdsForMutation,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
 
 interface IssueAskSeerSearchQuery {
   query: string;
@@ -29,123 +28,39 @@ interface IssueAskSeerSearchQuery {
   statsPeriod?: string;
 }
 
-interface IssueAskSeerTranslateResponse {
-  responses: Array<{
-    end: string | null;
-    group_by: string[];
-    query: string;
-    sort: string;
-    start: string | null;
-    stats_period: string;
-  }>;
-  unsupported_reason: string | null;
-}
-
-/**
- * Component that renders the AI-powered search combobox for the Issues list.
- * Uses the search-agent/translate endpoint with 'Issues' strategy.
- * Navigates directly to apply both query and sort in a single navigation.
- */
 export function IssueListSeerComboBox() {
-  const {projects} = useProjects();
-  const pageFilters = usePageFilters();
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
   const {setRunId} = useAiQueryContext();
   const analyticsArea = useAnalyticsArea();
-  const {query, committedQuery, parseQuery} = useSearchQueryBuilderState();
-  const {currentInputValueRef} = useSearchQueryBuilderLayout();
   const {enableAISearch, askSeerSuggestedQueryRef} = useSearchQueryBuilderAI();
 
-  let initialSeerQuery = '';
-  const queryDetails = useMemo(() => {
-    const queryToUse = committedQuery.length > 0 ? committedQuery : query;
-    const parsedQuery = parseQuery(queryToUse);
-    return {parsedQuery, queryToUse};
-  }, [committedQuery, query, parseQuery]);
+  const initialSeerQuery = useInitialSeerQuery();
+  const selectedProjectIds = useSelectedProjectIds();
+  const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
 
-  const inputValue = currentInputValueRef.current.trim();
-
-  // Only filter out FREE_TEXT tokens if there's actual input value to filter by
-  const filteredCommittedQuery = queryDetails?.parsedQuery
-    ?.filter(
-      token =>
-        !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
-    )
-    ?.map(token => stringifyToken(token))
-    ?.join(' ')
-    ?.trim();
-
-  // Use filteredCommittedQuery if it has content.
-  // Only fall back to queryToUse when there's no inputValue to filter by.
-  // This prevents duplication when the entire query is free text matching inputValue.
-  if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
-    initialSeerQuery = filteredCommittedQuery;
-  } else if (!inputValue && queryDetails?.queryToUse) {
-    initialSeerQuery = queryDetails.queryToUse;
-  }
-
-  if (inputValue) {
-    initialSeerQuery =
-      initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
-  }
-
-  // Get selected project IDs for the polling variant
-  const selectedProjectIds = useMemo(() => {
-    if (
-      pageFilters.selection.projects?.length > 0 &&
-      pageFilters.selection.projects?.[0] !== -1
-    ) {
-      return pageFilters.selection.projects;
-    }
-    return projects.filter(p => p.isMember).map(p => parseInt(p.id, 10));
-  }, [pageFilters.selection.projects, projects]);
-
-  // Transform the final_response from Seer to match the expected format
   const transformResponse = useCallback(
-    (response: IssueAskSeerSearchQuery): IssueAskSeerSearchQuery[] => {
-      const seerResponse = response as unknown as {
-        responses?: Array<{
-          end: string | null;
-          group_by: string[];
-          query: string;
-          sort: string;
-          start: string | null;
-          stats_period: string;
-        }>;
-      };
-
-      if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
-        return seerResponse.responses.map(r => ({
-          query: r?.query ?? '',
-          sort: r?.sort ?? '',
-          groupBys: r?.group_by ?? [],
-          statsPeriod: r?.stats_period ?? '',
-          start: r?.start ?? null,
-          end: r?.end ?? null,
-        }));
-      }
-
-      return [response];
-    },
+    (response: IssueAskSeerSearchQuery): IssueAskSeerSearchQuery[] =>
+      transformSeerResponse(response, r => ({
+        query: r?.query ?? '',
+        sort: r?.sort ?? '',
+        groupBys: r?.group_by ?? [],
+        statsPeriod: r?.stats_period ?? '',
+        start: r?.start ?? null,
+        end: r?.end ?? null,
+      })),
     []
   );
 
   const issueListAskSeerMutationOptions = mutationOptions({
     mutationFn: async (queryToSubmit: string) => {
-      const selectedProjects =
-        pageFilters.selection.projects?.length > 0 &&
-        pageFilters.selection.projects?.[0] !== -1
-          ? pageFilters.selection.projects
-          : projects.filter(p => p.isMember).map(p => p.id);
-
-      const data = await fetchMutation<IssueAskSeerTranslateResponse>({
+      const data = await fetchMutation<SeerRawResponse>({
         url: `/organizations/${organization.slug}/search-agent/translate/`,
         method: 'POST',
         data: {
           natural_language_query: queryToSubmit,
-          project_ids: selectedProjects,
+          project_ids: selectedProjectIdsForMutation,
           strategy: 'Issues',
         },
       });
@@ -179,7 +94,6 @@ export function IssueListSeerComboBox() {
         end: resultEnd,
       } = result;
 
-      // Store the suggested query for feedback tracking
       askSeerSuggestedQueryRef.current = JSON.stringify({
         query: queryToUse,
         sort,
@@ -197,7 +111,6 @@ export function IssueListSeerComboBox() {
       let timeParams: Record<string, string | undefined> = {};
 
       if (resultStart && resultEnd) {
-        // Strip 'Z' suffix to treat UTC dates as local time
         const startLocal = resultStart.endsWith('Z')
           ? resultStart.slice(0, -1)
           : resultStart;

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -92,6 +92,7 @@ export function IssueListSeerComboBox() {
       let timeParams: Record<string, string | undefined> = {};
 
       if (resultStart && resultEnd) {
+        // Strip 'Z' suffix to treat UTC dates as local time
         const startLocal = resultStart.endsWith('Z')
           ? resultStart.slice(0, -1)
           : resultStart;

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -5,8 +5,12 @@ import omit from 'lodash/omit';
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
-import type {SeerRawResponse} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
+import type {
+  AskSeerSearchQuery,
+  SeerRawResponse,
+} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
+  mapSeerResponseItem,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
@@ -18,15 +22,6 @@ import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-
-interface IssueAskSeerSearchQuery {
-  query: string;
-  end?: string | null;
-  groupBys?: string[];
-  sort?: string;
-  start?: string | null;
-  statsPeriod?: string;
-}
 
 export function IssueListSeerComboBox() {
   const organization = useOrganization();
@@ -41,15 +36,8 @@ export function IssueListSeerComboBox() {
   const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
 
   const transformResponse = useCallback(
-    (response: IssueAskSeerSearchQuery): IssueAskSeerSearchQuery[] =>
-      transformSeerResponse(response, r => ({
-        query: r?.query ?? '',
-        sort: r?.sort ?? '',
-        groupBys: r?.group_by ?? [],
-        statsPeriod: r?.stats_period ?? '',
-        start: r?.start ?? null,
-        end: r?.end ?? null,
-      })),
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
+      transformSeerResponse(response, responseItem => mapSeerResponseItem(responseItem)),
     []
   );
 
@@ -68,20 +56,13 @@ export function IssueListSeerComboBox() {
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(r => ({
-          query: r?.query ?? '',
-          sort: r?.sort ?? '',
-          groupBys: r?.group_by ?? [],
-          statsPeriod: r?.stats_period ?? '',
-          start: r?.start ?? null,
-          end: r?.end ?? null,
-        })),
+        queries: data.responses.map(response => mapSeerResponseItem(response)),
       };
     },
   });
 
   const applySeerSearchQuery = useCallback(
-    (result: IssueAskSeerSearchQuery, runId?: number) => {
+    (result: AskSeerSearchQuery, runId?: number) => {
       if (!result) {
         return;
       }
@@ -164,7 +145,7 @@ export function IssueListSeerComboBox() {
   }
 
   return (
-    <AskSeerPollingComboBox<IssueAskSeerSearchQuery>
+    <AskSeerPollingComboBox<AskSeerSearchQuery>
       initialQuery={initialSeerQuery}
       projectIds={selectedProjectIds}
       strategy="Issues"


### PR DESCRIPTION
Followup to #116050 — the reviewer noted that the same query-building logic was the same across 5 `*SeerComboBox` components, except a minor bug was present in only one. This change attempts to reduce code drift and make bug fixes easier.

This PR extracts the shared boilerplate into reusable hooks (`useSeerComboBoxSetup.ts`) and explore-specific helpers (`seerQuery.ts`), while keeping each component's domain logic (metrics encoding, Discover column mapping, etc.) inline. Each component shrinks by ~100-200 lines.

### What was extracted

- `useInitialSeerQuery` — the query construction + FREE_TEXT filtering that #116050 fixed
- `useSelectedProjectIds` / `useSelectedProjectIdsForMutation` — project ID computation
- `transformSeerResponse` / `mapSeerResponseItem` — Seer response normalization
- `buildSeerDateTimeSelection` — UTC Z-stripping + datetime fallback
- `getSeerExploreQuery` / `getSeerSort` — explore query normalization (used by Spans + Metrics)

### Test plan

- [x] `pnpm run typecheck` and `pnpm run lint:js` pass
- [x] 20 new unit tests for extracted hooks/helpers
- [x] Existing `askSeerComboBox` tests pass