### PR TITLE
fix(preprod): Reduce snapshot download concurrency to prevent stream failures

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_download.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_download.py
@@ -40,8 +40,8 @@ from sentry.utils.zip import is_unsafe_path
 
 logger = logging.getLogger(__name__)
 
-FETCH_MAX_WORKERS = 32
-FETCH_BATCH_SIZE = 200
+FETCH_MAX_WORKERS = 16
+FETCH_BATCH_SIZE = 100
 BATCH_TIMEOUT = 300
 
 


### PR DESCRIPTION
Reduce `FETCH_MAX_WORKERS` from 32 → 16 and `FETCH_BATCH_SIZE` from 200 → 100 in the snapshot image download endpoint.

Large snapshots (~40K images) cause the streaming download to fail after ~15 seconds with an HTTP/2 `INTERNAL_ERROR`. The server-side logs show:
- 2.37 GB yielded at ~157 MB/s throughput
- 906 MB RSS (well past the 600 MB `reload_on_rss` threshold)
- Only 3,947 / ~40,000 images delivered before `client_disconnect`
- 0 fetch failures — the objectstore reads are fine, the transport layer is the bottleneck

The high concurrency causes Python memory fragmentation (32 threads churning through ~600 KB images) that pushes RSS past container limits, and the throughput overwhelms HTTP/2 flow control. Halving both constants reduces memory pressure and data rate while keeping each batch well within the 90s proxy timeout.