### PR TITLE
fix(workflows): Update Workflows with org-scoped envs when transfered with a project

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -681,9 +681,22 @@ class Project(Model):
                 .values_list("id", flat=True)
             )
 
-            Workflow.objects.filter(id__in=exclusive_workflow_ids).update(
-                organization_id=organization.id
+            # Update org and environment references for transferred workflows
+            workflows_with_env = dict(
+                Workflow.objects.filter(
+                    id__in=exclusive_workflow_ids, environment_id__isnull=False
+                ).values_list("id", "environment_id")
             )
+            for workflow_id, env_id in workflows_with_env.items():
+                Workflow.objects.filter(id=workflow_id).update(
+                    organization_id=organization.id,
+                    environment_id=Environment.get_or_create(
+                        self, name=environment_names.get(env_id)
+                    ).id,
+                )
+            Workflow.objects.filter(id__in=exclusive_workflow_ids).exclude(
+                id__in=workflows_with_env.keys()
+            ).update(organization_id=organization.id)
 
             # Update DataConditionGroups connected to the transferred workflows
             # These are linked via WorkflowDataConditionGroup with a unique constraint on condition_group

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -638,6 +638,28 @@ class ProjectTest(APITestCase, TestCase):
         assert workflow.organization_id == to_org.id
         assert when_condition_group.organization_id == to_org.id
 
+    def test_transfer_to_organization_updates_workflow_environment(self) -> None:
+        from_org = self.create_organization()
+        to_org = self.create_organization()
+        team = self.create_team(organization=from_org)
+        project = self.create_project(teams=[team])
+
+        env = self.create_environment(project=project, name="production")
+        detector = self.create_detector(project=project)
+        workflow = self.create_workflow(organization=from_org, environment=env)
+        self.create_detector_workflow(detector=detector, workflow=workflow)
+
+        project.transfer_to(organization=to_org)
+
+        workflow.refresh_from_db()
+
+        assert workflow.organization_id == to_org.id
+        assert workflow.environment_id is not None
+        assert workflow.environment_id != env.id
+        new_env = Environment.objects.get(id=workflow.environment_id)
+        assert new_env.organization_id == to_org.id
+        assert new_env.name == "production"
+
     def test_transfer_to_organization_nulls_detector_owner(self) -> None:
         from_user = self.create_user()
         from_org = self.create_organization(owner=from_user)


### PR DESCRIPTION
If we're moving a Workflow to a new organization, we need to make sure the associated Environment is updated to one in that org.

Fixes ISWF-2687.