### PR TITLE
fix(preprod): Balance padding on active tag filter chips

### DIFF
--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -407,7 +407,7 @@ const TagFilterSection = memo(function TagFilterSection({
         </Disclosure.Content>
       </TagDisclosure>
       {hasActiveFilter && (
-        <Flex gap="xs" wrap="wrap" padding="lg" paddingTop="0">
+        <Flex gap="xs" wrap="wrap" padding="sm lg">
           {Object.entries(activeTagFilters).map(([key, value]) => (
             <TagChip
               isActive
@@ -528,7 +528,6 @@ const TagDisclosure = styled(Disclosure)`
     }
   }
 `;
-
 const VirtualRowPositioner = styled('div')`
   position: absolute;
   top: 0;


### PR DESCRIPTION
Even out the top and bottom padding on the active tag filter chips section below the Tags disclosure header in the snapshot sidebar. Previously, the top padding was removed (`paddingTop="0"`) creating an unbalanced look. This sets equal `sm` vertical padding with `lg` horizontal padding.