### PR TITLE
fix(snapshots): Increase snapshot test timeout to 30s

### DIFF
--- a/jest.config.snapshots.ts
+++ b/jest.config.snapshots.ts
@@ -41,6 +41,7 @@ const swcConfig: SwcOptions = {
 const ESM_NODE_MODULES = ['screenfull', 'cbor2', 'nuqs', 'color'];
 
 const config: Config.InitialOptions = {
+  testTimeout: 30_000,
   cacheDirectory: '.cache/jest-snapshots',
   // testEnvironment and testMatch are the core differences between this and the main config
   testEnvironment: 'node',


### PR DESCRIPTION
Snapshot tests launch Chromium via Playwright, render components to HTML, and capture PNG screenshots. Jest's default 5s test timeout is too tight for browser automation — especially when multiple workers run in parallel and compete for CPU/IO — causing spurious timeouts on tests that are otherwise correct.

Sets `testTimeout: 30_000` in `jest.config.snapshots.ts` to match Playwright Test's own default for browser-driven tests. This only affects snapshot tests; the main Jest config is unchanged.