### PR TITLE
ref(spans): Add loaded segment data model

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -129,9 +129,9 @@ from sentry.spans.buffer_types import (
     FlushCandidate,
     FlushedSegment,
     InsertedSubsegment,
-    LoadedSegmentData,
+    LoadedSegment,
     OutputSpan,
-    QueueKey,
+    SegmentIngestMetadata,
     Span,
     Subsegment,
 )
@@ -615,32 +615,21 @@ class SpansBuffer:
         )
 
         flush_candidates = self._acquire_locks_for_flush_candidates(flush_candidates)
-        segment_keys = [candidate.segment_key for candidate in flush_candidates]
 
-        loaded_segment_data, load_data_latency_ms, decompress_latency_ms = self._load_segment_data(
-            segment_keys
+        loaded_segments, load_data_latency_ms, decompress_latency_ms = self._load_segments(
+            flush_candidates
         )
 
-        segment_to_queue = {
-            candidate.segment_key: candidate.queue_key for candidate in flush_candidates
-        }
-        self._record_segment_loss_metrics(
-            segment_keys,
-            segment_to_queue,
-            now,
-            loaded_segment_data.payloads,
-        )
+        self._record_segment_loss_metrics(loaded_segments, now)
 
         flushed_segments, num_has_root_spans, any_shard_at_limit = self._build_flushed_segments(
-            flush_candidates,
-            loaded_segment_data,
+            loaded_segments,
             max_segments_per_shard,
             now,
         )
 
         self._flusher_logger.log_loaded_segments(
-            segment_keys,
-            loaded_segment_data.payloads,
+            loaded_segments,
             load_ids_latency_ms=load_ids_latency_ms,
             load_data_latency_ms=load_data_latency_ms,
             decompress_latency_ms=decompress_latency_ms,
@@ -699,8 +688,7 @@ class SpansBuffer:
 
     def _build_flushed_segments(
         self,
-        flush_candidates: Sequence[FlushCandidate],
-        loaded_segment_data: LoadedSegmentData,
+        loaded_segments: Sequence[LoadedSegment],
         max_segments_per_shard: int,
         now: int,
     ) -> tuple[dict[SegmentKey, FlushedSegment], int, bool]:
@@ -712,10 +700,10 @@ class SpansBuffer:
         num_has_root_spans = 0
         any_shard_at_limit = False
 
-        for flush_candidate in flush_candidates:
-            segment_key = flush_candidate.segment_key
+        for loaded_segment in loaded_segments:
+            segment_key = loaded_segment.segment_key
             segment_span_id = segment_key_to_span_id(segment_key).decode("ascii")
-            segment = loaded_segment_data.payloads.get(segment_key, [])
+            segment = loaded_segment.payloads
             project_id, _, _ = parse_segment_key(segment_key)
             if len(segment) >= max_segments_per_shard:
                 any_shard_at_limit = True
@@ -746,13 +734,13 @@ class SpansBuffer:
 
             metrics.incr(
                 "spans.buffer.flush_segments.num_segments_per_shard",
-                tags={"shard_i": flush_candidate.shard},
+                tags={"shard_i": loaded_segment.shard},
             )
             return_segments[segment_key] = FlushedSegment(
-                queue_key=flush_candidate.queue_key,
+                queue_key=loaded_segment.queue_key,
                 spans=output_spans,
                 project_id=int(project_id.decode("ascii")),
-                payload_keys=loaded_segment_data.payload_keys.get(segment_key, []),
+                payload_keys=loaded_segment.payload_keys,
             )
             num_has_root_spans += int(has_root_span)
 
@@ -761,24 +749,21 @@ class SpansBuffer:
                 segment_span_id=segment_span_id,
                 has_root_span=has_root_span,
                 num_spans=len(segment),
-                shard=flush_candidate.shard,
-                queue_key=flush_candidate.queue_key,
+                shard=loaded_segment.shard,
+                queue_key=loaded_segment.queue_key,
                 timestamp=now,
             ).emit(self._get_debug_trace_logger)
 
         return return_segments, num_has_root_spans, any_shard_at_limit
 
-    def _load_segment_data(
+    def _load_segments(
         self,
-        segment_keys: list[SegmentKey],
-    ) -> tuple[LoadedSegmentData, int, int]:
+        flush_candidates: Sequence[FlushCandidate],
+    ) -> tuple[list[LoadedSegment], int, int]:
         """
-        Load payload keys and span payload bytes for segment keys.
-
-        This is the load-data orchestration step for flushing. It returns the
-        loaded payload data plus phase latencies for cumulative flusher logging.
+        Load payloads and persisted metadata for flush candidates.
         """
-
+        segment_keys = [candidate.segment_key for candidate in flush_candidates]
         data_start = time.monotonic()
         with metrics.timer("spans.buffer.flush_segments.load_segment_data"):
             page_size = options.get("spans.buffer.segment-page-size")
@@ -789,12 +774,18 @@ class SpansBuffer:
                 page_size,
             )
         load_data_latency_ms = int((time.monotonic() - data_start) * 1000)
+        ingest_metadata = self._load_segment_ingest_metadata(segment_keys)
+        loaded_segments = [
+            LoadedSegment(
+                flush_candidate,
+                payloads.get(flush_candidate.segment_key, []),
+                payload_keys.get(flush_candidate.segment_key, []),
+                ingest_metadata.get(flush_candidate.segment_key, SegmentIngestMetadata()),
+            )
+            for flush_candidate in flush_candidates
+        ]
 
-        return (
-            LoadedSegmentData(payloads, payload_keys),
-            load_data_latency_ms,
-            decompress_latency_ms,
-        )
+        return loaded_segments, load_data_latency_ms, decompress_latency_ms
 
     def _load_payload_keys(
         self, segment_keys: Sequence[SegmentKey]
@@ -874,51 +865,58 @@ class SpansBuffer:
 
         return payloads, int(decompress_latency_ms)
 
+    def _load_segment_ingest_metadata(
+        self, segment_keys: Sequence[SegmentKey]
+    ) -> dict[SegmentKey, SegmentIngestMetadata]:
+        ingest_metadata = {key: SegmentIngestMetadata() for key in segment_keys}
+
+        with self.client.pipeline(transaction=False) as p:
+            for key in segment_keys:
+                p.get(b"span-buf:ic:" + key)
+                p.get(b"span-buf:ibc:" + key)
+
+            redis_results = p.execute()
+
+        for i, key in enumerate(segment_keys):
+            ingest_metadata[key] = SegmentIngestMetadata.from_redis_results(
+                redis_results[i * 2],
+                redis_results[i * 2 + 1],
+            )
+
+        return ingest_metadata
+
     def _record_segment_loss_metrics(
         self,
-        segment_keys: Sequence[SegmentKey],
-        segment_to_queue: dict[SegmentKey, QueueKey],
+        loaded_segments: Sequence[LoadedSegment],
         now: int,
-        payloads: dict[SegmentKey, list[bytes]],
     ) -> None:
         """
         Emit loss and expiration metrics for loaded segments.
         """
-        # Fetch ingested counts for all segments to calculate dropped spans
-        with self.client.pipeline(transaction=False) as p:
-            for key in segment_keys:
-                ingested_count_key = b"span-buf:ic:" + key
-                p.get(ingested_count_key)
-                ingested_byte_count_key = b"span-buf:ibc:" + key
-                p.get(ingested_byte_count_key)
-
-            ingested_results = p.execute()
-
         # Calculate dropped counts: total ingested - successfully loaded
         redis_ttl = options.get("spans.buffer.redis-ttl")
         root_timeout = options.get("spans.buffer.root-timeout")
 
-        for i, key in enumerate(segment_keys):
-            ingested_count = ingested_results[i * 2]
-            ingested_byte_count = ingested_results[i * 2 + 1]
+        for loaded_segment in loaded_segments:
+            ingest_metadata = loaded_segment.ingest_metadata
 
-            if ingested_byte_count:
+            if ingest_metadata.ingested_byte_count is not None:
                 metrics.timing(
                     "spans.buffer.flush_segments.ingested_bytes_per_segment",
-                    int(ingested_byte_count),
+                    ingest_metadata.ingested_byte_count,
                 )
 
-            if ingested_count:
-                total_ingested = int(ingested_count)
+            if ingest_metadata.ingested_count is not None:
+                total_ingested = ingest_metadata.ingested_count
                 metrics.timing(
                     "spans.buffer.flush_segments.ingested_spans_per_segment", total_ingested
                 )
-                successfully_loaded = len(payloads.get(key, []))
+                successfully_loaded = len(loaded_segment.payloads)
                 dropped = total_ingested - successfully_loaded
                 if dropped <= 0:
                     continue
 
-                project_id_bytes, _, _ = parse_segment_key(key)
+                project_id_bytes, _, _ = parse_segment_key(loaded_segment.segment_key)
                 project_id_int = int(project_id_bytes)
                 try:
                     project = Project.objects.get_from_cache(id=project_id_int)
@@ -937,27 +935,27 @@ class SpansBuffer:
                         category=DataCategory.SPAN_INDEXED,
                         quantity=dropped,
                     )
-            elif not payloads.get(key):
+            elif not loaded_segment.payloads:
                 # Both data and metadata are missing. This could be:
                 # 1. TTL expiration (segment sat in queue for >1 hour) - TRUE DATA LOSS
                 # 2. Race condition (another consumer flushed between load and metadata fetch)
                 # Only increment metric if segment is old enough to have actually expired.
-                queue_key = segment_to_queue.get(key)
-                if queue_key:
-                    deadline_score = self.client.zscore(queue_key, key)
-                    if deadline_score is not None:
-                        deadline = int(deadline_score)
-                        time_past_deadline = now - deadline
-                        # Estimate segment age: deadline = creation_time + timeout
-                        # Use root_timeout as conservative estimate (smaller value)
-                        estimated_age = time_past_deadline + root_timeout
+                deadline_score = self.client.zscore(
+                    loaded_segment.queue_key, loaded_segment.segment_key
+                )
+                if deadline_score is not None:
+                    deadline = int(deadline_score)
+                    time_past_deadline = now - deadline
+                    # Estimate segment age: deadline = creation_time + timeout
+                    # Use root_timeout as conservative estimate (smaller value)
+                    estimated_age = time_past_deadline + root_timeout
 
-                        if estimated_age > redis_ttl:
-                            # Segment is older than TTL - true expiration (data loss)
-                            metrics.incr("spans.buffer.segment_expired_before_flush")
+                    if estimated_age > redis_ttl:
+                        # Segment is older than TTL - true expiration (data loss)
+                        metrics.incr("spans.buffer.segment_expired_before_flush")
 
-        for key, spans in payloads.items():
-            if not spans:
+        for loaded_segment in loaded_segments:
+            if not loaded_segment.payloads:
                 # This is a bug, most likely the input topic is not
                 # partitioned by trace_id so multiple consumers are writing
                 # over each other. The consequence is duplicated segments,

--- a/src/sentry/spans/buffer_logger.py
+++ b/src/sentry/spans/buffer_logger.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Sequence
 from typing import Any, NamedTuple, TypeVar
 
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
 from sentry import options
-from sentry.spans.buffer_types import EvalshaData, EvalshaResult, InsertedSubsegment, Span
+from sentry.spans.buffer_types import (
+    EvalshaData,
+    EvalshaResult,
+    InsertedSubsegment,
+    LoadedSegment,
+    Span,
+)
 from sentry.spans.debug_trace_logger import DebugTraceLogger
 from sentry.spans.segment_key import SegmentKey, parse_segment_key
 from sentry.utils import metrics
@@ -168,8 +174,7 @@ class FlusherLogger:
 
     def log_loaded_segments(
         self,
-        segment_keys: Sequence[SegmentKey],
-        payloads: Mapping[SegmentKey, Sequence[bytes]],
+        loaded_segments: Sequence[LoadedSegment],
         *,
         load_ids_latency_ms: int,
         load_data_latency_ms: int,
@@ -183,17 +188,17 @@ class FlusherLogger:
             return
 
         entries: list[FlusherLogEntry] = []
-        for segment_key in segment_keys:
-            segment = payloads.get(segment_key, [])
-            if not segment:
+        for loaded_segment in loaded_segments:
+            if not loaded_segment.payloads:
                 continue
 
+            segment_key = loaded_segment.segment_key
             project_id, trace_id, _ = parse_segment_key(segment_key)
             entries.append(
                 FlusherLogEntry(
                     f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}",
-                    len(segment),
-                    sum(len(payload) for payload in segment),
+                    len(loaded_segment.payloads),
+                    sum(len(payload) for payload in loaded_segment.payloads),
                 )
             )
 

--- a/src/sentry/spans/buffer_types.py
+++ b/src/sentry/spans/buffer_types.py
@@ -112,15 +112,6 @@ class InsertedSubsegment(NamedTuple):
         return self.result.segment_key.endswith(self.subsegment.salt.encode("ascii"))
 
 
-class LoadedSegmentData(NamedTuple):
-    """
-    Raw payload data loaded for flush candidates.
-    """
-
-    payloads: dict[SegmentKey, list[bytes]]
-    payload_keys: dict[SegmentKey, list[PayloadKey]]
-
-
 class OutputSpan(NamedTuple):
     """
     A span payload after flush-time segment metadata has been attached.
@@ -141,6 +132,56 @@ class FlushCandidate(NamedTuple):
     queue_key: QueueKey
     segment_key: SegmentKey
     score: float
+
+
+class SegmentIngestMetadata(NamedTuple):
+    """
+    Ingest-time metadata stored alongside a segment.
+
+    These values may be missing when Redis data expired before the flusher loaded
+    the segment, or when another flusher won a race and cleaned up first.
+    """
+
+    ingested_count: int | None = None
+    ingested_byte_count: int | None = None
+
+    @classmethod
+    def from_redis_results(
+        cls,
+        ingested_count: bytes | int | None,
+        ingested_byte_count: bytes | int | None,
+    ) -> SegmentIngestMetadata:
+        return cls(
+            int(ingested_count) if ingested_count is not None else None,
+            int(ingested_byte_count) if ingested_byte_count is not None else None,
+        )
+
+
+class LoadedSegment(NamedTuple):
+    """
+    A flush candidate with its loaded payloads and ingest metadata.
+    """
+
+    flush_candidate: FlushCandidate
+    payloads: list[bytes]
+    payload_keys: list[PayloadKey]
+    ingest_metadata: SegmentIngestMetadata = SegmentIngestMetadata()
+
+    @property
+    def segment_key(self) -> SegmentKey:
+        return self.flush_candidate.segment_key
+
+    @property
+    def shard(self) -> int:
+        return self.flush_candidate.shard
+
+    @property
+    def queue_key(self) -> QueueKey:
+        return self.flush_candidate.queue_key
+
+    @property
+    def score(self) -> float:
+        return self.flush_candidate.score
 
 
 class FlushedSegment(NamedTuple):

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -21,8 +21,9 @@ from sentry.spans.buffer_types import (
     FlushCandidate,
     FlushedSegment,
     InsertedSubsegment,
-    LoadedSegmentData,
+    LoadedSegment,
     OutputSpan,
+    SegmentIngestMetadata,
     Span,
     Subsegment,
 )
@@ -2092,13 +2093,16 @@ def test_build_flushed_segments_adds_segment_metadata() -> None:
     segment_key = _segment_id(1, trace_id, segment_span_id)
     queue_key = buffer._get_queue_key(0)
     payload_key = _payload_key(1, trace_id, "1" * 32)
+    flush_candidate = FlushCandidate(0, queue_key, segment_key, 5)
 
     flushed_segments, num_has_root_spans, _ = buffer._build_flushed_segments(
-        [FlushCandidate(0, queue_key, segment_key, 5)],
-        LoadedSegmentData(
-            payloads={segment_key: [_payload(segment_span_id), _payload(child_span_id)]},
-            payload_keys={segment_key: [payload_key]},
-        ),
+        [
+            LoadedSegment(
+                flush_candidate,
+                [_payload(segment_span_id), _payload(child_span_id)],
+                [payload_key],
+            )
+        ],
         max_segments_per_shard=2,
         now=10,
     )
@@ -2159,7 +2163,7 @@ def test_load_payloads_from_keys_decompresses_payload_batches(
     assert decompress_latency_ms >= 0
 
 
-def test_load_segment_data_reads_payloads_from_distributed_keys(
+def test_load_segments_reads_payloads_from_distributed_keys(
     load_segment_buffer: SpansBuffer,
 ) -> None:
     buffer = load_segment_buffer
@@ -2179,16 +2183,23 @@ def test_load_segment_data_reads_payloads_from_distributed_keys(
     buffer.client.set(b"span-buf:ic:" + segment_key, 3)
     buffer.client.set(b"span-buf:ibc:" + segment_key, len(span_a) + len(span_b) + len(span_c))
 
-    loaded_segment_data, _, _ = buffer._load_segment_data([segment_key])
+    loaded_segments, _, _ = buffer._load_segments(
+        [FlushCandidate(0, buffer._get_queue_key(0), segment_key, 5)]
+    )
+    loaded_segment = loaded_segments[0]
 
-    assert set(loaded_segment_data.payloads[segment_key]) == {span_a, span_b, span_c}
-    assert set(loaded_segment_data.payload_keys[segment_key]) == {
+    assert set(loaded_segment.payloads) == {span_a, span_b, span_c}
+    assert set(loaded_segment.payload_keys) == {
         first_payload_key,
         second_payload_key,
     }
+    assert loaded_segment.ingest_metadata.ingested_count == 3
+    assert loaded_segment.ingest_metadata.ingested_byte_count == (
+        len(span_a) + len(span_b) + len(span_c)
+    )
 
 
-def test_load_segment_data_decompresses_payload_batches(
+def test_load_segments_decompresses_payload_batches(
     load_segment_buffer: SpansBuffer,
 ) -> None:
     buffer = load_segment_buffer
@@ -2204,30 +2215,33 @@ def test_load_segment_data_decompresses_payload_batches(
     buffer.client.sadd(payload_key, compressed)
     buffer.client.set(b"span-buf:ic:" + segment_key, 2)
 
-    loaded_segment_data, load_data_latency_ms, decompress_latency_ms = buffer._load_segment_data(
-        [segment_key]
+    loaded_segments, load_data_latency_ms, decompress_latency_ms = buffer._load_segments(
+        [FlushCandidate(0, buffer._get_queue_key(0), segment_key, 5)]
     )
+    loaded_segment = loaded_segments[0]
 
-    assert set(loaded_segment_data.payloads[segment_key]) == {span_a, span_b}
-    assert loaded_segment_data.payload_keys[segment_key] == [payload_key]
+    assert set(loaded_segment.payloads) == {span_a, span_b}
+    assert loaded_segment.payload_keys == [payload_key]
+    assert loaded_segment.ingest_metadata.ingested_count == 2
     assert load_data_latency_ms >= 0
     assert decompress_latency_ms >= 0
 
 
-def test_record_segment_loss_metrics_records_dropped_spans(
-    load_segment_buffer: SpansBuffer,
-) -> None:
-    buffer = load_segment_buffer
+def test_record_segment_loss_metrics_records_dropped_spans() -> None:
+    buffer = SpansBuffer(assigned_shards=[0])
     trace_id = "a" * 32
     segment_key = _segment_id(1, trace_id, "b" * 16)
-    salt = "1" * 32
-    payload_key = _payload_key(1, trace_id, salt)
+    payload_key = _payload_key(1, trace_id, "1" * 32)
     span_a = _payload("a" * 16)
-
-    buffer.client.sadd(buffer._get_payload_key_index(segment_key), salt)
-    buffer.client.sadd(payload_key, span_a)
-    buffer.client.set(b"span-buf:ic:" + segment_key, 3)
-    buffer.client.set(b"span-buf:ibc:" + segment_key, len(span_a))
+    loaded_segment = LoadedSegment(
+        FlushCandidate(0, buffer._get_queue_key(0), segment_key, 5),
+        payloads=[span_a],
+        payload_keys=[payload_key],
+        ingest_metadata=SegmentIngestMetadata(
+            ingested_count=3,
+            ingested_byte_count=len(span_a),
+        ),
+    )
 
     mock_project = mock.Mock(organization_id=100)
     with (
@@ -2235,16 +2249,17 @@ def test_record_segment_loss_metrics_records_dropped_spans(
         mock.patch("sentry.spans.buffer.track_outcome") as track_outcome,
     ):
         project_model.objects.get_from_cache.return_value = mock_project
-        loaded_segment_data, _, _ = buffer._load_segment_data([segment_key])
         buffer._record_segment_loss_metrics(
-            [segment_key],
-            {},
+            [loaded_segment],
             now=0,
-            payloads=loaded_segment_data.payloads,
         )
 
-    assert loaded_segment_data.payloads[segment_key] == [span_a]
-    assert loaded_segment_data.payload_keys[segment_key] == [payload_key]
+    assert loaded_segment.payloads == [span_a]
+    assert loaded_segment.payload_keys == [payload_key]
+    assert loaded_segment.ingest_metadata == SegmentIngestMetadata(
+        ingested_count=3,
+        ingested_byte_count=len(span_a),
+    )
     track_outcome.assert_called_once()
     outcome_kwargs = track_outcome.call_args.kwargs
     assert outcome_kwargs["org_id"] == 100
@@ -2274,25 +2289,30 @@ def test_record_segment_loss_metrics_records_dropped_spans(
     ],
 )
 def test_record_segment_loss_metrics_records_empty_expired_segments(
-    load_segment_buffer: SpansBuffer, deadline: int, now: int, expected_expired: bool
+    deadline: int, now: int, expected_expired: bool
 ) -> None:
-    buffer = load_segment_buffer
+    buffer = SpansBuffer(assigned_shards=[0])
     trace_id = "a" * 32
     segment_key = _segment_id(1, trace_id, "b" * 16)
-    queue_key = buffer._get_queue_key(0)
-    buffer.client.zadd(queue_key, {segment_key: deadline})
+    client = mock.Mock()
+    buffer.__dict__["client"] = client
+    loaded_segment = LoadedSegment(
+        FlushCandidate(0, buffer._get_queue_key(0), segment_key, deadline),
+        payloads=[],
+        payload_keys=[],
+    )
 
-    with mock.patch("sentry.spans.buffer.metrics.incr") as metrics_incr:
-        loaded_segment_data, _, _ = buffer._load_segment_data([segment_key])
+    with (
+        mock.patch.object(client, "zscore", return_value=deadline),
+        mock.patch("sentry.spans.buffer.metrics.incr") as metrics_incr,
+    ):
         buffer._record_segment_loss_metrics(
-            [segment_key],
-            {segment_key: queue_key},
+            [loaded_segment],
             now=now,
-            payloads=loaded_segment_data.payloads,
         )
 
-    assert loaded_segment_data.payloads[segment_key] == []
-    assert loaded_segment_data.payload_keys[segment_key] == []
+    assert loaded_segment.payloads == []
+    assert loaded_segment.payload_keys == []
     incr_names = [call.args[0] for call in metrics_incr.call_args_list]
     assert ("spans.buffer.segment_expired_before_flush" in incr_names) is expected_expired
     assert "spans.buffer.empty_segments" in incr_names

--- a/tests/sentry/spans/test_buffer_logger.py
+++ b/tests/sentry/spans/test_buffer_logger.py
@@ -14,7 +14,14 @@ from sentry.spans.buffer_logger import (
     SubsegmentDebugLog,
     emit_observability_metrics,
 )
-from sentry.spans.buffer_types import EvalshaResult, InsertedSubsegment, Span, Subsegment
+from sentry.spans.buffer_types import (
+    EvalshaResult,
+    FlushCandidate,
+    InsertedSubsegment,
+    LoadedSegment,
+    Span,
+    Subsegment,
+)
 from sentry.spans.segment_key import SegmentKey
 from sentry.testutils.helpers.options import override_options
 
@@ -351,12 +358,23 @@ def test_flusher_logger_records_loaded_segments(mock_time):
         empty_segment_key = _segment_id(3, "e" * 32, "f" * 16)
 
         flusher_logger.log_loaded_segments(
-            [first_segment_key, empty_segment_key, second_segment_key],
-            {
-                first_segment_key: [b"first", b"second"],
-                empty_segment_key: [],
-                second_segment_key: [b"third"],
-            },
+            [
+                LoadedSegment(
+                    FlushCandidate(0, b"queue", first_segment_key, 5),
+                    [b"first", b"second"],
+                    [],
+                ),
+                LoadedSegment(
+                    FlushCandidate(0, b"queue", empty_segment_key, 5),
+                    [],
+                    [],
+                ),
+                LoadedSegment(
+                    FlushCandidate(0, b"queue", second_segment_key, 5),
+                    [b"third"],
+                    [],
+                ),
+            ],
             load_ids_latency_ms=5,
             load_data_latency_ms=10,
             decompress_latency_ms=3,

--- a/tests/sentry/spans/test_buffer_types.py
+++ b/tests/sentry/spans/test_buffer_types.py
@@ -4,8 +4,10 @@ import orjson
 
 from sentry.spans.buffer_types import (
     EvalshaResult,
+    FlushCandidate,
     InsertedSubsegment,
-    LoadedSegmentData,
+    LoadedSegment,
+    SegmentIngestMetadata,
     Span,
     Subsegment,
 )
@@ -135,15 +137,31 @@ def test_inserted_subsegment_exposes_queue_and_cleanup_metadata() -> None:
     assert detached.is_detached_segment
 
 
-def test_loaded_segment_data_exposes_payloads() -> None:
+def test_segment_ingest_metadata_from_redis_results() -> None:
+    assert SegmentIngestMetadata.from_redis_results(b"3", b"42") == SegmentIngestMetadata(
+        ingested_count=3,
+        ingested_byte_count=42,
+    )
+    assert SegmentIngestMetadata.from_redis_results(None, None) == SegmentIngestMetadata()
+
+
+def test_loaded_segment_exposes_candidate_payloads_and_metadata() -> None:
     segment_key = _segment_id(1, "a" * 32, "b" * 16)
+    queue_key = b"span-buf:q:0"
     payload_key = PayloadKey(b"span-buf:s:{1:%s:salted}:salted" % (b"a" * 32))
     payload = _payload("a" * 16)
 
-    loaded_segment_data = LoadedSegmentData(
-        payloads={segment_key: [payload]},
-        payload_keys={segment_key: [payload_key]},
+    loaded_segment = LoadedSegment(
+        FlushCandidate(0, queue_key, segment_key, 5),
+        payloads=[payload],
+        payload_keys=[payload_key],
+        ingest_metadata=SegmentIngestMetadata(1, len(payload)),
     )
 
-    assert loaded_segment_data.payloads[segment_key] == [payload]
-    assert loaded_segment_data.payload_keys[segment_key] == [payload_key]
+    assert loaded_segment.segment_key == segment_key
+    assert loaded_segment.queue_key == queue_key
+    assert loaded_segment.shard == 0
+    assert loaded_segment.score == 5
+    assert loaded_segment.payloads == [payload]
+    assert loaded_segment.payload_keys == [payload_key]
+    assert loaded_segment.ingest_metadata == SegmentIngestMetadata(1, len(payload))


### PR DESCRIPTION
Refs STREAM-1001

Introduce LoadedSegment to keep a flush candidate, loaded payloads, payload keys, and ingest metadata together through the flush pipeline. This replaces parallel maps keyed by segment key and makes the next Redis store abstraction smaller and safer.