### PR TITLE
fix(alerts): Fall through to issue alert handler

### DIFF
--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
@@ -27,11 +27,9 @@ class MetricAlertRegistryHandler(LegacyRegistryHandler):
             handler = metric_alert_handler_registry.get(invocation.action.type)
             handler.invoke_legacy_registry(invocation)
         except NoRegistrationExistsError:
-            logger.exception(
-                "No metric alert handler found for action type: %s",
-                invocation.action.type,
-                extra={"action_id": invocation.action.id},
-            )
+            # Fall through silently: execute_via_group_type_registry catches this
+            # and routes to the issue alert handler for action types (e.g. WEBHOOK,
+            # PLUGIN, ticketing) that have no metric-alert-specific handler.
             raise
         except Exception:
             logger.exception(

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -60,10 +60,15 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
 
     @mock.patch(
+        "sentry.notifications.notification_action.group_type_notification_registry.handlers.metric_alert_registry_handler.logger"
+    )
+    @mock.patch(
         "sentry.notifications.notification_action.registry.metric_alert_handler_registry.get"
     )
-    def test_handle_workflow_action_no_handler(self, mock_registry_get: mock.MagicMock) -> None:
-        """Test that handle_workflow_action raises NoRegistrationExistsError when no handler exists"""
+    def test_handle_workflow_action_no_handler(
+        self, mock_registry_get: mock.MagicMock, mock_logger: mock.MagicMock
+    ) -> None:
+        """Test that handle_workflow_action re-raises NoRegistrationExistsError without logging it as an exception"""
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):
@@ -77,6 +82,8 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
                 workflow_id=self.workflow.id,
             )
             MetricAlertRegistryHandler.handle_workflow_action(invocation)
+
+        mock_logger.exception.assert_not_called()
 
     def test_handle_activity_update(self) -> None:
         self.event_data = WorkflowEventData(event=self.activity, group=self.group)


### PR DESCRIPTION
When a metric detector's action is webhook (or any non-explicitly supported action type) we hit a `NoRegistrationExists` error. If we let it fall through it will route to the issue alert handler it should be handled appropriately. 

Fixes https://sentry.sentry.io/issues/7230559910/