### PR TITLE
[WIP] feat(snapshots): Add Docker-based snapshot generation for CI parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,7 @@ agents.lock
 .agents/skills/warden/
 .agents/skills/warden-sweep/
 # end
+diff-output/
+.pnpm-store/
+snapshots-head/
+snapshots-base/

--- a/bin/run-snapshots-docker
+++ b/bin/run-snapshots-docker
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE="mcr.microsoft.com/playwright:v1.58.2-noble"
+VOLUME_NAME="sentry-snapshots-node-modules"
+OUTPUT_DIR=".artifacts/snapshots"
+
+mkdir -p "$REPO_ROOT/$OUTPUT_DIR"
+
+echo "Running snapshots in Docker (Ubuntu 24.04, matching CI)..."
+echo "Output: $REPO_ROOT/$OUTPUT_DIR"
+
+if ! docker volume inspect "$VOLUME_NAME" &>/dev/null; then
+  echo "First run — installing node_modules (cached for subsequent runs)."
+fi
+
+docker run --rm \
+  --ipc=host \
+  -v "$REPO_ROOT:/work" \
+  -v "$VOLUME_NAME:/work/node_modules" \
+  -w /work \
+  -e NODE_OPTIONS='--max-old-space-size=4096' \
+  -e SNAPSHOT_OUTPUT_DIR="$OUTPUT_DIR" \
+  "$IMAGE" \
+  bash -c '
+    corepack enable && corepack prepare pnpm@10.30.2 --activate
+    pnpm install --frozen-lockfile --store-dir /work/node_modules/.pnpm-store
+    pnpm run snapshots
+  '


### PR DESCRIPTION
Adds `bin/run-snapshots-docker`, a shell script that runs `pnpm run snapshots` inside Playwright's official Ubuntu 24.04 Docker image — the same OS and font rendering stack (FreeType) that CI uses.

**Problem:** Running `pnpm run snapshots` on macOS produces ~314/400 false positive diffs against CI-generated base snapshots, because macOS CoreText and Linux FreeType produce slightly different subpixel antialiasing even with `--font-render-hinting=none` and `--disable-skia-runtime-opts`.

**Solution:** Run snapshot generation in a Docker container matching CI's environment (`mcr.microsoft.com/playwright:v1.58.2-noble`). This eliminates all cross-platform rendering differences. A Docker named volume caches `node_modules` so only the first run is slow (~90s), subsequent runs take ~35s.

**Usage:**
```bash
./bin/run-snapshots-docker
sentry-cli snapshots diff ./snapshots-base/ .artifacts/snapshots
```

Also adds `.gitignore` entries for local snapshot working directories (`diff-output/`, `snapshots-base/`, `snapshots-head/`, `.pnpm-store/`).