### PR TITLE
feat(cmdk): Add Open in Production and Open in Development actions

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -22,6 +22,7 @@ import {
   getDsnNavTargets,
 } from 'sentry/components/search/sources/dsnLookupUtils';
 import type {DsnLookupResponse} from 'sentry/components/search/sources/dsnLookupUtils';
+import {DEPLOY_PREVIEW_CONFIG, NODE_ENV} from 'sentry/constants';
 import {
   IconAdd,
   IconAllProjects,
@@ -1053,6 +1054,34 @@ export function GlobalCommandPaletteActions() {
           />
         </CMDKAction>
       </CMDKAction>
+
+      {(NODE_ENV === 'development' || DEPLOY_PREVIEW_CONFIG) && (
+        <CMDKAction
+          display={{label: t('Open in Production'), icon: <IconOpen />}}
+          keywords={[t('production'), t('prod'), t('live')]}
+          onAction={() => {
+            window.open(
+              `https://${organization.slug}.sentry.io${location.pathname}${location.search}`,
+              '_blank',
+              'noreferrer'
+            );
+          }}
+        />
+      )}
+
+      {NODE_ENV === 'production' && user.isStaff && (
+        <CMDKAction
+          display={{label: t('Open in Development'), icon: <IconOpen />}}
+          keywords={[t('development'), t('dev'), t('dev-ui'), t('localhost'), t('local')]}
+          onAction={() => {
+            window.open(
+              `https://${organization.slug}.dev.getsentry.net:7999${location.pathname}${location.search}`,
+              '_blank',
+              'noreferrer'
+            );
+          }}
+        />
+      )}
     </CommandPaletteSlot>
   );
 }

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -1058,7 +1058,7 @@ export function GlobalCommandPaletteActions() {
       {(NODE_ENV === 'development' || DEPLOY_PREVIEW_CONFIG) && (
         <CMDKAction
           display={{label: t('Open in Production'), icon: <IconOpen />}}
-          keywords={[t('production'), t('prod'), t('live')]}
+          keywords={['production', 'prod', 'live']}
           onAction={() => {
             window.open(
               `https://${organization.slug}.sentry.io${location.pathname}${location.search}`,
@@ -1072,7 +1072,7 @@ export function GlobalCommandPaletteActions() {
       {NODE_ENV === 'production' && user.isStaff && (
         <CMDKAction
           display={{label: t('Open in Development'), icon: <IconOpen />}}
-          keywords={[t('development'), t('dev'), t('dev-ui'), t('localhost'), t('local')]}
+          keywords={['development', 'dev', 'dev-ui', 'localhost', 'local']}
           onAction={() => {
             window.open(
               `https://${organization.slug}.dev.getsentry.net:7999${location.pathname}${location.search}`,


### PR DESCRIPTION
Add two global command palette actions for quickly switching between
environments while preserving the current path and search string.

- **Open in Production**: available on the local dev server (`NODE_ENV === 'development'`)
  and Vercel preview deploys (`DEPLOY_PREVIEW_CONFIG`). Opens the current page on
  `https://{org}.sentry.io`.
- **Open in Development**: available in production (`NODE_ENV === 'production'`) for
  staff users (`user.isStaff`). Opens the current page on
  `https://{org}.dev.getsentry.net:7999`.

Both actions preserve the current pathname and search params — only the origin changes.