### PR TITLE
feat: Reorder get topic to resolve override before lookup

### DIFF
--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -115,14 +115,16 @@ def get_topic_definition(topic: Topic, kafka_slice_id: int | None = None) -> Top
             "real_topic_name": defn["topic"],
         }
 
+    real_topic_name = settings.KAFKA_TOPIC_OVERRIDES.get(topic.value, topic.value)
     return {
-        "cluster": settings.KAFKA_TOPIC_TO_CLUSTER[topic.value],
-        "real_topic_name": settings.KAFKA_TOPIC_OVERRIDES.get(topic.value, topic.value),
+        "cluster": settings.KAFKA_TOPIC_TO_CLUSTER[real_topic_name],
+        "real_topic_name": real_topic_name,
     }
 
 
 def get_topic_definition_from_name(topic_name: str) -> TopicDefinition:
+    real_topic_name = settings.KAFKA_TOPIC_OVERRIDES.get(topic_name, topic_name)
     return {
-        "cluster": settings.KAFKA_TOPIC_TO_CLUSTER.get(topic_name, "default"),
-        "real_topic_name": settings.KAFKA_TOPIC_OVERRIDES.get(topic_name, topic_name),
+        "cluster": settings.KAFKA_TOPIC_TO_CLUSTER.get(real_topic_name, "default"),
+        "real_topic_name": real_topic_name,
     }

--- a/tests/sentry/consumers/test_get_topic_definition.py
+++ b/tests/sentry/consumers/test_get_topic_definition.py
@@ -1,16 +1,36 @@
 from django.test import override_settings
 
 from sentry.conf.types.kafka_definition import Topic
-from sentry.utils.kafka_config import get_topic_definition
+from sentry.utils.kafka_config import get_topic_definition, get_topic_definition_from_name
 
 
 def test_get_topic_definition_without_slice_id() -> None:
     with override_settings(
-        KAFKA_TOPIC_TO_CLUSTER={"events": "default"},
+        KAFKA_TOPIC_TO_CLUSTER={"events": "default", "custom-events-topic": "default"},
         KAFKA_TOPIC_OVERRIDES={"events": "custom-events-topic"},
     ):
         topic_def = get_topic_definition(Topic.EVENTS)
         assert topic_def["cluster"] == "default"
+        assert topic_def["real_topic_name"] == "custom-events-topic"
+
+
+def test_get_topic_definition_cluster_lookup_uses_overridden_name() -> None:
+    with override_settings(
+        KAFKA_TOPIC_TO_CLUSTER={"custom-events-topic": "events-cluster"},
+        KAFKA_TOPIC_OVERRIDES={"events": "custom-events-topic"},
+    ):
+        topic_def = get_topic_definition(Topic.EVENTS)
+        assert topic_def["cluster"] == "events-cluster"
+        assert topic_def["real_topic_name"] == "custom-events-topic"
+
+
+def test_get_topic_definition_from_name_cluster_lookup_uses_overridden_name() -> None:
+    with override_settings(
+        KAFKA_TOPIC_TO_CLUSTER={"custom-events-topic": "events-cluster"},
+        KAFKA_TOPIC_OVERRIDES={"events": "custom-events-topic"},
+    ):
+        topic_def = get_topic_definition_from_name("events")
+        assert topic_def["cluster"] == "events-cluster"
         assert topic_def["real_topic_name"] == "custom-events-topic"
 
 

--- a/tests/sentry/monitors/clock_tasks/test_producer.py
+++ b/tests/sentry/monitors/clock_tasks/test_producer.py
@@ -8,7 +8,10 @@ from sentry_kafka_schemas.schema_types.monitors_clock_tasks_v1 import MarkTimeou
 from sentry.monitors.clock_tasks.producer import MONITORS_CLOCK_TASKS_CODEC, produce_task
 
 
-@override_settings(KAFKA_TOPIC_OVERRIDES={"monitors-clock-tasks": "monitors-test-topic"})
+@override_settings(
+    KAFKA_TOPIC_OVERRIDES={"monitors-clock-tasks": "monitors-test-topic"},
+    KAFKA_TOPIC_TO_CLUSTER={"monitors-test-topic": "default"},
+)
 @mock.patch("sentry.monitors.clock_tasks.producer._clock_task_producer")
 def test_produce_task(mock_producer: mock.MagicMock) -> None:
     message: MarkTimeout = {

--- a/tests/sentry/monitors/logic/test_incident_occurrence.py
+++ b/tests/sentry/monitors/logic/test_incident_occurrence.py
@@ -288,7 +288,8 @@ class IncidentOccurrenceTestCase(TestCase):
         )
 
     @override_settings(
-        KAFKA_TOPIC_OVERRIDES={"monitors-incident-occurrences": "monitors-test-topic"}
+        KAFKA_TOPIC_OVERRIDES={"monitors-incident-occurrences": "monitors-test-topic"},
+        KAFKA_TOPIC_TO_CLUSTER={"monitors-test-topic": "default"},
     )
     @mock.patch("sentry.monitors.logic.incident_occurrence._incident_occurrence_producer")
     def test_queue_incident_occurrence(self, mock_producer: mock.MagicMock) -> None:

--- a/tests/sentry/monitors/tasks/test_clock_pulse.py
+++ b/tests/sentry/monitors/tasks/test_clock_pulse.py
@@ -9,7 +9,10 @@ from django.test import override_settings
 from sentry.monitors.tasks.clock_pulse import MONITOR_CODEC, clock_pulse
 
 
-@override_settings(KAFKA_TOPIC_OVERRIDES={"ingest-monitors": "monitors-test-topic"})
+@override_settings(
+    KAFKA_TOPIC_OVERRIDES={"ingest-monitors": "monitors-test-topic"},
+    KAFKA_TOPIC_TO_CLUSTER={"monitors-test-topic": "default"},
+)
 @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
 @mock.patch("sentry.monitors.tasks.clock_pulse._checkin_producer")
 def test_clock_pulse(checkin_producer_mock: mock.MagicMock) -> None:

--- a/tests/sentry/monitors/test_clock_dispatch.py
+++ b/tests/sentry/monitors/test_clock_dispatch.py
@@ -138,7 +138,10 @@ def test_monitor_task_trigger_partition_tick_skip(dispatch_tick: mock.MagicMock)
     assert dispatch_tick.mock_calls[2] == mock.call(now + timedelta(minutes=2))
 
 
-@override_settings(KAFKA_TOPIC_OVERRIDES={"monitors-clock-tick": "clock-tick-test-topic"})
+@override_settings(
+    KAFKA_TOPIC_OVERRIDES={"monitors-clock-tick": "clock-tick-test-topic"},
+    KAFKA_TOPIC_TO_CLUSTER={"clock-tick-test-topic": "default"},
+)
 @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
 @mock.patch("sentry.monitors.clock_dispatch._clock_tick_producer")
 @override_options({"crons.system_incidents.collect_metrics": False})

--- a/tests/sentry/post_process_forwarder/test_post_process_forwarder.py
+++ b/tests/sentry/post_process_forwarder/test_post_process_forwarder.py
@@ -67,6 +67,10 @@ class PostProcessForwarderTest(TestCase):
                 "events": self.events_topic,
                 "transactions": self.events_topic,
             },
+            KAFKA_TOPIC_TO_CLUSTER={
+                **settings.KAFKA_TOPIC_TO_CLUSTER,
+                self.events_topic: settings.KAFKA_TOPIC_TO_CLUSTER["events"],
+            },
         )
 
         self.override_settings_cm.__enter__()


### PR DESCRIPTION
Requires: https://github.com/getsentry/getsentry/pull/20435

Reorder `get_topic_definition` and `get_topic_definition_from_name` to resolve `KAFKA_TOPIC_OVERRIDES` before the `KAFKA_TOPIC_TO_CLUSTER` lookup, so the cluster lookup uses the real provisioned topic name. Required for cutover to the topicctl-sourced configmap, which is keyed only by the real topic name (not the enum value). Without this reorder, every region with active overrides would KeyError on the lookup.