### PR TITLE
fix(code-mapping): update codeowners GET endpoint and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1788,7 +1788,6 @@ module = [
     "tests.sentry.api.endpoints.test_organization_auth_providers",
     "tests.sentry.api.endpoints.test_organization_auth_token_details",
     "tests.sentry.api.endpoints.test_organization_auth_tokens",
-    "tests.sentry.api.endpoints.test_organization_code_mapping_codeowners",
     "tests.sentry.api.endpoints.test_organization_config_integrations",
     "tests.sentry.api.endpoints.test_organization_events_trends_v2",
     "tests.sentry.api.endpoints.test_organization_fork",

--- a/src/sentry/integrations/api/endpoints/organization_code_mapping_codeowners.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mapping_codeowners.py
@@ -59,6 +59,10 @@ class OrganizationCodeMappingCodeOwnersEndpoint(OrganizationEndpoint):
         return (args, kwargs)
 
     def get(self, request: Request, config_id, organization, config) -> Response:
+        project = config.project_repository.project
+        if not request.access.has_project_access(project):
+            return self.respond(status=status.HTTP_403_FORBIDDEN)
+
         try:
             codeowner_contents = get_codeowner_contents(config)
         except ApiError as e:

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mapping_codeowners.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mapping_codeowners.py
@@ -18,6 +18,10 @@ class OrganizationCodeMappingCodeOwnersTest(APITestCase):
 
         self.login_as(user=self.user)
 
+        # Restrict project membership so that team assignment controls access.
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
         self.team = self.create_team(organization=self.organization, name="Mariachi Band")
         self.project = self.create_project(
             organization=self.organization, teams=[self.team], name="Bengal"
@@ -58,6 +62,43 @@ class OrganizationCodeMappingCodeOwnersTest(APITestCase):
         return_value=GITHUB_CODEOWNER,
     )
     def test_codeowner_contents(self, mock_get_codeowner_file: MagicMock) -> None:
+        resp = self.client.get(self.url)
+        assert resp.status_code == 200
+        assert resp.data == GITHUB_CODEOWNER
+
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_codeowner_file",
+        return_value=GITHUB_CODEOWNER,
+    )
+    def test_user_without_project_access_cannot_read_codeowners(
+        self, mock_get_codeowner_file: MagicMock
+    ) -> None:
+        outsider = self.create_user()
+        self.create_member(
+            organization=self.organization,
+            user=outsider,
+            has_global_access=False,
+            teams=[],
+        )
+        self.login_as(user=outsider)
+        resp = self.client.get(self.url)
+        assert resp.status_code == 403
+
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_codeowner_file",
+        return_value=GITHUB_CODEOWNER,
+    )
+    def test_user_with_project_access_can_read_codeowners(
+        self, mock_get_codeowner_file: MagicMock
+    ) -> None:
+        insider = self.create_user()
+        self.create_member(
+            organization=self.organization,
+            user=insider,
+            has_global_access=False,
+            teams=[self.team],
+        )
+        self.login_as(user=insider)
         resp = self.client.get(self.url)
         assert resp.status_code == 200
         assert resp.data == GITHUB_CODEOWNER


### PR DESCRIPTION
The GET handler for the codeowners endpoint looked up RepositoryProjectPathConfig by config id and organization only. The sibling PUT and DELETE handlers on the code-mapping details endpoint gate on project access; this brings the GET path in line with that behaviour.

Also moves the test file to the canonical mirror path under tests/sentry/integrations/api/endpoints/ to match the source module location, and consolidates the two test classes into one following the pattern established by the sibling endpoint tests.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
