### PR TITLE
style(conversations): add right padding to conversation copy button

### DIFF
--- a/static/app/components/events/autofix/v3/header.tsx
+++ b/static/app/components/events/autofix/v3/header.tsx
@@ -34,7 +34,7 @@ export function SeerDrawerHeader({
           <Text>{t('Seer Autofix')}</Text>
           {tooltip && <InfoTip title={tooltip} size="xs" />}
         </Flex>
-        <Flex align="center" gap="xs">
+        <Flex align="center" gap="xs" style={{paddingRight: 4}}>
           <Button
             size="xs"
             icon={<IconRefresh />}

--- a/static/app/components/events/autofix/v3/header.tsx
+++ b/static/app/components/events/autofix/v3/header.tsx
@@ -34,7 +34,7 @@ export function SeerDrawerHeader({
           <Text>{t('Seer Autofix')}</Text>
           {tooltip && <InfoTip title={tooltip} size="xs" />}
         </Flex>
-        <Flex align="center" gap="xs" style={{paddingRight: 4}}>
+        <Flex align="center" gap="xs">
           <Button
             size="xs"
             icon={<IconRefresh />}

--- a/static/app/views/explore/conversations/components/conversationView.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.tsx
@@ -133,6 +133,7 @@ function ConversationView({
               flexShrink={0}
               align="center"
               gap="sm"
+              paddingRight="sm"
               borderBottom="primary"
               background="primary"
             >


### PR DESCRIPTION
Add a small amount of right padding (4px) to the copy-as-markdown button in the conversation detail header so it doesn't sit flush against the edge.