### PR TITLE
ref(metrics): Metric detail action menu tweaks

### DIFF
--- a/static/app/components/events/metrics/metricsDrawer.tsx
+++ b/static/app/components/events/metrics/metricsDrawer.tsx
@@ -64,7 +64,7 @@ export function MetricsDrawer({event, project, group}: MetricsIssueDrawerProps) 
       </EventNavigator>
       <EventDrawerBody ref={containerRef}>
         <div>
-          <MetricsSamplesTable embedded />
+          <MetricsSamplesTable source="issueDetails" />
         </div>
       </EventDrawerBody>
     </EventDrawerContainer>

--- a/static/app/components/events/metrics/metricsSection.tsx
+++ b/static/app/components/events/metrics/metricsSection.tsx
@@ -147,7 +147,10 @@ function MetricsSectionContent({
   return (
     <FoldSection sectionKey={SectionKey.METRICS} title={t('Application Metrics')}>
       <Flex direction="column" gap="xl">
-        <MetricsSamplesTable embedded overrideTableData={abbreviatedTableData} />
+        <MetricsSamplesTable
+          source="issueDetails"
+          overrideTableData={abbreviatedTableData}
+        />
         {result.data && result.data.length > NUMBER_ABBREVIATED_METRICS ? (
           <div>
             <Button

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -222,6 +222,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
               isAggregate={
                 Boolean(func) || (isVisualizeEquation(visualize) && isEquation(field))
               }
+              source="metricsPage"
               sort={direction}
               handleSortClick={canSort ? updateSort : undefined}
             >
@@ -255,6 +256,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
                     key={j}
                     isAggregate={Boolean(parseFunction(field))}
                     offset={j === 0 ? firstColumnOffset : undefined}
+                    source="metricsPage"
                   >
                     <FieldRenderer
                       column={displayColumns.find(column => column.key === field)}

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -5,6 +5,10 @@ import {TabPanels} from '@sentry/scraps/tabs';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {TopResultsIndicator} from 'sentry/views/discover/table/topResultsIndicator';
 import {DetailsWrapper} from 'sentry/views/explore/logs/styles';
+import {
+  isEmbeddedMetricsSamplesTableSource,
+  type MetricsSamplesTableSource,
+} from 'sentry/views/explore/metrics/types';
 import {StyledPanel} from 'sentry/views/explore/tables/tracesTable/styles';
 
 export const TabListWrapper = styled('div')`
@@ -41,34 +45,60 @@ export const WrappingText = styled('div')`
   align-items: center;
 `;
 
-export const ExpandedRowContainer = styled('div')<{embedded?: boolean}>`
+export const ExpandedRowContainer = styled('div')`
   grid-column: 1 / -1;
 `;
 
 export const StyledSimpleTableRowCell = styled(SimpleTable.RowCell)<{
-  embedded?: boolean;
+  source: MetricsSamplesTableSource;
   noPadding?: boolean;
 }>`
-  padding: ${p => (p.noPadding ? 0 : p.embedded ? p.theme.space.xl : p.theme.space.lg)};
+  padding: ${p =>
+    p.noPadding
+      ? 0
+      : isEmbeddedMetricsSamplesTableSource(p.source)
+        ? p.theme.space.xl
+        : p.theme.space.lg};
   padding-top: ${p =>
-    p.noPadding ? 0 : p.embedded ? p.theme.space.sm : p.theme.space.xs};
+    p.noPadding
+      ? 0
+      : isEmbeddedMetricsSamplesTableSource(p.source)
+        ? p.theme.space.sm
+        : p.theme.space.xs};
   padding-bottom: ${p =>
-    p.noPadding ? 0 : p.embedded ? p.theme.space.sm : p.theme.space.xs};
+    p.noPadding
+      ? 0
+      : isEmbeddedMetricsSamplesTableSource(p.source)
+        ? p.theme.space.sm
+        : p.theme.space.xs};
 
   font-size: ${p => p.theme.font.size.sm};
 `;
 
 export const StyledSimpleTableHeaderCell = styled(SimpleTable.HeaderCell)<{
-  embedded?: boolean;
+  source: MetricsSamplesTableSource;
   noPadding?: boolean;
 }>`
   font-size: ${p => p.theme.font.size.sm};
   white-space: nowrap;
-  padding: ${p => (p.noPadding ? 0 : p.embedded ? p.theme.space.xl : p.theme.space.lg)};
+  padding: ${p =>
+    p.noPadding
+      ? 0
+      : isEmbeddedMetricsSamplesTableSource(p.source)
+        ? p.theme.space.xl
+        : p.theme.space.lg};
   padding-top: ${p =>
-    p.noPadding ? 0 : p.embedded ? p.theme.space.sm : p.theme.space.xs};
+    p.noPadding
+      ? 0
+      : isEmbeddedMetricsSamplesTableSource(p.source)
+        ? p.theme.space.sm
+        : p.theme.space.xs};
   padding-bottom: ${p =>
-    p.noPadding ? 0 : p.embedded ? p.theme.space.sm : p.theme.space.xs};
+    p.noPadding
+      ? 0
+      : isEmbeddedMetricsSamplesTableSource(p.source)
+        ? p.theme.space.sm
+        : p.theme.space.xs};
 `;
 
 export const StyledSimpleTableBody = styled('div')`

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTable.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTable.tsx
@@ -22,6 +22,9 @@ import {MetricsSamplesTableHeader} from 'sentry/views/explore/metrics/metricInfo
 import {SampleTableRow} from 'sentry/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
+  DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
+  isEmbeddedMetricsSamplesTableSource,
+  type MetricsSamplesTableSource,
   TraceMetricKnownFieldKey,
   type TraceMetricEventsResponseItem,
 } from 'sentry/views/explore/metrics/types';
@@ -33,19 +36,22 @@ const EMBEDDED_RESULT_LIMIT = 100;
 const TWO_MINUTE_DELAY = 120;
 
 interface MetricsSamplesTableProps {
-  embedded?: boolean;
   isMetricOptionsEmpty?: boolean;
   overrideTableData?: TraceMetricEventsResponseItem[];
+  source?: MetricsSamplesTableSource;
   traceMetric?: TraceMetric;
 }
 
 export function MetricsSamplesTable({
   traceMetric,
-  embedded = false,
+  source = DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
   isMetricOptionsEmpty,
   overrideTableData,
 }: MetricsSamplesTableProps) {
-  const columns = embedded ? TraceSamplesTableEmbeddedColumns : TraceSamplesTableColumns;
+  const isEmbedded = isEmbeddedMetricsSamplesTableSource(source);
+  const columns = isEmbedded
+    ? TraceSamplesTableEmbeddedColumns
+    : TraceSamplesTableColumns;
   const fields = getTraceSamplesTableFields(columns);
 
   const {
@@ -54,8 +60,10 @@ export function MetricsSamplesTable({
     error,
     isFetching,
   } = useMetricSamplesTable({
-    disabled: embedded ? !!overrideTableData : !traceMetric?.name || isMetricOptionsEmpty,
-    limit: embedded ? EMBEDDED_RESULT_LIMIT : RESULT_LIMIT,
+    disabled: isEmbedded
+      ? !!overrideTableData
+      : !traceMetric?.name || isMetricOptionsEmpty,
+    limit: isEmbedded ? EMBEDDED_RESULT_LIMIT : RESULT_LIMIT,
     traceMetric,
     fields,
     ingestionDelaySeconds: TWO_MINUTE_DELAY,
@@ -78,9 +86,9 @@ export function MetricsSamplesTable({
   }, [meta, traceMetric?.unit]);
 
   return (
-    <SimpleTableGrid embedded={embedded}>
+    <SimpleTableGrid source={source}>
       {isFetching && <TransparentLoadingMask />}
-      <MetricsSamplesTableHeader columns={columns} embedded={embedded} />
+      <MetricsSamplesTableHeader columns={columns} source={source} />
       <StyledSimpleTableBody>
         {!overrideTableData?.length && error ? (
           <SimpleTable.Empty style={{minHeight: '140px'}}>
@@ -93,7 +101,7 @@ export function MetricsSamplesTable({
               row={row}
               columns={columns}
               meta={metaWithValueUnit}
-              embedded={embedded}
+              source={source}
             />
           ))
         ) : isFetching ? (
@@ -111,10 +119,10 @@ export function MetricsSamplesTable({
 }
 
 const SimpleTableGrid = styled(StyledSimpleTable)<{
-  embedded: boolean;
+  source: MetricsSamplesTableSource;
 }>`
   grid-template-columns: ${p =>
-    p.embedded
+    isEmbeddedMetricsSamplesTableSource(p.source)
       ? `${p.theme.space['3xl']} min-content min-content minmax(0, 1fr) min-content min-content`
       : `${p.theme.space['3xl']} min-content minmax(0, 1fr) min-content min-content`};
   grid-column: 1 / -1;

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
@@ -9,6 +9,9 @@ import {
   StyledSimpleTableHeaderCell,
 } from 'sentry/views/explore/metrics/metricInfoTabs/metricInfoTabStyles';
 import {
+  DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
+  isEmbeddedMetricsSamplesTableSource,
+  type MetricsSamplesTableSource,
   SORTABLE_SAMPLE_COLUMNS,
   TraceMetricKnownFieldKey,
   VirtualTableSampleColumnKey,
@@ -22,12 +25,12 @@ import {
 
 interface MetricsSamplesTableHeaderProps {
   columns: SampleTableColumnKey[];
-  embedded?: boolean;
+  source?: MetricsSamplesTableSource;
 }
 
 export function MetricsSamplesTableHeader({
   columns,
-  embedded,
+  source = DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
 }: MetricsSamplesTableHeaderProps) {
   const sorts = useQueryParamsSortBys();
   const setSorts = useSetQueryParamsSortBys();
@@ -44,7 +47,7 @@ export function MetricsSamplesTableHeader({
             index={i}
             sort={sorts.find(s => s.field === field)?.kind}
             setSorts={setSorts}
-            embedded={embedded}
+            source={source}
           >
             {label}
           </FieldHeaderCellWrapper>
@@ -60,19 +63,20 @@ function FieldHeaderCellWrapper({
   index,
   sort,
   setSorts,
-  embedded = false,
+  source = DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
 }: {
   children: ReactNode;
   field: SampleTableColumnKey;
   index: number;
   setSorts: (sorts: Sort[]) => void;
-  embedded?: boolean;
   sort?: 'asc' | 'desc';
+  source?: MetricsSamplesTableSource;
 }) {
   const columnType = getMetricTableColumnType(field);
   const label = getFieldLabel(field);
   const hasPadding = field !== VirtualTableSampleColumnKey.EXPAND_ROW;
-  const canSort = !embedded && SORTABLE_SAMPLE_COLUMNS.has(field);
+  const canSort =
+    !isEmbeddedMetricsSamplesTableSource(source) && SORTABLE_SAMPLE_COLUMNS.has(field);
 
   function handleSortClick() {
     const kind = sort === 'desc' ? 'asc' : 'desc';
@@ -89,7 +93,7 @@ function FieldHeaderCellWrapper({
           justifyContent: 'flex-end',
           paddingRight: 'calc(12px + 15px)', // 12px is the padding of the cell, 15px is the width of the scrollbar.
         }}
-        embedded={embedded}
+        source={source}
       >
         <Tooltip showOnlyOnOverflow title={label}>
           {children}
@@ -104,7 +108,7 @@ function FieldHeaderCellWrapper({
       sort={sort}
       handleSortClick={canSort ? handleSortClick : undefined}
       noPadding={!hasPadding}
-      embedded={embedded}
+      source={source}
     >
       <Tooltip showOnlyOnOverflow title={label}>
         {children}

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
@@ -36,8 +36,11 @@ import {StyledTimestampWrapper} from 'sentry/views/explore/metrics/metricInfoTab
 import {stripMetricParamsFromLocation} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
 import {
+  DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
+  isEmbeddedMetricsSamplesTableSource,
   TraceMetricKnownFieldKey,
   VirtualTableSampleColumnKey,
+  type MetricsSamplesTableSource,
   type SampleTableColumnKey,
   type TraceMetricEventsResponseItem,
 } from 'sentry/views/explore/metrics/types';
@@ -52,19 +55,22 @@ const VALUE_COLUMN_MIN_WIDTH = '50px';
 const EXPLORE_SIMILAR_SPANS_REFERRER = 'trace-metrics-samples-table-similar-spans';
 
 const getExtraMenuItems = ({
-  embedded,
   field,
   organization,
   row,
   selection,
+  source,
 }: {
-  embedded: boolean;
   field: SampleTableColumnKey;
   organization: Organization;
   row: TraceMetricEventsResponseItem;
   selection: PageFilters;
+  source: MetricsSamplesTableSource;
 }): MenuItemProps[] | undefined => {
-  if (!embedded || field !== TraceMetricKnownFieldKey.METRIC_NAME) {
+  if (
+    !isEmbeddedMetricsSamplesTableSource(source) ||
+    field !== TraceMetricKnownFieldKey.METRIC_NAME
+  ) {
     return undefined;
   }
 
@@ -114,8 +120,8 @@ interface SampleTableRowProps {
   columns: SampleTableColumnKey[];
   meta: EventsMetaType;
   row: TraceMetricEventsResponseItem;
-  embedded?: boolean;
   ref?: (element: HTMLElement | null) => void;
+  source?: MetricsSamplesTableSource;
 }
 
 function FieldCellWrapper({
@@ -123,13 +129,13 @@ function FieldCellWrapper({
   row,
   children,
   index,
-  embedded = false,
+  source = DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
 }: {
   children: ReactNode;
   field: SampleTableColumnKey;
   index: number;
   row: TraceMetricEventsResponseItem;
-  embedded?: boolean;
+  source?: MetricsSamplesTableSource;
 }) {
   const columnType = getMetricTableColumnType(field);
   const hasPadding = field !== VirtualTableSampleColumnKey.EXPAND_ROW;
@@ -138,7 +144,7 @@ function FieldCellWrapper({
       <NumericSimpleTableRowCell
         key={index}
         style={{minWidth: VALUE_COLUMN_MIN_WIDTH}}
-        embedded={embedded}
+        source={source}
       >
         <Tooltip showOnlyOnOverflow title={row[TraceMetricKnownFieldKey.METRIC_VALUE]}>
           {children}
@@ -147,7 +153,7 @@ function FieldCellWrapper({
     );
   }
   return (
-    <StyledSimpleTableRowCell key={index} embedded={embedded} noPadding={!hasPadding}>
+    <StyledSimpleTableRowCell key={index} source={source} noPadding={!hasPadding}>
       {children}
     </StyledSimpleTableRowCell>
   );
@@ -157,7 +163,7 @@ export function SampleTableRow({
   row,
   columns,
   meta,
-  embedded = false,
+  source = DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
   ref,
 }: SampleTableRowProps) {
   const organization = useOrganization();
@@ -169,6 +175,7 @@ export function SampleTableRow({
   const projectId = row[TraceMetricKnownFieldKey.PROJECT_ID];
   const project = projects.projects.find(p => p.id === '' + projectId);
   const projectSlug = project?.slug ?? '';
+  const isEmbedded = isEmbeddedMetricsSamplesTableSource(source);
 
   const traceId = row[TraceMetricKnownFieldKey.TRACE];
 
@@ -178,7 +185,7 @@ export function SampleTableRow({
         icon={<IconChevron size="xs" direction={isExpanded ? 'down' : 'right'} />}
         aria-label={t('Toggle trace details')}
         aria-expanded={isExpanded}
-        size={embedded ? 'zero' : 'sm'}
+        size={isEmbedded ? 'zero' : 'sm'}
         variant="transparent"
         onClick={() => setIsExpanded(!isExpanded)}
       />
@@ -255,11 +262,11 @@ export function SampleTableRow({
         unit={meta?.units?.[field]}
         meta={meta}
         extraMenuItems={getExtraMenuItems({
-          embedded,
           field,
           organization,
           row,
           selection,
+          source,
         })}
       />
     );
@@ -302,13 +309,7 @@ export function SampleTableRow({
           const cellContent = renderFieldCell(field);
 
           return (
-            <FieldCellWrapper
-              key={i}
-              field={field}
-              index={i}
-              row={row}
-              embedded={embedded}
-            >
+            <FieldCellWrapper key={i} field={field} index={i} row={row} source={source}>
               {isValueColumn ? (
                 <Tooltip
                   showOnlyOnOverflow
@@ -325,7 +326,11 @@ export function SampleTableRow({
       </StickyTableRow>
       {isExpanded && (
         <ExpandedRowContainer>
-          <MetricDetails dataRow={row} ref={measureRef} showTelemetry={!embedded} />
+          <MetricDetails
+            dataRow={row}
+            ref={measureRef}
+            showTelemetry={source === 'metricsPage'}
+          />
         </ExpandedRowContainer>
       )}
     </TableRowContainer>

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
@@ -67,10 +67,7 @@ const getExtraMenuItems = ({
   selection: PageFilters;
   source: MetricsSamplesTableSource;
 }): MenuItemProps[] | undefined => {
-  if (
-    !isEmbeddedMetricsSamplesTableSource(source) ||
-    field !== TraceMetricKnownFieldKey.METRIC_NAME
-  ) {
+  if (source !== 'traceWaterfall' || field !== TraceMetricKnownFieldKey.METRIC_NAME) {
     return undefined;
   }
 

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
@@ -21,8 +21,11 @@ import {FieldValueType} from 'sentry/utils/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {Actions} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
+import {ALLOWED_CELL_ACTIONS} from 'sentry/views/explore/components/table';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {DEFAULT_YAXIS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
 import {MetricDetails} from 'sentry/views/explore/metrics/metricInfoTabs/metricDetails';
 import {
   ExpandedRowContainer,
@@ -33,7 +36,11 @@ import {
   WrappingText,
 } from 'sentry/views/explore/metrics/metricInfoTabs/metricInfoTabStyles';
 import {StyledTimestampWrapper} from 'sentry/views/explore/metrics/metricInfoTabs/styles';
-import {stripMetricParamsFromLocation} from 'sentry/views/explore/metrics/metricQuery';
+import {
+  defaultAggregateSortBys,
+  defaultMetricQuery,
+  stripMetricParamsFromLocation,
+} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
 import {
   DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
@@ -44,7 +51,12 @@ import {
   type SampleTableColumnKey,
   type TraceMetricEventsResponseItem,
 } from 'sentry/views/explore/metrics/types';
-import {getMetricTableColumnType} from 'sentry/views/explore/metrics/utils';
+import {
+  getMetricTableColumnType,
+  getMetricsUrl,
+  makeMetricsAggregate,
+} from 'sentry/views/explore/metrics/utils';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {FieldRenderer} from 'sentry/views/explore/tables/fieldRenderer';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
@@ -52,7 +64,17 @@ import {TraceLayoutTabKeys} from 'sentry/views/performance/newTraceDetails/useTr
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
 const VALUE_COLUMN_MIN_WIDTH = '50px';
-const EXPLORE_SIMILAR_SPANS_REFERRER = 'trace-metrics-samples-table-similar-spans';
+const VIEW_CONNECTED_TRACES_REFERRER = 'trace-metrics-samples-table-connected-traces';
+const OPEN_IN_EXPLORE_REFERRER = 'trace-metrics-samples-table-open-in-explore';
+const ISSUE_DETAILS_CELL_ACTIONS = ALLOWED_CELL_ACTIONS.filter(
+  action =>
+    ![
+      Actions.ADD,
+      Actions.EXCLUDE,
+      Actions.SHOW_GREATER_THAN,
+      Actions.SHOW_LESS_THAN,
+    ].includes(action)
+);
 
 const getExtraMenuItems = ({
   field,
@@ -67,7 +89,10 @@ const getExtraMenuItems = ({
   selection: PageFilters;
   source: MetricsSamplesTableSource;
 }): MenuItemProps[] | undefined => {
-  if (source !== 'traceWaterfall' || field !== TraceMetricKnownFieldKey.METRIC_NAME) {
+  if (
+    !isEmbeddedMetricsSamplesTableSource(source) ||
+    field !== TraceMetricKnownFieldKey.METRIC_NAME
+  ) {
     return undefined;
   }
 
@@ -83,15 +108,23 @@ const getExtraMenuItems = ({
     type: metricType,
     unit: metricUnit?.length > 0 ? metricUnit : undefined,
   };
+  const aggregateFields = [
+    new VisualizeFunction(
+      makeMetricsAggregate({
+        aggregate: DEFAULT_YAXIS_BY_TYPE[metric.type] ?? 'sum',
+        traceMetric: metric,
+      })
+    ),
+  ];
 
   return [
     {
-      key: 'explore-similar-spans',
-      label: t('Explore similar spans'),
+      key: 'view-connected-traces',
+      label: t('View connected traces'),
       to: getExploreUrl({
         organization,
         mode: Mode.SAMPLES,
-        referrer: EXPLORE_SIMILAR_SPANS_REFERRER,
+        referrer: VIEW_CONNECTED_TRACES_REFERRER,
         selection: {
           ...selection,
           datetime: {
@@ -106,6 +139,24 @@ const getExtraMenuItems = ({
             type: 'metrics',
             query: '',
             metric,
+          },
+        ],
+      }),
+    },
+    {
+      key: 'open-in-explore',
+      label: t('Open in Explore'),
+      to: getMetricsUrl({
+        organization,
+        referrer: OPEN_IN_EXPLORE_REFERRER,
+        selection,
+        metricQueries: [
+          {
+            metric,
+            queryParams: defaultMetricQuery().queryParams.replace({
+              aggregateFields,
+              aggregateSortBys: defaultAggregateSortBys(aggregateFields),
+            }),
           },
         ],
       }),
@@ -240,6 +291,7 @@ export function SampleTableRow({
     // instead of converting it with a duration assumption. The renderer
     // still picks up the correct formatter via meta.fields/meta.units.
     const isMetricValue = field === TraceMetricKnownFieldKey.METRIC_VALUE;
+    const shouldRemoveAddFilter = source === 'issueDetails';
     const discoverColumn: TableColumn<keyof TableDataRow> = {
       column: {
         field,
@@ -265,6 +317,7 @@ export function SampleTableRow({
           selection,
           source,
         })}
+        allowActions={shouldRemoveAddFilter ? ISSUE_DETAILS_CELL_ACTIONS : undefined}
       />
     );
   };

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -257,11 +257,11 @@ describe('MetricPanel', () => {
     expect(screen.getAllByText(/ago$/).length).toBeGreaterThan(0);
   });
 
-  it('links embedded metric names to span samples with a metrics cross-event query', async () => {
+  it('links trace waterfall metric names to span samples with a metrics cross-event query', async () => {
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
     const row = metricFixtures.detailedFixtures[0]!;
 
-    render(<MetricsSamplesTable embedded overrideTableData={[row]} />, {
+    render(<MetricsSamplesTable source="traceWaterfall" overrideTableData={[row]} />, {
       organization,
       additionalWrapper: createWrapper({queryParams, traceMetric}),
     });
@@ -310,7 +310,7 @@ describe('MetricPanel', () => {
     ]);
   });
 
-  it('does not add the similar spans action to non-embedded samples', async () => {
+  it('does not add the similar spans action to metrics page samples', async () => {
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
 
     render(
@@ -325,6 +325,27 @@ describe('MetricPanel', () => {
     expect(screen.queryByText('Explore similar spans')).not.toBeInTheDocument();
   });
 
+  it('does not add the similar spans action to issue details samples', async () => {
+    const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
+    const row = metricFixtures.detailedFixtures[0]!;
+
+    render(<MetricsSamplesTable source="issueDetails" overrideTableData={[row]} />, {
+      organization,
+      additionalWrapper: createWrapper({queryParams, traceMetric}),
+    });
+
+    const samplesTable = await screen.findByRole('table');
+    const metricNameCell = within(samplesTable)
+      .getByText(row[TraceMetricKnownFieldKey.METRIC_NAME])
+      .closest('[role="cell"]')!;
+    await userEvent.click(
+      within(metricNameCell as HTMLElement).getByRole('button', {name: 'Actions'})
+    );
+
+    expect(await screen.findByText('Copy to clipboard')).toBeInTheDocument();
+    expect(screen.queryByText('Explore similar spans')).not.toBeInTheDocument();
+  });
+
   it('does not add the similar spans action without a complete metric identity', async () => {
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
     const row = {
@@ -332,7 +353,7 @@ describe('MetricPanel', () => {
       [TraceMetricKnownFieldKey.METRIC_TYPE]: '',
     } as TraceMetricEventsResponseItem;
 
-    render(<MetricsSamplesTable embedded overrideTableData={[row]} />, {
+    render(<MetricsSamplesTable source="traceWaterfall" overrideTableData={[row]} />, {
       organization,
       additionalWrapper: createWrapper({queryParams, traceMetric}),
     });

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -257,7 +257,7 @@ describe('MetricPanel', () => {
     expect(screen.getAllByText(/ago$/).length).toBeGreaterThan(0);
   });
 
-  it('links trace waterfall metric names to span samples with a metrics cross-event query', async () => {
+  it('adds trace waterfall metric-name actions for connected traces and explore', async () => {
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
     const row = metricFixtures.detailedFixtures[0]!;
 
@@ -274,7 +274,7 @@ describe('MetricPanel', () => {
       within(metricNameCell as HTMLElement).getByRole('button', {name: 'Actions'})
     );
 
-    const link = (await screen.findByText('Explore similar spans')).closest('a')!;
+    const link = (await screen.findByText('View connected traces')).closest('a')!;
     for (const label of ['Copy to clipboard', 'Add to filter', 'Exclude from filter']) {
       const menuItem = await screen.findByText(label);
       expect(menuItem.compareDocumentPosition(link)).toBe(
@@ -292,7 +292,7 @@ describe('MetricPanel', () => {
       expect.objectContaining({
         mode: 'samples',
         project: project.id,
-        referrer: 'trace-metrics-samples-table-similar-spans',
+        referrer: 'trace-metrics-samples-table-connected-traces',
         statsPeriod: '24h',
       })
     );
@@ -308,9 +308,37 @@ describe('MetricPanel', () => {
         },
       },
     ]);
+
+    const openInExploreLink = (await screen.findByText('Open in Explore')).closest('a')!;
+    const openInExploreHref = openInExploreLink.getAttribute('href')!;
+    expect(
+      openInExploreHref.startsWith(
+        `/organizations/${organization.slug}/explore/metrics/?`
+      )
+    ).toBe(true);
+
+    const openInExploreQuery = qs.parse(openInExploreHref.split('?')[1]!);
+    expect(openInExploreQuery).toEqual(
+      expect.objectContaining({
+        project: project.id,
+        referrer: 'trace-metrics-samples-table-open-in-explore',
+      })
+    );
+    const aggregate = `sum(value,${row[TraceMetricKnownFieldKey.METRIC_NAME]},${row[TraceMetricKnownFieldKey.METRIC_TYPE]},${row[TraceMetricKnownFieldKey.METRIC_UNIT]})`;
+    expect(JSON.parse(openInExploreQuery.metric as string)).toEqual(
+      expect.objectContaining({
+        metric: {
+          name: row[TraceMetricKnownFieldKey.METRIC_NAME],
+          type: row[TraceMetricKnownFieldKey.METRIC_TYPE],
+          unit: row[TraceMetricKnownFieldKey.METRIC_UNIT],
+        },
+        aggregateFields: [{yAxes: [aggregate]}],
+        aggregateSortBys: [{field: aggregate, kind: 'desc'}],
+      })
+    );
   });
 
-  it('does not add the similar spans action to metrics page samples', async () => {
+  it('does not add embedded metric-name actions to metrics page samples', async () => {
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
 
     render(
@@ -322,10 +350,11 @@ describe('MetricPanel', () => {
     await userEvent.click(within(samplesTable).getByRole('button', {name: 'Actions'}));
 
     expect(await screen.findByText('Copy to clipboard')).toBeInTheDocument();
-    expect(screen.queryByText('Explore similar spans')).not.toBeInTheDocument();
+    expect(screen.queryByText('View connected traces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Open in Explore')).not.toBeInTheDocument();
   });
 
-  it('does not add the similar spans action to issue details samples', async () => {
+  it('adds issue details metric-name actions without add filter', async () => {
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
     const row = metricFixtures.detailedFixtures[0]!;
 
@@ -343,10 +372,13 @@ describe('MetricPanel', () => {
     );
 
     expect(await screen.findByText('Copy to clipboard')).toBeInTheDocument();
-    expect(screen.queryByText('Explore similar spans')).not.toBeInTheDocument();
+    expect(await screen.findByText('View connected traces')).toBeInTheDocument();
+    expect(await screen.findByText('Open in Explore')).toBeInTheDocument();
+    expect(screen.queryByText('Add to filter')).not.toBeInTheDocument();
+    expect(screen.queryByText('Exclude from filter')).not.toBeInTheDocument();
   });
 
-  it('does not add the similar spans action without a complete metric identity', async () => {
+  it('does not add embedded metric-name actions without a complete metric identity', async () => {
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
     const row = {
       ...metricFixtures.detailedFixtures[0]!,
@@ -367,7 +399,8 @@ describe('MetricPanel', () => {
     );
 
     expect(await screen.findByText('Copy to clipboard')).toBeInTheDocument();
-    expect(screen.queryByText('Explore similar spans')).not.toBeInTheDocument();
+    expect(screen.queryByText('View connected traces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Open in Explore')).not.toBeInTheDocument();
   });
 
   it('fetches trace meta for expanded samples with the row timestamp', async () => {

--- a/static/app/views/explore/metrics/types.tsx
+++ b/static/app/views/explore/metrics/types.tsx
@@ -120,6 +120,15 @@ export enum VirtualTableSampleColumnKey {
 
 export type SampleTableColumnKey = TraceMetricFieldKey | VirtualTableSampleColumnKey;
 
+export type MetricsSamplesTableSource = 'metricsPage' | 'traceWaterfall' | 'issueDetails';
+
+export const DEFAULT_METRICS_SAMPLES_TABLE_SOURCE: MetricsSamplesTableSource =
+  'metricsPage';
+
+export function isEmbeddedMetricsSamplesTableSource(source: MetricsSamplesTableSource) {
+  return source !== 'metricsPage';
+}
+
 export const SORTABLE_SAMPLE_COLUMNS = new Set<SampleTableColumnKey>([
   TraceMetricKnownFieldKey.METRIC_VALUE,
   TraceMetricKnownFieldKey.TIMESTAMP,

--- a/static/app/views/performance/newTraceDetails/traceMetrics.tsx
+++ b/static/app/views/performance/newTraceDetails/traceMetrics.tsx
@@ -110,7 +110,7 @@ function MetricsSectionContent() {
         onSearch={query => setMetricsQuery(query)}
       />
       <TableContainer>
-        <MetricsSamplesTable embedded />
+        <MetricsSamplesTable source="traceWaterfall" />
       </TableContainer>
     </Fragment>
   );


### PR DESCRIPTION
This PR refactors how the metric samples table renders based off of different sources. For the metrics page nothing has changed, however:

* Issue Detail & Trace Waterfall:
  * Rename view similar spans, to "View connected traces".
  * Add an "open in explore" button, which is just a shortcut to explore with that metric series open.
* Issue Details:
  *  Remove the add filter behavior

Closes LOGS-826

**Examples:**

**Trace Waterfall:**
<img width="438" height="201" alt="Screenshot 2026-05-27 at 10 34 12" src="https://github.com/user-attachments/assets/cf02923c-475e-43b6-9a52-4b998e2f9eef" />

**Issue Detail:**
<img width="489" height="165" alt="Screenshot 2026-05-27 at 10 34 46" src="https://github.com/user-attachments/assets/9d3c28a3-8dda-4f67-b38d-bc55eda13420" />