### PR TITLE
fix(issues): Fix sidebar comment box horizontal overflow

### DIFF
--- a/static/app/components/activity/note/compact.tsx
+++ b/static/app/components/activity/note/compact.tsx
@@ -237,6 +237,7 @@ const NoteInputForm = styled('form')<{error?: string}>`
   gap: ${p => p.theme.space.sm};
   align-items: flex-end;
   width: 100%;
+  min-width: 0;
   transition: padding 0.2s ease-in-out;
 
   ${getNoteInputErrorStyles};

--- a/static/app/components/activity/note/compact.tsx
+++ b/static/app/components/activity/note/compact.tsx
@@ -143,7 +143,15 @@ export function CompactNoteInput({
         aria-label={existingItem ? t('Edit comment') : t('Add a comment')}
         aria-errormessage={errorMessage ? errorId : undefined}
         style={{
-          ...mentionStyle({theme, minHeight: 14, streamlined: true}),
+          ...mentionStyle({
+            theme,
+            minHeight: 14,
+            inputStyle: {
+              padding: `${theme.space.md} ${theme.space.lg}`,
+              border: `1px solid ${theme.tokens.border.primary}`,
+              borderRadius: theme.radius.md,
+            },
+          }),
           width: '100%',
         }}
         placeholder={placeholder}

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useId, useState} from 'react';
 import {Mention, MentionsInput} from 'react-mentions';
 import type {Theme} from '@emotion/react';
-import {useTheme} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion, useReducedMotion} from 'framer-motion';
 import {z} from 'zod';
@@ -56,7 +56,7 @@ const noteInputSchema = z.object({
   text: z.string(),
 });
 
-function NoteInput({
+export function NoteInput({
   text,
   onCreate,
   onChange,
@@ -270,26 +270,23 @@ function NoteInput({
   );
 }
 
-export {NoteInput};
-
 type NotePreviewProps = {
   minHeight: Props['minHeight'];
   theme: Theme;
 };
 
-// This styles both the note preview and the note editor input
-const getNotePreviewCss = (p: NotePreviewProps) => {
-  const {minHeight, padding, overflow, border} = mentionStyle(p)['&multiLine'].input;
-
-  return `
+const getNotePreviewCss = (p: NotePreviewProps) => css`
   max-height: 1000px;
   max-width: 100%;
-  ${(minHeight && `min-height: ${minHeight}px`) || ''};
-  padding: ${padding};
-  overflow: ${overflow};
-  border: ${border};
+  ${p.minHeight
+    ? css`
+        min-height: ${p.minHeight}px;
+      `
+    : ''};
+  padding: ${p.theme.space.lg} ${p.theme.space.lg};
+  overflow: auto;
+  border: 0;
 `;
-};
 
 const EditorSurface = styled('div')`
   background: ${p => p.theme.tokens.background.primary};
@@ -308,6 +305,7 @@ const MentionsEditor = styled('div')`
 
 const MotionControls = styled(motion.div)`
   overflow: hidden;
+  isolation: isolate;
 `;
 
 const ErrorMessage = styled('span')`

--- a/static/app/components/activity/note/mentionStyle.tsx
+++ b/static/app/components/activity/note/mentionStyle.tsx
@@ -1,62 +1,36 @@
+import type {CSSProperties} from 'react';
 import type {Theme} from '@emotion/react';
 
 type Options = {
   theme: Theme;
+  inputStyle?: CSSProperties;
   minHeight?: number;
-  streamlined?: boolean;
 };
 
 /**
- * Note this is an object for `react-mentions` component and
- * not a styled component/emotion style
+ * Returns the `style` object for react-mentions `MentionsInput`.
  */
-export function mentionStyle({theme, minHeight, streamlined}: Options) {
-  const inputProps = {
+export function mentionStyle({theme, minHeight, inputStyle}: Options) {
+  const inputProps: CSSProperties = {
     fontSize: theme.font.size.md,
     padding: `${theme.space.lg} ${theme.space.lg}`,
     outline: 0,
     border: 0,
     minHeight,
     overflow: 'auto',
-  };
-
-  const streamlinedInputProps = {
-    fontSize: theme.font.size.md,
-    padding: `${theme.space.md} ${theme.space.lg}`,
-    outline: 0,
-    border: `1px solid ${theme.tokens.border.primary}`,
-    borderRadius: theme.radius.md,
-    minHeight,
-    overflow: 'auto',
-    overflowWrap: 'break-word' as const,
+    overflowWrap: 'break-word',
+    ...inputStyle,
   };
 
   return {
     control: {
       backgroundColor: 'transparent',
-      fontSize: 15,
-      fontWeight: 'normal',
+      fontSize: theme.font.size.md,
+      fontWeight: 'normal' as const,
     },
 
     input: {
       margin: 0,
-    },
-
-    '&singleLine': {
-      control: {
-        display: 'inline-block',
-        width: 130,
-      },
-
-      highlighter: {
-        padding: 1,
-        border: '2px inset transparent',
-      },
-
-      input: {
-        padding: 1,
-        border: '2px inset',
-      },
     },
 
     '&multiLine': {
@@ -65,9 +39,8 @@ export function mentionStyle({theme, minHeight, streamlined}: Options) {
         minHeight,
       },
 
-      // Use the same props for the highliter to keep the phantom text aligned
-      highlighter: streamlined ? streamlinedInputProps : inputProps,
-      input: streamlined ? streamlinedInputProps : inputProps,
+      highlighter: inputProps,
+      input: inputProps,
     },
 
     suggestions: {
@@ -75,6 +48,7 @@ export function mentionStyle({theme, minHeight, streamlined}: Options) {
         maxHeight: 142,
         minWidth: 220,
         overflow: 'auto',
+        zIndex: theme.zIndex.dropdown,
         backgroundColor: theme.tokens.background.primary,
         border: '1px solid rgba(0,0,0,0.15)',
         borderRadius: theme.radius.md,

--- a/static/app/components/activity/note/mentionStyle.tsx
+++ b/static/app/components/activity/note/mentionStyle.tsx
@@ -28,6 +28,7 @@ export function mentionStyle({theme, minHeight, streamlined}: Options) {
     borderRadius: theme.radius.md,
     minHeight,
     overflow: 'auto',
+    overflowWrap: 'break-word' as const,
   };
 
   return {

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -104,7 +104,7 @@ const Row = styled('div')<{hasMarker: boolean; showLastLine?: boolean}>`
 
 const MarkerWrapper = styled('div')`
   grid-column: span 1;
-  z-index: 10;
+  z-index: 1;
   display: grid;
   place-items: center;
   min-width: 22px;
@@ -116,7 +116,7 @@ const IconWrapper = styled('div')`
   border-radius: 100%;
   border: 1px solid;
   background: ${p => p.theme.tokens.background.primary};
-  z-index: 10;
+  z-index: 1;
   svg {
     display: block;
     margin: ${p => p.theme.space.xs};

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -496,6 +496,7 @@ const NoteWrapper = styled('div')<{size: 'sm' | 'md'}>`
 
 const ActivityInputFrame = styled('div')`
   color: ${p => p.theme.tokens.content.primary};
+  min-width: 0;
 `;
 
 const AvatarMarker = styled('span')<{color: string}>`


### PR DESCRIPTION
Pasting long text into the compact comment input in the sidebar overflows the page horizontally, pushing the submit button off screen.

Also cleans up `mentionStyle` - removes the dead `streamlined` toggle and `&singleLine` block, consolidates to one set of base styles with an `inputStyle` override, and stops round-tripping through mentionStyle for the preview pane CSS.

Fixes a zindex issue where the mention dropdown was behind buttons or activity