### PR TITLE
ref(flags): Remove organizations:insights-alerts

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -343,8 +343,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:insights-query-date-range-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Make Insights overview pages use EAP instead of transactions (because eap is not on AM1)
     manager.add("organizations:insights-modules-use-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable access to insights metrics alerts
-    manager.add("organizations:insights-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable data browsing heat map widget
     manager.add("organizations:data-browsing-heat-map-widget", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable public RPC endpoint for local seer development

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -210,11 +210,7 @@ def build_metric_alert_chart(
         ),
     }
 
-    allow_mri = features.has(
-        "organizations:insights-alerts",
-        organization,
-        actor=user,
-    )
+    allow_mri = False
     aggregate = translate_aggregate_field(
         snuba_query.aggregate,
         reverse=True,

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from django.utils import timezone
 
-from sentry import features
 from sentry.api import client
 from sentry.api.base import logger
 from sentry.api.utils import get_datetime_from_stats_period
@@ -210,11 +209,9 @@ def build_metric_alert_chart(
         ),
     }
 
-    allow_mri = False
     aggregate = translate_aggregate_field(
         snuba_query.aggregate,
         reverse=True,
-        allow_mri=allow_mri,
         allow_eap=dataset == Dataset.EventsAnalyticsPlatform,
     )
     # If we allow alerts to be across multiple orgs this will break

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -265,10 +265,6 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
             "organizations:custom-metrics",
             self.context["organization"],
             actor=self.context.get("user", None),
-        ) or features.has(
-            "organizations:insights-alerts",
-            self.context["organization"],
-            actor=self.context.get("user", None),
         )
         allow_eap = dataset == Dataset.EventsAnalyticsPlatform
 
@@ -302,10 +298,6 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
 
         if features.has(
             "organizations:custom-metrics",
-            self.context["organization"],
-            actor=self.context.get("user", None),
-        ) or features.has(
-            "organizations:insights-alerts",
             self.context["organization"],
             actor=self.context.get("user", None),
         ):


### PR DESCRIPTION
Limited-access flag registered Aug 2024, never GA'd (~22 months). Remove the flag and its MRI alert gating from charts.py and snuba_query_validator.py. The custom-metrics flag still gates MRI access where needed.
