### PR TITLE
feat(workflow-engine): Implement Seer Activity handler

### DIFF
--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -48,6 +48,7 @@ from sentry.taskworker.namespaces import seer_tasks
 from sentry.types.activity import ActivityType
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
+from sentry.workflow_engine.registry import invoke_workflow_activity_handlers
 
 SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
     SentryAppEventType.SEER_ROOT_CAUSE_STARTED: ActivityType.SEER_RCA_STARTED,
@@ -775,12 +776,13 @@ def _create_seer_activity(
         if pull_requests:
             activity_data["pull_requests"] = pull_requests
 
-    Activity.objects.create_group_activity(
+    activity = Activity.objects.create_group_activity(
         group,
         activity_type,
         data=activity_data if activity_data else None,
         send_notification=False,
     )
+    invoke_workflow_activity_handlers(group=group, activity=activity)
 
 
 @instrumented_task(

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -1,9 +1,64 @@
+import logging
+
+from sentry import features
 from sentry.models.activity import Activity
 from sentry.models.group import Group
+from sentry.types.activity import ActivityType
+from sentry.utils import metrics
 from sentry.workflow_engine.registry import workflow_activity_registry
+
+logger = logging.getLogger(__name__)
+
+SEER_WORKFLOW_ACTIVITIES = [
+    ActivityType.SEER_RCA_STARTED.value,
+    ActivityType.SEER_RCA_COMPLETED.value,
+    ActivityType.SEER_SOLUTION_STARTED.value,
+    ActivityType.SEER_SOLUTION_COMPLETED.value,
+    ActivityType.SEER_CODING_STARTED.value,
+    ActivityType.SEER_CODING_COMPLETED.value,
+    ActivityType.SEER_PR_CREATED.value,
+]
 
 
 @workflow_activity_registry.register("seer_activity")
 def seer_activity_handler(group: Group, activity: Activity) -> None:
-    # TODO(Leander): Implement this handler
-    pass
+    from sentry.workflow_engine.models import Detector
+    from sentry.workflow_engine.tasks.workflows import process_workflow_activity
+
+    if activity.type not in SEER_WORKFLOW_ACTIVITIES:
+        return
+
+    if not features.has(
+        "organizations:workflow-engine-evaluate-seer-activities", group.organization
+    ):
+        return
+
+    try:
+        activity_name = ActivityType(activity.type).name
+    except ValueError:
+        activity_name = "unknown"
+
+    logging_ctx = {
+        "activity_type": activity.type,
+        "activity_name": activity_name,
+        "group_id": group.id,
+        "project_id": group.project_id,
+    }
+
+    try:
+        detector = Detector.get_issue_stream_detector_for_project(group.project_id)
+    except Detector.DoesNotExist:
+        logger.error(
+            "workflow_engine.seer_activity_handler.missing_detector",
+            extra=logging_ctx,
+            exc_info=True,
+        )
+        return
+
+    process_workflow_activity.delay(
+        activity_id=activity.id,
+        group_id=group.id,
+        detector_id=detector.id,
+    )
+    metrics.incr("workflow_engine.seer_activity_handler", tags={"activity_name": activity_name})
+    logging.info("workflow_engine.seer_activity_handler.success", extra=logging_ctx)

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -61,4 +61,4 @@ def seer_activity_handler(group: Group, activity: Activity) -> None:
         detector_id=detector.id,
     )
     metrics.incr("workflow_engine.seer_activity_handler", tags={"activity_name": activity_name})
-    logging.info("workflow_engine.seer_activity_handler.success", extra=logging_ctx)
+    logger.info("workflow_engine.seer_activity_handler.success", extra=logging_ctx)

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -5,27 +5,41 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
+from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.registry import workflow_activity_registry
+from sentry.workflow_engine.tasks.workflows import process_workflow_activity
 
 logger = logging.getLogger(__name__)
 
 SEER_WORKFLOW_ACTIVITIES = [
-    ActivityType.SEER_RCA_STARTED.value,
-    ActivityType.SEER_RCA_COMPLETED.value,
-    ActivityType.SEER_SOLUTION_STARTED.value,
-    ActivityType.SEER_SOLUTION_COMPLETED.value,
-    ActivityType.SEER_CODING_STARTED.value,
-    ActivityType.SEER_CODING_COMPLETED.value,
-    ActivityType.SEER_PR_CREATED.value,
+    ActivityType.SEER_RCA_STARTED,
+    ActivityType.SEER_RCA_COMPLETED,
+    ActivityType.SEER_SOLUTION_STARTED,
+    ActivityType.SEER_SOLUTION_COMPLETED,
+    ActivityType.SEER_CODING_STARTED,
+    ActivityType.SEER_CODING_COMPLETED,
+    ActivityType.SEER_PR_CREATED,
 ]
 
 
 @workflow_activity_registry.register("seer_activity")
 def seer_activity_handler(group: Group, activity: Activity) -> None:
-    from sentry.workflow_engine.models import Detector
-    from sentry.workflow_engine.tasks.workflows import process_workflow_activity
+    logging_ctx = {
+        "activity_type": activity.type,
+        "group_id": group.id,
+        "project_id": group.project_id,
+    }
 
-    if activity.type not in SEER_WORKFLOW_ACTIVITIES:
+    try:
+        activity_type = ActivityType(activity.type)
+    except ValueError:
+        logger.exception(
+            "workflow_engine.seer_activity_handler.invalid_activity_type", extra=logging_ctx
+        )
+        return
+    logging_ctx["activity_name"] = activity_type.name
+
+    if activity_type not in SEER_WORKFLOW_ACTIVITIES:
         return
 
     if not features.has(
@@ -34,24 +48,10 @@ def seer_activity_handler(group: Group, activity: Activity) -> None:
         return
 
     try:
-        activity_name = ActivityType(activity.type).name
-    except ValueError:
-        activity_name = "unknown"
-
-    logging_ctx = {
-        "activity_type": activity.type,
-        "activity_name": activity_name,
-        "group_id": group.id,
-        "project_id": group.project_id,
-    }
-
-    try:
         detector = Detector.get_issue_stream_detector_for_project(group.project_id)
     except Detector.DoesNotExist:
-        logger.error(
-            "workflow_engine.seer_activity_handler.missing_detector",
-            extra=logging_ctx,
-            exc_info=True,
+        logger.exception(
+            "workflow_engine.seer_activity_handler.missing_detector", extra=logging_ctx
         )
         return
 
@@ -60,5 +60,8 @@ def seer_activity_handler(group: Group, activity: Activity) -> None:
         group_id=group.id,
         detector_id=detector.id,
     )
-    metrics.incr("workflow_engine.seer_activity_handler", tags={"activity_name": activity_name})
-    logger.info("workflow_engine.seer_activity_handler.success", extra=logging_ctx)
+    metrics.incr(
+        "workflow_engine.seer_activity_handler.complete",
+        tags={"activity_name": activity_type.name},
+    )
+    logger.info("workflow_engine.seer_activity_handler.complete", extra=logging_ctx)

--- a/src/sentry/workflow_engine/registry.py
+++ b/src/sentry/workflow_engine/registry.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 from sentry.models.activity import Activity
@@ -10,6 +11,8 @@ from sentry.workflow_engine.types import (
     WorkflowActivityHandler,
 )
 
+logger = logging.getLogger(__name__)
+
 data_source_type_registry = Registry[type[DataSourceTypeHandler[Any]]]()
 condition_handler_registry = Registry[type[DataConditionHandler[Any]]](enable_reverse_lookup=False)
 action_handler_registry = Registry[type[ActionHandler]](enable_reverse_lookup=False)
@@ -17,5 +20,17 @@ workflow_activity_registry = Registry[WorkflowActivityHandler](enable_reverse_lo
 
 
 def invoke_workflow_activity_handlers(group: Group, activity: Activity) -> None:
-    for handler in workflow_activity_registry.registrations.values():
-        handler(group, activity)
+    for handler_key, handler in workflow_activity_registry.registrations.items():
+        try:
+            handler(group, activity)
+        except Exception:
+            logger.exception(
+                "workflow_engine.invoke_workflow_activity_handlers.error",
+                extra={
+                    "group_id": group.id,
+                    "activity_id": activity.id,
+                    "handler_name": handler_key,
+                    "activity_type": activity.type,
+                },
+            )
+            continue

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -966,6 +966,25 @@ class SeerOperatorTest(TestCase):
             == "https://github.com/owner/repo/pull/42"
         )
 
+    @patch("sentry.seer.entrypoints.operator.invoke_workflow_activity_handlers")
+    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
+    def test_create_seer_activity_invokes_workflow_activity_handlers(
+        self, _mock_has_access, mock_invoke
+    ):
+        event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
+
+        with self.feature("organizations:seer-activity-timeline"):
+            process_autofix_updates(
+                event_type=SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
+                event_payload=event_payload,
+                organization_id=self.organization.id,
+            )
+
+        mock_invoke.assert_called_once()
+        call_kwargs = mock_invoke.call_args[1]
+        assert call_kwargs["group"] == self.group
+        assert call_kwargs["activity"].type == ActivityType.SEER_RCA_STARTED.value
+
 
 class TestGetAutofixExplorerStatus(TestCase):
     @staticmethod

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -44,6 +44,7 @@ from sentry.seer.models import SeerAutomationHandoffConfiguration, SeerProjectPr
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.testutils.asserts import assert_failure_metric
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 
 
@@ -966,6 +967,7 @@ class SeerOperatorTest(TestCase):
             == "https://github.com/owner/repo/pull/42"
         )
 
+    @with_feature("organizations:seer-activity-timeline")
     @patch("sentry.seer.entrypoints.operator.invoke_workflow_activity_handlers")
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_create_seer_activity_invokes_workflow_activity_handlers(
@@ -973,12 +975,11 @@ class SeerOperatorTest(TestCase):
     ):
         event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
 
-        with self.feature("organizations:seer-activity-timeline"):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
-                event_payload=event_payload,
-                organization_id=self.organization.id,
-            )
+        process_autofix_updates(
+            event_type=SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
+            event_payload=event_payload,
+            organization_id=self.organization.id,
+        )
 
         mock_invoke.assert_called_once()
         call_kwargs = mock_invoke.call_args[1]

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -1,11 +1,18 @@
 from unittest import mock
+from unittest.mock import MagicMock
 
 from sentry.testutils.cases import TestCase
 from sentry.types.activity import ActivityType
+from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import (
+    SEER_WORKFLOW_ACTIVITIES,
+    seer_activity_handler,
+)
+from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.registry import (
     invoke_workflow_activity_handlers,
     workflow_activity_registry,
 )
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
 class WorkflowActivityRegistryTest(TestCase):
@@ -36,3 +43,60 @@ class WorkflowActivityRegistryTest(TestCase):
     def test_invoke_handlers_no_registrants(self) -> None:
         with mock.patch.dict(workflow_activity_registry.registrations, {}, clear=True):
             invoke_workflow_activity_handlers(self.group, self.activity)
+
+
+class SeerActivityHandlerTest(TestCase):
+    def setUp(self) -> None:
+        self.group = self.create_group()
+        self.activity = self.create_group_activity(
+            group=self.group, type=ActivityType.SEER_PR_CREATED.value
+        )
+        self.detector = self.create_detector(type=IssueStreamGroupType.slug, project=self.project)
+
+    @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity")
+    def test_feature_flag_disabled(self, mock_process_workflow_activity: MagicMock) -> None:
+        seer_activity_handler(self.group, self.activity)
+        mock_process_workflow_activity.delay.assert_not_called()
+
+    @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity")
+    def test_all_supported_activity_types_dispatch(
+        self, mock_process_workflow_activity: MagicMock
+    ) -> None:
+        with self.feature("organizations:workflow-engine-evaluate-seer-activities"):
+            for activity_type_value in SEER_WORKFLOW_ACTIVITIES:
+                mock_process_workflow_activity.reset_mock()
+                activity = self.create_group_activity(group=self.group, type=activity_type_value)
+                seer_activity_handler(self.group, activity)
+                assert mock_process_workflow_activity.delay.called, (
+                    f"Task not dispatched for {activity_type_value}"
+                )
+                mock_process_workflow_activity.delay.assert_called_once_with(
+                    activity_id=activity.id,
+                    group_id=self.group.id,
+                    detector_id=self.detector.id,
+                )
+
+    @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity")
+    def test_skips_unsupported_activity_type(
+        self, mock_process_workflow_activity: MagicMock
+    ) -> None:
+        activity = self.create_group_activity(group=self.group, type=ActivityType.NOTE.value)
+        with self.feature("organizations:workflow-engine-evaluate-seer-activities"):
+            seer_activity_handler(self.group, activity)
+
+        mock_process_workflow_activity.delay.assert_not_called()
+
+    @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity")
+    @mock.patch(
+        "sentry.workflow_engine.models.Detector.get_issue_stream_detector_for_project",
+        side_effect=Exception("DoesNotExist"),
+    )
+    def test_skips_when_no_issue_stream_detector(
+        self, mock_get_detector: MagicMock, mock_process_workflow_activity: MagicMock
+    ) -> None:
+        mock_get_detector.side_effect = Detector.DoesNotExist
+
+        with self.feature("organizations:workflow-engine-evaluate-seer-activities"):
+            seer_activity_handler(self.group, self.activity)
+
+        mock_process_workflow_activity.delay.assert_not_called()

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -2,6 +2,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import (
     SEER_WORKFLOW_ACTIVITIES,
@@ -55,40 +56,49 @@ class SeerActivityHandlerTest(TestCase):
         )
         self.detector = self.create_detector(type=IssueStreamGroupType.slug, project=self.project)
 
-    @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
     def test_feature_flag_disabled(self, mock_process_workflow_activity: MagicMock) -> None:
         seer_activity_handler(self.group, self.activity)
         mock_process_workflow_activity.delay.assert_not_called()
 
-    @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity")
+    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
     def test_all_supported_activity_types_dispatch(
         self, mock_process_workflow_activity: MagicMock
     ) -> None:
-        with self.feature("organizations:workflow-engine-evaluate-seer-activities"):
-            for activity_type_value in SEER_WORKFLOW_ACTIVITIES:
-                mock_process_workflow_activity.reset_mock()
-                activity = self.create_group_activity(group=self.group, type=activity_type_value)
-                seer_activity_handler(self.group, activity)
-                assert mock_process_workflow_activity.delay.called, (
-                    f"Task not dispatched for {activity_type_value}"
-                )
-                mock_process_workflow_activity.delay.assert_called_once_with(
-                    activity_id=activity.id,
-                    group_id=self.group.id,
-                    detector_id=self.detector.id,
-                )
+        for activity_type in SEER_WORKFLOW_ACTIVITIES:
+            mock_process_workflow_activity.reset_mock()
+            activity = self.create_group_activity(group=self.group, type=activity_type.value)
+            seer_activity_handler(self.group, activity)
+            assert mock_process_workflow_activity.delay.called, (
+                f"Task not dispatched for {activity_type.value}"
+            )
+            mock_process_workflow_activity.delay.assert_called_once_with(
+                activity_id=activity.id,
+                group_id=self.group.id,
+                detector_id=self.detector.id,
+            )
 
-    @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity")
+    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
     def test_skips_unsupported_activity_type(
         self, mock_process_workflow_activity: MagicMock
     ) -> None:
         activity = self.create_group_activity(group=self.group, type=ActivityType.NOTE.value)
-        with self.feature("organizations:workflow-engine-evaluate-seer-activities"):
-            seer_activity_handler(self.group, activity)
+        seer_activity_handler(self.group, activity)
 
         mock_process_workflow_activity.delay.assert_not_called()
 
-    @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity")
+    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
     @mock.patch(
         "sentry.workflow_engine.models.Detector.get_issue_stream_detector_for_project",
         side_effect=Exception("DoesNotExist"),
@@ -98,7 +108,6 @@ class SeerActivityHandlerTest(TestCase):
     ) -> None:
         mock_get_detector.side_effect = Detector.DoesNotExist
 
-        with self.feature("organizations:workflow-engine-evaluate-seer-activities"):
-            seer_activity_handler(self.group, self.activity)
+        seer_activity_handler(self.group, self.activity)
 
         mock_process_workflow_activity.delay.assert_not_called()

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -26,19 +26,21 @@ class WorkflowActivityRegistryTest(TestCase):
         assert "seer_activity" in workflow_activity_registry.registrations
         assert len(workflow_activity_registry.registrations) == 1
 
-    def test_invoke_handlers(self) -> None:
+    def test_invoke_handlers_safely(self) -> None:
         handler_a = mock.Mock()
-        handler_b = mock.Mock()
+        handler_b = mock.Mock(side_effect=Exception("Test error"))
+        handler_c = mock.Mock()
 
         with mock.patch.dict(
             workflow_activity_registry.registrations,
-            {"handler_a": handler_a, "handler_b": handler_b},
+            {"handler_a": handler_a, "handler_b": handler_b, "handler_c": handler_c},
             clear=True,
         ):
             invoke_workflow_activity_handlers(self.group, self.activity)
 
         handler_a.assert_called_once_with(self.group, self.activity)
         handler_b.assert_called_once_with(self.group, self.activity)
+        handler_c.assert_called_once_with(self.group, self.activity)
 
     def test_invoke_handlers_no_registrants(self) -> None:
         with mock.patch.dict(workflow_activity_registry.registrations, {}, clear=True):


### PR DESCRIPTION
This will trigger the `process_workflow_activity` for relevant Seer activities, noop for unrelated activities or organizations missing the necessary flag.

The rest of the workflow engine will consume the activity just fine, but we're still lacking the data condition to set up alerts and the fixes on actions to support firing properly, (M2 and M3 respectively)

In practice an organization would need two flags, one for this workflow processor, one that permits creating seer activities in the first place.