### PR TITLE
feat(issues): Bring back `SEER_PR_CREATED` activity creation and hide from timeline

### DIFF
--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -56,11 +56,7 @@ SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
     SentryAppEventType.SEER_SOLUTION_COMPLETED: ActivityType.SEER_SOLUTION_COMPLETED,
     SentryAppEventType.SEER_CODING_STARTED: ActivityType.SEER_CODING_STARTED,
     SentryAppEventType.SEER_CODING_COMPLETED: ActivityType.SEER_CODING_COMPLETED,
-}
-
-SEER_OPERATOR_AUTOFIX_UPDATE_EVENTS: set[SentryAppEventType] = {
-    *SEER_EVENT_TO_ACTIVITY_TYPE.keys(),
-    SentryAppEventType.SEER_PR_CREATED,
+    SentryAppEventType.SEER_PR_CREATED: ActivityType.SEER_PR_CREATED,
 }
 
 logger = logging.getLogger(__name__)
@@ -774,6 +770,10 @@ def _create_seer_activity(
         solution = event_payload.get("solution")
         if solution:
             activity_data["summary"] = solution.get("one_line_summary")
+    elif event_type == SentryAppEventType.SEER_PR_CREATED:
+        pull_requests = event_payload.get("pull_requests", [])
+        if pull_requests:
+            activity_data["pull_requests"] = pull_requests
 
     Activity.objects.create_group_activity(
         group,
@@ -817,7 +817,7 @@ def process_autofix_updates(
             lifecycle.record_failure(failure_reason="missing_identifiers")
             return
 
-        if event_type not in SEER_OPERATOR_AUTOFIX_UPDATE_EVENTS:
+        if event_type not in SEER_EVENT_TO_ACTIVITY_TYPE:
             lifecycle.record_halt(halt_reason="skipped")
             return
 

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -629,6 +629,7 @@ export const SEER_ACTIVITY_TYPES = new Set<GroupActivityType>([
   GroupActivityType.SEER_SOLUTION_COMPLETED,
   GroupActivityType.SEER_CODING_STARTED,
   GroupActivityType.SEER_CODING_COMPLETED,
+  GroupActivityType.SEER_PR_CREATED,
 ]);
 
 interface GroupActivityBase {

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -597,7 +597,7 @@ describe('ActivitySection', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders Seer PR created activity with link', async () => {
+  it('does not render Seer PR created activity in timeline', () => {
     const seerPrGroup = GroupFixture({
       id: '1344',
       activity: [
@@ -627,11 +627,6 @@ describe('ActivitySection', () => {
     const org = OrganizationFixture({features: ['seer-activity-timeline']});
 
     render(<ActivitySection group={seerPrGroup} />, {organization: org});
-    expect(await screen.findByText('Pull Request Created')).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'pull request'})).toHaveAttribute(
-      'href',
-      'https://github.com/org/repo/pull/42'
-    );
-    expect(screen.getByText(/org\/repo/)).toBeInTheDocument();
+    expect(screen.queryByText('Pull Request Created')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -373,7 +373,7 @@ export function ActivitySection({
 
   const showSeerActivities = organization.features.includes('seer-activity-timeline');
   const visibleActivities = showSeerActivities
-    ? group.activity
+    ? group.activity.filter(item => item.type !== GroupActivityType.SEER_PR_CREATED)
     : group.activity.filter(item => !SEER_ACTIVITY_TYPES.has(item.type));
 
   const filteredActivities = visibleActivities.filter(

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -935,6 +935,37 @@ class SeerOperatorTest(TestCase):
         seer_type_values = [t.value for t in SEER_EVENT_TO_ACTIVITY_TYPE.values()]
         assert not Activity.objects.filter(group=self.group, type__in=seer_type_values).exists()
 
+    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
+    def test_create_seer_activity_pr_created_with_pull_requests(self, _mock_has_access):
+        event_payload = {
+            "run_id": MOCK_RUN_ID,
+            "group_id": self.group.id,
+            "pull_requests": [
+                {
+                    "pull_request": {
+                        "pr_number": 42,
+                        "pr_url": "https://github.com/owner/repo/pull/42",
+                    },
+                    "repo_name": "owner/repo",
+                    "provider": "github",
+                }
+            ],
+        }
+
+        with self.feature("organizations:seer-activity-timeline"):
+            process_autofix_updates(
+                event_type=SentryAppEventType.SEER_PR_CREATED,
+                event_payload=event_payload,
+                organization_id=self.organization.id,
+            )
+
+        activity = Activity.objects.get(group=self.group, type=ActivityType.SEER_PR_CREATED.value)
+        assert activity.data["pull_requests"][0]["repo_name"] == "owner/repo"
+        assert (
+            activity.data["pull_requests"][0]["pull_request"]["pr_url"]
+            == "https://github.com/owner/repo/pull/42"
+        )
+
 
 class TestGetAutofixExplorerStatus(TestCase):
     @staticmethod


### PR DESCRIPTION
Reverts https://github.com/getsentry/sentry/pull/115749 to restore `SEER_PR_CREATED` activity creation in the Seer operator pipeline (fed by webhook events received into Sentry from Seer).

Hides `SEER_PR_CREATED` activities from the frontend activity timeline on the issue details page - we continue to rely on `SET_RESOLVED_IN_PULL_REQUEST` activities for the UI display instead (to avoid duplicate "PR created" entries).