### PR TITLE
feat(utils): Add shuffle option to CursoredScheduler

### DIFF
--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import logging
 import math
+import random
 import time
 from collections.abc import Callable
 from datetime import timedelta
@@ -136,6 +137,7 @@ class CursoredScheduler[M: Model]:
         cycle_duration: timedelta,
         lock_duration: int = DEFAULT_LOCK_DURATION_SECONDS,
         validate_item: Callable[[int], bool] | None = None,
+        shuffle: bool = False,
     ):
         self.name = name
         self.schedule_key = schedule_key
@@ -151,6 +153,7 @@ class CursoredScheduler[M: Model]:
         self.cache_ttl = int(cycle_duration.total_seconds() * 2)
         self.lock_duration = lock_duration
         self.validate_item = validate_item
+        self.shuffle = shuffle
         self._metric_tags = {"scheduler": name}
 
     @property
@@ -232,6 +235,9 @@ class CursoredScheduler[M: Model]:
         init_start = time.time()
 
         all_pks = list(self.queryset.order_by("pk").values_list("pk", flat=True))
+
+        if self.shuffle:
+            random.shuffle(all_pks)
 
         client = self._get_redis_client()
 

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -447,6 +447,48 @@ class CursoredSchedulerTest(TestCase):
         scheduler.tick()
         assert self.mock_task.delay.call_count == 10
 
+    def test_shuffle_randomizes_pk_order(self):
+        """When shuffle=True, PKs are not in ascending order."""
+        ois = self._create_org_integrations(30)
+        sorted_pks = [oi.pk for oi in ois]
+
+        scheduler = CursoredScheduler(
+            name="test_scheduler",
+            schedule_key="test-scheduler-beat",
+            queryset=OrganizationIntegration.objects.filter(
+                integration__provider="github",
+                status=ObjectStatus.ACTIVE,
+            ),
+            task=self.mock_task,
+            cycle_duration=timedelta(minutes=3),
+            shuffle=True,
+        )
+
+        # Complete entire cycle to collect all dispatched PKs
+        all_dispatched = []
+        while scheduler.tick():
+            all_dispatched.extend(c.args[0] for c in self.mock_task.delay.call_args_list)
+            self.mock_task.reset_mock()
+        all_dispatched.extend(c.args[0] for c in self.mock_task.delay.call_args_list)
+
+        assert set(all_dispatched) == set(sorted_pks)
+        assert all_dispatched != sorted_pks
+
+    def test_shuffle_false_preserves_pk_order(self):
+        """When shuffle=False (default), PKs are in ascending PK order."""
+        ois = self._create_org_integrations(30)
+        sorted_pks = [oi.pk for oi in ois]
+
+        scheduler = self._make_scheduler()
+
+        all_dispatched = []
+        while scheduler.tick():
+            all_dispatched.extend(c.args[0] for c in self.mock_task.delay.call_args_list)
+            self.mock_task.reset_mock()
+        all_dispatched.extend(c.args[0] for c in self.mock_task.delay.call_args_list)
+
+        assert all_dispatched == sorted_pks
+
     def test_interval_decrease_halves_batch_size(self):
         """When tick interval is halved, batch size is halved for remaining items."""
         self._create_org_integrations(30)

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -465,7 +465,7 @@ class CursoredSchedulerTest(TestCase):
         )
 
         # Complete entire cycle to collect all dispatched PKs
-        all_dispatched = []
+        all_dispatched: list[int] = []
         while scheduler.tick():
             all_dispatched.extend(c.args[0] for c in self.mock_task.delay.call_args_list)
             self.mock_task.reset_mock()
@@ -481,7 +481,7 @@ class CursoredSchedulerTest(TestCase):
 
         scheduler = self._make_scheduler()
 
-        all_dispatched = []
+        all_dispatched: list[int] = []
         while scheduler.tick():
             all_dispatched.extend(c.args[0] for c in self.mock_task.delay.call_args_list)
             self.mock_task.reset_mock()


### PR DESCRIPTION
Add a `shuffle` parameter to `CursoredScheduler` that randomizes the PK
processing order at cycle start. Defaults to `False` for backward compatibility.

The CursoredScheduler currently always processes items in ascending PK order.
When items have varying processing yield, this creates a deterministic pattern of peaks and
dips that repeats every cycle. Shuffling distributes high-yield items randomly
across the cycle, smoothing throughput over time.