### PR TITLE
feat(issues): Fully enable recording of Seer actions as issue activities (with option)

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4204,3 +4204,12 @@ register(
     type=Bool,
     flags=FLAG_NOSTORE,
 )
+
+# Allows the recording of Seer actions as issue activities
+# https://linear.app/getsentry/project/add-seer-actions-to-issue-activityaction-log-0e641e1f5dac/overview
+register(
+    "issues.record-seer-actions-as-activities",
+    default=True,
+    type=Bool,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from sentry import features
+from sentry import features, options
 from sentry.constants import DataCategory
 from sentry.models.activity import Activity
 from sentry.models.group import Group
@@ -563,8 +563,7 @@ def _create_seer_activity(
     if not activity_type:
         return
 
-    organization = group.project.organization
-    if not features.has("organizations:seer-activity-timeline", organization):
+    if not options.get("issues.record-seer-actions-as-activities"):
         return
 
     run_id = event_payload.get("run_id")

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -37,6 +37,7 @@ from sentry.seer.entrypoints.types import (
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.testutils.asserts import assert_failure_metric
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.types.activity import ActivityType
 
 
@@ -448,12 +449,11 @@ class SeerOperatorTest(TestCase):
             },
         }
 
-        with self.feature("organizations:seer-activity-timeline"):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED,
-                event_payload=event_payload,
-                organization_id=self.organization.id,
-            )
+        process_autofix_updates(
+            event_type=SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED,
+            event_payload=event_payload,
+            organization_id=self.organization.id,
+        )
 
         activity = Activity.objects.get(
             group=self.group, type=ActivityType.SEER_RCA_COMPLETED.value
@@ -474,12 +474,11 @@ class SeerOperatorTest(TestCase):
             },
         }
 
-        with self.feature("organizations:seer-activity-timeline"):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_SOLUTION_COMPLETED,
-                event_payload=event_payload,
-                organization_id=self.organization.id,
-            )
+        process_autofix_updates(
+            event_type=SentryAppEventType.SEER_SOLUTION_COMPLETED,
+            event_payload=event_payload,
+            organization_id=self.organization.id,
+        )
 
         activity = Activity.objects.get(
             group=self.group, type=ActivityType.SEER_SOLUTION_COMPLETED.value
@@ -497,12 +496,11 @@ class SeerOperatorTest(TestCase):
             "code_changes": {"getsentry/sentry": [{"diff": "...", "path": "foo.py"}]},
         }
 
-        with self.feature("organizations:seer-activity-timeline"):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_CODING_COMPLETED,
-                event_payload=event_payload,
-                organization_id=self.organization.id,
-            )
+        process_autofix_updates(
+            event_type=SentryAppEventType.SEER_CODING_COMPLETED,
+            event_payload=event_payload,
+            organization_id=self.organization.id,
+        )
 
         activity = Activity.objects.get(
             group=self.group, type=ActivityType.SEER_CODING_COMPLETED.value
@@ -515,12 +513,11 @@ class SeerOperatorTest(TestCase):
     def test_create_seer_activity_all_mapped_event_types(self, _mock_has_access):
         for seer_event, expected_activity_type in SEER_EVENT_TO_ACTIVITY_TYPE.items():
             event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
-            with self.feature("organizations:seer-activity-timeline"):
-                process_autofix_updates(
-                    event_type=seer_event,
-                    event_payload=event_payload,
-                    organization_id=self.organization.id,
-                )
+            process_autofix_updates(
+                event_type=seer_event,
+                event_payload=event_payload,
+                organization_id=self.organization.id,
+            )
             assert Activity.objects.filter(
                 group=self.group, type=expected_activity_type.value
             ).exists(), f"Activity not created for {seer_event}"
@@ -529,25 +526,25 @@ class SeerOperatorTest(TestCase):
     def test_create_seer_activity_skips_non_seer_events(self, _mock_has_access):
         event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
 
-        with self.feature("organizations:seer-activity-timeline"):
-            process_autofix_updates(
-                event_type=SentryAppEventType.ISSUE_CREATED,
-                event_payload=event_payload,
-                organization_id=self.organization.id,
-            )
+        process_autofix_updates(
+            event_type=SentryAppEventType.ISSUE_CREATED,
+            event_payload=event_payload,
+            organization_id=self.organization.id,
+        )
 
         seer_type_values = [t.value for t in SEER_EVENT_TO_ACTIVITY_TYPE.values()]
         assert not Activity.objects.filter(group=self.group, type__in=seer_type_values).exists()
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_create_seer_activity_feature_flag_disabled(self, _mock_has_access):
+    def test_create_seer_activity_option_disabled(self, _mock_has_access):
         event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
 
-        process_autofix_updates(
-            event_type=SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
-            event_payload=event_payload,
-            organization_id=self.organization.id,
-        )
+        with override_options({"issues.record-seer-actions-as-activities": False}):
+            process_autofix_updates(
+                event_type=SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
+                event_payload=event_payload,
+                organization_id=self.organization.id,
+            )
 
         seer_type_values = [t.value for t in SEER_EVENT_TO_ACTIVITY_TYPE.values()]
         assert not Activity.objects.filter(group=self.group, type__in=seer_type_values).exists()
@@ -569,12 +566,11 @@ class SeerOperatorTest(TestCase):
             ],
         }
 
-        with self.feature("organizations:seer-activity-timeline"):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_PR_CREATED,
-                event_payload=event_payload,
-                organization_id=self.organization.id,
-            )
+        process_autofix_updates(
+            event_type=SentryAppEventType.SEER_PR_CREATED,
+            event_payload=event_payload,
+            organization_id=self.organization.id,
+        )
 
         activity = Activity.objects.get(group=self.group, type=ActivityType.SEER_PR_CREATED.value)
         assert activity.data["pull_requests"][0]["repo_name"] == "owner/repo"

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -579,7 +579,6 @@ class SeerOperatorTest(TestCase):
             == "https://github.com/owner/repo/pull/42"
         )
 
-    @with_feature("organizations:seer-activity-timeline")
     @patch("sentry.seer.entrypoints.operator.invoke_workflow_activity_handlers")
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_create_seer_activity_invokes_workflow_activity_handlers(


### PR DESCRIPTION
https://linear.app/getsentry/project/add-seer-actions-to-issue-activityaction-log-0e641e1f5dac/overview

Replaces the per-org `seer-activity-timeline` feature flag check with a global `issues.record-seer-actions-as-activities` option for gating the recording of Seer actions as issue activities in the backend, using the Seer webhook. This PR enables recording Seer activities (RCA, solution, coding, PR creation) for all organizations by default, while retaining an option-based killswitch.

The existing `seer-activity-timeline` feature flag is preserved and will be repurposed in a follow-up frontend PR to gate only the *display* of these activities in the issue details timeline.