### PR TITLE
ref(feature-flags): Remove `organizations:insights-ai-and-mcp-dashboard-migration`

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -191,8 +191,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-discover-get-custom-measurements-reduced-range", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Detect performance issues in the new standalone spans pipeline instead of on transactions
     manager.add("organizations:performance-issues-spans", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
-    # Enable AI and MCP module dashboards on dashboards platform
-    manager.add("organizations:insights-ai-and-mcp-dashboard-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable all registered prebuilt dashboards to be synced to the database
     manager.add("organizations:dashboards-sync-all-registered-prebuilt-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Seer Suggestions for Web Vitals Module


### PR DESCRIPTION
Remove `organizations:insights-ai-and-mcp-dashboard-migration`. This flag has 0 usages across code, frontend, and tests (dead for 78 days, first seen dead 2026-03-12). Not present in sentry-options-automator.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNki2RgdHF3ZuroLVpupeQ)_