### PR TITLE
fix(slack): Add invalid_arguments to Slack error categories

### DIFF
--- a/src/sentry/integrations/slack/utils/errors.py
+++ b/src/sentry/integrations/slack/utils/errors.py
@@ -30,6 +30,7 @@ SLACK_SDK_ERROR_CATEGORIES = (
     INVALID_BLOCKS := SlackSdkErrorCategory("invalid_blocks"),
     INVALID_ATTACHMENTS := SlackSdkErrorCategory("invalid_attachments"),
     INVALID_AUTH := SlackSdkErrorCategory("invalid_auth"),
+    INVALID_ARGUMENTS := SlackSdkErrorCategory("invalid_arguments"),
     NON_JSON_RESPONSE := SlackSdkErrorCategory("non_json_response"),
 )
 
@@ -46,6 +47,7 @@ SLACK_SDK_HALT_ERROR_CATEGORIES = (
     FATAL_ERROR,
     INTERNAL_ERROR,
     INVALID_AUTH,
+    INVALID_ARGUMENTS,
     NON_JSON_RESPONSE,
 )
 


### PR DESCRIPTION
The invalid_arguments error from Slack's chat.postEphemeral was not in the SLACK_SDK_ERROR_CATEGORIES allowlist, causing ~1.7K capture_message events/week. Classified as a halt error since it indicates a data/input issue that is not actionable on retry.

Fixes SENTRY-5N9P

<!-- Describe your PR here. -->