### PR TITLE
ref(integrations): Drop the external-install React route

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -165,10 +165,6 @@ function buildRoutes(): RouteObject[] {
       component: errorHandler(OrganizationContainerRoute),
       children: [
         {
-          path: '/extensions/external-install/:integrationSlug/:installationId',
-          component: make(() => import('sentry/views/integrationOrganizationLink')),
-        },
-        {
           path: '/extensions/:integrationSlug/link/',
           component: make(() => import('sentry/views/integrationOrganizationLink')),
         },

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -69,11 +69,13 @@ function trackExternalAnalytics({
 
 export default function IntegrationOrganizationLink() {
   const location = useLocation();
-  const {integrationSlug, installationId} = useParams<{
-    integrationSlug: string;
-    // installationId present for Github flow
-    installationId?: string;
-  }>();
+  const {integrationSlug} = useParams<{integrationSlug: string}>();
+  // GitHub installs forwarded here from `/extensions/external-install/...`
+  // carry `installationId` in the query string.
+  const installationId =
+    typeof location.query.installationId === 'string'
+      ? location.query.installationId
+      : undefined;
   const [selectedOrgSlug, setSelectedOrgSlug] = useState<string | null>(null);
 
   const {
@@ -194,7 +196,8 @@ export default function IntegrationOrganizationLink() {
 
     // GitHub is the only provider currently driven through the API pipeline
     // modal from this view — users land here after installing the Sentry
-    // GitHub App from github.com, with the `installationId` in the URL.
+    // GitHub App from github.com, with the `installationId` in the URL query
+    // (forwarded from `/extensions/external-install/...`).
     if (provider.key === 'github' && installationId) {
       startFlow({
         provider,


### PR DESCRIPTION
`IntegrationOrganizationLink` was wired at two different URL shapes — `/extensions/external-install/:integrationSlug/:installationId` for GitHub installs initiated from github.com, and `/extensions/:integrationSlug/link/` for everything else — and used `useParams` to pull the GitHub `installationId` out of the path on one of those routes. This made the component aware of two URL shapes for the same product flow.

The companion backend change in #116412 redirects GitHub-initiated installs straight to the `link/` route with `installationId` in the query string, so the external-install URL no longer needs to resolve at all. This drops the React route entry and updates the link view to read `installationId` from the query string. The link view now only handles one URL shape.

Depends on #116412 landing in production first.