### PR TITLE
docs(snapshots): Add public OpenAPI documentation for snapshot endpoints

### DIFF
--- a/src/sentry/apidocs/examples/preprod_examples.py
+++ b/src/sentry/apidocs/examples/preprod_examples.py
@@ -331,3 +331,240 @@ class PreprodExamples:
             response_only=True,
         ),
     ]
+
+    _SNAPSHOT_VCS_INFO = {
+        "head_sha": "abc123def456",
+        "base_sha": "789xyz000111",
+        "provider": "github",
+        "head_repo_name": "org/repo",
+        "base_repo_name": "org/repo",
+        "head_ref": "feature-branch",
+        "base_ref": "main",
+        "pr_number": 42,
+    }
+
+    _SNAPSHOT_IMAGE = {
+        "key": "a1b2c3d4e5f6",
+        "display_name": "Home Screen",
+        "group": "iPhone 15",
+        "image_file_name": "home_screen_iphone15.png",
+        "width": 1170,
+        "height": 2532,
+    }
+
+    EXAMPLE_SNAPSHOT_DETAILS_DIFF = {
+        "head_artifact_id": "100",
+        "base_artifact_id": "99",
+        "project_id": "1",
+        "comparison_type": "diff",
+        "state": "UPLOADED",
+        "vcs_info": _SNAPSHOT_VCS_INFO,
+        "app_id": "com.example.app",
+        "is_selective": False,
+        "images": [_SNAPSHOT_IMAGE],
+        "image_count": 1,
+        "added": [],
+        "added_count": 0,
+        "removed": [],
+        "removed_count": 0,
+        "renamed": [],
+        "renamed_count": 0,
+        "changed": [
+            {
+                "base_image": {**_SNAPSHOT_IMAGE, "key": "old_hash_123"},
+                "head_image": _SNAPSHOT_IMAGE,
+                "diff_image_key": "diff_hash_456",
+                "diff": 0.02,
+            }
+        ],
+        "changed_count": 1,
+        "unchanged": [],
+        "unchanged_count": 0,
+        "errored": [],
+        "errored_count": 0,
+        "skipped": [],
+        "skipped_count": 0,
+        "diff_threshold": 0.01,
+        "comparison_state": "success",
+        "approval_status": "requires_approval",
+        "comparison_error_message": None,
+        "approvers": [],
+    }
+
+    EXAMPLE_SNAPSHOT_DETAILS_SOLO = {
+        "head_artifact_id": "100",
+        "base_artifact_id": None,
+        "project_id": "1",
+        "comparison_type": "solo",
+        "state": "UPLOADED",
+        "vcs_info": {
+            "head_sha": "abc123def456",
+            "base_sha": None,
+            "provider": "github",
+            "head_repo_name": "org/repo",
+            "base_repo_name": None,
+            "head_ref": "main",
+            "base_ref": None,
+            "pr_number": None,
+        },
+        "app_id": "com.example.app",
+        "is_selective": False,
+        "images": [_SNAPSHOT_IMAGE],
+        "image_count": 1,
+        "added": [],
+        "added_count": 0,
+        "removed": [],
+        "removed_count": 0,
+        "renamed": [],
+        "renamed_count": 0,
+        "changed": [],
+        "changed_count": 0,
+        "unchanged": [],
+        "unchanged_count": 0,
+        "errored": [],
+        "errored_count": 0,
+        "skipped": [],
+        "skipped_count": 0,
+        "diff_threshold": 0.01,
+        "comparison_state": None,
+        "approval_status": None,
+        "comparison_error_message": None,
+        "approvers": [],
+    }
+
+    GET_SNAPSHOT_DETAILS = [
+        OpenApiExample(
+            "Snapshot with Comparison (Diff)",
+            value=EXAMPLE_SNAPSHOT_DETAILS_DIFF,
+            status_codes=["200"],
+            response_only=True,
+        ),
+        OpenApiExample(
+            "Snapshot without Comparison (Solo)",
+            value=EXAMPLE_SNAPSHOT_DETAILS_SOLO,
+            status_codes=["200"],
+            response_only=True,
+        ),
+    ]
+
+    EXAMPLE_SNAPSHOT_CREATED = {
+        "artifactId": "100",
+        "snapshotMetricsId": "200",
+        "imageCount": 5,
+        "snapshotUrl": "https://sentry.io/organizations/org/preprod/snapshots/100/",
+    }
+
+    CREATE_SNAPSHOT = [
+        OpenApiExample(
+            "Snapshot Created",
+            value=EXAMPLE_SNAPSHOT_CREATED,
+            status_codes=["200"],
+            response_only=True,
+        ),
+    ]
+
+    EXAMPLE_SNAPSHOT_IMAGE_DETAIL_CHANGED = {
+        "image_file_name": "home_screen_iphone15.png",
+        "comparison_status": "changed",
+        "head_image": {
+            "content_hash": "a1b2c3d4e5f6",
+            "display_name": "Home Screen",
+            "group": "iPhone 15",
+            "image_file_name": "home_screen_iphone15.png",
+            "width": 1170,
+            "height": 2532,
+            "diff_threshold": 0.01,
+            "description": None,
+            "tags": None,
+            "image_url": "/api/0/projects/org-slug/project-slug/files/images/a1b2c3d4e5f6/",
+        },
+        "base_image": {
+            "content_hash": "old_hash_123",
+            "display_name": "Home Screen",
+            "group": "iPhone 15",
+            "image_file_name": "home_screen_iphone15.png",
+            "width": 1170,
+            "height": 2532,
+            "diff_threshold": 0.01,
+            "description": None,
+            "tags": None,
+            "image_url": "/api/0/projects/org-slug/project-slug/files/images/old_hash_123/",
+        },
+        "diff_image_url": "/api/0/projects/org-slug/project-slug/files/images/diff_hash_456/",
+        "diff_percentage": 0.02,
+        "previous_image_file_name": None,
+    }
+
+    EXAMPLE_SNAPSHOT_IMAGE_DETAIL_ADDED = {
+        "image_file_name": "new_screen.png",
+        "comparison_status": "added",
+        "head_image": {
+            "content_hash": "new_hash_789",
+            "display_name": "New Screen",
+            "group": "iPhone 15",
+            "image_file_name": "new_screen.png",
+            "width": 1170,
+            "height": 2532,
+            "diff_threshold": None,
+            "description": None,
+            "tags": None,
+            "image_url": "/api/0/projects/org-slug/project-slug/files/images/new_hash_789/",
+        },
+        "base_image": None,
+        "diff_image_url": None,
+        "diff_percentage": None,
+        "previous_image_file_name": None,
+    }
+
+    GET_SNAPSHOT_IMAGE_DETAIL = [
+        OpenApiExample(
+            "Changed Image",
+            value=EXAMPLE_SNAPSHOT_IMAGE_DETAIL_CHANGED,
+            status_codes=["200"],
+            response_only=True,
+        ),
+        OpenApiExample(
+            "Added Image",
+            value=EXAMPLE_SNAPSHOT_IMAGE_DETAIL_ADDED,
+            status_codes=["200"],
+            response_only=True,
+        ),
+    ]
+
+    EXAMPLE_LATEST_BASE_SNAPSHOT = {
+        "head_artifact_id": "99",
+        "project_id": "1",
+        "project_slug": "my-project",
+        "app_id": "com.example.app",
+        "image_count": 2,
+        "images": [
+            {
+                "key": "a1b2c3d4e5f6",
+                "display_name": "Home Screen",
+                "group": "iPhone 15",
+                "image_file_name": "home_screen_iphone15.png",
+                "width": 1170,
+                "height": 2532,
+                "image_url": "/api/0/projects/org-slug/my-project/files/images/a1b2c3d4e5f6/",
+            },
+        ],
+        "diff_threshold": 0.01,
+        "date_added": "2025-01-15T10:30:00+00:00",
+        "vcs_info": {
+            "head_sha": "abc123def456",
+            "base_sha": None,
+            "head_ref": "main",
+            "base_ref": None,
+            "head_repo_name": "org/repo",
+            "pr_number": None,
+        },
+    }
+
+    GET_LATEST_BASE_SNAPSHOT = [
+        OpenApiExample(
+            "Latest Base Snapshot",
+            value=EXAMPLE_LATEST_BASE_SNAPSHOT,
+            status_codes=["200"],
+            response_only=True,
+        ),
+    ]

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -9,6 +9,7 @@ import pydantic
 from django.conf import settings
 from django.db import IntegrityError, router, transaction
 from django.utils import timezone
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -21,6 +22,10 @@ from sentry.api.bases.organization import (
     OrganizationReleasePermission,
 )
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.examples.preprod_examples import PreprodExamples
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.staff import is_active_staff
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
@@ -32,6 +37,10 @@ from sentry.preprod.analytics import (
 )
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     BuildDetailsVcsInfo,
+)
+from sentry.preprod.api.models.public.snapshots import (
+    SnapshotCreateResponseDict,
+    SnapshotDetailsResponseDict,
 )
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
     SnapshotApprover,
@@ -180,16 +189,40 @@ def _format_pydantic_error(e: pydantic.ValidationError) -> str:
     return f"Invalid image metadata: {msg}"
 
 
+@extend_schema(tags=["Snapshots"])
 @cell_silo_endpoint
 class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
-        "GET": ApiPublishStatus.EXPERIMENTAL,
-        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.PUBLIC,
+        "DELETE": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (OrganizationReleasePermission,)
 
+    @extend_schema(
+        operation_id="Delete a Snapshot",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OpenApiParameter(
+                name="snapshot_id",
+                type=str,
+                location="path",
+                required=True,
+                description="The ID of the snapshot to delete.",
+            ),
+        ],
+        request=None,
+        responses={204: None, 403: RESPONSE_FORBIDDEN, 404: RESPONSE_NOT_FOUND},
+    )
     def delete(self, request: Request, organization: Organization, snapshot_id: str) -> Response:
+        """
+        Delete a snapshot and all associated data (images, comparisons, metrics).
+
+        This is a permanent, irreversible operation. The snapshot and its images
+        will no longer be accessible after deletion.
+
+        This endpoint requires a bearer token with `project:write` access.
+        """
         if not settings.IS_DEV and not features.has(
             "organizations:preprod-snapshots", organization, actor=request.user
         ):
@@ -246,7 +279,49 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
 
         return Response(status=204)
 
+    @extend_schema(
+        operation_id="Retrieve Snapshot details",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OpenApiParameter(
+                name="snapshot_id",
+                type=str,
+                location="path",
+                required=True,
+                description="The ID of the snapshot.",
+            ),
+            OpenApiParameter(
+                name="compact_metadata",
+                type=str,
+                location="query",
+                required=False,
+                description="Set to '1' or 'true' to strip image metadata to display_name, image_file_name, group, and description only.",
+            ),
+        ],
+        request=None,
+        responses={
+            200: inline_sentry_response_serializer(
+                "SnapshotDetailsResponse", SnapshotDetailsResponseDict
+            ),
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=PreprodExamples.GET_SNAPSHOT_DETAILS,
+    )
     def get(self, request: Request, organization: Organization, snapshot_id: str) -> Response:
+        """
+        Retrieve full details for a snapshot, including categorized image lists
+        and comparison status.
+
+        When a comparison exists, images are categorized into `changed`, `added`,
+        `removed`, `renamed`, `unchanged`, `errored`, and `skipped` lists with
+        counts. Without a comparison, only the `images` list is populated.
+
+        Use `compact_metadata=1` to strip image objects down to `display_name`,
+        `image_file_name`, `group`, and `description` only.
+
+        This endpoint requires a bearer token with `project:read` access.
+        """
         if not settings.IS_DEV and not features.has(
             "organizations:preprod-snapshots", organization, actor=request.user
         ):
@@ -529,11 +604,12 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         return Response(response_data)
 
 
+@extend_schema(tags=["Snapshots"])
 @cell_silo_endpoint
 class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
-        "POST": ApiPublishStatus.EXPERIMENTAL,
+        "POST": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (ProjectReleasePermission,)
 
@@ -545,7 +621,33 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         }
     )
 
+    @extend_schema(
+        operation_id="Upload a Snapshot",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        request=None,
+        responses={
+            200: inline_sentry_response_serializer(
+                "SnapshotCreateResponse", SnapshotCreateResponseDict
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+        },
+        examples=PreprodExamples.CREATE_SNAPSHOT,
+    )
     def post(self, request: Request, project: Project) -> Response:
+        """
+        Upload a new snapshot with image metadata.
+
+        The request body is a JSON object containing `app_id` (required),
+        `images` (required, a mapping of filenames to image metadata objects),
+        and optional VCS fields (`head_sha`, `base_sha`, `provider`,
+        `head_repo_name`, `head_ref`, `base_repo_name`, `base_ref`, `pr_number`).
+
+        When VCS info with a `base_sha` is provided and a matching base snapshot
+        exists, a comparison is automatically triggered.
+
+        This endpoint requires a bearer token with `project:write` access.
+        """
         if not settings.IS_DEV and not features.has(
             "organizations:preprod-snapshots", project.organization, actor=request.user
         ):

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_download.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_download.py
@@ -15,6 +15,7 @@ import orjson
 from django.conf import settings
 from django.http import StreamingHttpResponse
 from django.http.response import HttpResponseBase
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -26,6 +27,8 @@ from sentry.api.bases.organization import (
     OrganizationEndpoint,
     OrganizationReleasePermission,
 )
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.parameters import GlobalParams
 from sentry.auth.staff import is_active_staff
 from sentry.models.organization import Organization
 from sentry.objectstore import get_preprod_session
@@ -82,17 +85,46 @@ def _build_hash_to_filenames(
     return result
 
 
+@extend_schema(tags=["Snapshots"])
 @cell_silo_endpoint
 class OrganizationPreprodSnapshotDownloadEndpoint(OrganizationEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
-        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (OrganizationReleasePermission,)
 
+    @extend_schema(
+        operation_id="Download Snapshot images as ZIP",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OpenApiParameter(
+                name="snapshot_id",
+                type=str,
+                location="path",
+                required=True,
+                description="The ID of the snapshot to download.",
+            ),
+        ],
+        request=None,
+        responses={
+            200: OpenApiResponse(description="A ZIP archive containing all snapshot images."),
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(
         self, request: Request, organization: Organization, snapshot_id: str
     ) -> HttpResponseBase:
+        """
+        Download all images in a snapshot as a ZIP archive.
+
+        The response is a streaming `application/zip` file. Images that share
+        the same content hash are deduplicated during fetch but written under
+        their original filenames in the archive.
+
+        This endpoint requires a bearer token with `project:read` access.
+        """
         if not settings.IS_DEV and not features.has(
             "organizations:preprod-snapshots", organization, actor=request.user
         ):

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
@@ -4,6 +4,7 @@ import logging
 
 import orjson
 from django.conf import settings
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,9 +16,14 @@ from sentry.api.bases.organization import (
     OrganizationEndpoint,
     OrganizationReleasePermission,
 )
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.examples.preprod_examples import PreprodExamples
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.staff import is_active_staff
 from sentry.models.organization import Organization
 from sentry.objectstore import get_preprod_session
+from sentry.preprod.api.models.public.snapshots import SnapshotImageDetailResponseDict
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
     SnapshotImageDetailImageInfo,
     SnapshotImageDetailResponse,
@@ -107,14 +113,44 @@ def _resolve_base_image_info(
 # Intentionally uses a flat response format (nullable fields, no conditional shapes)
 # rather than matching the details endpoint's SnapshotDiffPair/SnapshotImageResponse split.
 # This endpoint is designed for LLM/MCP consumers that benefit from a single uniform shape.
+@extend_schema(tags=["Snapshots"])
 @cell_silo_endpoint
 class OrganizationPreprodSnapshotImageDetailEndpoint(OrganizationEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
-        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (OrganizationReleasePermission,)
 
+    @extend_schema(
+        operation_id="Retrieve Snapshot image detail",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OpenApiParameter(
+                name="snapshot_id",
+                type=str,
+                location="path",
+                required=True,
+                description="The ID of the snapshot.",
+            ),
+            OpenApiParameter(
+                name="image_identifier",
+                type=str,
+                location="path",
+                required=True,
+                description="The image filename or content hash.",
+            ),
+        ],
+        request=None,
+        responses={
+            200: inline_sentry_response_serializer(
+                "SnapshotImageDetailResponse", SnapshotImageDetailResponseDict
+            ),
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=PreprodExamples.GET_SNAPSHOT_IMAGE_DETAIL,
+    )
     def get(
         self,
         request: Request,
@@ -122,6 +158,19 @@ class OrganizationPreprodSnapshotImageDetailEndpoint(OrganizationEndpoint):
         snapshot_id: str,
         image_identifier: str,
     ) -> Response:
+        """
+        Retrieve detailed information for a single image within a snapshot.
+
+        The `image_identifier` can be either the image filename or its content
+        hash. The response includes head and base image metadata, comparison
+        status, diff image URL, diff percentage, and previous filename for
+        renames.
+
+        This endpoint uses a flat response format with nullable fields designed
+        for LLM/MCP consumers.
+
+        This endpoint requires a bearer token with `project:read` access.
+        """
         if not settings.IS_DEV and not features.has(
             "organizations:preprod-snapshots", organization, actor=request.user
         ):

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -6,6 +6,7 @@ from typing import Any
 import orjson
 from django.conf import settings
 from django.db.models import Q
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -18,6 +19,10 @@ from sentry.api.bases.organization import (
     OrganizationEndpoint,
     OrganizationReleasePermission,
 )
+from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.examples.preprod_examples import PreprodExamples
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.staff import is_active_staff
 from sentry.models.organization import Organization
 from sentry.objectstore import get_preprod_session
@@ -25,6 +30,7 @@ from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot import (
     _strip_to_compact,
     build_snapshot_image_response,
 )
+from sentry.preprod.api.models.public.snapshots import LatestBaseSnapshotResponseDict
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.manifest import SnapshotManifest
 
@@ -51,19 +57,76 @@ LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS: dict[str, Any] = {
 }
 
 
+@extend_schema(tags=["Snapshots"])
 @cell_silo_endpoint
 class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
-        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (OrganizationReleasePermission,)
 
+    @extend_schema(
+        operation_id="Retrieve latest base Snapshot",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OpenApiParameter(
+                name="app_id",
+                type=str,
+                location="query",
+                required=True,
+                description="App identifier to match.",
+            ),
+            OpenApiParameter(
+                name="branch",
+                type=str,
+                location="query",
+                required=False,
+                description="Git branch name to filter on.",
+            ),
+            OpenApiParameter(
+                name="project",
+                type=int,
+                location="query",
+                required=False,
+                description="Project ID to scope the lookup.",
+            ),
+            OpenApiParameter(
+                name="compact_metadata",
+                type=str,
+                location="query",
+                required=False,
+                description="Set to '1' or 'true' to strip image metadata to display_name, image_file_name, group, description, and image_url only.",
+            ),
+        ],
+        request=None,
+        responses={
+            200: inline_sentry_response_serializer(
+                "LatestBaseSnapshotResponse", LatestBaseSnapshotResponseDict
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=PreprodExamples.GET_LATEST_BASE_SNAPSHOT,
+    )
     def get(
         self,
         request: Request,
         organization: Organization,
     ) -> Response:
+        """
+        Retrieve the most recent base snapshot for a given app.
+
+        A base snapshot is one uploaded without a `base_sha` (i.e., a snapshot
+        from a base branch like `main`). Use the optional `branch` and `project`
+        parameters to narrow the search.
+
+        The response includes the full image list with download URLs. Use
+        `compact_metadata=1` to reduce image metadata.
+
+        This endpoint requires a bearer token with `project:read` access.
+        """
         if not settings.IS_DEV and not features.has(
             "organizations:preprod-snapshots", organization, actor=request.user
         ):

--- a/src/sentry/preprod/api/models/public/snapshots.py
+++ b/src/sentry/preprod/api/models/public/snapshots.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+
+class VcsInfoResponseDict(TypedDict, total=False):
+    head_sha: str | None
+    base_sha: str | None
+    provider: str | None
+    head_repo_name: str | None
+    base_repo_name: str | None
+    head_ref: str | None
+    base_ref: str | None
+    pr_number: int | None
+
+
+class SnapshotImageResponseDict(TypedDict, total=False):
+    key: str
+    display_name: str | None
+    group: str | None
+    image_file_name: str
+    width: int
+    height: int
+
+
+class SnapshotDiffPairResponseDict(TypedDict, total=False):
+    base_image: SnapshotImageResponseDict
+    head_image: SnapshotImageResponseDict
+    diff_image_key: str | None
+    diff: float | None
+
+
+class SnapshotApproverResponseDict(TypedDict, total=False):
+    id: str | None
+    name: str | None
+    email: str | None
+    username: str | None
+    avatar_url: str | None
+    approved_at: str | None
+    source: Literal["sentry", "github"]
+
+
+class SnapshotDetailsResponseDict(TypedDict, total=False):
+    head_artifact_id: str
+    base_artifact_id: str | None
+    project_id: str
+    comparison_type: str
+    state: str
+    vcs_info: VcsInfoResponseDict
+    app_id: str | None
+    is_selective: bool
+    images: list[SnapshotImageResponseDict]
+    image_count: int
+    added: list[SnapshotImageResponseDict]
+    added_count: int
+    removed: list[SnapshotImageResponseDict]
+    removed_count: int
+    renamed: list[SnapshotDiffPairResponseDict]
+    renamed_count: int
+    changed: list[SnapshotDiffPairResponseDict]
+    changed_count: int
+    unchanged: list[SnapshotImageResponseDict]
+    unchanged_count: int
+    errored: list[SnapshotDiffPairResponseDict]
+    errored_count: int
+    skipped: list[SnapshotImageResponseDict]
+    skipped_count: int
+    diff_threshold: float | None
+    comparison_state: str | None
+    approval_status: str | None
+    comparison_error_message: str | None
+    approvers: list[SnapshotApproverResponseDict]
+
+
+class SnapshotCreateResponseDict(TypedDict):
+    artifactId: str
+    snapshotMetricsId: str
+    imageCount: int
+    snapshotUrl: str
+
+
+class SnapshotImageDetailImageInfoResponseDict(TypedDict, total=False):
+    content_hash: str
+    display_name: str | None
+    group: str | None
+    image_file_name: str
+    width: int
+    height: int
+    diff_threshold: float | None
+    description: str | None
+    tags: dict[str, str] | None
+    image_url: str
+
+
+class SnapshotImageDetailResponseDict(TypedDict, total=False):
+    image_file_name: str
+    comparison_status: str | None
+    head_image: SnapshotImageDetailImageInfoResponseDict | None
+    base_image: SnapshotImageDetailImageInfoResponseDict | None
+    diff_image_url: str | None
+    diff_percentage: float | None
+    previous_image_file_name: str | None
+
+
+class LatestBaseSnapshotImageResponseDict(TypedDict, total=False):
+    key: str
+    display_name: str | None
+    group: str | None
+    image_file_name: str
+    width: int
+    height: int
+    image_url: str
+
+
+class LatestBaseSnapshotVcsInfoResponseDict(TypedDict, total=False):
+    head_sha: str | None
+    base_sha: str | None
+    head_ref: str | None
+    base_ref: str | None
+    head_repo_name: str | None
+    pr_number: int | None
+
+
+class LatestBaseSnapshotResponseDict(TypedDict, total=False):
+    head_artifact_id: str
+    project_id: str
+    project_slug: str
+    app_id: str | None
+    image_count: int
+    images: list[LatestBaseSnapshotImageResponseDict]
+    diff_threshold: float | None
+    date_added: str
+    vcs_info: LatestBaseSnapshotVcsInfoResponseDict


### PR DESCRIPTION
Add public OpenAPI documentation (`drf-spectacular`) to 5 snapshot API endpoints, promoting them from `EXPERIMENTAL` to `PUBLIC`.

These endpoints power the Sentry Snapshots feature (visual regression testing for mobile apps) but were previously undocumented in the public API spec. This change adds full `@extend_schema` decorators with operation IDs, parameter descriptions, TypedDict response models, and example responses so they appear in the generated OpenAPI spec.

**Endpoints documented (7 methods across 5 classes):**
- `GET /organizations/{org}/preprodartifacts/snapshots/{id}/` — Retrieve snapshot details
- `DELETE /organizations/{org}/preprodartifacts/snapshots/{id}/` — Delete a snapshot
- `POST /projects/{org}/{project}/preprodartifacts/snapshots/` — Upload a snapshot
- `GET /organizations/{org}/preprodartifacts/snapshots/{id}/download/` — Download images as ZIP
- `GET /organizations/{org}/preprodartifacts/snapshots/{id}/images/{identifier}/` — Image detail
- `GET /organizations/{org}/preprodartifacts/snapshots/latest-base/` — Latest base snapshot

**Files changed:**
- **New**: `src/sentry/preprod/api/models/public/snapshots.py` — 11 TypedDict response models
- **Modified**: `src/sentry/apidocs/examples/preprod_examples.py` — Example responses for all endpoints
- **Modified**: 4 endpoint files in `src/sentry/preprod/api/endpoints/snapshots/` — `@extend_schema` decorators, `publish_status` → `PUBLIC`, docstrings

No behavior changes — this is purely additive documentation metadata.