### PR TITLE
chore(aci): Update alerts:write settings toggle label to include reference to monitors

### DIFF
--- a/static/app/components/core/form/generatedFieldRegistry.ts
+++ b/static/app/components/core/form/generatedFieldRegistry.ts
@@ -342,9 +342,9 @@ export const FORM_FIELD_REGISTRY: Record<string, FormFieldDefinition> = {
     name: 'alertsMemberWrite',
     formId: 'organization-settings-form',
     route: '/settings/organization/',
-    label: t('Let Members Create and Edit Alerts'),
+    label: t('Let Members Create and Edit Monitors and Alerts'),
     hintText: t(
-      'Allow members to create, edit, and delete alert rules by granting them the `alerts:write` scope.'
+      'Allow members to create, edit, and delete monitors and alert rules by granting them the `alerts:write` scope.'
     ),
   },
   'organization-settings-form.attachmentsRole': {

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -309,16 +309,16 @@ function OrganizationMembershipSettingsBase({
           confirm={value =>
             value
               ? t(
-                  'This will allow any members of your organization to create, edit, and delete alert rules in all projects. Do you want to continue?'
+                  'This will allow any members of your organization to create, edit, and delete monitors and alert rules in all projects. Do you want to continue?'
                 )
               : undefined
           }
         >
           {field => (
             <field.Layout.Row
-              label={t('Let Members Create and Edit Alerts')}
+              label={t('Let Members Create and Edit Monitors and Alerts')}
               hintText={t(
-                'Allow members to create, edit, and delete alert rules by granting them the `alerts:write` scope.'
+                'Allow members to create, edit, and delete monitors and alert rules by granting them the `alerts:write` scope.'
               )}
             >
               <field.Switch

--- a/static/gsApp/overrides/organizationMembershipSettingsForm.tsx
+++ b/static/gsApp/overrides/organizationMembershipSettingsForm.tsx
@@ -206,16 +206,16 @@ export function OrganizationMembershipSettingsForm({
           confirm={value =>
             value
               ? t(
-                  'This will allow any members of your organization to create, edit, and delete alert rules in all projects. Do you want to continue?'
+                  'This will allow any members of your organization to create, edit, and delete monitors and alert rules in all projects. Do you want to continue?'
                 )
               : undefined
           }
         >
           {field => (
             <field.Layout.Row
-              label={t('Let Members Create and Edit Alerts')}
+              label={t('Let Members Create and Edit Monitors and Alerts')}
               hintText={t(
-                'Allow members to create, edit, and delete alert rules by granting them the `alerts:write` scope.'
+                'Allow members to create, edit, and delete monitors and alert rules by granting them the `alerts:write` scope.'
               )}
             >
               <field.Switch


### PR DESCRIPTION
This setting affects Monitors & Alerts rather than just Alerts like it did before, so this PR updates copy to reflect that. 