### PR TITLE
fix(crons): Sync detector name when monitor name is updated via API

### DIFF
--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -44,6 +44,7 @@ from sentry.monitors.utils import (
     create_issue_alert_rule,
     ensure_cron_detector,
     get_checkin_margin,
+    get_detector_for_monitor,
     get_max_runtime,
     signal_monitor_created,
     update_issue_alert_rule,
@@ -512,6 +513,11 @@ class MonitorValidator(CamelSnakeSerializer):
                 event=audit_log.get_event_id("MONITOR_EDIT"),
                 data=instance.get_audit_log_data(),
             )
+
+        if "name" in params and not self.context.get("from_detector_flow"):
+            detector = get_detector_for_monitor(instance)
+            if detector is not None:
+                detector.update(name=params["name"])
 
         # Update monitor slug in billing
         if "slug" in params:

--- a/tests/sentry/monitors/test_validators.py
+++ b/tests/sentry/monitors/test_validators.py
@@ -19,7 +19,7 @@ from sentry.monitors.models import (
     is_monitor_muted,
 )
 from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
-from sentry.monitors.utils import get_detector_for_monitor
+from sentry.monitors.utils import ensure_cron_detector, get_detector_for_monitor
 from sentry.monitors.validators import (
     MonitorDataSourceValidator,
     MonitorIncidentDetectorValidator,
@@ -383,6 +383,27 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         updated_monitor = validator.save()
         assert updated_monitor.name == "Updated Monitor Name"
         assert updated_monitor.slug == "test-monitor"  # Slug unchanged
+
+    def test_update_name_syncs_detector(self) -> None:
+        detector = ensure_cron_detector(self.monitor)
+        assert detector is not None
+        assert detector.name == "Test Monitor"
+
+        validator = MonitorValidator(
+            instance=self.monitor,
+            data={"name": "Updated Monitor Name"},
+            partial=True,
+            context={
+                "organization": self.organization,
+                "access": self.access,
+                "request": self.request,
+            },
+        )
+        assert validator.is_valid()
+        validator.save()
+
+        detector.refresh_from_db()
+        assert detector.name == "Updated Monitor Name"
 
     def test_update_slug(self) -> None:
         """Test updating monitor slug."""


### PR DESCRIPTION
When a monitor's name is updated through the API, the associated Detector's name was not being synced. The new crons UI reads detector.name for the page title, so users saw the stale slug-based name even after updating via API.

Fixes https://github.com/getsentry/sentry/issues/116095

<!-- Describe your PR here. -->