### PR TITLE
feat(preprod): Add structured tags to snapshot test metadata

### DIFF
--- a/static/app/components/core/alert/alert.snapshots.tsx
+++ b/static/app/components/core/alert/alert.snapshots.tsx
@@ -24,7 +24,7 @@ describe('Alert', () => {
           </div>
         </ThemeProvider>
       ),
-      variant => ({theme: themeName, variant: String(variant)})
+      variant => ({tags: {theme: themeName, variant: String(variant), area: 'core'}})
     );
 
     it.snapshot.each<AlertProps['variant']>([
@@ -44,7 +44,14 @@ describe('Alert', () => {
           </div>
         </ThemeProvider>
       ),
-      variant => ({theme: themeName, variant: String(variant), showIcon: 'false'})
+      variant => ({
+        tags: {
+          theme: themeName,
+          variant: String(variant),
+          showIcon: 'false',
+          area: 'core',
+        },
+      })
     );
 
     it.snapshot.each<AlertProps['variant']>([
@@ -64,7 +71,9 @@ describe('Alert', () => {
           </div>
         </ThemeProvider>
       ),
-      variant => ({theme: themeName, variant: String(variant), system: 'true'})
+      variant => ({
+        tags: {theme: themeName, variant: String(variant), system: 'true', area: 'core'},
+      })
     );
   });
 });

--- a/static/app/components/core/alert/alert.snapshots.tsx
+++ b/static/app/components/core/alert/alert.snapshots.tsx
@@ -24,7 +24,7 @@ describe('Alert', () => {
           </div>
         </ThemeProvider>
       ),
-      variant => ({tags: {theme: themeName, variant: String(variant), area: 'core'}})
+      variant => ({tags: {variant: String(variant), area: 'core'}})
     );
 
     it.snapshot.each<AlertProps['variant']>([
@@ -44,14 +44,7 @@ describe('Alert', () => {
           </div>
         </ThemeProvider>
       ),
-      variant => ({
-        tags: {
-          theme: themeName,
-          variant: String(variant),
-          showIcon: 'false',
-          area: 'core',
-        },
-      })
+      variant => ({tags: {variant: String(variant), showIcon: 'false', area: 'core'}})
     );
 
     it.snapshot.each<AlertProps['variant']>([
@@ -71,9 +64,7 @@ describe('Alert', () => {
           </div>
         </ThemeProvider>
       ),
-      variant => ({
-        tags: {theme: themeName, variant: String(variant), system: 'true', area: 'core'},
-      })
+      variant => ({tags: {variant: String(variant), system: 'true', area: 'core'}})
     );
   });
 });

--- a/static/app/components/core/badge/badge.snapshots.tsx
+++ b/static/app/components/core/badge/badge.snapshots.tsx
@@ -31,7 +31,7 @@ describe('Badge', () => {
           </div>
         </ThemeProvider>
       ),
-      variant => ({tags: {theme: themeName, variant: String(variant), area: 'core'}})
+      variant => ({tags: {variant: String(variant), area: 'core'}})
     );
   });
 });

--- a/static/app/components/core/badge/badge.snapshots.tsx
+++ b/static/app/components/core/badge/badge.snapshots.tsx
@@ -31,7 +31,7 @@ describe('Badge', () => {
           </div>
         </ThemeProvider>
       ),
-      variant => ({theme: themeName, variant: String(variant)})
+      variant => ({tags: {theme: themeName, variant: String(variant), area: 'core'}})
     );
   });
 });

--- a/static/app/components/core/button/button.snapshots.tsx
+++ b/static/app/components/core/button/button.snapshots.tsx
@@ -46,12 +46,7 @@ describe('Button', () => {
           {
             group: `${themeName} – without icon`,
             display_name: `${themeName} / ${variant} / ${size} / without icon`,
-            tags: {
-              theme: themeName,
-              variant: String(variant),
-              size: String(size),
-              area: 'core',
-            },
+            tags: {variant: String(variant), size: String(size), area: 'core'},
           }
         );
 
@@ -67,12 +62,7 @@ describe('Button', () => {
           {
             group: `${themeName} – with icon`,
             display_name: `${themeName} / ${variant} / ${size} / with icon`,
-            tags: {
-              theme: themeName,
-              variant: String(variant),
-              size: String(size),
-              area: 'core',
-            },
+            tags: {variant: String(variant), size: String(size), area: 'core'},
           }
         );
 
@@ -91,12 +81,7 @@ describe('Button', () => {
           {
             group: `${themeName} – icon-only`,
             display_name: `${themeName} / ${variant} / ${size} / icon-only`,
-            tags: {
-              theme: themeName,
-              variant: String(variant),
-              size: String(size),
-              area: 'core',
-            },
+            tags: {variant: String(variant), size: String(size), area: 'core'},
           }
         );
       });

--- a/static/app/components/core/button/button.snapshots.tsx
+++ b/static/app/components/core/button/button.snapshots.tsx
@@ -46,6 +46,12 @@ describe('Button', () => {
           {
             group: `${themeName} – without icon`,
             display_name: `${themeName} / ${variant} / ${size} / without icon`,
+            tags: {
+              theme: themeName,
+              variant: String(variant),
+              size: String(size),
+              area: 'core',
+            },
           }
         );
 
@@ -61,6 +67,12 @@ describe('Button', () => {
           {
             group: `${themeName} – with icon`,
             display_name: `${themeName} / ${variant} / ${size} / with icon`,
+            tags: {
+              theme: themeName,
+              variant: String(variant),
+              size: String(size),
+              area: 'core',
+            },
           }
         );
 
@@ -79,6 +91,12 @@ describe('Button', () => {
           {
             group: `${themeName} – icon-only`,
             display_name: `${themeName} / ${variant} / ${size} / icon-only`,
+            tags: {
+              theme: themeName,
+              variant: String(variant),
+              size: String(size),
+              area: 'core',
+            },
           }
         );
       });

--- a/static/app/components/core/checkbox/checkbox.snapshots.tsx
+++ b/static/app/components/core/checkbox/checkbox.snapshots.tsx
@@ -17,31 +17,44 @@ describe('Checkbox', () => {
             <Checkbox checked={checked} onChange={() => {}} />
           </div>
         </ThemeProvider>
-      )
+      ),
+      checked => ({tags: {theme: themeName, checked: String(checked), area: 'core'}})
     );
 
-    it.snapshot.each<CheckboxProps['size']>(['xs', 'sm', 'md'])('size-%s', size => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Checkbox checked size={size} onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot.each<CheckboxProps['size']>(['xs', 'sm', 'md'])(
+      'size-%s',
+      size => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Checkbox checked size={size} onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      size => ({tags: {theme: themeName, size: String(size), area: 'core'}})
+    );
 
-    it.snapshot('disabled-unchecked', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Checkbox disabled onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'disabled-unchecked',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Checkbox disabled onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {theme: themeName, disabled: 'true', area: 'core'}}
+    );
 
-    it.snapshot('disabled-checked', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Checkbox checked disabled onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'disabled-checked',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Checkbox checked disabled onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {theme: themeName, disabled: 'true', checked: 'true', area: 'core'}}
+    );
   });
 });

--- a/static/app/components/core/checkbox/checkbox.snapshots.tsx
+++ b/static/app/components/core/checkbox/checkbox.snapshots.tsx
@@ -18,7 +18,7 @@ describe('Checkbox', () => {
           </div>
         </ThemeProvider>
       ),
-      checked => ({tags: {theme: themeName, checked: String(checked), area: 'core'}})
+      checked => ({tags: {checked: String(checked), area: 'core'}})
     );
 
     it.snapshot.each<CheckboxProps['size']>(['xs', 'sm', 'md'])(
@@ -30,7 +30,7 @@ describe('Checkbox', () => {
           </div>
         </ThemeProvider>
       ),
-      size => ({tags: {theme: themeName, size: String(size), area: 'core'}})
+      size => ({tags: {size: String(size), area: 'core'}})
     );
 
     it.snapshot(
@@ -42,7 +42,7 @@ describe('Checkbox', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, disabled: 'true', area: 'core'}}
+      {tags: {disabled: 'true', area: 'core'}}
     );
 
     it.snapshot(
@@ -54,7 +54,7 @@ describe('Checkbox', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, disabled: 'true', checked: 'true', area: 'core'}}
+      {tags: {disabled: 'true', checked: 'true', area: 'core'}}
     );
   });
 });

--- a/static/app/components/core/input/inputGroup.snapshots.tsx
+++ b/static/app/components/core/input/inputGroup.snapshots.tsx
@@ -22,7 +22,7 @@ describe('InputGroup', () => {
           </div>
         </ThemeProvider>
       ),
-      size => ({tags: {theme: themeName, size: String(size), area: 'core'}})
+      size => ({tags: {size: String(size), area: 'core'}})
     );
 
     it.snapshot(
@@ -36,7 +36,7 @@ describe('InputGroup', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, disabled: 'true', area: 'core'}}
+      {tags: {disabled: 'true', area: 'core'}}
     );
 
     it.snapshot(
@@ -53,7 +53,7 @@ describe('InputGroup', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -70,7 +70,7 @@ describe('InputGroup', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, disabled: 'true', area: 'core'}}
+      {tags: {disabled: 'true', area: 'core'}}
     );
   });
 });

--- a/static/app/components/core/input/inputGroup.snapshots.tsx
+++ b/static/app/components/core/input/inputGroup.snapshots.tsx
@@ -22,43 +22,55 @@ describe('InputGroup', () => {
           </div>
         </ThemeProvider>
       ),
-      size => ({theme: themeName, size: String(size)})
+      size => ({tags: {theme: themeName, size: String(size), area: 'core'}})
     );
 
-    it.snapshot('disabled', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8, width: 300}}>
-          <InputGroup>
-            <InputGroup.Input disabled placeholder="Disabled input" />
-          </InputGroup>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'disabled',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8, width: 300}}>
+            <InputGroup>
+              <InputGroup.Input disabled placeholder="Disabled input" />
+            </InputGroup>
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {theme: themeName, disabled: 'true', area: 'core'}}
+    );
 
-    it.snapshot('with-leading-items', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8, width: 300}}>
-          <InputGroup>
-            <InputGroup.LeadingItems disablePointerEvents>
-              <IconSearch />
-            </InputGroup.LeadingItems>
-            <InputGroup.Input placeholder="Search…" />
-          </InputGroup>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'with-leading-items',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8, width: 300}}>
+            <InputGroup>
+              <InputGroup.LeadingItems disablePointerEvents>
+                <IconSearch />
+              </InputGroup.LeadingItems>
+              <InputGroup.Input placeholder="Search…" />
+            </InputGroup>
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {theme: themeName, area: 'core'}}
+    );
 
-    it.snapshot('with-leading-items-disabled', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8, width: 300}}>
-          <InputGroup>
-            <InputGroup.LeadingItems disablePointerEvents>
-              <IconSearch />
-            </InputGroup.LeadingItems>
-            <InputGroup.Input disabled placeholder="Search…" />
-          </InputGroup>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'with-leading-items-disabled',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8, width: 300}}>
+            <InputGroup>
+              <InputGroup.LeadingItems disablePointerEvents>
+                <IconSearch />
+              </InputGroup.LeadingItems>
+              <InputGroup.Input disabled placeholder="Search…" />
+            </InputGroup>
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {theme: themeName, disabled: 'true', area: 'core'}}
+    );
   });
 });

--- a/static/app/components/core/radio/radio.snapshots.tsx
+++ b/static/app/components/core/radio/radio.snapshots.tsx
@@ -18,7 +18,7 @@ describe('Radio', () => {
           </div>
         </ThemeProvider>
       ),
-      size => ({tags: {theme: themeName, size, area: 'core'}})
+      size => ({tags: {size, area: 'core'}})
     );
 
     it.snapshot.each<'sm' | 'md'>(['sm', 'md'])(
@@ -30,7 +30,7 @@ describe('Radio', () => {
           </div>
         </ThemeProvider>
       ),
-      size => ({tags: {theme: themeName, size, checked: 'true', area: 'core'}})
+      size => ({tags: {size, checked: 'true', area: 'core'}})
     );
 
     it.snapshot(
@@ -42,7 +42,7 @@ describe('Radio', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, disabled: 'true', area: 'core'}}
+      {tags: {disabled: 'true', area: 'core'}}
     );
 
     it.snapshot(
@@ -54,7 +54,7 @@ describe('Radio', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, disabled: 'true', checked: 'true', area: 'core'}}
+      {tags: {disabled: 'true', checked: 'true', area: 'core'}}
     );
   });
 });

--- a/static/app/components/core/radio/radio.snapshots.tsx
+++ b/static/app/components/core/radio/radio.snapshots.tsx
@@ -9,36 +9,52 @@ const themes = {light: lightTheme, dark: darkTheme};
 
 describe('Radio', () => {
   describe.each(['light', 'dark'] as const)('theme-%s', themeName => {
-    it.snapshot.each<'sm' | 'md'>(['sm', 'md'])('size-%s-unchecked', size => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Radio size={size} onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot.each<'sm' | 'md'>(['sm', 'md'])(
+      'size-%s-unchecked',
+      size => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Radio size={size} onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      size => ({tags: {theme: themeName, size, area: 'core'}})
+    );
 
-    it.snapshot.each<'sm' | 'md'>(['sm', 'md'])('size-%s-checked', size => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Radio checked size={size} onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot.each<'sm' | 'md'>(['sm', 'md'])(
+      'size-%s-checked',
+      size => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Radio checked size={size} onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      size => ({tags: {theme: themeName, size, checked: 'true', area: 'core'}})
+    );
 
-    it.snapshot('disabled-unchecked', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Radio disabled onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'disabled-unchecked',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Radio disabled onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {theme: themeName, disabled: 'true', area: 'core'}}
+    );
 
-    it.snapshot('disabled-checked', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Radio checked disabled onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'disabled-checked',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Radio checked disabled onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {theme: themeName, disabled: 'true', checked: 'true', area: 'core'}}
+    );
   });
 });

--- a/static/app/components/core/switch/switch.snapshots.tsx
+++ b/static/app/components/core/switch/switch.snapshots.tsx
@@ -9,36 +9,54 @@ const themes = {light: lightTheme, dark: darkTheme};
 
 describe('Switch', () => {
   describe.each(['light', 'dark'] as const)('theme-%s', themeName => {
-    it.snapshot.each<SwitchProps['size']>(['sm', 'lg'])('size-%s-unchecked', size => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Switch size={size} onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot.each<SwitchProps['size']>(['sm', 'lg'])(
+      'size-%s-unchecked',
+      size => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Switch size={size} onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      size => ({tags: {theme: themeName, size: String(size), area: 'core'}})
+    );
 
-    it.snapshot.each<SwitchProps['size']>(['sm', 'lg'])('size-%s-checked', size => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Switch checked size={size} onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot.each<SwitchProps['size']>(['sm', 'lg'])(
+      'size-%s-checked',
+      size => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Switch checked size={size} onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      size => ({
+        tags: {theme: themeName, size: String(size), checked: 'true', area: 'core'},
+      })
+    );
 
-    it.snapshot('disabled-unchecked', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Switch disabled onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'disabled-unchecked',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Switch disabled onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {theme: themeName, disabled: 'true', area: 'core'}}
+    );
 
-    it.snapshot('disabled-checked', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Switch checked disabled onChange={() => {}} />
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'disabled-checked',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Switch checked disabled onChange={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {theme: themeName, disabled: 'true', checked: 'true', area: 'core'}}
+    );
   });
 });

--- a/static/app/components/core/switch/switch.snapshots.tsx
+++ b/static/app/components/core/switch/switch.snapshots.tsx
@@ -18,7 +18,7 @@ describe('Switch', () => {
           </div>
         </ThemeProvider>
       ),
-      size => ({tags: {theme: themeName, size: String(size), area: 'core'}})
+      size => ({tags: {size: String(size), area: 'core'}})
     );
 
     it.snapshot.each<SwitchProps['size']>(['sm', 'lg'])(
@@ -30,9 +30,7 @@ describe('Switch', () => {
           </div>
         </ThemeProvider>
       ),
-      size => ({
-        tags: {theme: themeName, size: String(size), checked: 'true', area: 'core'},
-      })
+      size => ({tags: {size: String(size), checked: 'true', area: 'core'}})
     );
 
     it.snapshot(
@@ -44,7 +42,7 @@ describe('Switch', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, disabled: 'true', area: 'core'}}
+      {tags: {disabled: 'true', area: 'core'}}
     );
 
     it.snapshot(
@@ -56,7 +54,7 @@ describe('Switch', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, disabled: 'true', checked: 'true', area: 'core'}}
+      {tags: {disabled: 'true', checked: 'true', area: 'core'}}
     );
   });
 });

--- a/static/app/components/core/text/text.snapshots.tsx
+++ b/static/app/components/core/text/text.snapshots.tsx
@@ -19,7 +19,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      size => ({tags: {theme: themeName, size, area: 'core'}})
+      size => ({tags: {size, area: 'core'}})
     );
 
     it.snapshot.each([
@@ -39,7 +39,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      variant => ({tags: {theme: themeName, variant, area: 'core'}})
+      variant => ({tags: {variant, area: 'core'}})
     );
 
     it.snapshot(
@@ -51,7 +51,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -63,7 +63,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -75,7 +75,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -87,7 +87,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -99,7 +99,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -111,7 +111,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -123,7 +123,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -135,7 +135,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -147,7 +147,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot.each(['left', 'center', 'right', 'justify'] as const)(
@@ -161,7 +161,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      align => ({tags: {theme: themeName, align, area: 'core'}})
+      align => ({tags: {align, area: 'core'}})
     );
 
     it.snapshot.each(['compressed', 'comfortable'] as const)(
@@ -176,7 +176,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      density => ({tags: {theme: themeName, density, area: 'core'}})
+      density => ({tags: {density, area: 'core'}})
     );
 
     it.snapshot(
@@ -190,7 +190,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -204,7 +204,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot.each(['balance', 'pretty', 'nowrap', 'stable'] as const)(
@@ -218,7 +218,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      textWrap => ({tags: {theme: themeName, textWrap, area: 'core'}})
+      textWrap => ({tags: {textWrap, area: 'core'}})
     );
 
     it.snapshot.each(['nowrap', 'pre', 'pre-line', 'pre-wrap'] as const)(
@@ -230,7 +230,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      wrap => ({tags: {theme: themeName, wrap, area: 'core'}})
+      wrap => ({tags: {wrap, area: 'core'}})
     );
 
     // === Combined props ===
@@ -245,7 +245,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -259,7 +259,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -273,7 +273,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -287,7 +287,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
 
     it.snapshot(
@@ -302,7 +302,7 @@ describe('Text', () => {
           </Container>
         </ThemeProvider>
       ),
-      {tags: {theme: themeName, area: 'core'}}
+      {tags: {area: 'core'}}
     );
   });
 });

--- a/static/app/components/core/text/text.snapshots.tsx
+++ b/static/app/components/core/text/text.snapshots.tsx
@@ -19,7 +19,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      size => ({theme: themeName, size})
+      size => ({tags: {theme: themeName, size, area: 'core'}})
     );
 
     it.snapshot.each([
@@ -39,7 +39,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      variant => ({theme: themeName, variant})
+      variant => ({tags: {theme: themeName, variant, area: 'core'}})
     );
 
     it.snapshot(
@@ -51,7 +51,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -63,7 +63,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -75,7 +75,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -87,7 +87,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -99,7 +99,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -111,7 +111,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -123,7 +123,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -135,7 +135,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -147,7 +147,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot.each(['left', 'center', 'right', 'justify'] as const)(
@@ -161,7 +161,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      align => ({theme: themeName, align})
+      align => ({tags: {theme: themeName, align, area: 'core'}})
     );
 
     it.snapshot.each(['compressed', 'comfortable'] as const)(
@@ -176,7 +176,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      density => ({theme: themeName, density})
+      density => ({tags: {theme: themeName, density, area: 'core'}})
     );
 
     it.snapshot(
@@ -190,7 +190,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -204,7 +204,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot.each(['balance', 'pretty', 'nowrap', 'stable'] as const)(
@@ -218,7 +218,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      textWrap => ({theme: themeName, textWrap})
+      textWrap => ({tags: {theme: themeName, textWrap, area: 'core'}})
     );
 
     it.snapshot.each(['nowrap', 'pre', 'pre-line', 'pre-wrap'] as const)(
@@ -230,7 +230,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      wrap => ({theme: themeName, wrap})
+      wrap => ({tags: {theme: themeName, wrap, area: 'core'}})
     );
 
     // === Combined props ===
@@ -245,7 +245,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -259,7 +259,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -273,7 +273,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -287,7 +287,7 @@ describe('Text', () => {
           </div>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
 
     it.snapshot(
@@ -302,7 +302,7 @@ describe('Text', () => {
           </Container>
         </ThemeProvider>
       ),
-      {theme: themeName}
+      {tags: {theme: themeName, area: 'core'}}
     );
   });
 });

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
@@ -100,7 +100,7 @@ describe('PreprodBuildsSnapshotTable', () => {
     }
 
     it.snapshot('status-approved', () => renderTable(makeBuild()), {
-      tags: {theme: themeName, state: 'status-approved', area: 'snapshots'},
+      tags: {theme: themeName, area: 'snapshots'},
     });
 
     it.snapshot(
@@ -121,7 +121,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             },
           })
         ),
-      {tags: {theme: themeName, state: 'status-needs-approval', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -142,7 +142,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             },
           })
         ),
-      {tags: {theme: themeName, state: 'status-no-base-build', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -153,7 +153,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             snapshot_comparison_info: undefined,
           })
         ),
-      {tags: {theme: themeName, state: 'status-no-comparison', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -174,7 +174,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             },
           })
         ),
-      {tags: {theme: themeName, state: 'changes-no-changes', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
   });
 });

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
@@ -100,7 +100,7 @@ describe('PreprodBuildsSnapshotTable', () => {
     }
 
     it.snapshot('status-approved', () => renderTable(makeBuild()), {
-      tags: {theme: themeName, area: 'snapshots'},
+      tags: {area: 'snapshots'},
     });
 
     it.snapshot(
@@ -121,7 +121,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             },
           })
         ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -142,7 +142,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             },
           })
         ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -153,7 +153,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             snapshot_comparison_info: undefined,
           })
         ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -174,7 +174,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             },
           })
         ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
   });
 });

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
@@ -100,8 +100,7 @@ describe('PreprodBuildsSnapshotTable', () => {
     }
 
     it.snapshot('status-approved', () => renderTable(makeBuild()), {
-      theme: themeName,
-      state: 'status-approved',
+      tags: {theme: themeName, state: 'status-approved', area: 'snapshots'},
     });
 
     it.snapshot(
@@ -122,7 +121,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             },
           })
         ),
-      {theme: themeName, state: 'status-needs-approval'}
+      {tags: {theme: themeName, state: 'status-needs-approval', area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -143,7 +142,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             },
           })
         ),
-      {theme: themeName, state: 'status-no-base-build'}
+      {tags: {theme: themeName, state: 'status-no-base-build', area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -154,7 +153,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             snapshot_comparison_info: undefined,
           })
         ),
-      {theme: themeName, state: 'status-no-comparison'}
+      {tags: {theme: themeName, state: 'status-no-comparison', area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -175,7 +174,7 @@ describe('PreprodBuildsSnapshotTable', () => {
             },
           })
         ),
-      {theme: themeName, state: 'changes-no-changes'}
+      {tags: {theme: themeName, state: 'changes-no-changes', area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
@@ -120,7 +120,7 @@ describe('DiffImageDisplay', () => {
           />
         </Wrapper>
       ),
-      _diffMode => ({tags: {theme: themeName, area: 'snapshots'}})
+      () => ({tags: {area: 'snapshots'}})
     );
 
     it.snapshot(
@@ -136,7 +136,7 @@ describe('DiffImageDisplay', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
@@ -120,7 +120,7 @@ describe('DiffImageDisplay', () => {
           />
         </Wrapper>
       ),
-      diffMode => ({tags: {theme: themeName, state: diffMode, area: 'snapshots'}})
+      _diffMode => ({tags: {theme: themeName, area: 'snapshots'}})
     );
 
     it.snapshot(
@@ -136,7 +136,7 @@ describe('DiffImageDisplay', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, state: 'split-missing-diff-image-key', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
@@ -120,7 +120,7 @@ describe('DiffImageDisplay', () => {
           />
         </Wrapper>
       ),
-      diffMode => ({theme: themeName, state: diffMode})
+      diffMode => ({tags: {theme: themeName, state: diffMode, area: 'snapshots'}})
     );
 
     it.snapshot(
@@ -136,7 +136,7 @@ describe('DiffImageDisplay', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'split-missing-diff-image-key'}
+      {tags: {theme: themeName, state: 'split-missing-diff-image-key', area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.snapshots.tsx
@@ -73,7 +73,7 @@ describe('SingleImageDisplay', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.snapshots.tsx
@@ -73,7 +73,7 @@ describe('SingleImageDisplay', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, state: 'basic-image-display', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.snapshots.tsx
@@ -73,7 +73,7 @@ describe('SingleImageDisplay', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'basic-image-display'}
+      {tags: {theme: themeName, state: 'basic-image-display', area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -193,7 +193,13 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'card-header-display-name-and-filename'}
+      {
+        tags: {
+          theme: themeName,
+          state: 'card-header-display-name-and-filename',
+          area: 'snapshots',
+        },
+      }
     );
 
     it.snapshot(
@@ -203,7 +209,7 @@ describe('SnapshotCards', () => {
           <CardHeader {...headerProps} displayName={null} status={DiffStatus.CHANGED} />
         </Wrapper>
       ),
-      {theme: themeName, state: 'card-header-filename-only'}
+      {tags: {theme: themeName, state: 'card-header-filename-only', area: 'snapshots'}}
     );
 
     function snapshotCardHeaderStatus({
@@ -227,7 +233,7 @@ describe('SnapshotCards', () => {
             />
           </Wrapper>
         ),
-        {theme: themeName, state: `card-header-${state}`}
+        {tags: {theme: themeName, state: `card-header-${state}`, area: 'snapshots'}}
       );
     }
 
@@ -259,7 +265,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'card-header-static'}
+      {tags: {theme: themeName, state: 'card-header-static', area: 'snapshots'}}
     );
 
     function snapshotPairCard({
@@ -292,7 +298,7 @@ describe('SnapshotCards', () => {
             />
           </Wrapper>
         ),
-        {theme: themeName, state: `pair-card-${state}`}
+        {tags: {theme: themeName, state: `pair-card-${state}`, area: 'snapshots'}}
       );
     }
 
@@ -337,7 +343,13 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'image-card-added-selected-with-display-name'}
+      {
+        tags: {
+          theme: themeName,
+          state: 'image-card-added-selected-with-display-name',
+          area: 'snapshots',
+        },
+      }
     );
 
     it.snapshot(
@@ -356,7 +368,13 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'image-card-removed-unselected'}
+      {
+        tags: {
+          theme: themeName,
+          state: 'image-card-removed-unselected',
+          area: 'snapshots',
+        },
+      }
     );
 
     it.snapshot(
@@ -376,7 +394,13 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'image-card-renamed-with-pair-metadata'}
+      {
+        tags: {
+          theme: themeName,
+          state: 'image-card-renamed-with-pair-metadata',
+          area: 'snapshots',
+        },
+      }
     );
 
     it.snapshot(
@@ -395,7 +419,13 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'image-card-solo-filename-only-no-status'}
+      {
+        tags: {
+          theme: themeName,
+          state: 'image-card-solo-filename-only-no-status',
+          area: 'snapshots',
+        },
+      }
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -193,7 +193,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -203,7 +203,7 @@ describe('SnapshotCards', () => {
           <CardHeader {...headerProps} displayName={null} status={DiffStatus.CHANGED} />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     function snapshotCardHeaderStatus({
@@ -227,7 +227,7 @@ describe('SnapshotCards', () => {
             />
           </Wrapper>
         ),
-        {tags: {theme: themeName, area: 'snapshots'}}
+        {tags: {area: 'snapshots'}}
       );
     }
 
@@ -259,7 +259,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     function snapshotPairCard({
@@ -292,7 +292,7 @@ describe('SnapshotCards', () => {
             />
           </Wrapper>
         ),
-        {tags: {theme: themeName, area: 'snapshots'}}
+        {tags: {area: 'snapshots'}}
       );
     }
 
@@ -337,7 +337,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -356,7 +356,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -376,7 +376,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -395,7 +395,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -193,13 +193,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {
-        tags: {
-          theme: themeName,
-          state: 'card-header-display-name-and-filename',
-          area: 'snapshots',
-        },
-      }
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -209,7 +203,7 @@ describe('SnapshotCards', () => {
           <CardHeader {...headerProps} displayName={null} status={DiffStatus.CHANGED} />
         </Wrapper>
       ),
-      {tags: {theme: themeName, state: 'card-header-filename-only', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     function snapshotCardHeaderStatus({
@@ -233,7 +227,7 @@ describe('SnapshotCards', () => {
             />
           </Wrapper>
         ),
-        {tags: {theme: themeName, state: `card-header-${state}`, area: 'snapshots'}}
+        {tags: {theme: themeName, area: 'snapshots'}}
       );
     }
 
@@ -265,7 +259,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, state: 'card-header-static', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     function snapshotPairCard({
@@ -298,7 +292,7 @@ describe('SnapshotCards', () => {
             />
           </Wrapper>
         ),
-        {tags: {theme: themeName, state: `pair-card-${state}`, area: 'snapshots'}}
+        {tags: {theme: themeName, area: 'snapshots'}}
       );
     }
 
@@ -343,13 +337,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {
-        tags: {
-          theme: themeName,
-          state: 'image-card-added-selected-with-display-name',
-          area: 'snapshots',
-        },
-      }
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -368,13 +356,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {
-        tags: {
-          theme: themeName,
-          state: 'image-card-removed-unselected',
-          area: 'snapshots',
-        },
-      }
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -394,13 +376,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {
-        tags: {
-          theme: themeName,
-          state: 'image-card-renamed-with-pair-metadata',
-          area: 'snapshots',
-        },
-      }
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -419,13 +395,7 @@ describe('SnapshotCards', () => {
           />
         </Wrapper>
       ),
-      {
-        tags: {
-          theme: themeName,
-          state: 'image-card-solo-filename-only-no-status',
-          area: 'snapshots',
-        },
-      }
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
@@ -73,7 +73,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, state: 'default', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -92,7 +92,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, state: 'active-group', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -110,7 +110,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, state: 'filtered', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -128,7 +128,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, state: 'no-results', area: 'snapshots'}}
+      {tags: {theme: themeName, area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
@@ -73,7 +73,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'default'}
+      {tags: {theme: themeName, state: 'default', area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -92,7 +92,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'active-group'}
+      {tags: {theme: themeName, state: 'active-group', area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -110,7 +110,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'filtered'}
+      {tags: {theme: themeName, state: 'filtered', area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -128,7 +128,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'no-results'}
+      {tags: {theme: themeName, state: 'no-results', area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
@@ -73,7 +73,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -92,7 +92,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -110,7 +110,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -128,7 +128,7 @@ describe('SnapshotSidebarContent', () => {
           />
         </Wrapper>
       ),
-      {tags: {theme: themeName, area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
   });
 });

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -7,6 +7,7 @@ interface SnapshotDetails {
   displayName: string;
   fileSlug: string;
   group: string | null;
+  theme: string | undefined;
 }
 
 /**
@@ -27,14 +28,17 @@ function parseSnapshotDetails(testName: string, fallbackName: string): SnapshotD
       displayName: fallbackName,
       fileSlug: fallbackName.toLowerCase(),
       group: null,
+      theme: undefined,
     };
   }
 
-  const group = parts[0]!.trim().replace(/\s+/g, '/');
+  const ancestry = parts[0]!.trim();
+  const group = ancestry.replace(/\s+/g, '/');
   const displayName = parts[1]!.trim();
   const fileSlug = `${group}/${displayName}`.replace(/\s+/g, '').toLowerCase();
+  const themeMatch = ancestry.match(/\b(light|dark)\b/);
 
-  return {displayName, fileSlug, group};
+  return {displayName, fileSlug, group, theme: themeMatch?.[1]};
 }
 
 function snapshotTest(
@@ -48,17 +52,15 @@ function snapshotTest(
       throw new Error('Could not determine test file path');
     }
 
-    const {displayName, fileSlug, group} = parseSnapshotDetails(
-      currentTestName ?? '',
-      name
-    );
+    const details = parseSnapshotDetails(currentTestName ?? '', name);
 
     await takeSnapshot({
-      fileSlug,
-      displayName,
+      fileSlug: details.fileSlug,
+      displayName: details.displayName,
       renderFn,
       testFilePath: testPath,
-      group,
+      group: details.group,
+      theme: details.theme,
       metadata,
     });
   });

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -1,6 +1,7 @@
 import type {ReactElement} from 'react';
 
 import {closeBrowser, takeSnapshot} from './snapshot';
+import type {SnapshotTestMetadata} from './snapshot-image-metadata';
 
 interface SnapshotDetails {
   displayName: string;
@@ -39,7 +40,7 @@ function parseSnapshotDetails(testName: string, fallbackName: string): SnapshotD
 function snapshotTest(
   name: string,
   renderFn: () => ReactElement,
-  metadata: Record<string, string> = {}
+  metadata: SnapshotTestMetadata = {}
 ): void {
   test(`snapshot: ${name}`, async () => {
     const {testPath, currentTestName} = expect.getState();
@@ -67,7 +68,7 @@ snapshotTest.each = function snapshotEach<T>(table: T[]) {
   return (
     name: string,
     renderFn: (value: T) => ReactElement,
-    metadataFn?: (value: T) => Record<string, string>
+    metadataFn?: (value: T) => SnapshotTestMetadata
   ) => {
     for (const value of table) {
       const testName = name.replace('%s', String(value));
@@ -91,7 +92,7 @@ declare global {
         ) => (
           name: string,
           renderFn: (value: T) => ReactElement,
-          metadataFn?: (value: T) => Record<string, string>
+          metadataFn?: (value: T) => SnapshotTestMetadata
         ) => void;
       };
     }

--- a/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
@@ -5,5 +5,12 @@ export interface SnapshotImageMetadata {
     test_file_path: string;
   };
   group?: string | null;
+  tags?: Record<string, string>;
   // Skip height, width and image_file_name as they're handled by the CLI
+}
+
+export interface SnapshotTestMetadata {
+  display_name?: string;
+  group?: string;
+  tags?: Record<string, string>;
 }

--- a/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
@@ -9,9 +9,9 @@ export interface SnapshotImageMetadata {
   // Skip height, width and image_file_name as they're handled by the CLI
 }
 
-export type SnapshotArea = 'core' | 'snapshots';
+type SnapshotArea = 'core' | 'snapshots';
 
-export type SnapshotTags = {area: SnapshotArea} & Record<string, string>;
+type SnapshotTags = {area: SnapshotArea} & Record<string, string>;
 
 export interface SnapshotTestMetadata {
   display_name?: string;

--- a/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
@@ -9,8 +9,12 @@ export interface SnapshotImageMetadata {
   // Skip height, width and image_file_name as they're handled by the CLI
 }
 
+export type SnapshotArea = 'core' | 'snapshots';
+
+export type SnapshotTags = {area: SnapshotArea} & Record<string, string>;
+
 export interface SnapshotTestMetadata {
   display_name?: string;
   group?: string;
-  tags?: Record<string, string>;
+  tags?: SnapshotTags;
 }

--- a/tests/js/sentry-test/snapshots/snapshot.ts
+++ b/tests/js/sentry-test/snapshots/snapshot.ts
@@ -107,6 +107,7 @@ interface TakeSnapshotOptions {
   metadata: SnapshotTestMetadata;
   renderFn: () => ReactElement;
   testFilePath: string;
+  theme: string | undefined;
 }
 
 export async function takeSnapshot({
@@ -115,6 +116,7 @@ export async function takeSnapshot({
   renderFn,
   testFilePath,
   group,
+  theme,
   metadata,
 }: TakeSnapshotOptions): Promise<void> {
   const element = renderFn();
@@ -145,10 +147,16 @@ export async function takeSnapshot({
       mkdirSync(outputDir, {recursive: true});
     }
 
+    const autoTags: Record<string, string> = {};
+    if (theme) {
+      autoTags.theme = theme;
+    }
+    const tags = {...autoTags, ...metadata.tags};
+
     const meta: SnapshotImageMetadata = {
-      display_name: displayName,
-      group,
-      ...metadata,
+      display_name: metadata.display_name ?? displayName,
+      group: metadata.group ?? group,
+      tags: Object.keys(tags).length > 0 ? tags : undefined,
       context: {test_file_path: relativePath},
     };
 

--- a/tests/js/sentry-test/snapshots/snapshot.ts
+++ b/tests/js/sentry-test/snapshots/snapshot.ts
@@ -10,7 +10,10 @@ import {CacheProvider} from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import {chromium, type Browser} from 'playwright';
 
-import type {SnapshotImageMetadata} from 'sentry-test/snapshots/snapshot-image-metadata';
+import type {
+  SnapshotImageMetadata,
+  SnapshotTestMetadata,
+} from 'sentry-test/snapshots/snapshot-image-metadata';
 
 const PROJECT_ROOT = path.resolve(__dirname, '../../../..');
 const FONTS_DIR = path.resolve(PROJECT_ROOT, 'static/fonts');
@@ -101,7 +104,7 @@ interface TakeSnapshotOptions {
   displayName: string;
   fileSlug: string;
   group: string | null;
-  metadata: Record<string, string>;
+  metadata: SnapshotTestMetadata;
   renderFn: () => ReactElement;
   testFilePath: string;
 }


### PR DESCRIPTION
Move all custom metadata (theme, variant, size, state, etc.) from flat top-level keys into a structured `tags: Record<string, string>` field across all 14 snapshot test files. This makes snapshot properties filterable and queryable on the product side without relying on `extra = "allow"` passthrough fields.

**Framework type changes**

`SnapshotTestMetadata` replaces the previous `Record<string, string>` parameter on `it.snapshot()` and `it.snapshot.each()`. The new type restricts metadata to three keys: `group`, `display_name`, and `tags`. The `SnapshotImageMetadata` output interface gains a matching `tags` field. No backend changes needed — `ImageMetadata` in `manifest.py` already has `tags: dict[str, str] | None` with coercion.

**Per-file tag mapping**

Every snapshot test now passes an explicit `tags` object containing the relevant axes for that component — `theme` is universal, `size`/`variant`/`state` vary by file. An `area` tag distinguishes core design system primitives (`core`) from product-side snapshot UI (`snapshots`). Three files (checkbox, radio, switch) that previously had no metadata now gain tags for the first time.