### PR TITLE
test(snuba): Re-enable boolean double-write tests

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -1112,7 +1112,6 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert "tag.op" in keys
         assert "tag.op2" in keys
 
-    @pytest.mark.skip(reason="Re-enable once Snuba PR #7689 stops boolean double-writing")
     def test_empty_attribute_type_for_all_attribute_types(self) -> None:
         span1 = self.create_span(start_ts=before_now(days=0, minutes=10))
         span1["data"] = {
@@ -1136,7 +1135,6 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert ("tag.string", "string") in keys
         assert ("tags[tag.number,number]", "number") in keys
 
-    @pytest.mark.skip(reason="Re-enable once Snuba PR #7689 stops boolean double-writing")
     def test_multiple_attribute_types(self) -> None:
         span1 = self.create_span(start_ts=before_now(days=0, minutes=10))
         span1["data"] = {


### PR DESCRIPTION
Remove the `@pytest.mark.skip` markers on
`test_empty_attribute_type_for_all_attribute_types` and
`test_multiple_attribute_types` in
`tests/snuba/api/endpoints/test_organization_trace_item_attributes.py`.

Snuba PR getsentry/snuba#7689 removed boolean attribute double-writing,
and #111421 (cd2fcde567c) already updated the assertions in these tests
for the post-double-write world but kept the skip markers in place. Both
tests now pass locally against current Snuba, so the markers can go.

The three other boolean attribute tests called out in #111421
(`test_boolean_attributes` for logs and spans, and
`test_trace_metrics_boolean_attributes`) also pass locally — no
additional changes needed.

Refs #111421
Refs getsentry/snuba#7689


Agent transcript: https://claudescope.sentry.dev/share/93vAKRpZyG9v5qDWDpIGfdIhSi1T6ak7JYSJsC0-k54