### PR TITLE
chore(relocation) Exclude Email model from relocations v2 

### DIFF
--- a/fixtures/backup/app-user-with-empty-email.json
+++ b/fixtures/backup/app-user-with-empty-email.json
@@ -1,13 +1,5 @@
 [
   {
-    "model": "sentry.email",
-    "pk": 9,
-    "fields": {
-      "email": "",
-      "date_added": "2023-07-26T19:19:37.201Z"
-    }
-  },
-  {
     "model": "sentry.user",
     "pk": 34,
     "fields": {

--- a/src/sentry/users/models/email.py
+++ b/src/sentry/users/models/email.py
@@ -18,7 +18,7 @@ class Email(Model):
     UserEmail represents whether a given user account has access to that email.
     """
 
-    __relocation_scope__ = RelocationScope.User
+    __relocation_scope__ = RelocationScope.Excluded
     __relocation_dependencies__ = {"sentry.User"}
     __relocation_custom_ordinal__ = ["email"]
 

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -26,7 +26,6 @@ from sentry.models.options.option import Option
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.orgauthtoken import OrgAuthToken
-from sentry.silo.base import SiloMode
 from sentry.testutils.helpers.backups import (
     NOOP_PRINTER,
     BackupTransactionTestCase,
@@ -35,8 +34,6 @@ from sentry.testutils.helpers.backups import (
     generate_rsa_key_pair,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.silo import assume_test_silo_mode
-from sentry.users.models.email import Email
 from sentry.users.models.user import User
 from sentry.users.models.useremail import UserEmail
 from sentry.users.models.userpermission import UserPermission
@@ -463,12 +460,9 @@ class FilteringTests(ExportTestCase):
             data = self.export(tmp_dir, scope=ExportScope.User, filter_by={"user_2"})
 
             # Count users, but also count a random model naively derived from just `User` alone,
-            # like `UserEmail`. Because `Email` and `UserEmail` have some automagic going on that
-            # causes them to be created when a `User` is, we explicitly check to ensure that they
-            # are behaving correctly as well.
+            # like `UserEmail`.
             assert self.count(data, User) == 1
             assert self.count(data, UserEmail) == 1
-            assert self.count(data, Email) == 1
 
             assert not self.exists(data, User, "username", "user_1")
             assert self.exists(data, User, "username", "user_2")
@@ -488,7 +482,6 @@ class FilteringTests(ExportTestCase):
 
             assert self.count(data, User) == 3
             assert self.count(data, UserEmail) == 3
-            assert self.count(data, Email) == 2
 
             assert self.exists(data, User, "username", "user_1")
             assert self.exists(data, User, "username", "user_2")
@@ -503,30 +496,6 @@ class FilteringTests(ExportTestCase):
             data = self.export(tmp_dir, scope=ExportScope.User, filter_by=set())
 
             assert len(data) == 0
-
-    def test_export_user_mismatched_email(self) -> None:
-        self.create_user(
-            email="Testing.Upper@example.com",
-            username="user_1",
-            is_staff=False,
-            is_superuser=False,
-        )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            # Modify the generated email record to have different casing.
-            # This can happen if a useremail record is updated as we don't sync
-            # data to sentry_email on update.
-            email = Email.objects.get(email="Testing.Upper@example.com")
-            email.email = "testing.upper@example.com"
-            email.save()
-
-        with TemporaryDirectory() as tmp_dir:
-            data = self.export(tmp_dir, scope=ExportScope.User)
-
-            # Ensure email record is exported despite email casing being different.
-            assert self.count(data, User) == 1
-            assert self.count(data, UserEmail) == 1
-            assert self.count(data, Email) == 1
-            assert self.exists(data, User, "username", "user_1")
 
     def test_export_filter_orgs_single(self) -> None:
         # Create a superadmin not in any orgs, so that we can test that `OrganizationMember`s
@@ -587,7 +556,6 @@ class FilteringTests(ExportTestCase):
 
             assert self.count(data, User) == 7
             assert self.count(data, UserEmail) == 7
-            assert self.count(data, Email) == 6  # Lower due to `shared@example.com`
 
             assert not self.exists(data, User, "username", "user_a_only")
             assert self.exists(data, User, "username", "user_b_only")
@@ -673,7 +641,6 @@ class FilteringTests(ExportTestCase):
 
             assert self.count(data, User) == 8
             assert self.count(data, UserEmail) == 8
-            assert self.count(data, Email) == 6  # Lower due to `shared@example.com`
 
             assert self.exists(data, User, "username", "user_a_only")
             assert not self.exists(data, User, "username", "user_b_only")

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -75,7 +75,6 @@ from sentry.testutils.helpers.backups import (
 from sentry.testutils.hybrid_cloud import use_split_dbs
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.users.models.authenticator import Authenticator
-from sentry.users.models.email import Email
 from sentry.users.models.lostpasswordhash import LostPasswordHash
 from sentry.users.models.user import User
 from sentry.users.models.user_option import UserOption
@@ -118,9 +117,6 @@ class SanitizationTests(ImportTestCase):
                 == 4
             )
 
-            # Every user except `max_user` shares an email.
-            assert Email.objects.count() == 2
-
             # All `UserEmail`s must have their verification status reset in this scope.
             assert UserEmail.objects.count() == 4
             assert UserEmail.objects.filter(is_verified=True).count() == 0
@@ -158,9 +154,6 @@ class SanitizationTests(ImportTestCase):
                 User.objects.filter(is_managed=False, is_staff=False, is_superuser=False).count()
                 == 4
             )
-
-            # Every user except `max_user` shares an email.
-            assert Email.objects.count() == 2
 
             # All `UserEmail`s must have their verification status reset in this scope.
             assert UserEmail.objects.count() == 4
@@ -210,9 +203,6 @@ class SanitizationTests(ImportTestCase):
             # scope.
             assert Authenticator.objects.count() == 0
 
-            # Every user except `max_user` shares an email.
-            assert Email.objects.count() == 2
-
             # All `UserEmail`s must have their verification status reset in this scope.
             assert UserEmail.objects.count() == 4
             assert UserEmail.objects.filter(is_verified=True).count() == 0
@@ -257,9 +247,6 @@ class SanitizationTests(ImportTestCase):
 
             # Unlike the "config" scope, we keep authentication information for the "global" scope.
             assert Authenticator.objects.count() == 4
-
-            # Every user except `max_user` shares an email.
-            assert Email.objects.count() == 2
 
             # All `UserEmail`s must have their imported verification status reset in this scope.
             assert UserEmail.objects.count() == 4
@@ -530,7 +517,7 @@ class SanitizationTests(ImportTestCase):
                 models = self.json_of_exhaustive_user_with_minimum_privileges()
 
                 # Add two copies (1 verified, 1 not) of the same `UserEmail` - so the user now has 3
-                # `UserEmail` models, the latter of which have no corresponding `Email` entry.
+                # `UserEmail` models.
                 models.append(
                     {
                         "model": "sentry.useremail",
@@ -582,7 +569,7 @@ class SanitizationTests(ImportTestCase):
                 models = self.json_of_exhaustive_user_with_minimum_privileges()
 
                 # Add two copies (1 verified, 1 not) of the same `UserEmail` - so the user now has 3
-                # `UserEmail` models, the latter of which have no corresponding `Email` entry.
+                # `UserEmail` models.
                 models.append(
                     {
                         "model": "sentry.useremail",
@@ -699,7 +686,7 @@ class SignalingTests(ImportTestCase):
     """
     Some models are automatically created via signals and similar automagic from related models. We
     test that behavior here. Specifically, we test the following:
-        - That `Email` and `UserEmail` are automatically created when `User` is.
+        - That `UserEmail` is automatically created when `User` is.
         - That `OrganizationMapping` and `OrganizationMemberMapping` are automatically created when
           `Organization is.
         - That `ProjectKey` and `ProjectOption` instances are automatically created when `Project`
@@ -720,9 +707,6 @@ class SignalingTests(ImportTestCase):
 
             assert UserEmail.objects.count() == 1
             assert UserEmail.objects.filter(email="me@example.com").exists()
-
-            assert Email.objects.count() == 1
-            assert Email.objects.filter(email="me@example.com").exists()
 
     def test_import_signaling_organization(self) -> None:
         owner = self.create_exhaustive_user("owner")
@@ -1131,12 +1115,11 @@ class FilterTests(ImportTestCase):
 
         with assume_test_silo_mode(SiloMode.CONTROL):
             # Count users, but also count a random model naively derived from just `User` alone,
-            # like `UserEmail`. Because `Email` and `UserEmail` have some automagic going on that
-            # causes them to be created when a `User` is, we explicitly check to ensure that they
-            # are behaving correctly as well.
+            # like `UserEmail`. Because `UserEmail` have some automagic going on that
+            # causes them to be created when a `User` is, we explicitly check to ensure that it
+            # is behaving correctly as well.
             assert User.objects.count() == 1
             assert UserEmail.objects.count() == 1
-            assert Email.objects.count() == 1
 
             assert (
                 ControlImportChunk.objects.filter(
@@ -1147,12 +1130,6 @@ class FilterTests(ImportTestCase):
             assert (
                 ControlImportChunk.objects.filter(
                     model="sentry.useremail", min_ordinal=1, max_ordinal=1
-                ).count()
-                == 1
-            )
-            assert (
-                ControlImportChunk.objects.filter(
-                    model="sentry.email", min_ordinal=1, max_ordinal=1
                 ).count()
                 == 1
             )
@@ -1176,7 +1153,6 @@ class FilterTests(ImportTestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert User.objects.count() == 3
             assert UserEmail.objects.count() == 3
-            assert Email.objects.count() == 2  # Lower due to shared emails
 
             assert (
                 ControlImportChunk.objects.filter(
@@ -1187,12 +1163,6 @@ class FilterTests(ImportTestCase):
             assert (
                 ControlImportChunk.objects.filter(
                     model="sentry.useremail", min_ordinal=1, max_ordinal=3
-                ).count()
-                == 1
-            )
-            assert (
-                ControlImportChunk.objects.filter(
-                    model="sentry.email", min_ordinal=1, max_ordinal=2
                 ).count()
                 == 1
             )
@@ -1214,7 +1184,6 @@ class FilterTests(ImportTestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert User.objects.count() == 0
             assert UserEmail.objects.count() == 0
-            assert Email.objects.count() == 0
 
     def test_import_filter_orgs_single(self) -> None:
         a = self.create_exhaustive_user("user_a_only", email="shared@example.com")
@@ -1249,7 +1218,6 @@ class FilterTests(ImportTestCase):
 
             assert User.objects.count() == 4
             assert UserEmail.objects.count() == 4
-            assert Email.objects.count() == 3  # Lower due to `shared@example.com`
 
             assert not User.objects.filter(username="user_a_only").exists()
             assert User.objects.filter(username="user_b_only").exists()
@@ -1299,7 +1267,6 @@ class FilterTests(ImportTestCase):
 
             assert User.objects.count() == 5
             assert UserEmail.objects.count() == 5
-            assert Email.objects.count() == 3  # Lower due to `shared@example.com`
 
             assert User.objects.filter(username="user_a_only").exists()
             assert not User.objects.filter(username="user_b_only").exists()
@@ -1331,7 +1298,6 @@ class FilterTests(ImportTestCase):
 
             assert User.objects.count() == 0
             assert UserEmail.objects.count() == 0
-            assert Email.objects.count() == 0
 
 
 COLLISION_TESTED: set[NormalizedModelName] = set()
@@ -1907,7 +1873,7 @@ class CollisionTests(ImportTestCase):
             with open(tmp_path, "rb") as tmp_file:
                 verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
-    @expect_models(COLLISION_TESTED, Email, User, UserEmail)
+    @expect_models(COLLISION_TESTED, User, UserEmail)
     def test_colliding_user_with_merging_enabled_in_user_scope(
         self, expected_models: list[type[Model]]
     ):
@@ -1927,7 +1893,6 @@ class CollisionTests(ImportTestCase):
                 assert User.objects.count() == 1
                 assert UserEmail.objects.count() == 1  # Keep only original when merging.
                 assert Authenticator.objects.count() == 1
-                assert Email.objects.count() == 2
 
                 user_chunk = ControlImportChunk.objects.get(
                     model="sentry.user", min_ordinal=1, max_ordinal=1
@@ -1951,7 +1916,7 @@ class CollisionTests(ImportTestCase):
             with open(tmp_path, "rb") as tmp_file:
                 verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
-    @expect_models(COLLISION_TESTED, Email, User, UserEmail)
+    @expect_models(COLLISION_TESTED, User, UserEmail)
     def test_colliding_user_with_merging_disabled_in_user_scope(
         self, expected_models: list[type[Model]]
     ):
@@ -1971,7 +1936,6 @@ class CollisionTests(ImportTestCase):
                 assert User.objects.count() == 2
                 assert UserEmail.objects.count() == 2
                 assert Authenticator.objects.count() == 1  # Only imported in global scope
-                assert Email.objects.count() == 2
 
                 user_chunk = ControlImportChunk.objects.get(
                     model="sentry.user", min_ordinal=1, max_ordinal=1
@@ -1996,7 +1960,7 @@ class CollisionTests(ImportTestCase):
             with open(tmp_path, "rb") as tmp_file:
                 verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
-    @expect_models(COLLISION_TESTED, Email, Organization, OrganizationMember, User, UserEmail)
+    @expect_models(COLLISION_TESTED, Organization, OrganizationMember, User, UserEmail)
     def test_colliding_user_with_merging_enabled_in_organization_scope(
         self, expected_models: list[type[Model]]
     ):
@@ -2030,7 +1994,6 @@ class CollisionTests(ImportTestCase):
                 assert User.objects.count() == 1
                 assert UserEmail.objects.count() == 1  # Keep only original when merging.
                 assert Authenticator.objects.count() == 1  # Only imported in global scope
-                assert Email.objects.count() == 2
 
                 user_chunk = ControlImportChunk.objects.get(
                     model="sentry.user", min_ordinal=1, max_ordinal=1
@@ -2083,7 +2046,7 @@ class CollisionTests(ImportTestCase):
             with open(tmp_path, "rb") as tmp_file:
                 verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
-    @expect_models(COLLISION_TESTED, Email, Organization, OrganizationMember, User, UserEmail)
+    @expect_models(COLLISION_TESTED, Organization, OrganizationMember, User, UserEmail)
     def test_colliding_user_with_merging_disabled_in_organization_scope(
         self, expected_models: list[type[Model]]
     ):
@@ -2118,7 +2081,6 @@ class CollisionTests(ImportTestCase):
                 assert User.objects.count() == 2
                 assert UserEmail.objects.count() == 2
                 assert Authenticator.objects.count() == 1  # Only imported in global scope
-                assert Email.objects.count() == 2
 
                 user_chunk = ControlImportChunk.objects.get(
                     model="sentry.user", min_ordinal=1, max_ordinal=1
@@ -2175,7 +2137,7 @@ class CollisionTests(ImportTestCase):
             with open(tmp_path, "rb") as tmp_file:
                 verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
-    @expect_models(COLLISION_TESTED, Email, User, UserEmail, UserPermission)
+    @expect_models(COLLISION_TESTED, User, UserEmail, UserPermission)
     def test_colliding_user_with_merging_enabled_in_config_scope(
         self, expected_models: list[type[Model]]
     ):
@@ -2198,7 +2160,6 @@ class CollisionTests(ImportTestCase):
                 assert UserEmail.objects.count() == 1  # Keep only original when merging.
                 assert UserPermission.objects.count() == 1  # Keep only original when merging.
                 assert Authenticator.objects.count() == 1
-                assert Email.objects.count() == 2
 
                 user_chunk = ControlImportChunk.objects.get(
                     model="sentry.user", min_ordinal=1, max_ordinal=1
@@ -2223,7 +2184,7 @@ class CollisionTests(ImportTestCase):
             with open(tmp_path, "rb") as tmp_file:
                 verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
-    @expect_models(COLLISION_TESTED, Email, User, UserEmail, UserPermission)
+    @expect_models(COLLISION_TESTED, User, UserEmail, UserPermission)
     def test_colliding_user_with_merging_disabled_in_config_scope(
         self, expected_models: list[type[Model]]
     ):
@@ -2246,7 +2207,6 @@ class CollisionTests(ImportTestCase):
                 assert UserEmail.objects.count() == 2
                 assert UserPermission.objects.count() == 2
                 assert Authenticator.objects.count() == 1  # Only imported in global scope
-                assert Email.objects.count() == 2
 
                 user_chunk = ControlImportChunk.objects.get(
                     model="sentry.user", min_ordinal=1, max_ordinal=1

--- a/tests/sentry/backup/test_validate.py
+++ b/tests/sentry/backup/test_validate.py
@@ -261,10 +261,10 @@ def test_auto_assign_email_obfuscating_comparator() -> None:
     email_left = orjson.loads(
         """
             {
-                "model": "sentry.email",
+                "model": "sentry.sentryapp",
                 "pk": 1,
                 "fields": {
-                    "email": "testing@example.com",
+                    "creator_label": "testing@example.com",
                     "date_added": "2023-06-22T00:00:00.000Z"
                 }
             }
@@ -273,10 +273,10 @@ def test_auto_assign_email_obfuscating_comparator() -> None:
     email_right = orjson.loads(
         """
             {
-                "model": "sentry.email",
+                "model": "sentry.sentryapp",
                 "pk": 1,
                 "fields": {
-                    "email": "foo@example.fake",
+                    "creator_label": "foo@example.fake",
                     "date_added": "2023-06-22T00:00:00.000Z"
                 }
             }
@@ -290,10 +290,10 @@ def test_auto_assign_email_obfuscating_comparator() -> None:
     assert len(findings) == 1
 
     assert findings[0].kind == ComparatorFindingKind.EmailObfuscatingComparator
-    assert findings[0].on == InstanceID("sentry.email", 1)
+    assert findings[0].on == InstanceID("sentry.sentryapp", 1)
     assert findings[0].left_pk == 1
     assert findings[0].right_pk == 1
-    assert """`email`""" in findings[0].reason
+    assert """`creator_label`""" in findings[0].reason
     assert """left value ("t...@...le.com")""" in findings[0].reason
     assert """right value ("f...@...e.fake")""" in findings[0].reason
 
@@ -476,64 +476,6 @@ def test_auto_assign_ignored_comparator() -> None:
     assert not findings
 
 
-def test_bad_missing_custom_ordinal() -> None:
-    left = orjson.loads(
-        """
-            [
-                {
-                    "model": "sentry.email",
-                    "pk": 1,
-                    "fields": {
-                        "email": "a@example.com",
-                        "date_added": "2023-06-22T00:00:00.000Z"
-                    }
-                },
-                {
-                    "model": "sentry.email",
-                    "pk": 2,
-                    "fields": {
-                        "email": "b@example.com",
-                        "date_added": "2023-06-22T00:00:00.000Z"
-                    }
-                }
-            ]
-        """
-    )
-    right = orjson.loads(
-        """
-            [
-                {
-                    "model": "sentry.email",
-                    "pk": 1,
-                    "fields": {
-                        "email": "c@example.com",
-                        "date_added": "2023-06-22T00:00:00.000Z"
-                    }
-                },
-                {
-                    "model": "sentry.email",
-                    "pk": 2,
-                    "fields": {
-                        "email": "a@example.com",
-                        "date_added": "2023-06-22T00:00:00.000Z"
-                    }
-                }
-            ]
-        """
-    )
-    out = validate(left, right)
-    findings = out.findings
-
-    assert len(findings) == 1
-
-    assert findings[0].kind == ComparatorFindingKind.EmailObfuscatingComparator
-    assert findings[0].on == InstanceID("sentry.email", 2)
-    assert findings[0].left_pk == 2
-    assert findings[0].right_pk == 1
-    assert "b...@...le.com" in findings[0].reason
-    assert "c...@...le.com" in findings[0].reason
-
-
 def test_bad_unequal_custom_ordinal() -> None:
     left = orjson.loads(
         """
@@ -682,22 +624,6 @@ def test_good_user_custom_ordinal() -> None:
                     }
                 },
                 {
-                    "model": "sentry.email",
-                    "pk": 1,
-                    "fields": {
-                        "email": "a@example.com",
-                        "date_added": "2023-06-22T00:00:00.000Z"
-                    }
-                },
-                {
-                    "model": "sentry.email",
-                    "pk": 2,
-                    "fields": {
-                        "email": "b@example.com",
-                        "date_added": "2023-06-22T00:00:00.000Z"
-                    }
-                },
-                {
                 "model": "sentry.useremail",
                     "pk": 56,
                     "fields": {
@@ -747,22 +673,6 @@ def test_good_user_custom_ordinal() -> None:
                         "username": "someuser",
                         "name": "",
                         "email": "a@example.com"
-                    }
-                },
-                {
-                    "model": "sentry.email",
-                    "pk": 1,
-                    "fields": {
-                        "email": "b@example.com",
-                        "date_added": "2023-06-22T00:00:00.000Z"
-                    }
-                },
-                {
-                    "model": "sentry.email",
-                    "pk": 2,
-                    "fields": {
-                        "email": "a@example.com",
-                        "date_added": "2023-06-22T00:00:00.000Z"
                     }
                 },
                 {


### PR DESCRIPTION
Redo of https://github.com/getsentry/sentry/pull/116226 which I reverted because it caused test failures on master that weren't caught by selective testing.

------

This model frequently blocks relocations for import/export differences,
and I'd like that to not happen anymore.

The Email model is populated by signals on create/delete operations to UserEmail it does not synchronize state on updates, and there are several older user accounts that are missing records in sentry_email that are present in sentry_useremail which cause relocations to fail.

By excluding this model from exports, these records won't participate in the validation checks and can't cause diffs. When the relocation is processed records will still be stored in sentry_email because of the aformentioned signals.