### PR TITLE
feat(discord): Wire App Directory installs through the API pipeline modal

### DIFF
--- a/static/app/components/pipeline/integrationDiscord/index.spec.tsx
+++ b/static/app/components/pipeline/integrationDiscord/index.spec.tsx
@@ -94,4 +94,34 @@ describe('DiscordOAuthLoginStep', () => {
 
     expect(screen.getByRole('button', {name: 'Authorize Discord'})).toBeDisabled();
   });
+
+  it('auto-advances when stepData indicates an App Directory install', () => {
+    const advance = jest.fn();
+    render(
+      <DiscordOAuthLoginStep
+        {...makeStepProps({
+          stepData: {
+            appDirectoryInstall: true,
+            code: 'auth-code-456',
+            guildId: '9876543210',
+            state: 'pipeline-sig',
+          },
+          advance,
+        })}
+      />
+    );
+
+    expect(advance).toHaveBeenCalledWith({
+      code: 'auth-code-456',
+      guildId: '9876543210',
+      state: 'pipeline-sig',
+    });
+    expect(advance).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole('button', {name: 'Authorize Discord'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Finishing up Discord integration installation...')
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/components/pipeline/integrationDiscord/index.tsx
+++ b/static/app/components/pipeline/integrationDiscord/index.tsx
@@ -1,4 +1,6 @@
-import {useCallback} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
+
+import {Text} from '@sentry/scraps/text';
 
 import type {OAuthCallbackData} from 'sentry/components/pipeline/shared/oauthLoginStep';
 import {OAuthLoginStep} from 'sentry/components/pipeline/shared/oauthLoginStep';
@@ -10,12 +12,24 @@ import {pipelineComplete} from 'sentry/components/pipeline/types';
 import {t} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 
+type DiscordOAuthStepData =
+  | {
+      appDirectoryInstall: true;
+      code: string;
+      guildId: string;
+      state: string;
+    }
+  | {
+      appDirectoryInstall?: false;
+      oauthUrl?: string;
+    };
+
 function DiscordOAuthLoginStep({
   stepData,
   advance,
   isAdvancing,
 }: PipelineStepProps<
-  {oauthUrl?: string},
+  DiscordOAuthStepData,
   {code: string; guildId: string; state: string}
 >) {
   const handleOAuthCallback = useCallback(
@@ -24,6 +38,26 @@ function DiscordOAuthLoginStep({
     },
     [advance]
   );
+
+  // App Directory installs arrive with OAuth already complete. The backend
+  // signals this by returning `appDirectoryInstall` in step data along with
+  // the values to advance with — no popup, no user interaction.
+  const hasAutoAdvanced = useRef(false);
+  useEffect(() => {
+    if (!stepData?.appDirectoryInstall || hasAutoAdvanced.current) {
+      return;
+    }
+    hasAutoAdvanced.current = true;
+    advance({
+      code: stepData.code,
+      guildId: stepData.guildId,
+      state: stepData.state,
+    });
+  }, [stepData, advance]);
+
+  if (stepData?.appDirectoryInstall) {
+    return <Text>{t('Finishing up Discord integration installation...')}</Text>;
+  }
 
   return (
     <OAuthLoginStep

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -67,6 +67,29 @@ function trackExternalAnalytics({
   );
 }
 
+/**
+ * Landing page that completes an integration install initiated from a
+ * third-party "app directory" or marketplace listing. After the user authorizes
+ * on the provider side, the provider redirects here so the user can pick which
+ * Sentry organization the install should land in, and then the install
+ * pipeline is driven with the params the provider supplied.
+ *
+ * Provider-initiated entry points handled here:
+ *
+ *  - GitHub
+ *    `/extensions/github/link/?installationId=…` (redirected from
+ *    `/extensions/external-install/github/:installationId`). Drives the
+ *    pipeline with `gitHubAppListingParams`.
+ *
+ *  - Discord
+ *    `/extensions/discord/link/?code=…&guild_id=…` (redirected from
+ *    `/extensions/discord/configure/`). Drives the pipeline with
+ *    `discordAppDirectoryParams`.
+ *
+ *  - Anything else
+ *    falls through to {@link finishLegacyInstallation}, which bounces to the
+ *    legacy `/extensions/<slug>/configure/` backend endpoint.
+ */
 export default function IntegrationOrganizationLink() {
   const location = useLocation();
   const {integrationSlug} = useParams<{integrationSlug: string}>();
@@ -155,8 +178,9 @@ export default function IntegrationOrganizationLink() {
   const {startFlow} = useAddIntegration();
 
   // Lands the user on the integration's settings page after a successful
-  // API-driven install. Used as `startFlow`'s `onInstall` callback.
-  const onInstallWithInstallationId = useCallback(
+  // API-driven install. Used as `startFlow`'s `onInstall` callback by both
+  // the GitHub App listing and Discord App Directory entry points.
+  const onInstall = useCallback(
     (data: Integration) => {
       const orgId = organization?.slug;
       const normalizedUrl = normalizeUrl(
@@ -168,6 +192,31 @@ export default function IntegrationOrganizationLink() {
     },
     [organization]
   );
+
+  // GitHub App listing installs arrive here with `installationId` as a URL
+  // path segment. The install button uses this as `initialData` for the
+  // pipeline modal.
+  const gitHubAppListingParams = useMemo<Record<string, string> | null>(() => {
+    if (integrationSlug !== 'github' || !installationId) {
+      return null;
+    }
+    return {installation_id: installationId};
+  }, [integrationSlug, installationId]);
+
+  // Discord App Directory installs arrive here with `code` and `guild_id` in
+  // the URL query (forwarded from `/extensions/discord/configure/`). The
+  // install button uses these as `initialData` for the pipeline modal.
+  const discordAppDirectoryParams = useMemo<Record<string, string> | null>(() => {
+    if (integrationSlug !== 'discord') {
+      return null;
+    }
+    const code = location.query.code;
+    const guildId = location.query.guild_id;
+    if (typeof code !== 'string' || typeof guildId !== 'string') {
+      return null;
+    }
+    return {code, guild_id: guildId, use_configure: '1'};
+  }, [integrationSlug, location.query]);
 
   // Legacy install path. Redirects to `/extensions/<slug>/configure/`, which
   // runs the Django-rendered `IntegrationExtensionConfigurationView` to drive
@@ -194,17 +243,12 @@ export default function IntegrationOrganizationLink() {
       return;
     }
 
-    // GitHub is the only provider currently driven through the API pipeline
-    // modal from this view — users land here after installing the Sentry
-    // GitHub App from github.com, with the `installationId` in the URL query
-    // (forwarded from `/extensions/external-install/...`).
-    if (provider.key === 'github' && installationId) {
-      startFlow({
-        provider,
-        organization,
-        onInstall: onInstallWithInstallationId,
-        urlParams: {installation_id: installationId},
-      });
+    // Each provider-initiated entry point contributes its own params bag.
+    // Whichever one is non-null routes through the API pipeline modal;
+    // otherwise we fall back to the legacy server-driven install flow.
+    const urlParams = gitHubAppListingParams ?? discordAppDirectoryParams;
+    if (urlParams) {
+      startFlow({provider, organization, onInstall, urlParams});
       return;
     }
 
@@ -212,9 +256,10 @@ export default function IntegrationOrganizationLink() {
   }, [
     provider,
     organization,
-    installationId,
+    gitHubAppListingParams,
+    discordAppDirectoryParams,
     startFlow,
-    onInstallWithInstallationId,
+    onInstall,
     finishLegacyInstallation,
   ]);
 


### PR DESCRIPTION
When a user installs the Sentry Discord app from Discord's App Directory, Discord redirects to `/extensions/discord/configure/` with `code` and `guild_id`. The configure URL forwards to `/extensions/discord/link/` (the org-picker), and from there the install needs to drive the existing API pipeline modal — there's a Discord-specific pipeline (added in #116375) that consumes those params and completes the install.

This wires up the frontend side of that flow.

In the org-link view (`IntegrationOrganizationLink`):

- Add a `discordAppDirectoryParams` memo that returns `{code, guild_id, use_configure: '1'}` when `code` and `guild_id` are present in the URL query, else null.
- Refactor `handleInstallClick` to dispatch via `gitHubAppListingParams ?? discordAppDirectoryParams` — whichever is non-null routes through `startFlow`, otherwise we fall back to the legacy install path.
- Rename `onInstallWithInstallationId` → `onInstall` since both flows use it now.
- Refresh the top-of-component docstring to enumerate both provider-initiated entry points.

In the Discord pipeline step (`integrationDiscord`):

- Make `stepData` a discriminated union of the existing OAuth shape (`{oauthUrl}`) and the new App Directory shape (`{appDirectoryInstall: true, code, guildId, state}`).
- When the backend signals `appDirectoryInstall`, auto-advance via a `useEffect` (guarded by a ref so React strict mode doesn't double-POST) and render `<Text>Finishing up Discord integration installation...</Text>` instead of the OAuth button.

Backend support landed in #116375.