### PR TITLE
fix(spans): deprecations shouldn't shadow public field names

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -556,7 +556,10 @@ def _update_attribute_definitions_with_deprecations(
                     deprecation_status=status,
                 )
                 # TODO: Introduce units to attribute schema.
-                if replacement not in attribute_definitions:
+                if (
+                    replacement not in attribute_definitions
+                    and replacement not in span_attribute_definitions_by_internal_name
+                ):
                     attribute_definitions[replacement] = replace(
                         deprecated_attr,
                         public_alias=replacement,
@@ -575,7 +578,10 @@ def _update_attribute_definitions_with_deprecations(
                     deprecation_status=status,
                 )
 
-                if replacement not in attribute_definitions:
+                if (
+                    replacement not in attribute_definitions
+                    and replacement not in span_attribute_definitions_by_internal_name
+                ):
                     attribute_definitions[replacement] = ResolvedAttribute(
                         public_alias=replacement,
                         internal_name=replacement,
@@ -585,9 +591,10 @@ def _update_attribute_definitions_with_deprecations(
             span_attribute_definitions_by_internal_name[key] = attribute_definitions[
                 deprecated_public_alias
             ]
-            span_attribute_definitions_by_internal_name[replacement] = attribute_definitions[
-                replacement
-            ]
+            if replacement in attribute_definitions:
+                span_attribute_definitions_by_internal_name[replacement] = attribute_definitions[
+                    replacement
+                ]
 
 
 try:

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -1210,6 +1210,50 @@ def test_deprecated_attribute_does_not_overwrite_existing_replacement() -> None:
     assert replacement_attr.replacement is None
 
 
+def test_deprecated_attribute_replacement_does_not_shadow_existing_internal_name() -> None:
+    attribute_definitions = {
+        "environment": ResolvedAttribute(
+            public_alias="environment",
+            internal_name="sentry.environment",
+            search_type="string",
+        ),
+    }
+
+    _update_attribute_definitions_with_deprecations(
+        attribute_definitions,
+        [
+            {
+                "key": "resource.deployment.environment",
+                "type": "string",
+                "deprecation": {
+                    "_status": "backfill",
+                    "replacement": "sentry.environment",
+                },
+            },
+            {
+                "key": "resource.deployment.environment.name",
+                "type": "string",
+                "deprecation": {
+                    "_status": "backfill",
+                    "replacement": "sentry.environment",
+                },
+            },
+        ],
+    )
+
+    assert "sentry.environment" not in attribute_definitions
+    assert attribute_definitions["environment"].public_alias == "environment"
+    assert attribute_definitions["environment"].internal_name == "sentry.environment"
+
+    assert (
+        attribute_definitions["resource.deployment.environment"].replacement == "sentry.environment"
+    )
+    assert (
+        attribute_definitions["resource.deployment.environment.name"].replacement
+        == "sentry.environment"
+    )
+
+
 def test_deprecated_attribute_normalizes_supported_convention_attribute_types() -> None:
     attribute_definitions: dict[str, ResolvedAttribute] = {}
 

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -1161,6 +1161,32 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert ("tags[tag.number,number]", "number") in keys
         assert ("tag.string", "string") in keys
 
+    def test_sentry_environment_attribute_name(self) -> None:
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            span_id=uuid4().hex[:16],
+            organization_id=self.organization.id,
+            parent_span_id=None,
+            timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+            transaction="foo",
+            duration=100,
+            exclusive_time=100,
+            environment="prod",
+        )
+
+        response = self.do_request(
+            query={
+                "attributeType": "string",
+                "substringMatch": "environment",
+            }
+        )
+        assert response.status_code == 200, response.content
+
+        names = {item["name"] for item in response.data}
+        assert "environment" in names
+
 
 class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
     OrganizationTraceItemAttributesEndpointTestBase, TraceMetricsTestCase


### PR DESCRIPTION
The canonical attribute name for current environment (`production`, `staging`, etc) is `sentry.environment`. However, for users' convenience, we instead expose this in search as `environment`:

https://github.com/getsentry/sentry/blob/a26a0bef04d21e6ee7b6a55d7324ce01f7e3c9d3/src/sentry/search/eap/spans/attributes.py#L431

We also have code that makes Sentry aware of deprecated attributes from https://github.com/getsentry/sentry-conventions, in `_update_attribute_definitions_with_deprecations`:

https://github.com/getsentry/sentry/blob/a26a0bef04d21e6ee7b6a55d7324ce01f7e3c9d3/src/sentry/search/eap/spans/attributes.py#L528-L590

When the sentry-conventions package was updated in #113515 it brought in two new attributes that backfill into `sentry.environment`:

```json
{"key": "resource.deployment.environment", "_status": "backfill", "replacement": "sentry.environment"}
{"key": "resource.deployment.environment.name", "_status": "backfill", "replacement": "sentry.environment"}
```

With this, `_update_attribute_definitions_with_deprecations` started adding a field definition for `sentry.environment`, shadowing our explicit mapping to the public field name `environment`. Not only did this start defining the wrong attribute name, it actually hid environment entirely, due to separate handling that filters out `sentry.`-prefixed attribute names.

This PR explicitly checks for existing field definitions _before_ adding new ones from sentry-conventions' deprecations. Currently `environment`/`sentry.environment` appears to be the only field affected by this bug, but this pattern in general should work if new such definitions/deprecations are ever added.

Fixes BROWSE-527.

---

🤖: Claude Code (Opus 4.6) used to generate the code, with human editing + careful review. All words my own.