### PR TITLE
chore(issues): Remove redundant check on `event_id`

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -387,8 +387,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                     serialized_groups = serialize(
                         groups, request.user, serializer(), request=request
                     )
-                    if event_id:
-                        serialized_groups[0]["matchingEventId"] = event_id
+                    serialized_groups[0]["matchingEventId"] = event_id
                     response = Response(serialized_groups)
                     response["X-Sentry-Direct-Hit"] = "1"
                     return response


### PR DESCRIPTION
`event_id` is always defined in this branch, so removing this redundant check in `OrganizationGroupIndexEndpoint`.