### PR TITLE
fix(autofix): Set default stopping point based on preferences

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -423,9 +423,7 @@ def run_automation(
     if is_seer_autotriggered_autofix_rate_limited_and_increment(group.project, group.organization):
         return
 
-    stopping_point = None
-    if is_seer_seat_based_tier_enabled(group.organization):
-        stopping_point = get_automation_stopping_point(group)
+    stopping_point = get_automation_stopping_point(group)
 
     _trigger_autofix_task.delay(
         group_id=group.id,
@@ -464,16 +462,22 @@ def is_group_triggering_automation(group: Group) -> bool:
     return True
 
 
-def get_automation_stopping_point(group: Group) -> AutofixStoppingPoint:
+def get_automation_stopping_point(group: Group) -> AutofixStoppingPoint | None:
     """
     Get the automation stopping point for a group.
     """
-    fixability_score = get_and_update_group_fixability_score(group)
-    fixability_stopping_point = _get_stopping_point_from_fixability(fixability_score)
-
     user_preference = read_preference_from_sentry_db(group.project).automated_run_stopping_point
 
-    return _apply_user_preference_upper_bound(fixability_stopping_point, user_preference)
+    if is_seer_seat_based_tier_enabled(group.organization):
+        fixability_score = get_and_update_group_fixability_score(group)
+        fixability_stopping_point = _get_stopping_point_from_fixability(fixability_score)
+
+        return _apply_user_preference_upper_bound(fixability_stopping_point, user_preference)
+
+    if user_preference:
+        return AutofixStoppingPoint(user_preference)
+
+    return None
 
 
 def _generate_summary(

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -924,7 +924,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
             run_automation(self.group, self.user, self.event, SeerAutomationSource.POST_PROCESS)
 
         mock_trigger.assert_called_once()
-        assert mock_trigger.call_args[1]["stopping_point"] is None
+        assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.CODE_CHANGES
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
@@ -1277,6 +1277,7 @@ class TestIsGroupTriggeringAutomation(APITestCase, SnubaTestCase):
         assert is_group_triggering_automation(self.group) is False
 
 
+@patch("sentry.seer.autofix.issue_summary.is_seer_seat_based_tier_enabled", return_value=True)
 @with_feature({"organizations:gen-ai-features": True})
 class TestGetAutomationStoppingPoint(TestCase):
     def setUp(self) -> None:
@@ -1284,21 +1285,21 @@ class TestGetAutomationStoppingPoint(TestCase):
         self.group = self.create_group()
 
     @patch("sentry.seer.autofix.issue_summary.get_and_update_group_fixability_score")
-    def test_default_preference_limits_stopping_point(self, mock_fixability):
+    def test_default_preference_limits_stopping_point(self, mock_fixability, mock_seat_based_tier):
         """Unset preference falls back to the well-known default (code_changes)."""
         mock_fixability.return_value = 0.80
 
         assert get_automation_stopping_point(self.group) == AutofixStoppingPoint.CODE_CHANGES
 
     @patch("sentry.seer.autofix.issue_summary.get_and_update_group_fixability_score")
-    def test_user_preference_limits_stopping_point(self, mock_fixability):
+    def test_user_preference_limits_stopping_point(self, mock_fixability, mock_seat_based_tier):
         mock_fixability.return_value = 0.80
         self.group.project.update_option("sentry:seer_automated_run_stopping_point", "solution")
 
         assert get_automation_stopping_point(self.group) == AutofixStoppingPoint.SOLUTION
 
     @patch("sentry.seer.autofix.issue_summary.get_and_update_group_fixability_score")
-    def test_low_fixability_returns_root_cause(self, mock_fixability):
+    def test_low_fixability_returns_root_cause(self, mock_fixability, mock_seat_based_tier):
         mock_fixability.return_value = 0.50
         self.group.project.update_option("sentry:seer_automated_run_stopping_point", "open_pr")
 
@@ -1306,7 +1307,9 @@ class TestGetAutomationStoppingPoint(TestCase):
 
     @patch("sentry.seer.autofix.issue_summary.read_preference_from_sentry_db")
     @patch("sentry.seer.autofix.issue_summary.get_and_update_group_fixability_score")
-    def test_null_stopping_point_uses_fixability_only(self, mock_fixability, mock_read_pref):
+    def test_null_stopping_point_uses_fixability_only(
+        self, mock_fixability, mock_read_pref, mock_seat_based_tier
+    ):
         """When preference.automated_run_stopping_point is None, fixability score alone drives the result."""
         from sentry.seer.models.seer_api_models import SeerProjectPreference
 


### PR DESCRIPTION
Previously, legacy autofix agent would read the preferences to decide a stopping point for automated runs without a stopping point. The seer agent doesnt do that so to fix it, we can just pass the stopping point from the beginning to avoid another fetch.

See https://github.com/getsentry/seer/blob/67e6c232f708a03b59b4cab09381668ae5eb92b9/src/seer/automation/autofix/tasks.py#L145-L148