### PR TITLE
feat(bitbucket-server): Add frontend pipeline steps for Bitbucket Server integration setup

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationBitbucketServer.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationBitbucketServer.spec.tsx
@@ -1,0 +1,168 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {bitbucketServerIntegrationPipeline} from './pipelineIntegrationBitbucketServer';
+import {createMakeStepProps, dispatchPipelineMessage, setupMockPopup} from './testUtils';
+
+const InstallationConfigStep = bitbucketServerIntegrationPipeline.steps[0].component;
+const OAuthCallbackStep = bitbucketServerIntegrationPipeline.steps[1].component;
+
+const makeStepProps = createMakeStepProps({totalSteps: 2});
+
+let mockPopup: Window;
+
+beforeEach(() => {
+  mockPopup = setupMockPopup();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function fillRequiredConfigFields() {
+  await userEvent.type(
+    screen.getByRole('textbox', {name: 'Bitbucket URL'}),
+    'https://bitbucket.example.com'
+  );
+  await userEvent.type(
+    screen.getByRole('textbox', {name: 'Bitbucket Consumer Key'}),
+    'sentry-bot'
+  );
+  await userEvent.type(
+    screen.getByRole('textbox', {name: 'Bitbucket Consumer Private Key'}),
+    '-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----'
+  );
+}
+
+describe('Bitbucket Server InstallationConfigStep', () => {
+  it('renders the config form fields', () => {
+    render(<InstallationConfigStep {...makeStepProps({stepData: {}})} />);
+
+    expect(screen.getByRole('textbox', {name: 'Bitbucket URL'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', {name: 'Bitbucket Consumer Key'})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', {name: 'Bitbucket Consumer Private Key'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
+  });
+
+  it('calls advance with form data on submit', async () => {
+    const advance = jest.fn();
+    render(<InstallationConfigStep {...makeStepProps({stepData: {}, advance})} />);
+
+    await fillRequiredConfigFields();
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({
+        url: 'https://bitbucket.example.com',
+        consumerKey: 'sentry-bot',
+        privateKey: '-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----',
+        verifySsl: true,
+      });
+    });
+  });
+
+  it('strips trailing slashes from the URL', async () => {
+    const advance = jest.fn();
+    render(<InstallationConfigStep {...makeStepProps({stepData: {}, advance})} />);
+
+    await fillRequiredConfigFields();
+    await userEvent.clear(screen.getByRole('textbox', {name: 'Bitbucket URL'}));
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Bitbucket URL'}),
+      'https://bitbucket.example.com///'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith(
+        expect.objectContaining({url: 'https://bitbucket.example.com'})
+      );
+    });
+  });
+
+  it('shows busy state when isAdvancing', () => {
+    render(
+      <InstallationConfigStep {...makeStepProps({stepData: {}, isAdvancing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+  });
+});
+
+describe('Bitbucket Server OAuthCallbackStep', () => {
+  const oauthUrl =
+    'https://bitbucket.example.com/plugins/servlet/oauth/authorize?oauth_token=req-token';
+
+  it('renders the authorize button', () => {
+    render(<OAuthCallbackStep {...makeStepProps({stepData: {oauthUrl}})} />);
+
+    expect(
+      screen.getByRole('button', {name: 'Authorize Bitbucket Server'})
+    ).toBeInTheDocument();
+  });
+
+  it('opens the popup and advances with oauthToken on callback', async () => {
+    const advance = jest.fn();
+    render(<OAuthCallbackStep {...makeStepProps({stepData: {oauthUrl}, advance})} />);
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Authorize Bitbucket Server'})
+    );
+
+    expect(window.open).toHaveBeenCalledWith(
+      oauthUrl,
+      'pipeline_popup',
+      expect.any(String)
+    );
+
+    dispatchPipelineMessage({
+      source: mockPopup,
+      data: {
+        _pipeline_source: 'sentry-pipeline',
+        oauth_token: 'callback-token',
+      },
+    });
+
+    expect(advance).toHaveBeenCalledWith({oauthToken: 'callback-token'});
+  });
+
+  it('disables the authorize button when oauthUrl is missing', () => {
+    render(<OAuthCallbackStep {...makeStepProps({stepData: {}})} />);
+
+    expect(
+      screen.getByRole('button', {name: 'Authorize Bitbucket Server'})
+    ).toBeDisabled();
+  });
+
+  it('shows popup-blocked notice when window.open returns null', async () => {
+    jest.spyOn(window, 'open').mockReturnValue(null);
+
+    render(<OAuthCallbackStep {...makeStepProps({stepData: {oauthUrl}})} />);
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Authorize Bitbucket Server'})
+    );
+
+    expect(
+      screen.getByText(
+        'The authorization popup was blocked by your browser. Please ensure popups are allowed and try again.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('shows busy state when isAdvancing', () => {
+    render(
+      <OAuthCallbackStep {...makeStepProps({stepData: {oauthUrl}, isAdvancing: true})} />
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Authorize Bitbucket Server'})
+    ).toHaveAttribute('aria-busy', 'true');
+  });
+});

--- a/static/app/components/pipeline/pipelineIntegrationBitbucketServer.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationBitbucketServer.tsx
@@ -1,0 +1,235 @@
+import {useCallback, useEffect} from 'react';
+import {z} from 'zod';
+
+import {Button} from '@sentry/scraps/button';
+import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {t, tct} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import {useRedirectPopupStep} from './shared/useRedirectPopupStep';
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+const installationConfigSchema = z.object({
+  url: z
+    .string()
+    .min(1, t('Bitbucket URL is required'))
+    .url(t('Enter a valid URL'))
+    .transform(v => v.replace(/\/+$/, '')),
+  consumerKey: z
+    .string()
+    .min(1, t('Consumer Key is required'))
+    .max(200, t('Consumer Key is limited to 200 characters')),
+  privateKey: z.string().min(1, t('Private Key is required')),
+  verifySsl: z.boolean(),
+});
+
+interface InstallationConfigAdvanceData {
+  consumerKey: string;
+  privateKey: string;
+  url: string;
+  verifySsl: boolean;
+}
+
+function InstallationConfigStep({
+  advance,
+  advanceError,
+  isAdvancing,
+  isInitializing,
+}: PipelineStepProps<Record<string, never>, InstallationConfigAdvanceData>) {
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      url: '',
+      consumerKey: '',
+      privateKey: '',
+      verifySsl: true,
+    },
+    validators: {onDynamic: installationConfigSchema},
+    onSubmit: ({value}) => {
+      advance(installationConfigSchema.parse(value));
+    },
+  });
+
+  useEffect(() => {
+    if (advanceError) {
+      setFieldErrors(form, advanceError);
+    }
+  }, [advanceError, form]);
+
+  return (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        <Text>
+          {tct(
+            'Create an Application Link on your Bitbucket Server instance for Sentry, then enter the consumer credentials below. Refer to the [link:documentation] for setup instructions.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/organization/integrations/source-code-mgmt/bitbucket-server/" />
+              ),
+            }
+          )}
+        </Text>
+
+        <form.AppField name="url">
+          {field => (
+            <field.Layout.Stack
+              label={t('Bitbucket URL')}
+              hintText={t(
+                'The base URL for your Bitbucket Server instance, including the host and protocol.'
+              )}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="https://bitbucket.example.com"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="consumerKey">
+          {field => (
+            <field.Layout.Stack
+              label={t('Bitbucket Consumer Key')}
+              hintText={t('The consumer key configured on the Application Link.')}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="sentry-consumer-key"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="privateKey">
+          {field => (
+            <field.Layout.Stack
+              label={t('Bitbucket Consumer Private Key')}
+              hintText={t('The RSA private key paired with the Application Link.')}
+              required
+            >
+              <field.TextArea
+                value={field.state.value}
+                onChange={field.handleChange}
+                rows={3}
+                placeholder={
+                  '-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----'
+                }
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="verifySsl">
+          {field => (
+            <field.Layout.Stack
+              label={t('Verify SSL')}
+              hintText={t(
+                'Verify SSL certificates when making requests to your Bitbucket instance.'
+              )}
+            >
+              <field.Switch checked={field.state.value} onChange={field.handleChange} />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <Flex>
+          <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
+            {t('Continue')}
+          </form.SubmitButton>
+        </Flex>
+      </Stack>
+    </form.AppForm>
+  );
+}
+
+interface OAuthStepData {
+  oauthUrl?: string;
+}
+
+function OAuthCallbackStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<OAuthStepData, {oauthToken: string}>) {
+  const handleCallback = useCallback(
+    (data: Record<string, string>) => {
+      if (data.oauth_token) {
+        advance({oauthToken: data.oauth_token});
+      }
+    },
+    [advance]
+  );
+
+  const {openPopup, isWaitingForCallback, popupStatus} = useRedirectPopupStep({
+    redirectUrl: stepData?.oauthUrl,
+    onCallback: handleCallback,
+  });
+
+  return (
+    <Stack gap="lg" align="start">
+      <Stack gap="sm">
+        <Text>
+          {t(
+            'Authorize Sentry on your Bitbucket Server instance to complete the integration setup.'
+          )}
+        </Text>
+        {isWaitingForCallback && (
+          <Text variant="muted" size="sm">
+            {t('A popup should have opened to authorize with Bitbucket Server.')}
+          </Text>
+        )}
+        {popupStatus === 'failed-to-open' && (
+          <Text variant="danger" size="sm">
+            {t(
+              'The authorization popup was blocked by your browser. Please ensure popups are allowed and try again.'
+            )}
+          </Text>
+        )}
+      </Stack>
+      {isWaitingForCallback && !isAdvancing ? (
+        <Button size="sm" onClick={openPopup}>
+          {t('Reopen authorization window')}
+        </Button>
+      ) : (
+        <Button
+          size="sm"
+          variant="primary"
+          onClick={openPopup}
+          busy={isAdvancing}
+          disabled={!stepData?.oauthUrl}
+        >
+          {t('Authorize Bitbucket Server')}
+        </Button>
+      )}
+    </Stack>
+  );
+}
+
+export const bitbucketServerIntegrationPipeline = {
+  type: 'integration',
+  provider: 'bitbucket_server',
+  actionTitle: t('Installing Bitbucket Server Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'installation_config',
+      shortDescription: t('Configuring Bitbucket Server connection'),
+      component: InstallationConfigStep,
+    },
+    {
+      stepId: 'oauth_callback',
+      shortDescription: t('Authorizing via OAuth'),
+      component: OAuthCallbackStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -1,6 +1,7 @@
 import {dummyIntegrationPipeline} from './pipelineDummyProvider';
 import {awsLambdaIntegrationPipeline} from './pipelineIntegrationAwsLambda';
 import {bitbucketIntegrationPipeline} from './pipelineIntegrationBitbucket';
+import {bitbucketServerIntegrationPipeline} from './pipelineIntegrationBitbucketServer';
 import {claudeCodeIntegrationPipeline} from './pipelineIntegrationClaudeCode';
 import {cursorIntegrationPipeline} from './pipelineIntegrationCursor';
 import {discordIntegrationPipeline} from './pipelineIntegrationDiscord';
@@ -23,6 +24,7 @@ import {vstsIntegrationPipeline} from './pipelineIntegrationVsts';
 export const PIPELINE_REGISTRY = [
   awsLambdaIntegrationPipeline,
   bitbucketIntegrationPipeline,
+  bitbucketServerIntegrationPipeline,
   claudeCodeIntegrationPipeline,
   cursorIntegrationPipeline,
   discordIntegrationPipeline,


### PR DESCRIPTION
Register Bitbucket Server in the pipeline registry with two steps: an installation config form (URL, consumer key, RSA private key, SSL toggle) and a popup-based OAuth 1.0a authorization step using `useRedirectPopupStep`. Unlike OAuth 2.0 providers, the Bitbucket Server callback returns an `oauth_token` (used as the verifier), which the frontend relays to the backend as `oauthToken`.

Ref [VDY-99](https://linear.app/getsentry/issue/VDY-99/bitbucket-server-api-driven-integration-setup)
