### PR TITLE
fix(traces): Downgrade Group.DoesNotExist log to info in trace serialization

### DIFF
--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -140,8 +140,8 @@ def _serialize_rpc_issue(
         else:
             try:
                 issue = Group.objects.get(id=issue_id, project__id=occurrence.project_id)
-            except Group.DoesNotExist as e:
-                logger.error(e)
+            except Group.DoesNotExist:
+                logger.info("Group %s not found in _serialize_rpc_issue", issue_id)
                 return None
             group_cache[issue_id] = issue
         return SerializedIssue(
@@ -171,8 +171,8 @@ def _serialize_rpc_issue(
         else:
             try:
                 issue = Group.objects.get(id=issue_id, project__id=event["project.id"])
-            except Group.DoesNotExist as e:
-                logger.error(e)
+            except Group.DoesNotExist:
+                logger.info("Group %s not found in _serialize_rpc_issue", issue_id)
                 return None
             group_cache[issue_id] = issue
 


### PR DESCRIPTION
logger.error() in _serialize_rpc_issue causes Sentry to capture these as error events (~14K/day), but a deleted/merged group during trace rendering is an expected race condition. The function already handles this gracefully by returning None. Downgrade to logger.info to stop generating noise.

Fixes SENTRY-5KWJ
