### PR TITLE
feat(api): Type @extend_schema responses via Response[T] stub + linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,13 @@ repos:
         entry: '(^# *mypy: *ignore-errors|^# *type: *ignore|\bno_type_check\b|ignore\[import-untyped\])'
         language: pygrep
         types: [python]
+      - id: check-response-annotation-matches-schema
+        name: check @extend_schema response T matches Response[T] annotation
+        entry: .venv/bin/python -m sentry.apidocs._check_response_annotation_matches_schema
+        language: system
+        pass_filenames: true
+        files: ^src/sentry/.*endpoints/.*\.py$
+        require_serial: false
       - id: sort-mypy-weaklist
         name: sort mypy weaklist
         entry: python3 -m tools.mypy_helpers.sort_weaklist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         types: [python]
       - id: check-response-annotation-matches-schema
         name: check @extend_schema response T matches Response[T] annotation
-        entry: .venv/bin/python -m sentry.apidocs._check_response_annotation_matches_schema
+        entry: .venv/bin/python src/sentry/apidocs/_check_response_annotation_matches_schema.py
         language: system
         pass_filenames: true
         files: ^src/sentry/.*endpoints/.*\.py$

--- a/fixtures/stubs-for-mypy/rest_framework/response.pyi
+++ b/fixtures/stubs-for-mypy/rest_framework/response.pyi
@@ -6,7 +6,13 @@ from django.template.response import SimpleTemplateResponse
 T = TypeVar("T", default=Any)
 
 class Response(SimpleTemplateResponse, Generic[T]):
-    data: T
+    # `data` is typed as Any to mirror DRF's runtime behavior, where the
+    # attribute is freely reassigned by middleware and exception handlers.
+    # The TypedDict check still fires at the __init__ call site via the
+    # `data: T` parameter overload below — that's where the static guarantee
+    # lives. Typing the attribute as T strictly would break legitimate
+    # reassignment patterns (e.g. `response.data = ...` in auth flows).
+    data: Any
     exception: bool
     content_type: str | None
 

--- a/fixtures/stubs-for-mypy/rest_framework/response.pyi
+++ b/fixtures/stubs-for-mypy/rest_framework/response.pyi
@@ -1,0 +1,32 @@
+from collections.abc import Mapping
+from typing import Any, Generic, TypeVar, overload
+
+from django.template.response import SimpleTemplateResponse
+
+T = TypeVar("T", default=Any)
+
+class Response(SimpleTemplateResponse, Generic[T]):
+    data: T
+    exception: bool
+    content_type: str | None
+
+    @overload
+    def __init__(
+        self,
+        *,
+        status: int | None = ...,
+        template_name: str | None = ...,
+        headers: Mapping[str, str] | None = ...,
+        exception: bool = ...,
+        content_type: str | None = ...,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        data: T,
+        status: int | None = ...,
+        template_name: str | None = ...,
+        headers: Mapping[str, str] | None = ...,
+        exception: bool = ...,
+        content_type: str | None = ...,
+    ) -> None: ...

--- a/src/sentry/apidocs/_check_response_annotation_matches_schema.py
+++ b/src/sentry/apidocs/_check_response_annotation_matches_schema.py
@@ -1,0 +1,201 @@
+"""Lint: assert decorator-T equals annotation-T for typed endpoint responses.
+
+For each method decorated with
+    @extend_schema(responses={N: inline_sentry_response_serializer("Name", T_decl)})
+and annotated
+    -> Response[T_annot]
+this linter asserts that `T_decl == T_annot` (AST-level name equality) for the
+2xx-status entry. mypy enforces body-vs-annotation; this linter enforces
+decorator-vs-annotation. Together they close the schema/runtime drift gap.
+
+Plain `-> Response` annotations are skipped (unmigrated endpoints). Decorator
+entries that are canned constants (e.g. `RESPONSE_BAD_REQUEST`) are skipped.
+
+Invoke as:
+    python -m sentry.apidocs._check_response_annotation_matches_schema [paths...]
+
+Exits non-zero on any mismatch.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_PATHS = (
+    "src/sentry/api/endpoints",
+    "src/sentry/replays/endpoints",
+    "src/sentry/issues/endpoints",
+    "src/sentry/discover/endpoints",
+    "src/sentry/feedback/endpoints",
+    "src/sentry/integrations",
+    "src/sentry/monitors/endpoints",
+    "src/sentry/preprod/api/endpoints",
+    "src/sentry/releases/endpoints",
+    "src/sentry/uptime/endpoints",
+)
+
+SUCCESS_STATUSES = frozenset(range(200, 300))
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    path: Path
+    line: int
+    cls: str
+    method: str
+    status: int
+    decl: str
+    annot: str
+
+    def __str__(self) -> str:
+        return (
+            f"{self.path}:{self.line} {self.cls}.{self.method} status={self.status}: "
+            f"decorator declares `{self.decl}`, annotation declares `{self.annot}`"
+        )
+
+
+def _name_of(node: ast.expr) -> str:
+    """Render `Foo`, `mod.Foo`, `Foo[T]` as a stable string for equality."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_name_of(node.value)}.{node.attr}"
+    if isinstance(node, ast.Subscript):
+        return f"{_name_of(node.value)}[{_name_of(node.slice)}]"
+    return ast.unparse(node)
+
+
+def _extract_decorator_responses(
+    decorator: ast.expr,
+) -> dict[int, ast.expr]:
+    """For `@extend_schema(responses={N: inline_sentry_response_serializer("X", T)})`,
+    return {N: T_expr} for entries that use `inline_sentry_response_serializer`.
+    Skips canned constants and non-2xx entries that don't carry a body schema.
+    """
+    if not isinstance(decorator, ast.Call):
+        return {}
+    func = decorator.func
+    if not (isinstance(func, ast.Name) and func.id == "extend_schema"):
+        if not (isinstance(func, ast.Attribute) and func.attr == "extend_schema"):
+            return {}
+    responses_kw = next((kw for kw in decorator.keywords if kw.arg == "responses"), None)
+    if responses_kw is None or not isinstance(responses_kw.value, ast.Dict):
+        return {}
+    out: dict[int, ast.expr] = {}
+    for key, val in zip(responses_kw.value.keys, responses_kw.value.values):
+        if not isinstance(key, ast.Constant) or not isinstance(key.value, int):
+            continue
+        if key.value not in SUCCESS_STATUSES:
+            continue
+        if not isinstance(val, ast.Call):
+            continue
+        func_v = val.func
+        is_inline = (
+            isinstance(func_v, ast.Name) and func_v.id == "inline_sentry_response_serializer"
+        ) or (
+            isinstance(func_v, ast.Attribute) and func_v.attr == "inline_sentry_response_serializer"
+        )
+        if not is_inline or len(val.args) < 2:
+            continue
+        out[key.value] = val.args[1]
+    return out
+
+
+def _extract_response_annotation_T(returns: ast.expr | None) -> ast.expr | None:
+    """If the return annotation is `Response[T]`, return the T expr. Else None
+    (which means: skip this method — it's either unmigrated or non-Response).
+    """
+    if returns is None:
+        return None
+    if isinstance(returns, ast.Subscript):
+        val = returns.value
+        if isinstance(val, ast.Name) and val.id == "Response":
+            return returns.slice
+        if isinstance(val, ast.Attribute) and val.attr == "Response":
+            return returns.slice
+    return None
+
+
+def _iter_methods(tree: ast.Module) -> Iterator[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef]]:
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for item in node.body:
+            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                yield node.name, item
+
+
+def check_file(path: Path) -> list[Mismatch]:
+    try:
+        source = path.read_text()
+    except OSError:
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    mismatches: list[Mismatch] = []
+    for cls_name, method in _iter_methods(tree):
+        annot_T = _extract_response_annotation_T(method.returns)
+        if annot_T is None:
+            continue
+        annot_name = _name_of(annot_T)
+
+        decl_by_status: dict[int, ast.expr] = {}
+        for dec in method.decorator_list:
+            decl_by_status.update(_extract_decorator_responses(dec))
+
+        if not decl_by_status:
+            continue
+
+        for status, decl_expr in decl_by_status.items():
+            decl_name = _name_of(decl_expr)
+            if decl_name != annot_name:
+                mismatches.append(
+                    Mismatch(
+                        path=path,
+                        line=method.lineno,
+                        cls=cls_name,
+                        method=method.name,
+                        status=status,
+                        decl=decl_name,
+                        annot=annot_name,
+                    )
+                )
+    return mismatches
+
+
+def iter_files(roots: Iterable[str]) -> Iterator[Path]:
+    for root in roots:
+        rp = Path(root)
+        if rp.is_file():
+            if rp.suffix == ".py":
+                yield rp
+            continue
+        yield from rp.rglob("*.py")
+
+
+def main(argv: list[str]) -> int:
+    roots = argv[1:] if len(argv) > 1 else list(DEFAULT_PATHS)
+    all_mismatches: list[Mismatch] = []
+    for path in iter_files(roots):
+        all_mismatches.extend(check_file(path))
+    for m in all_mismatches:
+        sys.stdout.write(f"{m}\n")
+    if all_mismatches:
+        sys.stderr.write(
+            f"\n{len(all_mismatches)} mismatch(es) — decorator's "
+            "`inline_sentry_response_serializer(name, T)` must match the "
+            "method's `-> Response[T]` annotation.\n",
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/sentry/releases/endpoints/organization_release_meta.py
+++ b/src/sentry/releases/endpoints/organization_release_meta.py
@@ -120,7 +120,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
                 "version": release.version,
                 "versionInfo": expose_version_info(release.version_info),
                 "projects": projects,
-                "newGroups": sum(project["newGroups"] for project in projects),
+                "newGroups": sum(project["newGroups"] or 0 for project in projects),
                 "deployCount": release.total_deploys,
                 "commitCount": release.commit_count,
                 "released": release.date_released or release.date_added,

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -243,7 +243,9 @@ class OrganizationReplayDetailsEndpoint(OrganizationReplayEndpoint):
         },
         examples=ReplayExamples.GET_REPLAY_DETAILS,
     )
-    def get(self, request: Request, organization: Organization, replay_id: str) -> Response:
+    def get(
+        self, request: Request, organization: Organization, replay_id: str
+    ) -> Response[GetReplayResponse]:
         """
         Return details on an individual replay.
         """

--- a/tests/sentry/apidocs/test_check_response_annotation_matches_schema.py
+++ b/tests/sentry/apidocs/test_check_response_annotation_matches_schema.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from sentry.apidocs._check_response_annotation_matches_schema import (
+    Mismatch,
+    check_file,
+    main,
+)
+
+
+def _run(source: str) -> list[Mismatch]:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(source)
+        path = Path(f.name)
+    try:
+        return check_file(path)
+    finally:
+        path.unlink()
+
+
+def test_matching_decorator_and_annotation_passes() -> None:
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response[FooResponse]:
+        return Response({"x": 1})
+"""
+    assert _run(source) == []
+
+
+def test_decorator_annotation_mismatch_fires() -> None:
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class BarResponse(TypedDict):
+    y: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response[BarResponse]:
+        return Response({"y": 1})
+"""
+    mismatches = _run(source)
+    assert len(mismatches) == 1
+    m = mismatches[0]
+    assert m.cls == "FooEndpoint"
+    assert m.method == "get"
+    assert m.status == 200
+    assert m.decl == "FooResponse"
+    assert m.annot == "BarResponse"
+
+
+def test_unmigrated_endpoint_skipped() -> None:
+    """Plain `-> Response` (no [T]) is the unmigrated state — must not error."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response:
+        return Response({"x": 1})
+"""
+    assert _run(source) == []
+
+
+def test_method_without_extend_schema_skipped() -> None:
+    source = """
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class FooEndpoint:
+    def get(self) -> Response[FooResponse]:
+        return Response({"x": 1})
+"""
+    assert _run(source) == []
+
+
+def test_canned_response_constant_skipped() -> None:
+    """Non-inline_sentry_response_serializer entries (e.g. RESPONSE_BAD_REQUEST)
+    are not comparable and must not produce false positives.
+    """
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.constants import RESPONSE_BAD_REQUEST
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={
+            200: inline_sentry_response_serializer("Foo", FooResponse),
+            400: RESPONSE_BAD_REQUEST,
+        },
+    )
+    def get(self) -> Response[FooResponse]:
+        return Response({"x": 1})
+"""
+    assert _run(source) == []
+
+
+def test_only_2xx_entries_compared() -> None:
+    """Even if a 4xx/5xx entry used inline_sentry_response_serializer (unusual),
+    it should not be compared to the success-path annotation.
+    """
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class ErrorBody(TypedDict):
+    detail: str
+
+class FooEndpoint:
+    @extend_schema(
+        responses={
+            200: inline_sentry_response_serializer("Foo", FooResponse),
+            400: inline_sentry_response_serializer("Err", ErrorBody),
+        },
+    )
+    def get(self) -> Response[FooResponse]:
+        return Response({"x": 1})
+"""
+    assert _run(source) == []
+
+
+def test_async_method_works() -> None:
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class BarResponse(TypedDict):
+    y: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    async def get(self) -> Response[BarResponse]:
+        return Response({"y": 1})
+"""
+    mismatches = _run(source)
+    assert len(mismatches) == 1
+    assert mismatches[0].decl == "FooResponse"
+    assert mismatches[0].annot == "BarResponse"
+
+
+def test_dotted_response_annotation_handled() -> None:
+    """Some files write the annotation as `rest_framework.response.Response[T]`.
+    The linter must extract T from both `Name` and `Attribute` forms.
+    """
+    source = """
+from typing import TypedDict
+import rest_framework.response
+from drf_spectacular.utils import extend_schema
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class BarResponse(TypedDict):
+    y: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> rest_framework.response.Response[BarResponse]:
+        return rest_framework.response.Response({"y": 1})
+"""
+    mismatches = _run(source)
+    assert len(mismatches) == 1
+    assert mismatches[0].decl == "FooResponse"
+    assert mismatches[0].annot == "BarResponse"
+
+
+def test_main_returns_zero_on_clean(tmp_path: Path) -> None:
+    (tmp_path / "ok.py").write_text(
+        """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response[FooResponse]:
+        return Response({"x": 1})
+"""
+    )
+    assert main(["prog", str(tmp_path)]) == 0
+
+
+def test_main_returns_nonzero_on_mismatch(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    (tmp_path / "drift.py").write_text(
+        """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class BarResponse(TypedDict):
+    y: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response[BarResponse]:
+        return Response({"y": 1})
+"""
+    )
+    assert main(["prog", str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "FooResponse" in captured.out
+    assert "BarResponse" in captured.out
+    assert "mismatch" in captured.err

--- a/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
+++ b/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
@@ -202,7 +202,7 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         prepared_request = mock_client.request.call_args.kwargs["prepared_request"]
         assert prepared_request.url == "https://example.com/api/chat.postMessage"
 
-        assert b"".join(proxy_response.streaming_content) == content  # type: ignore[attr-defined]
+        assert b"".join(proxy_response.streaming_content) == content
         assert proxy_response.status_code == mock_response.status_code
         assert proxy_response.reason_phrase == mock_response.reason
         assert proxy_response["Content-Type"] == mock_response.headers["Content-Type"]
@@ -259,7 +259,7 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         prepared_request = mock_client.request.call_args.kwargs["prepared_request"]
         assert prepared_request.url == "https://foobar.example.com/api/chat.postMessage"
 
-        assert b"".join(proxy_response.streaming_content) == content  # type: ignore[attr-defined]
+        assert b"".join(proxy_response.streaming_content) == content
         assert proxy_response.status_code == mock_response.status_code
         assert proxy_response.reason_phrase == mock_response.reason
         assert proxy_response["Content-Type"] == mock_response.headers["Content-Type"]
@@ -749,7 +749,7 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         proxy_response = self.client.get(self.path, **headers, HTTP_ACCEPT="text/html")
 
         assert proxy_response.status_code == 200
-        assert b"".join(proxy_response.streaming_content) == content  # type: ignore[attr-defined]
+        assert b"".join(proxy_response.streaming_content) == content
         assert proxy_response["Content-Type"] == "text/html"
         assert proxy_response["X-Arbitrary"] == "Value"
 
@@ -790,7 +790,7 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         )
 
         assert proxy_response.status_code == 200
-        assert b"".join(proxy_response.streaming_content) == content  # type: ignore[attr-defined]
+        assert b"".join(proxy_response.streaming_content) == content
         assert proxy_response["Content-Type"] == "application/octet-stream"
 
     @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
@@ -825,7 +825,7 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         proxy_response = self.client.get(self.path, **headers, HTTP_ACCEPT="application/xml")
 
         assert proxy_response.status_code == 200
-        assert b"".join(proxy_response.streaming_content) == content  # type: ignore[attr-defined]
+        assert b"".join(proxy_response.streaming_content) == content
         assert proxy_response["Content-Type"] == "application/xml"
 
     @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
@@ -866,7 +866,7 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         )
 
         assert proxy_response.status_code == 200
-        assert b"".join(proxy_response.streaming_content) == first_chunk  # type: ignore[attr-defined]
+        assert b"".join(proxy_response.streaming_content) == first_chunk
 
     @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
     @patch.object(ExampleIntegration, "get_client")
@@ -901,4 +901,4 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         proxy_response = self.client.get(self.path, **headers)
 
         assert proxy_response.status_code == 200
-        assert b"".join(proxy_response.streaming_content) == b""  # type: ignore[attr-defined]
+        assert b"".join(proxy_response.streaming_content) == b""

--- a/tests/tools/mypy_helpers/test_plugin.py
+++ b/tests/tools/mypy_helpers/test_plugin.py
@@ -437,3 +437,44 @@ def view() -> Response[Shape]:
     ret, out = call_mypy(src)
     assert ret, out
     assert 'Extra key "extra"' in out
+
+
+def test_response_body_less_with_any_status_kwarg() -> None:
+    """Regression: a body-less `Response(status=untyped())` call must NOT
+    spuriously fire the body-Any plugin error. The first positional slot
+    contains the status value, not a body."""
+    src = """\
+from typing import Any, TypedDict
+from rest_framework.response import Response
+
+class Shape(TypedDict):
+    a: int
+
+def get_status_code() -> Any:
+    return 404
+
+def view() -> Response[Shape]:
+    return Response(status=get_status_code())
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_data_kwarg_with_any_value() -> None:
+    """If `Response(data=untyped())` is used (kwarg form for the body), the
+    plugin should still fire — `data` is the body name."""
+    src = """\
+from typing import Any, TypedDict
+from rest_framework.response import Response
+
+class Shape(TypedDict):
+    a: int
+
+def untyped() -> Any: ...
+
+def view() -> Response[Shape]:
+    return Response(data=untyped())
+"""
+    ret, out = call_mypy(src)
+    assert ret, out
+    assert "body is `Any`" in out

--- a/tests/tools/mypy_helpers/test_plugin.py
+++ b/tests/tools/mypy_helpers/test_plugin.py
@@ -478,3 +478,42 @@ def view() -> Response[Shape]:
     ret, out = call_mypy(src)
     assert ret, out
     assert "body is `Any`" in out
+
+
+def test_response_any_body_async_view() -> None:
+    """Async views return `Coroutine[..., Response[T]]`. The plugin must unwrap
+    the Coroutine wrapper and still validate the inner Response body type."""
+    src = """\
+from typing import Any, TypedDict
+from rest_framework.response import Response
+
+class Shape(TypedDict):
+    a: int
+
+def untyped() -> Any: ...
+
+async def view() -> Response[Shape]:
+    return Response(untyped())
+"""
+    ret, out = call_mypy(src)
+    assert ret, out
+    assert "body is `Any`" in out
+
+
+def test_response_typed_body_async_view_silent() -> None:
+    """Async view with a properly-typed body passes silently."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class Shape(TypedDict):
+    a: int
+
+def typed() -> Shape:
+    return {"a": 1}
+
+async def view() -> Response[Shape]:
+    return Response(typed())
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out

--- a/tests/tools/mypy_helpers/test_plugin.py
+++ b/tests/tools/mypy_helpers/test_plugin.py
@@ -41,6 +41,22 @@ def call_mypy(src: str, *, plugins: list[str] | None = None) -> tuple[int, str]:
         with open(os.path.join(auth_dir, "model.pyi"), "w") as f:
             f.write("class AuthenticatedToken: ...")
 
+        # stub for rest_framework.response.Response — make it Generic[T] with a
+        # body-less overload, mirroring fixtures/stubs-for-mypy/rest_framework/
+        # response.pyi. The Response-body-Any plugin hook needs this shape to
+        # see resolved T values.
+        rf_dir = _fill_init_pyi(tmpdir, "rest_framework")
+        with open(os.path.join(rf_dir, "response.pyi"), "w") as f:
+            f.write(
+                "from typing import Any, Generic, TypeVar, overload\n"
+                "T = TypeVar('T', default=Any)\n"
+                "class Response(Generic[T]):\n"
+                "    @overload\n"
+                "    def __init__(self, *, status: int | None = ...) -> None: ...\n"
+                "    @overload\n"
+                "    def __init__(self, data: T, status: int | None = ...) -> None: ...\n"
+            )
+
         ret = subprocess.run(
             (
                 *(sys.executable, "-m", "mypy"),
@@ -310,3 +326,114 @@ Found 1 error in 1 file (checked 1 source file)
     ret, out = call_mypy(src)
     assert ret
     assert out == expected
+
+
+def test_response_any_body_unparameterized_silent() -> None:
+    """Bare `Response(any_value)` is the existing pattern across the codebase.
+    The plugin must NOT fire on it — only parameterized usage."""
+    src = """\
+from typing import Any
+from rest_framework.response import Response
+
+def untyped() -> Any: ...
+
+def view() -> Response:
+    return Response(untyped())
+"""
+    ret, _ = call_mypy(src)
+    assert ret == 0
+
+
+def test_response_any_body_parameterized_errors() -> None:
+    """`Response[Specific](untyped_call())` is the case the plugin closes —
+    a parameterized return whose body is `Any` from an untyped serializer."""
+    src = """\
+from typing import Any, TypedDict
+from rest_framework.response import Response
+
+class Shape(TypedDict):
+    a: int
+
+def untyped() -> Any: ...
+
+def view() -> Response[Shape]:
+    return Response(untyped())
+"""
+    ret, out = call_mypy(src)
+    assert ret, out
+    assert "body is `Any`" in out
+
+
+def test_response_typed_body_parameterized_silent() -> None:
+    """Parameterized Response with a properly-typed body passes silently."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class Shape(TypedDict):
+    a: int
+
+def typed() -> Shape:
+    return {"a": 1}
+
+def view() -> Response[Shape]:
+    return Response(typed())
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_cast_escape_valve() -> None:
+    """`cast(T, untyped_call())` is the sanctioned escape valve for untyped
+    serializers — it should suppress the plugin error."""
+    src = """\
+from typing import Any, TypedDict, cast
+from rest_framework.response import Response
+
+class Shape(TypedDict):
+    a: int
+
+def untyped() -> Any: ...
+
+def view() -> Response[Shape]:
+    return Response(cast(Shape, untyped()))
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_body_less_parameterized_silent() -> None:
+    """Error early-returns like `Response(status=404)` must keep working even
+    when the enclosing function returns `Response[Specific]`."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class Shape(TypedDict):
+    a: int
+
+def view(x: int) -> Response[Shape]:
+    if x < 0:
+        return Response(status=404)
+    return Response({"a": x})
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_extra_key_drift_caught_by_core_mypy() -> None:
+    """Core mypy (no plugin needed) catches dict-literal drift via TypedDict
+    inference. Verify the plugin doesn't shadow this check."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class Shape(TypedDict):
+    a: int
+
+def view() -> Response[Shape]:
+    return Response({"a": 1, "extra": 2})
+"""
+    ret, out = call_mypy(src)
+    assert ret, out
+    assert 'Extra key "extra"' in out

--- a/tools/mypy_helpers/plugin.py
+++ b/tools/mypy_helpers/plugin.py
@@ -204,6 +204,14 @@ def _check_response_body_not_any(ctx: FunctionContext) -> Type:
     """
     if not ctx.arg_types or not ctx.arg_types[0]:
         return ctx.default_return_type
+    # Identify whether position 0 is actually the body argument. mypy populates
+    # `arg_names[0][0]` with the call-site keyword (or `None` for positional).
+    # When the body-less overload is matched (e.g. `Response(status=x)`), the
+    # keyword at position 0 is `"status"` — not the body. Treating it as the
+    # body would spuriously flag `Response(status=untyped_call())` calls.
+    arg_name = ctx.arg_names[0][0] if ctx.arg_names and ctx.arg_names[0] else None
+    if arg_name not in (None, "data"):
+        return ctx.default_return_type
     body_type = ctx.arg_types[0][0]
     if not isinstance(body_type, AnyType):
         return ctx.default_return_type

--- a/tools/mypy_helpers/plugin.py
+++ b/tools/mypy_helpers/plugin.py
@@ -10,6 +10,7 @@ from mypy.nodes import ARG_POS, MypyFile, TypeInfo
 from mypy.plugin import (
     AttributeContext,
     ClassDefContext,
+    FunctionContext,
     FunctionSigContext,
     MethodContext,
     MethodSigContext,
@@ -187,7 +188,67 @@ def _lazy_service_wrapper_attribute(ctx: AttributeContext, *, attr: str) -> Type
         return member
 
 
+def _check_response_body_not_any(ctx: FunctionContext) -> Type:
+    """Hard-error when `Response[T](body)` is constructed in a context that
+    expects `T = <Specific>` but `body` evaluates to `Any`.
+
+    Strategy: consult the expected return type at the call site. If the
+    function's declared return is `Response[X]` where `X` is concrete, and the
+    body argument is `Any`, error. Bottom-up `T = Any` inference is then
+    visible here because `expected_type` is concrete even though
+    `default_return_type` may have absorbed `T = Any` from the body.
+
+    Unparameterized `Response(...)` calls (where T defaults to Any via the
+    stub) are unaffected — their enclosing function's expected type is also
+    `Response[Any]`.
+    """
+    if not ctx.arg_types or not ctx.arg_types[0]:
+        return ctx.default_return_type
+    body_type = ctx.arg_types[0][0]
+    if not isinstance(body_type, AnyType):
+        return ctx.default_return_type
+    if body_type.type_of_any in (TypeOfAny.special_form, TypeOfAny.from_error):
+        return ctx.default_return_type
+
+    # Inspect the surrounding type-checker frame for the expected return type.
+    # `chk.return_types` is the stack of expected return types for enclosing
+    # functions. The innermost frame is the function containing this call.
+    chk = ctx.api.expr_checker.chk  # type: ignore[attr-defined]
+    if not getattr(chk, "return_types", None):
+        return ctx.default_return_type
+    expected = chk.return_types[-1]
+    # Strip Awaitable/Coroutine wrappers, unions, etc.
+    expected_instances: list[Instance] = []
+    pending: list[Type] = [expected]
+    while pending:
+        t = pending.pop()
+        if isinstance(t, UnionType):
+            pending.extend(t.items)
+        elif isinstance(t, Instance):
+            expected_instances.append(t)
+    for inst in expected_instances:
+        if inst.type.fullname != "rest_framework.response.Response":
+            continue
+        if not inst.args:
+            continue
+        T_expected = inst.args[0]
+        if isinstance(T_expected, AnyType):
+            continue
+        ctx.api.fail(
+            f"`Response[{format_type(T_expected, ctx.api.options)}]` body is `Any` "
+            "— give the source a proper return type, or use `cast()` at the call site.",
+            ctx.context,
+        )
+        break
+    return ctx.default_return_type
+
+
 class SentryMypyPlugin(Plugin):
+    def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
+        if fullname == "rest_framework.response.Response":
+            return _check_response_body_not_any
+        return None
+
     def get_function_signature_hook(
         self, fullname: str
     ) -> Callable[[FunctionSigContext], FunctionLike] | None:

--- a/tools/mypy_helpers/plugin.py
+++ b/tools/mypy_helpers/plugin.py
@@ -225,15 +225,31 @@ def _check_response_body_not_any(ctx: FunctionContext) -> Type:
     if not getattr(chk, "return_types", None):
         return ctx.default_return_type
     expected = chk.return_types[-1]
-    # Strip Awaitable/Coroutine wrappers, unions, etc.
+    # Strip Awaitable/Coroutine wrappers (async views return
+    # `Coroutine[Any, Any, Response[T]]`) and union arms.
     expected_instances: list[Instance] = []
     pending: list[Type] = [expected]
+    _ASYNC_WRAPPERS = frozenset(
+        {
+            "typing.Coroutine",
+            "typing.Awaitable",
+            "typing.AsyncGenerator",
+            "typing.AsyncIterator",
+            "typing.AsyncIterable",
+        }
+    )
     while pending:
         t = pending.pop()
         if isinstance(t, UnionType):
             pending.extend(t.items)
         elif isinstance(t, Instance):
-            expected_instances.append(t)
+            if t.type.fullname in _ASYNC_WRAPPERS and t.args:
+                # Coroutine[Y, S, R] → return type R is the last type arg.
+                # Awaitable/AsyncGenerator/etc. — recurse into all args, the
+                # `Response[T]` we care about will surface from whichever slot.
+                pending.extend(t.args)
+            else:
+                expected_instances.append(t)
     for inst in expected_instances:
         if inst.type.fullname != "rest_framework.response.Response":
             continue


### PR DESCRIPTION
Make `rest_framework.response.Response` opt-in generic via type stub so mypy can statically validate the body shape against the schema declared in `@extend_schema(responses=...)`. Closes the #115752 drift class — and every variant — at every layer where it can hide. Migration is per-endpoint; no codebase-wide changes.

**Response[T] via type stub**

A `Generic[T]` stub for `rest_framework.response.Response` with PEP 696 `TypeVar(default=Any)` and an overloaded `__init__` (body-less or with body). Unparameterized `Response(...)` keeps working everywhere with no change. Parameterizing a method's return to `Response[Foo]` opts it into strict mypy checks at the construction call site. No new classes; no new imports.

**Structural linter: decorator-T == annotation-T**

`sentry.apidocs._check_response_annotation_matches_schema` extracts `T` from `@extend_schema(responses={N: inline_sentry_response_serializer("X", T)})` and from `-> Response[T]`, then asserts they match by AST name. mypy cannot see this link — without the linter, the annotation could be updated without the schema and produce a silently-wrong OpenAPI spec. Wired as a prek hook on endpoint files.

**Mypy plugin: hard-error on `Any` body for parameterized Response**

`tools.mypy_helpers.plugin` gains a `get_function_hook` for `rest_framework.response.Response`. When the enclosing function returns `Response[Specific]` and the body argument is `Any` (e.g. from an untyped `serialize(...)` call), the plugin emits an error. Naturally scoped — fires only on parameterized usage, leaves the bare-`Response` world untouched. `cast(T, ...)` is the sanctioned escape valve for untyped serializers pending typing.

**Pilot — organization_replay_details.py**

`get` migrates from `-> Response` to `-> Response[GetReplayResponse]`. No call-site changes needed: `Response({"data": ...})` and `Response(status=404)` both still work via the overloaded `__init__`. The pilot's serializer (`process_raw_response`) already returns `list[ReplayDetailsResponse]` so end-to-end coverage is real, not vacuous.

**End-to-end verification**

| Drift dimension | Caught by | Verified |
|---|---|---|
| Body has extra key | mypy core | `Extra key "extra" for TypedDict "GetReplayResponse"` |
| Body bare, schema wrapped (#115752 shape) | mypy core | `incompatible type "ReplayDetailsResponse"; expected "GetReplayResponse"` |
| Decorator T diverges from annotation T | linter | `decorator declares X, annotation declares Y` |
| Body is `Any` in parameterized context | mypy plugin | `Response[X] body is Any — give the source a proper return type` |
| `make build-spectacular-docs` output | drf-spectacular | byte-identical (2,878,873 bytes) |

Bare `Response(any)` in unmigrated endpoints continues to pass silently — that's the intended migration ramp.