### PR TITLE
feat(onboarding): Add ScmAnalyticsFlow for project-creation reuse

### DIFF
--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -11,6 +11,38 @@ export type ProjectCreationEventParameters = {
     platform: string;
     project_id: string;
   };
+  // SCM-first project creation flow (mirrors onboarding.scm_*)
+  'project_creation.scm_connect_repo_selected': {
+    provider: string;
+    repo: string;
+  };
+  'project_creation.scm_connect_step_viewed': Record<string, unknown>;
+  'project_creation.scm_platform_change_platform_clicked': Record<string, unknown>;
+  'project_creation.scm_platform_feature_toggled': {
+    enabled: boolean;
+    feature: string;
+    platform: string;
+  };
+  'project_creation.scm_platform_features_step_viewed': Record<string, unknown>;
+  'project_creation.scm_platform_selected': {
+    platform: string;
+    source: 'detected' | 'manual';
+  };
+  'project_creation.scm_project_details_alert_selected': {
+    option: string;
+  };
+  'project_creation.scm_project_details_create_clicked': Record<string, unknown>;
+  'project_creation.scm_project_details_create_failed': Record<string, unknown>;
+  'project_creation.scm_project_details_create_succeeded': {
+    project_slug: string;
+  };
+  'project_creation.scm_project_details_name_edited': {
+    custom: boolean;
+  };
+  'project_creation.scm_project_details_step_viewed': Record<string, unknown>;
+  'project_creation.scm_project_details_team_selected': {
+    team: string;
+  };
   'project_creation.select_framework_modal_close_button_clicked': {
     platform: string;
   };
@@ -54,6 +86,30 @@ export const projectCreationEventMap: Record<
     'Project Creation: Data Removal Modal Rendered',
   'project_creation.data_removed': 'Project Creation: Data Removed',
   'project_creation.back_button_clicked': 'Project Creation: Back Button Clicked',
+  'project_creation.scm_connect_repo_selected':
+    'Project Creation: SCM Connect Repo Selected',
+  'project_creation.scm_connect_step_viewed': 'Project Creation: SCM Connect Step Viewed',
+  'project_creation.scm_platform_change_platform_clicked':
+    'Project Creation: SCM Platform Change Platform Clicked',
+  'project_creation.scm_platform_feature_toggled':
+    'Project Creation: SCM Platform Feature Toggled',
+  'project_creation.scm_platform_features_step_viewed':
+    'Project Creation: SCM Platform Features Step Viewed',
+  'project_creation.scm_platform_selected': 'Project Creation: SCM Platform Selected',
+  'project_creation.scm_project_details_alert_selected':
+    'Project Creation: SCM Project Details Alert Selected',
+  'project_creation.scm_project_details_create_clicked':
+    'Project Creation: SCM Project Details Create Clicked',
+  'project_creation.scm_project_details_create_failed':
+    'Project Creation: SCM Project Details Create Failed',
+  'project_creation.scm_project_details_create_succeeded':
+    'Project Creation: SCM Project Details Create Succeeded',
+  'project_creation.scm_project_details_name_edited':
+    'Project Creation: SCM Project Details Name Edited',
+  'project_creation.scm_project_details_step_viewed':
+    'Project Creation: SCM Project Details Step Viewed',
+  'project_creation.scm_project_details_team_selected':
+    'Project Creation: SCM Project Details Team Selected',
   'project_creation.source_maps_wizard_button_copy_clicked':
     'Project Creation: Source Maps Wizard Button Copy Clicked',
   'project_creation.source_maps_wizard_selected_and_copied':

--- a/static/app/views/onboarding/components/scmAnalyticsFlow.ts
+++ b/static/app/views/onboarding/components/scmAnalyticsFlow.ts
@@ -1,0 +1,6 @@
+/**
+ * Which flow is hosting the SCM step components. Used to pick which
+ * `*.scm_*` analytics event names the components fire (onboarding for
+ * new-org onboarding, project-creation for the project creation wizard).
+ */
+export type ScmAnalyticsFlow = 'onboarding' | 'project-creation';

--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -5,6 +5,7 @@ import {RepositoryFixture} from 'sentry-fixture/repository';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {Integration, Repository} from 'sentry/types/integrations';
+import * as analytics from 'sentry/utils/analytics';
 
 import {ScmRepoSelector} from './scmRepoSelector';
 
@@ -25,6 +26,7 @@ jest.mock('@tanstack/react-virtual', () => ({
 
 interface DefaultPropsOverrides {
   integration: Integration;
+  analyticsFlow?: 'onboarding' | 'project-creation';
   onClearDerivedState?: jest.Mock;
   onRepositoryChange?: jest.Mock;
   selectedRepository?: Repository;
@@ -32,11 +34,13 @@ interface DefaultPropsOverrides {
 
 function defaultProps({
   integration,
+  analyticsFlow = 'onboarding',
   onClearDerivedState = jest.fn(),
   onRepositoryChange = jest.fn(),
   selectedRepository,
 }: DefaultPropsOverrides) {
   return {
+    analyticsFlow,
     integration,
     selectedRepository,
     onRepositoryChange,
@@ -201,6 +205,55 @@ describe('ScmRepoSelector', () => {
 
     await waitFor(() => expect(reposLookup).toHaveBeenCalled());
     expect(onRepositoryChange).toHaveBeenCalled();
+  });
+
+  it('fires project_creation.scm_connect_repo_selected when analyticsFlow=project-creation', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
+      body: {
+        repos: [
+          {
+            externalId: '1',
+            identifier: 'getsentry/sentry',
+            name: 'sentry',
+            isInstalled: false,
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      body: [
+        RepositoryFixture({name: 'getsentry/sentry', externalSlug: 'getsentry/sentry'}),
+      ],
+    });
+
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+
+    render(
+      <ScmRepoSelector
+        {...defaultProps({
+          integration: mockIntegration,
+          analyticsFlow: 'project-creation',
+        })}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'sentry'}));
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.scm_connect_repo_selected',
+      expect.objectContaining({
+        provider: mockIntegration.provider.key,
+        repo: 'sentry',
+      })
+    );
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'onboarding.scm_connect_repo_selected',
+      expect.anything()
+    );
   });
 
   it('clears the selected repo', async () => {

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -7,12 +7,20 @@ import type {Integration, Repository} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
 import {ScmSearchControl} from './scmSearchControl';
 import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
 import {useScmRepos} from './useScmRepos';
 import {useScmRepoSelection} from './useScmRepoSelection';
 
+const REPO_SELECTED_EVENT = {
+  onboarding: 'onboarding.scm_connect_repo_selected',
+  'project-creation': 'project_creation.scm_connect_repo_selected',
+} as const;
+
 interface ScmRepoSelectorProps {
+  // Which flow this component is rendered in. Drives analytics event names.
+  analyticsFlow: ScmAnalyticsFlow;
   integration: Integration;
   // Fired once per user-driven change (select or clear) so callers can
   // invalidate state derived from the repo (platform, features, created
@@ -25,6 +33,7 @@ interface ScmRepoSelectorProps {
 }
 
 export function ScmRepoSelector({
+  analyticsFlow,
   integration,
   onClearDerivedState,
   onRepositoryChange,
@@ -67,7 +76,7 @@ export function ScmRepoSelector({
     } else {
       const repo = reposByIdentifier.get(option.value);
       if (repo) {
-        trackAnalytics('onboarding.scm_connect_repo_selected', {
+        trackAnalytics(REPO_SELECTED_EVENT[analyticsFlow], {
           organization,
           provider: integration.provider.key,
           repo: repo.name,

--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -132,6 +132,7 @@ export function ScmConnect({
                 )}
               </Text>
               <ScmRepoSelector
+                analyticsFlow="onboarding"
                 integration={effectiveIntegration}
                 selectedRepository={selectedRepository}
                 onRepositoryChange={onRepositoryChange}


### PR DESCRIPTION
## TL;DR
Introduces the `ScmAnalyticsFlow` type and the `project_creation.scm_*` event registry so SCM components reused in the project creation wizard can fire analytics under the `project-creation` namespace. Adds `analyticsFlow` as a required prop on `ScmRepoSelector`, the only SCM component consumed by both flows today. The connect-step, platform-features, and project-details wrappers remain onboarding-only and continue to fire `onboarding.scm_*` events directly. When VDY-75/76 extract project-creation cores from `ScmPlatformFeatures` and `ScmProjectDetails`, those cores will accept `analyticsFlow` the same way the upcoming `ScmIntegrationConnect` core does (extracted in PR 3 of this stack).

---

## Stack
- **PR 1 (this):** Add `ScmAnalyticsFlow` for project-creation reuse
- [PR 2](https://github.com/getsentry/sentry/pull/116577): Scaffold SCM-first project creation as a single view
- [PR 3](https://github.com/getsentry/sentry/pull/116581): Extract `ScmIntegrationConnect` from `ScmConnect`
- [PR 4](https://github.com/getsentry/sentry/pull/116582): Wire `ScmIntegrationConnect` into the single-view scaffold

## Summary
- New file `static/app/views/onboarding/components/scmAnalyticsFlow.ts` exports `ScmAnalyticsFlow = 'onboarding' | 'project-creation'`.
- New file `static/app/utils/analytics/projectCreationAnalyticsEvents.tsx` registers 13 `project_creation.scm_*` events mirroring the existing `onboarding.scm_*` payloads. Most are not fired yet; the downstream stack starts firing the connect-related ones.
- `ScmRepoSelector` gains a required `analyticsFlow` prop and uses it to pick between `onboarding.scm_connect_repo_selected` and `project_creation.scm_connect_repo_selected`. New tests cover both flows.
- `ScmConnect` hardcodes `analyticsFlow="onboarding"` when rendering the repo selector. No other changes.

## Out of scope
- `analyticsFlow` plumbing on `ScmConnect`, `ScmPlatformFeatures`, `ScmProjectDetails` wrappers. We are not consuming those wrappers directly from project creation. PR 3 extracts a separate core (`ScmIntegrationConnect`) for that; VDY-75/76 will do the same for the other two.
- Funnel construction in Amplitude. BI work.

Refs VDY-77