### PR TITLE
chore(alerts): Clean up usage of AlertRuleSerializerResponse

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -16,8 +16,6 @@ from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.charts.types import ChartSize
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.charts import build_metric_alert_chart
-from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
-from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.incidents.models.alert_rule import (
     AlertRuleDetectionType,
@@ -152,8 +150,6 @@ def format_duration(minutes: int | float) -> str:
 def generate_incident_trigger_email_context(
     project: Project,
     organization: Organization,
-    alert_rule_serialized_response: AlertRuleSerializerResponse,
-    incident_serialized_response: DetailedIncidentSerializerResponse,
     metric_issue_context: MetricIssueContext,
     alert_context: AlertContext,
     open_period_context: OpenPeriodContext,
@@ -207,8 +203,6 @@ def generate_incident_trigger_email_context(
         try:
             chart_url = build_metric_alert_chart(
                 organization=organization,
-                alert_rule_serialized_response=alert_rule_serialized_response,
-                selected_incident_serialized=incident_serialized_response,
                 snuba_query=snuba_query,
                 alert_context=alert_context,
                 open_period_context=open_period_context,
@@ -302,8 +296,6 @@ def email_users(
     metric_issue_context: MetricIssueContext,
     open_period_context: OpenPeriodContext,
     alert_context: AlertContext,
-    alert_rule_serialized_response: AlertRuleSerializerResponse,
-    incident_serialized_response: DetailedIncidentSerializerResponse,
     trigger_status: TriggerStatus,
     targets: list[tuple[int, str]],
     project: Project,
@@ -323,8 +315,6 @@ def email_users(
             project=project,
             organization=project.organization,
             metric_issue_context=metric_issue_context,
-            alert_rule_serialized_response=alert_rule_serialized_response,
-            incident_serialized_response=incident_serialized_response,
             alert_context=alert_context,
             open_period_context=open_period_context,
             trigger_status=trigger_status,

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -11,8 +11,6 @@ from sentry.api.base import logger
 from sentry.api.utils import get_datetime_from_stats_period
 from sentry.charts import backend as charts
 from sentry.charts.types import ChartSize, ChartType
-from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
-from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
 from sentry.incidents.logic import translate_aggregate_field
 from sentry.incidents.typings.metric_detector import AlertContext, OpenPeriodContext
 from sentry.models.apikey import ApiKey
@@ -187,11 +185,9 @@ def fetch_metric_issue_open_periods(
 
 def build_metric_alert_chart(
     organization: Organization,
-    alert_rule_serialized_response: AlertRuleSerializerResponse,
     snuba_query: SnubaQuery,
     alert_context: AlertContext,
     open_period_context: OpenPeriodContext | None = None,
-    selected_incident_serialized: DetailedIncidentSerializerResponse | None = None,
     period: str | None = None,
     start: str | None = None,
     end: str | None = None,
@@ -206,22 +202,12 @@ def build_metric_alert_chart(
     dataset = Dataset(snuba_query.dataset)
     query_type = SnubaQuery.Type(snuba_query.type)
     is_crash_free_alert = query_type == SnubaQuery.Type.CRASH_RATE
-    using_new_charts = features.has(
-        "organizations:workflow-engine-ui",
-        organization,
+
+    style = (
+        ChartType.SLACK_METRIC_DETECTOR_SESSIONS
+        if is_crash_free_alert
+        else ChartType.SLACK_METRIC_DETECTOR_EVENTS
     )
-    if is_crash_free_alert:
-        style = (
-            ChartType.SLACK_METRIC_DETECTOR_SESSIONS
-            if using_new_charts
-            else ChartType.SLACK_METRIC_ALERT_SESSIONS
-        )
-    else:
-        style = (
-            ChartType.SLACK_METRIC_DETECTOR_EVENTS
-            if using_new_charts
-            else ChartType.SLACK_METRIC_ALERT_EVENTS
-        )
 
     if open_period_context:
         time_period = incident_date_range(
@@ -237,33 +223,17 @@ def build_metric_alert_chart(
             "start": period_start.strftime(TIME_FORMAT),
             "end": timezone.now().strftime(TIME_FORMAT),
         }
-    if features.has(
-        "organizations:workflow-engine-ui",
-        organization,
-    ):
-        # TODO(mifu67): create detailed serializer for open period, pass here.
-        # But we don't need it to render the chart, so it's fine for now.
-        chart_data_detector = {
-            "detector": detector_serialized_response,
-            "openPeriods": fetch_metric_issue_open_periods(
-                organization,
-                alert_context.action_identifier_id,
-                time_period,
-                user,
-                snuba_query.time_window,
-            ),
-        }
-    else:
-        chart_data_alert_rule = {
-            "rule": alert_rule_serialized_response,
-            "selectedIncident": selected_incident_serialized,
-            "incidents": fetch_metric_issue_open_periods(
-                organization,
-                alert_context.action_identifier_id,
-                time_period,
-                user,
-            ),
-        }
+
+    chart_data_detector = {
+        "detector": detector_serialized_response,
+        "openPeriods": fetch_metric_issue_open_periods(
+            organization,
+            alert_context.action_identifier_id,
+            time_period,
+            user,
+            snuba_query.time_window,
+        ),
+    }
 
     allow_mri = features.has(
         "organizations:insights-alerts",
@@ -343,10 +313,7 @@ def build_metric_alert_chart(
         )
 
     try:
-        if using_new_charts:
-            chart_data.update(chart_data_detector)
-        else:
-            chart_data.update(chart_data_alert_rule)
+        chart_data.update(chart_data_detector)
         return charts.generate_chart(style, chart_data, size=size)
     except RuntimeError as exc:
         logger.error(

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -25,7 +25,6 @@ from sentry.users.services.user import RpcUser
 from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
     DetectorSerializerResponse,
 )
-from sentry.workflow_engine.models import AlertRuleDetector
 
 CRASH_FREE_SESSIONS = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
 CRASH_FREE_USERS = "percentage(users_crashed, users) AS _crash_rate_alert_aggregate"
@@ -138,41 +137,17 @@ def fetch_metric_issue_open_periods(
 ) -> list[Any]:
     detector_id = open_period_identifier
     try:
-        # temporarily fetch the alert rule ID from the detector ID
-        alert_rule_detector = AlertRuleDetector.objects.filter(
-            detector_id=open_period_identifier, alert_rule_id__isnull=False
-        ).first()
-        if alert_rule_detector is not None:
-            # open_period_identifier is a metric detector ID -> get the alert rule ID
-            open_period_identifier = alert_rule_detector.alert_rule_id
+        resp = client.get(
+            auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),
+            user=user,
+            path=f"/organizations/{organization.slug}/open-periods/",
+            params={
+                "detectorId": detector_id,
+                "bucketSize": time_window,
+                **time_period,
+            },
+        )
 
-        if features.has(
-            "organizations:workflow-engine-ui",
-            organization,
-        ):
-            resp = client.get(
-                auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),
-                user=user,
-                path=f"/organizations/{organization.slug}/open-periods/",
-                params={
-                    "detectorId": detector_id,
-                    "bucketSize": time_window,
-                    **time_period,
-                },
-            )
-        else:
-            resp = client.get(
-                auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),
-                user=user,
-                path=f"/organizations/{organization.slug}/incidents/",
-                params={
-                    "alertRule": open_period_identifier,
-                    "expand": "activities",
-                    "includeSnapshots": True,
-                    "project": -1,
-                    **time_period,
-                },
-            )
         return resp.data
     except Exception as exc:
         logger.error(

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -4,8 +4,6 @@ import sentry_sdk
 
 from sentry import features
 from sentry.incidents.charts import build_metric_alert_chart
-from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
-from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
     MetricIssueContext,
@@ -37,25 +35,17 @@ def send_incident_alert_notification(
     notification_context: NotificationContext,
     metric_issue_context: MetricIssueContext,
     open_period_context: OpenPeriodContext,
-    alert_rule_serialized_response: AlertRuleSerializerResponse | None,
-    incident_serialized_response: DetailedIncidentSerializerResponse | None,
     detector_serialized_response: DetectorSerializerResponse | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     chart_url = None
-    if (
-        features.has("organizations:metric-alert-chartcuterie", organization)
-        and alert_rule_serialized_response
-        and incident_serialized_response
-    ):
+    if features.has("organizations:metric-alert-chartcuterie", organization):
         try:
             chart_url = build_metric_alert_chart(
                 organization=organization,
-                alert_rule_serialized_response=alert_rule_serialized_response,
                 snuba_query=metric_issue_context.snuba_query,
                 alert_context=alert_context,
                 open_period_context=open_period_context,
-                selected_incident_serialized=incident_serialized_response,
                 subscription=metric_issue_context.subscription,
                 detector_serialized_response=detector_serialized_response,
             )

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import enum
 import logging
 
-from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
-from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
     MetricIssueContext,
@@ -115,8 +113,6 @@ def send_incident_alert_notification(
     notification_context: NotificationContext,
     metric_issue_context: MetricIssueContext,
     open_period_context: OpenPeriodContext,
-    alert_rule_serialized_response: AlertRuleSerializerResponse | None,
-    incident_serialized_response: DetailedIncidentSerializerResponse | None,
     notification_uuid: str | None = None,
 ) -> bool:
     from .card_builder.incident_attachment import build_incident_attachment

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -13,8 +13,6 @@ from slack_sdk.webhook import WebhookClient
 from sentry import features
 from sentry.constants import METRIC_ALERTS_THREAD_DEFAULT, ObjectStatus
 from sentry.incidents.charts import build_metric_alert_chart
-from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
-from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
 from sentry.incidents.models.incident import IncidentStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -129,25 +127,17 @@ def _build_notification_payload(
     alert_context: AlertContext,
     metric_issue_context: MetricIssueContext,
     open_period_context: OpenPeriodContext,
-    alert_rule_serialized_response: AlertRuleSerializerResponse | None,
-    incident_serialized_response: DetailedIncidentSerializerResponse | None,
     detector_serialized_response: DetectorSerializerResponse | None,
     notification_uuid: str | None,
 ) -> tuple[str, str]:
     chart_url = None
-    if (
-        features.has("organizations:metric-alert-chartcuterie", organization)
-        and alert_rule_serialized_response
-        and incident_serialized_response
-    ):
+    if features.has("organizations:metric-alert-chartcuterie", organization):
         try:
             chart_url = build_metric_alert_chart(
                 organization=organization,
-                alert_rule_serialized_response=alert_rule_serialized_response,
                 snuba_query=metric_issue_context.snuba_query,
                 alert_context=alert_context,
                 open_period_context=open_period_context,
-                selected_incident_serialized=incident_serialized_response,
                 subscription=metric_issue_context.subscription,
                 detector_serialized_response=detector_serialized_response,
             )
@@ -290,8 +280,6 @@ def send_incident_alert_notification(
     notification_context: NotificationContext,
     metric_issue_context: MetricIssueContext,
     open_period_context: OpenPeriodContext,
-    alert_rule_serialized_response: AlertRuleSerializerResponse | None,
-    incident_serialized_response: DetailedIncidentSerializerResponse | None,
     detector_serialized_response: DetectorSerializerResponse | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
@@ -315,8 +303,6 @@ def send_incident_alert_notification(
         alert_context=alert_context,
         metric_issue_context=metric_issue_context,
         open_period_context=open_period_context,
-        alert_rule_serialized_response=alert_rule_serialized_response,
-        incident_serialized_response=incident_serialized_response,
         notification_uuid=notification_uuid,
         detector_serialized_response=detector_serialized_response,
     )

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/discord_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/discord_metric_alert_handler.py
@@ -11,8 +11,6 @@ from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_alert_rule_serializer,
-    get_detailed_incident_serializer,
     get_detector_serializer,
 )
 from sentry.notifications.notification_action.registry import metric_alert_handler_registry
@@ -48,9 +46,7 @@ class DiscordMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
-        alert_rule_serialized_response = get_alert_rule_serializer(detector)
         detector_serialized_response = get_detector_serializer(detector)
-        incident_serialized_response = get_detailed_incident_serializer(open_period)
 
         logger.info(
             "notification_action.execute_via_metric_alert_handler.discord",
@@ -66,7 +62,5 @@ class DiscordMetricAlertHandler(BaseMetricAlertHandler):
             open_period_context=open_period_context,
             organization=organization,
             notification_uuid=notification_uuid,
-            alert_rule_serialized_response=alert_rule_serialized_response,
-            incident_serialized_response=incident_serialized_response,
             detector_serialized_response=detector_serialized_response,
         )

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/email_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/email_metric_alert_handler.py
@@ -16,8 +16,6 @@ from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_alert_rule_serializer,
-    get_detailed_incident_serializer,
     get_detector_serializer,
 )
 from sentry.notifications.notification_action.registry import metric_alert_handler_registry
@@ -53,9 +51,7 @@ class EmailMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
-        alert_rule_serialized_response = get_alert_rule_serializer(detector)
         detector_serialized_response = get_detector_serializer(detector)
-        incident_serialized_response = get_detailed_incident_serializer(open_period)
 
         recipients = list(
             get_email_addresses(
@@ -76,8 +72,6 @@ class EmailMetricAlertHandler(BaseMetricAlertHandler):
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
             alert_context=alert_context,
-            alert_rule_serialized_response=alert_rule_serialized_response,
-            incident_serialized_response=incident_serialized_response,
             detector_serialized_response=detector_serialized_response,
             trigger_status=trigger_status,
             targets=targets,

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/msteams_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/msteams_metric_alert_handler.py
@@ -10,10 +10,6 @@ from sentry.incidents.typings.metric_detector import (
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_alert_rule_serializer,
-    get_detailed_incident_serializer,
-)
 from sentry.notifications.notification_action.registry import metric_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseMetricAlertHandler
 from sentry.workflow_engine.models import Action, Detector
@@ -45,9 +41,6 @@ class MSTeamsMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
-        alert_rule_serialized_response = get_alert_rule_serializer(detector)
-        incident_serialized_response = get_detailed_incident_serializer(open_period)
-
         logger.info(
             "notification_action.execute_via_metric_alert_handler.msteams",
             extra={
@@ -62,6 +55,4 @@ class MSTeamsMetricAlertHandler(BaseMetricAlertHandler):
             open_period_context=open_period_context,
             organization=organization,
             notification_uuid=notification_uuid,
-            alert_rule_serialized_response=alert_rule_serialized_response,
-            incident_serialized_response=incident_serialized_response,
         )

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
@@ -4,8 +4,6 @@ import sentry_sdk
 
 from sentry import features
 from sentry.incidents.charts import build_metric_alert_chart
-from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
-from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -19,8 +17,6 @@ from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_alert_rule_serializer,
-    get_detailed_incident_serializer,
     get_detector_serializer,
 )
 from sentry.notifications.notification_action.registry import metric_alert_handler_registry
@@ -49,9 +45,7 @@ def _send_via_notification_platform(
     open_period_context: OpenPeriodContext,
     notification_uuid: str,
     organization: Organization,
-    alert_rule_serialized_response: AlertRuleSerializerResponse,
     detector_serialized_response: DetectorSerializerResponse,
-    incident_serialized_response: DetailedIncidentSerializerResponse,
 ) -> None:
     if notification_context.integration_id is None:
         raise ValueError("Integration ID is None")
@@ -68,19 +62,13 @@ def _send_via_notification_platform(
     )
 
     chart_url = None
-    if (
-        features.has("organizations:metric-alert-chartcuterie", organization)
-        and alert_rule_serialized_response
-        and incident_serialized_response
-    ):
+    if features.has("organizations:metric-alert-chartcuterie", organization):
         try:
             chart_url = build_metric_alert_chart(
                 organization=organization,
-                alert_rule_serialized_response=alert_rule_serialized_response,
                 snuba_query=metric_issue_context.snuba_query,
                 alert_context=alert_context,
                 open_period_context=open_period_context,
-                selected_incident_serialized=incident_serialized_response,
                 subscription=metric_issue_context.subscription,
                 detector_serialized_response=detector_serialized_response,
             )
@@ -147,18 +135,7 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
-        alert_rule_serialized_response = get_alert_rule_serializer(detector)
         detector_serialized_response = get_detector_serializer(detector)
-        incident_serialized_response = get_detailed_incident_serializer(open_period)
-
-        logger.info(
-            "notification_action.execute_via_metric_alert_handler.slack",
-            extra={
-                "action_id": alert_context.action_identifier_id,
-                "serialized_incident": incident_serialized_response,
-                "serialized_alert_rule": alert_rule_serialized_response,
-            },
-        )
 
         if NotificationService.has_access(organization, NotificationSource.METRIC_ALERT):
             _send_via_notification_platform(
@@ -168,9 +145,7 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
                 open_period_context=open_period_context,
                 notification_uuid=notification_uuid,
                 organization=organization,
-                alert_rule_serialized_response=alert_rule_serialized_response,
                 detector_serialized_response=detector_serialized_response,
-                incident_serialized_response=incident_serialized_response,
             )
         else:
             send_incident_alert_notification(
@@ -180,8 +155,6 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
                 open_period_context=open_period_context,
                 organization=organization,
                 notification_uuid=notification_uuid,
-                alert_rule_serialized_response=alert_rule_serialized_response,
-                incident_serialized_response=incident_serialized_response,
                 detector_serialized_response=detector_serialized_response,
             )
 

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/utils.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/utils.py
@@ -1,14 +1,8 @@
 from sentry.api.serializers import serialize
-from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
 from sentry.incidents.endpoints.serializers.incident import (
-    DetailedIncidentSerializerResponse,
     IncidentSerializerResponse,
 )
-from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
-    WorkflowEngineDetectorSerializer,
-)
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
-    WorkflowEngineDetailedIncidentSerializer,
     WorkflowEngineIncidentSerializer,
 )
 from sentry.models.groupopenperiod import GroupOpenPeriod
@@ -19,20 +13,8 @@ from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
 from sentry.workflow_engine.models import Detector
 
 
-def get_alert_rule_serializer(detector: Detector) -> AlertRuleSerializerResponse:
-    return serialize(detector, None, WorkflowEngineDetectorSerializer())
-
-
 def get_detector_serializer(detector: Detector) -> DetectorSerializerResponse:
     return serialize(detector, None, DetectorSerializer())
-
-
-# TODO(mifu67): These take an open period, get the incident, and call the incident
-# serializer on the incident. They will need to be replaced.
-def get_detailed_incident_serializer(
-    open_period: GroupOpenPeriod,
-) -> DetailedIncidentSerializerResponse:
-    return serialize(open_period, None, WorkflowEngineDetailedIncidentSerializer())
 
 
 def get_incident_serializer(open_period: GroupOpenPeriod) -> IncidentSerializerResponse:

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -147,8 +147,6 @@ def metric_alert_notification_data_factory(
     issue_notif_context: IssueNotificationContext,
 ) -> MetricAlertNotificationData:
     from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-        get_alert_rule_serializer,
-        get_detailed_incident_serializer,
         get_detector_serializer,
     )
 
@@ -173,24 +171,16 @@ def metric_alert_notification_data_factory(
         referrer=referrer,
     )
 
-    alert_rule_serialized_response = get_alert_rule_serializer(issue_notif_context.detector)
     detector_serialized_response = get_detector_serializer(issue_notif_context.detector)
-    incident_serialized_response = get_detailed_incident_serializer(issue_notif_context.open_period)
 
     chart_url = None
-    if (
-        features.has("organizations:metric-alert-chartcuterie", organization)
-        and alert_rule_serialized_response
-        and incident_serialized_response
-    ):
+    if features.has("organizations:metric-alert-chartcuterie", organization):
         try:
             chart_url = build_metric_alert_chart(
                 organization=organization,
-                alert_rule_serialized_response=alert_rule_serialized_response,
                 snuba_query=metric_issue_context.snuba_query,
                 alert_context=alert_context,
                 open_period_context=open_period_context,
-                selected_incident_serialized=incident_serialized_response,
                 subscription=metric_issue_context.subscription,
                 detector_serialized_response=detector_serialized_response,
             )

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
@@ -11,8 +10,6 @@ from sentry.incidents.charts import (
     fetch_metric_issue_open_periods,
     incident_date_range,
 )
-from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
-from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
 from sentry.incidents.models.incident import Incident, IncidentActivityType, IncidentStatus
@@ -105,16 +102,11 @@ class BuildMetricAlertChartTest(TestCase):
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
         self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
 
-        alert_rule_serialized_response = cast(AlertRuleSerializerResponse, {})
-        incident_serialized_response = cast(DetailedIncidentSerializerResponse, {})
-
         url = build_metric_alert_chart(
             self.organization,
-            alert_rule_serialized_response=alert_rule_serialized_response,
             alert_context=AlertContext.from_alert_rule_incident(alert_rule),
             snuba_query=alert_rule.snuba_query,
             open_period_context=OpenPeriodContext.from_incident(incident),
-            selected_incident_serialized=incident_serialized_response,
         )
 
         assert url == "chart-url"
@@ -156,7 +148,6 @@ class BuildMetricAlertChartTest(TestCase):
 
         url = build_metric_alert_chart(
             self.organization,
-            alert_rule_serialized_response=cast(AlertRuleSerializerResponse, {}),
             alert_context=AlertContext.from_alert_rule_incident(alert_rule),
             snuba_query=alert_rule.snuba_query,
             open_period_context=OpenPeriodContext.from_incident(incident),
@@ -192,16 +183,11 @@ class BuildMetricAlertChartTest(TestCase):
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
         self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
 
-        alert_rule_serialized_response = cast(AlertRuleSerializerResponse, {})
-        incident_serialized_response = cast(DetailedIncidentSerializerResponse, {})
-
         url = build_metric_alert_chart(
             self.organization,
-            alert_rule_serialized_response=alert_rule_serialized_response,
             alert_context=AlertContext.from_alert_rule_incident(alert_rule),
             snuba_query=alert_rule.snuba_query,
             open_period_context=OpenPeriodContext.from_incident(incident),
-            selected_incident_serialized=incident_serialized_response,
         )
 
         assert url == "chart-url"

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -199,7 +199,7 @@ class BuildMetricAlertChartTest(TestCase):
 class FetchOpenPeriodsTest(BaseMetricIssueTest):
     @freeze_time(frozen_time)
     @with_feature("organizations:incidents")
-    def test_get_incidents_from_detector(self) -> None:
+    def test_get_open_periods_from_detector(self) -> None:
         group = self.create_group(
             project=self.project, type=MetricIssue.type_id, priority=PriorityLevel.HIGH
         )
@@ -225,20 +225,20 @@ class FetchOpenPeriodsTest(BaseMetricIssueTest):
         chart_data = fetch_metric_issue_open_periods(
             self.organization, self.detector.id, time_period
         )
-        assert chart_data[0]["alertRule"]["id"] == str(self.alert_rule.id)
-        assert chart_data[0]["projects"] == [self.project.slug]
-        assert chart_data[0]["dateStarted"] == group_open_period.date_started
+        assert chart_data[0]["id"] == str(group_open_period.id)
+        assert chart_data[0]["start"] == group_open_period.date_started
 
         assert len(chart_data[0]["activities"]) == 2
         opened_activity_resp = chart_data[0]["activities"][0]
         closed_activity_resp = chart_data[0]["activities"][1]
 
         assert opened_activity_resp["id"] == str(opened_gopa.id)
-        assert opened_activity_resp["type"] == IncidentActivityType.STATUS_CHANGE.value
+        assert opened_activity_resp["type"] == OpenPeriodActivityType(opened_gopa.type).to_str()
+        assert opened_activity_resp["value"] == PriorityLevel(group.priority).to_str()
         assert opened_activity_resp["dateCreated"] == opened_gopa.date_added
 
         assert closed_activity_resp["id"] == str(closed_gopa.id)
-        assert closed_activity_resp["type"] == IncidentActivityType.STATUS_CHANGE.value
+        assert closed_activity_resp["type"] == OpenPeriodActivityType(closed_gopa.type).to_str()
         assert closed_activity_resp["dateCreated"] == closed_gopa.date_added
 
     @freeze_time(frozen_time)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -14,8 +14,6 @@ from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import DiscordMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_alert_rule_serializer,
-    get_detailed_incident_serializer,
     get_detector_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
@@ -78,8 +76,6 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             notification_context=notification_context,
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
-            alert_rule_serialized_response=get_alert_rule_serializer(self.detector),
-            incident_serialized_response=get_detailed_incident_serializer(self.open_period),
             detector_serialized_response=get_detector_serializer(self.detector),
             notification_uuid=notification_uuid,
         )

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -14,8 +14,6 @@ from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import EmailMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_alert_rule_serializer,
-    get_detailed_incident_serializer,
     get_detector_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
@@ -78,8 +76,6 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
             alert_context=alert_context,
-            alert_rule_serialized_response=get_alert_rule_serializer(self.detector),
-            incident_serialized_response=get_detailed_incident_serializer(self.open_period),
             detector_serialized_response=get_detector_serializer(self.detector),
             trigger_status=TriggerStatus.ACTIVE,
             targets=[(self.user.id, self.user.email)],

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -13,10 +13,6 @@ from sentry.incidents.typings.metric_detector import (
 from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import MSTeamsMetricAlertHandler
-from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_alert_rule_serializer,
-    get_detailed_incident_serializer,
-)
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
@@ -78,8 +74,6 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             notification_context=notification_context,
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
-            alert_rule_serialized_response=get_alert_rule_serializer(self.detector),
-            incident_serialized_response=get_detailed_incident_serializer(self.open_period),
             notification_uuid=notification_uuid,
         )
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -21,8 +21,6 @@ from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import SlackMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_alert_rule_serializer,
-    get_detailed_incident_serializer,
     get_detector_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
@@ -128,8 +126,6 @@ class TestSlackMetricAlertHandlerSendAlert(MetricAlertHandlerBase):
             notification_context=kwargs["notification_context"],
             metric_issue_context=kwargs["metric_issue_context"],
             open_period_context=kwargs["open_period_context"],
-            alert_rule_serialized_response=get_alert_rule_serializer(self.detector),
-            incident_serialized_response=get_detailed_incident_serializer(self.open_period),
             detector_serialized_response=get_detector_serializer(self.detector),
             notification_uuid=kwargs["notification_uuid"],
         )


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/116052 to remove most uses of `AlertRuleSerializerResponse` and `DetailedIncidentSerializerResponse` - the only remaining place they're used is in the forwards compatible serializers to make sure the payload shape matches the old one. 