### PR TITLE
fix(integrations): Return the proper error response shape from the integration details POST endpoint

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integration_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_details.py
@@ -153,7 +153,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
             installation.update_organization_config(request.data)
         except (IntegrationError, ApiError) as e:
             sentry_sdk.capture_exception(e)
-            return self.respond({"detail": [str(e)]}, status=400)
+            return self.respond({"detail": str(e)}, status=400)
 
         self.create_audit_entry(
             request=request,

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -89,7 +89,7 @@ class OrganizationIntegrationDetailsPostTest(OrganizationIntegrationDetailsTest)
             response = self.get_error_response(
                 self.organization.slug, self.integration.id, **config, status_code=400
             )
-            assert response.data["detail"] == ["hello"]
+            assert response.data["detail"] == "hello"
 
         with patch.object(
             GitlabIntegration,
@@ -99,7 +99,7 @@ class OrganizationIntegrationDetailsPostTest(OrganizationIntegrationDetailsTest)
             response = self.get_error_response(
                 self.organization.slug, self.integration.id, **config, status_code=400
             )
-            assert response.data["detail"] == ["hi"]
+            assert response.data["detail"] == "hi"
 
 
 @control_silo_test


### PR DESCRIPTION
Ref ISWF-2677

The `OrganizationIntegrationDetailsEndpoint` POST handler was returning error messages wrapped in an array (`{"detail": ["error message"]}`), which is inconsistent with the standard convention of `{"detail": "error message"}`, so it doesn't work with our standard frontend utils which extract the message and show it to the user.

This removes the list wrapper so the endpoint returns a plain string, consistent with how other endpoints in the codebase return errors.