### PR TITLE
fix(metrics): Pass timestamp to trace item details

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
@@ -1,0 +1,143 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+describe('useTraceItemDetails', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture({id: '1', slug: 'project-slug'});
+
+  function initializePageFilters(
+    datetime: Parameters<typeof PageFiltersStore.onInitializeUrlState>[0]['datetime']
+  ) {
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState({
+      projects: [Number(project.id)],
+      environments: [],
+      datetime,
+    });
+  }
+
+  function addTraceItemDetailsMock() {
+    return MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/item-id/`,
+      body: {
+        itemId: 'item-id',
+        links: null,
+        meta: {},
+        timestamp: '2025-04-03T15:50:10.000Z',
+        attributes: [],
+      },
+    });
+  }
+
+  function renderTraceItemDetailsHook(timestamp?: number) {
+    return renderHookWithProviders(
+      () =>
+        useTraceItemDetails({
+          projectId: project.id,
+          traceItemId: 'item-id',
+          traceId: '1234567890abcdef1234567890abcdef',
+          traceItemType: TraceItemDataset.LOGS,
+          referrer: 'api.explore.log-item-details',
+          timestamp,
+        }),
+      {organization}
+    );
+  }
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    act(() => ProjectsStore.loadInitialData([project]));
+  });
+
+  it('uses timestamp instead of page filter datetime when timestamp is passed', async () => {
+    initializePageFilters({
+      period: '14d',
+      start: null,
+      end: null,
+      utc: false,
+    });
+    const traceItemDetailsMock = addTraceItemDetailsMock();
+
+    renderTraceItemDetailsHook(123);
+
+    await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({
+      timestamp: 123,
+    });
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).not.toHaveProperty(
+      'statsPeriod'
+    );
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).not.toHaveProperty('start');
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).not.toHaveProperty('end');
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).not.toHaveProperty('utc');
+  });
+
+  it('uses page filter relative datetime when timestamp is not passed', async () => {
+    initializePageFilters({
+      period: '14d',
+      start: null,
+      end: null,
+      utc: false,
+    });
+    const traceItemDetailsMock = addTraceItemDetailsMock();
+
+    renderTraceItemDetailsHook();
+
+    await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({
+      statsPeriod: '14d',
+    });
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).not.toHaveProperty('timestamp');
+  });
+
+  it('uses page filter absolute datetime when timestamp is not passed', async () => {
+    initializePageFilters({
+      period: null,
+      start: '2025-04-03T15:00:00.000Z',
+      end: '2025-04-03T16:00:00.000Z',
+      utc: true,
+    });
+    const traceItemDetailsMock = addTraceItemDetailsMock();
+
+    renderTraceItemDetailsHook();
+
+    await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({
+      start: '2025-04-03T15:00:00.000',
+      end: '2025-04-03T16:00:00.000',
+      utc: 'true',
+    });
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).not.toHaveProperty('timestamp');
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).not.toHaveProperty(
+      'statsPeriod'
+    );
+  });
+
+  it('passes zero as a valid timestamp', async () => {
+    initializePageFilters({
+      period: '14d',
+      start: null,
+      end: null,
+      utc: false,
+    });
+    const traceItemDetailsMock = addTraceItemDetailsMock();
+
+    renderTraceItemDetailsHook(0);
+
+    await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({
+      timestamp: 0,
+    });
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).not.toHaveProperty(
+      'statsPeriod'
+    );
+  });
+});

--- a/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
@@ -1,7 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -37,24 +37,12 @@ describe('useTraceItemDetails', () => {
     });
   }
 
-  function renderTraceItemDetailsHook(timestamp?: number | null) {
-    return renderHookWithProviders(
-      () =>
-        useTraceItemDetails({
-          projectId: project.id,
-          traceItemId: 'item-id',
-          traceId: '1234567890abcdef1234567890abcdef',
-          traceItemType: TraceItemDataset.LOGS,
-          referrer: 'api.explore.log-item-details',
-          timestamp,
-        }),
-      {organization}
-    );
-  }
-
   beforeEach(() => {
+    ProjectsStore.loadInitialData([project]);
+  });
+
+  afterEach(() => {
     MockApiClient.clearMockResponses();
-    act(() => ProjectsStore.loadInitialData([project]));
   });
 
   it('uses timestamp instead of page filter datetime when timestamp is passed', async () => {
@@ -66,7 +54,17 @@ describe('useTraceItemDetails', () => {
     });
     const traceItemDetailsMock = addTraceItemDetailsMock();
 
-    renderTraceItemDetailsHook(123);
+    renderHookWithProviders(useTraceItemDetails, {
+      organization,
+      initialProps: {
+        projectId: project.id,
+        traceItemId: 'item-id',
+        traceId: '1234567890abcdef1234567890abcdef',
+        traceItemType: TraceItemDataset.LOGS,
+        referrer: 'api.explore.log-item-details',
+        timestamp: 123,
+      },
+    });
 
     await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
     expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({
@@ -89,7 +87,16 @@ describe('useTraceItemDetails', () => {
     });
     const traceItemDetailsMock = addTraceItemDetailsMock();
 
-    renderTraceItemDetailsHook();
+    renderHookWithProviders(useTraceItemDetails, {
+      organization,
+      initialProps: {
+        projectId: project.id,
+        traceItemId: 'item-id',
+        traceId: '1234567890abcdef1234567890abcdef',
+        traceItemType: TraceItemDataset.LOGS,
+        referrer: 'api.explore.log-item-details',
+      },
+    });
 
     await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
     expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({
@@ -107,7 +114,17 @@ describe('useTraceItemDetails', () => {
     });
     const traceItemDetailsMock = addTraceItemDetailsMock();
 
-    renderTraceItemDetailsHook(null);
+    renderHookWithProviders(useTraceItemDetails, {
+      organization,
+      initialProps: {
+        projectId: project.id,
+        traceItemId: 'item-id',
+        traceId: '1234567890abcdef1234567890abcdef',
+        traceItemType: TraceItemDataset.LOGS,
+        referrer: 'api.explore.log-item-details',
+        timestamp: null,
+      },
+    });
 
     await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
     expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({
@@ -125,7 +142,16 @@ describe('useTraceItemDetails', () => {
     });
     const traceItemDetailsMock = addTraceItemDetailsMock();
 
-    renderTraceItemDetailsHook();
+    renderHookWithProviders(useTraceItemDetails, {
+      organization,
+      initialProps: {
+        projectId: project.id,
+        traceItemId: 'item-id',
+        traceId: '1234567890abcdef1234567890abcdef',
+        traceItemType: TraceItemDataset.LOGS,
+        referrer: 'api.explore.log-item-details',
+      },
+    });
 
     await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
     expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({
@@ -148,7 +174,17 @@ describe('useTraceItemDetails', () => {
     });
     const traceItemDetailsMock = addTraceItemDetailsMock();
 
-    renderTraceItemDetailsHook(0);
+    renderHookWithProviders(useTraceItemDetails, {
+      organization,
+      initialProps: {
+        projectId: project.id,
+        traceItemId: 'item-id',
+        traceId: '1234567890abcdef1234567890abcdef',
+        traceItemType: TraceItemDataset.LOGS,
+        referrer: 'api.explore.log-item-details',
+        timestamp: 0,
+      },
+    });
 
     await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
     expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({

--- a/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
@@ -37,7 +37,7 @@ describe('useTraceItemDetails', () => {
     });
   }
 
-  function renderTraceItemDetailsHook(timestamp?: number) {
+  function renderTraceItemDetailsHook(timestamp?: number | null) {
     return renderHookWithProviders(
       () =>
         useTraceItemDetails({
@@ -90,6 +90,24 @@ describe('useTraceItemDetails', () => {
     const traceItemDetailsMock = addTraceItemDetailsMock();
 
     renderTraceItemDetailsHook();
+
+    await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({
+      statsPeriod: '14d',
+    });
+    expect(traceItemDetailsMock.mock.calls[0]![1].query).not.toHaveProperty('timestamp');
+  });
+
+  it('uses page filter stats period as fallback when timestamp is null', async () => {
+    initializePageFilters({
+      period: '14d',
+      start: null,
+      end: null,
+      utc: false,
+    });
+    const traceItemDetailsMock = addTraceItemDetailsMock();
+
+    renderTraceItemDetailsHook(null);
 
     await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
     expect(traceItemDetailsMock.mock.calls[0]![1].query).toMatchObject({

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -2,7 +2,10 @@ import {useState} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {captureException} from '@sentry/react';
 
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {Meta} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery, type ApiQueryKey} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -41,7 +44,7 @@ interface UseTraceItemDetailsProps {
    */
   enabled?: boolean;
   /**
-   * Optional unix timestamp to disambiguate trace item lookup.
+   * Optional Unix timestamp in seconds to disambiguate trace item lookup.
    */
   timestamp?: number;
 }
@@ -82,9 +85,24 @@ type TraceItemDetailsUrlParams = {
 
 type TraceItemDetailsQueryParams = {
   referrer: string;
-  timestamp: number | undefined;
   traceId: string;
   traceItemType: TraceItemDataset;
+  end?: string;
+  start?: string;
+  statsPeriod?: string | null;
+  timestamp?: number;
+  utc?: string;
+};
+
+type TraceItemDetailsApiQuery = {
+  item_type: TraceItemDataset;
+  referrer: string;
+  trace_id: string;
+  end?: string;
+  start?: string;
+  statsPeriod?: string | null;
+  timestamp?: number;
+  utc?: string;
 };
 
 export type TraceItemResponseAttribute =
@@ -98,6 +116,7 @@ export type TraceItemResponseAttribute =
  */
 export function useTraceItemDetails(props: UseTraceItemDetailsProps) {
   const organization = useOrganization();
+  const {selection} = usePageFilters();
   const {fetching} = useProjects();
   const project = useProjectFromId({project_id: props.projectId});
   const enabled = (props.enabled ?? true) && !!project;
@@ -109,9 +128,14 @@ export function useTraceItemDetails(props: UseTraceItemDetailsProps) {
     );
   }
 
+  const timeQueryParams =
+    props.timestamp === undefined
+      ? normalizeDateTimeParams(selection.datetime)
+      : {timestamp: props.timestamp};
+
   const queryParams: TraceItemDetailsQueryParams = {
     referrer: props.referrer,
-    timestamp: props.timestamp,
+    ...timeQueryParams,
     traceItemType: props.traceItemType,
     traceId: props.traceId,
   };
@@ -143,13 +167,26 @@ function traceItemDetailsQueryKey({
   queryParams: TraceItemDetailsQueryParams;
   urlParams: TraceItemDetailsUrlParams;
 }): ApiQueryKey {
-  const query: Record<string, unknown> = {
+  const query: TraceItemDetailsApiQuery = {
     item_type: queryParams.traceItemType,
     referrer: queryParams.referrer,
     trace_id: queryParams.traceId,
   };
 
-  if (queryParams.timestamp !== undefined) {
+  if (queryParams.timestamp === undefined) {
+    if (defined(queryParams.statsPeriod)) {
+      query.statsPeriod = queryParams.statsPeriod;
+    }
+    if (defined(queryParams.start)) {
+      query.start = queryParams.start;
+    }
+    if (defined(queryParams.end)) {
+      query.end = queryParams.end;
+    }
+    if (defined(queryParams.utc)) {
+      query.utc = queryParams.utc;
+    }
+  } else {
     query.timestamp = queryParams.timestamp;
   }
 

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -46,7 +46,7 @@ interface UseTraceItemDetailsProps {
   /**
    * Optional Unix timestamp in seconds to disambiguate trace item lookup.
    */
-  timestamp?: number;
+  timestamp?: number | null;
 }
 
 export type TraceItemAttributeMeta = Pick<Meta, 'len' | 'rem'>;
@@ -128,10 +128,9 @@ export function useTraceItemDetails(props: UseTraceItemDetailsProps) {
     );
   }
 
-  const timeQueryParams =
-    props.timestamp === undefined
-      ? normalizeDateTimeParams(selection.datetime)
-      : {timestamp: props.timestamp};
+  const timeQueryParams = defined(props.timestamp)
+    ? {timestamp: props.timestamp}
+    : normalizeDateTimeParams(selection.datetime);
 
   const queryParams: TraceItemDetailsQueryParams = {
     referrer: props.referrer,

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -40,6 +40,10 @@ interface UseTraceItemDetailsProps {
    * Alias for `enabled` in react-query.
    */
   enabled?: boolean;
+  /**
+   * Optional unix timestamp to disambiguate trace item lookup.
+   */
+  timestamp?: number;
 }
 
 export type TraceItemAttributeMeta = Pick<Meta, 'len' | 'rem'>;
@@ -78,6 +82,7 @@ type TraceItemDetailsUrlParams = {
 
 type TraceItemDetailsQueryParams = {
   referrer: string;
+  timestamp: number | undefined;
   traceId: string;
   traceItemType: TraceItemDataset;
 };
@@ -106,6 +111,7 @@ export function useTraceItemDetails(props: UseTraceItemDetailsProps) {
 
   const queryParams: TraceItemDetailsQueryParams = {
     referrer: props.referrer,
+    timestamp: props.timestamp,
     traceItemType: props.traceItemType,
     traceId: props.traceId,
   };
@@ -137,11 +143,15 @@ function traceItemDetailsQueryKey({
   queryParams: TraceItemDetailsQueryParams;
   urlParams: TraceItemDetailsUrlParams;
 }): ApiQueryKey {
-  const query: Record<string, string | string[]> = {
+  const query: Record<string, unknown> = {
     item_type: queryParams.traceItemType,
     referrer: queryParams.referrer,
     trace_id: queryParams.traceId,
   };
+
+  if (queryParams.timestamp !== undefined) {
+    query.timestamp = queryParams.timestamp;
+  }
 
   return [
     getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/trace-items/$itemId/', {
@@ -161,6 +171,7 @@ export function useFetchTraceItemDetailsOnHover({
   traceId,
   traceItemType,
   referrer,
+  timestamp,
   hoverPrefetchDisabled,
   sharedHoverTimeoutRef,
   timeout,
@@ -186,6 +197,7 @@ export function useFetchTraceItemDetailsOnHover({
     traceId,
     traceItemType,
     referrer,
+    timestamp,
     enabled: timeoutReached,
   });
 

--- a/static/app/views/explore/metrics/hooks/useMetricTraceDetail.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTraceDetail.tsx
@@ -6,11 +6,13 @@ export function useMetricTraceDetail(props: {
   projectId: string;
   traceId: string;
   enabled?: boolean;
+  timestamp?: number;
 }) {
   return useTraceItemDetails({
     traceItemId: String(props.metricId),
     projectId: props.projectId,
     traceId: props.traceId,
+    timestamp: props.timestamp,
     traceItemType: TraceItemDataset.TRACEMETRICS,
     referrer: 'api.explore.metric-trace-detail',
     enabled: props.enabled,

--- a/static/app/views/explore/metrics/metricInfoTabs/metricDetails.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricDetails.tsx
@@ -78,6 +78,9 @@ export function MetricDetails({
     defined(dataRow[TraceMetricKnownFieldKey.ID]) &&
     defined(dataRow[TraceMetricKnownFieldKey.PROJECT_ID]) &&
     defined(dataRow[TraceMetricKnownFieldKey.TRACE]);
+  const timestamp = getTimeStampFromTableDateField(
+    dataRow[TraceMetricKnownFieldKey.TIMESTAMP]
+  );
 
   const {
     data: traceDetailsData,
@@ -87,13 +90,11 @@ export function MetricDetails({
     metricId: String(dataRow[TraceMetricKnownFieldKey.ID] ?? ''),
     projectId: String(dataRow[TraceMetricKnownFieldKey.PROJECT_ID] ?? ''),
     traceId: String(dataRow[TraceMetricKnownFieldKey.TRACE] ?? ''),
+    timestamp,
     enabled: enableQueries,
   });
 
   const traceSlug = String(dataRow[TraceMetricKnownFieldKey.TRACE] ?? '');
-  const timestamp = getTimeStampFromTableDateField(
-    dataRow[TraceMetricKnownFieldKey.TIMESTAMP]
-  );
   const {
     data: traceMeta,
     isLoading: isTraceMetaLoading,

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -349,7 +349,7 @@ describe('MetricPanel', () => {
     expect(screen.queryByText('Explore similar spans')).not.toBeInTheDocument();
   });
 
-  it('fetches trace meta for expanded samples with the row timestamp', async () => {
+  it('fetches expanded sample details with the row timestamp', async () => {
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
     const row = metricFixtures.detailedFixtures[0]!;
     const timestamp = new Date(row.timestamp).getTime() / 1000;

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -353,6 +353,19 @@ describe('MetricPanel', () => {
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
     const row = metricFixtures.detailedFixtures[0]!;
     const timestamp = new Date(row.timestamp).getTime() / 1000;
+    const metricId = row[TraceMetricKnownFieldKey.ID];
+    const traceDetailsMock = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${metricId}/`,
+      match: [MockApiClient.matchQuery({timestamp})],
+      body: {
+        itemId: metricId,
+        links: null,
+        meta: {},
+        timestamp: row.timestamp,
+        attributes: [],
+      },
+    });
     const traceMetaMock = MockApiClient.addMockResponse({
       method: 'GET',
       url: `/organizations/${organization.slug}/events-trace-meta/${row.trace}/`,
@@ -380,6 +393,7 @@ describe('MetricPanel', () => {
       }
     );
 
+    await waitFor(() => expect(traceDetailsMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(traceMetaMock).toHaveBeenCalledTimes(1));
     expect(
       await screen.findByText('Errors: 1, Logs: 0, Spans: 2, Metrics: 0')


### PR DESCRIPTION
Pass the timestamp along for the given metrics trace item details.

Closes LOGS-828