### PR TITLE
feat(cells): Implement owner=1 on control silo org listing

### DIFF
--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -253,7 +253,10 @@ class OrganizationIndexEndpoint(Endpoint):
 
         owner_only = request.GET.get("owner") in ("1", "true")
 
-        # This is used when closing an account.
+        # owner=1 (used by the account-close flow) means "orgs I own", which is
+        # defined by the user's membership rows. A userless token (org auth token
+        # or DSN) passes the permission check but can never satisfy it, so reject
+        # it instead of falling through to the token-scoped, wrong-shaped listing.
         if owner_only and request.user.is_authenticated:
             return self._get_owned_from_control(request)
 

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -6,6 +6,7 @@ from django.db.models import Count, OuterRef, Q, Subquery
 from django.db.models.functions import Coalesce
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -255,9 +256,11 @@ class OrganizationIndexEndpoint(Endpoint):
 
         # owner=1 (used by the account-close flow) means "orgs I own", which is
         # defined by the user's membership. A userless token (org auth token or
-        # DSN) has no membership to resolve, so the is_authenticated guard lets it
-        # fall through to the general token-scoped listing below.
-        if owner_only and request.user.is_authenticated:
+        # DSN) passes the permission check but has no membership to resolve, so
+        # reject it rather than falling through to the general token-scoped listing.
+        if owner_only:
+            if not request.user.is_authenticated:
+                raise PermissionDenied
             return self._get_owned_from_control(request)
 
         queryset = OrganizationMapping.objects.distinct()

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -254,9 +254,9 @@ class OrganizationIndexEndpoint(Endpoint):
         owner_only = request.GET.get("owner") in ("1", "true")
 
         # owner=1 (used by the account-close flow) means "orgs I own", which is
-        # defined by the user's membership rows. A userless token (org auth token
-        # or DSN) passes the permission check but can never satisfy it, so reject
-        # it instead of falling through to the token-scoped, wrong-shaped listing.
+        # defined by the user's membership. A userless token (org auth token or
+        # DSN) has no membership to resolve, so the is_authenticated guard lets it
+        # fall through to the general token-scoped listing below.
         if owner_only and request.user.is_authenticated:
             return self._get_owned_from_control(request)
 

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -9,7 +9,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, options
+from sentry import features, options, roles
 from sentry import ratelimits as ratelimiter
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
@@ -253,11 +253,9 @@ class OrganizationIndexEndpoint(Endpoint):
 
         owner_only = request.GET.get("owner") in ("1", "true")
 
-        if owner_only:
-            return Response(
-                {"detail": "The control-silo organizations endpoint does not support owner=1."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        # This is used when closing an account.
+        if owner_only and request.user.is_authenticated:
+            return self._get_owned_from_control(request)
 
         queryset = OrganizationMapping.objects.distinct()
 
@@ -357,6 +355,50 @@ class OrganizationIndexEndpoint(Endpoint):
                 serializer=ControlSiloOrganizationMappingSerializer(),
             ),
             paginator_cls=paginator_cls,
+        )
+
+    def _get_owned_from_control(self, request: Request) -> Response:
+        assert request.user.id is not None
+        owner_role = roles.get_top_dog().id
+
+        owner_org_ids = OrganizationMemberMapping.objects.filter(
+            user_id=request.user.id,
+            role=owner_role,
+        ).values_list("organization_id", flat=True)
+
+        org_mappings = list(
+            OrganizationMapping.objects.filter(
+                organization_id__in=owner_org_ids,
+                status=OrganizationStatus.ACTIVE,
+            ).order_by("name")
+        )
+
+        owner_counts = (
+            OrganizationMemberMapping.objects.filter(
+                organization_id__in=[m.organization_id for m in org_mappings],
+                role=owner_role,
+                user_id__isnull=False,
+                user__is_active=True,
+            )
+            .values("organization_id")
+            .annotate(count=Count("id"))
+        )
+        single_owner_org_ids = {row["organization_id"] for row in owner_counts if row["count"] == 1}
+
+        serialized = serialize(
+            org_mappings,
+            request.user,
+            serializer=ControlSiloOrganizationMappingSerializer(),
+        )
+
+        return Response(
+            [
+                {
+                    "organization": data,
+                    "singleOwner": mapping.organization_id in single_owner_org_ids,
+                }
+                for mapping, data in zip(org_mappings, serialized)
+            ]
         )
 
     def post(self, request: Request) -> Response:

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -176,15 +176,28 @@ class OrganizationsControlListTest(OrganizationIndexTest):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(org1.id)
 
-    def test_owner_not_supported(self) -> None:
-        self.create_organization(cell="us", owner=self.user)
+    def test_ownership_across_cells(self) -> None:
+        org_a = self.create_organization(cell="us", name="A", owner=self.user)
+        org_b = self.create_organization(cell="de", name="B", owner=self.user)
 
-        response = self.get_error_response(status_code=400, owner="1")
+        user2 = self.create_user(email="user2@example.com")
+        org_c = self.create_organization(cell="us", name="C", owner=user2)
+        self.create_organization(cell="de", name="D", owner=user2)
+        org_e = self.create_organization(cell="us", name="E", owner=user2)
 
-        assert (
-            response.data["detail"]
-            == "The control-silo organizations endpoint does not support owner=1."
-        )
+        self.create_member(user=user2, organization=org_b, role="owner")
+        self.create_member(user=self.user, organization=org_c, role="owner")
+        self.create_member(user=self.user, organization=org_e, role="member")
+
+        response = self.get_success_response(qs_params={"owner": 1})
+
+        assert len(response.data) == 3
+        assert response.data[0]["organization"]["id"] == str(org_a.id)
+        assert response.data[0]["singleOwner"] is True
+        assert response.data[1]["organization"]["id"] == str(org_b.id)
+        assert response.data[1]["singleOwner"] is False
+        assert response.data[2]["organization"]["id"] == str(org_c.id)
+        assert response.data[2]["singleOwner"] is False
 
     def test_sort_by_members(self) -> None:
         smaller_org = self.create_organization(


### PR DESCRIPTION
Replaces the `owner=1` → 400 stub in `OrganizationIndexEndpoint._get_from_control` with a real implementation that queries `OrganizationMemberMapping` for the user's owner-role orgs and computes `singleOwner` from an aggregated count of active co-owners. Returns the same `[{organization, singleOwner}]` shape as the cell-side path, so existing frontend callers (account close + security enrolment) can migrate to this endpoint without major frontend changes.

Also fixes an N+1 query in the existing cell-side path. The cell version runs `has_single_owner()` and a full feature-flag evaluation (`features.batch_has`
+ per-feature `features.has` + onboarding/option queries) per org. Control issues the same queries regardless of org count and skips feature evaluation entirely since org features are no longer returned from control.
