### PR TITLE
fix(replays): Remove timeline icon z-index workaround

### DIFF
--- a/static/app/components/activity/note/mentionStyle.tsx
+++ b/static/app/components/activity/note/mentionStyle.tsx
@@ -48,7 +48,6 @@ export function mentionStyle({theme, minHeight, inputStyle}: Options) {
         maxHeight: 142,
         minWidth: 220,
         overflow: 'auto',
-        zIndex: theme.zIndex.dropdown,
         backgroundColor: theme.tokens.background.primary,
         border: '1px solid rgba(0,0,0,0.15)',
         borderRadius: theme.radius.md,

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -157,29 +157,26 @@ const StyledTimelineItem = styled(Timeline.Item)`
   padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
   margin: 0;
   &:hover {
-    background: ${p => p.theme.colors.surface200};
+    background-color: ${p => p.theme.colors.surface200};
     .timeline-icon-wrapper {
-      background: ${p => p.theme.colors.surface200};
+      background-color: ${p => p.theme.colors.surface200};
     }
-  }
-  .timeline-icon-wrapper {
-    z-index: 1;
   }
   cursor: pointer;
   /* vertical line connecting items */
-  &:not(:last-child)::before {
-    content: '';
-    position: absolute;
-    left: 16.5px;
-    width: 1px;
-    top: -2px;
-    bottom: -9px;
+  &:not(:last-child) {
     /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
-    background: ${p => p.theme.tokens.border.primary};
-    z-index: 0;
+    background-image: linear-gradient(
+      ${p => p.theme.tokens.border.primary},
+      ${p => p.theme.tokens.border.primary}
+    );
+    background-position: 16.5px -2px;
+    background-repeat: no-repeat;
+    background-size: 1px calc(100% + 11px);
   }
-  &:first-child::before {
-    top: 4px;
+  &:first-child {
+    background-position: 16.5px 4px;
+    background-size: 1px calc(100% + 5px);
   }
 `;
 

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -162,6 +162,9 @@ const StyledTimelineItem = styled(Timeline.Item)`
       background: ${p => p.theme.colors.surface200};
     }
   }
+  .timeline-icon-wrapper {
+    z-index: 1;
+  }
   cursor: pointer;
   /* vertical line connecting items */
   &:not(:last-child)::before {

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -153,7 +153,6 @@ export function BreadcrumbItem({
 
 const StyledTimelineItem = styled(Timeline.Item)`
   width: 100%;
-  position: relative;
   padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
   margin: 0;
   &:hover {

--- a/static/app/components/timeline/index.stories.tsx
+++ b/static/app/components/timeline/index.stories.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
@@ -10,13 +9,11 @@ import {StructuredData} from 'sentry/components/structuredEventData';
 import {Timeline} from 'sentry/components/timeline';
 import {
   IconClock,
-  IconCommit,
   IconCursorArrow,
   IconDashboard,
   IconFire,
   IconSentry,
   IconSort,
-  IconUser,
 } from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
@@ -132,10 +129,6 @@ export default Storybook.story('Timeline', story => {
             <code>isActive</code> - If set to true, will display a border under the item
           </li>
           <li>
-            <code>marker</code> - A component to render in the first column, before the
-            activity icon
-          </li>
-          <li>
             <code>onClick</code> - React event handler for the entire item
           </li>
           <li>
@@ -204,56 +197,6 @@ export default Storybook.story('Timeline', story => {
         >
           <Timeline.Text>This is a description of the error</Timeline.Text>
         </Timeline.Item>
-      </Fragment>
-    );
-  });
-
-  story('Two-column layout', () => {
-    const theme = useTheme();
-    return (
-      <Fragment>
-        <p>
-          Timeline items can render a separate <code>marker</code> column before the
-          activity icon. This is used when the actor and activity type both need a visible
-          marker.
-        </p>
-        <h6>Example</h6>
-        <Timeline.Container>
-          <Timeline.Item
-            marker={
-              <StoryMarker size={22}>
-                <IconUser size="xs" />
-              </StoryMarker>
-            }
-            title="Jane Doe resolved this issue"
-            icon={<IconCommit size="xs" />}
-            timestamp={<DateTime date={now} />}
-            colorConfig={{
-              title: theme.tokens.content.primary,
-              icon: theme.tokens.graphics.success.vibrant,
-              iconBorder: theme.tokens.border.success.vibrant,
-            }}
-          >
-            <Timeline.Text>Marked as resolved in release 24.6.1.</Timeline.Text>
-          </Timeline.Item>
-          <Timeline.Item
-            marker={
-              <StoryMarker size={22}>
-                <IconSentry size="xs" />
-              </StoryMarker>
-            }
-            title="Sentry detected a regression"
-            icon={<IconFire size="xs" />}
-            timestamp={<DateTime date={now} />}
-            colorConfig={{
-              title: theme.tokens.content.primary,
-              icon: theme.tokens.graphics.danger.vibrant,
-              iconBorder: theme.tokens.border.danger.vibrant,
-            }}
-          >
-            <Timeline.Text>The issue regressed in the latest deploy.</Timeline.Text>
-          </Timeline.Item>
-        </Timeline.Container>
       </Fragment>
     );
   });
@@ -346,15 +289,3 @@ const JSONPayload: Record<string, any> = {
 };
 
 const now = new Date();
-
-const StoryMarker = styled('span')<{
-  size: number;
-}>`
-  display: grid;
-  place-items: center;
-  width: ${p => p.size}px;
-  height: ${p => p.size}px;
-  border-radius: 100%;
-  color: ${p => p.theme.tokens.content.secondary};
-  background: ${p => p.theme.tokens.background.primary};
-`;

--- a/static/app/components/timeline/index.stories.tsx
+++ b/static/app/components/timeline/index.stories.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
@@ -9,11 +10,13 @@ import {StructuredData} from 'sentry/components/structuredEventData';
 import {Timeline} from 'sentry/components/timeline';
 import {
   IconClock,
+  IconCommit,
   IconCursorArrow,
   IconDashboard,
   IconFire,
   IconSentry,
   IconSort,
+  IconUser,
 } from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
@@ -129,6 +132,10 @@ export default Storybook.story('Timeline', story => {
             <code>isActive</code> - If set to true, will display a border under the item
           </li>
           <li>
+            <code>marker</code> - A component to render in the first column, before the
+            activity icon
+          </li>
+          <li>
             <code>onClick</code> - React event handler for the entire item
           </li>
           <li>
@@ -197,6 +204,56 @@ export default Storybook.story('Timeline', story => {
         >
           <Timeline.Text>This is a description of the error</Timeline.Text>
         </Timeline.Item>
+      </Fragment>
+    );
+  });
+
+  story('Two-column layout', () => {
+    const theme = useTheme();
+    return (
+      <Fragment>
+        <p>
+          Timeline items can render a separate <code>marker</code> column before the
+          activity icon. This is used when the actor and activity type both need a visible
+          marker.
+        </p>
+        <h6>Example</h6>
+        <Timeline.Container>
+          <Timeline.Item
+            marker={
+              <StoryMarker size={22}>
+                <IconUser size="xs" />
+              </StoryMarker>
+            }
+            title="Jane Doe resolved this issue"
+            icon={<IconCommit size="xs" />}
+            timestamp={<DateTime date={now} />}
+            colorConfig={{
+              title: theme.tokens.content.primary,
+              icon: theme.tokens.graphics.success.vibrant,
+              iconBorder: theme.tokens.border.success.vibrant,
+            }}
+          >
+            <Timeline.Text>Marked as resolved in release 24.6.1.</Timeline.Text>
+          </Timeline.Item>
+          <Timeline.Item
+            marker={
+              <StoryMarker size={22}>
+                <IconSentry size="xs" />
+              </StoryMarker>
+            }
+            title="Sentry detected a regression"
+            icon={<IconFire size="xs" />}
+            timestamp={<DateTime date={now} />}
+            colorConfig={{
+              title: theme.tokens.content.primary,
+              icon: theme.tokens.graphics.danger.vibrant,
+              iconBorder: theme.tokens.border.danger.vibrant,
+            }}
+          >
+            <Timeline.Text>The issue regressed in the latest deploy.</Timeline.Text>
+          </Timeline.Item>
+        </Timeline.Container>
       </Fragment>
     );
   });
@@ -289,3 +346,15 @@ const JSONPayload: Record<string, any> = {
 };
 
 const now = new Date();
+
+const StoryMarker = styled('span')<{
+  size: number;
+}>`
+  display: grid;
+  place-items: center;
+  width: ${p => p.size}px;
+  height: ${p => p.size}px;
+  border-radius: 100%;
+  color: ${p => p.theme.tokens.content.secondary};
+  background: ${p => p.theme.tokens.background.primary};
+`;

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -104,7 +104,6 @@ const Row = styled('div')<{hasMarker: boolean; showLastLine?: boolean}>`
 
 const MarkerWrapper = styled('div')`
   grid-column: span 1;
-  z-index: 1;
   display: grid;
   place-items: center;
   min-width: 22px;
@@ -116,7 +115,6 @@ const IconWrapper = styled('div')`
   border-radius: 100%;
   border: 1px solid;
   background: ${p => p.theme.tokens.background.primary};
-  z-index: 1;
   svg {
     display: block;
     margin: ${p => p.theme.space.xs};


### PR DESCRIPTION
removes stacking fight by drawing replay's breadcrumb connector as a row background instead of an overlapping element

refs #116209 that was the wrong solution