### PR TITLE
ref(issues): Rename feature flag to be specific to displaying Seer actions as issue details activities

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -295,8 +295,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-slack-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Show Seer run ID in Slack notification footers
     manager.add("organizations:seer-run-id-in-slack", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable Seer activity events in the issue activity timeline
-    manager.add("organizations:seer-activity-timeline", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Gate display of Seer action events in the issue activity timeline
+    # https://linear.app/getsentry/project/add-seer-actions-to-issue-activityaction-log-0e641e1f5dac/overview
+    manager.add("organizations:display-seer-actions-as-issue-activities", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Gate outbox-based mirroring of SeerRun records to Seer
     manager.add("organizations:seer-run-mirror", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Gate outbox-based mirroring for autofix writes

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -594,7 +594,9 @@ describe('ActivitySection', () => {
       project,
     });
 
-    const org = OrganizationFixture({features: ['seer-activity-timeline']});
+    const org = OrganizationFixture({
+      features: ['display-seer-actions-as-issue-activities'],
+    });
 
     render(<ActivitySection group={seerGroup} />, {organization: org});
     expect(await screen.findByText('Root Cause Analysis')).toBeInTheDocument();
@@ -650,7 +652,9 @@ describe('ActivitySection', () => {
       project,
     });
 
-    const org = OrganizationFixture({features: ['seer-activity-timeline']});
+    const org = OrganizationFixture({
+      features: ['display-seer-actions-as-issue-activities'],
+    });
 
     render(<ActivitySection group={seerPrGroup} />, {organization: org});
     expect(screen.queryByText('Pull Request Created')).not.toBeInTheDocument();

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -368,7 +368,9 @@ export function ActivitySection({
     },
   };
 
-  const showSeerActivities = organization.features.includes('seer-activity-timeline');
+  const showSeerActivities = organization.features.includes(
+    'display-seer-actions-as-issue-activities'
+  );
   const visibleActivities = showSeerActivities
     ? group.activity.filter(item => item.type !== GroupActivityType.SEER_PR_CREATED)
     : group.activity.filter(item => !SEER_ACTIVITY_TYPES.has(item.type));


### PR DESCRIPTION
https://linear.app/getsentry/project/add-seer-actions-to-issue-activityaction-log-0e641e1f5dac/overview

Follow-up to https://github.com/getsentry/sentry/pull/116424.

Renames the `seer-activity-timeline` feature flag to `display-seer-actions-as-issue-activities` to clarify that this flag only gates the *display* of Seer activities in the issue details timeline. The *recording* of these activities is controlled by the `issues.record-seer-actions-as-activities` option added in the above PR.



