### PR TITLE
feat(cells): Use control silo organization listing for setup wizard

### DIFF
--- a/static/app/views/setupWizard/types.tsx
+++ b/static/app/views/setupWizard/types.tsx
@@ -1,10 +1,6 @@
-import type {Organization, OrganizationSummary} from 'sentry/types/organization';
+import type {OrganizationSummary} from 'sentry/types/organization';
 import type {Region} from 'sentry/types/system';
 
 export type OrganizationSummaryWithRegion = OrganizationSummary & {
-  region: Region;
-};
-
-export type OrganizationWithRegion = Organization & {
   region: Region;
 };

--- a/static/app/views/setupWizard/types.tsx
+++ b/static/app/views/setupWizard/types.tsx
@@ -1,5 +1,9 @@
-import type {Organization} from 'sentry/types/organization';
+import type {Organization, OrganizationSummary} from 'sentry/types/organization';
 import type {Region} from 'sentry/types/system';
+
+export type OrganizationSummaryWithRegion = OrganizationSummary & {
+  region: Region;
+};
 
 export type OrganizationWithRegion = Organization & {
   region: Region;

--- a/static/app/views/setupWizard/utils/setupWizardAnalytics.tsx
+++ b/static/app/views/setupWizard/utils/setupWizardAnalytics.tsx
@@ -1,9 +1,9 @@
 import {useCallback, useEffect, useMemo} from 'react';
 
-import type {Organization} from 'sentry/types/organization';
+import type {OrganizationSummary} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
-function useSetupWizardAnalyticsParams(organizations: Organization[]) {
+function useSetupWizardAnalyticsParams(organizations: OrganizationSummary[]) {
   const urlParams = new URLSearchParams(location.search);
   const projectPlatform = urlParams.get('project_platform') ?? undefined;
 
@@ -20,7 +20,9 @@ function useSetupWizardAnalyticsParams(organizations: Organization[]) {
 
 const EMPTY_ARRAY: any = [];
 
-export function useSetupWizardViewedAnalytics(organizations: Organization[] | undefined) {
+export function useSetupWizardViewedAnalytics(
+  organizations: OrganizationSummary[] | undefined
+) {
   const analyticsParams = useSetupWizardAnalyticsParams(organizations ?? EMPTY_ARRAY);
 
   useEffect(() => {
@@ -31,7 +33,7 @@ export function useSetupWizardViewedAnalytics(organizations: Organization[] | un
   }, [analyticsParams, organizations?.length]);
 }
 
-export function useSetupWizardCompletedAnalytics(organizations: Organization[]) {
+export function useSetupWizardCompletedAnalytics(organizations: OrganizationSummary[]) {
   const analyticsParams = useSetupWizardAnalyticsParams(organizations);
 
   return useCallback(() => {

--- a/static/app/views/setupWizard/utils/useCreateProjectFromWizard.tsx
+++ b/static/app/views/setupWizard/utils/useCreateProjectFromWizard.tsx
@@ -3,13 +3,13 @@ import {useMutation} from '@tanstack/react-query';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
 import {useApi} from 'sentry/utils/useApi';
-import type {OrganizationWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
 export function useCreateProjectFromWizard() {
   const api = useApi();
   return useMutation({
     mutationFn: (params: {
       name: string;
-      organization: OrganizationWithRegion;
+      organization: OrganizationSummaryWithRegion;
       platform: string;
       team: string | null;
     }): Promise<Project> => {

--- a/static/app/views/setupWizard/utils/useOrganizationDetails.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationDetails.tsx
@@ -2,12 +2,12 @@ import {skipToken, useQuery} from '@tanstack/react-query';
 
 import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {OrganizationWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
 
 export function useOrganizationDetails({
   organization,
 }: {
-  organization?: OrganizationWithRegion;
+  organization?: OrganizationSummaryWithRegion;
 }) {
   return useQuery({
     ...apiOptions.as<Organization>()('/organizations/$organizationIdOrSlug/', {

--- a/static/app/views/setupWizard/utils/useOrganizationProjects.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationProjects.tsx
@@ -2,13 +2,13 @@ import {skipToken, useQuery} from '@tanstack/react-query';
 
 import type {Project} from 'sentry/types/project';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {OrganizationWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
 
 export function useOrganizationProjects({
   organization,
   query,
 }: {
-  organization?: OrganizationWithRegion;
+  organization?: OrganizationSummaryWithRegion;
   query?: string;
 }) {
   return useQuery({

--- a/static/app/views/setupWizard/utils/useOrganizationTeams.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationTeams.tsx
@@ -2,12 +2,12 @@ import {skipToken, useQuery} from '@tanstack/react-query';
 
 import type {Team} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {OrganizationWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
 
 export function useOrganizationTeams({
   organization,
 }: {
-  organization?: OrganizationWithRegion;
+  organization?: OrganizationSummaryWithRegion;
 }) {
   return useQuery({
     ...apiOptions.as<Team[]>()('/organizations/$organizationIdOrSlug/teams/', {

--- a/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import {useQuery} from '@tanstack/react-query';
 
 import {ConfigStore} from 'sentry/stores/configStore';
@@ -21,6 +22,18 @@ export function useOrganizationsWithRegion() {
       return response.json.flatMap((org): OrganizationSummaryWithRegion[] => {
         const region = regionByUrl.get(org.links.regionUrl);
         if (!region) {
+          // This is not expected to happen, but log it so we can diagnose if
+          // an organization's region is missing from the member regions.
+          Sentry.captureMessage(
+            'Could not match organization region URL to a member region',
+            {
+              level: 'warning',
+              extra: {
+                organizationSlug: org.slug,
+                regionUrl: org.links.regionUrl,
+              },
+            }
+          );
           return [];
         }
         return [{...org, region} as OrganizationSummaryWithRegion];

--- a/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
@@ -1,37 +1,36 @@
-import {queryOptions, useQueries} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 
 import {ConfigStore} from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {Organization} from 'sentry/types/organization';
+import type {OrganizationSummary} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {OrganizationWithRegion} from 'sentry/views/setupWizard/types';
 
 export function useOrganizationsWithRegion() {
-  const {memberRegions} = useLegacyStore(ConfigStore);
+  const {memberRegions, links} = useLegacyStore(ConfigStore);
 
-  return useQueries({
-    queries: memberRegions.map(region =>
-      queryOptions({
-        ...apiOptions.as<Organization[]>()('/organizations/', {
-          host: region.url,
-          // Authentication errors can happen as we span regions.
-          allowAuthError: true,
-          staleTime: 0,
-        }),
-        refetchOnWindowFocus: false,
-        retry: false,
-        select: response =>
-          response.json.map(org => ({
-            ...org,
-            region,
-          })),
-      })
-    ),
-    combine: results => {
-      return {
-        data: results.flatMap(r => r.data ?? []),
-        isError: results.some(r => r.isError),
-        isPending: results.some(r => r.isPending),
-      };
+  const query = useQuery({
+    ...apiOptions.as<OrganizationSummary[]>()('/organizations/', {
+      host: links.sentryUrl, // request from control silo
+      staleTime: 0,
+    }),
+    refetchOnWindowFocus: false,
+    retry: false,
+    select: response => {
+      const regionByUrl = new Map(memberRegions.map(region => [region.url, region]));
+      return response.json.flatMap((org): OrganizationWithRegion[] => {
+        const region = regionByUrl.get(org.links.regionUrl);
+        if (!region) {
+          return [];
+        }
+        return [{...org, region} as OrganizationWithRegion];
+      });
     },
   });
+
+  return {
+    data: query.data ?? [],
+    isError: query.isError,
+    isPending: query.isPending,
+  };
 }

--- a/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
@@ -4,7 +4,7 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {OrganizationSummary} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {OrganizationWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
 
 export function useOrganizationsWithRegion() {
   const {memberRegions, links} = useLegacyStore(ConfigStore);
@@ -18,12 +18,12 @@ export function useOrganizationsWithRegion() {
     retry: false,
     select: response => {
       const regionByUrl = new Map(memberRegions.map(region => [region.url, region]));
-      return response.json.flatMap((org): OrganizationWithRegion[] => {
+      return response.json.flatMap((org): OrganizationSummaryWithRegion[] => {
         const region = regionByUrl.get(org.links.regionUrl);
         if (!region) {
           return [];
         }
-        return [{...org, region} as OrganizationWithRegion];
+        return [{...org, region} as OrganizationSummaryWithRegion];
       });
     },
   });

--- a/static/app/views/setupWizard/waitingForWizardToConnect.tsx
+++ b/static/app/views/setupWizard/waitingForWizardToConnect.tsx
@@ -6,7 +6,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconCheckmark} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
+import type {OrganizationSummary} from 'sentry/types/organization';
 import {useApi} from 'sentry/utils/useApi';
 import {useSetupWizardCompletedAnalytics} from 'sentry/views/setupWizard/utils/setupWizardAnalytics';
 
@@ -15,7 +15,7 @@ export function WaitingForWizardToConnect({
   organizations,
 }: {
   hash: string;
-  organizations: Organization[];
+  organizations: OrganizationSummary[];
 }) {
   const api = useApi();
   const closeTimeoutRef = useRef<number | undefined>(undefined);

--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -18,12 +18,12 @@ import {allPlatforms as platforms} from 'sentry/data/platforms';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
-import type {Organization} from 'sentry/types/organization';
+import type {OrganizationSummary} from 'sentry/types/organization';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 import {ProjectLoadingError} from 'sentry/views/setupWizard/projectLoadingError';
-import type {OrganizationWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
 import {useCreateProjectFromWizard} from 'sentry/views/setupWizard/utils/useCreateProjectFromWizard';
 import {useOrganizationDetails} from 'sentry/views/setupWizard/utils/useOrganizationDetails';
 import {useOrganizationProjects} from 'sentry/views/setupWizard/utils/useOrganizationProjects';
@@ -37,11 +37,11 @@ const urlParams = new URLSearchParams(location.search);
 const platformParam = urlParams.get('project_platform');
 const orgSlugParam = urlParams.get('org_slug');
 
-function getOrgDisplayName(organization: Organization) {
+function getOrgDisplayName(organization: OrganizationSummary) {
   return organization.name || organization.slug;
 }
 
-function getInitialOrgId(organizations: Organization[]) {
+function getInitialOrgId(organizations: OrganizationSummary[]) {
   if (organizations.length === 1) {
     return organizations[0]!.id;
   }
@@ -76,7 +76,7 @@ export function WizardProjectSelection({
   organizations,
 }: {
   hash: string;
-  organizations: OrganizationWithRegion[];
+  organizations: OrganizationSummaryWithRegion[];
 }) {
   const [search, setSearch] = useState('');
 


### PR DESCRIPTION
This replaces the per-locality fan-out and merge in the setup wizard frontend code with a single call to `/organizations/` from the control silo.

The cell silo version of this endpoint will be deprecated in the future as it cannot be supported when we have multiple cells per locality.

This version should also be more robust as it removes the partial failure mode, which could occur if a single cell was unavailable.
