### PR TITLE
fix(integrations): Use paginated jira projects endpoint, behind flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -143,6 +143,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-gitlab-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Temporary: log full Jira Cloud `issue.updated` webhook payloads so we can design project-change link rewriting.
     manager.add("organizations:jira-issue-updated-payload-logging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use the paginated project endpoint in Jira org config to avoid timeouts on large instances.
+    manager.add("organizations:jira-paginated-project-config", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable inviting billing members to organizations at the member limit.
     manager.add("organizations:invite-billing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
     # Enable inviting members to organizations.

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -164,13 +164,30 @@ class JiraIntegration(IssueSyncIntegration):
     def get_organization_config(self) -> list[dict[str, Any]]:
         configuration: list[dict[str, Any]] = self._get_organization_config_default_values()
 
+        context = organization_service.get_organization_by_id(
+            id=self.organization_id, include_projects=False, include_teams=False
+        )
+        assert context, "organizationcontext must exist to get org"
+        organization = context.organization
+
         client = self.get_client()
 
         try:
-            projects: list[JiraProjectMapping] = [
-                JiraProjectMapping(value=p["id"], label=p["name"])
-                for p in client.get_projects_list()
-            ]
+            if features.has("organizations:jira-paginated-project-config", organization):
+                # Use the paginated endpoint to avoid fetching all projects at once,
+                # which can time out for large Jira instances. The settings page
+                # dropdown search (typeahead) handles finding projects beyond this
+                # initial page via JiraSearchEndpoint.
+                projects_response = client.get_projects_paginated(params={"maxResults": 50})
+                projects: list[JiraProjectMapping] = [
+                    JiraProjectMapping(value=p["id"], label=p["name"])
+                    for p in projects_response.get("values", [])
+                ]
+            else:
+                projects = [
+                    JiraProjectMapping(value=p["id"], label=p["name"])
+                    for p in client.get_projects_list()
+                ]
             self._set_status_choices_in_organization_config(configuration, projects)
             configuration[0]["addDropdown"]["items"] = projects
         except ApiError:
@@ -178,12 +195,6 @@ class JiraIntegration(IssueSyncIntegration):
             configuration[0]["disabledReason"] = _(
                 "Unable to communicate with the Jira instance. You may need to reinstall the addon."
             )
-
-        context = organization_service.get_organization_by_id(
-            id=self.organization_id, include_projects=False, include_teams=False
-        )
-        assert context, "organizationcontext must exist to get org"
-        organization = context.organization
 
         has_issue_sync = features.has("organizations:integrations-issue-sync", organization)
         if not has_issue_sync:

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1297,6 +1297,112 @@ class JiraIntegrationTest(APITestCase):
             == "hello world, goodnight, moon"
         )
 
+    @responses.activate
+    def test_get_organization_config_uses_projects_list_without_flag(self) -> None:
+        integration = self.create_provider_integration(
+            provider="jira",
+            name="Example Jira",
+            metadata={
+                "oauth_client_id": "oauth-client-id",
+                "shared_secret": "a-super-secret-key-from-atlassian",
+                "base_url": "https://example.atlassian.net",
+                "domain_name": "example.atlassian.net",
+            },
+        )
+        integration.add_organization(self.organization, self.user)
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project",
+            json=[{"id": "10000", "name": "Project A"}],
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/statuses/search",
+            json={"values": []},
+        )
+
+        installation = integration.get_installation(self.organization.id)
+        config = installation.get_organization_config()
+
+        assert config[0]["addDropdown"]["items"] == [
+            {"value": "10000", "label": "Project A"},
+        ]
+        assert any(
+            "rest/api/2/project" in call.request.url and "search" not in call.request.url
+            for call in responses.calls
+        )
+
+    @responses.activate
+    def test_get_organization_config_uses_paginated_endpoint_with_flag(self) -> None:
+        integration = self.create_provider_integration(
+            provider="jira",
+            name="Example Jira",
+            metadata={
+                "oauth_client_id": "oauth-client-id",
+                "shared_secret": "a-super-secret-key-from-atlassian",
+                "base_url": "https://example.atlassian.net",
+                "domain_name": "example.atlassian.net",
+            },
+        )
+        integration.add_organization(self.organization, self.user)
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project/search",
+            json={
+                "values": [
+                    {"id": "10000", "name": "Project A"},
+                    {"id": "10001", "name": "Project B"},
+                ],
+                "maxResults": 50,
+                "total": 2,
+            },
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/statuses/search",
+            json={"values": []},
+        )
+
+        installation = integration.get_installation(self.organization.id)
+        with self.feature("organizations:jira-paginated-project-config"):
+            config = installation.get_organization_config()
+
+        assert config[0]["addDropdown"]["items"] == [
+            {"value": "10000", "label": "Project A"},
+            {"value": "10001", "label": "Project B"},
+        ]
+        assert any("rest/api/2/project/search" in call.request.url for call in responses.calls)
+
+    @responses.activate
+    def test_get_organization_config_paginated_api_error_disables_config(self) -> None:
+        integration = self.create_provider_integration(
+            provider="jira",
+            name="Example Jira",
+            metadata={
+                "oauth_client_id": "oauth-client-id",
+                "shared_secret": "a-super-secret-key-from-atlassian",
+                "base_url": "https://example.atlassian.net",
+                "domain_name": "example.atlassian.net",
+            },
+        )
+        integration.add_organization(self.organization, self.user)
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project/search",
+            json={"errorMessages": ["Something went wrong"]},
+            status=500,
+        )
+
+        installation = integration.get_installation(self.organization.id)
+        with self.feature("organizations:jira-paginated-project-config"):
+            config = installation.get_organization_config()
+
+        assert config[0]["disabled"] is True
+        assert "Unable to communicate" in config[0]["disabledReason"]
+
     def test_error_fields_from_json_issue_not_found(self) -> None:
         integration = self.create_provider_integration(provider="jira", name="Example Jira")
         integration.add_organization(self.organization, self.user)


### PR DESCRIPTION
Resolves ISWF-2751

It's simple enough to use the paginated endpoint, but let's make sure it works before turning it on for all customers.