### PR TITLE
feat(waterfall): Add visual indication for SDK-sent v2 spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -2,12 +2,15 @@ import {Fragment, useEffect, useMemo} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import type {Location} from 'history';
 
+import {Tooltip} from '@sentry/scraps/tooltip';
+
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {useSpanProfileDetails} from 'sentry/components/events/interfaces/spans/spanProfileDetails';
 import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {IconBroadcast} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {EventTransaction} from 'sentry/types/event';
 import type {NewQuery, Organization} from 'sentry/types/organization';
@@ -494,12 +497,26 @@ function EAPSpanNodeDetailsContent({
     }
   }, [hasProfileDetails, hasLogDetails, organization]);
 
+  // The presence of this attribute indicates that the EAP span was sent as a v2 span
+  // from SDKs rather than an SDK-sent transaction converted to EAP spans during ingestion.
+  const isSdkSentV2Span = attributes.some(a => a.name === 'observed_timestamp_nanos');
+
   return (
     <TraceDrawerComponents.DetailContainer>
       <TraceDrawerComponents.HeaderContainer>
         <TraceDrawerComponents.Title>
           <TraceDrawerComponents.LegacyTitleText>
-            <TraceDrawerComponents.TitleText>{t('Span')}</TraceDrawerComponents.TitleText>
+            <TraceDrawerComponents.TitleText>
+              {t('Span')}
+              {isSdkSentV2Span && (
+                <Fragment>
+                  {' '}
+                  <Tooltip title={t('Streamed Span')}>
+                    <IconBroadcast size="xs" />
+                  </Tooltip>
+                </Fragment>
+              )}
+            </TraceDrawerComponents.TitleText>
             <TraceDrawerComponents.SubtitleWithCopyButton
               subTitle={`ID: ${node.id}`}
               clipboardText={node.id}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -507,10 +507,8 @@ function EAPSpanNodeDetailsContent({
     // from SDKs rather than an SDK-sent transaction converted to EAP spans during ingestion.
     attributesMap.observed_timestamp_nanos &&
     // Furthermore, to distinguish between v2 and v1 web vital spans, we can check that the old
-    // web vital attributes (only present on v1 spans) are undefined.
-    !attributesMap.lcp &&
-    !attributesMap.cls &&
-    !attributesMap.inp;
+    // report_event only sent on v1 spans attribute is undefined
+    !attributesMap.report_event;
 
   return (
     <TraceDrawerComponents.DetailContainer>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -28,7 +28,6 @@ import {
 import {
   useTraceItemDetails,
   type TraceItemDetailsResponse,
-  type TraceItemResponseAttribute,
 } from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {ProfileGroupProvider} from 'sentry/views/explore/profiling/profileGroupProvider';
@@ -459,14 +458,20 @@ function EAPSpanNodeDetailsContent({
   traceItemData: TraceItemDetailsResponse;
 }) {
   const attributes = traceItemData.attributes;
+
+  const attributesMap = attributes.reduce<Record<string, string | number | boolean>>(
+    (acc, attribute) => {
+      acc[attribute.name] = attribute.value;
+      return acc;
+    },
+    {}
+  );
+
   const links = traceItemData.links;
   const isTransaction = node.value.is_transaction && !!eventTransaction;
 
-  const threadIdAttribute: TraceItemResponseAttribute | undefined = attributes.find(
-    attribute => attribute.name === 'thread.id'
-  );
-  const threadId =
-    typeof threadIdAttribute?.value === 'string' ? threadIdAttribute.value : undefined;
+  const threadIdAttribute = attributesMap['thread.id'];
+  const threadId = typeof threadIdAttribute === 'string' ? threadIdAttribute : undefined;
 
   const span = useMemo(() => {
     return {
@@ -497,9 +502,15 @@ function EAPSpanNodeDetailsContent({
     }
   }, [hasProfileDetails, hasLogDetails, organization]);
 
-  // The presence of this attribute indicates that the EAP span was sent as a v2 span
-  // from SDKs rather than an SDK-sent transaction converted to EAP spans during ingestion.
-  const isSdkSentV2Span = attributes.some(a => a.name === 'observed_timestamp_nanos');
+  const isSdkSentV2Span =
+    // The presence of this attribute indicates that the EAP span was sent as a v2 span
+    // from SDKs rather than an SDK-sent transaction converted to EAP spans during ingestion.
+    attributesMap.observed_timestamp_nanos &&
+    // Furthermore, to distinguish between v2 and v1 web vital spans, we can check that the old
+    // web vital attributes (only present on v1 spans) are undefined.
+    !attributesMap.lcp &&
+    !attributesMap.cls &&
+    !attributesMap.inp;
 
   return (
     <TraceDrawerComponents.DetailContainer>


### PR DESCRIPTION
At the moment, there's no intuitive way for users to know that a span they're looking at comes from an SDK they configured for span streaming as opposed to from an SDK-sent transaction that was converted to EAP spans. This makes it hard for users to verify, without deeply debugging their SDK, that they migrated their SDKs correctly. 

So my thinking is, we can (for a while) add a small hint that this is in fact the case, which our Span Streaming migration docs (WIP, see https://github.com/getsentry/sentry-docs/pull/17834) can include in the `## Verify` section. This PR proposes to add the broadcast icon and a "Streamed Span" tooltip when hovering over the icon in the details panel of the trace waterfall. 

How do we distinguish SDK-sent vs. transaction-converted EAP spans? By checking for the presence of the `observed_timestamp_nanos` attribute which is only present on SDK-sent spans.

UPDATE: I also had to add an additional attribute check to distinguish v2 from v1 spans because they look almost identically. What I ended up with: We can identify v1 web vital spans based on them having the `report_event` attribute. V2 spans no longer have this attribute, so it should be enough to distinguish them. This works because AFAIK, we only send web vital spans as standalone v1 spans. 

I'm happy to change or drop this PR if anyone has concerns, but figured I'd open it anyway, since it was a quick change. Also have some alternative suggestions (see the Slack thread). 

<img width="1356" height="719" alt="image" src="https://github.com/user-attachments/assets/cdb5cbf1-3bed-4f5b-b7a1-2eba8e660bdb" />

<img width="1356" height="721" alt="image" src="https://github.com/user-attachments/assets/4436cc9d-abcd-45d9-acf7-91a0db7da3b1" />


 