### PR TITLE
ref: delete unused options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -46,7 +46,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register("system.secret-key", flags=FLAG_CREDENTIAL | FLAG_NOSTORE)
-register("system.root-api-key", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("system.logging-format", default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint
 register("system.upload-url-prefix", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
@@ -91,12 +90,6 @@ register(
 )
 # The region that this instance is currently running in.
 register("system.region", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE)
-# Enable date-util parsing for timestamps
-register(
-    "system.use-date-util-timestamps",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Organization
 register(
@@ -127,7 +120,6 @@ register(
     default={"default": {"hosts": {0: {"host": "127.0.0.1", "port": 6379}}}},
     flags=FLAG_NOSTORE | FLAG_IMMUTABLE,
 )
-register("redis.options", type=Dict, flags=FLAG_NOSTORE)
 
 # Processing worker caches
 register(
@@ -140,12 +132,6 @@ register(
     "releasefile.cache-path",
     type=String,
     default="/tmp/sentry-releasefile-cache",
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "releasefile.cache-limit",
-    type=Int,
-    default=10 * 1024 * 1024,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
@@ -322,27 +308,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# API Tokens
-register(
-    "apitoken.auto-add-last-chars",
-    default=True,
-    type=Bool,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "apitoken.save-hash-on-create",
-    default=True,
-    type=Bool,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# Controls the rate of using the hashed value of User API tokens for lookups when logging in
-# and also updates tokens which are not hashed
-register(
-    "apitoken.use-and-update-hash-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "api.rate-limit.org-create",
@@ -408,10 +373,6 @@ register(
 register("filestore.control.backend", default="", flags=FLAG_NOSTORE)
 register("filestore.control.options", default={}, flags=FLAG_NOSTORE)
 
-# Whether to use a redis lock on fileblob uploads and deletes
-register("fileblob.upload.use_lock", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Whether to use redis to cache `FileBlob.id` lookups
-register("fileblob.upload.use_blobid_cache", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # New `objectstore` service configuration. Additional supported options and
 # their defaults:
@@ -499,18 +460,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Configuration Options
-register(
-    "configurations.storage.backend",
-    default=None,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "configurations.storage.options",
-    type=Dict,
-    default=None,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Flag Options
 register(
@@ -568,13 +517,6 @@ register(
     default=0.0,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Enables profiling for replay recording ingestion.
-register(
-    "replay.consumer.recording.profiling.enabled",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Enable new msgspec-based recording parser.
 register(
     "replay.consumer.msgspec_recording_parser",
@@ -628,15 +570,6 @@ register(
 register(
     "ourlogs.sentry-emit-rollout",
     default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# Ingest only a random fraction of logs sent to relay. Used to roll out ourlogs ingestion.
-#
-# NOTE: Any value below 1.0 will cause customer data to not appear and can break the product. Do not override in production.
-register(
-    "relay.ourlogs-ingestion.sample-rate",
-    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
@@ -755,7 +688,6 @@ register(
 
 # Codecov Integration
 register("codecov.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
-register("codecov.base-url", default="https://api.codecov.io")
 register("codecov.api-bridge-signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
 # GitHub Integration
@@ -838,16 +770,6 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register("github-login.organization", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
-register(
-    "github-extension.enabled",
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "github-extension.enabled-orgs",
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # VSTS Integration
 register("vsts.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
@@ -931,16 +853,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "snuba.search.pre-snuba-candidates-percentage",
-    default=0.2,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "snuba.search.project-group-count-cache-time",
-    default=24 * 60 * 60,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "snuba.search.min-pre-snuba-candidates",
     default=500,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
@@ -989,7 +901,6 @@ register(
     default={7001: 0.15},
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
-register("snuba.track-outcomes-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
 register(
@@ -1006,27 +917,7 @@ register(
     type=Int,
 )
 
-# Kafka Publisher
-register(
-    "kafka-publisher.raw-event-sample-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# Enable multiple topics for eventstream. It allows specific event types to be sent
-# to specific topic.
-register(
-    "store.eventstream-per-type-topic",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# Query and supply Bundle Indexes to Symbolicator SourceMap processing
-register(
-    "symbolicator.sourcemaps-bundle-index-sample-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Refresh Bundle Indexes reported as used by symbolicator
 register(
     "symbolicator.sourcemaps-bundle-index-refresh-sample-rate",
@@ -1042,18 +933,8 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Enables setting a sampling rate when producing the tag facet.
-register(
-    "discover2.tags_facet_enable_sampling",
-    default=True,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# Enable use of symbolic-sourcemapcache for JavaScript Source Maps processing.
-# Set this value of the fraction of projects that you want to use it for.
-register(
-    "processing.sourcemapcache-processor", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
-)  # unused
+# unused
 
 # Killswitch for sending internal errors to the internal project or
 # `SENTRY_SDK_CONFIG.relay_dsn`. Set to `0` to only send to
@@ -1068,23 +949,12 @@ register("store.allow-s4s-ddm-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MO
 # Sample rate for transaction/span data sent to S4S upstream (1.0 = keep all, 0.05 = keep 5%)
 register("store.s4s-transaction-sample-rate", default=1.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# Mock out integrations and services for tests
-register("mocks.jira", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# Record statistics about event payloads and their compressibility
-register(
-    "store.nodestore-stats-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
-)  # unused
+# unused
 
 # Killswitch to stop storing any reprocessing payloads.
 register("store.reprocessing-force-disable", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# Enable calling the severity modeling API on group creation
-register(
-    "processing.calculate-severity-on-group-creation",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Enable sending the flag to the microservice to tell it to purposefully take longer than our
 # timeout, to see the effect on the overall error event processing backlog
@@ -1102,12 +972,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "issues.severity.first-event-severity-calculation-projects-allowlist",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "issues.severity.seer-project-rate-limit",
@@ -1137,20 +1001,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "issues.priority.projects-allowlist",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# Killswitch for issue priority
-register(
-    "issues.priority.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Killswitch for batched nodestore fetches in group events endpoint.
 # When disabled, falls back to lazy per-event nodestore fetches.
@@ -1190,12 +1040,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "seer.similarity-embeddings-grouping-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "seer.similarity-embeddings-delete-by-hash-killswitch.enabled",
     default=False,
     type=Bool,
@@ -1218,30 +1062,6 @@ register(
     type=Int,
     default=1,
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.severity-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.breakpoint-detection-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.autofix-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.anomaly-detection-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # Agent context engine indexing options
@@ -1339,37 +1159,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# seer nearest neighbour endpoint timeout
-register(
-    "embeddings-grouping.seer.nearest-neighbour-timeout",
-    type=Float,
-    default=0.1,
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# seer embeddings record update endpoint timeout
-register(
-    "embeddings-grouping.seer.embeddings-record-update-timeout",
-    type=Float,
-    default=0.05,
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# seer embeddings record delete endpoint timeout
-register(
-    "embeddings-grouping.seer.embeddings-record-delete-timeout",
-    type=Float,
-    default=0.1,
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# seer embeddings ratelimit in percentage that is allowed
-register(
-    "embeddings-grouping.seer.ratelimit",
-    type=Int,
-    default=0,
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "embeddings-grouping.seer.delete-record-batch-size",
@@ -1487,12 +1276,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "store.save-event-highcpu-platforms",
-    type=Sequence,
-    default=[],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "post_process.get-autoassign-owners",
     type=Sequence,
     default=[],
@@ -1533,9 +1316,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Minimum number of files in an archive. Archives with fewer files are extracted and have their
-# contents stored as separate release files.
-register("processing.release-archive-min-files", default=10, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # All Relay options (statically authenticated Relays can be registered here)
 register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
@@ -1582,15 +1362,6 @@ register(
 # Subscription queries sampling rate
 register("subscriptions-query.sample-rate", default=0.01, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# The ratio of symbolication requests for which metrics will be submitted to redis.
-#
-# This is to allow gradual rollout of metrics collection for symbolication requests and can be
-# removed once it is fully rolled out.
-register(
-    "symbolicate-event.low-priority.metrics.submission-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # The ratio of events for which we emit verbose apple symbol stats.
 #
@@ -1728,13 +1499,6 @@ register(
 
 register(
     "organization-abuse-quota.metric-bucket-limit",
-    type=Int,
-    default=0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "organization-abuse-quota.custom-metric-bucket-limit",
     type=Int,
     default=0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
@@ -1992,11 +1756,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "sentry-metrics.synchronize-kafka-rebalances",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "sentry-metrics.synchronized-rebalance-delay",
@@ -2234,57 +1993,9 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "performance.traces.trace-explorer-buffer-hours",
-    type=Float,
-    default=1.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-max-trace-ids-per-chunk",
-    type=Int,
-    default=2500,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-skip-floating-spans",
-    type=Bool,
-    default=True,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-scan-max-block-size-hours",
-    type=Int,
-    default=8,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-scan-max-batches",
-    type=Int,
-    default=7,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-scan-max-execution-seconds",
-    type=Int,
-    default=30,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.trace-explorer-scan-max-parallel-queries",
-    type=Int,
-    default=3,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "performance.traces.trace-explorer-skip-recent-seconds",
     type=Int,
     default=0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.traces.span_query_minimum_spans",
-    type=Int,
-    default=10000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -2313,21 +2024,9 @@ register(
 )
 
 register(
-    "performance.spans-tags-key.sample-rate",
-    type=Float,
-    default=1.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "performance.spans-tags-key.max",
     type=Int,
     default=1000,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "performance.spans-tags-value.sample-rate",
-    type=Float,
-    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -2349,14 +2048,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# In Single Tenant with 100% DS, we may need to reverse the UI change made by dynamic-sampling
-# if metrics extraction isn't ready.
-register(
-    "performance.hide-metrics-ui",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Used for the z-score when calculating the margin of error in performance
 register(
@@ -2466,8 +2157,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Flagpole Configuration (used in getsentry)
-register("flagpole.debounce_reporting_seconds", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Feature flagging error capture rate.
 # When feature flagging has faults, it can become very high volume and we can overwhelm sentry.
@@ -2477,7 +2166,6 @@ register("features.error.capture_rate", default=0.1, flags=FLAG_AUTOMATOR_MODIFI
 register("hybridcloud.regionsiloclient.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.rpc.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.integrationproxy.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("hybridcloud.endpoint_flag_logging", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register(
     "hybridcloud.rpc.method_retry_overrides",
     default={},
@@ -2701,18 +2389,6 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "statistical_detectors.enable.projects.performance",
-    type=Sequence,
-    default=[],
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "statistical_detectors.enable.projects.profiling",
-    type=Sequence,
-    default=[],
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "statistical_detectors.query.batch_size",
     type=Int,
     default=100,
@@ -2798,11 +2474,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "metric_extraction.max_span_attribute_specs",
-    default=100,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "metric_alerts.extended_max_subscriptions",
@@ -2941,12 +2612,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# The flag disables the file io on main thread detector
-register(
-    "performance_issues.file_io_main_thread.disabled",
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Enables on-demand metric extraction for Dashboard Widgets.
 register(
@@ -3047,12 +2712,6 @@ register(
     flags=FLAG_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Relocation: globally limits the number of large (>100MB) relocations allowed per silo per day.
-register(
-    "relocation.daily-limit.large",
-    default=0,
-    flags=FLAG_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "profiling.killswitch.ingest-profiles",
@@ -3128,31 +2787,7 @@ register(
 )
 
 
-# Switch to read assemble status from Redis instead of memcache
-register("assemble.read_from_redis", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
-
 # Sampling rates for testing Rust-based grouping enhancers
-
-# Rate at which to run the Rust implementation of `assemble_stacktrace_component`
-# and compare the results
-register(
-    "grouping.rust_enhancers.compare_components",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-# Rate at which to prefer the Rust implementation of `assemble_stacktrace_component`.
-register(
-    "grouping.rust_enhancers.prefer_rust_components",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "metrics.sample-list.sample-rate",
-    type=Float,
-    default=100_000.0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 
 # TODO: For now, only a small number of projects are going through a grouping config transition at
@@ -3187,20 +2822,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-
-# Sample rate for double writing to experimental dsn
-register(
-    "store.experimental-dsn-double-write.sample-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# temporary option for logging canonical key fallback stacktraces
-register(
-    "canonical-fallback.send-error-to-sentry",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # SPAN BUFFER
 # Span buffer killswitch
@@ -3396,30 +3017,6 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "indexed-spans.agg-span-waterfall.enable",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "traces.sample-list.sample-rate",
-    type=Float,
-    default=0.0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "discover.saved-query-dataset-split.enable",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "discover.saved-query-dataset-split.organization-id-allowlist",
-    type=Sequence,
-    default=[],
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "feedback.filter_garbage_messages",
@@ -3473,38 +3070,6 @@ register(
 )
 # Notification Options - End
 
-# List of organizations with increased rate limits for organization_events API
-register(
-    "api.organization_events.rate-limit-increased.orgs",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-# Increased rate limits for organization_events API for the orgs above
-register(
-    "api.organization_events.rate-limit-increased.limits",
-    type=Dict,
-    default={"limit": 50, "window": 1, "concurrent_limit": 50},
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-# Reduced rate limits for organization_events API for the orgs in LA/EA/GA rollout
-# Once GA'd, this will be the default rate limit for all orgs not on the increase list
-register(
-    "api.organization_events.rate-limit-reduced.limits",
-    type=Dict,
-    default={"limit": 1000, "window": 300, "concurrent_limit": 15},
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-
-# TODO: remove once removed from options
-register(
-    "issue_platform.use_kafka_partition_key",
-    type=Bool,
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 
 register(
     "sentry.save-event-attachments.project-per-5-minute-limit",
@@ -3534,21 +3099,7 @@ register(
     default=250,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Limits the total duration of profile chunks to aggregate in flamegraphs
-register(
-    "profiling.continuous-profiling.flamegraph.max-seconds",
-    type=Int,
-    default=10 * 60,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
-# Enable orjson in the occurrence_consumer.process_[message|batch]
-register(
-    "issues.occurrence_consumer.use_orjson",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Controls the rate of using the sentry api shared secret for communicating to sentry.
 # DEPRECATED: will be removed after the shared secret is confirmed to always be set.
@@ -3559,11 +3110,6 @@ register(
 )
 
 register(
-    "similarity.backfill_project_cohort_size",
-    default=1000,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "similarity.new_project_seer_grouping.enabled",
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
@@ -3571,12 +3117,6 @@ register(
 register(
     "delayed_processing.batch_size",
     default=10000,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "delayed_processing.emit_logs",
-    type=Bool,
-    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -3691,17 +3231,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Disables specific uptime checker regions. This is a list of region slugs
-# which must match regions available in the settings.UPTIME_REGIONS list.
-#
-# Useful to remove a region from check rotation if there is some kind of
-# problem with the region.
-register(
-    "uptime.disabled-checker-regions",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 register(
     "uptime.checker-regions-mode-override",
     type=Dict,
@@ -3946,17 +3475,6 @@ register(
 register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 
-# option used to enable/disable tracking
-# rate of potential functions metrics to
-# be written into EAP
-register(
-    "profiling.track_functions_metrics_write_rate.eap.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-
 register(
     "sentry.send_onboarding_task_metrics",
     type=Bool,
@@ -4139,12 +3657,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "seer.scanner_no_consent.rollout_rate",
-    type=Float,
-    default=0.0,
-    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Enabled Prebuilt Dashboard IDs
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2708,6 +2708,12 @@ register(
     flags=FLAG_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Relocation: globally limits the number of large (>100MB) relocations allowed per silo per day.
+register(
+    "relocation.daily-limit.large",
+    default=0,
+    flags=FLAG_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "profiling.killswitch.ingest-profiles",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -934,8 +934,6 @@ register(
 )
 
 
-# unused
-
 # Killswitch for sending internal errors to the internal project or
 # `SENTRY_SDK_CONFIG.relay_dsn`. Set to `0` to only send to
 # `SENTRY_SDK_CONFIG.dsn` (the "upstream transport") and nothing else.
@@ -949,8 +947,6 @@ register("store.allow-s4s-ddm-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MO
 # Sample rate for transaction/span data sent to S4S upstream (1.0 = keep all, 0.05 = keep 5%)
 register("store.s4s-transaction-sample-rate", default=1.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-
-# unused
 
 # Killswitch to stop storing any reprocessing payloads.
 register("store.reprocessing-force-disable", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
@@ -2785,9 +2781,6 @@ register(
     default=False,
     flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
-
-
-# Sampling rates for testing Rust-based grouping enhancers
 
 
 # TODO: For now, only a small number of projects are going through a grouping config transition at

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -183,7 +183,6 @@ class OptionsManager:
     def __init__(self, store: OptionsStore):
         self.store = store
         self.registry: dict[str, Key] = {}
-        self._seen: set[str] = set()
 
     def set(self, key: str, value, coerce=True, channel: UpdateChannel = UpdateChannel.UNKNOWN):
         """
@@ -284,13 +283,6 @@ class OptionsManager:
         """
         return key in settings.SENTRY_OPTIONS
 
-    def _record_seen(self, key: str) -> None:
-        """Emit one log line per key per process lifetime so reads can be
-        audited in GCP. Logs before adding to _seen so a logging failure
-        doesn't permanently suppress the event."""
-        logger.info("option.seen", extra={"option_key": key})
-        self._seen.add(key)
-
     def get(self, key: str, silent=False):
         """
         Get the value of an option, falling back to the local configuration.
@@ -314,12 +306,6 @@ class OptionsManager:
             sample_rate=0.01,
         ) as tags:
             opt = self.lookup_key(key)
-            if key not in self._seen:
-                try:
-                    self._record_seen(key)
-                except Exception:
-                    # Tracking is best-effort. Never let it affect option reads.
-                    pass
 
             # First check if the option should exist on disk, and if it actually
             # has a value set, let's use that one instead without even attempting

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -287,10 +287,8 @@ class OptionsManager:
     def _record_seen(self, key: str) -> None:
         """Emit one log line per key per process lifetime so reads can be
         audited in GCP. Logs before adding to _seen so a logging failure
-        doesn't permanently suppress the event. In debug mode, mark keys as
-        seen without logging to keep local tooling output clean."""
-        if not settings.DEBUG:
-            logger.info("option.seen", extra={"option_key": key})
+        doesn't permanently suppress the event."""
+        logger.info("option.seen", extra={"option_key": key})
         self._seen.add(key)
 
     def get(self, key: str, silent=False):

--- a/tests/sentry/tasks/test_options.py
+++ b/tests/sentry/tasks/test_options.py
@@ -11,15 +11,12 @@ from sentry.testutils.silo import all_silo_test
 class SyncOptionsTest(TestCase):
     _TEST_KEY = "foo"
 
-    _SEEN_TEST_KEY = "test.option-seen"
-
     def tearDown(self) -> None:
         super().tearDown()
-        for key in (self._TEST_KEY, self._SEEN_TEST_KEY):
-            try:
-                default_manager.unregister(key)
-            except UnknownOption:
-                pass
+        try:
+            default_manager.unregister(self._TEST_KEY)
+        except UnknownOption:
+            pass
 
     def test_task_persistent_name(self) -> None:
         assert sync_options.name == "sentry.tasks.options.sync_options"
@@ -38,22 +35,3 @@ class SyncOptionsTest(TestCase):
         sync_options(cutoff=60)
 
         assert not mock_set_cache.called
-
-    def test_option_seen_logs_first_access_and_short_circuits(self) -> None:
-        default_manager.register(self._SEEN_TEST_KEY, default="x")
-        default_manager._seen.discard(self._SEEN_TEST_KEY)
-
-        # First read: must emit exactly one log record with the key in extra.
-        with self.assertLogs("sentry", level="INFO") as cm:
-            default_manager.get(self._SEEN_TEST_KEY)
-
-        assert any(
-            r.getMessage() == "option.seen"
-            and getattr(r, "option_key", None) == self._SEEN_TEST_KEY
-            for r in cm.records
-        )
-        assert self._SEEN_TEST_KEY in default_manager._seen
-
-        # Second read: short-circuit — _record_seen must not be called again.
-        with self.assertNoLogs("sentry", level="INFO"):
-            default_manager.get(self._SEEN_TEST_KEY)


### PR DESCRIPTION
this removes 93 unused options identified via tracking read options via logging in #115610 (which this PR also reverts as I'm done collecting data) cross referenced with static analysis in https://github.com/getsentry/sentry-options/pull/123

the details are in https://github.com/getsentry/sentry-options/pull/123 - `scripts/migration/safe.txt` is essentially the set intersection of statically unreferenced options and unseen/unread options over 120 hours of GCP production logs.

the unseen list was determined by subtracting options.seen unique events from all known options (options.all()) and I observed no newly seen options beyond the ~100 hour mark (`scripts/migration/collect-seen-options-out.txt`).

getsentry options that were unused are removed here too: https://github.com/getsentry/getsentry/pull/20449