### PR TITLE
fix(ui): Add inset focus ring to SimpleTable header cells

### DIFF
--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -165,6 +165,10 @@ const ColumnHeaderCell = styled('div')<{isSorted?: boolean}>`
   gap: ${p => p.theme.space.md};
   height: 100%;
 
+  &:focus-visible {
+    box-shadow: inset 0 0 0 2px ${p => p.theme.tokens.focus.default};
+  }
+
   &:first-child {
     ${HeaderDivider} {
       display: none;


### PR DESCRIPTION
Sortable header cells in `SimpleTable` now show a visible focus ring when navigated via keyboard. The ring uses an inset `box-shadow` so it isn't clipped by the Panel's `overflow: hidden` and border.

before:

https://github.com/user-attachments/assets/a0f87102-dee4-4231-ad59-c23cf8121a61

after:

https://github.com/user-attachments/assets/62a74372-e18a-4b76-b275-48b119daa23c

