### PR TITLE
fix(theme): Update config.theme when mutating user theme option

### DIFF
--- a/static/app/utils/useMutateUserOptions.tsx
+++ b/static/app/utils/useMutateUserOptions.tsx
@@ -25,6 +25,13 @@ export function useMutateUserOptions({onSuccess, onError}: Props = {}) {
       });
     },
     onMutate: (options: UpdateUserOptionsVariables) => {
+      if (
+        options.theme &&
+        user.options.theme !== options.theme &&
+        options.theme !== 'system'
+      ) {
+        ConfigStore.set('theme', options.theme);
+      }
       ConfigStore.set('user', merge({}, user, {options}));
       return onSuccess?.();
     },


### PR DESCRIPTION
The command palette's theme switching uses `useMutateUserOptions`, which optimistically updates `config.user.options.theme` but never updates the derived `config.theme` field that `ThemeAndStyleProvider` reads. On the first dark→light switch after page load, the theme object stays stale until `useColorscheme`'s `useEffect` catches up a frame later, causing some tokens to not update.

Set `config.theme` directly in `onMutate` for non-system theme changes, matching the pattern already used by `updateUser` in `actionCreators/account.tsx`.

fixes DE-1266