### PR TITLE
fix(oauth): Use hashed token lookup and reject tokens for inactive users

### DIFF
--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -101,6 +101,15 @@ class OAuthUserInfoEndpoint(Endpoint):
         if token_details.is_expired():
             raise BearerTokenInvalid()
 
+        if not token_details.user.is_active:
+            raise BearerTokenInvalid()
+
+        if getattr(token_details.user, "is_suspended", False):
+            raise BearerTokenInvalid()
+
+        if token_details.application is not None and not token_details.application.is_active:
+            raise BearerTokenInvalid()
+
         scopes = token_details.get_scopes()
         if "openid" not in scopes:
             raise BearerTokenInsufficientScope()

--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from rest_framework import status
 from rest_framework.authentication import get_authorization_header
 from rest_framework.exceptions import APIException
@@ -80,10 +82,21 @@ class OAuthUserInfoEndpoint(Endpoint):
             raise BearerTokenMissing()
 
         access_token = auth_header[1].decode("utf-8")
+        hashed_token = hashlib.sha256(access_token.encode()).hexdigest()
         try:
-            token_details = ApiToken.objects.get(token=access_token)
+            token_details = ApiToken.objects.select_related("user", "application").get(
+                hashed_token=hashed_token
+            )
         except ApiToken.DoesNotExist:
-            raise BearerTokenInvalid()
+            try:
+                token_details = ApiToken.objects.select_related("user", "application").get(
+                    token=access_token
+                )
+            except ApiToken.DoesNotExist:
+                raise BearerTokenInvalid()
+            else:
+                token_details.hashed_token = hashed_token
+                token_details.save(update_fields=["hashed_token"])
 
         if token_details.is_expired():
             raise BearerTokenInvalid()

--- a/tests/sentry/api/endpoints/test_oauth_userinfo.py
+++ b/tests/sentry/api/endpoints/test_oauth_userinfo.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
+from sentry.models.apiapplication import ApiApplication, ApiApplicationStatus
 from sentry.models.apitoken import ApiToken
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
@@ -164,3 +165,37 @@ class OAuthUserInfoTest(APITestCase):
 
         assert response.status_code == 200
         assert response.data["sub"] == str(self.user.id)
+
+    def test_rejects_token_for_inactive_user(self) -> None:
+        token = self.create_user_auth_token(user=self.user, scope_list=["openid"])
+        self.user.update(is_active=False)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.token}")
+        response = self.client.get(self.path)
+
+        assert response.status_code == 401
+        assert response.data["error"] == "invalid_token"
+
+    def test_rejects_token_for_suspended_user(self) -> None:
+        token = self.create_user_auth_token(user=self.user, scope_list=["openid"])
+        self.user.update(is_suspended=True)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.token}")
+        response = self.client.get(self.path)
+
+        assert response.status_code == 401
+        assert response.data["error"] == "invalid_token"
+
+    def test_rejects_token_for_inactive_application(self) -> None:
+        app = ApiApplication.objects.create(
+            name="test-app",
+            redirect_uris="https://example.com/callback",
+        )
+        token = self.create_user_auth_token(user=self.user, scope_list=["openid"], application=app)
+        app.update(status=ApiApplicationStatus.inactive)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.token}")
+        response = self.client.get(self.path)
+
+        assert response.status_code == 401
+        assert response.data["error"] == "invalid_token"

--- a/tests/sentry/api/endpoints/test_oauth_userinfo.py
+++ b/tests/sentry/api/endpoints/test_oauth_userinfo.py
@@ -1,9 +1,11 @@
 import datetime
+import hashlib
 
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
+from sentry.models.apitoken import ApiToken
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
@@ -146,4 +148,19 @@ class OAuthUserInfoTest(APITestCase):
         assert response.data["email_verified"]
 
         # openid information
+        assert response.data["sub"] == str(self.user.id)
+
+    def test_resolves_token_by_hash_when_plaintext_cleared(self) -> None:
+        token = self.create_user_auth_token(user=self.user, scope_list=["openid"])
+        plaintext = token.token
+        expected_hash = hashlib.sha256(plaintext.encode()).hexdigest()
+        assert token.hashed_token == expected_hash
+
+        # Scramble the plaintext column so only the hashed path can match
+        ApiToken.objects.filter(id=token.id).update(token=f"scrambled-{plaintext[:50]}")
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {plaintext}")
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
         assert response.data["sub"] == str(self.user.id)


### PR DESCRIPTION
Fixed 2 vulns:
- Use hashed token lookup in `/oauth/userinfo` endpoint. The endpoint was looking up tokens by plaintext column only, diverging from the standard hash-first path used everywhere else. Switch to `hashed_token` lookup with plaintext fallback and migration, matching `UserAuthTokenAuthentication._find_or_update_token_by_hash`.
- Reject tokens for inactive/suspended users and disabled apps in '/oauth/userinfo`. The endpoint was missing is_active checks that the standard `UserAuthTokenAuthentication` path enforces. Tokens belonging to deactivated users or disabled OAuth applications now return 401.
