### PR TITLE
fix(ratelimits): Handle AnonymousUser missing is_sentry_app attribute

### DIFF
--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -103,7 +103,7 @@ def get_rate_limit_key(
         else:
             assert False  # Can't happen as asserted by is_api_token_auth check
 
-        if request_user.is_sentry_app:
+        if getattr(request_user, "is_sentry_app", False):
             category = "org"
             id = get_organization_id_from_token(token_id)
 


### PR DESCRIPTION
When an API token's user no longer exists, transform_auth sets the user to AnonymousUser which lacks is_sentry_app. Use getattr with a False default, matching the safe pattern in access.py.

Fixes SENTRY-5PWZ

<!-- Describe your PR here. -->