### PR TITLE
ref(integrations): Redirect GitHub installs straight to the link page

### DIFF
--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -116,7 +116,6 @@ class IntegrationClassification(BaseClassification):
             and not request.path.endswith("/setup/")
             # or match the routes for integrationOrganizationLink page (See routes.tsx)
             and not request.path.endswith("/link/")
-            and not request.path.startswith("/extensions/external-install/")
         )
 
     def get_response(self, request: HttpRequest) -> HttpResponseBase:

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -64,9 +64,12 @@ def _render_trampoline(request: HttpRequest, pipeline: object, provider_id: str)
     # trampoline can navigate there if there's no opener window.
     installation_id = request.GET.get("installation_id")
     if request.GET.get("setup_action") == "install" and installation_id:
-        fallback_url = str(
-            dumps_htmlsafe(reverse("integration-installation", args=[provider_id, installation_id]))
+        link_url = reverse(
+            "sentry-integration-installation-link",
+            kwargs={"integration_slug": provider_id},
+            query={"installationId": installation_id},
         )
+        fallback_url = str(dumps_htmlsafe(link_url))
     else:
         fallback_url = "null"
 
@@ -132,7 +135,11 @@ class PipelineAdvancerView(BaseView):
             and installation_id
         ):
             return self.redirect(
-                reverse("integration-installation", args=[provider_id, installation_id])
+                reverse(
+                    "sentry-integration-installation-link",
+                    kwargs={"integration_slug": provider_id},
+                    query={"installationId": installation_id},
+                )
             )
 
         if pipeline is None or not pipeline.is_valid():

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -802,9 +802,9 @@ urlpatterns += [
         ),
     ),
     re_path(
-        r"^extensions/external-install/(?P<provider_id>\w+)/(?P<installation_id>\w+)/$",
+        r"^extensions/(?P<integration_slug>[^/]+)/link/$",
         react_page_view,
-        name="integration-installation",
+        name="sentry-integration-installation-link",
     ),
     re_path(
         r"^unsubscribe/(?P<organization_slug>[^/]+)/project/(?P<project_id>\d+)/$",

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -1850,7 +1850,11 @@ class GitHubPipelineAdvancerTest(IntegrationTestCase):
         )
 
     def _get_expected_redirect(self, installation_id: str = "12345") -> str:
-        return reverse("integration-installation", args=["github", installation_id])
+        return reverse(
+            "sentry-integration-installation-link",
+            kwargs={"integration_slug": "github"},
+            query={"installationId": installation_id},
+        )
 
     @responses.activate
     def test_no_pipeline_redirects_to_org_picker(self) -> None:
@@ -1874,7 +1878,7 @@ class GitHubPipelineAdvancerTest(IntegrationTestCase):
         resp = self.client.get(self._get_setup_install_url())
         assert resp.status_code == 200
         assert b"window.opener" in resp.content
-        assert b"extensions/external-install" in resp.content
+        assert b'"/extensions/github/link/?installationId=12345"' in resp.content
 
 
 @control_silo_test

--- a/tests/sentry/middleware/integrations/test_parsers_defined.py
+++ b/tests/sentry/middleware/integrations/test_parsers_defined.py
@@ -29,7 +29,7 @@ def test_parsers_for_all_extension_urls() -> None:
         [_, provider, _trailing] = pattern.split("/", maxsplit=2)
 
         # Ignore dynamic segments or providers without middleware parsers
-        if provider[0] in {"(", "["} or provider in {"external-install", "cursor"}:
+        if provider[0] in {"(", "["} or provider in {"cursor"}:
             continue
 
         # Ensure the expected module exists


### PR DESCRIPTION
When a user installs the Sentry GitHub App directly from github.com, GitHub redirects to `/extensions/github/setup/?setup_action=install&...` and `PipelineAdvancerView` was bouncing them onward to the legacy `/extensions/external-install/<provider>/<id>/` URL, which existed only to render the React org-picker. This skips the intermediate hop and redirects straight to the picker's real URL, `/extensions/<slug>/link/?installationId=<id>`. The trampoline page's fallback URL (for the rare case where the OAuth popup has no opener) gets the same treatment.

To make this `reverse()`-able rather than a hardcoded path string, the `/extensions/<slug>/link/` route is registered as `sentry-integration-installation-link` (it was previously served only by the catch-all). The now-unused `integration-installation` URL is removed, and the matching carve-out in the integration request classifier middleware goes with it.

The companion frontend cleanup (deleting `GitHubInstallRedirect` and its route entry) lands in a follow-up PR.