### PR TITLE
feat(bitbucket-server): Route install through API pipeline modal

### DIFF
--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -46,6 +46,7 @@ export interface AddIntegrationParams {
 const UNCONDITIONAL_API_PIPELINE_PROVIDERS = [
   'aws_lambda',
   'bitbucket',
+  'bitbucket_server',
   'claude_code',
   'cursor',
   'discord',


### PR DESCRIPTION
Add `bitbucket_server` to the list of providers that use the new API-driven pipeline modal instead of the legacy popup-based flow.

Refs [VDY-99: Bitbucket Server: API-driven integration setup](https://linear.app/getsentry/issue/VDY-99/bitbucket-server-api-driven-integration-setup)