### PR TITLE
fix(events): correctly parse full parameter in group hashes endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_hashes.py
+++ b/src/sentry/issues/endpoints/group_hashes.py
@@ -49,7 +49,7 @@ class GroupHashesEndpoint(GroupEndpoint):
         :pparam bool full: If this is set to true, the event payload will include the full event body, including the stacktrace.
         :auth: required
         """
-        full = request.GET.get("full", True)
+        full = request.GET.get("full") not in ("0", "false")
 
         data_fn = partial(
             lambda *args, **kwargs: raw_query(*args, **kwargs)["data"],

--- a/tests/sentry/issues/endpoints/test_group_hashes.py
+++ b/tests/sentry/issues/endpoints/test_group_hashes.py
@@ -163,6 +163,29 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
         # hash2 should be matched by seer (it points to hash1)
         assert hash2_data["mergedBySeer"] is True
 
+    def test_full_param(self) -> None:
+        self.login_as(user=self.user)
+
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": before_now(minutes=1).isoformat(),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group_id}/hashes/"
+
+        response = self.client.get(f"{url}?full=true", format="json")
+        assert response.status_code == 200, response.content
+        assert "entries" in response.data[0]["latestEvent"]
+
+        response = self.client.get(f"{url}?full=false", format="json")
+        assert response.status_code == 200, response.content
+        assert "entries" not in response.data[0]["latestEvent"]
+
     def test_unmerge(self) -> None:
         self.login_as(user=self.user)
 


### PR DESCRIPTION
Same fix as https://github.com/getsentry/sentry/pull/116216. When a caller passes e.g. ?full=false, we get the string `false`, which is truthy, so we always use the full event serializer rather than the simple one. Apply the same fix as https://github.com/getsentry/sentry/pull/52452, by checking for the strings "0" and "false" instead.
