### PR TITLE
feat(seer): remove stale feature flag `organizations:seer-agent-pr-consolidation`

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -307,7 +307,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:search-query-attribute-validation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable search query builder raw search replacement
     manager.add("organizations:search-query-builder-raw-search-replacement", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:seer-agent-pr-consolidation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Disables the enableSeerCoding setting, preventing orgs from changing code generation behavior
     manager.add("organizations:seer-disable-coding-setting", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GitLab as a supported SCM provider for Seer


### PR DESCRIPTION
Removes the stale `organizations:seer-agent-pr-consolidation` feature flag.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XcDoaRsnBiJaLHEPf8Mk3g)_