### PR TITLE
fix(integrations): Use paginated jira projects endpoint in another place

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -173,11 +173,19 @@ class JiraIntegration(IssueSyncIntegration):
         client = self.get_client()
 
         try:
-            if features.has("organizations:jira-paginated-project-config", organization):
-                # Use the paginated endpoint to avoid fetching all projects at once,
-                # which can time out for large Jira instances. The settings page
-                # dropdown search (typeahead) handles finding projects beyond this
-                # initial page via JiraSearchEndpoint.
+            use_paginated = features.has(
+                "organizations:jira-paginated-project-config", organization
+            )
+            logger.info(
+                "jira.get-organization-config.projects",
+                extra={
+                    "org_id": self.organization_id,
+                    "org_slug": organization.slug,
+                    "integration_id": self.model.id,
+                    "paginated": use_paginated,
+                },
+            )
+            if use_paginated:
                 projects_response = client.get_projects_paginated(params={"maxResults": 50})
                 projects: list[JiraProjectMapping] = [
                     JiraProjectMapping(value=p["id"], label=p["name"])
@@ -398,8 +406,21 @@ class JiraIntegration(IssueSyncIntegration):
             self.org_integration = org_integration
 
     def _filter_active_projects(self, project_mappings: QuerySet[IntegrationExternalProject]):
-        project_ids_set = {p["id"] for p in self.get_client().get_projects_list()}
+        client = self.get_client()
+        context = organization_service.get_organization_by_id(
+            id=self.organization_id, include_projects=False, include_teams=False
+        )
+        if context and features.has(
+            "organizations:jira-paginated-project-config", context.organization
+        ):
+            project_ids = [pm.external_id for pm in project_mappings]
+            if not project_ids:
+                return []
+            response = client.get_projects_paginated(params={"id": project_ids})
+            active_ids = {p["id"] for p in response.get("values", [])}
+            return [pm for pm in project_mappings if pm.external_id in active_ids]
 
+        project_ids_set = {p["id"] for p in client.get_projects_list()}
         return [pm for pm in project_mappings if pm.external_id in project_ids_set]
 
     def get_config_data(self):

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -38,7 +38,6 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
-from sentry.organizations.services.organization.service import organization_service
 from sentry.pipeline.views.base import PipelineView
 from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import (
@@ -164,28 +163,10 @@ class JiraIntegration(IssueSyncIntegration):
     def get_organization_config(self) -> list[dict[str, Any]]:
         configuration: list[dict[str, Any]] = self._get_organization_config_default_values()
 
-        context = organization_service.get_organization_by_id(
-            id=self.organization_id, include_projects=False, include_teams=False
-        )
-        assert context, "organizationcontext must exist to get org"
-        organization = context.organization
-
         client = self.get_client()
 
         try:
-            use_paginated = features.has(
-                "organizations:jira-paginated-project-config", organization
-            )
-            logger.info(
-                "jira.get-organization-config.projects",
-                extra={
-                    "org_id": self.organization_id,
-                    "org_slug": organization.slug,
-                    "integration_id": self.model.id,
-                    "paginated": use_paginated,
-                },
-            )
-            if use_paginated:
+            if features.has("organizations:jira-paginated-project-config", self.organization):
                 projects_response = client.get_projects_paginated(params={"maxResults": 50})
                 projects: list[JiraProjectMapping] = [
                     JiraProjectMapping(value=p["id"], label=p["name"])
@@ -204,7 +185,7 @@ class JiraIntegration(IssueSyncIntegration):
                 "Unable to communicate with the Jira instance. You may need to reinstall the addon."
             )
 
-        has_issue_sync = features.has("organizations:integrations-issue-sync", organization)
+        has_issue_sync = features.has("organizations:integrations-issue-sync", self.organization)
         if not has_issue_sync:
             for field in configuration:
                 field["disabled"] = True
@@ -407,12 +388,7 @@ class JiraIntegration(IssueSyncIntegration):
 
     def _filter_active_projects(self, project_mappings: QuerySet[IntegrationExternalProject]):
         client = self.get_client()
-        context = organization_service.get_organization_by_id(
-            id=self.organization_id, include_projects=False, include_teams=False
-        )
-        if context and features.has(
-            "organizations:jira-paginated-project-config", context.organization
-        ):
+        if features.has("organizations:jira-paginated-project-config", self.organization):
             project_ids = [pm.external_id for pm in project_mappings]
             if not project_ids:
                 return []

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -392,7 +392,9 @@ class JiraIntegration(IssueSyncIntegration):
             project_ids = [pm.external_id for pm in project_mappings]
             if not project_ids:
                 return []
-            response = client.get_projects_paginated(params={"id": project_ids})
+            response = client.get_projects_paginated(
+                params={"id": project_ids, "maxResults": len(project_ids)}
+            )
             active_ids = {p["id"] for p in response.get("values", [])}
             return [pm for pm in project_mappings if pm.external_id in active_ids]
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1260,6 +1260,65 @@ class JiraIntegrationTest(APITestCase):
         }
 
     @responses.activate
+    def test_get_config_data_filters_via_paginated_endpoint_with_flag(self) -> None:
+        integration = self.create_provider_integration(
+            provider="jira",
+            name="Example Jira",
+            metadata={
+                "oauth_client_id": "oauth-client-id",
+                "shared_secret": "a-super-secret-key-from-atlassian",
+                "base_url": "https://example.atlassian.net",
+                "domain_name": "example.atlassian.net",
+            },
+        )
+        integration.add_organization(self.organization, self.user)
+
+        org_integration = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration_id=integration.id
+        )
+
+        org_integration.config = {
+            "sync_comments": True,
+            "sync_forward_assignment": True,
+            "sync_reverse_assignment": True,
+            "sync_status_reverse": True,
+            "sync_status_forward": True,
+        }
+        org_integration.save()
+
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id="12345",
+            unresolved_status="in_progress",
+            resolved_status="done",
+        )
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id="67890",
+            unresolved_status="in_progress",
+            resolved_status="done",
+        )
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project/search",
+            json={"values": [{"id": "12345", "name": "Active Project"}]},
+        )
+
+        installation = integration.get_installation(self.organization.id)
+
+        with self.feature("organizations:jira-paginated-project-config"):
+            config = installation.get_config_data()
+
+        assert config["sync_status_forward"] == {
+            "12345": {"on_resolve": "done", "on_unresolve": "in_progress"},
+        }
+        assert len(responses.calls) == 1
+        assert "rest/api/2/project/search" in responses.calls[0].request.url
+        assert "id=12345" in responses.calls[0].request.url
+        assert "id=67890" in responses.calls[0].request.url
+
+    @responses.activate
     def test_get_config_data_issue_keys(self) -> None:
         integration = self.create_provider_integration(
             provider="jira",


### PR DESCRIPTION
#116327 used the paginated Jira project endpoint, but we were also using the unpaginated version in `_filter_active_projects`. Instead of grabbing the whole list, we can search just the project ids we have set up, also using the paginated endpoint.