### PR TITLE
test(logs): Update trace item timestamp expectations

### DIFF
--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -223,6 +223,10 @@ describe('logsTableRow', () => {
     });
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('hovering the row causes prefetching of the row details', async () => {
     jest.useFakeTimers();
     expect(rowDetailsMock).toHaveBeenCalledTimes(0);
@@ -253,10 +257,9 @@ describe('logsTableRow', () => {
       expect(rowDetailsMock).toHaveBeenCalledTimes(1);
     });
     expect(rowDetailsMock.mock.calls[0]![1].query).toMatchObject({
-      timestamp: rowDataTimestamp,
+      timestamp: Math.trunc(rowDataTimestamp),
     });
     expect(rowDetailsMock.mock.calls[0]![1].query).not.toHaveProperty('statsPeriod');
-    jest.useRealTimers();
   });
 
   it('renders row details', async () => {
@@ -315,7 +318,7 @@ describe('logsTableRow', () => {
       expect(rowDetailsMock).toHaveBeenCalledTimes(1);
     });
     expect(rowDetailsMock.mock.calls[0]![1].query).toMatchObject({
-      timestamp: rowDataTimestamp,
+      timestamp: Math.trunc(rowDataTimestamp),
     });
     expect(rowDetailsMock.mock.calls[0]![1].query).not.toHaveProperty('statsPeriod');
 


### PR DESCRIPTION
Fixing issue with failing log tests introduced in: https://github.com/getsentry/sentry/pull/116374