### PR TITLE
ref(assemble): Validate debug ids on assemble endpoint

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -446,7 +446,7 @@ def parse_assemble_request_payload(body: bytes) -> AssembleRequestPayload:
                 "required": ["name", "chunks"],
                 "properties": {
                     "name": {"type": "string"},
-                    "debug_id": {"type": "string"},
+                    "debug_id": {"type": "string", "pattern": "^[A-Fa-f0-9-]+$"},
                     "chunks": {
                         "type": "array",
                         "items": {"type": "string", "pattern": "^[0-9a-f]{40}$"},

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -63,6 +63,24 @@ class DifAssembleEndpoint(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data[checksum]["state"] == ChunkFileState.NOT_FOUND
 
+    def test_assemble_rejects_invalid_debug_id(self) -> None:
+        checksum = sha1(b"1").hexdigest()
+
+        response = self.client.post(
+            self.url,
+            data={
+                checksum: {
+                    "name": "dif",
+                    "debug_id": "invalid-debug-id",
+                    "chunks": [],
+                }
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+
+        assert response.status_code == 400, response.content
+        assert response.data["error"] == "'invalid-debug-id' does not match '^[A-Fa-f0-9-]+$'"
+
     def test_assemble_check(self) -> None:
         content = b"foo bar"
         fileobj = ContentFile(content)


### PR DESCRIPTION
Validate debug ids in the endpoint. Ideally followed up with a change to the db model after.

This is a slightly less strict variation of [`DebugId`](https://docs.rs/debugid/latest/debugid/struct.DebugId.html), but strict enough to catch most invalid and all problematic data.