### PR TITLE
fix(jest): rename __dirname shadow in build scripts; revert #116413 workaround

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -323,15 +323,7 @@ const config: Config.InitialOptions = {
     '<rootDir>/tests/js/setupFramework.ts',
   ],
   testMatch: testMatch || ['<rootDir>/(static|tests/js)/**/?(*.)+(spec|test).[jt]s?(x)'],
-  testPathIgnorePatterns: [
-    '<rootDir>/tests/sentry/lang/javascript/',
-    // ESM-style helper scripts (e.g. scripts/genPlatformProductInfo.ts use
-    // `const __dirname = path.dirname(fileURLToPath(import.meta.url))`) that
-    // SWC's CJS transform redeclares — collides with Node's module wrapper.
-    // None of these are tests; keep them out of Jest's discovery entirely.
-    '<rootDir>/scripts/',
-  ],
-  modulePathIgnorePatterns: ['<rootDir>/scripts/'],
+  testPathIgnorePatterns: ['<rootDir>/tests/sentry/lang/javascript/'],
 
   unmockedModulePathPatterns: [
     '<rootDir>/node_modules/react',

--- a/scripts/extractFormFields.ts
+++ b/scripts/extractFormFields.ts
@@ -11,8 +11,14 @@ import {fileURLToPath} from 'node:url';
 
 import * as ts from 'typescript';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+// Named THIS_FILE / THIS_DIR rather than the conventional __filename /
+// __dirname so SWC's CJS transform (used by Jest) doesn't emit a
+// `const __dirname = ...` that collides with the wrapper-provided
+// binding and crashes the frontend test run with a SyntaxError.
+// Behavior-equivalent at runtime — the originals only shadowed the
+// wrapper inside this module.
+const THIS_FILE = fileURLToPath(import.meta.url);
+const THIS_DIR = path.dirname(THIS_FILE);
 
 interface ExtractedField {
   formId: string;
@@ -480,14 +486,14 @@ ${registryEntries}
 
 // Main execution
 try {
-  const configPath = path.join(__dirname, '../tsconfig.json');
+  const configPath = path.join(THIS_DIR, '../tsconfig.json');
   const extractor = new FormFieldExtractor(configPath);
 
   console.log('🔍 Extracting form fields from TypeScript files...');
   const fields = extractor.extractAllFields();
 
   const outputPath = path.join(
-    __dirname,
+    THIS_DIR,
     '../static/app/components/core/form/generatedFieldRegistry.ts'
   );
 

--- a/scripts/genPlatformProductInfo.ts
+++ b/scripts/genPlatformProductInfo.ts
@@ -26,8 +26,13 @@ import {fileURLToPath} from 'node:url';
 import * as ts from 'typescript';
 import {parse as parseYaml} from 'yaml';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SENTRY_ROOT = path.resolve(__dirname, '..');
+// Named THIS_DIR rather than __dirname so SWC's CJS transform (used by Jest)
+// doesn't emit a `const __dirname = ...` that collides with the wrapper-
+// provided binding and crashes the whole frontend test run with a
+// SyntaxError. The original `__dirname` only shadowed the wrapper inside
+// this module anyway, so the rename is behavior-equivalent at runtime.
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SENTRY_ROOT = path.resolve(THIS_DIR, '..');
 const DOCS_ROOT = process.env.SENTRY_DOCS_PATH
   ? path.resolve(process.env.SENTRY_DOCS_PATH)
   : path.resolve(SENTRY_ROOT, '..', 'sentry-docs');


### PR DESCRIPTION
## Problem

PR #116413 added \`<rootDir>/scripts/\` to \`testPathIgnorePatterns\` and \`modulePathIgnorePatterns\` to work around a Jest+SWC cascade:

\`\`\`
/scripts/genPlatformProductInfo.ts:51
const __dirname = _nodepath.dirname((0, _nodeurl.fileURLToPath)(require(\"url\").pathToFileURL(__filename).toString()));
      ^
SyntaxError: Identifier '__dirname' has already been declared
\`\`\`

That fix appeared to work on the original REVENG-86 PR (getsentry/sentry#116269) and was merged, but a later PR ([getsentry/sentry#116420](https://github.com/getsentry/sentry/pull/116420)) reproduced the exact same cascade despite the ignore patterns being present.

Reason: \`testPathIgnorePatterns\` and \`modulePathIgnorePatterns\` only govern Jest's test-discovery and runtime-environment \`require\`. They don't stop Jest's pre-test transform during \`--listTests --changedSince\` from invoking SWC on files in \`scripts/\`. So the parse error still happens whenever \`--changedSince\` traversal reaches one of these scripts.

## Solution

Fix at the source. Two files use \`fileURLToPath(import.meta.url)\` to recover ESM-equivalent \`__dirname\` (and one of them \`__filename\`):

- \`scripts/genPlatformProductInfo.ts:29\`
- \`scripts/extractFormFields.ts:14–15\`

When SWC compiles these to CommonJS for Jest, the generated \`const __dirname = ...\` collides with the binding Node already provides via the module wrapper, producing the SyntaxError. Renaming the locals to \`THIS_DIR\` / \`THIS_FILE\` removes the collision without changing behavior — those identifiers were only used as locals within their own modules.

### Commits

1. \`fix(scripts): rename local __dirname shadow that breaks Jest+SWC\` — the actual root-cause fix.
2. \`revert(jest): remove scripts/ ignore patterns now that root cause is fixed\` — removes the #116413 workaround that was dead config and misleadingly documented.

### Verified on

- Local: \`pnpm exec jest --listTests --json --changedSince=\$(git rev-parse origin/master) --passWithNoTests\` returns \`[]\` cleanly with both changes applied.
- CI: same two commits were carried temporarily on getsentry/sentry#116420 — the Jest shards went green for the first time with just the rename, and stayed green after the revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)