### PR TITLE
ref(dynamic-sampling): only run sliding window calculations when config is enabled

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/tasks/configuration.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/configuration.py
@@ -110,6 +110,8 @@ class AutomaticDynamicSamplingConfiguration(BaseDynamicSamplingConfiguration):
             )
         except ObjectDoesNotExist as exc:
             raise DynamicSamplingException(DynamicSamplingStatus.NO_SUBSCRIPTION) from exc
+        if not self.is_enabled:
+            return
         self.projects = self._get_projects()
         self.sliding_window_sample_rate = self._get_sliding_window_sample_rate()
 

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_configuration.py
@@ -132,15 +132,22 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
 
     def test_subscription_backed_org_without_sample_rate_is_disabled(self) -> None:
         org = self.create_organization()
+        self.create_project(organization=org)
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=None,
+        with (
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.configuration.quotas.backend.get_blended_sample_rate",
+                return_value=None,
+            ),
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.configuration.get_eap_organization_volume",
+            ) as get_volume,
         ):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, NoDynamicSamplingConfiguration)
         assert not configuration.is_enabled
+        get_volume.assert_not_called()
         with pytest.raises(AttributeError):
             getattr(configuration, "measure")
         with pytest.raises(AttributeError):


### PR DESCRIPTION
- Add an enabled check to the config init to prevent queries from being run if DS is not enabled for this org