### PR TITLE
fix(replays): Shrink timeline hover timestamp

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineTooltip.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineTooltip.tsx
@@ -81,7 +81,7 @@ export function TimelineTooltip({container}: Props) {
 
 const CursorLabel = styled(Overlay)`
   position: absolute;
-  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
+  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.sm};
   pointer-events: none;
   white-space: nowrap;
   z-index: 1000;

--- a/static/app/components/replays/breadcrumbs/replayTimelineTooltip.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineTooltip.tsx
@@ -61,7 +61,7 @@ export function TimelineTooltip({container}: Props) {
         transform: 'translateX(10px)',
       }}
     >
-      <Text size="xs" tabular style={{fontWeight: 'normal'}}>
+      <Text size="sm" tabular style={{fontWeight: 'normal'}}>
         {timestampType === 'absolute'
           ? getFormattedDate(
               startTimestamp + (lastHoverTime ?? 0),
@@ -81,7 +81,7 @@ export function TimelineTooltip({container}: Props) {
 
 const CursorLabel = styled(Overlay)`
   position: absolute;
-  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
   pointer-events: none;
   white-space: nowrap;
   z-index: 1000;

--- a/static/app/components/replays/breadcrumbs/replayTimelineTooltip.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineTooltip.tsx
@@ -56,12 +56,12 @@ export function TimelineTooltip({container}: Props) {
     <CursorLabel
       ref={labelRef}
       style={{
-        display: lastHoverTime ? 'block' : 'none',
+        display: lastHoverTime === undefined ? 'none' : 'block',
         left: toPercent(divide(lastHoverTime ?? 0, durationMs)),
         transform: 'translateX(10px)',
       }}
     >
-      <Text size="sm" tabular style={{fontWeight: 'normal'}}>
+      <Text size="xs" tabular style={{fontWeight: 'normal'}}>
         {timestampType === 'absolute'
           ? getFormattedDate(
               startTimestamp + (lastHoverTime ?? 0),
@@ -81,7 +81,7 @@ export function TimelineTooltip({container}: Props) {
 
 const CursorLabel = styled(Overlay)`
   position: absolute;
-  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
   pointer-events: none;
   white-space: nowrap;
   z-index: 1000;


### PR DESCRIPTION
The replay scrubber hover timestamp was tall enough to trigger page overflow in the details layout.

before

<img width="350" height="86" alt="image" src="https://github.com/user-attachments/assets/23b3ef15-b2df-4bbb-90c9-bb52e8020a32" />

after

<img width="275" height="76" alt="image" src="https://github.com/user-attachments/assets/8e245a06-0a5c-4b83-bad3-83897752f0fc" />
