### PR TITLE
feat(explore): Remove beta badge for attribute breakdown

### DIFF
--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useEffect} from 'react';
 
-import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
@@ -123,7 +122,6 @@ export function ExploreTables(props: ExploreTablesProps) {
               disabled={hasCrossEvents}
             >
               {t('Attribute Breakdowns')}
-              <FeatureBadge type="beta" />
             </TabList.Item>
           </TabList>
         </Tabs>


### PR DESCRIPTION
Removing the beta badge for the attribute breakdown feature in Explore. I think this feature is fully GA'd by this point, I didn't see any gated feature flagging code around it. 