### PR TITLE
ref(alerts): Disable alert buttons for users without write access

### DIFF
--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -8,7 +8,6 @@ import {LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {hasEveryAccess} from 'sentry/components/acl/access';
 import {LoadingError} from 'sentry/components/loadingError';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {SelectAllHeaderCheckbox} from 'sentry/components/workflowEngine/ui/selectAllHeaderCheckbox';
@@ -25,6 +24,7 @@ import {
   AutomationListRowSkeleton,
 } from 'sentry/views/automations/components/automationListTable/row';
 import {AUTOMATION_LIST_PAGE_LIMIT} from 'sentry/views/automations/constants';
+import {useCanEditAutomation} from 'sentry/views/automations/hooks/useCanEditAutomation';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 type AutomationListTableProps = {
@@ -91,7 +91,7 @@ export function AutomationListTable({
   allResultsVisible,
 }: AutomationListTableProps) {
   const organization = useOrganization();
-  const canEditAutomations = hasEveryAccess(['alerts:write'], {organization});
+  const canEditAutomations = useCanEditAutomation();
   const [query] = useQueryState('query', parseAsString);
   const [selected, setSelected] = useState(new Set<string>());
 

--- a/static/app/views/automations/components/automationListTable/row.tsx
+++ b/static/app/views/automations/components/automationListTable/row.tsx
@@ -3,16 +3,15 @@ import styled from '@emotion/styled';
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {Flex} from '@sentry/scraps/layout';
 
-import {hasEveryAccess} from 'sentry/components/acl/access';
 import {Placeholder} from 'sentry/components/placeholder';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import {AutomationTitleCell} from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {AutomationListConnectedDetectors} from 'sentry/views/automations/components/automationListTable/connectedDetectors';
 import {ProjectsCell} from 'sentry/views/automations/components/automationListTable/projectsCell';
+import {useCanEditAutomation} from 'sentry/views/automations/hooks/useCanEditAutomation';
 import {getAutomationActions} from 'sentry/views/automations/hooks/utils';
 
 type AutomationListRowProps = {
@@ -26,8 +25,7 @@ export function AutomationListRow({
   selected,
   onSelect,
 }: AutomationListRowProps) {
-  const organization = useOrganization();
-  const canEditAutomations = hasEveryAccess(['alerts:write'], {organization});
+  const canEditAutomations = useCanEditAutomation();
 
   const actions = getAutomationActions(automation);
   const {enabled, lastTriggered, detectorIds} = automation;

--- a/static/app/views/automations/components/disabledAlert.spec.tsx
+++ b/static/app/views/automations/components/disabledAlert.spec.tsx
@@ -89,7 +89,7 @@ describe('DisabledAlert', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          'You do not have permission to edit this alert. Ask your organization owner or manager to enable alert access for you.'
+          'You do not have permission to create or edit alerts. Ask your organization owner or manager to enable alert access for you.'
         )
       )
     ).toBeInTheDocument();

--- a/static/app/views/automations/components/disabledAlert.tsx
+++ b/static/app/views/automations/components/disabledAlert.tsx
@@ -1,14 +1,15 @@
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {hasEveryAccess} from 'sentry/components/acl/access';
 import {IconPlay} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUpdateAutomation} from 'sentry/views/automations/hooks';
+import {
+  getNoAlertWritePermissionTooltip,
+  useCanEditAutomation,
+} from 'sentry/views/automations/hooks/useCanEditAutomation';
 
 type DisabledAlertProps = {
   automation: Automation;
@@ -20,10 +21,9 @@ type DisabledAlertProps = {
  * enable it. The alert automatically hides when the automation is enabled.
  */
 export function DisabledAlert({automation}: DisabledAlertProps) {
-  const organization = useOrganization();
   const {mutate: updateAutomation, isPending: isEnabling} = useUpdateAutomation();
 
-  const canEdit = hasEveryAccess(['alerts:write'], {organization});
+  const canEdit = useCanEditAutomation();
 
   if (automation.enabled) {
     return null;
@@ -37,19 +37,7 @@ export function DisabledAlert({automation}: DisabledAlertProps) {
     });
   };
 
-  const permissionTooltipText = tct(
-    'You do not have permission to edit this alert. Ask your organization owner or manager to [settingsLink:enable alert access] for you.',
-    {
-      settingsLink: (
-        <Link
-          to={{
-            pathname: `/settings/${organization.slug}/`,
-            hash: 'alertsMemberWrite',
-          }}
-        />
-      ),
-    }
-  );
+  const permissionTooltipText = getNoAlertWritePermissionTooltip();
 
   return (
     <Alert.Container>

--- a/static/app/views/automations/components/editAutomationActions.tsx
+++ b/static/app/views/automations/components/editAutomationActions.tsx
@@ -14,6 +14,10 @@ import {
   useDeleteAutomationMutation,
   useUpdateAutomation,
 } from 'sentry/views/automations/hooks';
+import {
+  getNoAlertWritePermissionTooltip,
+  useCanEditAutomation,
+} from 'sentry/views/automations/hooks/useCanEditAutomation';
 import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
 
 interface EditAutomationActionsProps {
@@ -24,6 +28,8 @@ interface EditAutomationActionsProps {
 export function EditAutomationActions({automation, form}: EditAutomationActionsProps) {
   const organization = useOrganization();
   const navigate = useNavigate();
+  const canEdit = useCanEditAutomation();
+  const permissionTooltipText = canEdit ? undefined : getNoAlertWritePermissionTooltip();
   const {mutateAsync: deleteAutomation, isPending: isDeleting} =
     useDeleteAutomationMutation();
   const {mutate: updateAutomation, isPending: isUpdating} = useUpdateAutomation();
@@ -63,16 +69,30 @@ export function EditAutomationActions({automation, form}: EditAutomationActionsP
           variant="secondary"
           size="sm"
           onClick={toggleDisabled}
-          disabled={isUpdating}
+          disabled={!canEdit || isUpdating}
+          tooltipProps={{title: permissionTooltipText, isHoverable: true}}
         >
           {automation.enabled ? t('Disable') : t('Enable')}
         </Button>
-        <Button variant="danger" onClick={handleDelete} disabled={isDeleting} size="sm">
+        <Button
+          variant="danger"
+          onClick={handleDelete}
+          disabled={!canEdit || isDeleting}
+          tooltipProps={{title: permissionTooltipText, isHoverable: true}}
+          size="sm"
+        >
           {t('Delete')}
         </Button>
         <Observer>
           {() => (
-            <Button type="submit" variant="primary" size="sm" busy={form.isSaving}>
+            <Button
+              type="submit"
+              variant="primary"
+              size="sm"
+              busy={form.isSaving}
+              disabled={!canEdit}
+              tooltipProps={{title: permissionTooltipText, isHoverable: true}}
+            >
               {t('Save')}
             </Button>
           )}

--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -267,6 +267,29 @@ describe('AutomationDetail', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('disables action buttons without alerts:write permission', async () => {
+    const noWriteOrg = OrganizationFixture({
+      features: ['workflow-engine-ui'],
+      access: ['org:read', 'alerts:read'],
+    });
+
+    render(<AutomationDetail />, {
+      organization: noWriteOrg,
+      initialRouterConfig: {
+        route: '/alerts/:automationId/',
+        location: {pathname: '/alerts/123/'},
+      },
+    });
+
+    await screen.findByRole('heading', {name: 'Test Automation'});
+
+    expect(screen.getByRole('button', {name: 'Disable'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Edit'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
   it('displays connected projects and monitors', async () => {
     const project = ProjectFixture({id: '10', slug: 'my-project', name: 'My Project'});
     ProjectsStore.loadInitialData([project]);

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -37,6 +37,10 @@ import {ConnectedMonitorsList} from 'sentry/views/automations/components/connect
 import {ConnectedProjectsList} from 'sentry/views/automations/components/connectedProjectsList';
 import {DisabledAlert} from 'sentry/views/automations/components/disabledAlert';
 import {useAutomationQuery, useUpdateAutomation} from 'sentry/views/automations/hooks';
+import {
+  getNoAlertWritePermissionTooltip,
+  useCanEditAutomation,
+} from 'sentry/views/automations/hooks/useCanEditAutomation';
 import {getAutomationActionsWarning} from 'sentry/views/automations/hooks/utils';
 import {
   makeAutomationBasePathname,
@@ -270,6 +274,8 @@ export default function AutomationDetail() {
 function Actions({automation, size}: {automation: Automation; size?: 'sm'}) {
   const organization = useOrganization();
   const {mutate: updateAutomation, isPending: isUpdating} = useUpdateAutomation();
+  const canEdit = useCanEditAutomation();
+  const permissionTooltipText = canEdit ? undefined : getNoAlertWritePermissionTooltip();
 
   const toggleDisabled = () => {
     const newEnabled = !automation.enabled;
@@ -289,11 +295,20 @@ function Actions({automation, size}: {automation: Automation; size?: 'sm'}) {
 
   return (
     <Fragment>
-      <Button variant="secondary" size={size} onClick={toggleDisabled} busy={isUpdating}>
+      <Button
+        variant="secondary"
+        size={size}
+        onClick={toggleDisabled}
+        busy={isUpdating}
+        disabled={!canEdit}
+        tooltipProps={{title: permissionTooltipText, isHoverable: true}}
+      >
         {automation.enabled ? t('Disable') : t('Enable')}
       </Button>
       <LinkButton
         to={makeAutomationEditPathname(organization.slug, automation.id)}
+        disabled={!canEdit}
+        tooltipProps={{title: permissionTooltipText, isHoverable: true}}
         variant="primary"
         icon={<IconEdit />}
         size={size}

--- a/static/app/views/automations/hooks/useCanEditAutomation.tsx
+++ b/static/app/views/automations/hooks/useCanEditAutomation.tsx
@@ -1,0 +1,34 @@
+import type {ReactNode} from 'react';
+
+import {Link} from '@sentry/scraps/link';
+
+import {hasEveryAccess} from 'sentry/components/acl/access';
+import {tct} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export function useCanEditAutomation(): boolean {
+  const organization = useOrganization();
+  return hasEveryAccess(['alerts:write'], {organization});
+}
+
+function AlertsMemberWriteSettingsLink({children}: {children?: ReactNode}) {
+  const organization = useOrganization();
+
+  return (
+    <Link
+      to={{
+        hash: 'alertsMemberWrite',
+        pathname: `/settings/${organization.slug}/`,
+      }}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export function getNoAlertWritePermissionTooltip() {
+  return tct(
+    'You do not have permission to create or edit alerts. Ask your organization owner or manager to [settingsLink:enable alert access] for you.',
+    {settingsLink: <AlertsMemberWriteSettingsLink />}
+  );
+}

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -591,4 +591,17 @@ describe('AutomationsList', () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('disables the create alert button without alerts:write permission', async () => {
+    const noWriteOrg = OrganizationFixture({
+      features: ['workflow-engine-ui'],
+      access: ['org:read', 'alerts:read'],
+    });
+
+    render(<AutomationsList />, {organization: noWriteOrg});
+    await screen.findByText('Automation 1');
+
+    const createButton = screen.getByRole('button', {name: 'Create Alert'});
+    expect(createButton).toHaveAttribute('aria-disabled', 'true');
+  });
 });

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -25,6 +25,10 @@ import {AutomationListTable} from 'sentry/views/automations/components/automatio
 import {AutomationSearch} from 'sentry/views/automations/components/automationListTable/search';
 import {AUTOMATION_LIST_PAGE_LIMIT} from 'sentry/views/automations/constants';
 import {automationsApiOptions} from 'sentry/views/automations/hooks';
+import {
+  getNoAlertWritePermissionTooltip,
+  useCanEditAutomation,
+} from 'sentry/views/automations/hooks/useCanEditAutomation';
 import {makeAutomationCreatePathname} from 'sentry/views/automations/pathnames';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
@@ -131,6 +135,7 @@ function TableHeader() {
   const location = useLocation();
   const navigate = useNavigate();
   const hasPageFrameFeature = useHasPageFrameFeature();
+  const canCreateAlert = useCanEditAutomation();
   const initialQuery =
     typeof location.query.query === 'string' ? location.query.query : '';
 
@@ -159,6 +164,11 @@ function TableHeader() {
         {hasPageFrameFeature ? (
           <LinkButton
             to={makeAutomationCreatePathname(organization.slug)}
+            disabled={!canCreateAlert}
+            tooltipProps={{
+              title: canCreateAlert ? undefined : getNoAlertWritePermissionTooltip(),
+              isHoverable: true,
+            }}
             variant="primary"
             icon={<IconAdd />}
             size="sm"
@@ -174,6 +184,7 @@ function TableHeader() {
 function Actions() {
   const organization = useOrganization();
   const hasPageFrameFeature = useHasPageFrameFeature();
+  const canCreateAlert = useCanEditAutomation();
   return (
     <Flex gap="sm">
       <AlertsMonitorsShowcaseButton />
@@ -181,6 +192,11 @@ function Actions() {
       {hasPageFrameFeature ? null : (
         <LinkButton
           to={makeAutomationCreatePathname(organization.slug)}
+          disabled={!canCreateAlert}
+          tooltipProps={{
+            title: canCreateAlert ? undefined : getNoAlertWritePermissionTooltip(),
+            isHoverable: true,
+          }}
           variant="primary"
           icon={<IconAdd />}
           size="sm"

--- a/static/app/views/detectors/components/details/common/automations.tsx
+++ b/static/app/views/detectors/components/details/common/automations.tsx
@@ -230,7 +230,7 @@ export function DetectorDetailsAutomations({detector}: Props) {
               icon={<IconAdd />}
               onClick={openCreateDrawer}
               disabled={!canEditWorkflowConnections}
-              tooltipProps={{title: permissionTooltipText}}
+              tooltipProps={{title: permissionTooltipText, isHoverable: true}}
             >
               {t('New Alert')}
             </Button>
@@ -238,7 +238,7 @@ export function DetectorDetailsAutomations({detector}: Props) {
               size="xs"
               onClick={toggleDrawer}
               disabled={!canEditWorkflowConnections}
-              tooltipProps={{title: permissionTooltipText}}
+              tooltipProps={{title: permissionTooltipText, isHoverable: true}}
               icon={<IconEdit />}
             >
               {t('Edit Alerts')}
@@ -256,7 +256,7 @@ export function DetectorDetailsAutomations({detector}: Props) {
                     size="sm"
                     onClick={toggleDrawer}
                     disabled={!canEditWorkflowConnections}
-                    tooltipProps={{title: permissionTooltipText}}
+                    tooltipProps={{title: permissionTooltipText, isHoverable: true}}
                   >
                     {t('Connect Existing Alerts')}
                   </Button>
@@ -265,7 +265,7 @@ export function DetectorDetailsAutomations({detector}: Props) {
                     icon={<IconAdd />}
                     onClick={openCreateDrawer}
                     disabled={!canEditWorkflowConnections}
-                    tooltipProps={{title: permissionTooltipText}}
+                    tooltipProps={{title: permissionTooltipText, isHoverable: true}}
                   >
                     {t('Create a New Alert')}
                   </Button>

--- a/static/app/views/detectors/components/details/common/automations.tsx
+++ b/static/app/views/detectors/components/details/common/automations.tsx
@@ -7,7 +7,6 @@ import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {Button} from '@sentry/scraps/button';
 import {useDrawer} from '@sentry/scraps/drawer';
 import {Flex, Stack} from '@sentry/scraps/layout';
-import {Link} from '@sentry/scraps/link';
 import {getPaginationCaption, Pagination} from '@sentry/scraps/pagination';
 
 import {addLoadingMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -27,6 +26,7 @@ import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {AutomationBuilderDrawerForm} from 'sentry/views/automations/components/automationBuilderDrawerForm';
 import {AutomationSearch} from 'sentry/views/automations/components/automationListTable/search';
 import {automationsApiOptions} from 'sentry/views/automations/hooks';
+import {getNoAlertWritePermissionTooltip} from 'sentry/views/automations/hooks/useCanEditAutomation';
 import {getAutomationActions} from 'sentry/views/automations/hooks/utils';
 import {ConnectAutomationsDrawer} from 'sentry/views/detectors/components/connectAutomationsDrawer';
 import {useUpdateDetector} from 'sentry/views/detectors/hooks';
@@ -217,19 +217,7 @@ export function DetectorDetailsAutomations({detector}: Props) {
 
   const permissionTooltipText = canEditWorkflowConnections
     ? undefined
-    : t(
-        'Ask your organization owner or manager to [settingsLink:enable alerts access] for you.',
-        {
-          settingsLink: (
-            <Link
-              to={{
-                pathname: `/settings/${organization.slug}/`,
-                hash: 'alertsMemberWrite',
-              }}
-            />
-          ),
-        }
-      );
+    : getNoAlertWritePermissionTooltip();
 
   return (
     <Fragment>

--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -16,6 +16,10 @@ import {IconAdd, IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {AutomationBuilderDrawerForm} from 'sentry/views/automations/components/automationBuilderDrawerForm';
+import {
+  getNoAlertWritePermissionTooltip,
+  useCanEditAutomation,
+} from 'sentry/views/automations/hooks/useCanEditAutomation';
 import {ConnectAutomationsDrawer} from 'sentry/views/detectors/components/connectAutomationsDrawer';
 import {ConnectedAutomationsList} from 'sentry/views/detectors/components/connectedAutomationList';
 import {useDetectorFormProject} from 'sentry/views/detectors/components/forms/common/useDetectorFormProject';
@@ -82,6 +86,10 @@ function AutomateSectionInner({
 }: AutomateSectionInnerProps) {
   const ref = useRef<HTMLButtonElement>(null);
   const {openDrawer, closeDrawer, isDrawerOpen} = useDrawer();
+  const canEditAutomation = useCanEditAutomation();
+  const permissionTooltipText = canEditAutomation
+    ? undefined
+    : getNoAlertWritePermissionTooltip();
 
   const toggleDrawer = () => {
     if (isDrawerOpen) {
@@ -140,10 +148,22 @@ function AutomateSectionInner({
           />
         </FormSection>
         <ButtonWrapper justify="between">
-          <Button size="sm" icon={<IconAdd />} onClick={openCreateDrawer}>
+          <Button
+            size="sm"
+            icon={<IconAdd />}
+            onClick={openCreateDrawer}
+            disabled={!canEditAutomation}
+            tooltipProps={{title: permissionTooltipText, isHoverable: true}}
+          >
             {t('Create New Alert')}
           </Button>
-          <Button size="sm" icon={<IconEdit />} onClick={toggleDrawer}>
+          <Button
+            size="sm"
+            icon={<IconEdit />}
+            onClick={toggleDrawer}
+            disabled={!canEditAutomation}
+            tooltipProps={{title: permissionTooltipText, isHoverable: true}}
+          >
             {t('Edit Alerts')}
           </Button>
         </ButtonWrapper>
@@ -170,10 +190,17 @@ function AutomateSectionInner({
                   size="sm"
                   style={{width: 'min-content'}}
                   onClick={toggleDrawer}
+                  disabled={!canEditAutomation}
+                  tooltipProps={{title: permissionTooltipText, isHoverable: true}}
                 >
                   {t('Connect Existing Alerts')}
                 </Button>
-                <Button size="sm" onClick={openCreateDrawer}>
+                <Button
+                  size="sm"
+                  onClick={openCreateDrawer}
+                  disabled={!canEditAutomation}
+                  tooltipProps={{title: permissionTooltipText, isHoverable: true}}
+                >
                   {t('Create New Alert')}
                 </Button>
                 <Text variant="muted" align="center" density="comfortable">

--- a/static/app/views/detectors/list/common/detectorListActions.tsx
+++ b/static/app/views/detectors/list/common/detectorListActions.tsx
@@ -46,6 +46,7 @@ export function DetectorListActions({children, detectorType}: DetectorListAction
             title: canCreateDetector
               ? undefined
               : getNoPermissionToCreateMonitorsTooltip(),
+            isHoverable: true,
           }}
         >
           {t('Create Monitor')}

--- a/static/app/views/detectors/list/common/detectorListHeader.tsx
+++ b/static/app/views/detectors/list/common/detectorListHeader.tsx
@@ -80,6 +80,7 @@ export function DetectorListHeader({
               title: canCreateDetector
                 ? undefined
                 : getNoPermissionToCreateMonitorsTooltip(),
+              isHoverable: true,
             }}
           >
             {t('Create Monitor')}

--- a/static/app/views/detectors/utils/monitorAccessMessages.tsx
+++ b/static/app/views/detectors/utils/monitorAccessMessages.tsx
@@ -1,9 +1,11 @@
+import type {ReactNode} from 'react';
+
 import {Link} from '@sentry/scraps/link';
 
 import {t, tct} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-function AlertsMemberWriteSettingsLink() {
+function AlertsMemberWriteSettingsLink({children}: {children?: ReactNode}) {
   const organization = useOrganization();
 
   return (
@@ -12,7 +14,9 @@ function AlertsMemberWriteSettingsLink() {
         hash: 'alertsMemberWrite',
         pathname: `/settings/${organization.slug}/`,
       }}
-    />
+    >
+      {children}
+    </Link>
   );
 }
 


### PR DESCRIPTION
Ref ISWF-2645

We were not checking the `alerts:write` permission on the frontend on both the alerts list and details pages, so users in orgs with that setting disabled were able to attempt to create/edit alerts but would eventually get rejected by the form.

This PR disables those buttons with an explanatory tooltip in all locations where a user can create/edit alerts.

<img width="304" height="173" alt="CleanShot 2026-05-26 at 16 54 50" src="https://github.com/user-attachments/assets/82639bf4-5caf-4ec1-a615-81909db48b09" />
<img width="238" height="164" alt="CleanShot 2026-05-26 at 16 54 44" src="https://github.com/user-attachments/assets/a5cf6900-4555-4bed-8626-def465132510" />
