### PR TITLE
fix(conversations): Restore side-by-side layout for platform option dropdown

### DIFF
--- a/static/app/views/explore/conversations/onboarding.tsx
+++ b/static/app/views/explore/conversations/onboarding.tsx
@@ -377,7 +377,9 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
     <ConversationOnboardingPanel project={project}>
       <SetupTitle project={project} />
       <Stack gap="md">
-        <PlatformOptionDropdown platformOptions={integrationOptions} />
+        <Flex gap="md" align="center" wrap="wrap">
+          <PlatformOptionDropdown platformOptions={integrationOptions} />
+        </Flex>
         {introduction && <Prose>{introduction}</Prose>}
         <GuidedSteps
           key={selectedIntegration}


### PR DESCRIPTION
Restore the inline `with <SDK>` layout on the conversations onboarding panel.

In #116082 the `<Flex gap="md" align="center" wrap="wrap" paddingBottom="md">` wrapper around `PlatformOptionDropdown` was replaced by a `<Stack gap="md">` that now wraps the dropdown, the introduction, and the guided steps together. `PlatformOptionDropdown` returns a Fragment containing the `"with"` text node and the `OptionControl` dropdown(s) as siblings — so the Stack hoisted them as separate vertical items and the label ended up above the selector.

Wrap just the dropdown row in a `<Flex gap="md" align="center" wrap="wrap">` inside the Stack. The Stack's own `gap="md"` already handles spacing to the next row, so the previous `paddingBottom="md"` is no longer needed.

Refs GH-116082