### PR TITLE
fix(issues): Align collapsed activity row

### DIFF
--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {SentryAppAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -380,7 +380,6 @@ export function ActivitySection({
     item => !filterComments || item.type === GroupActivityType.NOTE
   );
   const inputVariant = variant === 'sidebar' ? 'compact' : 'full';
-  const useTwoColumnLayout = organization.features.includes('issue-activity-feed-v2');
 
   const renderActivityItem = (item: GroupActivity) => (
     <TimelineItem
@@ -441,8 +440,11 @@ export function ActivitySection({
           ) : (
             <Fragment>
               {filteredActivities.slice(0, 3).map(renderActivityItem)}
-              <ActivityTimelineItem
-                title={
+              <MoreActivityRow>
+                <MoreActivityIcon>
+                  <RotatedEllipsisIcon direction="up" />
+                </MoreActivityIcon>
+                <Container marginTop="xs" style={{whiteSpace: 'nowrap'}}>
                   <LinkButton
                     aria-label={t('View all activity')}
                     to={activityLink}
@@ -457,10 +459,8 @@ export function ActivitySection({
                   >
                     {t('View %s more', filteredActivities.length - 3)}
                   </LinkButton>
-                }
-                marker={useTwoColumnLayout ? <span /> : undefined}
-                icon={<RotatedEllipsisIcon direction="up" />}
-              />
+                </Container>
+              </MoreActivityRow>
             </Fragment>
           )}
         </Timeline.Container>
@@ -486,7 +486,39 @@ const Timestamp = styled(TimeSince)`
 `;
 
 const RotatedEllipsisIcon = styled(IconEllipsis)`
-  transform: rotate(90deg) translateY(1px);
+  position: relative;
+  left: 1px;
+  transform: rotate(90deg) translate(1px, 1px);
+`;
+
+const MoreActivityRow = styled('div')`
+  position: relative;
+  display: grid;
+  align-items: center;
+  grid-template-columns: 22px minmax(0, 1fr);
+  grid-column-gap: ${p => p.theme.space.md};
+  margin: ${p => p.theme.space.md} 0 0;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 10.5px;
+    top: 50%;
+    bottom: 0;
+    width: 1px;
+    background: ${p => p.theme.tokens.background.primary};
+  }
+`;
+
+const MoreActivityIcon = styled('div')`
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  min-height: 22px;
+  color: ${p => p.theme.tokens.content.secondary};
+  background: ${p => p.theme.tokens.background.primary};
 `;
 
 const NoteWrapper = styled('div')<{size: 'sm' | 'md'}>`

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -444,7 +444,7 @@ export function ActivitySection({
                 <MoreActivityIcon>
                   <RotatedEllipsisIcon direction="up" />
                 </MoreActivityIcon>
-                <Container marginTop="xs" style={{whiteSpace: 'nowrap'}}>
+                <Container marginTop="xs">
                   <LinkButton
                     aria-label={t('View all activity')}
                     to={activityLink}

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -103,7 +103,9 @@ export function StreamlinedSidebar({group, event, project}: Props) {
               <ExternalIssueSidebarList group={group} event={event} project={project} />
             </ErrorBoundary>
           )}
-          <ActivitySection group={group} />
+          <ErrorBoundary mini>
+            <ActivitySection group={group} />
+          </ErrorBoundary>
           {showPeopleSection && (
             <PeopleSection
               userParticipants={userParticipants}


### PR DESCRIPTION
instead of attempting to overrides the styles of a timeline item render a custom timeline component. It was never really a timeline item. Adds missing error boundary to sidebar.

before

<img width="312" height="151" alt="image" src="https://github.com/user-attachments/assets/1e3c5a55-0b49-4295-8311-f92dad965f7a" />


after

<img width="335" height="127" alt="image" src="https://github.com/user-attachments/assets/765977b8-d9ad-47dd-823e-87b65c30bb6d" />
