### PR TITLE
fix(profiling): render single-sample continuous profile chunks

### DIFF
--- a/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
@@ -88,7 +88,13 @@ function getMaxConfigSpace(
   unit: ProfilingFormatterUnit | string,
   [start, end]: readonly [number, number] | readonly [null, null]
 ): Rect {
-  const maxProfileDuration = Math.max(...profileGroup.profiles.map(p => p.duration));
+  // Use the end position of each profile (startedAt offset + duration) rather than
+  // just duration, so profiles that start late in the window don't get clipped.
+  const maxProfileEnd = Math.max(
+    ...profileGroup.profiles.map(p =>
+      start === null ? p.duration : p.startedAt - start + p.duration
+    )
+  );
   const spaceDuration = start !== null && end !== null ? end - start : 0;
 
   if (transactionSpan) {
@@ -103,15 +109,15 @@ function getMaxConfigSpace(
     // and profile are fully visible to the user.
     const duration = Math.max(
       formatTo(transactionDuration, 'seconds', unit),
-      maxProfileDuration,
+      maxProfileEnd,
       spaceDuration
     );
     return new Rect(0, 0, duration, 0);
   }
 
   // No transaction was found, so best we can do is align it to the starting
-  // position of the profiles - find the max of profile durations
-  return new Rect(0, 0, Math.max(maxProfileDuration, spaceDuration), 0);
+  // position of the profiles - find the max end position across all profiles
+  return new Rect(0, 0, Math.max(maxProfileEnd, spaceDuration), 0);
 }
 
 function getProfileOffset(

--- a/static/app/utils/profiling/profile/continuousProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/continuousProfile.spec.tsx
@@ -13,6 +13,23 @@ import {
 
 describe('ContinuousProfile', () => {
   describe('sampled profile', () => {
+    it('single sample renders using a default 10ms weight', () => {
+      const chunk: Profiling.ContinuousProfile = {
+        samples: [{timestamp: Date.now() / 1e3, stack_id: 0, thread_id: '0'}],
+        frames: [{function: 'foo', in_app: true}],
+        stacks: [[0]],
+      };
+
+      const profile = ContinuousProfile.FromProfile(
+        chunk,
+        createContinuousProfileFrameIndex(chunk.frames, 'node'),
+        {minTimestamp: 0, type: 'flamechart'}
+      );
+
+      expect(profile.samples).toHaveLength(1);
+      expect(profile.duration).toBe(10);
+    });
+
     it('imports the base properties', () => {
       const trace = makeSentryContinuousProfile({
         profile: {

--- a/static/app/utils/profiling/profile/continuousProfile.tsx
+++ b/static/app/utils/profiling/profile/continuousProfile.tsx
@@ -46,13 +46,15 @@ export class ContinuousProfile extends Profile {
     }
 
     const weightedSamples: WeightedSample[] = chunk.samples.map((sample, i) => {
-      // falling back to the current sample timestamp has the effect
-      // of giving the last sample a weight of 0
       const nextSample = chunk.samples[i + 1] ?? sample;
+      const weight = (nextSample.timestamp - sample.timestamp) * 1e3;
       return {
         ...sample,
-        // Chunk timestamps are in seconds, convert them to ms
-        weight: (nextSample.timestamp - sample.timestamp) * 1e3,
+        // Chunk timestamps are in seconds, convert them to ms.
+        // For a single-sample chunk every sample diffs against itself (weight=0),
+        // which would cause the sample to be discarded. Use a 10ms default (100Hz)
+        // so the stack is still visible.
+        weight: weight === 0 && chunk.samples.length === 1 ? 10 : weight,
       };
     });
 


### PR DESCRIPTION
Continuous profile chunks with a single sample give weight 0 to that sample (it diffs against itself). That causes `appendSample` to discard it and show "This flamegraph has no data." This adds a 10ms default instead to match matching the 100Hz sampling rate so the stack is still visible.

This also fixes `getMaxConfigSpace` to use each profile's end position (`startedAt` + `duration`) instead of just `duration`. Without this, a profile that starts late in the observability window renders its frames mostly off-screen, appearing blank even after the weight fix.

Put together, this fixes rendering for the two main views reported in PRO-43.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="1049" height="731" alt="before" src="https://github.com/user-attachments/assets/7e21d762-80aa-4386-aed1-d3e46c26fadb" />
</td>
<td>
<img width="1049" height="731" alt="after" src="https://github.com/user-attachments/assets/1bb946cb-642d-4616-9cd3-40bdef64d3e0" />
</td>
</tr>
</tbody>
</table>

Closes PRO-43.
