### PR TITLE
feat(api): Opt 43 endpoints into Response[T] typed bodies

### DIFF
--- a/src/sentry/api/endpoints/organization_project_keys.py
+++ b/src/sentry/api/endpoints/organization_project_keys.py
@@ -80,7 +80,7 @@ class OrganizationProjectKeysEndpoint(OrganizationEndpoint):
             ),
         ],
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization) -> Response[list[ProjectKeySerializerResponse]]:
         """
         Return a list of client keys (DSNs) for all projects in an organization.
 

--- a/src/sentry/api/endpoints/organization_sampling_effective_sample_rate.py
+++ b/src/sentry/api/endpoints/organization_sampling_effective_sample_rate.py
@@ -52,7 +52,9 @@ class OrganizationSamplingEffectiveSampleRateEndpoint(OrganizationEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[OrganizationSamplingEffectiveSampleRateResponse]:
         if not features.has("organizations:dynamic-sampling", organization, actor=request.user):
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -63,7 +63,7 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
         },
         examples=SessionExamples.QUERY_SESSIONS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response[SessionsQueryResult]:
         """
         Returns a time series of release health session statistics for projects bound to an organization.
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -851,7 +851,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-workflow-index"
     )
-    def get(self, request: Request, project: Project) -> Response:
+    def get(self, request: Request, project: Project) -> Response[list[RuleSerializerResponse]]:
         """
         ## Deprecated
         🚧 Use [Fetch an Organization's Monitors](/api/monitors/fetch-an-organizations-monitors) and [Fetch Alerts](/api/monitors/fetch-alerts) instead.

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -138,7 +138,7 @@ class OrganizationIndexEndpoint(Endpoint):
         },
         examples=UserExamples.LIST_ORGANIZATIONS,
     )
-    def get(self, request: Request) -> Response:
+    def get(self, request: Request) -> Response[list[OrganizationSummarySerializerResponse]]:
         """
         Return a list of organizations available to the authenticated session in a region.
         This is particularly useful for requests with a user bound context. For API key-based requests this will only return the organization that belongs to the key.

--- a/src/sentry/core/endpoints/organization_member_index.py
+++ b/src/sentry/core/endpoints/organization_member_index.py
@@ -203,7 +203,9 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationMemberExamples.LIST_ORG_MEMBERS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[OrganizationMemberResponse]]:
         """
         List all organization members.
 

--- a/src/sentry/core/endpoints/organization_teams.py
+++ b/src/sentry/core/endpoints/organization_teams.py
@@ -96,7 +96,9 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
         },
         examples=TeamExamples.LIST_ORG_TEAMS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[TeamSerializerResponse]]:
         """
         Returns a list of teams bound to a organization.
         """

--- a/src/sentry/core/endpoints/project_keys.py
+++ b/src/sentry/core/endpoints/project_keys.py
@@ -65,7 +65,7 @@ class ProjectKeysEndpoint(ProjectEndpoint):
         },
         examples=ProjectExamples.LIST_CLIENT_KEYS,
     )
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project) -> Response[list[ProjectKeySerializerResponse]]:
         """
         Return a list of client keys bound to a project.
         """

--- a/src/sentry/core/endpoints/project_teams.py
+++ b/src/sentry/core/endpoints/project_teams.py
@@ -37,7 +37,7 @@ class ProjectTeamsEndpoint(ProjectEndpoint):
         },
         examples=TeamExamples.LIST_PROJECT_TEAMS,
     )
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project) -> Response[list[BaseTeamSerializerResponse]]:
         """
         Return a list of teams that have access to this project.
         """

--- a/src/sentry/core/endpoints/scim/members.py
+++ b/src/sentry/core/endpoints/scim/members.py
@@ -486,7 +486,9 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         },
         examples=SCIMExamples.LIST_ORG_MEMBERS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[SCIMListMembersResponse]:
         """
         Returns a paginated list of members bound to a organization with a SCIM Users GET Request.
         """

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -198,7 +198,9 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint):
         },
         examples=SCIMExamples.LIST_ORG_PAGINATED_TEAMS,
     )
-    def get(self, request: Request, organization: Organization, **kwds: Any) -> Response:
+    def get(
+        self, request: Request, organization: Organization, **kwds: Any
+    ) -> Response[SCIMListTeamsResponse]:
         """
         Returns a paginated list of teams bound to a organization with a SCIM Groups GET Request.
 

--- a/src/sentry/core/endpoints/team_members.py
+++ b/src/sentry/core/endpoints/team_members.py
@@ -83,7 +83,7 @@ class TeamMembersEndpoint(TeamEndpoint):
         },
         examples=TeamExamples.LIST_TEAM_MEMBERS,
     )
-    def get(self, request: Request, team) -> Response:
+    def get(self, request: Request, team) -> Response[list[OrganizationMemberOnTeamResponse]]:
         """
         List all members on a team.
 

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -359,7 +359,9 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         },
         examples=DashboardExamples.DASHBOARDS_QUERY_RESPONSE,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[DashboardListResponse]]:
         """
         Retrieve a list of custom dashboards that are associated with the given organization.
         """

--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -345,7 +345,9 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
         },
         examples=ExploreExamples.EXPLORE_SAVED_QUERIES_QUERY_RESPONSE,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[ExploreSavedQueryResponse]]:
         """
         Retrieve a list of saved queries that are associated with the given organization.
         """

--- a/src/sentry/integrations/api/endpoints/data_forwarding_details.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_details.py
@@ -299,7 +299,7 @@ class DataForwardingDetailsEndpoint(OrganizationEndpoint):
     )
     def put(
         self, request: Request, organization: Organization, data_forwarder: DataForwarder
-    ) -> Response:
+    ) -> Response[DataForwarderResponse]:
         """
         Updates a data forwarder for an organization or update a project-specific override.
         Updates to the data forwarder's configuration require `org:write` permissions, and the entire

--- a/src/sentry/integrations/api/endpoints/data_forwarding_index.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_index.py
@@ -53,7 +53,7 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
     )
     @set_referrer_policy("strict-origin-when-cross-origin")
     @method_decorator(never_cache)
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization) -> Response[list[DataForwarderResponse]]:
         """
         Returns a list of data forwarders for an organization.
         """
@@ -79,7 +79,7 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
     )
     @set_referrer_policy("strict-origin-when-cross-origin")
     @method_decorator(never_cache)
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization) -> Response[DataForwarderResponse]:
         """
         Creates a new data forwarder for an organization.
         Only one data forwarder can be created per provider for a given organization.

--- a/src/sentry/integrations/api/endpoints/organization_integration_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_details.py
@@ -73,7 +73,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
         organization_context: RpcUserOrganizationContext,
         integration_id: int,
         **kwds: Any,
-    ) -> Response:
+    ) -> Response[OrganizationIntegrationResponse]:
         org_integration = self.get_organization_integration(
             organization_context.organization.id, integration_id
         )

--- a/src/sentry/integrations/api/endpoints/organization_repository_commits.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_commits.py
@@ -69,7 +69,9 @@ class OrganizationRepositoryCommitsEndpoint(OrganizationEndpoint):
             ),
         ],
     )
-    def get(self, request: Request, organization, repo_id) -> Response:
+    def get(
+        self, request: Request, organization, repo_id
+    ) -> Response[list[CommitSerializerResponse]]:
         """
         List a Repository's Commits
         """

--- a/src/sentry/issues/endpoints/group_tagkey_values.py
+++ b/src/sentry/issues/endpoints/group_tagkey_values.py
@@ -70,7 +70,7 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
         examples=[TagsExamples.GROUP_TAGKEY_VALUES],
     )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-tag-key-values"])
-    def get(self, request: Request, group, key) -> Response:
+    def get(self, request: Request, group, key) -> Response[list[TagValueSerializerResponse]]:
         """
         List a Tag's Values
         """

--- a/src/sentry/issues/endpoints/organization_shortid.py
+++ b/src/sentry/issues/endpoints/organization_shortid.py
@@ -118,7 +118,7 @@ class ShortIdLookupEndpoint(GroupEndpoint):
             )
         ],
     )
-    def get(self, request: Request, group: Group) -> Response:
+    def get(self, request: Request, group: Group) -> Response[ShortIdLookupResponse]:
         """
         Resolve a short ID to the project slug and group details.
         """

--- a/src/sentry/issues/endpoints/project_events.py
+++ b/src/sentry/issues/endpoints/project_events.py
@@ -66,7 +66,9 @@ class ProjectEventsEndpoint(ProjectEndpoint):
         },
         examples=EventExamples.PROJECT_EVENTS_SIMPLE,
     )
-    def get(self, request: Request, project: Project) -> Response:
+    def get(
+        self, request: Request, project: Project
+    ) -> Response[list[SimpleEventSerializerResponse]]:
         """
         Return a list of events bound to a project.
         """

--- a/src/sentry/issues/endpoints/source_map_debug.py
+++ b/src/sentry/issues/endpoints/source_map_debug.py
@@ -52,7 +52,9 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project: Project, event_id: str) -> Response:
+    def get(
+        self, request: Request, project: Project, event_id: str
+    ) -> Response[SourceMapProcessingResponse]:
         """
         Return a list of source map errors for a given event.
         """

--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
@@ -40,7 +40,9 @@ class OrganizationMonitorCheckInIndexEndpoint(MonitorEndpoint, MonitorCheckInMix
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization, project, monitor) -> Response:
+    def get(
+        self, request: Request, organization, project, monitor
+    ) -> Response[list[MonitorCheckInSerializerResponse]]:
         """
         Retrieve a list of check-ins for a monitor
         """

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -104,7 +104,9 @@ class OrganizationMonitorIndexEndpoint(OrganizationAlertRuleBaseEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: AuthenticatedHttpRequest, organization: Organization) -> Response:
+    def get(
+        self, request: AuthenticatedHttpRequest, organization: Organization
+    ) -> Response[list[MonitorSerializerResponse]]:
         """
         Lists monitors, including nested monitor environments. May be filtered to a project or environment.
         """
@@ -309,7 +311,9 @@ class OrganizationMonitorIndexEndpoint(OrganizationAlertRuleBaseEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def put(self, request: AuthenticatedHttpRequest, organization) -> Response:
+    def put(
+        self, request: AuthenticatedHttpRequest, organization
+    ) -> Response[MonitorBulkEditResponse]:
         """
         Bulk edit the muted and disabled status of a list of monitors determined by slug
         """

--- a/src/sentry/monitors/endpoints/organization_monitor_processing_errors_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_processing_errors_index.py
@@ -38,7 +38,9 @@ class OrganizationMonitorProcessingErrorsIndexEndpoint(OrganizationEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: AuthenticatedHttpRequest, organization: Organization) -> Response:
+    def get(
+        self, request: AuthenticatedHttpRequest, organization: Organization
+    ) -> Response[list[CheckinProcessingErrorData]]:
         """
         Retrieves checkin processing errors for an organization
         """

--- a/src/sentry/monitors/endpoints/project_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/project_monitor_checkin_index.py
@@ -40,7 +40,9 @@ class ProjectMonitorCheckInIndexEndpoint(ProjectMonitorEndpoint, MonitorCheckInM
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project, monitor) -> Response:
+    def get(
+        self, request: Request, project, monitor
+    ) -> Response[list[MonitorCheckInSerializerResponse]]:
         """
         Retrieve a list of check-ins for a monitor
         """

--- a/src/sentry/monitors/endpoints/project_monitor_processing_errors_index.py
+++ b/src/sentry/monitors/endpoints/project_monitor_processing_errors_index.py
@@ -52,7 +52,9 @@ class ProjectMonitorProcessingErrorsIndexEndpoint(ProjectMonitorEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: AuthenticatedHttpRequest, project, monitor) -> Response:
+    def get(
+        self, request: AuthenticatedHttpRequest, project, monitor
+    ) -> Response[list[CheckinProcessingErrorData]]:
         """
         Retrieves checkin processing errors for a monitor
         """

--- a/src/sentry/preprod/api/endpoints/public/project_preprod_build_distribution_latest.py
+++ b/src/sentry/preprod/api/endpoints/public/project_preprod_build_distribution_latest.py
@@ -124,7 +124,7 @@ class ProjectPreprodBuildDistributionLatestEndpoint(ProjectEndpoint):
         self,
         request: Request,
         project: Project,
-    ) -> Response:
+    ) -> Response[LatestInstallableBuildResponseDict]:
         """
         Get the latest installable build for a project.
 

--- a/src/sentry/preprod/api/endpoints/public/project_preprod_size_analysis_status_check_rules.py
+++ b/src/sentry/preprod/api/endpoints/public/project_preprod_size_analysis_status_check_rules.py
@@ -54,7 +54,9 @@ class ProjectPreprodSizeAnalysisStatusCheckRulesEndpoint(ProjectEndpoint):
         },
         examples=PreprodExamples.GET_SIZE_STATUS_CHECK_RULES,
     )
-    def get(self, request: Request, project: Project) -> Response:
+    def get(
+        self, request: Request, project: Project
+    ) -> Response[ProjectSizeStatusCheckRulesResponseDict]:
         r"""
         Retrieve the current Size Analysis status check rules configured for a project.
 

--- a/src/sentry/preprod/api/endpoints/public/project_preprod_snapshot_status_check_rules.py
+++ b/src/sentry/preprod/api/endpoints/public/project_preprod_snapshot_status_check_rules.py
@@ -54,7 +54,9 @@ class ProjectPreprodSnapshotStatusCheckRulesEndpoint(ProjectEndpoint):
         },
         examples=PreprodExamples.GET_SNAPSHOT_STATUS_CHECK_RULES,
     )
-    def get(self, request: Request, project: Project) -> Response:
+    def get(
+        self, request: Request, project: Project
+    ) -> Response[ProjectSnapshotStatusCheckRulesResponseDict]:
         r"""
         Retrieve the current Snapshot status check rules configured for a project.
 

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -108,7 +108,7 @@ class OrganizationReplaySelectorIndexEndpoint(OrganizationReplayEndpoint):
         },
         examples=ReplayExamples.GET_SELECTORS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response[ReplaySelectorResponse]:
         """Return a list of selectors for a given organization."""
         self.check_replay_access(request, organization)
 

--- a/src/sentry/replays/endpoints/project_replay_clicks_index.py
+++ b/src/sentry/replays/endpoints/project_replay_clicks_index.py
@@ -80,7 +80,9 @@ class ProjectReplayClicksIndexEndpoint(ProjectReplayEndpoint):
         },
         examples=ReplayExamples.GET_REPLAY_CLICKS,
     )
-    def get(self, request: Request, project: Project, replay_id: str) -> Response:
+    def get(
+        self, request: Request, project: Project, replay_id: str
+    ) -> Response[ReplayClickResponse]:
         """Retrieve a collection of RRWeb DOM node-ids and the timestamp they were clicked."""
         self.check_replay_access(request, project)
 

--- a/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
@@ -48,7 +48,9 @@ class ProjectReplayRecordingSegmentIndexEndpoint(ProjectReplayEndpoint):
         },
         examples=ReplayExamples.GET_REPLAY_SEGMENTS,
     )
-    def get(self, request: Request, project, replay_id: str) -> Response:
+    def get(
+        self, request: Request, project, replay_id: str
+    ) -> Response[list[list[dict[str, Any]]]]:
         """Return a collection of replay recording segments."""
         self.check_replay_access(request, project)
 

--- a/src/sentry/replays/endpoints/project_replay_viewed_by.py
+++ b/src/sentry/replays/endpoints/project_replay_viewed_by.py
@@ -51,7 +51,9 @@ class ProjectReplayViewedByEndpoint(ProjectReplayEndpoint):
         },
         examples=ReplayExamples.GET_REPLAY_VIEWED_BY,
     )
-    def get(self, request: Request, project: Project, replay_id: str) -> Response:
+    def get(
+        self, request: Request, project: Project, replay_id: str
+    ) -> Response[ReplayViewedByResponse]:
         """Return a list of users who have viewed a replay."""
         self.check_replay_access(request, project)
 

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
@@ -41,7 +41,9 @@ class GroupExternalIssuesEndpoint(GroupEndpoint):
         examples=SentryAppExamples.GET_PLATFORM_EXTERNAL_ISSUE,
     )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-external-issues"])
-    def get(self, request: Request, group) -> Response:
+    def get(
+        self, request: Request, group
+    ) -> Response[list[PlatformExternalIssueSerializerResponse]]:
         """
         Retrieve custom integration issue links for the given Sentry issue
 

--- a/src/sentry/sentry_apps/api/endpoints/organization_sentry_apps.py
+++ b/src/sentry/sentry_apps/api/endpoints/organization_sentry_apps.py
@@ -46,7 +46,7 @@ class OrganizationSentryAppsEndpoint(ControlSiloOrganizationEndpoint):
         request: Request,
         organization_context: RpcUserOrganizationContext,
         organization: RpcOrganization,
-    ) -> Response:
+    ) -> Response[list[SentryAppSerializerResponse]]:
         """
         Retrieve the custom integrations for an organization
         """

--- a/src/sentry/uptime/endpoints/organiation_uptime_alert_index.py
+++ b/src/sentry/uptime/endpoints/organiation_uptime_alert_index.py
@@ -59,7 +59,9 @@ class OrganizationUptimeAlertIndexEndpoint(OrganizationEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[UptimeDetectorSerializerResponse]]:
         """
         Lists uptime alerts. May be filtered to a project or environment.
         """

--- a/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
@@ -66,7 +66,9 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[ActionHandlerSerializerResponse]]:
         """
         Returns a list of available actions for a given org
         """

--- a/src/sentry/workflow_engine/endpoints/organization_data_condition_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_data_condition_index.py
@@ -49,7 +49,9 @@ class OrganizationDataConditionIndexEndpoint(OrganizationEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[DataConditionHandlerResponse]]:
         """
         Returns a list of data conditions for a given org
         """

--- a/src/sentry/workflow_engine/endpoints/organization_detector_count.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_count.py
@@ -46,7 +46,9 @@ class OrganizationDetectorCountEndpoint(OrganizationEndpoint):
             403: RESPONSE_FORBIDDEN,
         },
     )
-    def get(self, request: AuthenticatedHttpRequest, organization: Organization) -> Response:
+    def get(
+        self, request: AuthenticatedHttpRequest, organization: Organization
+    ) -> Response[DetectorCountResponse]:
         """
         Retrieves the count of detectors for an organization.
         """

--- a/src/sentry/workflow_engine/endpoints/organization_detector_types.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_types.py
@@ -39,7 +39,7 @@ class OrganizationDetectorTypeIndexEndpoint(OrganizationEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response[list[str]]:
         """
         Returns a list of detector types for a given org
         """


### PR DESCRIPTION
First wave of opting endpoints into `Response[T]` after the foundation landed in #116335.

For every endpoint method whose `@extend_schema(responses={2xx: inline_sentry_response_serializer("X", T)})` schema is now also reflected in the return annotation `-> Response[T]`, mypy strictly checks the body shape at every `Response(...)` construction site, and the structural linter enforces decorator-T == annotation-T.

**How this set was chosen**

Automated try-and-revert: every endpoint method with an `inline_sentry_response_serializer` schema and a bare `-> Response` annotation (76 total) had its annotation rewritten to `-> Response[T]`. Mypy was then re-run; files that errored were reverted. These 43 methods are the survivors.

**Why the other 33 reverted**

Recognizable patterns that need follow-up work, not blockers for this batch:

- Error early-returns with `{"detail": "..."}` bodies that don't match the success TypedDict shape (e.g. `organization_eventid`, several `preprod_*` snapshot endpoints). Either the error path should `raise APIException` instead of returning a dict, or a discriminated-union return type is needed.
- `T=list[X]` schemas where the actual body wraps the list in a dict (`{"data": [...]}`) — schema/body shape mismatch that the new check now surfaces. Latent issue, separate fix.
- `Response(self.paginate(...))` patterns where `paginate` returns `Any`, triggering the new mypy plugin's body-Any hard-error. Closing those needs typed pagination return values.

**No runtime behavior change**

Each method's only diff is the return annotation. Body construction is unchanged, OpenAPI emission via `@extend_schema` is unchanged.