### PR TITLE
fix(logs) - Fix logs table when auto-refresh toggles

### DIFF
--- a/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
+++ b/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
@@ -150,13 +150,11 @@ export function useSetLogsAutoRefresh() {
         queryClient.removeQueries({queryKey});
       }
 
-      if (autoRefresh !== 'enabled') {
-        queryClient.removeQueries({queryKey});
-      }
       const newPausedAt = autoRefresh === 'paused' ? Date.now() : undefined;
       const target: Location = {...location, query: {...location.query}};
       if (autoRefresh === 'paused') {
         setPausedAt(newPausedAt);
+        queryClient.removeQueries({queryKey});
       } else if (autoRefresh !== 'enabled') {
         // Any error state, or disabled state, should reset the pause state.
         setPausedAt(undefined);

--- a/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
+++ b/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
@@ -132,7 +132,9 @@ function pausedAtAllowedToContinue(pausedAt: number | undefined) {
 export function useSetLogsAutoRefresh() {
   const location = useLocation();
   const navigate = useNavigate();
-  const highFidelity = useLogsQueryHighFidelity();
+  const rawHighFidelity = useLogsQueryHighFidelity();
+  const {hasInitialized: autoRefreshHasInitialized} = useLogsAutoRefresh();
+  const highFidelity = autoRefreshHasInitialized ? false : rawHighFidelity;
   const {infiniteApiOptions} = useLogsApiOptionsWithInfinite({
     referrer: 'api.explore.logs-table',
     autoRefresh: true,
@@ -148,6 +150,9 @@ export function useSetLogsAutoRefresh() {
         queryClient.removeQueries({queryKey});
       }
 
+      if (autoRefresh !== 'enabled') {
+        queryClient.removeQueries({queryKey});
+      }
       const newPausedAt = autoRefresh === 'paused' ? Date.now() : undefined;
       const target: Location = {...location, query: {...location.query}};
       if (autoRefresh === 'paused') {

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -366,7 +366,8 @@ describe('LogsPage', () => {
       // - one for the table
       // - one for the normal sample mode count
       // - one for the high accuracy sample mode count
-      expect(eventTableMock).toHaveBeenCalledTimes(3);
+      // - one for the table refetch triggered by resetQueries when auto-refresh is paused
+      expect(eventTableMock).toHaveBeenCalledTimes(4);
 
       eventTableMock.mockClear();
       eventTableMock = setupEventsMock(autorefreshBaseFixtures.slice(0, 5));

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -355,4 +355,20 @@ describe('LogsTabContent', () => {
       );
     });
   });
+
+  it('should disable manual refresh button when autorefresh is enabled', async () => {
+    const autorefreshEnabledRouterConfig = structuredClone(initialRouterConfig);
+    autorefreshEnabledRouterConfig.location.query[LOGS_AUTO_REFRESH_KEY] = 'enabled';
+    render(
+      <ProviderWrapper>
+        <LogsTabContentHarness datePageFilterProps={datePageFilterProps} />
+      </ProviderWrapper>,
+      {
+        initialRouterConfig: autorefreshEnabledRouterConfig,
+        organization,
+      }
+    );
+    const refreshButton = await screen.findByRole('button', {name: 'Refresh'});
+    expect(refreshButton).toBeDisabled();
+  });
 });

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -184,12 +184,11 @@ describe('LogsTabContent', () => {
   });
 
   it('should call APIs as expected', async () => {
-    render(
-      <ProviderWrapper>
-        <LogsTabContentHarness datePageFilterProps={datePageFilterProps} />
-      </ProviderWrapper>,
-      {initialRouterConfig, organization}
-    );
+    render(<LogsTabContentHarness datePageFilterProps={datePageFilterProps} />, {
+      initialRouterConfig,
+      organization,
+      additionalWrapper: ProviderWrapper,
+    });
 
     expect(eventTableMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/events/`,
@@ -234,12 +233,11 @@ describe('LogsTabContent', () => {
   });
 
   it('should switch between modes', async () => {
-    render(
-      <ProviderWrapper>
-        <LogsTabContentHarness datePageFilterProps={datePageFilterProps} />
-      </ProviderWrapper>,
-      {initialRouterConfig, organization}
-    );
+    render(<LogsTabContentHarness datePageFilterProps={datePageFilterProps} />, {
+      initialRouterConfig,
+      organization,
+      additionalWrapper: ProviderWrapper,
+    });
 
     expect(screen.getByRole('tab', {name: 'Logs'})).toHaveAttribute(
       'aria-selected',
@@ -278,12 +276,11 @@ describe('LogsTabContent', () => {
   });
 
   it('should pass caseInsensitive to the query', async () => {
-    render(
-      <ProviderWrapper>
-        <LogsTabContentHarness datePageFilterProps={datePageFilterProps} />
-      </ProviderWrapper>,
-      {initialRouterConfig, organization}
-    );
+    render(<LogsTabContentHarness datePageFilterProps={datePageFilterProps} />, {
+      initialRouterConfig,
+      organization,
+      additionalWrapper: ProviderWrapper,
+    });
 
     expect(eventTableMock).toHaveBeenCalled();
 
@@ -334,15 +331,11 @@ describe('LogsTabContent', () => {
   it('should add a timestamp_precise filter when autorefresh is enabled', async () => {
     const autorefreshEnabledRouterConfig = structuredClone(initialRouterConfig);
     autorefreshEnabledRouterConfig.location.query[LOGS_AUTO_REFRESH_KEY] = 'enabled';
-    render(
-      <ProviderWrapper>
-        <LogsTabContentHarness datePageFilterProps={datePageFilterProps} />
-      </ProviderWrapper>,
-      {
-        initialRouterConfig: autorefreshEnabledRouterConfig,
-        organization,
-      }
-    );
+    render(<LogsTabContentHarness datePageFilterProps={datePageFilterProps} />, {
+      initialRouterConfig: autorefreshEnabledRouterConfig,
+      organization,
+      additionalWrapper: ProviderWrapper,
+    });
 
     await waitFor(() => {
       expect(eventsTimeSeriesMock).toHaveBeenCalledWith(
@@ -359,15 +352,11 @@ describe('LogsTabContent', () => {
   it('should disable manual refresh button when autorefresh is enabled', async () => {
     const autorefreshEnabledRouterConfig = structuredClone(initialRouterConfig);
     autorefreshEnabledRouterConfig.location.query[LOGS_AUTO_REFRESH_KEY] = 'enabled';
-    render(
-      <ProviderWrapper>
-        <LogsTabContentHarness datePageFilterProps={datePageFilterProps} />
-      </ProviderWrapper>,
-      {
-        initialRouterConfig: autorefreshEnabledRouterConfig,
-        organization,
-      }
-    );
+    render(<LogsTabContentHarness datePageFilterProps={datePageFilterProps} />, {
+      initialRouterConfig: autorefreshEnabledRouterConfig,
+      organization,
+      additionalWrapper: ProviderWrapper,
+    });
     const refreshButton = await screen.findByRole('button', {name: 'Refresh'});
     expect(refreshButton).toBeDisabled();
   });

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -27,6 +27,7 @@ import type {AggregationKey} from 'sentry/utils/fields';
 import {HOUR} from 'sentry/utils/formatters';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {usePrevious} from 'sentry/utils/usePrevious';
 import {OverChartButtonGroup} from 'sentry/views/explore/components/overChartButtonGroup';
 import {SchemaHintsList} from 'sentry/views/explore/components/schemaHints/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
@@ -289,6 +290,15 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
 
   const [sidebarOpen, setSidebarOpen] = useState(mode === Mode.AGGREGATE);
 
+  const prevAutorefreshEnabled = usePrevious(autorefreshEnabled);
+
+  // Reset the query data when auto-refresh is disabled to avoid stale data when switching between modes
+  useEffect(() => {
+    if (prevAutorefreshEnabled && !autorefreshEnabled) {
+      queryClient.resetQueries({queryKey: tableData.queryKey});
+    }
+  }, [autorefreshEnabled, prevAutorefreshEnabled, queryClient, tableData.queryKey]);
+
   useEffect(() => {
     if (autorefreshEnabled) {
       setTimeseriesIngestDelay(getMaxIngestDelayTimestamp());
@@ -402,9 +412,19 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
   };
 
   /**
-   * Manual refresh doesn't work for longer relative periods as it hits cacheing. Only allow manual refresh if the relative period or absolute time range is less than 1 hour.
+   * Manual refresh doesn't work for longer relative periods as it hits cacheing.
+   * Only allow manual refresh if the relative period or absolute time range is less than 1 hour,
+   * or if auto-refresh is disabled.
    */
   const {canManuallyRefresh, manualRefreshDisabledReason} = useMemo(() => {
+    if (autorefreshEnabled) {
+      return {
+        canManuallyRefresh: false,
+        manualRefreshDisabledReason: t(
+          'Auto-refresh is enabled. Please disable auto-refresh to manually refresh the table.'
+        ),
+      };
+    }
     if (pageFilters.selection.datetime.period) {
       const parsedPeriod = parsePeriodToHours(pageFilters.selection.datetime.period);
       if (parsedPeriod <= 1) {
@@ -440,7 +460,7 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
         'Manual refresh is only available for time ranges of 1 hour or less.'
       ),
     };
-  }, [pageFilters.selection.datetime]);
+  }, [pageFilters.selection.datetime, autorefreshEnabled]);
 
   const {infiniteLogsQueryResult} = useLogsPageData();
 

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -27,7 +27,6 @@ import type {AggregationKey} from 'sentry/utils/fields';
 import {HOUR} from 'sentry/utils/formatters';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {usePrevious} from 'sentry/utils/usePrevious';
 import {OverChartButtonGroup} from 'sentry/views/explore/components/overChartButtonGroup';
 import {SchemaHintsList} from 'sentry/views/explore/components/schemaHints/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
@@ -289,15 +288,6 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
   const [interval] = useChartInterval();
 
   const [sidebarOpen, setSidebarOpen] = useState(mode === Mode.AGGREGATE);
-
-  const prevAutorefreshEnabled = usePrevious(autorefreshEnabled);
-
-  // Reset the query data when auto-refresh is disabled to avoid stale data when switching between modes
-  useEffect(() => {
-    if (prevAutorefreshEnabled && !autorefreshEnabled) {
-      queryClient.resetQueries({queryKey: tableData.queryKey});
-    }
-  }, [autorefreshEnabled, prevAutorefreshEnabled, queryClient, tableData.queryKey]);
 
   useEffect(() => {
     if (autorefreshEnabled) {

--- a/static/app/views/explore/logs/useVirtualStreaming.spec.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.spec.tsx
@@ -1,12 +1,10 @@
 import type {InfiniteData} from '@tanstack/react-query';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {initializeLogsTest, LogFixture} from 'sentry-fixture/log';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
-import {useLocation} from 'sentry/utils/useLocation';
 import {
   LOGS_AUTO_REFRESH_KEY,
   type AutoRefreshState,
@@ -22,9 +20,6 @@ import {
   updateVirtualStreamingTimestamp,
   useVirtualStreaming,
 } from 'sentry/views/explore/logs/useVirtualStreaming';
-
-jest.mock('sentry/utils/useLocation');
-const mockUseLocation = jest.mocked(useLocation);
 
 describe('useVirtualStreaming', () => {
   let requestAnimationFrameSpy: jest.SpyInstance<number, [FrameRequestCallback]>;
@@ -50,23 +45,24 @@ describe('useVirtualStreaming', () => {
     cancelAnimationFrameSpy.mockRestore();
   });
 
-  const createWrapper = ({autoRefresh = 'idle'}: {autoRefresh?: AutoRefreshState}) => {
-    return function ({children}: {children: React.ReactNode}) {
-      mockUseLocation.mockReturnValue(
-        LocationFixture({
-          query: {[LOGS_AUTO_REFRESH_KEY]: autoRefresh},
-        })
-      );
-      return (
-        <LogsQueryParamsProvider
-          analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-          source="location"
-        >
-          {children}
-        </LogsQueryParamsProvider>
-      );
+  const additionalWrapper = ({children}: {children: React.ReactNode}) => (
+    <LogsQueryParamsProvider
+      analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+      source="location"
+    >
+      {children}
+    </LogsQueryParamsProvider>
+  );
+
+  function getRouterConfig(autoRefresh: AutoRefreshState) {
+    return {
+      location: {
+        pathname: `/organizations/${organization.slug}/explore/logs/`,
+        query: {[LOGS_AUTO_REFRESH_KEY]: autoRefresh},
+      },
+      route: '/organizations/:orgId/explore/logs/',
     };
-  };
+  }
 
   it('should initialize virtual timestamp to the latest timestamp before the ingest delay', async () => {
     const now = Date.now();
@@ -104,7 +100,11 @@ describe('useVirtualStreaming', () => {
 
     const {result} = renderHookWithProviders(
       () => useVirtualStreaming({data: mockData}),
-      {additionalWrapper: createWrapper({autoRefresh: 'enabled'}), organization}
+      {
+        additionalWrapper,
+        organization,
+        initialRouterConfig: getRouterConfig('enabled'),
+      }
     );
 
     await waitFor(() => {
@@ -117,7 +117,7 @@ describe('useVirtualStreaming', () => {
     expect(result.current.virtualStreamedTimestamp).toBe(now - 46000);
   });
 
-  it('should not initialize when auto refresh is disabled', () => {
+  it('should reset virtual timestamp when auto refresh transitions from enabled to idle', async () => {
     const mockData = createMockData([
       LogFixture({
         [OurLogKnownFieldKey.ID]: '1',
@@ -127,12 +127,27 @@ describe('useVirtualStreaming', () => {
       }),
     ]);
 
-    const {result} = renderHookWithProviders(
+    const {result, router} = renderHookWithProviders(
       () => useVirtualStreaming({data: mockData}),
-      {additionalWrapper: createWrapper({autoRefresh: 'idle'}), organization}
+      {
+        additionalWrapper,
+        organization,
+        initialRouterConfig: getRouterConfig('enabled'),
+      }
     );
 
-    expect(result.current.virtualStreamedTimestamp).toBeUndefined();
+    await waitFor(() => {
+      expect(result.current.virtualStreamedTimestamp).toBeDefined();
+    });
+
+    router.navigate({
+      pathname: `/organizations/${organization.slug}/explore/logs/`,
+      search: `?${LOGS_AUTO_REFRESH_KEY}=idle`,
+    });
+
+    await waitFor(() => {
+      expect(result.current.virtualStreamedTimestamp).toBeUndefined();
+    });
   });
 
   it('should start RAF when auto refresh is enabled', async () => {
@@ -146,8 +161,9 @@ describe('useVirtualStreaming', () => {
     ]);
 
     renderHookWithProviders(() => useVirtualStreaming({data: mockData}), {
-      additionalWrapper: createWrapper({autoRefresh: 'enabled'}),
+      additionalWrapper,
       organization,
+      initialRouterConfig: getRouterConfig('enabled'),
     });
 
     await waitFor(() => {
@@ -165,21 +181,22 @@ describe('useVirtualStreaming', () => {
       }),
     ]);
 
-    const {unmount} = renderHookWithProviders(
+    const {router} = renderHookWithProviders(
       () => useVirtualStreaming({data: mockData}),
-      {additionalWrapper: createWrapper({autoRefresh: 'enabled'})}
+      {
+        additionalWrapper,
+        organization,
+        initialRouterConfig: getRouterConfig('enabled'),
+      }
     );
 
     await waitFor(() => {
       expect(requestAnimationFrameSpy).toHaveBeenCalled();
     });
 
-    unmount();
-
-    // Re-render with disabled autorefresh
-    renderHookWithProviders(() => useVirtualStreaming({data: mockData}), {
-      additionalWrapper: createWrapper({autoRefresh: 'idle'}),
-      organization,
+    router.navigate({
+      pathname: `/organizations/${organization.slug}/explore/logs/`,
+      search: `?${LOGS_AUTO_REFRESH_KEY}=idle`,
     });
 
     await waitFor(() => {

--- a/static/app/views/explore/logs/useVirtualStreaming.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.tsx
@@ -127,8 +127,10 @@ export function useVirtualStreaming({
     setVirtualTimestamp(initialTimestamp);
   }, [data, refreshInterval]);
 
+  // Reset the virtual timestamp when auto-refresh is disabled to avoid stale data when switching between modes
   useEffect(() => {
     if (!autoRefresh) {
+      setVirtualTimestamp(undefined);
       return;
     }
 

--- a/static/app/views/explore/logs/useVirtualStreaming.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.tsx
@@ -130,7 +130,7 @@ export function useVirtualStreaming({
   // Reset the virtual timestamp when toggling auto-refresh
   useEffect(() => {
     if (!autoRefresh) {
-      // setVirtualTimestamp(undefined);
+      setVirtualTimestamp(undefined);
       return;
     }
 

--- a/static/app/views/explore/logs/useVirtualStreaming.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.tsx
@@ -127,10 +127,10 @@ export function useVirtualStreaming({
     setVirtualTimestamp(initialTimestamp);
   }, [data, refreshInterval]);
 
-  // Reset the virtual timestamp when auto-refresh is disabled to avoid stale data when switching between modes
+  // Reset the virtual timestamp when toggling auto-refresh
   useEffect(() => {
     if (!autoRefresh) {
-      setVirtualTimestamp(undefined);
+      // setVirtualTimestamp(undefined);
       return;
     }
 


### PR DESCRIPTION
The logs table behaves inconsistently in two scenarios:

1) When you toggle the auto-refresh button and then click the manual refresh button (behavior seen more clearly in low traffic organizations)
2) When you toggle the auto-refresh button, on and off, and then click the manual refresh button

The fixes:

1) Disable the manual refresh button while the auto-refresh is on. It feels redundant to have the manual button accessible from a UX perspective when auto-referesh is on, therefore I added logic to disable it and a tooltip explaining why. 
2) Add logic to reset the query when toggle goes from on to off + set the virtual timestamp to `undefined`
  - [This line](https://github.com/getsentry/sentry/blob/2de34fd5da9af5af1762d829904a02c991c25c2b/static/app/views/explore/logs/useVirtualStreaming.tsx#L303-L304) is used to dictate if we show all rows, and the virtual timestamp's value wasn't being changed when untoggling - the bug
  - Resetting the query removes data from the cache and informs subscribers about it, likely leading to a queryFn retrigger.

Additionally, added tests and modified the virtualStreaming spec to use the location router instead of the mocked one. 

Closes LOGS-821