### PR TITLE
feat(api-docs): publish project releases list endpoint

### DIFF
--- a/src/sentry/apidocs/examples/release_examples.py
+++ b/src/sentry/apidocs/examples/release_examples.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+
+from drf_spectacular.utils import OpenApiExample
+
+from sentry.api.serializers.types import ReleaseSerializerResponse
+
+RELEASE: ReleaseSerializerResponse = {
+    "id": 1,
+    "version": "frontend@1.0.0",
+    "shortVersion": "frontend@1.0.0",
+    "status": "open",
+    "versionInfo": {
+        "package": "frontend",
+        "version": {
+            "raw": "1.0.0",
+            "major": 1,
+            "minor": 0,
+            "patch": 0,
+            "pre": None,
+            "buildCode": None,
+            "components": 3,
+        },
+        "description": "1.0.0",
+        "buildHash": None,
+    },
+    "ref": None,
+    "url": None,
+    "dateReleased": None,
+    "dateCreated": datetime.fromisoformat("2024-01-01T00:00:00Z"),
+    "data": {},
+    "newGroups": 0,
+    "owner": None,
+    "commitCount": 0,
+    "lastCommit": None,
+    "deployCount": 0,
+    "lastDeploy": None,
+    "authors": [],
+    "projects": [
+        {
+            "id": 1,
+            "slug": "sentry",
+            "name": "sentry",
+            "newGroups": 0,
+            "platform": "javascript",
+            "platforms": ["javascript"],
+            "hasHealthData": False,
+        }
+    ],
+    "firstEvent": None,
+    "lastEvent": None,
+    "currentProjectMeta": {},
+    "userAgent": None,
+}
+
+
+class ReleaseExamples:
+    LIST_PROJECT_RELEASES = [
+        OpenApiExample(
+            "Return a list of releases for a project",
+            value=[RELEASE],
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -231,6 +231,13 @@ class ReleaseParams:
         type=str,
         description="The version identifier of the release",
     )
+    QUERY = OpenApiParameter(
+        name="query",
+        location="query",
+        required=False,
+        type=OpenApiTypes.STR,
+        description="Case-insensitive substring match against the release version.",
+    )
     PROJECT_ID = OpenApiParameter(
         name="project_id",
         location="query",

--- a/src/sentry/releases/endpoints/project_releases.py
+++ b/src/sentry/releases/endpoints/project_releases.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import sentry_sdk
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
 from sentry.analytics.events.release_created import ReleaseCreatedEvent
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
@@ -15,7 +17,16 @@ from sentry.api.helpers.environments import get_environment
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ReleaseWithVersionSerializer
+from sentry.api.serializers.types import ReleaseSerializerResponse
 from sentry.api.utils import get_auth_api_token_type
+from sentry.apidocs.constants import (
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.examples.release_examples import ReleaseExamples
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.orgauthtoken import is_org_auth_token_auth, update_org_auth_token_last_used
@@ -27,10 +38,12 @@ from sentry.types.activity import ActivityType
 from sentry.utils.sdk import bind_organization_context
 
 
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleasesEndpoint(ProjectEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.UNKNOWN,
     }
     permission_classes = (ProjectReleasePermission,)
@@ -38,19 +51,28 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
         group="CLI", limit_overrides={"GET": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}
     )
 
+    @extend_schema(
+        operation_id="List a Project's Releases",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            GlobalParams.ENVIRONMENT,
+            ReleaseParams.QUERY,
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListProjectReleasesResponse", list[ReleaseSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=ReleaseExamples.LIST_PROJECT_RELEASES,
+    )
     def get(self, request: Request, project) -> Response:
         """
-        List a Project's Releases
-        `````````````````````````
-
         Retrieve a list of releases for a given project.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to list the
-                                     releases of.
-        :qparam string query: this parameter can be used to create a
-                              "starts with" filter for the version.
         """
         query = request.GET.get("query")
         try:

--- a/tests/apidocs/endpoints/releases/test_project_releases.py
+++ b/tests/apidocs/endpoints/releases/test_project_releases.py
@@ -1,0 +1,23 @@
+from django.test.client import RequestFactory
+from django.urls import reverse
+
+from fixtures.apidocs_test_case import APIDocsTestCase
+
+
+class ProjectReleasesDocsTest(APIDocsTestCase):
+    def setUp(self) -> None:
+        self.create_release(project=self.project, version="1.0.0")
+        self.url = reverse(
+            "sentry-api-0-project-releases",
+            kwargs={
+                "organization_id_or_slug": self.project.organization.slug,
+                "project_id_or_slug": self.project.slug,
+            },
+        )
+        self.login_as(user=self.user)
+
+    def test_get(self) -> None:
+        response = self.client.get(self.url)
+        request = RequestFactory().get(self.url)
+
+        self.validate_schema(request, response)


### PR DESCRIPTION
Update the docs for the project releases endpoint to use the modern drf-spec system. Adds an example + an API doc test. Stacked on https://github.com/getsentry/sentry/pull/116358

