### PR TITLE
feat(seer): admit seer-gitlab-support orgs through code review preflight

### DIFF
--- a/src/sentry/seer/code_review/preflight.py
+++ b/src/sentry/seer/code_review/preflight.py
@@ -84,7 +84,11 @@ class CodeReviewPreflightService:
         return None
 
     def _check_org_feature_enablement(self) -> PreflightDenialReason | None:
-        if self._is_seat_based_seer_plan_org or self._is_code_review_beta_org:
+        if (
+            self._is_seat_based_seer_plan_org
+            or self._is_code_review_beta_org
+            or self._is_gitlab_la_org
+        ):
             return None
 
         return PreflightDenialReason.ORG_NOT_ELIGIBLE_FOR_CODE_REVIEW
@@ -101,6 +105,12 @@ class CodeReviewPreflightService:
         then that means that they've opened a PR before, and either have a seat already OR it's their
         "Free action."
         """
+        # GitLab LA orgs run with no seat-based billing wired up yet — skip the
+        # contributor lookup entirely. Once they're moved onto seat-based-seer
+        # (which takes precedence below) this bypass is no longer taken.
+        if self._is_gitlab_la_org and not self._is_seat_based_seer_plan_org:
+            return None
+
         if self.integration_id is None or self.pr_author_external_id is None:
             return PreflightDenialReason.BILLING_MISSING_CONTRIBUTOR_INFO
 
@@ -145,3 +155,7 @@ class CodeReviewPreflightService:
     @cached_property
     def _is_code_review_beta_org(self) -> bool:
         return features.has("organizations:code-review-beta", self.organization)
+
+    @cached_property
+    def _is_gitlab_la_org(self) -> bool:
+        return features.has("organizations:seer-gitlab-support", self.organization)

--- a/src/sentry/seer/code_review/preflight.py
+++ b/src/sentry/seer/code_review/preflight.py
@@ -108,6 +108,9 @@ class CodeReviewPreflightService:
         # GitLab LA orgs run with no seat-based billing wired up yet — skip the
         # contributor lookup entirely. Once they're moved onto seat-based-seer
         # (which takes precedence below) this bypass is no longer taken.
+        # The PR_AUTHOR_EXCLUDED check below is skipped on this path because it
+        # is keyed off contributor.alias (GitHub-shaped usernames). GitLab bot
+        # filtering is tracked as a follow-up on SCM-99.
         if self._is_gitlab_la_org and not self._is_seat_based_seer_plan_org:
             return None
 

--- a/tests/sentry/seer/code_review/test_preflight.py
+++ b/tests/sentry/seer/code_review/test_preflight.py
@@ -99,6 +99,27 @@ class TestCodeReviewPreflightService(TestCase):
         assert result.allowed is False
         assert result.denial_reason == PreflightDenialReason.ORG_NOT_ELIGIBLE_FOR_CODE_REVIEW
 
+    @with_feature(["organizations:gen-ai-features", "organizations:seer-gitlab-support"])
+    def test_denied_when_gitlab_la_org_has_no_repo_settings(self) -> None:
+        service = self._create_service()
+        result = service.check()
+
+        assert result.allowed is False
+        assert result.denial_reason == PreflightDenialReason.REPO_CODE_REVIEW_DISABLED
+
+    @with_feature(["organizations:gen-ai-features", "organizations:seer-gitlab-support"])
+    def test_allowed_when_gitlab_la_org_has_repo_settings_enabled(self) -> None:
+        self.create_repository_settings(
+            repository=self.repo,
+            enabled_code_review=True,
+        )
+
+        service = self._create_service()
+        result = service.check()
+
+        assert result.allowed is True
+        assert result.denial_reason is None
+
     # -------------------------------------------------------------------------
     # Seer-added (legacy usage-based) org tests - not eligible for code review
     # -------------------------------------------------------------------------
@@ -326,6 +347,49 @@ class TestCodeReviewPreflightService(TestCase):
 
         assert result.allowed is False
         assert result.denial_reason == PreflightDenialReason.ORG_CONTRIBUTOR_NOT_FOUND
+
+    @with_feature(["organizations:gen-ai-features", "organizations:seer-gitlab-support"])
+    def test_gitlab_la_org_bypasses_contributor_lookup(self) -> None:
+        self.create_repository_settings(
+            repository=self.repo,
+            enabled_code_review=True,
+        )
+
+        # No OrganizationContributors row exists — must still be allowed.
+        service = self._create_service()
+        result = service.check()
+
+        assert result.allowed is True
+        assert result.denial_reason is None
+
+    @patch("sentry.quotas.backend.check_seer_quota")
+    @with_feature(
+        [
+            "organizations:gen-ai-features",
+            "organizations:seer-gitlab-support",
+            "organizations:seat-based-seer-enabled",
+        ]
+    )
+    def test_gitlab_la_org_still_checks_quota_when_seat_based_also_enabled(
+        self, mock_check_quota: MagicMock
+    ) -> None:
+        mock_check_quota.return_value = False
+
+        self.create_repository_settings(
+            repository=self.repo,
+            enabled_code_review=True,
+        )
+        OrganizationContributors.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            external_identifier=self.external_identifier,
+        )
+
+        service = self._create_service()
+        result = service.check()
+
+        assert result.allowed is False
+        assert result.denial_reason == PreflightDenialReason.BILLING_QUOTA_EXCEEDED
 
     @patch("sentry.quotas.backend.check_seer_quota")
     @with_feature(["organizations:gen-ai-features", "organizations:seat-based-seer-enabled"])


### PR DESCRIPTION
Adds `organizations:seer-gitlab-support` as a third "beta-style" eligibility path in `CodeReviewPreflightService`, alongside `code-review-beta` and `seat-based-seer-enabled`. Orgs on the flag are admitted for code review and skip the contributor / seat-quota check until they're also moved onto `organizations:seat-based-seer-enabled`.

This unblocks the GitLab Limited Alpha rollout. The cohort has no seat-based billing wired up yet, so we need a path that:
1. Lets the org pass `_check_org_feature_enablement`.
2. Skips `_check_billing` entirely (no `OrganizationContributors` row exists for GitLab authors yet — see the companion PR that wires `track_contributor_seat` into the GitLab MR webhook).
