### PR TITLE
fix(project-filter): increase bottom margin

### DIFF
--- a/static/app/components/core/compactSelect/useVirtualizedItems.tsx
+++ b/static/app/components/core/compactSelect/useVirtualizedItems.tsx
@@ -10,6 +10,13 @@ const heightEstimations = {
   xs: {regular: 25, large: 42},
 } as const satisfies Record<FormSize, {large: number; regular: number}>;
 
+/**
+ * Matches `theme.space.xs` used as vertical padding on ListWrap (ul).
+ * Added to the virtualizer's wrapper height so the ListWrap's top/bottom
+ * padding remains visible when the list shrinks to a small number of items.
+ */
+const listPaddingVertical = 4;
+
 // explicitly using object here because Record<PropertyKey, unknown> requires an index signature
 // eslint-disable-next-line @typescript-eslint/no-restricted-types
 type ObjectLike = object;
@@ -51,7 +58,7 @@ export function useVirtualizedItems<T extends ObjectLike>({
       wrapperProps: {
         'data-is-virtualized': true,
         style: {
-          height: virtualizer.getTotalSize(),
+          height: virtualizer.getTotalSize() + listPaddingVertical * 2,
           width: '100%',
           position: 'relative',
         },


### PR DESCRIPTION
Fix a small misalignment between highlight and the bottom of the project selector. Same fix as:
https://github.com/getsentry/sentry/blob/b68ea049d1ae2be4471a52fd42de580ab6b71223/static/app/components/core/compactSelect/listBox/index.tsx#L296

Before:
<img width="723" height="175" alt="Screenshot 2026-05-27 at 10 25 39 AM" src="https://github.com/user-attachments/assets/f32301af-2baf-4aa9-a8b3-74661917c906" />
After:
<img width="835" height="220" alt="Screenshot 2026-05-27 at 11 24 50 AM" src="https://github.com/user-attachments/assets/106c079a-0567-4ef3-9554-356321dcb401" />
