### PR TITLE
feat(api-docs): publish organization trace meta endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_meta.py
+++ b/src/sentry/api/endpoints/organization_trace_meta.py
@@ -1,17 +1,23 @@
 import logging
-from typing import TypedDict
 
 import sentry_sdk
 from django.http import HttpRequest, HttpResponse
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableResponse
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_events_trace import count_performance_issues
+from sentry.api.endpoints.organization_trace_meta_types import OrganizationTraceMetaResponse
 from sentry.api.utils import handle_query_errors, update_snuba_params_with_timestamp
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.examples.trace_examples import TraceExamples
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.organizations.services.organization import RpcOrganization
@@ -19,7 +25,7 @@ from sentry.search.eap.occurrences.common_queries import count_occurrences_group
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.search.eap.types import EAPResponse, SearchResolverConfig
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
-from sentry.search.events.types import SnubaData, SnubaParams
+from sentry.search.events.types import SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.occurrences_rpc import OccurrenceCategory
 from sentry.snuba.ourlogs import OurLogs
@@ -32,17 +38,22 @@ from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
+TRACE_ID_PATH_PARAM = OpenApiParameter(
+    name="trace_id",
+    location="path",
+    required=True,
+    type=str,
+    description="The ID of the trace, a 32-character hexadecimal string.",
+)
 
-class SerializedResponse(TypedDict, total=False):
-    errorsCount: int
-    logsCount: int
-    metricsCount: int
-    performanceIssuesCount: int
-    spansCount: int
-    uptimeCount: int
-
-    transactionChildCountMap: SnubaData
-    spansCountMap: dict[str, int]
+INCLUDE_UPTIME_PARAM = OpenApiParameter(
+    name="include_uptime",
+    location="query",
+    required=False,
+    type=str,
+    enum=["0", "1"],
+    description="Set to `1` to include uptime check counts in the response. Defaults to `0` (disabled).",
+)
 
 
 def extract_uptime_count(uptime_result: list[TraceItemTableResponse]) -> int:
@@ -101,10 +112,12 @@ def run_errors_query(trace_id: str, snuba_params: SnubaParams) -> int:
     return errors_count
 
 
+@extend_schema(tags=["Discover"])
 @cell_silo_endpoint
 class OrganizationTraceMetaEndpoint(OrganizationEventsEndpointBase):
+    owner = ApiOwner.EXPLORE
     publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PUBLIC,
     }
 
     def get_projects(
@@ -208,7 +221,32 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsEndpointBase):
             ]
         )
 
+    @extend_schema(
+        operation_id="Retrieve Trace Metadata",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            TRACE_ID_PATH_PARAM,
+            GlobalParams.STATS_PERIOD,
+            GlobalParams.START,
+            GlobalParams.END,
+            INCLUDE_UPTIME_PARAM,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "OrganizationTraceMetaResponse", OrganizationTraceMetaResponse
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=TraceExamples.TRACE_META,
+    )
     def get(self, request: Request, organization: Organization, trace_id: str) -> HttpResponse:
+        """
+        Retrieve aggregate metadata for a single trace, including counts of spans,
+        errors, performance issues, logs, and metrics, along with per-span-operation
+        and per-transaction child-count breakdowns.
+        """
         if not self.has_feature(organization, request):
             return Response(status=404)
 
@@ -261,9 +299,9 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsEndpointBase):
         errors_count: int,
         perf_issues: int,
         uptime_count: int | None = None,
-    ) -> SerializedResponse:
+    ) -> OrganizationTraceMetaResponse:
         # Values can be null if there's no result
-        response: SerializedResponse = {
+        response: OrganizationTraceMetaResponse = {
             "errorsCount": errors_count,
             "logsCount": results["logs_meta"]["data"][0].get("count()") or 0,
             "metricsCount": results["metrics_meta"]["data"][0].get("count(value)") or 0,

--- a/src/sentry/api/endpoints/organization_trace_meta_types.py
+++ b/src/sentry/api/endpoints/organization_trace_meta_types.py
@@ -1,0 +1,17 @@
+from typing import TypedDict
+
+from sentry.search.events.types import SnubaData
+
+
+class OrganizationTraceMetaResponseOptional(TypedDict, total=False):
+    uptimeCount: int
+
+
+class OrganizationTraceMetaResponse(OrganizationTraceMetaResponseOptional):
+    errorsCount: int
+    logsCount: float
+    metricsCount: float
+    performanceIssuesCount: int
+    spansCount: float
+    transactionChildCountMap: SnubaData
+    spansCountMap: dict[str, float]

--- a/src/sentry/apidocs/examples/trace_examples.py
+++ b/src/sentry/apidocs/examples/trace_examples.py
@@ -1,0 +1,31 @@
+from drf_spectacular.utils import OpenApiExample
+
+from sentry.api.endpoints.organization_trace_meta_types import OrganizationTraceMetaResponse
+
+TRACE_META: OrganizationTraceMetaResponse = {
+    "errorsCount": 0,
+    "logsCount": 5.0,
+    "metricsCount": 0,
+    "performanceIssuesCount": 0,
+    "spansCount": 195.0,
+    "transactionChildCountMap": [
+        {"transaction.event_id": "280027d94f30428c83a2de46f932612a", "count()": 7.0},
+        {"transaction.event_id": "66087f4e87c847759db67fd62e32829c", "count()": 38.0},
+    ],
+    "spansCountMap": {
+        "db": 58.0,
+        "cache.get": 56.0,
+        "http.server": 6.0,
+    },
+}
+
+
+class TraceExamples:
+    TRACE_META = [
+        OpenApiExample(
+            "Return aggregate metadata for a trace",
+            value=TRACE_META,
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]

--- a/tests/apidocs/endpoints/events/test_organization_trace_meta.py
+++ b/tests/apidocs/endpoints/events/test_organization_trace_meta.py
@@ -1,0 +1,35 @@
+from django.test.client import RequestFactory
+from django.urls import reverse
+
+from fixtures.apidocs_test_case import APIDocsTestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+class OrganizationTraceMetaDocs(APIDocsTestCase):
+    def setUp(self) -> None:
+        self.login_as(user=self.user)
+        self.trace_id = "a" * 32
+
+        # Seed an event so the trace has at least one project bound to it.
+        self.store_event(
+            data={
+                "fingerprint": ["group1"],
+                "timestamp": before_now(minutes=1).isoformat(),
+                "contexts": {"trace": {"trace_id": self.trace_id, "span_id": "b" * 16}},
+            },
+            project_id=self.project.id,
+        )
+
+        self.url = reverse(
+            "sentry-api-0-organization-trace-meta",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "trace_id": self.trace_id,
+            },
+        )
+
+    def test_get(self) -> None:
+        response = self.client.get(f"{self.url}?statsPeriod=1h&project=-1")
+        request = RequestFactory().get(self.url)
+
+        self.validate_schema(request, response)


### PR DESCRIPTION
Publishes `OrganizationTraceMetaEndpoint` as part of https://linear.app/getsentry/project/api-docs-for-agents-c7863fd8bbe0/overview. Adds types + an API docs test. 