### PR TITLE
fix(tracemetrics): Use equation alias format for widget builder

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -191,4 +191,24 @@ describe('convertWidgetToBuilderState', () => {
     expect(params.textContent).toBeUndefined();
     expect(params.description).toBe('Widget description');
   });
+
+  describe('tracemetrics widget', () => {
+    it('converts raw equation sort to equation[0] alias format', () => {
+      const widget = {
+        ...getDefaultWidget(WidgetType.TRACEMETRICS),
+        displayType: DisplayType.LINE,
+        queries: [
+          {
+            aggregates: ['equation|count(span.duration) / 2'],
+            columns: [],
+            conditions: '',
+            name: '',
+            orderby: '-equation|count(span.duration) / 2',
+          },
+        ],
+      };
+      const params = convertWidgetToBuilderState(widget);
+      expect(params.sort).toEqual(['-equation[0]']);
+    });
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -46,7 +46,7 @@ export function convertWidgetToQueryParams(
       // Convert tracemetrics equations to the alias format when passing off to the dashboard widget builder
       // due to the internal representation required for the widget builder to properly select this equation
       // as a sort field
-      const equations = q.aggregates.find(a => isEquation(a));
+      const equations = q.aggregates.filter(isEquation);
       const equationIndex = equations?.indexOf(decodedSort.field);
       if (defined(equationIndex) && equationIndex >= 0) {
         return `${decodedSort.kind === 'desc' ? '-' : ''}equation[${equationIndex}]`;

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -1,4 +1,6 @@
-import {explodeField} from 'sentry/utils/discover/fields';
+import {defined} from 'sentry/utils';
+import {explodeField, isEquation} from 'sentry/utils/discover/fields';
+import {decodeSorts} from 'sentry/utils/queryString';
 import {
   DisplayType,
   WidgetType,
@@ -34,7 +36,24 @@ export function convertWidgetToQueryParams(
   widget: Widget
 ): WidgetBuilderStateQueryParams {
   const query = widget.queries.flatMap(q => q.conditions);
-  const sort = widget.queries.flatMap(q => q.orderby);
+  const sort = widget.queries.flatMap(q => {
+    const decodedSort = decodeSorts(q.orderby)[0];
+    if (
+      decodedSort &&
+      widget.widgetType === WidgetType.TRACEMETRICS &&
+      isEquation(decodedSort.field)
+    ) {
+      // Convert tracemetrics equations to the alias format when passing off to the dashboard widget builder
+      // due to the internal representation required for the widget builder to properly select this equation
+      // as a sort field
+      const equations = q.aggregates.find(a => isEquation(a));
+      const equationIndex = equations?.indexOf(decodedSort.field);
+      if (defined(equationIndex) && equationIndex >= 0) {
+        return `${decodedSort.kind === 'desc' ? '-' : ''}equation[${equationIndex}]`;
+      }
+    }
+    return q.orderby;
+  });
   let legendAlias = widget.queries.flatMap(q => q.name);
 
   // y-axes and fields are shared across all queries

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -232,7 +232,6 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
                 if (isUnsupported) {
                   return;
                 }
-                // TODO: Handle sorting by equation better
                 addToDashboard(metricQuery);
               },
               disabled: isUnsupported,


### PR DESCRIPTION
When passing the widget off from the Add to Dashboard preview to the widget builder, we need to convert the equation from the full raw form (because the raw form is used in the chart) to the equation alias format in widget builder because that's the way some of the UI expects it to be to make the correct selection

If not, then the UI renders a custom equation field which we do not support at this time for metrics widgets in dashboards