### PR TITLE
feat(issues): Use shared markdown component for activity notes

### DIFF
--- a/static/app/components/activity/note/body.tsx
+++ b/static/app/components/activity/note/body.tsx
@@ -1,50 +1,15 @@
-import styled from '@emotion/styled';
-
-import {MarkedText} from 'sentry/utils/marked/markedText';
+import {Markdown} from '@sentry/scraps/markdown';
 
 type Props = {
   text: string;
 };
 
 function NoteBody({text}: Props) {
-  return <StyledNoteBody data-test-id="activity-note-body" text={text} />;
+  return (
+    <div data-test-id="activity-note-body">
+      <Markdown raw={text} />
+    </div>
+  );
 }
-
-const StyledNoteBody = styled(MarkedText)`
-  ul {
-    list-style: disc;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  p,
-  ul:not(.nav),
-  ol,
-  pre,
-  hr,
-  blockquote {
-    margin-bottom: ${p => p.theme.space.xl};
-  }
-
-  ul,
-  ol {
-    padding-left: 20px;
-  }
-
-  p {
-    a {
-      word-wrap: break-word;
-    }
-  }
-
-  blockquote {
-    font-size: 15px;
-    border-left: 5px solid ${p => p.theme.tokens.border.secondary};
-    padding-left: ${p => p.theme.space.md};
-    margin-left: 0;
-  }
-`;
 
 export {NoteBody};

--- a/static/app/components/activity/note/compact.tsx
+++ b/static/app/components/activity/note/compact.tsx
@@ -1,8 +1,7 @@
 import {useCallback, useId, useState} from 'react';
 import type {MentionsInputProps} from 'react-mentions';
 import {Mention, MentionsInput} from 'react-mentions';
-import type {Theme} from '@emotion/react';
-import {css, useTheme} from '@emotion/react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -152,7 +151,6 @@ export function CompactNoteInput({
               borderRadius: theme.radius.md,
             },
           }),
-          width: '100%',
         }}
         placeholder={placeholder}
         onChange={handleChange}
@@ -200,46 +198,7 @@ export function CompactNoteInput({
   );
 }
 
-const getNoteInputErrorStyles = (p: {theme: Theme; error?: string}) => {
-  if (!p.error) {
-    return '';
-  }
-
-  return css`
-    color: ${p.theme.tokens.content.danger};
-    margin: -1px;
-    border: 1px solid ${p.theme.tokens.border.danger};
-    border-radius: ${p.theme.radius.md};
-
-    &:before {
-      display: block;
-      content: '';
-      width: 0;
-      height: 0;
-      border-top: 7px solid transparent;
-      border-bottom: 7px solid transparent;
-      border-right: 7px solid ${p.theme.colors.red400};
-      position: absolute;
-      left: -7px;
-      top: 12px;
-    }
-
-    &:after {
-      display: block;
-      content: '';
-      width: 0;
-      height: 0;
-      border-top: 6px solid transparent;
-      border-bottom: 6px solid transparent;
-      border-right: 6px solid #fff;
-      position: absolute;
-      left: -5px;
-      top: 12px;
-    }
-  `;
-};
-
-const NoteInputForm = styled('form')<{error?: string}>`
+const NoteInputForm = styled('form')`
   display: flex;
   flex-direction: column;
   gap: ${p => p.theme.space.sm};
@@ -247,6 +206,4 @@ const NoteInputForm = styled('form')<{error?: string}>`
   width: 100%;
   min-width: 0;
   transition: padding 0.2s ease-in-out;
-
-  ${getNoteInputErrorStyles};
 `;

--- a/static/app/components/activity/note/input.spec.tsx
+++ b/static/app/components/activity/note/input.spec.tsx
@@ -104,7 +104,7 @@ describe('NoteInput', () => {
   describe('Existing Item', () => {
     const props = {
       noteId: 'item-id',
-      text: 'an existing item',
+      text: 'an **existing** [item](https://docs.sentry.io/)',
     };
 
     it('edits existing message', async () => {
@@ -114,18 +114,24 @@ describe('NoteInput', () => {
       // Switch to preview
       await userEvent.click(screen.getByRole('radio', {name: 'Preview'}));
 
-      expect(screen.getByText('an existing item')).toBeInTheDocument();
+      expect(screen.getByText('existing').closest('strong')).toBeInTheDocument();
+      expect(screen.getByRole('link', {name: 'item'})).toHaveAttribute(
+        'href',
+        'https://docs.sentry.io/'
+      );
 
       // Switch to edit
       await userEvent.click(screen.getByRole('radio', {name: 'Edit'}));
 
-      expect(screen.getByRole('textbox')).toHaveTextContent('an existing item');
+      expect(screen.getByRole('textbox')).toHaveTextContent(
+        'an **existing** [item](https://docs.sentry.io/)'
+      );
 
       // Can edit text
       await userEvent.type(screen.getByRole('textbox'), ' new content{Control>}{Enter}');
 
       expect(onUpdate).toHaveBeenCalledWith({
-        text: 'an existing item new content',
+        text: 'an **existing** [item](https://docs.sentry.io/) new content',
         mentions: [],
       });
     });

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useId, useState} from 'react';
 import {Mention, MentionsInput} from 'react-mentions';
-import type {Theme} from '@emotion/react';
-import {css, useTheme} from '@emotion/react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion, useReducedMotion} from 'framer-motion';
 import {z} from 'zod';
@@ -9,13 +8,13 @@ import {z} from 'zod';
 import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
 import {Flex} from '@sentry/scraps/layout';
+import {Markdown} from '@sentry/scraps/markdown';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
+import {Text} from '@sentry/scraps/text';
 
 import {IconMarkdown} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {textStyles} from 'sentry/styles/text';
 import type {NoteType} from 'sentry/types/alerts';
-import {MarkedText} from 'sentry/utils/marked/markedText';
 import {useMemberMentionData} from 'sentry/utils/members/useMemberMentionData';
 import {useTeams} from 'sentry/utils/useTeams';
 
@@ -156,65 +155,62 @@ export function NoteInput({
       <EditorSurface>
         <form.AppField name="text">
           {field => (
-            <NoteInputPanel>
+            <div>
               {editorMode === 'write' ? (
                 <field.Base<HTMLTextAreaElement>>
                   {({ref, ...fieldProps}) => (
-                    <MentionsEditor>
-                      <MentionsInput
-                        {...fieldProps}
-                        aria-label={existingItem ? t('Edit comment') : t('Add a comment')}
-                        aria-errormessage={errorMessage ? errorId : undefined}
-                        inputRef={ref}
-                        style={mentionStyle({theme, minHeight})}
-                        placeholder={placeholder}
-                        onChange={(e: MentionChangeEvent) => {
-                          setAreControlsVisible(true);
-                          field.handleChange(e.target.value);
-                          onChange?.(e, {updating: existingItem});
-                        }}
-                        onFocus={() => setAreControlsVisible(true)}
-                        onKeyDown={e => {
-                          if (
-                            e.key === 'Enter' &&
-                            (e.metaKey || e.ctrlKey) &&
-                            field.state.value.trim() !== ''
-                          ) {
-                            e.preventDefault();
-                            form.handleSubmit();
-                          }
-                        }}
-                        value={field.state.value}
-                        required
-                        autoFocus={existingItem}
-                      >
-                        <Mention
-                          trigger="@"
-                          data={getMemberSuggestions}
-                          onAdd={handleAddMember}
-                          displayTransform={(_id, display) => `@${display}`}
-                          markup="**[sentry.strip:member]__display__**"
-                          appendSpaceOnAdd
-                        />
-                        <Mention
-                          trigger="#"
-                          data={suggestTeams}
-                          onAdd={handleAddTeam}
-                          markup="**[sentry.strip:team]__display__**"
-                          displayTransform={(_id, display) => display}
-                          appendSpaceOnAdd
-                        />
-                      </MentionsInput>
-                    </MentionsEditor>
+                    <MentionsInput
+                      {...fieldProps}
+                      aria-label={existingItem ? t('Edit comment') : t('Add a comment')}
+                      aria-errormessage={errorMessage ? errorId : undefined}
+                      inputRef={ref}
+                      style={mentionStyle({theme, minHeight})}
+                      placeholder={placeholder}
+                      onChange={(e: MentionChangeEvent) => {
+                        setAreControlsVisible(true);
+                        field.handleChange(e.target.value);
+                        onChange?.(e, {updating: existingItem});
+                      }}
+                      onFocus={() => setAreControlsVisible(true)}
+                      onKeyDown={e => {
+                        if (
+                          e.key === 'Enter' &&
+                          (e.metaKey || e.ctrlKey) &&
+                          field.state.value.trim() !== ''
+                        ) {
+                          e.preventDefault();
+                          form.handleSubmit();
+                        }
+                      }}
+                      value={field.state.value}
+                      required
+                      autoFocus={existingItem}
+                    >
+                      <Mention
+                        trigger="@"
+                        data={getMemberSuggestions}
+                        onAdd={handleAddMember}
+                        displayTransform={(_id, display) => `@${display}`}
+                        markup="**[sentry.strip:member]__display__**"
+                        appendSpaceOnAdd
+                      />
+                      <Mention
+                        trigger="#"
+                        data={suggestTeams}
+                        onAdd={handleAddTeam}
+                        markup="**[sentry.strip:team]__display__**"
+                        displayTransform={(_id, display) => display}
+                        appendSpaceOnAdd
+                      />
+                    </MentionsInput>
                   )}
                 </field.Base>
               ) : (
-                <NotePreview
-                  minHeight={minHeight}
-                  text={getCleanMarkdown(field.state.value)}
-                />
+                <NotePreview style={{minHeight}}>
+                  <Markdown raw={getCleanMarkdown(field.state.value)} />
+                </NotePreview>
               )}
-            </NoteInputPanel>
+            </div>
           )}
         </form.AppField>
       </EditorSurface>
@@ -236,16 +232,20 @@ export function NoteInput({
                     {t('Preview')}
                   </SegmentedControl.Item>
                 </SegmentedControl>
-                <MarkdownIndicator>
+                <Flex as="span" align="center" gap="xs" color="content.secondary">
                   <IconMarkdown size="sm" />
-                  {t('Markdown supported')}
-                </MarkdownIndicator>
+                  <Text as="span" size="sm" variant="muted">
+                    {t('Markdown supported')}
+                  </Text>
+                </Flex>
               </Flex>
               <Flex align="center" gap="sm">
                 {errorMessage && (
-                  <div id={errorId}>
-                    <ErrorMessage>{errorMessage}</ErrorMessage>
-                  </div>
+                  <Flex id={errorId} align="center" height="100%">
+                    <Text as="span" variant="danger" size="sm">
+                      {errorMessage}
+                    </Text>
+                  </Flex>
                 )}
                 <Flex gap="sm">
                   {existingItem && (
@@ -270,37 +270,10 @@ export function NoteInput({
   );
 }
 
-type NotePreviewProps = {
-  minHeight: Props['minHeight'];
-  theme: Theme;
-};
-
-const getNotePreviewCss = (p: NotePreviewProps) => css`
-  max-height: 1000px;
-  max-width: 100%;
-  ${p.minHeight
-    ? css`
-        min-height: ${p.minHeight}px;
-      `
-    : ''};
-  padding: ${p.theme.space.lg} ${p.theme.space.lg};
-  overflow: auto;
-  border: 0;
-`;
-
 const EditorSurface = styled('div')`
   background: ${p => p.theme.tokens.background.primary};
   border: 1px solid ${p => p.theme.tokens.border.primary};
   border-radius: ${p => p.theme.radius.md};
-`;
-
-const NoteInputPanel = styled('div')`
-  ${textStyles}
-`;
-
-const MentionsEditor = styled('div')`
-  flex: 1;
-  min-width: 0;
 `;
 
 const MotionControls = styled(motion.div)`
@@ -308,24 +281,9 @@ const MotionControls = styled(motion.div)`
   isolation: isolate;
 `;
 
-const ErrorMessage = styled('span')`
-  display: flex;
-  align-items: center;
-  height: 100%;
-  color: ${p => p.theme.tokens.content.danger};
-  font-size: 0.9em;
-`;
-
-const MarkdownIndicator = styled('span')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  color: ${p => p.theme.tokens.content.secondary};
-  font-size: ${p => p.theme.font.size.sm};
-`;
-
-const NotePreview = styled(MarkedText, {
-  shouldForwardProp: prop => prop !== 'minHeight',
-})<{minHeight: Props['minHeight']}>`
-  ${p => getNotePreviewCss(p)};
+const NotePreview = styled('div')`
+  max-height: 1000px;
+  max-width: 100%;
+  padding: ${p => p.theme.space.lg};
+  overflow: auto;
 `;

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -232,8 +232,8 @@ export function NoteInput({
                     {t('Preview')}
                   </SegmentedControl.Item>
                 </SegmentedControl>
-                <Flex as="span" align="center" gap="xs" color="content.secondary">
-                  <IconMarkdown size="sm" />
+                <Flex as="span" align="center" gap="xs">
+                  <IconMarkdown size="sm" variant="muted" />
                   <Text as="span" size="sm" variant="muted">
                     {t('Markdown supported')}
                   </Text>

--- a/static/app/components/activity/note/mentionStyle.tsx
+++ b/static/app/components/activity/note/mentionStyle.tsx
@@ -23,6 +23,8 @@ export function mentionStyle({theme, minHeight, inputStyle}: Options) {
   };
 
   return {
+    width: '100%',
+
     control: {
       backgroundColor: 'transparent',
       fontSize: theme.font.size.md,

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -174,6 +174,32 @@ describe('ActivitySection', () => {
     expect(screen.queryByText('Test Note')).not.toBeInTheDocument();
   });
 
+  it('renders note markdown', async () => {
+    const activityGroup = GroupFixture({
+      id: '1338',
+      activity: [
+        {
+          type: GroupActivityType.NOTE,
+          id: 'note-1',
+          data: {text: '**Bold Note** and [docs](https://docs.sentry.io/)'},
+          dateCreated: '2020-01-01T00:00:00',
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(<ActivitySection group={activityGroup} />);
+
+    expect(await screen.findByTestId('activity-note-body')).toContainElement(
+      screen.getByText('Bold Note').closest('strong')
+    );
+    expect(screen.getByRole('link', {name: 'docs'})).toHaveAttribute(
+      'href',
+      'https://docs.sentry.io/'
+    );
+  });
+
   it('renders activity actor markers', async () => {
     const activityGroup = GroupFixture({
       id: '1338',

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -17,7 +17,6 @@ import {TimeSince} from 'sentry/components/timeSince';
 import {IconEllipsis} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
-import {textStyles} from 'sentry/styles/text';
 import type {NoteType} from 'sentry/types/alerts';
 import type {Group, GroupActivity, GroupActivityNote} from 'sentry/types/group';
 import {GroupActivityType, SEER_ACTIVITY_TYPES} from 'sentry/types/group';
@@ -205,9 +204,7 @@ function TimelineItem({
           onCancel={() => setEditing(false)}
         />
       ) : typeof message === 'string' ? (
-        <NoteWrapper size={size}>
-          <NoteBody text={message} />
-        </NoteWrapper>
+        <NoteBody text={message} />
       ) : (
         <Text as="div" size={size}>
           {message}
@@ -519,11 +516,6 @@ const MoreActivityIcon = styled('div')`
   min-height: 22px;
   color: ${p => p.theme.tokens.content.secondary};
   background: ${p => p.theme.tokens.background.primary};
-`;
-
-const NoteWrapper = styled('div')<{size: 'sm' | 'md'}>`
-  ${textStyles}
-  font-size: ${p => (p.size === 'md' ? p.theme.font.size.md : p.theme.font.size.sm)};
 `;
 
 const ActivityInputFrame = styled('div')`


### PR DESCRIPTION
Activity notes and the note preview were still using MarkedText with local markdown styles layered on top. This swaps both to the core Markdown component and lets it own the rendered markdown styling.

Only real functional change is internal links (missing https://) are no longer allowed, which i think is fine.

before

<img width="396" height="267" alt="image" src="https://github.com/user-attachments/assets/db1bbca4-cea5-45ea-a721-82cade2f4681" />


after

<img width="353" height="181" alt="image" src="https://github.com/user-attachments/assets/66a8a4a3-ee85-496a-b599-0e1a14d56c3d" />
