### PR TITLE
ref(replays): Remove control-silo URL pattern for removed data export endpoint

### DIFF
--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -167,7 +167,6 @@ export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^api/0/api-tokens/[^/]+/$'),
   new RegExp('^api/0/authenticators/$'),
   new RegExp('^api/0/accept-invite/[^/]+/[^/]+/[^/]+/$'),
-  new RegExp('^api/0/data-export/notifications/google-cloud/$'),
   new RegExp('^api/0/notification-defaults/$'),
   new RegExp('^api/0/sentry-apps-stats/$'),
   new RegExp('^api/0/doc-integrations/$'),


### PR DESCRIPTION
## Summary

- Removes the control-silo URL pattern entry for `/api/0/data-export/notifications/google-cloud/` from `static/app/data/controlsiloUrlPatterns.ts`.
- Follow-up to #116232, which removes the backend endpoint itself.

## Notes

- `static/app/utils/api/knownSentryApiUrls.generated.ts` still lists the URL on line 33. That file is auto-generated by `python3 -m tools.api_urls_to_typescript` and its header explicitly notes that it is safe to deploy alongside backend changes — it will be cleaned up the next time the generator runs against a backend that no longer registers the route.
- Frontend-only by design, per the repo's split-deploy rule (frontend and backend are not atomically deployed). Can land in any order relative to #116232.

Refs REPLAY-920
Refs VULN-1598