### PR TITLE
ref(preprod): Simplify project filtering in latest base snapshot endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -96,7 +96,7 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
             .select_related("commit_comparison", "project", "preprodsnapshotmetrics")
         )
 
-        if project_id:
+        if project_id is not None:
             qs = qs.filter(project_id=project_id)
         if branch:
             qs = qs.filter(commit_comparison__head_ref=branch)

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -14,7 +14,6 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import (
-    NoProjects,
     OrganizationEndpoint,
     OrganizationReleasePermission,
 )
@@ -78,15 +77,11 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
         branch = request.GET.get("branch")
         compact = request.GET.get("compact_metadata", "0") in ("1", "true")
 
-        try:
-            params = self.get_filter_params(request, organization, date_filter_optional=True)
-        except NoProjects:
-            return Response({"detail": "No snapshot found"}, status=404)
+        project_id = request.GET.get("project")
 
         qs = (
             PreprodArtifact.objects.filter(
                 project__organization_id=organization.id,
-                project_id__in=params["project_id"],
                 app_id=app_id,
                 preprodsnapshotmetrics__isnull=False,
             )
@@ -98,6 +93,8 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
             .select_related("commit_comparison", "project", "preprodsnapshotmetrics")
         )
 
+        if project_id:
+            qs = qs.filter(project_id=project_id)
         if branch:
             qs = qs.filter(commit_comparison__head_ref=branch)
 

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -77,7 +77,10 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
         branch = request.GET.get("branch")
         compact = request.GET.get("compact_metadata", "0") in ("1", "true")
 
-        project_id = request.GET.get("project")
+        try:
+            project_id = int(request.GET["project"]) if "project" in request.GET else None
+        except (ValueError, TypeError):
+            return Response({"detail": "Invalid project parameter"}, status=400)
 
         qs = (
             PreprodArtifact.objects.filter(


### PR DESCRIPTION
Replaces the `get_filter_params` project resolution mechanism with a direct
`project` query parameter in the latest base snapshot endpoint.

The previous approach used `get_filter_params` which resolved project IDs
from request parameters and raised `NoProjects` when none matched. This was
unnecessarily complex for this endpoint — callers already know the project
they want. The new approach accepts an optional `project` query parameter
and filters directly, removing the `NoProjects` import and error path
entirely. When no project is specified, the query returns results across all
projects in the organization (filtered by app_id).