### PR TITLE
feat(explore): promote schema hints removal from now-done logs to remaining pages

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -107,6 +107,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dynamic-sampling-minimum-sample-rate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable explore -> errors ui
     manager.add("organizations:explore-errors", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable removing the schema hints section to declutter the explore UI
+    manager.add("organizations:explore-schema-hints-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable returning the migrated discover queries in explore saved queries
     manager.add("organizations:expose-migrated-discover-queries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI features such as Autofix and Issue Summary
@@ -414,8 +416,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:ourlogs-modal-export", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable pinning logs to the top of the table in the logs UI and query parameters
     manager.add("organizations:ourlogs-pinning", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable removing the schema hints section to declutter the logs UI
-    manager.add("organizations:ourlogs-schema-hints-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable alerting on trace metrics
     # Enable trace metrics product (known internally as tracemetrics) in UI and backend
     manager.add("organizations:tracemetrics-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -107,8 +107,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dynamic-sampling-minimum-sample-rate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable explore -> errors ui
     manager.add("organizations:explore-errors", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable removing the schema hints section to declutter the explore UI
-    manager.add("organizations:explore-schema-hints-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable returning the migrated discover queries in explore saved queries
     manager.add("organizations:expose-migrated-discover-queries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI features such as Autofix and Issue Summary
@@ -416,6 +414,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:ourlogs-modal-export", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable pinning logs to the top of the table in the logs UI and query parameters
     manager.add("organizations:ourlogs-pinning", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable removing the schema hints section to declutter the logs UI
+    manager.add("organizations:ourlogs-schema-hints-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable alerting on trace metrics
     # Enable trace metrics product (known internally as tracemetrics) in UI and backend
     manager.add("organizations:tracemetrics-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
@@ -445,8 +445,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sentry-app-webhook-circuit-breaker", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Override dry-run to enable real blocking per app-owner org during rollout
     manager.add("organizations:sentry-app-webhook-circuit-breaker-live-run", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Create organiations via control-scoped domains in saas.
-    manager.add("organizations:create-org-control", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # Enables organization access to the new notification platform
     manager.add("organizations:notification-platform.internal-testing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/static/app/views/explore/errors/filterContent.spec.tsx
+++ b/static/app/views/explore/errors/filterContent.spec.tsx
@@ -1,0 +1,54 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+
+import {ErrorsFilterSection} from './filterContent';
+
+const mockUseExploreSchemaHintsRemoval = jest.fn();
+
+jest.mock('sentry/views/explore/useExploreSchemaHintsRemoval', () => ({
+  get useExploreSchemaHintsRemoval() {
+    return mockUseExploreSchemaHintsRemoval;
+  },
+}));
+
+describe('ErrorsFilterSection', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {period: '14d', start: null, end: null, utc: false},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [],
+    });
+  });
+
+  it('renders schema hints when useExploreSchemaHintsRemoval returns false', async () => {
+    mockUseExploreSchemaHintsRemoval.mockReturnValue(false);
+
+    render(<ErrorsFilterSection />);
+
+    expect(await screen.findByText('See full list')).toBeInTheDocument();
+  });
+
+  it('does not render schema hints when useExploreSchemaHintsRemoval returns true', async () => {
+    mockUseExploreSchemaHintsRemoval.mockReturnValue(true);
+
+    render(<ErrorsFilterSection />);
+
+    await screen.findByRole('combobox');
+    expect(screen.queryByText('See full list')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/errors/filterContent.tsx
+++ b/static/app/views/explore/errors/filterContent.tsx
@@ -12,8 +12,11 @@ import {ExploreSchemaHintsSection} from 'sentry/views/explore/components/styles'
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {StyledPageFilterBar} from 'sentry/views/explore/spans/spansTabSearchSection';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {useExploreSchemaHintsRemoval} from 'sentry/views/explore/useExploreSchemaHintsRemoval';
 
 export function ErrorsFilterSection() {
+  const schemaHintsRemoval = useExploreSchemaHintsRemoval();
+
   return (
     <Layout.Main width="full">
       <SearchQueryBuilderProvider
@@ -43,17 +46,19 @@ export function ErrorsFilterSection() {
             stringSecondaryAliases={{}}
           />
         </Grid>
-        <ExploreSchemaHintsSection>
-          <SchemaHintsList
-            supportedAggregates={[]}
-            booleanTags={{}}
-            numberTags={{}}
-            stringTags={{}}
-            isLoading={false}
-            exploreQuery=""
-            source={SchemaHintsSources.ERRORS}
-          />
-        </ExploreSchemaHintsSection>
+        {!schemaHintsRemoval && (
+          <ExploreSchemaHintsSection>
+            <SchemaHintsList
+              supportedAggregates={[]}
+              booleanTags={{}}
+              numberTags={{}}
+              stringTags={{}}
+              isLoading={false}
+              exploreQuery=""
+              source={SchemaHintsSources.ERRORS}
+            />
+          </ExploreSchemaHintsSection>
+        )}
       </SearchQueryBuilderProvider>
     </Layout.Main>
   );

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -1,4 +1,4 @@
-import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {memo, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {useQueryClient} from '@tanstack/react-query';
 
@@ -23,19 +23,15 @@ import {t} from 'sentry/locale';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
-import type {AggregationKey} from 'sentry/utils/fields';
 import {HOUR} from 'sentry/utils/formatters';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {OverChartButtonGroup} from 'sentry/views/explore/components/overChartButtonGroup';
-import {SchemaHintsList} from 'sentry/views/explore/components/schemaHints/schemaHintsList';
-import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
 import {
   ExploreBodyContent,
   ExploreBodySearch,
   ExploreContentSection,
   ExploreControlSection,
-  ExploreSchemaHintsSection,
 } from 'sentry/views/explore/components/styles';
 import {TableActionButton} from 'sentry/views/explore/components/tableActionButton';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
@@ -72,7 +68,6 @@ import {
 } from 'sentry/views/explore/logs/styles';
 import {LogsAggregateTable} from 'sentry/views/explore/logs/tables/logsAggregateTable';
 import {LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
-import {useOurLogsSchemaHintsRemoval} from 'sentry/views/explore/logs/tables/useOurLogsSchemaHintsRemoval';
 import {useLogsAggregatesTable} from 'sentry/views/explore/logs/useLogsAggregatesTable';
 import {getMaxIngestDelayTimestamp} from 'sentry/views/explore/logs/useLogsQuery';
 import {useLogsSearchQueryBuilderProps} from 'sentry/views/explore/logs/useLogsSearchQueryBuilderProps';
@@ -121,15 +116,12 @@ function LogsSearchBar({tracesItemSearchQueryBuilderProps}: LogsSearchBarProps) 
 
 interface LogsSearchSectionProps {
   datePageFilterProps: DatePageFilterProps;
-  searchBarWidthOffset?: number;
 }
 
 const LogsSearchSection = memo(function LogsSearchSection({
   datePageFilterProps,
-  searchBarWidthOffset,
 }: LogsSearchSectionProps) {
   const logsSearch = useQueryParamsSearch();
-  const logsSearchQuery = logsSearch.formatString();
   const groupBys = useQueryParamsGroupBys();
   const mode = useQueryParamsMode();
   const [interval] = useChartInterval();
@@ -145,21 +137,12 @@ const LogsSearchSection = memo(function LogsSearchSection({
     sortBys: aggregateSortBys,
   });
 
-  const {
-    attributes: stringAttributes,
-    isLoading: stringAttributesLoading,
-    secondaryAliases: stringSecondaryAliases,
-  } = useLogItemAttributes({}, 'string', HiddenLogSearchFields);
-  const {
-    attributes: numberAttributes,
-    isLoading: numberAttributesLoading,
-    secondaryAliases: numberSecondaryAliases,
-  } = useLogItemAttributes({}, 'number', HiddenLogSearchFields);
-  const {
-    attributes: booleanAttributes,
-    isLoading: booleanAttributesLoading,
-    secondaryAliases: booleanSecondaryAliases,
-  } = useLogItemAttributes({}, 'boolean', HiddenLogSearchFields);
+  const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
+    useLogItemAttributes({}, 'string', HiddenLogSearchFields);
+  const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
+    useLogItemAttributes({}, 'number', HiddenLogSearchFields);
+  const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useLogItemAttributes({}, 'boolean', HiddenLogSearchFields);
 
   const {tracesItemSearchQueryBuilderProps, searchQueryBuilderProviderProps} =
     useLogsSearchQueryBuilderProps({
@@ -171,15 +154,10 @@ const LogsSearchSection = memo(function LogsSearchSection({
       stringSecondaryAliases,
     });
 
-  const supportedAggregates = useMemo<AggregationKey[]>(() => {
-    return [];
-  }, []);
-
   const organization = useOrganization();
   const hasTranslateEndpoint = organization.features.includes(
     'gen-ai-search-agent-translate'
   );
-  const schemaHintsRemoval = useOurLogsSchemaHintsRemoval();
 
   return (
     <SearchQueryBuilderProvider
@@ -222,24 +200,6 @@ const LogsSearchSection = memo(function LogsSearchSection({
               />
             )}
           </LogsFilterSection>
-          {!schemaHintsRemoval && (
-            <ExploreSchemaHintsSection>
-              <SchemaHintsList
-                supportedAggregates={supportedAggregates}
-                booleanTags={booleanAttributes}
-                numberTags={numberAttributes}
-                stringTags={stringAttributes}
-                isLoading={
-                  numberAttributesLoading ||
-                  stringAttributesLoading ||
-                  booleanAttributesLoading
-                }
-                exploreQuery={logsSearchQuery}
-                source={SchemaHintsSources.LOGS}
-                searchBarWidthOffset={searchBarWidthOffset}
-              />
-            </ExploreSchemaHintsSection>
-          )}
         </Layout.Main>
       </ExploreBodySearch>
     </SearchQueryBuilderProvider>
@@ -283,7 +243,6 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
   const [_, setPersistentParams] = usePersistedLogsPageParams();
   usePersistentLogsPageParameters(); // persist the columns you chose last time
 
-  const columnEditorButtonRef = useRef<HTMLButtonElement>(null);
   // always use the smallest interval possible (the most bars)
   const [interval] = useChartInterval();
 
@@ -446,10 +405,7 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
 
   return (
     <LogsSidebarProvider value={setSidebarOpen}>
-      <LogsSearchSection
-        datePageFilterProps={datePageFilterProps}
-        searchBarWidthOffset={columnEditorButtonRef.current?.clientWidth}
-      />
+      <LogsSearchSection datePageFilterProps={datePageFilterProps} />
       <ViewportConstrainedPage constrained={mode === Mode.SAMPLES} hideFooter>
         <ViewportConstrainedBody>
           <LogsControlSection expanded={sidebarOpen}>

--- a/static/app/views/explore/spans/spansTabSearchSection.spec.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.spec.tsx
@@ -1,0 +1,80 @@
+import type {ReactNode} from 'react';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/datePageFilter';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
+
+import {SpanTabSearchSection} from './spansTabSearchSection';
+
+jest.mock('sentry/views/explore/hooks/useTraceItemAttributes', () => ({
+  useSpanItemAttributes: () => ({attributes: {}, isLoading: false, secondaryAliases: {}}),
+}));
+
+const mockUseExploreSchemaHintsRemoval = jest.fn();
+
+jest.mock('sentry/views/explore/useExploreSchemaHintsRemoval', () => ({
+  get useExploreSchemaHintsRemoval() {
+    return mockUseExploreSchemaHintsRemoval;
+  },
+}));
+
+const datePageFilterProps: DatePageFilterProps = {
+  defaultPeriod: '7d' as const,
+  maxPickableDays: 7,
+  relativeOptions: ({arbitraryOptions}) => arbitraryOptions,
+};
+
+function Wrapper({children}: {children: ReactNode}) {
+  return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
+}
+
+describe('SpanTabSearchSection', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {period: '7d', start: null, end: null, utc: false},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/seer/setup-check/',
+      body: {},
+    });
+  });
+
+  it('shows schema hints when hook returns false', async () => {
+    mockUseExploreSchemaHintsRemoval.mockReturnValue(false);
+
+    render(<SpanTabSearchSection datePageFilterProps={datePageFilterProps} />, {
+      additionalWrapper: Wrapper,
+    });
+
+    expect(await screen.findByText('See full list')).toBeInTheDocument();
+  });
+
+  it('hides schema hints when hook returns true', async () => {
+    mockUseExploreSchemaHintsRemoval.mockReturnValue(true);
+
+    render(<SpanTabSearchSection datePageFilterProps={datePageFilterProps} />, {
+      additionalWrapper: Wrapper,
+    });
+
+    await screen.findByRole('combobox');
+    expect(screen.queryByText('See full list')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -47,6 +47,7 @@ import {SpansTabCrossEventSearchBars} from 'sentry/views/explore/spans/crossEven
 import {SamplesModeAggregateFilterWarning} from 'sentry/views/explore/spans/samplesModeAggregateFilterWarning';
 import {SpansTabSeerComboBox} from 'sentry/views/explore/spans/spansTabSeerComboBox';
 import {ExploreSpansTour, ExploreSpansTourContext} from 'sentry/views/explore/spans/tour';
+import {useExploreSchemaHintsRemoval} from 'sentry/views/explore/useExploreSchemaHintsRemoval';
 import {findSuggestedColumns} from 'sentry/views/explore/utils';
 
 function SpansSearchBar({
@@ -153,6 +154,8 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
   const {spanSearchQueryBuilderProviderProps, spanSearchQueryBuilderProps} =
     useSpanSearchQueryBuilderProps(searchQueryBuilderProps);
 
+  const schemaHintsRemoval = useExploreSchemaHintsRemoval();
+
   return (
     <Layout.Main width="full">
       <SearchQueryBuilderProvider
@@ -197,7 +200,7 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
                   <SpansTabCrossEventSearchBars hasIndependentDateColumn />
                 ) : null}
               </Grid>
-              {hasCrossEvents ? null : (
+              {hasCrossEvents || schemaHintsRemoval ? null : (
                 <ExploreSchemaHintsSection>
                   <SchemaHintsList
                     supportedAggregates={

--- a/static/app/views/explore/useExploreSchemaHintsRemoval.tsx
+++ b/static/app/views/explore/useExploreSchemaHintsRemoval.tsx
@@ -1,12 +1,12 @@
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-export function useOurLogsSchemaHintsRemoval() {
+export function useExploreSchemaHintsRemoval() {
   const organization = useOrganization();
   const location = useLocation();
 
   return (
-    organization.features.includes('ourlogs-schema-hints-removal') ||
-    location.query.logsSchemaHintsRemoval === 'true'
+    organization.features.includes('explore-schema-hints-removal') ||
+    location.query.exploreSchemaHintsRemoval === 'true'
   );
 }


### PR DESCRIPTION
This is a bit of a conjoined PR for two things:

1. [LOGS-788 Clear out schema hints code from logs](https://linear.app/getsentry/issue/LOGS-788/clear-out-schema-hints-code-from-logs): since removing schema hints from logs is rolled out to GA, we don't need to keep the old code & feature flag around.
2. [LOGS-790 Add flag to clear out schema hints from elsewhere in Sentry](https://linear.app/getsentry/issue/LOGS-790/add-flag-to-clear-out-schema-hints-from-elsewhere-in-sentry): adds an equivalent feature flag & removal of the schema hints usage from the remaining two parts of Explore:
    * Errors
    * Traces

I figured it'd be less churn if I did those two things together in one PR. I can split this up if requested to.

Uses the feature flag change from https://github.com/getsentry/sentry-options-automator/pull/7936 & #116225.

Closes LOGS-788.