### PR TITLE
fix(issue search): Fix invalid search query error message for device classes

### DIFF
--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -241,7 +241,7 @@ def convert_device_class_value(
     for device_class in value:
         device_class_values = DEVICE_CLASS.get(device_class)
         if not device_class_values:
-            raise InvalidSearchQuery(f"Invalid type value of '{type}'")
+            raise InvalidSearchQuery(f"Invalid device class value of '{device_class}'")
         results.update(device_class_values)
     return list(results)
 


### PR DESCRIPTION
Fixing this `InvalidSearchQuery` error message for invalid device class values.