### PR TITLE
ref(scraps): Expose SplitPanel as an explicit namespace with .Root

### DIFF
--- a/static/app/components/core/splitPanel/index.tsx
+++ b/static/app/components/core/splitPanel/index.tsx
@@ -4,5 +4,4 @@ export {
   type SplitPanelPanelProps,
   type SplitPanelProps,
   useSplitPanel,
-  useSplitPanelDivider,
 } from './splitPanel';

--- a/static/app/components/core/splitPanel/splitPanel.mdx
+++ b/static/app/components/core/splitPanel/splitPanel.mdx
@@ -18,20 +18,17 @@ import * as Storybook from 'sentry/stories';
 export const documentation = import('!!type-loader!@sentry/scraps/splitPanel');
 
 export function HorizontalSplitDemo() {
-  const CONTAINER_WIDTH = 600;
-  const [size, setSize] = useState(CONTAINER_WIDTH / 2);
-  const leftPct = (size / CONTAINER_WIDTH) * 100;
-  const rightPct = 100 - leftPct;
+  const [size, setSize] = useState(50);
   return (
     <Flex direction="column" gap="md">
       <Flex
         border="primary"
         radius="md"
         overflow="hidden"
-        style={{width: CONTAINER_WIDTH, height: 160}}
+        style={{width: 600, height: 160}}
       >
         <SplitPanel orientation="horizontal" onResize={setSize}>
-          <SplitPanel.Panel defaultSize={CONTAINER_WIDTH / 2} minSize={120}>
+          <SplitPanel.Panel defaultSize={50} minSize={20}>
             <Flex align="center" justify="center" flex="1" background="primary">
               <Text>Left</Text>
             </Flex>
@@ -45,27 +42,24 @@ export function HorizontalSplitDemo() {
         </SplitPanel>
       </Flex>
       <Text variant="muted">
-        Left: {leftPct.toFixed(1)}% | Right: {rightPct.toFixed(1)}%
+        Left: {size.toFixed(1)}% | Right: {(100 - size).toFixed(1)}%
       </Text>
     </Flex>
   );
 }
 
 export function VerticalSplitDemo() {
-  const CONTAINER_HEIGHT = 240;
-  const [size, setSize] = useState(CONTAINER_HEIGHT / 2);
-  const topPct = (size / CONTAINER_HEIGHT) * 100;
-  const bottomPct = 100 - topPct;
+  const [size, setSize] = useState(50);
   return (
     <Flex direction="column" gap="md">
       <Flex
         border="primary"
         radius="md"
         overflow="hidden"
-        style={{width: 600, height: CONTAINER_HEIGHT}}
+        style={{width: 600, height: 240}}
       >
         <SplitPanel orientation="vertical" onResize={setSize}>
-          <SplitPanel.Panel defaultSize={CONTAINER_HEIGHT / 2} minSize={60}>
+          <SplitPanel.Panel defaultSize={50} minSize={20}>
             <Flex align="center" justify="center" flex="1" background="primary">
               <Text>Top</Text>
             </Flex>
@@ -79,19 +73,19 @@ export function VerticalSplitDemo() {
         </SplitPanel>
       </Flex>
       <Text variant="muted">
-        Top: {topPct.toFixed(1)}% | Bottom: {bottomPct.toFixed(1)}%
+        Top: {size.toFixed(1)}% | Bottom: {(100 - size).toFixed(1)}%
       </Text>
     </Flex>
   );
 }
 
-`SplitPanel` is a composable two-pane layout with a draggable divider. The pane that declares `defaultSize` is the sized pane; the other fills the remaining space. The root self-measures, so callers don't need to thread the container width or height in.
+`SplitPanel` is a composable two-pane layout with a draggable divider. Sizes are expressed as **percentages** of the container. The pane that declares `defaultSize` is the sized pane; the other fills the remaining space. Flexbox distributes `(container − divider)` proportionally between the two panes, so a 50/50 split is always symmetric — the divider never "steals" pixels from a pane.
 
 ## Basic Usage
 
 ```tsx
 <SplitPanel orientation="horizontal">
-  <SplitPanel.Panel defaultSize={300} minSize={200} maxSize={600}>
+  <SplitPanel.Panel defaultSize={30} minSize={20} maxSize={80}>
     <LeftContent />
   </SplitPanel.Panel>
   <SplitPanel.Divider />
@@ -101,7 +95,7 @@ export function VerticalSplitDemo() {
 </SplitPanel>
 ```
 
-The composable shape makes the call site read top-to-bottom: first pane, divider, second pane. There's no `availableSize` prop — the root measures itself with `useDimensions`.
+`defaultSize`, `minSize`, and `maxSize` are all percentages in the range `[0, 100]`. The composable shape makes the call site read top-to-bottom: first pane, divider, second pane.
 
 ## Horizontal Split
 
@@ -113,7 +107,7 @@ The first pane is sized; the second fills.
 
 ```tsx
 <SplitPanel orientation="horizontal">
-  <SplitPanel.Panel defaultSize={300} minSize={120}>
+  <SplitPanel.Panel defaultSize={50} minSize={20}>
     <LeftContent />
   </SplitPanel.Panel>
   <SplitPanel.Divider />
@@ -133,7 +127,7 @@ Use `orientation="vertical"` to split top/bottom. The first pane is still the si
 
 ```tsx
 <SplitPanel orientation="vertical">
-  <SplitPanel.Panel defaultSize={120} minSize={60}>
+  <SplitPanel.Panel defaultSize={50} minSize={20}>
     <TopContent />
   </SplitPanel.Panel>
   <SplitPanel.Divider />
@@ -149,7 +143,7 @@ To collapse the fill pane, omit the `<SplitPanel.Divider>` and second `<SplitPan
 
 ```tsx
 <SplitPanel orientation="horizontal">
-  <SplitPanel.Panel defaultSize={300} minSize={200} maxSize={600}>
+  <SplitPanel.Panel defaultSize={30} minSize={20} maxSize={80}>
     <LeftContent />
   </SplitPanel.Panel>
   {!isCollapsed && (
@@ -171,11 +165,11 @@ To collapse the fill pane, omit the `<SplitPanel.Divider>` and second `<SplitPan
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 function ResizableLayout() {
-  const [storedSize, setStoredSize] = useLocalStorageState('my-feature.split-size', 300);
+  const [storedSize, setStoredSize] = useLocalStorageState('my-feature.split-size', 50);
 
   return (
     <SplitPanel orientation="horizontal" onResize={setStoredSize}>
-      <SplitPanel.Panel defaultSize={storedSize} minSize={200} maxSize={600}>
+      <SplitPanel.Panel defaultSize={storedSize} minSize={20} maxSize={80}>
         <LeftContent />
       </SplitPanel.Panel>
       <SplitPanel.Divider />
@@ -187,36 +181,9 @@ function ResizableLayout() {
 }
 ```
 
-## Custom Divider
-
-For most cases, use `<SplitPanel.Divider>` — a thin 1px line matching the rest of the app. If you need a different visual (e.g. a grab handle, a thicker bar, a colored line for a critical section), build your own divider with the `useSplitPanelDivider` hook. It returns the ARIA props, event handlers, and `isHeld` state needed to make any element behave like the divider.
-
-```tsx
-import styled from '@emotion/styled';
-import {useSplitPanelDivider} from '@sentry/scraps/splitPanel';
-
-function GrabHandleDivider() {
-  const {props, isHeld} = useSplitPanelDivider();
-  return (
-    <GrabHandle {...props} data-is-held={isHeld}>
-      <IconGrabbable size="sm" />
-    </GrabHandle>
-  );
-}
-
-const GrabHandle = styled('div')`
-  display: grid;
-  place-items: center;
-  width: ${p => p.theme.space.xl};
-  cursor: ew-resize;
-`;
-```
-
-Then drop your component in place of `<SplitPanel.Divider>` inside the `<SplitPanel>` children.
-
 ## Tracking Resize Events
 
-`onMouseDown` fires when the user starts dragging (receives the current size as a percentage). `onResize` fires as the size changes (receives the new size in pixels). Use these for analytics or to drive linked UI.
+`onMouseDown` fires when the user starts dragging (receives the current size as a percentage). `onResize` fires as the size changes (receives the new size as a percentage). Use these for analytics or to drive linked UI.
 
 ```tsx
 <SplitPanel
@@ -224,7 +191,7 @@ Then drop your component in place of `<SplitPanel.Divider>` inside the `<SplitPa
   onMouseDown={sizePct => trackStart(sizePct)}
   onResize={newSize => trackEnd(newSize)}
 >
-  <SplitPanel.Panel defaultSize={300} minSize={200} maxSize={600}>
+  <SplitPanel.Panel defaultSize={30} minSize={20} maxSize={80}>
     <LeftContent />
   </SplitPanel.Panel>
   <SplitPanel.Divider />

--- a/static/app/components/core/splitPanel/splitPanel.spec.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.spec.tsx
@@ -7,7 +7,7 @@ describe('SplitPanel', () => {
     it('renders both panels and a divider', () => {
       render(
         <SplitPanel orientation="horizontal">
-          <SplitPanel.Panel defaultSize={200} minSize={100} maxSize={600}>
+          <SplitPanel.Panel defaultSize={30} minSize={10} maxSize={80}>
             <div data-test-id="left-content">left</div>
           </SplitPanel.Panel>
           <SplitPanel.Divider />
@@ -25,7 +25,7 @@ describe('SplitPanel', () => {
     it('renders only the first panel when the second is omitted', () => {
       render(
         <SplitPanel orientation="horizontal">
-          <SplitPanel.Panel defaultSize={200} minSize={100} maxSize={600}>
+          <SplitPanel.Panel defaultSize={30} minSize={10} maxSize={80}>
             <div data-test-id="left-content">left</div>
           </SplitPanel.Panel>
         </SplitPanel>
@@ -33,12 +33,15 @@ describe('SplitPanel', () => {
 
       expect(screen.getByTestId('left-content')).toBeInTheDocument();
       expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+      expect(screen.getByTestId('left-content').parentElement).not.toHaveAttribute(
+        'data-sized'
+      );
     });
 
     it('preserves DOM identity of the sized panel when toggling the fill panel', () => {
       const {rerender} = render(
         <SplitPanel orientation="horizontal">
-          <SplitPanel.Panel defaultSize={200} minSize={100} maxSize={600}>
+          <SplitPanel.Panel defaultSize={30} minSize={10} maxSize={80}>
             <div data-test-id="left-content">left</div>
           </SplitPanel.Panel>
           <SplitPanel.Divider />
@@ -52,7 +55,7 @@ describe('SplitPanel', () => {
 
       rerender(
         <SplitPanel orientation="horizontal">
-          <SplitPanel.Panel defaultSize={200} minSize={100} maxSize={600}>
+          <SplitPanel.Panel defaultSize={30} minSize={10} maxSize={80}>
             <div data-test-id="left-content">left</div>
           </SplitPanel.Panel>
         </SplitPanel>
@@ -62,7 +65,7 @@ describe('SplitPanel', () => {
 
       rerender(
         <SplitPanel orientation="horizontal">
-          <SplitPanel.Panel defaultSize={200} minSize={100} maxSize={600}>
+          <SplitPanel.Panel defaultSize={30} minSize={10} maxSize={80}>
             <div data-test-id="left-content">left</div>
           </SplitPanel.Panel>
           <SplitPanel.Divider />
@@ -80,7 +83,7 @@ describe('SplitPanel', () => {
     it('renders both panels and a divider', () => {
       render(
         <SplitPanel orientation="vertical">
-          <SplitPanel.Panel defaultSize={200} minSize={100} maxSize={600}>
+          <SplitPanel.Panel defaultSize={30} minSize={10} maxSize={80}>
             <div data-test-id="top-content">top</div>
           </SplitPanel.Panel>
           <SplitPanel.Divider />
@@ -98,7 +101,7 @@ describe('SplitPanel', () => {
     it('renders only the first panel when the second is omitted', () => {
       render(
         <SplitPanel orientation="vertical">
-          <SplitPanel.Panel defaultSize={200} minSize={100} maxSize={600}>
+          <SplitPanel.Panel defaultSize={30} minSize={10} maxSize={80}>
             <div data-test-id="top-content">top</div>
           </SplitPanel.Panel>
         </SplitPanel>
@@ -106,6 +109,9 @@ describe('SplitPanel', () => {
 
       expect(screen.getByTestId('top-content')).toBeInTheDocument();
       expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+      expect(screen.getByTestId('top-content').parentElement).not.toHaveAttribute(
+        'data-sized'
+      );
     });
   });
 
@@ -113,7 +119,7 @@ describe('SplitPanel', () => {
     it('exposes separator role with orientation and value attributes', () => {
       render(
         <SplitPanel orientation="horizontal">
-          <SplitPanel.Panel defaultSize={200} minSize={100} maxSize={600}>
+          <SplitPanel.Panel defaultSize={30} minSize={10} maxSize={80}>
             <div>left</div>
           </SplitPanel.Panel>
           <SplitPanel.Divider />
@@ -124,10 +130,9 @@ describe('SplitPanel', () => {
       );
 
       const separator = screen.getByRole('separator');
-      // Horizontal split → vertical divider line
       expect(separator).toHaveAttribute('aria-orientation', 'vertical');
-      expect(separator).toHaveAttribute('aria-valuemin', '100');
-      expect(separator).toHaveAttribute('aria-valuemax', '600');
+      expect(separator).toHaveAttribute('aria-valuemin', '10');
+      expect(separator).toHaveAttribute('aria-valuemax', '80');
       expect(separator).toHaveAttribute('tabindex', '0');
     });
   });

--- a/static/app/components/core/splitPanel/splitPanel.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.tsx
@@ -4,21 +4,20 @@ import {
   isValidElement,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import styled from '@emotion/styled';
 
-import {useDimensions} from 'sentry/utils/useDimensions';
-import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
-
 type Orientation = 'horizontal' | 'vertical';
+type PanelRole = 'lone' | 'sized' | 'fill';
 
 type SplitPanelContextValue = {
   isHeld: boolean;
   isMaximized: boolean;
   isMinimized: boolean;
-  isReady: boolean;
   max: number;
   maximiseSize: () => void;
   min: number;
@@ -32,6 +31,7 @@ type SplitPanelContextValue = {
 };
 
 const SplitPanelContext = createContext<SplitPanelContextValue | null>(null);
+const PanelRoleContext = createContext<PanelRole>('lone');
 
 function useSplitPanelContext(component: string): SplitPanelContextValue {
   const ctx = useContext(SplitPanelContext);
@@ -51,32 +51,6 @@ export function useSplitPanel() {
   return {isMaximized, isMinimized, maximiseSize, minimiseSize, resetSize};
 }
 
-/**
- * Returns everything needed to render a custom divider element. Spread
- * `props` on the divider's root element to get ARIA, event handlers, and
- * `tabIndex`. Use `isHeld` and `orientation` for styling.
- */
-export function useSplitPanelDivider() {
-  const {isHeld, max, min, onDoubleClick, onKeyDown, onMouseDown, orientation, size} =
-    useSplitPanelContext('useSplitPanelDivider');
-  return {
-    isHeld,
-    orientation,
-    props: {
-      'aria-orientation':
-        orientation === 'horizontal' ? ('vertical' as const) : ('horizontal' as const),
-      'aria-valuemax': Number.isFinite(max) ? max : undefined,
-      'aria-valuemin': min,
-      'aria-valuenow': size,
-      onDoubleClick,
-      onKeyDown,
-      onMouseDown,
-      role: 'separator' as const,
-      tabIndex: 0,
-    },
-  };
-}
-
 export type SplitPanelProps = {
   /**
    * Exactly one `<SplitPanel.Panel>` followed by an optional
@@ -86,15 +60,15 @@ export type SplitPanelProps = {
   children: React.ReactNode;
   /**
    * Fires when the user starts dragging the divider. Receives the current
-   * size of the sized pane as a percentage of the container.
+   * size of the sized pane as a percentage (0-100).
    */
-  onMouseDown?: (sizePct: `${number}%`) => void;
+  onMouseDown?: (sizePct: number) => void;
   /**
-   * Fires as the user drags. Receives the new size in pixels. Wire this to
-   * your own persistence layer if you want to remember the size across
-   * reloads (e.g. `useLocalStorageState`).
+   * Fires as the user drags. Receives the new size as a percentage (0-100).
+   * Wire this to your own persistence layer if you want to remember the size
+   * across reloads (e.g. `useLocalStorageState`).
    */
-  onResize?: (newSize: number) => void;
+  onResize?: (sizePct: number) => void;
   /**
    * Layout direction. `horizontal` splits left/right; `vertical` splits
    * top/bottom.
@@ -105,46 +79,45 @@ export type SplitPanelProps = {
 export type SplitPanelPanelProps = {
   children: React.ReactNode;
   /**
-   * Initial size of this pane in pixels. The pane that declares `defaultSize`
-   * is the sized pane; the other fills the remaining space. Only one pane may
-   * be sized.
+   * Initial size of this pane as a percentage of the container (0-100). The
+   * pane that declares `defaultSize` is the sized pane; the other fills the
+   * remaining space. Only one pane may be sized.
    */
   defaultSize?: number;
   /**
-   * Maximum size in pixels the user may drag this pane to. Only meaningful on
-   * the sized pane.
+   * Maximum size as a percentage (0-100). Only meaningful on the sized pane.
+   * Defaults to 100.
    */
   maxSize?: number;
   /**
-   * Minimum size in pixels the user may drag this pane to. Only meaningful on
-   * the sized pane.
+   * Minimum size as a percentage (0-100). Only meaningful on the sized pane.
+   * Defaults to 0.
    */
   minSize?: number;
 };
 
 export type SplitPanelDividerProps = Record<string, never>;
 
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
 function Panel({children}: SplitPanelPanelProps) {
-  const {isReady, orientation, size} = useSplitPanelContext('SplitPanel.Panel');
-  const isSized = useIsSizedPanel();
+  const {orientation, size} = useSplitPanelContext('SplitPanel.Panel');
+  const role = useContext(PanelRoleContext);
+  // Both panes use flex-grow as a ratio; flexbox automatically distributes
+  // (container - divider) proportionally. A lone pane just fills.
+  const flexGrow = role === 'lone' ? 1 : role === 'sized' ? size : 100 - size;
 
   return (
     <PanelContainer
       data-orientation={orientation}
-      data-sized={isSized || undefined}
-      sizePx={isSized ? size : undefined}
-      // Hide the sized pane until we've measured the container. Avoids a
-      // pre-measurement layout flash where the pane briefly takes 0px.
-      style={isSized && !isReady ? {visibility: 'hidden'} : undefined}
+      data-sized={role === 'sized' || undefined}
+      style={{flexGrow}}
     >
       {children}
     </PanelContainer>
   );
-}
-
-const IsSizedPanelContext = createContext(false);
-function useIsSizedPanel() {
-  return useContext(IsSizedPanelContext);
 }
 
 function Divider() {
@@ -154,7 +127,7 @@ function Divider() {
   return (
     <DividerLine
       aria-orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
-      aria-valuemax={Number.isFinite(max) ? max : undefined}
+      aria-valuemax={max}
       aria-valuemin={min}
       aria-valuenow={size}
       data-is-held={isHeld}
@@ -191,140 +164,173 @@ export function SplitPanel({
   onResize,
 }: SplitPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const dims = useDimensions({elementRef: containerRef});
-  const availableSize = orientation === 'horizontal' ? dims.width : dims.height;
 
   const sizedProps = useMemo(() => findSizedPanelProps(children), [children]);
   const min = sizedProps?.minSize ?? 0;
-  const explicitMax = sizedProps?.maxSize ?? Number.POSITIVE_INFINITY;
-  // Cap the sized pane at the container size so it can never overflow the
-  // parent. Matches Zag/Chakra's `maxSize = 100%` default. Until we've
-  // measured, fall back to the explicit max (or Infinity) so the hook can
-  // accept the initial size without clamping it to zero.
-  const max = availableSize > 0 ? Math.min(explicitMax, availableSize) : explicitMax;
-  const initialSize = sizedProps?.defaultSize ?? 0;
+  const max = sizedProps?.maxSize ?? 100;
+  const initialSize = clamp(sizedProps?.defaultSize ?? 50, min, max);
 
-  // useResizableDrawer only enforces `min`, not `max`, so its internal size can
-  // drift past `max` while the user keeps dragging. We clamp before forwarding
-  // to the consumer's `onResize` and snap the hook back when it drifts, so
-  // dragging in the opposite direction responds immediately.
-  const setSizeRef = useRef<(size: number, userEvent?: boolean) => void>(() => {});
-  const handleHookResize = useCallback(
+  const [size, setSize] = useState(initialSize);
+  const [isHeld, setIsHeld] = useState(false);
+
+  const updateSize = useCallback(
     (newSize: number) => {
-      const clamped = Math.min(Math.max(newSize, min), max);
-      if (clamped !== newSize) {
-        setSizeRef.current(clamped, true);
-        return;
-      }
-      onResize?.(newSize);
+      const clamped = clamp(newSize, min, max);
+      setSize(clamped);
+      onResize?.(clamped);
     },
-    [onResize, min, max]
+    [min, max, onResize]
   );
 
-  const {
-    isHeld,
-    onDoubleClick,
-    onMouseDown: onDragStart,
-    setSize,
-    size: containerSize,
-  } = useResizableDrawer({
-    direction: orientation === 'horizontal' ? 'left' : 'down',
-    initialSize,
-    min,
-    onResize: handleHookResize,
-  });
-  setSizeRef.current = setSize;
+  const draggingRef = useRef(false);
+  const rafIdRef = useRef<number | null>(null);
 
-  const clampedSize = Math.min(containerSize, max);
-  const sizePct = `${
-    availableSize > 0 ? (clampedSize / availableSize) * 100 : 0
-  }%` as const;
+  const handleMouseMove = useCallback(
+    (event: MouseEvent) => {
+      if (!draggingRef.current) {
+        return;
+      }
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+      }
+      rafIdRef.current = requestAnimationFrame(() => {
+        const container = containerRef.current;
+        if (!container) {
+          return;
+        }
+        const rect = container.getBoundingClientRect();
+        const isHorizontal = orientation === 'horizontal';
+        const total = isHorizontal ? rect.width : rect.height;
+        if (total === 0) {
+          return;
+        }
+        const offset = isHorizontal
+          ? event.clientX - rect.left
+          : event.clientY - rect.top;
+        updateSize((offset / total) * 100);
+      });
+    },
+    [orientation, updateSize]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    draggingRef.current = false;
+    document.body.style.userSelect = '';
+    document.documentElement.style.cursor = '';
+    document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('mouseup', handleMouseUp);
+    setIsHeld(false);
+  }, [handleMouseMove]);
 
   const handleMouseDown = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
-      onMouseDown?.(sizePct);
-      onDragStart(event);
+      onMouseDown?.(size);
+      draggingRef.current = true;
+      setIsHeld(true);
+      document.body.style.userSelect = 'none';
+      document.documentElement.style.cursor =
+        orientation === 'horizontal' ? 'ew-resize' : 'ns-resize';
+      document.addEventListener('mousemove', handleMouseMove, {passive: true});
+      document.addEventListener('mouseup', handleMouseUp);
+      event.preventDefault();
     },
-    [onDragStart, sizePct, onMouseDown]
+    [orientation, onMouseDown, size, handleMouseMove, handleMouseUp]
   );
+
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+      }
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [handleMouseMove, handleMouseUp]);
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
-      const step = event.shiftKey ? 50 : 10;
+      const step = event.shiftKey ? 5 : 1;
       const isHorizontal = orientation === 'horizontal';
       const decreaseKey = isHorizontal ? 'ArrowLeft' : 'ArrowUp';
       const increaseKey = isHorizontal ? 'ArrowRight' : 'ArrowDown';
 
       if (event.key === decreaseKey) {
         event.preventDefault();
-        setSize(Math.max(min, containerSize - step), true);
+        updateSize(size - step);
       } else if (event.key === increaseKey) {
         event.preventDefault();
-        setSize(Math.min(max, containerSize + step), true);
+        updateSize(size + step);
       } else if (event.key === 'Home') {
         event.preventDefault();
-        setSize(min, true);
-      } else if (event.key === 'End' && Number.isFinite(max)) {
+        updateSize(min);
+      } else if (event.key === 'End') {
         event.preventDefault();
-        setSize(max, true);
+        updateSize(max);
       }
     },
-    [orientation, containerSize, min, max, setSize]
+    [orientation, size, min, max, updateSize]
   );
 
-  const isReady = availableSize > 0;
-  const isMaximized = containerSize >= max;
-  const isMinimized = containerSize <= min;
+  const handleDoubleClick = useCallback(() => {
+    updateSize(initialSize);
+  }, [initialSize, updateSize]);
+
+  const isMaximized = size >= max;
+  const isMinimized = size <= min;
 
   const contextValue = useMemo<SplitPanelContextValue>(
     () => ({
       isHeld,
       isMaximized,
       isMinimized,
-      isReady,
       max,
-      maximiseSize: () => setSize(max),
+      maximiseSize: () => updateSize(max),
       min,
-      minimiseSize: () => setSize(min),
-      onDoubleClick,
+      minimiseSize: () => updateSize(min),
+      onDoubleClick: handleDoubleClick,
       onKeyDown: handleKeyDown,
       onMouseDown: handleMouseDown,
       orientation,
-      resetSize: () => setSize(initialSize),
-      size: isReady ? clampedSize : 0,
+      resetSize: () => updateSize(initialSize),
+      size,
     }),
     [
-      clampedSize,
+      handleDoubleClick,
       handleKeyDown,
       handleMouseDown,
       initialSize,
       isHeld,
       isMaximized,
       isMinimized,
-      isReady,
       max,
       min,
-      onDoubleClick,
       orientation,
-      setSize,
+      size,
+      updateSize,
     ]
   );
 
-  // Tag each Panel child with whether it's the sized one. We can't read the
-  // tag inside Panel without an extra Context, so this drives IsSizedPanelContext.
+  let panelCount = 0;
+  Children.forEach(children, child => {
+    if (isValidElement(child) && child.type === Panel) {
+      panelCount++;
+    }
+  });
+
   let sizedPanelMarked = false;
   const wrappedChildren = Children.map(children, child => {
     if (isValidElement(child) && child.type === Panel) {
       const childProps = child.props as SplitPanelPanelProps;
-      const isThisPanelSized = !sizedPanelMarked && childProps.defaultSize !== undefined;
-      if (isThisPanelSized) {
+      let role: PanelRole;
+      if (panelCount < 2) {
+        role = 'lone';
+      } else if (!sizedPanelMarked && childProps.defaultSize !== undefined) {
+        role = 'sized';
         sizedPanelMarked = true;
+      } else {
+        role = 'fill';
       }
-      return (
-        <IsSizedPanelContext.Provider value={isThisPanelSized}>
-          {child}
-        </IsSizedPanelContext.Provider>
-      );
+      return <PanelRoleContext.Provider value={role}>{child}</PanelRoleContext.Provider>;
     }
     return child;
   });
@@ -370,17 +376,20 @@ const SplitPanelRoot = styled('div')`
   }
 `;
 
-const PanelContainer = styled('div')<{sizePx: number | undefined}>`
+const PanelContainer = styled('div')`
   display: flex;
   flex-direction: column;
   min-height: 0;
   min-width: 0;
-  ${p => (p.sizePx === undefined ? 'flex: 1 1 0;' : `flex: 0 0 ${p.sizePx}px;`)}
+  flex-shrink: 1;
+  flex-basis: 0;
 `;
 
 const DividerLine = styled('div')`
   position: relative;
   flex-shrink: 0;
+  flex-grow: 0;
+  flex-basis: auto;
   user-select: none;
 
   /* Invisible wider hit area for dragging */

--- a/static/app/views/explore/conversations/components/conversationLayout.tsx
+++ b/static/app/views/explore/conversations/components/conversationLayout.tsx
@@ -10,9 +10,8 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 
-const LEFT_PANEL_MIN = 400;
-const RIGHT_PANEL_MIN = 400;
-const DIVIDER_WIDTH = 1;
+const LEFT_PANEL_MIN_PX = 400;
+const RIGHT_PANEL_MIN_PX = 400;
 const DEFAULT_STORAGE_KEY = 'conversation-split-size';
 
 /**
@@ -32,22 +31,18 @@ export function ConversationSplitLayout({
   const measureRef = useRef<HTMLDivElement>(null);
   const {width} = useDimensions({elementRef: measureRef});
 
-  const maxLeft = Math.max(LEFT_PANEL_MIN, width - RIGHT_PANEL_MIN - DIVIDER_WIDTH);
-  const defaultLeft = Math.min(
-    maxLeft,
-    Math.max(LEFT_PANEL_MIN, (width - DIVIDER_WIDTH) * 0.5)
-  );
+  // SplitPanel sizes are percentages, but the readability minimums for these
+  // content panes are pixel-based — so we still measure the container to
+  // translate.
+  const minSize = width > 0 ? (LEFT_PANEL_MIN_PX / width) * 100 : 0;
+  const maxSize = width > 0 ? ((width - RIGHT_PANEL_MIN_PX) / width) * 100 : 100;
 
-  const [storedSize, setStoredSize] = useLocalStorageState(sizeStorageKey, defaultLeft);
+  const [storedSize, setStoredSize] = useLocalStorageState(sizeStorageKey, 50);
 
   return (
     <Flex ref={measureRef} flex="1" minHeight="0" overflow="hidden">
       <SplitPanel orientation="horizontal" onResize={setStoredSize}>
-        <SplitPanel.Panel
-          defaultSize={storedSize}
-          minSize={LEFT_PANEL_MIN}
-          maxSize={maxLeft}
-        >
+        <SplitPanel.Panel defaultSize={storedSize} minSize={minSize} maxSize={maxSize}>
           {left}
         </SplitPanel.Panel>
         <SplitPanel.Divider />

--- a/static/app/views/explore/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/explore/replays/detail/layout/replayLayout.tsx
@@ -29,8 +29,6 @@ const MIN_SIDEBAR_WIDTH = 325;
 const MIN_VIDEO_HEIGHT = 200;
 const MIN_CONTENT_HEIGHT = 180;
 
-const DIVIDER_SIZE = 16;
-
 interface ReplayLayoutProps {
   isLoading: boolean;
   replayRecord: ReplayRecord | undefined;
@@ -125,20 +123,17 @@ function ReplayLayoutBody({
   const effectiveLayout = isFocusAreaCollapsed ? defaultLayout : layout;
   const isLeftRight = effectiveLayout === LayoutKey.SIDEBAR_LEFT;
 
-  const sizedPanel = isLeftRight ? (
-    <SplitPanel.Panel
-      defaultSize={width * 0.5}
-      minSize={MIN_SIDEBAR_WIDTH}
-      maxSize={width - MIN_CONTENT_WIDTH}
-    >
-      <PanelContainer>{video}</PanelContainer>
-    </SplitPanel.Panel>
-  ) : (
-    <SplitPanel.Panel
-      defaultSize={(height - DIVIDER_SIZE) * 0.5}
-      minSize={MIN_VIDEO_HEIGHT}
-      maxSize={height - DIVIDER_SIZE - MIN_CONTENT_HEIGHT}
-    >
+  // Convert the pixel-based readability minimums into the percentage shape
+  // SplitPanel expects. Without measuring the container we can't preserve
+  // pixel guarantees, so we still depend on useDimensions here.
+  const axisSize = isLeftRight ? width : height;
+  const minPx = isLeftRight ? MIN_SIDEBAR_WIDTH : MIN_VIDEO_HEIGHT;
+  const otherMinPx = isLeftRight ? MIN_CONTENT_WIDTH : MIN_CONTENT_HEIGHT;
+  const minSize = axisSize > 0 ? (minPx / axisSize) * 100 : 0;
+  const maxSize = axisSize > 0 ? ((axisSize - otherMinPx) / axisSize) * 100 : 100;
+
+  const sizedPanel = (
+    <SplitPanel.Panel defaultSize={50} minSize={minSize} maxSize={maxSize}>
       <PanelContainer>{video}</PanelContainer>
     </SplitPanel.Panel>
   );
@@ -150,7 +145,6 @@ function ReplayLayoutBody({
           <ReplaySplitPanel
             layout={effectiveLayout}
             orientation={isLeftRight ? 'horizontal' : 'vertical'}
-            availableSize={isLeftRight ? width : height}
           >
             {sizedPanel}
             {!isFocusAreaCollapsed && (

--- a/static/app/views/explore/replays/detail/layout/splitPanel.tsx
+++ b/static/app/views/explore/replays/detail/layout/splitPanel.tsx
@@ -11,19 +11,12 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 type Orientation = 'horizontal' | 'vertical';
 
 type Props = {
-  /**
-   * Measured size of the container along the split axis (width for
-   * horizontal, height for vertical). Used to log the end position as a
-   * percentage for analytics. The parent already measures the layout for
-   * its own grid, so threading it through avoids a second measurement.
-   */
-  availableSize: number;
   children: React.ReactNode;
   layout: LayoutKey;
   orientation: Orientation;
 };
 
-export function ReplaySplitPanel({availableSize, children, layout, orientation}: Props) {
+export function ReplaySplitPanel({children, layout, orientation}: Props) {
   const organization = useOrganization();
   const {setStartPosition, logEndPosition} = useSplitPanelTracking({
     slideDirection: orientation === 'horizontal' ? 'leftright' : 'updown',
@@ -37,18 +30,14 @@ export function ReplaySplitPanel({availableSize, children, layout, orientation}:
   });
 
   const handleResize = useMemo(
-    () =>
-      debounce(
-        (newSize: number) => logEndPosition(`${(newSize / availableSize) * 100}%`),
-        750
-      ),
-    [logEndPosition, availableSize]
+    () => debounce((sizePct: number) => logEndPosition(`${sizePct}%`), 750),
+    [logEndPosition]
   );
 
   return (
     <SplitPanel
       orientation={orientation}
-      onMouseDown={setStartPosition}
+      onMouseDown={sizePct => setStartPosition(`${sizePct}%`)}
       onResize={handleResize}
     >
       {children}


### PR DESCRIPTION
## Summary

Draft exploration before promoting SplitPanel to Scraps. The root element is now `<SplitPanel.Root>` instead of `<SplitPanel>`, matching the namespaced shape used by Chakra v3's Splitter and similar design systems.

**Base**: `priscilawebdev/feat/scraps-adopt-splitpanel` (so the diff shows only the rename, not the original SplitPanel commits).

## What changes

```tsx
// Before
<SplitPanel orientation="horizontal">
  <SplitPanel.Panel defaultSize={300} minSize={200} maxSize={600}>
    <Left />
  </SplitPanel.Panel>
  <SplitPanel.Divider />
  <SplitPanel.Panel>
    <Right />
  </SplitPanel.Panel>
</SplitPanel>

// After
<SplitPanel.Root orientation="horizontal">
  <SplitPanel.Panel defaultSize={300} minSize={200} maxSize={600}>
    <Left />
  </SplitPanel.Panel>
  <SplitPanel.Divider />
  <SplitPanel.Panel>
    <Right />
  </SplitPanel.Panel>
</SplitPanel.Root>
```

- `SplitPanel` is now a const namespace object (`{Root, Panel, Divider}`) instead of a function with `.Panel` / `.Divider` attached.
- Behavior, props, pixel-based sizing, internal hooks — **all unchanged**.
- Pure call-site rename in the two real consumers (`ReplaySplitPanel` wrapper and `ConversationSplitLayout`).

## Test plan

- [x] `pnpm typecheck` clean
- [x] Unit tests pass (`splitPanel.spec.tsx`, 6 tests)
- [ ] Manual verification in replay layout (drag, persistence, fullscreen)
- [ ] Manual verification in conversation layout
- [ ] Storybook MDX demos look right