### PR TITLE
ref(monitors): Port incident occurrences consumer to taskbroker raw mode

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -914,6 +914,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.issues.escalating.forecasts",
     "sentry.middleware.integrations.tasks",
     "sentry.models.counter",
+    "sentry.monitors.consumers.incident_occurrences_consumer",
     "sentry.monitors.tasks.clock_pulse",
     "sentry.monitors.tasks.detect_broken_monitor_envs",
     "sentry.notifications.platform.service",

--- a/src/sentry/monitors/consumers/incident_occurrences_consumer.py
+++ b/src/sentry/monitors/consumers/incident_occurrences_consumer.py
@@ -16,12 +16,16 @@ from cachetools.func import ttl_cache
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.monitors_incident_occurrences_v1 import IncidentOccurrence
 from sentry_sdk.tracing import Span, Transaction
+from taskbroker_client.retry import Retry
 
 from sentry import options
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.monitors.logic.incident_occurrence import send_incident_occurrence
 from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorIncident
 from sentry.monitors.system_incidents import TickAnomalyDecision, get_clock_tick_decision
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import ingest_monitors_incident_occurrences_raw_tasks
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -29,6 +33,12 @@ logger = logging.getLogger(__name__)
 MONITORS_INCIDENT_OCCURRENCES: Codec[IncidentOccurrence] = get_topic_codec(
     Topic.MONITORS_INCIDENT_OCCURRENCES
 )
+
+
+class PendingTickDecision(Exception):
+    """Raised when the tick decision is still pending and we need to retry."""
+
+    pass
 
 
 @ttl_cache(ttl=5)
@@ -41,17 +51,14 @@ def memoized_tick_decision(tick: datetime) -> TickAnomalyDecision | None:
     return get_clock_tick_decision(tick)
 
 
-def _process_incident_occurrence(
-    message: Message[KafkaPayload | FilteredPayload], txn: Transaction | Span
-) -> None:
+def _process_incident_occurrence(message_bytes: bytes, txn: Transaction | Span) -> None:
     """
     Process a incident occurrence message. This will immediately dispatch an
     issue occurrence via send_incident_occurrence.
-    """
-    assert not isinstance(message.payload, FilteredPayload)
-    assert isinstance(message.value, BrokerValue)
 
-    wrapper: IncidentOccurrence = MONITORS_INCIDENT_OCCURRENCES.decode(message.payload.value)
+    Raises PendingTickDecision if the tick decision is pending and processing should be delayed.
+    """
+    wrapper: IncidentOccurrence = MONITORS_INCIDENT_OCCURRENCES.decode(message_bytes)
     clock_tick = datetime.fromtimestamp(wrapper["clock_tick_ts"], UTC)
 
     # May be used as a killswitch if system incident decisions become incorrect
@@ -65,16 +72,13 @@ def _process_incident_occurrence(
         # incident occurrence, or if we should drop the occurrence and mark the
         # associated check-ins as UNKNOWN due to a system incident.
         txn.set_tag("result", "delayed")
-
-        # XXX(epurkhiser): MessageRejected tells arroyo that we can't process
-        # this message right now and it should try again
-        raise MessageRejected()
+        raise PendingTickDecision()
 
     try:
         incident = MonitorIncident.objects.get(id=int(wrapper["incident_id"]))
     except MonitorIncident.DoesNotExist:
         logger.exception("missing_incident")
-        return None
+        return
 
     # previous_checkin_ids includes the failed_checkin_id
     checkins = MonitorCheckIn.objects.filter(id__in=wrapper["previous_checkin_ids"])
@@ -89,7 +93,7 @@ def _process_incident_occurrence(
     # Unlikely, but if we can't find all the check-ins we can't produce an occurrence
     if failed_checkin is None or not has_all(previous_checkins):
         logger.error("missing_check_ins")
-        return None
+        return
 
     received = datetime.fromtimestamp(wrapper["received_ts"], UTC)
 
@@ -115,7 +119,7 @@ def _process_incident_occurrence(
         # Do NOT send the occurrence
         txn.set_tag("result", "dropped")
         metrics.incr("monitors.incident_ocurrences.dropped_incident_occurrence")
-        return None
+        return
 
     try:
         send_incident_occurrence(failed_checkin, previous_checkins, incident, received)
@@ -126,11 +130,35 @@ def _process_incident_occurrence(
 
 
 def process_incident_occurrence(message: Message[KafkaPayload | FilteredPayload]) -> None:
+    assert not isinstance(message.payload, FilteredPayload)
+    assert isinstance(message.value, BrokerValue)
+
     with sentry_sdk.start_transaction(
         op="_process_incident_occurrence",
         name="monitors.incident_occurrence_consumer",
     ) as txn:
-        _process_incident_occurrence(message, txn)
+        try:
+            _process_incident_occurrence(message.payload.value, txn)
+        except PendingTickDecision:
+            # XXX(epurkhiser): MessageRejected tells arroyo that we can't process
+            # this message right now and it should try again
+            raise MessageRejected()
+
+
+@instrumented_task(
+    name="sentry.monitors.consumers.incident_occurrences_consumer.process_incident_occurrence_from_kafka",
+    namespace=ingest_monitors_incident_occurrences_raw_tasks,
+    processing_deadline_duration=60,
+    retry=Retry(times=10, delay=5, on=(PendingTickDecision,)),
+    silo_mode=SiloMode.CELL,
+)
+def process_incident_occurrence_from_kafka(message_bytes: bytes) -> None:
+    """Process an incident occurrence from raw Kafka message bytes (taskbroker raw mode)."""
+    with sentry_sdk.start_transaction(
+        op="_process_incident_occurrence",
+        name="monitors.incident_occurrence_consumer",
+    ) as txn:
+        _process_incident_occurrence(message_bytes, txn)
 
 
 class MonitorIncidentOccurenceStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -38,6 +38,11 @@ crons_tasks = app.taskregistry.create_namespace(
     app_feature="crons",
 )
 
+ingest_monitors_incident_occurrences_raw_tasks = app.taskregistry.create_namespace(
+    "ingest.monitors.incident_occurrences.raw",
+    app_feature="crons",
+)
+
 deletion_tasks = app.taskregistry.create_namespace(
     "deletions",
     processing_deadline_duration=60 * 20,

--- a/tests/sentry/monitors/consumers/test_incident_occurrence_consumer.py
+++ b/tests/sentry/monitors/consumers/test_incident_occurrence_consumer.py
@@ -11,6 +11,8 @@ from sentry_kafka_schemas.schema_types.monitors_incident_occurrences_v1 import I
 from sentry.monitors.consumers.incident_occurrences_consumer import (
     MONITORS_INCIDENT_OCCURRENCES,
     MonitorIncidentOccurenceStrategyFactory,
+    PendingTickDecision,
+    process_incident_occurrence_from_kafka,
 )
 from sentry.monitors.models import (
     CheckInStatus,
@@ -211,5 +213,86 @@ class MonitorsIncidentOccurrenceConsumerTestCase(TestCase):
         assert mock_send_incident_occurrence.call_count == 0
 
         # The failed check-in is updated as UNKNOWN
+        self.failed_checkin.refresh_from_db()
+        assert self.failed_checkin.status == CheckInStatus.UNKNOWN
+
+    @mock.patch("sentry.monitors.consumers.incident_occurrences_consumer.send_incident_occurrence")
+    def test_taskbroker_task_simple(self, mock_send_incident_occurrence: mock.MagicMock) -> None:
+        """Test the taskbroker passthrough task processes messages correctly."""
+        ts = timezone.now().replace(second=0, microsecond=0)
+
+        message: IncidentOccurrence = {
+            "clock_tick_ts": int(ts.timestamp()),
+            "received_ts": int(self.failed_checkin.date_added.timestamp()),
+            "incident_id": self.incident.id,
+            "failed_checkin_id": self.failed_checkin.id,
+            "previous_checkin_ids": [self.failed_checkin.id],
+        }
+
+        message_bytes = MONITORS_INCIDENT_OCCURRENCES.encode(message)
+        process_incident_occurrence_from_kafka(message_bytes)
+
+        assert mock_send_incident_occurrence.call_count == 1
+        assert mock_send_incident_occurrence.mock_calls[0] == mock.call(
+            self.failed_checkin,
+            [self.failed_checkin],
+            self.incident,
+            self.failed_checkin.date_added.replace(microsecond=0),
+        )
+
+    @mock.patch("sentry.monitors.consumers.incident_occurrences_consumer.send_incident_occurrence")
+    @mock.patch("sentry.monitors.consumers.incident_occurrences_consumer.memoized_tick_decision")
+    @override_options({"crons.system_incidents.use_decisions": True})
+    def test_taskbroker_task_pending_decision_raises(
+        self,
+        mock_memoized_tick_decision,
+        mock_send_incident_occurrence,
+    ):
+        """Test the taskbroker task raises PendingTickDecision for retry when decision is pending."""
+        mock_memoized_tick_decision.return_value = TickAnomalyDecision.ABNORMAL
+
+        ts = timezone.now().replace(second=0, microsecond=0)
+
+        message: IncidentOccurrence = {
+            "clock_tick_ts": int(ts.timestamp()),
+            "received_ts": int(self.failed_checkin.date_added.timestamp()),
+            "incident_id": self.incident.id,
+            "failed_checkin_id": self.failed_checkin.id,
+            "previous_checkin_ids": [self.failed_checkin.id],
+        }
+
+        message_bytes = MONITORS_INCIDENT_OCCURRENCES.encode(message)
+
+        with pytest.raises(PendingTickDecision):
+            process_incident_occurrence_from_kafka(message_bytes)
+
+        assert mock_send_incident_occurrence.call_count == 0
+
+    @mock.patch("sentry.monitors.consumers.incident_occurrences_consumer.send_incident_occurrence")
+    @mock.patch("sentry.monitors.consumers.incident_occurrences_consumer.memoized_tick_decision")
+    @override_options({"crons.system_incidents.use_decisions": True})
+    def test_taskbroker_task_incident_decision(
+        self,
+        mock_memoized_tick_decision,
+        mock_send_incident_occurrence,
+    ):
+        """Test the taskbroker task handles INCIDENT decision by updating check-in status."""
+        mock_memoized_tick_decision.return_value = TickAnomalyDecision.INCIDENT
+
+        ts = timezone.now().replace(second=0, microsecond=0)
+
+        message: IncidentOccurrence = {
+            "clock_tick_ts": int(ts.timestamp()),
+            "received_ts": int(self.failed_checkin.date_added.timestamp()),
+            "incident_id": self.incident.id,
+            "failed_checkin_id": self.failed_checkin.id,
+            "previous_checkin_ids": [self.failed_checkin.id],
+        }
+
+        message_bytes = MONITORS_INCIDENT_OCCURRENCES.encode(message)
+        process_incident_occurrence_from_kafka(message_bytes)
+
+        assert mock_send_incident_occurrence.call_count == 0
+
         self.failed_checkin.refresh_from_db()
         assert self.failed_checkin.status == CheckInStatus.UNKNOWN


### PR DESCRIPTION
Port monitors incident occurrences consumer to taskbroker raw mode.

This would allow this consumer to be replaced with taskbroker, meaning that we can consolidate infrastructure and autoscale more easily. This task currently does 1 msg/s in prod, so it seemed like a good candidate.

The only thing i'm unclear on is the backpressure. We can emulate backpressure using retries but 1) retries are bounded 2) it's not particularly efficient to do so. The consumer doesn't seem to have actual ordering requirements.

ref STREAM-1017