### PR TITLE
fix(userfeedback): Rendering of user feedback in Issue stream when name/email not set

### DIFF
--- a/static/app/components/events/userFeedback.spec.tsx
+++ b/static/app/components/events/userFeedback.spec.tsx
@@ -86,4 +86,13 @@ describe('EventUserFeedback', () => {
     const comment = document.querySelector('p');
     expect(comment?.textContent).toBe('Line one\n<script>alert("x")</script>');
   });
+
+  it('renders when name and email are null', () => {
+    render(
+      <EventUserFeedback report={makeReport({name: null, email: null, user: null})} />
+    );
+
+    expect(screen.getByText('Line one', {exact: false})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /copy/i})).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/userFeedback.tsx
+++ b/static/app/components/events/userFeedback.tsx
@@ -20,9 +20,13 @@ type Props = {
 
 export function EventUserFeedback({eventLink, report}: Props) {
   const {copy} = useCopyToClipboard();
-  const showEmailLabel = !isSameIdentity(report.name, report.email);
-  const copyEmail = () =>
-    copy(report.email, {successMessage: t('Copied email to clipboard')});
+  const showEmailLabel =
+    report.email !== null && !isSameIdentity(report.name, report.email);
+  const copyEmail = () => {
+    if (report.email) {
+      copy(report.email, {successMessage: t('Copied email to clipboard')});
+    }
+  };
 
   return (
     <Flex data-test-id="activity-item" gap="md">
@@ -34,20 +38,22 @@ export function EventUserFeedback({eventLink, report}: Props) {
             <Text as="span" bold size="md">
               {report.name}
             </Text>
-            <Button
-              aria-label={showEmailLabel ? undefined : t('Copy email address')}
-              variant="transparent"
-              onClick={copyEmail}
-              size="zero"
-              tooltipProps={{delay: 0, title: t('Copy email address')}}
-              icon={<IconCopy size="xs" variant="muted" />}
-            >
-              {showEmailLabel && (
-                <Text as="span" size="sm" variant="muted">
-                  {report.email}
-                </Text>
-              )}
-            </Button>
+            {report.email && (
+              <Button
+                aria-label={showEmailLabel ? undefined : t('Copy email address')}
+                variant="transparent"
+                onClick={copyEmail}
+                size="zero"
+                tooltipProps={{delay: 0, title: t('Copy email address')}}
+                icon={<IconCopy size="xs" variant="muted" />}
+              >
+                {showEmailLabel && (
+                  <Text as="span" size="sm" variant="muted">
+                    {report.email}
+                  </Text>
+                )}
+              </Button>
+            )}
 
             {eventLink && (
               <Text as="span" size="sm">
@@ -71,7 +77,10 @@ export function EventUserFeedback({eventLink, report}: Props) {
   );
 }
 
-function isSameIdentity(name: string, email: string) {
+function isSameIdentity(name: string | null, email: string | null) {
+  if (!name || !email) {
+    return false;
+  }
   return name.trim().toLowerCase() === email.trim().toLowerCase();
 }
 
@@ -81,8 +90,8 @@ function getAvatarUser(report: UserReport): AvatarUser | undefined {
   if (!user) {
     return {
       id: '',
-      email: report.email,
-      name: report.name,
+      email: report.email ?? '',
+      name: report.name ?? '',
       username: '',
       ip_address: '',
     };
@@ -91,7 +100,7 @@ function getAvatarUser(report: UserReport): AvatarUser | undefined {
   return {
     id: user.id,
     email: user.email ?? '',
-    name: user.name ?? report.name,
+    name: user.name ?? report.name ?? '',
     username: user.username ?? '',
     ip_address: user.ipAddress ?? '',
     avatarUrl: user.avatarUrl ?? undefined,

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -1262,11 +1262,11 @@ export type ChunkType = {
 export type UserReport = {
   comments: string;
   dateCreated: string;
-  email: string;
+  email: string | null;
   event: {eventID: string; id: string};
   eventID: string;
   id: string;
-  name: string;
+  name: string | null;
   user: {
     avatarUrl: string | null;
     email: string | null;


### PR DESCRIPTION
* UserFeedback name and email typed as `string | null` to match the backend `UserReportSerializerResponse`.
* isSameIdentity accepts nullable inputs
* regression test for rendering a report with name/email/user set to null

<img width="793" height="141" alt="image" src="https://github.com/user-attachments/assets/c5ac6a5d-a953-46e4-9c85-a0514b0aa444" />

Surfaced after: https://github.com/getsentry/sentry/pull/116318