### PR TITLE
fix(feedback): Downgrade log level for insufficient feedback count

### DIFF
--- a/src/sentry/feedback/endpoints/organization_feedback_categories.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_categories.py
@@ -152,7 +152,7 @@ class OrganizationFeedbackCategoriesEndpoint(OrganizationEndpoint):
         )
 
         if len(recent_feedbacks) < MIN_FEEDBACKS_CONTEXT:
-            logger.error("Too few feedbacks to generate categories")
+            logger.info("Too few feedbacks to generate categories")
             return Response(
                 {
                     "categories": None,


### PR DESCRIPTION
This error is noisy and not really buying us much, switching down to info level logs. We can get it from our log provider if it's important

Fixes SENTRY-4D0M

<!-- Describe your PR here. -->