### PR TITLE
fix(jest): exclude scripts/ from discovery and module resolution

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -323,7 +323,15 @@ const config: Config.InitialOptions = {
     '<rootDir>/tests/js/setupFramework.ts',
   ],
   testMatch: testMatch || ['<rootDir>/(static|tests/js)/**/?(*.)+(spec|test).[jt]s?(x)'],
-  testPathIgnorePatterns: ['<rootDir>/tests/sentry/lang/javascript/'],
+  testPathIgnorePatterns: [
+    '<rootDir>/tests/sentry/lang/javascript/',
+    // ESM-style helper scripts (e.g. scripts/genPlatformProductInfo.ts use
+    // `const __dirname = path.dirname(fileURLToPath(import.meta.url))`) that
+    // SWC's CJS transform redeclares — collides with Node's module wrapper.
+    // None of these are tests; keep them out of Jest's discovery entirely.
+    '<rootDir>/scripts/',
+  ],
+  modulePathIgnorePatterns: ['<rootDir>/scripts/'],
 
   unmockedModulePathPatterns: [
     '<rootDir>/node_modules/react',


### PR DESCRIPTION
## Problem

Jest 30 + SWC fails to parse \`scripts/genPlatformProductInfo.ts\`:

\`\`\`
/scripts/genPlatformProductInfo.ts:51
const __dirname = _nodepath.dirname((0, _nodeurl.fileURLToPath)(require(\"url\").pathToFileURL(__filename).toString()));
      ^
SyntaxError: Identifier '__dirname' has already been declared
\`\`\`

The source uses \`const __dirname = path.dirname(fileURLToPath(import.meta.url))\` to recover \`__dirname\` under ESM. SWC's CJS transform emits that \`const\` verbatim, which collides with the \`__dirname\` Node already provides via the module wrapper.

On PR runs where Jest goes through the \`--listTests --changedSince\` path, that crash cascades — workers report a wave of \"Your test suite must contain at least one test\" errors against unrelated source files (illustrations, theme tokens, jquery vendored copy, etc.) and the shards time out at 30 min. Symptom observed repeatedly on getsentry/sentry#116269 across multiple pushes regardless of rebase/merge shape. Master pushes were unaffected because they don't trigger the same traversal.

## Solution

Add \`<rootDir>/scripts/\` to both \`testPathIgnorePatterns\` and \`modulePathIgnorePatterns\` in \`jest.config.ts\`. Jest's discovery and module resolution both skip the directory.

### Why this is safe

- Nothing in \`scripts/\` is a test — \`testMatch\` already scopes test discovery to \`(static|tests/js)/**\`.
- Nothing in \`static/*\` or \`tests/js/*\` imports from \`scripts/\` (grep-verified).
- \`scripts/\` is build-time tooling (codegen, type coverage, dev-ui-server, etc.).

### Future durable fix

A cleaner fix would patch \`scripts/genPlatformProductInfo.ts\` to rename its local \`__dirname\` binding (e.g. \`THIS_DIR\`) so the SWC-transformed output doesn't collide. This PR is the lower-risk version that unblocks CI without modifying the codegen script (which \`pnpm gen:platform-info\` depends on).

### Verified on

PR getsentry/sentry#116269 carried this fix as a tentative experimental commit and the Jest shards went green for the first time after several days of timeouts. Splitting it out here per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)