### PR TITLE
fix(forms): Surface backend error messages in AutoSaveForm

### DIFF
--- a/static/app/components/core/form/autoSaveForm.spec.tsx
+++ b/static/app/components/core/form/autoSaveForm.spec.tsx
@@ -236,6 +236,41 @@ describe('AutoSaveForm', () => {
       expect(await screen.findByText('Failed to save')).toBeInTheDocument();
     });
 
+    it('shows detail message from RequestError', async () => {
+      function TestComponent() {
+        return (
+          <AutoSaveForm
+            name="testField"
+            schema={testSchema}
+            initialValue="initial"
+            mutationOptions={{
+              mutationFn: () => {
+                const error = new RequestError('POST', '/test/', new Error('test'));
+                error.responseJSON = {detail: 'Organization is suspended'};
+                throw error;
+              },
+            }}
+          >
+            {field => (
+              <field.Layout.Row label="Name">
+                <field.Input value={field.state.value} onChange={field.handleChange} />
+                <field.Meta />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+        );
+      }
+
+      render(<TestComponent />);
+
+      const input = screen.getByRole('textbox', {name: 'Name'});
+      await userEvent.clear(input);
+      await userEvent.type(input, 'new value');
+      await userEvent.tab();
+
+      expect(await screen.findByText('Organization is suspended')).toBeInTheDocument();
+    });
+
     it('shows generic error when RequestError has no responseJSON', async () => {
       function TestComponent() {
         return (

--- a/static/app/components/core/form/autoSaveForm.tsx
+++ b/static/app/components/core/form/autoSaveForm.tsx
@@ -203,13 +203,14 @@ export function AutoSaveForm<
         if (resetOnErrorRef.current) {
           formApi.reset();
         }
-        const hasBackendErrors =
-          error instanceof RequestError ? setFieldErrors(formApi, error) : false;
+        const isRequestError = error instanceof RequestError;
+        const hasBackendErrors = isRequestError ? setFieldErrors(formApi, error) : false;
         if (!hasBackendErrors) {
+          const message = isRequestError
+            ? getRequestErrorUserMessage(error, t('Failed to save'))
+            : t('Failed to save');
           setFieldErrors(formApi, {
-            [name]: {
-              message: getRequestErrorUserMessage(error, t('Failed to save')),
-            },
+            [name]: {message},
           } as never);
         }
       };

--- a/static/app/components/core/form/autoSaveForm.tsx
+++ b/static/app/components/core/form/autoSaveForm.tsx
@@ -13,6 +13,7 @@ import {
 
 import {openConfirmModal} from 'sentry/components/confirm';
 import {t} from 'sentry/locale';
+import {getRequestErrorUserMessage} from 'sentry/utils/requestError/getRequestErrorUserMessage';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 
 /**
@@ -206,7 +207,9 @@ export function AutoSaveForm<
           error instanceof RequestError ? setFieldErrors(formApi, error) : false;
         if (!hasBackendErrors) {
           setFieldErrors(formApi, {
-            [name]: {message: t('Failed to save')},
+            [name]: {
+              message: getRequestErrorUserMessage(error, t('Failed to save')),
+            },
           } as never);
         }
       };


### PR DESCRIPTION
Ref ISWF-2677

When `AutoSaveForm` gets back an error response that doesn't contain field-level errors (e.g. `{detail: "Cannot override environment variable EXAMPLE"}` instead of `{project_mappings: ["error"]}`), it currently falls back to a generic "Failed to save" message. This PR attempts to extract any `detail` errors before falling back.

This change, combined with https://github.com/getsentry/sentry/pull/116447, should properly surface specific integration configuration errors to the user.