### PR TITLE
fix(api-logs): log snuba throttle_threshold on rate-limited requests

### DIFF
--- a/src/sentry/api/handlers.py
+++ b/src/sentry/api/handlers.py
@@ -21,6 +21,7 @@ def custom_exception_handler(exc, context):
                 storage_key=exc.storage_key,
                 quota_used=exc.quota_used,
                 rejection_threshold=exc.rejection_threshold,
+                throttle_threshold=exc.throttle_threshold,
             )
 
         # capture the rate limited exception so we can see it in Sentry

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -75,6 +75,7 @@ def _get_rate_limit_stats_dict(request: Request) -> dict[str, str | int | None]:
         "snuba_rejection_threshold": getattr(
             snuba_rate_limit_metadata, "rejection_threshold", None
         ),
+        "snuba_throttle_threshold": getattr(snuba_rate_limit_metadata, "throttle_threshold", None),
         "snuba_storage_key": getattr(snuba_rate_limit_metadata, "storage_key", None),
     }
 

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -76,4 +76,5 @@ class SnubaRateLimitMeta:
     quota_unit: str | None
     quota_used: int | None
     rejection_threshold: int | None
+    throttle_threshold: int | None
     storage_key: str | None

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -387,6 +387,7 @@ class RateLimitExceeded(SnubaError):
         storage_key: str | None = None,
         quota_used: int | None = None,
         rejection_threshold: int | None = None,
+        throttle_threshold: int | None = None,
     ) -> None:
         super().__init__(message)
         self.policy = policy
@@ -394,6 +395,7 @@ class RateLimitExceeded(SnubaError):
         self.storage_key = storage_key
         self.quota_used = quota_used
         self.rejection_threshold = rejection_threshold
+        self.throttle_threshold = throttle_threshold
 
 
 class SchemaValidationError(QueryExecutionError):
@@ -1351,8 +1353,8 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                                     quota_unit=policy_info["quota_unit"],
                                     storage_key=policy_info["storage_key"],
                                     quota_used=policy_info["quota_used"],
-                                    # We won't have rejection_threshold for throttled_by errors
                                     rejection_threshold=policy_info.get("rejection_threshold"),
+                                    throttle_threshold=policy_info.get("throttle_threshold"),
                                 )
                         except KeyError:
                             logger.warning(

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -88,6 +88,7 @@ class SnubaRateLimitedEndpoint(Endpoint):
             policy="ConcurrentRateLimitAllocationPolicy",
             quota_used=41,
             rejection_threshold=40,
+            throttle_threshold=30,
             quota_unit="no_units",
             storage_key="test_storage_key",
         )
@@ -202,6 +203,7 @@ optional_access_log_fields = (
     "snuba_storage_key",
     "snuba_quota_used",
     "snuba_rejection_threshold",
+    "snuba_throttle_threshold",
     "token_last_characters",
     "gateway_proxy",
 )
@@ -265,6 +267,7 @@ class TestAccessLogSnubaRateLimited(LogCaptureAPITestCase):
         assert self.captured_logs[0].snuba_storage_key == "test_storage_key"
         assert self.captured_logs[0].snuba_quota_used == "41"
         assert self.captured_logs[0].snuba_rejection_threshold == "40"
+        assert self.captured_logs[0].snuba_throttle_threshold == "30"
 
 
 @all_silo_test

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -666,3 +666,5 @@ class SnubaQueryRateLimitTest(TestCase):
         assert exc_info.value.storage_key == "errors_ro"
         assert exc_info.value.quota_used == 1500000000000
         assert exc_info.value.quota_unit == "bytes"
+        assert exc_info.value.throttle_threshold == 1000000000000
+        assert exc_info.value.rejection_threshold is None


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry/pull/116263. Log the throttled threshold when we get a 429 response due to throttling from snuba.