### PR TITLE
fix(api-logs): preserve snuba policy info on throttles

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1351,7 +1351,8 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                                     quota_unit=policy_info["quota_unit"],
                                     storage_key=policy_info["storage_key"],
                                     quota_used=policy_info["quota_used"],
-                                    rejection_threshold=policy_info["rejection_threshold"],
+                                    # We won't have rejection_threshold for throttled_by errors
+                                    rejection_threshold=policy_info.get("rejection_threshold"),
                                 )
                         except KeyError:
                             logger.warning(

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -628,3 +628,41 @@ class SnubaQueryRateLimitTest(TestCase):
         assert (
             str(exc_info.value) == "Query on could not be run due to allocation policies, info: ..."
         )
+
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_rate_limit_error_handling_throttle_only(self, mock_snuba_query) -> None:
+        """
+        Test that policy metadata propagates when the 429 came from a throttle:
+        rejected_by is empty and throttled_by carries throttle_threshold, with no rejection_threshold
+        """
+        mock_response = mock.Mock(spec=HTTPResponse)
+        mock_response.status = 429
+        mock_response.data = json.dumps(
+            {
+                "error": {
+                    "message": "Query scanned more than the allocated amount of bytes",
+                },
+                "quota_allowance": {
+                    "summary": {
+                        "rejected_by": {},
+                        "throttled_by": {
+                            "policy": "BytesScannedRejectingPolicy",
+                            "quota_used": 1500000000000,
+                            "throttle_threshold": 1000000000000,
+                            "quota_unit": "bytes",
+                            "storage_key": "errors_ro",
+                        },
+                    }
+                },
+            }
+        ).encode()
+
+        mock_snuba_query.return_value = ("test_referrer", mock_response, lambda x: x, lambda x: x)
+
+        with pytest.raises(RateLimitExceeded) as exc_info:
+            _bulk_snuba_query([self.snuba_request])
+
+        assert exc_info.value.policy == "BytesScannedRejectingPolicy"
+        assert exc_info.value.storage_key == "errors_ro"
+        assert exc_info.value.quota_used == 1500000000000
+        assert exc_info.value.quota_unit == "bytes"


### PR DESCRIPTION
I'm noticing that several api access logs are missing snuba policy info, even though they show a rate limit category of 'snuba'. I believe this is because we (me 9 months ago) originally focused on only errors returned from snuba, writing this line `rejection_threshold=policy_info["rejection_threshold"],` assuming that `rejection_threshold` would be on every snuba error. However, throttling seems to be a big source of errors as well, and doesn't have that field, leading to us accidentally not attaching the policy info on throttled errors. Fix the error by using `.get` instead.

I chose this fix since I wanted to make the safest possible fix for now. We can look at putting 'throttled_by' in the rate limit error later.