### PR TITLE
fix(releases): combine duplicate Author type

### DIFF
--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -5,8 +5,9 @@ from typing import NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.pullrequest import PullRequestSerializerResponse
-from sentry.api.serializers.models.release import Author, get_users_for_authors
+from sentry.api.serializers.models.release import get_users_for_authors
 from sentry.api.serializers.models.repository import RepositorySerializerResponse
+from sentry.api.serializers.release_details_types import Author
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.pullrequest import PullRequest

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -24,7 +24,6 @@ from sentry.api.serializers.models.role import (
     TeamRoleSerializerResponse,
 )
 from sentry.api.serializers.models.team import TeamSerializerResponse
-from sentry.api.serializers.types import SerializedAvatarFields
 from sentry.api.utils import generate_locality_url
 from sentry.auth.access import Access
 from sentry.auth.services.auth import RpcOrganizationAuthConfig, auth_service
@@ -86,6 +85,7 @@ from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.replays.models import OrganizationMemberReplayAccess
 from sentry.seer.autofix.utils import get_valid_automated_run_stopping_points
 from sentry.types.cell import get_locality_name_for_cell
+from sentry.users.api.serializers.user import SerializedAvatarFields
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -17,7 +17,6 @@ from sentry import features, options, projectoptions, quotas, release_health, ro
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.plugin import PluginSerializer
 from sentry.api.serializers.models.team import get_org_roles
-from sentry.api.serializers.types import SerializedAvatarFields
 from sentry.app import env
 from sentry.auth.access import Access
 from sentry.auth.superuser import is_active_superuser
@@ -49,6 +48,7 @@ from sentry.search.events.types import SnubaParams
 from sentry.services.eventstore.models import DEFAULT_SUBJECT_TEMPLATE
 from sentry.snuba import discover
 from sentry.tempest.utils import has_tempest_access
+from sentry.users.api.serializers.user import SerializedAvatarFields
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 

--- a/src/sentry/api/serializers/models/pullrequest.py
+++ b/src/sentry/api/serializers/models/pullrequest.py
@@ -2,8 +2,9 @@ from datetime import datetime
 from typing import TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.api.serializers.models.release import Author, get_users_for_authors
+from sentry.api.serializers.models.release import get_users_for_authors
 from sentry.api.serializers.models.repository import RepositorySerializerResponse
+from sentry.api.serializers.release_details_types import Author
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from typing import Any, NotRequired, TypedDict, Union
+from typing import Any, NotRequired, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
@@ -11,7 +11,7 @@ from django.db.models import Sum
 
 from sentry import release_health, tagstore
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.api.serializers.release_details_types import VersionInfo
+from sentry.api.serializers.release_details_types import Author, NonMappableUser, VersionInfo
 from sentry.api.serializers.types import (
     GroupEventReleaseSerializerResponse,
     ReleaseSerializerResponse,
@@ -224,14 +224,6 @@ def _get_last_deploy_metadata(item_list, user):
 def _user_to_author_cache_key(organization_id: int, author: CommitAuthor) -> str:
     author_hash = md5_text(author.email.lower()).hexdigest()
     return f"get_users_for_authors:{organization_id}:{author_hash}"
-
-
-class NonMappableUser(TypedDict):
-    name: str | None
-    email: str
-
-
-Author = Union[UserSerializerResponse, NonMappableUser]
 
 
 def get_author_users_by_external_actors(

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -11,7 +11,6 @@ from django.db.models import Count
 
 from sentry import roles
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.api.serializers.types import SerializedAvatarFields
 from sentry.app import env
 from sentry.auth.access import (
     Access,
@@ -28,6 +27,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.team import Team
 from sentry.roles import organization_roles, team_roles
+from sentry.users.api.serializers.user import SerializedAvatarFields
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.query import RangeQuerySetWrapper

--- a/src/sentry/api/serializers/release_details_types.py
+++ b/src/sentry/api/serializers/release_details_types.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Any, TypedDict
 
+from sentry.users.api.serializers.user import UserSerializerResponse
+
 
 class VersionInfoOptional(TypedDict, total=False):
     description: str
@@ -24,28 +26,12 @@ class LastDeploy(LastDeployOptional):
     name: str
 
 
-class AuthorOptional(TypedDict, total=False):
-    lastLogin: str
-    has2fa: bool
-    lastActive: str
-    isSuperuser: bool
-    isStaff: bool
-    experiments: dict[str, str | int | float | bool | None]
-    emails: list[dict[str, int | str | bool]]
-    avatar: dict[str, str | None]
-
-
-class Author(AuthorOptional):
-    id: int
-    name: str
-    username: str
+class NonMappableUser(TypedDict):
+    name: str | None
     email: str
-    avatarUrl: str
-    isActive: bool
-    isSuspended: bool
-    hasPasswordAuth: bool
-    isManaged: bool
-    dateJoined: str
+
+
+Author = UserSerializerResponse | NonMappableUser
 
 
 class HealthDataOptional(TypedDict, total=False):

--- a/src/sentry/api/serializers/types.py
+++ b/src/sentry/api/serializers/types.py
@@ -4,12 +4,6 @@ from typing import Any, TypedDict
 from sentry.api.serializers.release_details_types import Author, LastDeploy, Project, VersionInfo
 
 
-class SerializedAvatarFields(TypedDict, total=False):
-    avatarType: str
-    avatarUuid: str | None
-    avatarUrl: str | None
-
-
 # Reponse type for OrganizationReleaseDetailsEndpoint
 class ReleaseSerializerResponseOptional(TypedDict, total=False):
     ref: str | None

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -772,7 +772,7 @@ class OrganizationExamples:
                 },
                 "authors": [
                     {
-                        "id": 2837091,
+                        "id": "2837091",
                         "name": "Raj's Raspberries",
                         "username": "rajraspberry",
                         "email": "raj@raspberries",

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -12,7 +12,6 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 
 from sentry.api.serializers import Serializer, register
-from sentry.api.serializers.types import SerializedAvatarFields
 from sentry.app import env
 from sentry.auth.elevated_mode import has_elevated_mode
 from sentry.hybridcloud.services.organization_mapping import organization_mapping_service
@@ -32,6 +31,12 @@ from sentry.users.models.userrole import UserRoleUser
 from sentry.users.services.user import RpcUser
 from sentry.utils.avatar import get_gravatar_url
 from sentry.utils.serializers import manytoone_to_dict
+
+
+class SerializedAvatarFields(TypedDict, total=False):
+    avatarType: str
+    avatarUuid: str | None
+    avatarUrl: str | None
 
 
 class _UserEmails(TypedDict):

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -12,7 +12,7 @@ from django.db.models import Q
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.commit import CommitSerializer, get_users_for_commits
-from sentry.api.serializers.models.release import Author, NonMappableUser
+from sentry.api.serializers.release_details_types import Author, NonMappableUser
 from sentry.models.commit import Commit
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.group import Group


### PR DESCRIPTION
We had duplicate definitions of 'Author' across releases. Consolidate them to the type `UserSerializerResponse | NonMappableUser`.