### PR TITLE
feat(webhooks): Add dry run check to sentry app webhook path

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -94,4 +94,5 @@ class WebhookActionHandler(ActionHandler):
                     group_event=invocation.event_data.event,
                     sentry_app_slug=target_identifier,
                     rule_label=get_triggering_rule_name(invocation),
+                    organization=organization,
                 )

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import logging
 from typing import Any, TypedDict
 
+from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.models.options.project_option import ProjectOption
+from sentry.models.organization import Organization
 from sentry.models.rule import Rule
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.tasks.sentry_apps import send_alert_webhook_v2
@@ -90,16 +92,29 @@ def send_sentry_app_webhook(
     group_event: GroupEvent,
     sentry_app_slug: str | None,
     rule_label: str,
+    organization: Organization,
 ) -> None:
+    logging_context = {
+        "organization_id": organization.id,
+        "sentry_app_slug": sentry_app_slug,
+    }
+
     if not sentry_app_slug:
-        logger.warning("webhook_action_handler.missing_target_identifier")
+        logger.warning("webhook_action_handler.missing_target_identifier", extra=logging_context)
         return
 
     sentry_app = app_service.get_sentry_app_by_slug(slug=sentry_app_slug)
     if sentry_app is None:
         logger.warning(
             "webhook_action_handler.sentry_app_not_found",
-            extra={"sentry_app_slug": sentry_app_slug},
+            extra=logging_context,
+        )
+        return
+
+    if features.has("organizations:legacy-webhook-dry-run", organization):
+        logger.info(
+            "webhook_action_handler.sentry_app_dry_run",
+            extra=logging_context,
         )
         return
 

--- a/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
+++ b/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
@@ -195,7 +195,7 @@ class TestWebhookActionHandlerExecute(BaseWorkflowTest):
             notification_uuid=str(uuid.uuid4()),
             workflow_id=self.workflow.id,
         )
-        self.create_sentry_app(slug="my-app", organization=self.organization)
+        self.create_sentry_app(name="My App", organization=self.organization)
         self.create_sentry_app_installation(
             slug="my-app", organization=self.organization, user=self.user
         )

--- a/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
+++ b/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
@@ -9,6 +9,7 @@ from sentry.notifications.notification_action.action_handler_registry.webhook_ha
     WebhookActionHandler,
 )
 from sentry.plugins.base import plugins
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.utils import json
 from sentry.workflow_engine.models import Action
@@ -171,6 +172,37 @@ class TestWebhookActionHandlerExecute(BaseWorkflowTest):
         assert call_kwargs["sentry_app_slug"] == "my-app"
         assert "rule_label" in call_kwargs
         mock_legacy.assert_not_called()
+
+    @with_feature(
+        {
+            "organizations:legacy-webhook-new-path": True,
+            "organizations:legacy-webhook-disable-old-path": True,
+            "organizations:legacy-webhook-dry-run": True,
+        }
+    )
+    @mock.patch("sentry.sentry_apps.services.legacy_webhook.service.send_alert_webhook_v2")
+    def test_new_path_sentry_app_dry_run_does_not_send(
+        self, mock_send_alert: mock.MagicMock
+    ) -> None:
+        action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={"target_identifier": "my-app"},
+        )
+        invocation = ActionInvocation(
+            event_data=self.event_data,
+            action=action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
+        )
+        self.create_sentry_app(slug="my-app", organization=self.organization)
+        self.create_sentry_app_installation(
+            slug="my-app", organization=self.organization, user=self.user
+        )
+
+        WebhookActionHandler.execute(invocation)
+
+        mock_send_alert.delay.assert_not_called()
 
     @mock.patch(
         "sentry.notifications.notification_action.action_handler_registry.webhook_handler.send_sentry_app_webhook"

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
@@ -170,6 +170,7 @@ class TestSendSentryAppWebhook(BaseWorkflowTest):
                 group_event=self.group_event,
                 sentry_app_slug=self.sentry_app.slug,
                 rule_label="My Rule",
+                organization=self.organization,
             )
 
         assert safe_urlopen.called
@@ -206,10 +207,14 @@ class TestSendSentryAppWebhook(BaseWorkflowTest):
                 group_event=self.group_event,
                 sentry_app_slug="nonexistent-app",
                 rule_label="My Rule",
+                organization=self.organization,
             )
 
         mock_logger.warning.assert_called_once_with(
             "webhook_action_handler.sentry_app_not_found",
-            extra={"sentry_app_slug": "nonexistent-app"},
+            extra={
+                "organization_id": self.organization.id,
+                "sentry_app_slug": "nonexistent-app",
+            },
         )
         mock_task.delay.assert_not_called()


### PR DESCRIPTION
Add dry run flag check to sentry app webhook path too, so we don't double send when turning on dual write