### PR TITLE
feat(snapshots): Add all_image_file_names_as_regex (new regex dep)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
   "google-cloud-storage>=2.18.0",
   "google-cloud-storage-transfer>=1.17.0",
   "google-crc32c>=1.6.0",
+  # Linear-time regex engine (RE2). Used for client-supplied snapshot image-name
+  # patterns: no catastrophic backtracking (ReDoS-safe), no backreferences/lookaround.
+  "google-re2>=1.1.20251105",
   "googleapis-common-protos>=1.63.2",
   "granian[pname,reload,uvloop]>=2.7",
   "grpc-google-iam-v1>=0.13.1",
@@ -376,6 +379,7 @@ module = [
   "pymemcache.*",
   "P4",
   "rb.*",
+  "re2.*",
   "statsd.*",
   "tokenizers.*",
   "u2flib_server.model.*",

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Collection
 from typing import Any
 
 import jsonschema
@@ -62,8 +63,10 @@ from sentry.preprod.snapshots.constants import MISSING_BASE_GRACE_PERIOD_SECONDS
 from sentry.preprod.snapshots.manifest import (
     ComparisonManifest,
     ImageMetadata,
+    InvalidImageNamePattern,
     SnapshotManifest,
     image_metadata_extras,
+    make_image_name_matcher,
 )
 from sentry.preprod.snapshots.models import (
     PreprodSnapshotComparison,
@@ -99,6 +102,13 @@ SNAPSHOT_POST_REQUEST_SCHEMA: dict[str, Any] = {
             "items": {"type": "string"},
             "maxItems": 50000,
         },
+        # Sanity bounds for client-supplied patterns; ReDoS-safety comes from RE2's
+        # linear-time matching (see make_image_name_matcher in manifest.py).
+        "all_image_file_names_as_regex": {
+            "type": "array",
+            "items": {"type": "string", "maxLength": 500},
+            "maxItems": 100,
+        },
         **VCS_SCHEMA_PROPERTIES,
     },
     "required": ["app_id", "images"],
@@ -110,6 +120,7 @@ SNAPSHOT_POST_REQUEST_ERROR_MESSAGES: dict[str, str] = {
     "images": "The images field is required and must be an object mapping image names to image metadata.",
     "selective": "The selective field must be a boolean.",
     "all_image_file_names": "The all_image_file_names field must be an array of strings with at most 50000 entries.",
+    "all_image_file_names_as_regex": "The all_image_file_names_as_regex field must be an array of regex pattern strings (each at most 500 characters) with at most 100 entries.",
     **VCS_ERROR_MESSAGES,
 }
 
@@ -172,6 +183,35 @@ def _format_validation_error(e: jsonschema.ValidationError) -> str:
             return friendly
 
     return e.message
+
+
+def _validate_image_name_coverage(
+    image_names: Collection[str],
+    all_image_file_names: list[str] | None,
+    all_image_file_names_as_regex: list[str] | None,
+) -> str | None:
+    """
+    Ensure every uploaded image name is covered by the head build's declared set
+    of image names (a literal name list or a list of regex patterns). Returns an
+    error detail string, or None when valid.
+    """
+    if all_image_file_names is not None:
+        if not all_image_file_names:
+            return "all_image_file_names must not be empty."
+        if set(image_names) - set(all_image_file_names):
+            return "Every image name must appear in all_image_file_names."
+
+    if all_image_file_names_as_regex is not None:
+        if not all_image_file_names_as_regex:
+            return "all_image_file_names_as_regex must not be empty."
+        try:
+            matches = make_image_name_matcher(all_image_file_names_as_regex)
+        except InvalidImageNamePattern as e:
+            return f"all_image_file_names_as_regex contains an invalid regex pattern: {e.pattern}"
+        if any(not matches(name) for name in image_names):
+            return "Every image name must match a pattern in all_image_file_names_as_regex."
+
+    return None
 
 
 def _format_pydantic_error(e: pydantic.ValidationError) -> str:
@@ -673,10 +713,23 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
 
         selective = data.get("selective", False)
         all_image_file_names = data.get("all_image_file_names")
+        all_image_file_names_as_regex = data.get("all_image_file_names_as_regex")
 
-        if all_image_file_names is not None and not selective:
+        if all_image_file_names is not None and all_image_file_names_as_regex is not None:
             return Response(
-                {"detail": "all_image_file_names requires selective to be true."},
+                {
+                    "detail": "all_image_file_names and all_image_file_names_as_regex are mutually exclusive."
+                },
+                status=400,
+            )
+
+        if (
+            all_image_file_names is not None or all_image_file_names_as_regex is not None
+        ) and not selective:
+            return Response(
+                {
+                    "detail": "all_image_file_names and all_image_file_names_as_regex require selective to be true."
+                },
                 status=400,
             )
 
@@ -686,19 +739,11 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 status=400,
             )
 
-        if all_image_file_names is not None:
-            if not all_image_file_names:
-                return Response(
-                    {"detail": "all_image_file_names must not be empty."},
-                    status=400,
-                )
-            all_image_file_names_set = set(all_image_file_names)
-            missing = set(images.keys()) - all_image_file_names_set
-            if missing:
-                return Response(
-                    {"detail": "Every image name must appear in all_image_file_names."},
-                    status=400,
-                )
+        coverage_error = _validate_image_name_coverage(
+            images.keys(), all_image_file_names, all_image_file_names_as_regex
+        )
+        if coverage_error:
+            return Response({"detail": coverage_error}, status=400)
 
         # Validate before entering the transaction so invalid data never creates
         # orphaned DB records.
@@ -708,6 +753,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 diff_threshold=diff_threshold,
                 selective=selective,
                 all_image_file_names=all_image_file_names,
+                all_image_file_names_as_regex=all_image_file_names_as_regex,
             )
         except pydantic.ValidationError as e:
             return Response(

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -1,9 +1,38 @@
 from __future__ import annotations
 
-from collections.abc import Set
+from collections.abc import Callable, Sequence, Set
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, validator
+import re2
+from pydantic import BaseModel, Field, root_validator, validator
+
+# Invalid patterns are client input we surface as a 400, not a server error worth logging.
+_RE2_OPTIONS = re2.Options()
+_RE2_OPTIONS.log_errors = False
+
+
+class InvalidImageNamePattern(ValueError):
+    def __init__(self, pattern: str) -> None:
+        super().__init__(pattern)
+        self.pattern = pattern
+
+
+def make_image_name_matcher(patterns: Sequence[str]) -> Callable[[str], bool]:
+    """
+    Build a predicate testing whether a name fully matches any of `patterns`.
+
+    Patterns compile with RE2, a linear-time engine: matching cannot catastrophically
+    backtrack, so no time budget is needed. RE2 rejects unsupported constructs
+    (backreferences, lookaround) at compile time; we raise InvalidImageNamePattern
+    carrying the offending pattern.
+    """
+    compiled: list[Any] = []
+    for pattern in patterns:
+        try:
+            compiled.append(re2.compile(pattern, _RE2_OPTIONS))
+        except re2.error as e:
+            raise InvalidImageNamePattern(pattern) from e
+    return lambda name: any(compiled_pattern.fullmatch(name) for compiled_pattern in compiled)
 
 
 class ImageMetadata(BaseModel):
@@ -57,6 +86,30 @@ class SnapshotManifest(BaseModel):
     diff_threshold: float | None = Field(default=None, ge=0.0, lt=1.0)
     selective: bool = False
     all_image_file_names: list[str] | None = None
+    all_image_file_names_as_regex: list[str] | None = None
+
+    @root_validator(skip_on_failure=True)
+    def _all_image_file_names_mutually_exclusive(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if (
+            values.get("all_image_file_names") is not None
+            and values.get("all_image_file_names_as_regex") is not None
+        ):
+            raise ValueError(
+                "all_image_file_names and all_image_file_names_as_regex are mutually exclusive"
+            )
+        return values
+
+    def head_image_name_matcher(self) -> Callable[[str], bool] | None:
+        """
+        Return a check for whether a name is in the head's declared image set, or
+        None if the head didn't declare one. Distinguishes removed images (not in the
+        set) from skipped ones (in the set but not re-uploaded).
+        """
+        if self.all_image_file_names is not None:
+            return set(self.all_image_file_names).__contains__
+        if self.all_image_file_names_as_regex is not None:
+            return make_image_name_matcher(self.all_image_file_names_as_regex)
+        return None
 
 
 class ComparisonImageResult(BaseModel):

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -85,15 +85,15 @@ def categorize_image_diff(
     head_by_name = {key: meta.content_hash for key, meta in head_manifest.images.items()}
     base_by_name = {key: meta.content_hash for key, meta in base_manifest.images.items()}
 
-    all_image_file_names = head_manifest.all_image_file_names
+    matches_head_image = head_manifest.head_image_name_matcher()
 
     matched = head_by_name.keys() & base_by_name.keys()
     added = head_by_name.keys() - base_by_name.keys()
 
-    if all_image_file_names is not None:
-        all_names_set = set(all_image_file_names)
-        removed = base_by_name.keys() - all_names_set
-        skipped = (all_names_set - head_by_name.keys()) & base_by_name.keys()
+    if matches_head_image is not None:
+        base_in_head = {name for name in base_by_name.keys() if matches_head_image(name)}
+        removed = base_by_name.keys() - base_in_head
+        skipped = base_in_head - head_by_name.keys()
     elif head_manifest.selective:
         removed = set()
         skipped = base_by_name.keys() - head_by_name.keys()

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -332,6 +332,13 @@ class ProjectPreprodSnapshotTest(APITestCase):
                 self._get_create_url(), self._selective_data(**overrides), format="json"
             )
 
+    def _post_regex(self, patterns, **overrides):
+        data = self._selective_data(**overrides)
+        del data["all_image_file_names"]
+        data["all_image_file_names_as_regex"] = patterns
+        with self.feature("organizations:preprod-snapshots"):
+            return self.client.post(self._get_create_url(), data, format="json")
+
     def test_all_image_file_names_rejects_empty_list(self):
         response = self._post_selective(images={}, all_image_file_names=[])
         assert response.status_code == 400
@@ -362,6 +369,48 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_selective_with_all_image_file_names_accepted(self):
         response = self._post_selective()
         assert response.status_code == 200
+
+    def test_all_image_file_names_as_regex_accepted(self):
+        response = self._post_regex([r".*\.png"])
+        assert response.status_code == 200
+
+    def test_all_image_file_names_as_regex_mutually_exclusive(self):
+        response = self._post_selective(all_image_file_names_as_regex=[r".*\.png"])
+        assert response.status_code == 400
+        assert "mutually exclusive" in response.data["detail"]
+
+    def test_all_image_file_names_as_regex_requires_selective(self):
+        response = self._post_regex([r".*\.png"], selective=False)
+        assert response.status_code == 400
+        assert "selective" in response.data["detail"]
+
+    def test_all_image_file_names_as_regex_rejects_empty_list(self):
+        response = self._post_regex([])
+        assert response.status_code == 400
+        assert "empty" in response.data["detail"]
+
+    def test_all_image_file_names_as_regex_rejects_invalid_pattern(self):
+        response = self._post_regex(["["])
+        assert response.status_code == 400
+        assert "all_image_file_names_as_regex" in response.data["detail"]
+        assert "invalid regex pattern" in response.data["detail"]
+        assert "[" in response.data["detail"]
+
+    def test_all_image_file_names_as_regex_rejects_unsupported_construct(self):
+        response = self._post_regex([r"screen(?=\.png)"])
+        assert response.status_code == 400
+        assert "invalid regex pattern" in response.data["detail"]
+        assert r"screen(?=\.png)" in response.data["detail"]
+
+    def test_all_image_file_names_as_regex_must_match_all_images(self):
+        response = self._post_regex([r"other\.png"])
+        assert response.status_code == 400
+        assert "must match a pattern" in response.data["detail"]
+
+    def test_all_image_file_names_as_regex_rejects_overlong_pattern(self):
+        response = self._post_regex(["a" * 501])
+        assert response.status_code == 400
+        assert "all_image_file_names_as_regex" in response.data["detail"]
 
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.compare_snapshots")

--- a/tests/sentry/preprod/snapshots/test_manifest.py
+++ b/tests/sentry/preprod/snapshots/test_manifest.py
@@ -1,12 +1,54 @@
 import jsonschema
+import pydantic
+import pytest
 
-from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
+from sentry.preprod.snapshots.manifest import (
+    ImageMetadata,
+    InvalidImageNamePattern,
+    SnapshotManifest,
+    make_image_name_matcher,
+)
 
 
 def _meta(**kwargs: object) -> dict:
     defaults: dict = {"content_hash": "abc123", "width": 100, "height": 200}
     defaults.update(kwargs)
     return defaults
+
+
+class TestSnapshotManifestHeadImageNameMatcher:
+    def test_no_declared_set_returns_none(self) -> None:
+        manifest = SnapshotManifest(images={})
+        assert manifest.head_image_name_matcher() is None
+
+    def test_literal_names_matcher(self) -> None:
+        manifest = SnapshotManifest(images={}, all_image_file_names=["a.png", "b.png"])
+        matches_head_image = manifest.head_image_name_matcher()
+        assert matches_head_image is not None
+        assert matches_head_image("a.png")
+        assert not matches_head_image("c.png")
+
+    def test_regex_matcher_uses_full_match(self) -> None:
+        manifest = SnapshotManifest(images={}, all_image_file_names_as_regex=[r"login\.png"])
+        matches_head_image = manifest.head_image_name_matcher()
+        assert matches_head_image is not None
+        assert matches_head_image("login.png")
+        assert not matches_head_image("screens/login.png")
+
+    def test_both_fields_set_is_rejected(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            SnapshotManifest(
+                images={},
+                all_image_file_names=["a.png"],
+                all_image_file_names_as_regex=[r"a\.png"],
+            )
+
+    def test_make_image_name_matcher_rejects_unsupported_construct(self) -> None:
+        with pytest.raises(InvalidImageNamePattern) as exc:
+            make_image_name_matcher([r"a(?=b)"])
+        assert exc.value.pattern == r"a(?=b)"
+        with pytest.raises(InvalidImageNamePattern):
+            make_image_name_matcher([r"(a)\1"])
 
 
 class TestImageMetadataTagsCoercion:

--- a/tests/sentry/preprod/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/snapshots/test_tasks.py
@@ -242,3 +242,74 @@ class TestCategorizeImageDiffSelective:
         assert result.skipped == {"b.png", "c.png"}
         assert result.removed == set()
         assert result.matched == {"a.png"}
+
+
+class TestCategorizeImageDiffSelectiveRegex:
+    def test_regex_all_categories(self) -> None:
+        head = SnapshotManifest(
+            images={"new.png": _meta("h_new"), "matched.png": _meta("h1")},
+            selective=True,
+            all_image_file_names_as_regex=[r".*\.png"],
+        )
+        base = SnapshotManifest(
+            images={
+                "matched.png": _meta("h1"),
+                "skipped.png": _meta("h2"),
+                "deleted.txt": _meta("h3"),
+            }
+        )
+
+        result = categorize_image_diff(head, base)
+
+        assert result.added == {"new.png"}
+        assert result.matched == {"matched.png"}
+        assert result.skipped == {"skipped.png"}
+        assert result.removed == {"deleted.txt"}
+
+    def test_regex_multiple_patterns(self) -> None:
+        head = SnapshotManifest(
+            images={"dark/a.png": _meta("h1")},
+            selective=True,
+            all_image_file_names_as_regex=[r"dark/.*", r"light/.*"],
+        )
+        base = SnapshotManifest(
+            images={
+                "dark/a.png": _meta("h1"),
+                "light/b.png": _meta("h2"),
+                "other/c.png": _meta("h3"),
+            }
+        )
+
+        result = categorize_image_diff(head, base)
+
+        assert result.matched == {"dark/a.png"}
+        assert result.skipped == {"light/b.png"}
+        assert result.removed == {"other/c.png"}
+
+    def test_regex_rename_old_name_not_matching(self) -> None:
+        head = SnapshotManifest(
+            images={"new.png": _meta("shared")},
+            selective=True,
+            all_image_file_names_as_regex=[r"new\.png"],
+        )
+        base = SnapshotManifest(images={"old.png": _meta("shared")})
+
+        result = categorize_image_diff(head, base)
+
+        assert result.renamed_pairs == [("new.png", "old.png")]
+        assert result.removed == set()
+
+    def test_regex_rename_old_name_matching_is_detected_from_skipped(self) -> None:
+        head = SnapshotManifest(
+            images={"screens/new.png": _meta("shared")},
+            selective=True,
+            all_image_file_names_as_regex=[r"screens/.*"],
+        )
+        base = SnapshotManifest(images={"screens/old.png": _meta("shared")})
+
+        result = categorize_image_diff(head, base)
+
+        assert result.renamed_pairs == [("screens/new.png", "screens/old.png")]
+        assert result.skipped == set()
+        assert result.added == set()
+        assert result.removed == set()

--- a/uv.lock
+++ b/uv.lock
@@ -810,6 +810,19 @@ wheels = [
 ]
 
 [[package]]
+name = "google-re2"
+version = "1.1.20251105"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:83292e23963aa1b219d5f64a65365b0880448a6a060276027b55270bc5b18c7e" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b1458d9ca588124cd61aa1bf5388a216e1247e7d474f8e5e1530498044f5c87" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a52cb204e49d20cdbb66faf394d57f476e96c39c23a328442ab0194fc6bd1a2b" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:79ce664038194a31bbcf422137f9607ae3d9946a5cff98cf0efbeb7f9411e64b" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85feec3161ffdc12f6b144e37a2f91f80b771c72ffadde60191e89a49f6d7e81" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7bfaa2cf55daf0c5c650e68526bb20b61e37d7f3ae53f6893013acc1c91c116" },
+]
+
+[[package]]
 name = "google-resumable-media"
 version = "2.7.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
@@ -2188,6 +2201,7 @@ dependencies = [
     { name = "google-cloud-storage", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "google-cloud-storage-transfer", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "google-crc32c", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "google-re2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "googleapis-common-protos", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "granian", extra = ["pname", "reload", "uvloop"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "grpc-google-iam-v1", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2362,6 +2376,7 @@ requires-dist = [
     { name = "google-cloud-storage", specifier = ">=2.18.0" },
     { name = "google-cloud-storage-transfer", specifier = ">=1.17.0" },
     { name = "google-crc32c", specifier = ">=1.6.0" },
+    { name = "google-re2", specifier = ">=1.1.20251105" },
     { name = "googleapis-common-protos", specifier = ">=1.63.2" },
     { name = "granian", extras = ["pname", "reload", "uvloop"], specifier = ">=2.7" },
     { name = "grpc-google-iam-v1", specifier = ">=0.13.1" },


### PR DESCRIPTION
Adds an optional `all_image_file_names_as_regex` field to the snapshot upload endpoint. It works like the existing `all_image_file_names`, except each entry is a regex pattern (matched with `fullmatch`) rather than a literal file name. This lets callers declare the head build's complete image set with a handful of patterns instead of an exhaustive list — useful for selective uploads, where only changed images are sent but the full set is needed downstream to tell `removed` images apart from `skipped` ones.

The two fields are mutually exclusive and both require `selective`. Every uploaded image name must be covered by the declared set (appear in the list, or match at least one pattern), preserving the existing invariant. `fullmatch` (not `search`) is used because the literal field uses exact full-string equality, and full-match is its faithful regex analog.

Renames still work: rename detection runs after the removed/skipped partitioning by matching content hashes across `added`/`removed`/`skipped`, and that shared logic is unchanged.

### New dependency: `google-re2`

Patterns are **client-supplied**, so they cannot be matched with a backtracking engine (stdlib `re` or the `regex` lib) without exposing a ReDoS vector — a pathological pattern can hang a worker. This PR matches them with **RE2** ([`google-re2`](https://github.com/google/re2)), a linear-time, finite-automaton engine:

- **Catastrophic backtracking is impossible by construction** — no time budget or timeout needed.
- **Unsupported constructs (backreferences, lookaround) are rejected at compile time** (`re2.error`), so the engine enforces the safe subset. These make no sense for filename patterns anyway.

Compiling a pattern *is* the validation (invalid/unsupported → 400), and the same compiled object does the matching. Pattern length (500 chars) and count (100) caps remain as sanity bounds. Reviewed with security; RE2's linear-time guarantee is the agreed approach over a wall-clock-timeout mitigation.

`google-re2` was added to the internal PyPI mirror in getsentry/pypi#2192 (merged). It ships prebuilt wheels for all our targets and has no new transitive dependencies.

### Refactor included

To avoid a third parallel code path, the literal and regex modes are unified behind a single `SnapshotManifest.head_image_name_matcher()` consumed by `categorize_image_diff`, and the endpoint's coverage checks are consolidated into one helper (`make_image_name_matcher`). Behavior-preserving. A `root_validator` on `SnapshotManifest` enforces the mutual-exclusion invariant at the model level.
