### PR TITLE
ref(rpc): log from `_make_rpc_request`

### DIFF
--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -145,19 +145,6 @@ def _make_rpc_requests(
             else "EndpointTimeSeries"
         )
         endpoint_names.append(endpoint_name)
-        logger_extra = {
-            "rpc_query": json.loads(MessageToJson(request)),
-            "referrer": request.meta.referrer,
-            "organization_id": request.meta.organization_id,
-            "trace_item_type": request.meta.trace_item_type,
-            "debug": debug is not False,
-        }
-        if isinstance(debug, str):
-            logger_extra["debug_msg"] = debug
-        logger.info(
-            f"Running a {endpoint_name} RPC query",  # noqa: LOG011
-            extra=logger_extra,
-        )
 
     referrers = [req.meta.referrer for req in requests]
     assert len(referrers) == len(requests) == len(endpoint_names), (
@@ -172,6 +159,7 @@ def _make_rpc_requests(
         _make_rpc_request,
         thread_isolation_scope=sentry_sdk.get_isolation_scope(),
         thread_current_scope=sentry_sdk.get_current_scope(),
+        debug=debug,
     )
     with ContextPropagatingThreadPoolExecutor(
         thread_name_prefix=__name__, max_workers=10
@@ -368,7 +356,23 @@ def _make_rpc_request(
     req: SnubaRPCRequest | CreateSubscriptionRequest,
     thread_isolation_scope: sentry_sdk.Scope | None = None,
     thread_current_scope: sentry_sdk.Scope | None = None,
+    debug: str | bool = False,
 ) -> BaseHTTPResponse:
+    logger_extra: dict[str, object] = {
+        "rpc_query": json.loads(MessageToJson(req)),  # type: ignore[arg-type]
+        "referrer": referrer,
+        "debug": debug is not False,
+    }
+    if isinstance(req, ProtobufMessage) and hasattr(req, "meta"):
+        logger_extra["organization_id"] = req.meta.organization_id
+        logger_extra["trace_item_type"] = req.meta.trace_item_type
+    if isinstance(debug, str):
+        logger_extra["debug_msg"] = debug
+    logger.info(
+        f"Running a {endpoint_name} RPC query",  # noqa: LOG011
+        extra=logger_extra,
+    )
+
     thread_isolation_scope = (
         sentry_sdk.get_isolation_scope()
         if thread_isolation_scope is None

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -358,20 +358,23 @@ def _make_rpc_request(
     thread_current_scope: sentry_sdk.Scope | None = None,
     debug: str | bool = False,
 ) -> BaseHTTPResponse:
-    logger_extra: dict[str, object] = {
-        "rpc_query": json.loads(MessageToJson(req)),  # type: ignore[arg-type]
-        "referrer": referrer,
-        "debug": debug is not False,
-    }
-    if isinstance(req, ProtobufMessage) and hasattr(req, "meta"):
-        logger_extra["organization_id"] = req.meta.organization_id
-        logger_extra["trace_item_type"] = req.meta.trace_item_type
-    if isinstance(debug, str):
-        logger_extra["debug_msg"] = debug
-    logger.info(
-        f"Running a {endpoint_name} RPC query",  # noqa: LOG011
-        extra=logger_extra,
-    )
+    try:
+        logger_extra: dict[str, object] = {
+            "rpc_query": json.loads(MessageToJson(req)),  # type: ignore[arg-type]
+            "referrer": referrer,
+            "debug": debug is not False,
+        }
+        if isinstance(req, ProtobufMessage) and hasattr(req, "meta"):
+            logger_extra["organization_id"] = req.meta.organization_id
+            logger_extra["trace_item_type"] = req.meta.trace_item_type
+        if isinstance(debug, str):
+            logger_extra["debug_msg"] = debug
+        logger.info(
+            f"Running a {endpoint_name} RPC query",  # noqa: LOG011
+            extra=logger_extra,
+        )
+    except Exception:
+        logger.exception("Failed to log RPC query")
 
     thread_isolation_scope = (
         sentry_sdk.get_isolation_scope()


### PR DESCRIPTION
Move the request logging from `_make_rpc_requests` to `_make_rpc_request`, which it delegates each individual request to. We were already logging one line per RPC request, and this way we will also log for callers who call `_make_rpc_request` directly.

🤖: The typing got a little nasty and I used Claude Code (Opus 4.6) to resolve the issues.