### PR TITLE
fix(replays): Query canonical replay id in trace tab

### DIFF
--- a/static/app/views/explore/replays/detail/trace/useReplayTraces.spec.tsx
+++ b/static/app/views/explore/replays/detail/trace/useReplayTraces.spec.tsx
@@ -2,9 +2,12 @@ import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {getReplayTraceSearchQuery} from 'sentry/views/performance/newTraceDetails/traceApi/replayTraceSearch';
+
 import {useReplayTraces} from './useReplayTraces';
 
 const replayRecord = ReplayRecordFixture();
+const replayTraceQuery = getReplayTraceSearchQuery(replayRecord.id);
 
 describe('useTraceMeta', () => {
   beforeEach(() => {
@@ -33,7 +36,7 @@ describe('useTraceMeta', () => {
           },
         ],
       },
-      match: [MockApiClient.matchQuery({dataset: 'spans'})],
+      match: [MockApiClient.matchQuery({dataset: 'spans', query: replayTraceQuery})],
     });
 
     const {result} = renderHookWithProviders(() => useReplayTraces({replayRecord}));
@@ -60,7 +63,7 @@ describe('useTraceMeta', () => {
       headers: {Link: pageLinks},
       url: '/organizations/org-slug/events/',
       statusCode: 400,
-      match: [MockApiClient.matchQuery({dataset: 'spans'})],
+      match: [MockApiClient.matchQuery({dataset: 'spans', query: replayTraceQuery})],
     });
 
     const {result} = renderHookWithProviders(() => useReplayTraces({replayRecord}));

--- a/static/app/views/explore/replays/detail/trace/useReplayTraces.tsx
+++ b/static/app/views/explore/replays/detail/trace/useReplayTraces.tsx
@@ -11,6 +11,7 @@ import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {HydratedReplayRecord} from 'sentry/views/explore/replays/types';
+import {getReplayTraceSearchQuery} from 'sentry/views/performance/newTraceDetails/traceApi/replayTraceSearch';
 
 export type ReplayTrace = {
   timestamp: number | undefined;
@@ -58,13 +59,14 @@ export function useReplayTraces({
     }
     const replayId = replayRecord?.id;
     const projectId = replayRecord?.project_id;
+    const query = getReplayTraceSearchQuery(replayId);
 
     return EventView.fromSavedQuery({
       id: undefined,
       name: `Traces in replay ${replayId}`,
       fields: ['trace', 'min(precise.start_ts)'],
       orderby: 'min_precise_start_ts',
-      query: `replayId:${replayId}`,
+      query,
       projects: [Number(projectId)],
       version: 2,
       start,

--- a/static/app/views/performance/newTraceDetails/traceApi/replayTraceSearch.ts
+++ b/static/app/views/performance/newTraceDetails/traceApi/replayTraceSearch.ts
@@ -1,0 +1,3 @@
+export function getReplayTraceSearchQuery(replayId: string) {
+  return `(replay.id:${replayId} OR replayId:${replayId})`;
+}

--- a/static/app/views/performance/newTraceDetails/traceApi/useReplayTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useReplayTraceMeta.spec.tsx
@@ -1,0 +1,80 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
+
+import {getReplayTraceSearchQuery} from './replayTraceSearch';
+import {useReplayTraceMeta} from './useReplayTraceMeta';
+
+jest.mock('sentry/utils/useSyncedLocalStorageState', () => ({
+  useSyncedLocalStorageState: jest.fn(),
+}));
+
+const organization = OrganizationFixture();
+const replayRecord = ReplayRecordFixture();
+const replayTraceQuery = getReplayTraceSearchQuery(replayRecord.id);
+
+describe('useReplayTraceMeta', () => {
+  beforeEach(() => {
+    jest.mocked(useSyncedLocalStorageState).mockReturnValue(['non-eap', jest.fn()]);
+    jest.clearAllMocks();
+  });
+
+  it('queries replay traces from the spans dataset using canonical and legacy replay ids', async () => {
+    const eventsRequest = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [
+          {
+            trace: 'trace1',
+            'min(precise.start_ts)': 1,
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events-trace-meta/trace1/',
+      body: {
+        errors: 1,
+        performance_issues: 2,
+        projects: 1,
+        transactions: 3,
+        transaction_child_count_map: [],
+        span_count: 4,
+        span_count_map: {
+          op1: 4,
+        },
+      },
+    });
+
+    const {result} = renderHookWithProviders(() => useReplayTraceMeta(replayRecord), {
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('success'));
+
+    expect(eventsRequest).toHaveBeenCalledTimes(1);
+    expect(eventsRequest.mock.calls[0]![1].query).toMatchObject({
+      dataset: 'spans',
+      field: ['trace', 'min(precise.start_ts)'],
+      query: replayTraceQuery,
+      referrer: 'api.replays.replay-trace-meta',
+      sort: ['min_precise_start_ts', 'trace'],
+    });
+    expect(result.current.data).toEqual({
+      errors: 1,
+      performance_issues: 2,
+      projects: 1,
+      transactions: 3,
+      transaction_child_count_map: {},
+      span_count: 4,
+      span_count_map: {
+        op1: 4,
+      },
+    });
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceApi/useReplayTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useReplayTraceMeta.tsx
@@ -5,10 +5,12 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {getTimeStampFromTableDateField, getUtcDateString} from 'sentry/utils/dates';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {EventView} from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {HydratedReplayRecord} from 'sentry/views/explore/replays/types';
 
+import {getReplayTraceSearchQuery} from './replayTraceSearch';
 import {
   useTraceMeta,
   type TraceMetaQueryResults,
@@ -38,13 +40,14 @@ export function useReplayTraceMeta(
     }
     const replayId = replayRecord?.id;
     const projectId = replayRecord?.project_id;
+    const query = getReplayTraceSearchQuery(replayId);
 
     return EventView.fromSavedQuery({
       id: undefined,
       name: `Traces in replay ${replayId}`,
-      fields: ['trace', 'count(trace)', 'min(timestamp)'],
-      orderby: 'min_timestamp',
-      query: `replayId:${replayId}`,
+      fields: ['trace', 'min(precise.start_ts)'],
+      orderby: 'min_precise_start_ts',
+      query,
       projects: [Number(projectId)],
       version: 2,
       start,
@@ -67,7 +70,9 @@ export function useReplayTraceMeta(
                 end,
                 limit: 10,
               } as unknown as Location),
-              sort: ['min_timestamp', 'trace'],
+              dataset: DiscoverDatasets.SPANS,
+              referrer: 'api.replays.replay-trace-meta',
+              sort: ['min_precise_start_ts', 'trace'],
             }
           : {},
       },
@@ -85,7 +90,7 @@ export function useReplayTraceMeta(
       if (row.trace) {
         traces.push({
           traceSlug: String(row.trace),
-          timestamp: getTimeStampFromTableDateField(row['min(timestamp)']),
+          timestamp: getTimeStampFromTableDateField(row['min(precise.start_ts)']),
         });
       }
     }


### PR DESCRIPTION
Fix replay trace discovery after the Trace tab switched to the spans dataset.

The Replay Trace tab still queried spans with only the legacy `replayId` tag. That misses SDK data where the replay id is propagated through the canonical span field as `replay.id` instead of the JavaScript-specific tag.

Query both `replay.id` and `replayId` so new canonical span data works while preserving compatibility with older JavaScript/legacy data. Apply the same query and spans dataset to the replay trace metadata pre-query, otherwise non-JS SDKs can load the trace list while missing metadata counts.

I also checked the existing `replay` alias, but it is not active for this request path in production, so the query stays explicit.

Refs REPLAY-915