### PR TITLE
fix(metrics): Skip tag validation when deleting Snuba subscriptions 

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -697,7 +697,10 @@ class MetricsQueryBuilder(BaseQueryBuilder):
         value = self.column_remapping.get(value, value)
 
         if self.use_default_tags:
-            if value in self.default_metric_tags:
+            if (
+                value in self.default_metric_tags
+                or self.builder_config.skip_field_validation_for_entity_subscription_deletion
+            ):
                 return self.resolve_metric_index(value)
             else:
                 raise IncompatibleMetricsQuery(f"{value} is not a tag in the metrics dataset")

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -442,6 +442,31 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
                 selected_columns=["transaction", "count_unique(test)"],
             )
 
+    def test_non_default_tag_in_query_raises(self) -> None:
+        with pytest.raises(IncompatibleMetricsQuery):
+            MetricsQueryBuilder(
+                self.params,
+                query="http.url:https://example.com",
+                dataset=Dataset.PerformanceMetrics,
+                selected_columns=["count()"],
+            )
+
+    def test_non_default_tag_in_query_skipped_for_subscription_deletion(self) -> None:
+        indexer.record(
+            use_case_id=UseCaseID.TRANSACTIONS,
+            org_id=self.organization.id,
+            string="http.url",
+        )
+        MetricsQueryBuilder(
+            self.params,
+            query="http.url:https://example.com",
+            dataset=Dataset.PerformanceMetrics,
+            selected_columns=["count()"],
+            config=QueryBuilderConfig(
+                skip_field_validation_for_entity_subscription_deletion=True,
+            ),
+        )
+
     def test_project_filter(self) -> None:
         query = MetricsQueryBuilder(
             self.params,


### PR DESCRIPTION
The skip_field_validation_for_entity_subscription_deletion flag was added to bypass query validation during subscription deletion, but it only covered default_filter_converter. The resolve_tag_key method was still raising IncompatibleMetricsQuery for tags not in default_metric_tags (e.g. http.url), causing deletion to fail.

Fixes SENTRY-5HAG