### PR TITLE
test(eap): Query typed-colon attribute as boolean instead of number

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5016,8 +5016,8 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
 
         response = self.do_request(
             {
-                "field": ["tags[flag.evaluation.feature.organizations:foo,number]"],
-                "query": "has:tags[flag.evaluation.feature.organizations:foo,number] tags[flag.evaluation.feature.organizations:foo,number]:1",
+                "field": ["tags[flag.evaluation.feature.organizations:foo,boolean]"],
+                "query": "has:tags[flag.evaluation.feature.organizations:foo,boolean] tags[flag.evaluation.feature.organizations:foo,boolean]:true",
                 "project": self.project.id,
                 "dataset": "spans",
             }
@@ -5027,7 +5027,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
             {
                 "id": span["span_id"],
                 "project.name": self.project.slug,
-                "tags[flag.evaluation.feature.organizations:foo,number]": 1,
+                "tags[flag.evaluation.feature.organizations:foo,boolean]": True,
             },
         ]
 


### PR DESCRIPTION
## Summary
- `test_typed_attributes_with_colons` stored a boolean and queried it as a `,number]`, which only worked because the eap-items consumer double-wrote booleans into the float columns
- Snuba is removing that double-write in getsentry/snuba#7689, breaking the assertion in Snuba CI
- Query the same attribute with its real `,boolean]` type so the colon-in-key check is exercised against the column the value actually lives in

## Test plan
- [x] CI on this branch

Refs getsentry/snuba#7689