### PR TITLE
feat(dashboards): Add Mobile Vitals "About this page" widget

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
@@ -269,12 +269,32 @@ const AVG_FRAME_DELAY_WIDGET: PrebuiltWidget = {
   },
 };
 
+const PLAYBOOK_TEXT_WIDGET: PrebuiltWidget = {
+  id: 'playbook-text',
+  title: t('Playbook'),
+  description: `Top-level widgets show overall app health: average app start, TTID/TTFD, rendering, and crash-free session metrics.
+
+Tables show which screens contribute most to those metrics.
+
+App start metrics in this dashboard only include launches that open the app UI, not headless or background starts.
+
+[Read the Mobile Vitals docs](https://docs.sentry.io/product/dashboards/sentry-dashboards/mobile/mobile-vitals/) for detailed definitions of app start, TTID/TTFD, and frame metrics.`,
+  displayType: DisplayType.TEXT,
+  interval: '1h',
+  queries: [],
+  layout: {
+    h: 2,
+    x: 4,
+    y: 0,
+    w: 2,
+    minH: 2,
+  },
+};
+
 const APP_START_TABLE: PrebuiltWidget = {
   id: 'app-start-table',
   title: t('App Starts'),
-  description: t(
-    "On iOS, cold and warm start classification may differ from Apple's definitions. Sentry defines a cold start as a launch after first install, reboot, or update; all other launches are warm starts. Warm start results may differ between prewarmed and non-prewarmed launches."
-  ),
+  description: '',
   displayType: DisplayType.TABLE,
   widgetType: WidgetType.SPANS,
   interval: '1h',
@@ -435,6 +455,7 @@ export const MOBILE_VITALS_PREBUILT_CONFIG: PrebuiltDashboard = {
   widgets: [
     ...FIRST_ROW_WIDGETS,
     ...SECOND_ROW_WIDGETS,
+    PLAYBOOK_TEXT_WIDGET,
     APP_START_TABLE,
     SCREEN_LOAD_TABLE,
     SCREEN_RENDERING_TABLE,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
@@ -272,13 +272,14 @@ const AVG_FRAME_DELAY_WIDGET: PrebuiltWidget = {
 const ABOUT_THIS_PAGE_TEXT_WIDGET: PrebuiltWidget = {
   id: 'about-this-page-text',
   title: t('About this page'),
-  description: `Top-level widgets show overall app health: average app start, TTID/TTFD, rendering, and crash-free session metrics.
+  description:
+    t(`Top-level widgets show overall app health: average app start, TTID/TTFD, rendering, and crash-free session metrics.
 
 Tables show which screens contribute most to those metrics.
 
 App start metrics in this dashboard only include launches that open the app UI, not headless or background starts.
 
-[Read the Mobile Vitals docs](https://docs.sentry.io/product/dashboards/sentry-dashboards/mobile/mobile-vitals/) for detailed definitions of app start, TTID/TTFD, and frame metrics.`,
+[Read the Mobile Vitals docs](https://docs.sentry.io/product/insights/mobile/mobile-vitals/) for detailed definitions of app start, TTID/TTFD, and frame metrics.`),
   displayType: DisplayType.TEXT,
   interval: '1h',
   queries: [],

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
@@ -273,13 +273,11 @@ const ABOUT_THIS_PAGE_TEXT_WIDGET: PrebuiltWidget = {
   id: 'about-this-page-text',
   title: t('About this page'),
   description:
-    t(`Top-level widgets show overall app health: average app start, TTID/TTFD, rendering, and crash-free session metrics.
+    t(`Top-level widgets show overall app health: app start, TTID/TTFD, rendering, and crash-free sessions. Tables show which screens contribute most.
 
-Tables show which screens contribute most to those metrics.
+App start metrics only count launches that open the app UI, not headless or background starts.
 
-App start metrics in this dashboard only include launches that open the app UI, not headless or background starts.
-
-[Read the Mobile Vitals docs](https://docs.sentry.io/product/insights/mobile/mobile-vitals/) for detailed definitions of app start, TTID/TTFD, and frame metrics.`),
+See the [Mobile Vitals docs](https://docs.sentry.io/product/insights/mobile/mobile-vitals/).`),
   displayType: DisplayType.TEXT,
   interval: '1h',
   queries: [],

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
@@ -269,9 +269,9 @@ const AVG_FRAME_DELAY_WIDGET: PrebuiltWidget = {
   },
 };
 
-const PLAYBOOK_TEXT_WIDGET: PrebuiltWidget = {
-  id: 'playbook-text',
-  title: t('Playbook'),
+const ABOUT_THIS_PAGE_TEXT_WIDGET: PrebuiltWidget = {
+  id: 'about-this-page-text',
+  title: t('About this page'),
   description: `Top-level widgets show overall app health: average app start, TTID/TTFD, rendering, and crash-free session metrics.
 
 Tables show which screens contribute most to those metrics.
@@ -455,7 +455,7 @@ export const MOBILE_VITALS_PREBUILT_CONFIG: PrebuiltDashboard = {
   widgets: [
     ...FIRST_ROW_WIDGETS,
     ...SECOND_ROW_WIDGETS,
-    PLAYBOOK_TEXT_WIDGET,
+    ABOUT_THIS_PAGE_TEXT_WIDGET,
     APP_START_TABLE,
     SCREEN_LOAD_TABLE,
     SCREEN_RENDERING_TABLE,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
@@ -273,11 +273,11 @@ const ABOUT_THIS_PAGE_TEXT_WIDGET: PrebuiltWidget = {
   id: 'about-this-page-text',
   title: t('About this page'),
   description:
-    t(`Top-level widgets show overall app health: app start, TTID/TTFD, rendering, and crash-free sessions. Tables show which screens contribute most.
+    t(`The top-level metrics summarize your app's health at a glance. When one looks off, use the tables below to find which screens are responsible, then drill into a screen to investigate individual events.
 
 App start metrics only count launches that open the app UI, not headless or background starts.
 
-See the [Mobile Vitals docs](https://docs.sentry.io/product/insights/mobile/mobile-vitals/).`),
+See the [Mobile Vitals docs](https://docs.sentry.io/product/insights/mobile/mobile-vitals/) for more information.`),
   displayType: DisplayType.TEXT,
   interval: '1h',
   queries: [],

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
@@ -273,9 +273,9 @@ const ABOUT_THIS_PAGE_TEXT_WIDGET: PrebuiltWidget = {
   id: 'about-this-page-text',
   title: t('About this page'),
   description:
-    t(`The top-level metrics summarize your app's health at a glance. When one looks off, use the tables below to find which screens are responsible, then drill into a screen to investigate individual events.
+    t(`Top-level metrics show your app's health. When one looks off, use the tables below to find the screens responsible, then drill in to investigate.
 
-App start metrics only count launches that open the app UI, not headless or background starts.
+App start metrics only count launches that open the app UI, not background starts.
 
 See the [Mobile Vitals docs](https://docs.sentry.io/product/insights/mobile/mobile-vitals/) for more information.`),
   displayType: DisplayType.TEXT,


### PR DESCRIPTION
## Summary
- Adds a short text widget to the Mobile Vitals prebuilt dashboard to explain how to use the top-level metrics and tables.
- Replaces the iOS-specific App Starts table hint with broader guidance, including foreground app start scope and a link to the Mobile Vitals docs.

<img width="1425" height="837" alt="image" src="https://github.com/user-attachments/assets/b70e1407-846d-4fb2-995b-07608a9a3a7d" />

Made with [Cursor](https://cursor.com)