### PR TITLE
ref(snuba): Use metrics.timer for get_snuba_map timing

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -812,7 +812,7 @@ def _prepare_query_params(query_params: SnubaQueryParams, referrer: str | None =
     kwargs = deepcopy(query_params.kwargs)
     query_params_conditions = deepcopy(query_params.conditions)
 
-    with timer("get_snuba_map"):
+    with metrics.timer("snuba.client.get_snuba_map"):
         forward, reverse = get_snuba_translators(
             query_params.filter_keys, is_grouprelease=query_params.is_grouprelease
         )


### PR DESCRIPTION
Replace the bespoke timer context manager with metrics.timer for the get_snuba_map call site only, as a canary to confirm metric values are unchanged before migrating the remaining call sites in #115279.

There are monitors on some of the other call sites in #115279 and I'd like to not page anyone.