### PR TITLE
fix(issues): Render ANSI colors in issue text

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@types/reflux": "0.4.1",
     "@types/scroll-to-element": "^2.0.2",
     "@types/webpack-env": "1.18.8",
-    "ansi-to-react": "^6.1.6",
+    "anser": "2.3.5",
     "base64-arraybuffer": "^1.0.1",
     "buffer": "^6.0.3",
     "cbor2": "^1.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,9 +310,9 @@ importers:
       '@types/webpack-env':
         specifier: 1.18.8
         version: 1.18.8
-      ansi-to-react:
-        specifier: ^6.1.6
-        version: 6.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      anser:
+        specifier: 2.3.5
+        version: 2.3.5
       base64-arraybuffer:
         specifier: ^1.0.1
         version: 1.0.2
@@ -4289,8 +4289,8 @@ packages:
   algoliasearch@4.13.1:
     resolution: {integrity: sha512-dtHUSE0caWTCE7liE1xaL+19AFf6kWEcyn76uhcitWpntqvicFHXKFoZe5JJcv9whQOTRM6+B8qJz6sFj+rDJA==}
 
-  anser@1.4.10:
-    resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
+  anser@2.3.5:
+    resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -4318,12 +4318,6 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
-
-  ansi-to-react@6.1.6:
-    resolution: {integrity: sha512-+HWn72GKydtupxX9TORBedqOMsJRiKTqaLUKW8txSBZw9iBpzPKLI8KOu4WzwD4R7hSv1zEspobY6LwlWvwZ6Q==}
-    peerDependencies:
-      react: ^16.3.2 || ^17.0.0
-      react-dom: ^16.3.2 || ^17.0.0
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -5252,9 +5246,6 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  escape-carriage@1.3.0:
-    resolution: {integrity: sha512-ATWi5MD8QlAGQOeMgI8zTp671BG8aKvAC0M7yenlxU4CRLGO/sKthxVUyjiOFKjHdIo+6dZZUNFgHFeVEaKfGQ==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -13148,7 +13139,7 @@ snapshots:
       '@algolia/requester-node-http': 4.13.1
       '@algolia/transporter': 4.13.1
 
-  anser@1.4.10: {}
+  anser@2.3.5: {}
 
   ansi-align@3.0.1:
     dependencies:
@@ -13169,13 +13160,6 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
-
-  ansi-to-react@6.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      anser: 1.4.10
-      escape-carriage: 1.3.0
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
 
   anymatch@3.1.3:
     dependencies:
@@ -14257,8 +14241,6 @@ snapshots:
       '@esbuild/win32-x64': 0.25.10
 
   escalade@3.2.0: {}
-
-  escape-carriage@1.3.0: {}
 
   escape-string-regexp@1.0.5: {}
 

--- a/static/app/components/ansiText/ansiToReact.tsx
+++ b/static/app/components/ansiText/ansiToReact.tsx
@@ -1,0 +1,266 @@
+/**
+ * This is vendored from ansi-to-react v6.2.6
+ *
+ * The link rendering was changed to use Sentry's external-link modal.
+ *
+ * Copyright (c) 2016, nteract contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of nteract nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import type {CSSProperties, ReactElement, ReactNode} from 'react';
+import {Fragment, useMemo} from 'react';
+import {type Theme, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import Anser from 'anser';
+import type {AnserJsonEntry} from 'anser';
+
+import {ExternalLink} from '@sentry/scraps/link';
+
+import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import {IconOpen} from 'sentry/icons';
+import {isValidUrl} from 'sentry/utils/string/isValidUrl';
+
+type AnsiToReactProps = {
+  text: string;
+};
+
+const ESCAPE_CHARACTER = '\u001B';
+
+export function AnsiToReact({text}: AnsiToReactProps): ReactElement {
+  if (!text.includes(ESCAPE_CHARACTER)) {
+    return <Fragment>{renderLinksInPlainText(text, 'plain')}</Fragment>;
+  }
+
+  return <AnsiSpans text={text} />;
+}
+
+function AnsiSpans({text}: AnsiToReactProps): ReactElement {
+  const theme = useTheme();
+  const bundles = useMemo(
+    () =>
+      Anser.ansiToJson(text, {
+        json: true,
+        remove_empty: true,
+        use_classes: true,
+      }),
+    [text]
+  );
+
+  return (
+    <Fragment>
+      {bundles.map((bundle, index) => (
+        <span key={index} style={getAnsiStyle(bundle, theme)}>
+          {renderLinksInPlainText(bundle.content, `ansi-${index}`)}
+        </span>
+      ))}
+    </Fragment>
+  );
+}
+
+// https?: Matches both "http" and "https"
+// :\/\/: This is a literal match for "://"
+// (?:www\.)?: Matches URLs with or without "www."
+// [-a-zA-Z0-9@:%._\+~#=]{1,256}: Matches the domain name
+//    It allows for a range of characters (letters, digits, and special characters)
+//    The {1,256} specifies that these characters can occur anywhere from 1 to 256 times, which covers the range of typical domain name lengths
+// \.: Matches the dot before the top-level domain (like ".com")
+// [a-zA-Z0-9]{1,6}: Matches the top-level domain (like "com" or "org"). It's limited to letters and digits and can be between 1 and 6 characters long
+// (?:[-a-zA-Z0-9@:%_\+~#?&\/=,\[\].]*[-a-zA-Z0-9@:%_\+~#?&\/=,\[\]])?: Matches the path, query parameters, or fragments that can follow the domain in a URL
+//    It now includes periods within the character set to allow for file extensions (e.g., ".html") and other period-containing segments in the URL path
+//    This pattern matches a wide range of characters typically found in paths, query strings, and fragments, including periods
+//    The final character set ensures that the URL ends with a character typically allowed in a path, query string, or fragment, excluding special characters like a trailing period not part of the URL
+// /gi: The regex will match all occurrences in the string, not just the first one
+//    The "i" modifier makes the regex match both upper and lower case characters
+// Links are rendered as React nodes so ANSI text never needs HTML injection.
+const URL_REGEX =
+  /https?:\/\/(?:www\.)?[-\w@:%.+~#=]{1,256}\.[a-z0-9]{1,6}(?:[-\w@:%+~#?&/=,[\].]*[-\w@:%+~#?&/=,[\]])?/gi;
+
+function renderLinksInPlainText(text: string, keyPrefix: string): ReactNode {
+  if (!text.includes('http://') && !text.includes('https://')) {
+    return text;
+  }
+
+  const elements: ReactNode[] = [];
+  let lastIndex = 0;
+  let hasLink = false;
+
+  for (const match of text.matchAll(URL_REGEX)) {
+    const url = match[0];
+    const index = match.index ?? 0;
+    hasLink = true;
+
+    if (index > lastIndex) {
+      elements.push(
+        <Fragment key={`${keyPrefix}-text-${lastIndex}`}>
+          {text.slice(lastIndex, index)}
+        </Fragment>
+      );
+    }
+
+    if (isValidUrl(url)) {
+      elements.push(
+        <ExternalLink
+          key={`${keyPrefix}-link-${index}`}
+          onClick={event => {
+            event.preventDefault();
+            openNavigateToExternalLinkModal({linkText: url});
+          }}
+        >
+          {url}
+          <IconPlacement size="xs" />
+        </ExternalLink>
+      );
+    } else {
+      elements.push(<span key={`${keyPrefix}-invalid-url-${index}`}>{url}</span>);
+    }
+
+    lastIndex = index + url.length;
+  }
+
+  if (!hasLink) {
+    return text;
+  }
+
+  if (lastIndex < text.length) {
+    elements.push(
+      <Fragment key={`${keyPrefix}-text-${lastIndex}`}>{text.slice(lastIndex)}</Fragment>
+    );
+  }
+
+  return elements;
+}
+
+function getAnsiStyle(bundle: AnserJsonEntry, theme: Theme): CSSProperties | undefined {
+  const style: CSSProperties = {};
+  const color = getAnsiColor(bundle.fg, bundle.fg_truecolor, theme);
+  const backgroundColor = getAnsiColor(bundle.bg, bundle.bg_truecolor, theme);
+
+  if (bundle.decoration === 'reverse') {
+    if (backgroundColor) {
+      style.color = backgroundColor;
+    }
+    if (color) {
+      style.backgroundColor = color;
+    }
+  } else {
+    if (color) {
+      style.color = color;
+    }
+    if (backgroundColor) {
+      style.backgroundColor = backgroundColor;
+    }
+  }
+
+  switch (bundle.decoration) {
+    case 'bold':
+      style.fontWeight = 'bold';
+      break;
+    case 'dim':
+      style.opacity = 0.65;
+      break;
+    case 'italic':
+      style.fontStyle = 'italic';
+      break;
+    case 'underline':
+      style.textDecorationLine = 'underline';
+      break;
+    case 'hidden':
+      style.visibility = 'hidden';
+      break;
+    case 'strikethrough':
+      style.textDecorationLine = 'line-through';
+      break;
+    case 'blink':
+    case 'reverse':
+    case null:
+      break;
+    default:
+      break;
+  }
+
+  return Object.keys(style).length > 0 ? style : undefined;
+}
+
+function getAnsiColor(
+  colorClass: string | null,
+  trueColor: string | null,
+  theme: Theme
+): string | undefined {
+  if (!colorClass) {
+    return undefined;
+  }
+
+  if (colorClass === 'ansi-truecolor' && trueColor) {
+    return `rgb(${trueColor})`;
+  }
+
+  if (colorClass.startsWith('ansi-bright-')) {
+    return getThemeAnsiColor(colorClass.replace('ansi-bright-', ''), theme, true);
+  }
+
+  if (colorClass.startsWith('ansi-')) {
+    return getThemeAnsiColor(colorClass.replace('ansi-', ''), theme);
+  }
+
+  return undefined;
+}
+
+function getThemeAnsiColor(
+  colorName: string,
+  theme: Theme,
+  bright = false
+): string | undefined {
+  if (colorName === 'black' || colorName === 'white') {
+    return theme.colors[colorName];
+  }
+
+  const themeColorName = COLOR_MAP[colorName as keyof typeof COLOR_MAP];
+  if (!themeColorName) {
+    return undefined;
+  }
+
+  const themeColorWeight = bright ? '200' : '500';
+  return theme.colors[`${themeColorName}${themeColorWeight}`];
+}
+
+/**
+ * Maps ANSI color names -> theme.tsx color names
+ */
+const COLOR_MAP = {
+  red: 'red',
+  green: 'green',
+  blue: 'blue',
+  yellow: 'yellow',
+  magenta: 'pink',
+  cyan: 'blue',
+} as const;
+
+const IconPlacement = styled(IconOpen)`
+  display: inline-block;
+  margin-left: 5px;
+  vertical-align: center;
+`;

--- a/static/app/components/ansiText/index.spec.tsx
+++ b/static/app/components/ansiText/index.spec.tsx
@@ -1,0 +1,94 @@
+import {ThemeFixture} from 'sentry-fixture/theme';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {AnsiText} from 'sentry/components/ansiText';
+
+describe('AnsiText', () => {
+  it('renders ANSI standard and bright colors without escape codes', () => {
+    render(<AnsiText text={'\u001B[31mred\u001B[0m plain \u001B[91mbright\u001B[0m'} />);
+
+    expect(screen.getByText('red')).toHaveStyle({color: ThemeFixture().colors.red500});
+    expect(screen.getByText('bright')).toHaveStyle({
+      color: ThemeFixture().colors.red200,
+    });
+    expect(screen.queryByText(text => text.includes('\u001B'))).not.toBeInTheDocument();
+  });
+
+  it('renders nested ANSI foreground and background colors with reset behavior', () => {
+    render(<AnsiText text={'hello \u001B[32mwo\u001B[43mrl\u001B[0;md'} />);
+
+    expect(screen.getByText('wo')).toHaveStyle({
+      color: ThemeFixture().colors.green500,
+    });
+    expect(screen.getByText('rl')).toHaveStyle({
+      backgroundColor: ThemeFixture().colors.yellow500,
+      color: ThemeFixture().colors.green500,
+    });
+    expect(screen.getByText('d')).not.toHaveStyle({
+      color: ThemeFixture().colors.green500,
+    });
+  });
+
+  it('renders ANSI text decorations', () => {
+    render(<AnsiText text={'hello \u001B[32m\u001B[1mworld\u001B[0;m!'} />);
+
+    expect(screen.getByText('world')).toHaveStyle({
+      color: ThemeFixture().colors.green500,
+      fontWeight: 'bold',
+    });
+    expect(screen.getByText('!')).not.toHaveStyle({
+      fontWeight: 'bold',
+    });
+  });
+
+  it('strips ANSI 256-color codes and renders truecolor values', () => {
+    render(
+      <AnsiText
+        text={'\u001B[38;5;196mindexed\u001B[0m \u001B[38;2;1;2;3mtruecolor\u001B[0m'}
+      />
+    );
+
+    expect(screen.getByText('indexed')).toBeInTheDocument();
+    expect(screen.getByText('truecolor')).toHaveStyle({color: 'rgb(1, 2, 3)'});
+    expect(screen.queryByText(text => text.includes('\u001B'))).not.toBeInTheDocument();
+  });
+
+  it('keeps URLs clickable inside ANSI colored text', () => {
+    const url = 'https://docs.sentry.io';
+
+    render(<AnsiText text={`\u001B[32m${url}\u001B[0m`} />);
+
+    const link = screen.getByText(url).closest('a');
+    expect(link).toBeInTheDocument();
+    expect(link?.closest('span')).toHaveStyle({color: ThemeFixture().colors.green500});
+  });
+
+  it('can normalize terminal backspaces and carriage returns', () => {
+    const {container} = render(
+      <AnsiText text={'abc\bde\nprogress 10%\rprogress 20%'} normalizeTerminalSequences />
+    );
+
+    expect(container).toHaveTextContent('abde progress 20%');
+  });
+
+  it('handles terminal carriage returns across lines', () => {
+    const {container} = render(
+      <AnsiText
+        text={'this sentence\rthat\nwill make you pause'}
+        normalizeTerminalSequences
+      />
+    );
+
+    expect(container).toHaveTextContent('that sentence\nwill make you pause', {
+      normalizeWhitespace: false,
+    });
+  });
+
+  it('does not linkify URL-ish text', () => {
+    render(<AnsiText text="<transport.model.TransportInfo" />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('<transport.model.TransportInfo')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/ansiText/index.tsx
+++ b/static/app/components/ansiText/index.tsx
@@ -1,0 +1,22 @@
+import type {ReactElement} from 'react';
+import {useMemo} from 'react';
+
+import {AnsiToReact} from 'sentry/components/ansiText/ansiToReact';
+import {normalizeTerminalText} from 'sentry/components/ansiText/normalizeTerminalText';
+
+type AnsiTextProps = {
+  text: string;
+  normalizeTerminalSequences?: boolean;
+};
+
+export function AnsiText({
+  text,
+  normalizeTerminalSequences = false,
+}: AnsiTextProps): ReactElement {
+  const displayText = useMemo(
+    () => (normalizeTerminalSequences ? normalizeTerminalText(text) : text),
+    [normalizeTerminalSequences, text]
+  );
+
+  return <AnsiToReact text={displayText} />;
+}

--- a/static/app/components/ansiText/normalizeTerminalText.ts
+++ b/static/app/components/ansiText/normalizeTerminalText.ts
@@ -1,0 +1,41 @@
+export function normalizeTerminalText(text: string): string {
+  return applyCarriageReturns(removeBackspaces(text));
+}
+
+function removeBackspaces(text: string): string {
+  const characters: string[] = [];
+
+  for (const character of text) {
+    if (character === '\b') {
+      if (characters.length > 0 && characters[characters.length - 1] !== '\n') {
+        characters.pop();
+      }
+      continue;
+    }
+
+    characters.push(character);
+  }
+
+  return characters.join('');
+}
+
+function applyCarriageReturns(text: string): string {
+  return text
+    .replace(/\r+\n/g, '\n')
+    .split('\n')
+    .map(applyLineCarriageReturns)
+    .join('\n');
+}
+
+function applyLineCarriageReturns(line: string): string {
+  if (!line.includes('\r')) {
+    return line;
+  }
+
+  const [firstSegment = '', ...segments] = line.split('\r');
+
+  return segments.reduce(
+    (currentLine, segment) => segment + currentLine.slice(segment.length),
+    firstSegment
+  );
+}

--- a/static/app/components/events/attachmentViewers/logFileViewer.tsx
+++ b/static/app/components/events/attachmentViewers/logFileViewer.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import Ansi from 'ansi-to-react';
 
+import {AnsiText} from 'sentry/components/ansiText';
 import {PreviewPanelItem} from 'sentry/components/events/attachmentViewers/previewPanelItem';
 import type {ViewerProps} from 'sentry/components/events/attachmentViewers/utils';
 import {getAttachmentUrl} from 'sentry/components/events/attachmentViewers/utils';
@@ -31,48 +31,13 @@ export function LogFileViewer(props: ViewerProps) {
   return data ? (
     <PreviewPanelItem>
       <CodeWrapper>
-        <SentryStyleAnsi useClasses>{data}</SentryStyleAnsi>
+        <Code>
+          <AnsiText text={data} normalizeTerminalSequences />
+        </Code>
       </CodeWrapper>
     </PreviewPanelItem>
   ) : null;
 }
-
-/**
- * Maps ANSI color names -> theme.tsx color names
- */
-const COLOR_MAP = {
-  red: 'red',
-  green: 'green',
-  blue: 'blue',
-  yellow: 'yellow',
-  magenta: 'pink',
-  cyan: 'blue',
-} as const;
-
-const SentryStyleAnsi = styled(Ansi)`
-  ${p =>
-    Object.entries(COLOR_MAP).map(
-      ([ansiColor, themeColor]) => `
-      .ansi-${ansiColor}-bg {
-        background-color: ${p.theme.colors[`${themeColor}500`]};
-      }
-      .ansi-${ansiColor}-fg {
-        color: ${p.theme.colors[`${themeColor}500`]};
-      }
-      .ansi-bright-${ansiColor}-fg {
-        color: ${p.theme.colors[`${themeColor}200`]};
-      }`
-    )}
-
-  .ansi-black-fg,
-  .ansi-bright-black-fg {
-    color: ${p => p.theme.colors.black};
-  }
-  .ansi-white-fg,
-  .ansi-bright-white-fg {
-    color: ${p => p.theme.colors.white};
-  }
-`;
 
 const CodeWrapper = styled('pre')`
   padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
@@ -81,4 +46,8 @@ const CodeWrapper = styled('pre')`
   &:after {
     content: '';
   }
+`;
+
+const Code = styled('code')`
+  display: block;
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import {AnsiText} from 'sentry/components/ansiText';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import {Timeline} from 'sentry/components/timeline';
@@ -44,7 +45,11 @@ export function BreadcrumbItemContent({
 
   const defaultMessage = defined(bc.message) ? (
     <BreadcrumbText>
-      <StructuredData value={bc.message} meta={meta?.message} {...structuredDataProps} />
+      {meta?.message ? (
+        <StructuredData value={bc.message} meta={meta.message} {...structuredDataProps} />
+      ) : (
+        <AnsiText text={bc.message} />
+      )}
     </BreadcrumbText>
   ) : null;
 
@@ -201,12 +206,22 @@ function ExceptionCrumbContent({
 
   const hasValue = value !== null && value !== undefined && value !== '';
   const formattedValue = hasValue ? formatValue(value) : '';
+  let renderedValue: React.ReactNode = null;
+
+  if (hasValue) {
+    renderedValue = meta?.data?.value ? (
+      formattedValue
+    ) : (
+      <AnsiText text={formattedValue} />
+    );
+  }
 
   return (
     <Fragment>
       <BreadcrumbText>
         {type ? type : null}
-        {type && hasValue ? `: ${formattedValue}` : hasValue ? formattedValue : null}
+        {type && hasValue ? ': ' : null}
+        {renderedValue}
       </BreadcrumbText>
       {children}
       {Object.keys(otherData).length > 0 ? (

--- a/static/app/components/events/eventMessage.tsx
+++ b/static/app/components/events/eventMessage.tsx
@@ -4,6 +4,7 @@ import {ErrorLevel} from 'sentry/components/events/errorLevel';
 import {UnhandledTag} from 'sentry/components/group/inboxBadges/unhandledTag';
 import {t} from 'sentry/locale';
 import type {EventOrGroupType, Level} from 'sentry/types/event';
+import {stripAnsi} from 'sentry/utils/ansiEscapeCodes';
 import {eventTypeHasLogLevel} from 'sentry/utils/events';
 import {Divider} from 'sentry/views/issueDetails/divider';
 
@@ -23,8 +24,9 @@ export function EventMessage({
   showUnhandled = false,
 }: Props) {
   const showEventLevel = level && eventTypeHasLogLevel(type);
+  const displayMessage = typeof message === 'string' ? stripAnsi(message) : message;
   const renderedMessage = message ? (
-    <Message>{message}</Message>
+    <Message>{displayMessage}</Message>
   ) : (
     <NoMessage>({t('No error message')})</NoMessage>
   );

--- a/static/app/components/events/interfaces/crashContent/exception/utils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/utils.tsx
@@ -1,12 +1,6 @@
 import type {ReactElement} from 'react';
-import {Fragment} from 'react';
-import styled from '@emotion/styled';
 
-import {ExternalLink} from '@sentry/scraps/link';
-
-import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
-import {IconOpen} from 'sentry/icons';
-import {isValidUrl} from 'sentry/utils/string/isValidUrl';
+import {AnsiText} from 'sentry/components/ansiText';
 
 interface RenderLinksInTextProps {
   exceptionText: string;
@@ -15,53 +9,7 @@ interface RenderLinksInTextProps {
 export const renderLinksInText = ({
   exceptionText,
 }: RenderLinksInTextProps): ReactElement => {
-  // https?: Matches both "http" and "https"
-  // :\/\/: This is a literal match for "://"
-  // (?:www\.)?: Matches URLs with or without "www."
-  // [-a-zA-Z0-9@:%._\+~#=]{1,256}: Matches the domain name
-  //    It allows for a range of characters (letters, digits, and special characters)
-  //    The {1,256} specifies that these characters can occur anywhere from 1 to 256 times, which covers the range of typical domain name lengths
-  // \.: Matches the dot before the top-level domain (like ".com")
-  // [a-zA-Z0-9]{1,6}: Matches the top-level domain (like "com" or "org"). It's limited to letters and digits and can be between 1 and 6 characters long
-  // (?:[-a-zA-Z0-9@:%_\+~#?&\/=,\[\].]*[-a-zA-Z0-9@:%_\+~#?&\/=,\[\]])?: Matches the path, query parameters, or fragments that can follow the domain in a URL
-  //    It now includes periods within the character set to allow for file extensions (e.g., ".html") and other period-containing segments in the URL path
-  //    This pattern matches a wide range of characters typically found in paths, query strings, and fragments, including periods
-  //    The final character set ensures that the URL ends with a character typically allowed in a path, query string, or fragment, excluding special characters like a trailing period not part of the URL
-  // /gi: The regex will match all occurrences in the string, not just the first one
-  //    The "i" modifier makes the regex match both upper and lower case characters
-
-  const urlRegex =
-    /https?:\/\/(?:www\.)?[-\w@:%.+~#=]{1,256}\.[a-z0-9]{1,6}(?:[-\w@:%+~#?&/=,[\].]*[-\w@:%+~#?&/=,[\]])?/gi;
-
-  const parts = exceptionText.split(urlRegex);
-  const urls = exceptionText.match(urlRegex) || [];
-
-  const elements = parts.flatMap((part, index) => {
-    const url = urls[index]!;
-    const linkIsValid = isValidUrl(url);
-
-    let link: ReactElement | undefined;
-    if (linkIsValid) {
-      link = (
-        <ExternalLink
-          key={`link-${index}`}
-          onClick={e => {
-            e.preventDefault();
-            openNavigateToExternalLinkModal({linkText: url});
-          }}
-        >
-          {url}
-          <IconPlacement size="xs" />
-        </ExternalLink>
-      );
-    } else if (url) {
-      link = <span key={`invalid-url-${index}`}>{url}</span>;
-    }
-
-    return [<Fragment key={`text-${index}`}>{part}</Fragment>, link];
-  });
-
-  return <Fragment>{elements}</Fragment>;
+  return <AnsiText text={exceptionText} />;
 };
 
 // Maps the SDK name to the url token for docs
@@ -94,9 +42,3 @@ export const sourceMapSdkDocsMap: Record<string, string> = {
   'sentry.javascript.react-native': 'react-native',
   'sentry.javascript.astro': 'astro',
 };
-
-const IconPlacement = styled(IconOpen)`
-  display: inline-block;
-  margin-left: 5px;
-  vertical-align: center;
-`;


### PR DESCRIPTION
ANSI escape codes were showing up literally in exception values, message interfaces, and breadcrumb text. This adds a shared ANSI renderer that parses the display string into React spans, maps standard colors through the Sentry theme, and keeps URLs going through Sentry's external-link modal.

This also vendors the small ansi-to-react path we still needed for attachment logs, with the BSD notice preserved, so we can drop the package and avoid raw anchor/linkify behavior.

Fixes https://github.com/getsentry/sentry/issues/116110