### PR TITLE
feat(cmdk): Add search keywords to reduce no-result queries

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -345,7 +345,11 @@ export function GlobalCommandPaletteActions() {
         </CMDKAction>
 
         <CMDKAction display={{label: t('Explore'), icon: <IconCompass />}} limit={4}>
-          <CMDKAction display={{label: t('Traces')}} to={`${prefix}/explore/traces/`} />
+          <CMDKAction
+            display={{label: t('Traces')}}
+            keywords={[t('spans'), t('trace explorer')]}
+            to={`${prefix}/explore/traces/`}
+          />
           {organization.features.includes('ourlogs-enabled') && (
             <CMDKAction display={{label: t('Logs')}} to={`${prefix}/explore/logs/`} />
           )}
@@ -365,17 +369,20 @@ export function GlobalCommandPaletteActions() {
           {organization.features.includes('profiling') && (
             <CMDKAction
               display={{label: t('Profiles')}}
+              keywords={[t('profiling')]}
               to={`${prefix}/explore/profiles/`}
             />
           )}
           {organization.features.includes('session-replay-ui') && (
             <CMDKAction
               display={{label: t('Replays')}}
+              keywords={[t('rum'), t('session replay')]}
               to={`${prefix}/explore/replays/`}
             />
           )}
           <CMDKAction
             display={{label: t('Releases')}}
+            keywords={[t('release health')]}
             to={`${prefix}/explore/releases/`}
           />
           {organization.features.includes('gen-ai-conversations') && (
@@ -529,6 +536,7 @@ export function GlobalCommandPaletteActions() {
             )}
             <CMDKAction
               display={{label: t('Alerts')}}
+              keywords={[t('alert rules'), t('issue alert')]}
               to={`${prefix}/monitors/alerts/`}
             />
           </CMDKAction>
@@ -766,7 +774,7 @@ export function GlobalCommandPaletteActions() {
         />
         <CMDKAction
           display={{label: t('Create Alert'), icon: <IconAdd />}}
-          keywords={[t('add alert')]}
+          keywords={[t('add alert'), t('alert rules'), t('issue alert')]}
           to={`${prefix}/issues/alerts/wizard/`}
         />
         <CMDKAction
@@ -787,7 +795,10 @@ export function GlobalCommandPaletteActions() {
         />
       </CMDKAction>
 
-      <CMDKAction display={{label: t('DSN')}} keywords={[t('client keys')]}>
+      <CMDKAction
+        display={{label: t('DSN')}}
+        keywords={[t('client keys'), t('sentry dsn')]}
+      >
         <CMDKAction
           display={{
             label: t('Reverse DSN lookup'),

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -64,6 +64,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
         {
           path: `${userSettingsPathPrefix}/close-account/`,
           title: t('Close Account'),
+          keywords: [t('delete account')],
           description: t('Permanently close your Sentry account'),
         },
       ],
@@ -247,6 +248,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
             t('pagerduty'),
             t('opsgenie'),
             t('discord'),
+            t('linear'),
             t('microsoft teams'),
             t('msteams'),
             t('aws lambda'),
@@ -301,6 +303,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
             t('api token'),
             t('token'),
             t('credentials'),
+            t('user auth tokens'),
           ],
           description: t('Manage organization tokens'),
           id: 'auth-tokens',
@@ -315,6 +318,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
             t('api token'),
             t('token'),
             t('credentials'),
+            t('user auth tokens'),
           ],
           description: t(
             "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -59,7 +59,13 @@ export function getNavigationConfiguration({
         {
           path: `${pathPrefix}/ownership/`,
           title: t('Ownership Rules'),
-          keywords: [t('ownership'), t('codeowners'), t('owners'), t('owner rules')],
+          keywords: [
+            t('ownership'),
+            t('codeowners'),
+            t('code owners'),
+            t('owners'),
+            t('owner rules'),
+          ],
           description: t('Manage ownership rules for a project'),
         },
         {
@@ -107,6 +113,7 @@ export function getNavigationConfiguration({
         {
           path: `${pathPrefix}/issue-grouping/`,
           title: t('Issue Grouping'),
+          keywords: [t('fingerprinting'), t('fingerprint rules')],
         },
         {
           path: `${pathPrefix}/debug-symbols/`,
@@ -173,7 +180,14 @@ export function getNavigationConfiguration({
           path: `${pathPrefix}/keys/`,
           title: t('Client Keys (DSN)'),
           description: t("View and manage the project's client keys (DSN)"),
-          keywords: [t('dsn'), t('auth'), t('token'), t('client key'), t('dsn key')],
+          keywords: [
+            t('dsn'),
+            t('auth'),
+            t('token'),
+            t('client key'),
+            t('dsn key'),
+            t('allowed domains'),
+          ],
         },
         {
           path: `${pathPrefix}/loader-script/`,


### PR DESCRIPTION
Add synonyms and alternative search terms to command palette actions based on
analysis of top no-result queries from Amplitude data.

Many users search for features using terms that don't match any existing action
label, details, or keyword — resulting in zero results. Since the command palette
uses fzf subsequence matching, the query must appear as a subsequence within a
single candidate string (label, details, or keyword). Longer queries can't match
shorter candidates, and space-separated terms won't match their concatenated forms.

Each addition was verified against the fzf matching algorithm to confirm it's not
already reachable via existing candidates:

| Action | Keywords Added | Top Queries Covered |
|--------|---------------|---------------------|
| Create Alert | `alert rules`, `issue alert` | "alert rules", "issue alert" (~15) |
| Monitors > Alerts | `alert rules`, `issue alert` | same, for workflow-engine-ui users |
| DSN | `sentry dsn` | "Sentry DSN", "sentry d" (~8) |
| Traces | `spans`, `trace explorer` | "spans", "Trace Explorer" (~5) |
| Replays | `rum`, `session replay` | "RUM", "Session Replay" (~6) |
| Releases | `release health` | "Release Health" (2) |
| Profiles | `profiling` | "Profiling" (3) |
| Organization Tokens | `user auth tokens` | "user auth", "User Auth Tokens" (~26) |
| Personal Tokens | `user auth tokens` | same |
| Close Account | `delete account` | "delete account", "delete" (~5) |
| Integrations | `linear` | "linear", "Linear" (~5) |
| Issue Grouping | `fingerprinting`, `fingerprint rules` | "fingerprint" (~14) |
| Client Keys (DSN) | `allowed domains` | "allow", "allowed dom" (~14) |
| Ownership Rules | `code owners` | "code owner" (~5) |