### PR TITLE
feat(lint): Add S019 to flag non-2xx Response calls

### DIFF
--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -393,3 +393,97 @@ def test_S015_current_or_future_year() -> None:
         )
         == []
     )
+
+
+def test_S019_non_2xx_status_kwarg() -> None:
+    src = """\
+from rest_framework.response import Response
+
+def view():
+    return Response({"detail": "bad"}, status=400)
+"""
+    out = _run(src)
+    assert len(out) == 1
+    assert "S019" in out[0]
+    assert "t.py:4:11" in out[0]
+
+
+def test_S019_status_constant() -> None:
+    src = """\
+from rest_framework import status
+from rest_framework.response import Response
+
+def view():
+    return Response({"detail": "not found"}, status=status.HTTP_404_NOT_FOUND)
+"""
+    out = _run(src)
+    assert len(out) == 1
+    assert "S019" in out[0]
+
+
+def test_S019_positional_status() -> None:
+    src = """\
+from rest_framework.response import Response
+
+def view():
+    return Response({"detail": "boom"}, 500)
+"""
+    out = _run(src)
+    assert len(out) == 1
+    assert "S019" in out[0]
+
+
+def test_S019_body_less_non_2xx() -> None:
+    """Body-less `Response(status=404)` is also flagged — it should `raise NotFound()`."""
+    src = """\
+from rest_framework.response import Response
+
+def view():
+    return Response(status=404)
+"""
+    out = _run(src)
+    assert len(out) == 1
+    assert "S019" in out[0]
+
+
+def test_S019_2xx_status_not_flagged() -> None:
+    src = """\
+from rest_framework.response import Response
+
+def view():
+    return Response({"x": 1}, status=200)
+"""
+    assert _run(src) == []
+
+
+def test_S019_default_status_not_flagged() -> None:
+    """`Response(body)` with no explicit status defaults to 200 — not flagged."""
+    src = """\
+from rest_framework.response import Response
+
+def view():
+    return Response({"x": 1})
+"""
+    assert _run(src) == []
+
+
+def test_S019_dynamic_status_not_flagged() -> None:
+    """When status isn't a static literal, we can't tell — don't flag."""
+    src = """\
+from rest_framework.response import Response
+
+def view(code):
+    return Response({"detail": "..."}, status=code)
+"""
+    assert _run(src) == []
+
+
+def test_S019_skipped_in_tests() -> None:
+    """Tests legitimately mock non-2xx responses — don't flag them."""
+    src = """\
+from rest_framework.response import Response
+
+def test_view():
+    return Response({"detail": "..."}, status=400)
+"""
+    assert _run(src, filename="tests/sentry/api/test_thing.py") == []

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -55,6 +55,42 @@ S018_msg = (
 S018_fqn = "django.core.cache.backends.memcached.PyMemcacheCache"  # noqa: S018
 S018_module = "django.core.cache.backends.memcached"
 
+S019_msg = (
+    "S019 Use `raise <APIException subclass>(...)` instead of `Response(...)` with a "
+    "non-2xx status code. See `sentry.api.exceptions` (BadRequest, ResourceDoesNotExist, "
+    "ConflictError, …) or `rest_framework.exceptions` (ValidationError, NotFound, "
+    "PermissionDenied, Throttled, …). The wire response shape is identical."
+)
+
+
+def _resolve_response_status(call: ast.Call) -> int | None:
+    """Return the int status code from a `Response(...)` call, or None if it
+    can't be statically resolved.
+
+    Recognized forms for the status argument:
+        Response(..., status=400)               → 400
+        Response(..., status=status.HTTP_400_*) → 400
+        Response(<body>, 400)                   → 400 (positional)
+        Response(<body>, status.HTTP_400_*)     → 400 (positional via constant)
+    """
+    candidate: ast.expr | None = None
+    for kw in call.keywords:
+        if kw.arg == "status":
+            candidate = kw.value
+            break
+    if candidate is None and len(call.args) >= 2:
+        candidate = call.args[1]
+    if candidate is None:
+        return None
+    if isinstance(candidate, ast.Constant) and isinstance(candidate.value, int):
+        return candidate.value
+    if isinstance(candidate, ast.Attribute):
+        # status.HTTP_400_BAD_REQUEST → 400
+        attr = candidate.attr
+        if attr.startswith("HTTP_") and len(attr) >= 8 and attr[5:8].isdigit():
+            return int(attr[5:8])
+    return None
+
 
 # --- S015: do not hardcode current or future UTC year as test "now" ---
 # Flag year >= current UTC year at lint time. Module/class scope + freeze_time(datetime(...)).
@@ -284,6 +320,15 @@ class SentryVisitor(ast.NodeVisitor):
                 y = _wall_clock_year_from_datetime_call(node.args[0])
                 if y is not None and y >= self._s015_year:
                     self.errors.append((node.lineno, node.col_offset, self._s015_msg))
+        # S019: Response(..., status=<non-2xx>) should be `raise APIException(...)`.
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "Response"
+            and not _is_tests_path(self.filename)
+        ):
+            status = _resolve_response_status(node)
+            if status is not None and not (200 <= status < 300):
+                self.errors.append((node.lineno, node.col_offset, S019_msg))
         if (
             # override_settings(...)
             (isinstance(node.func, ast.Name) and node.func.id == "override_settings")


### PR DESCRIPTION
Adds a flake8 rule (`S019`) that flags every `Response(<body>, status=N)` where `N` is not 2xx. These calls should be converted to `raise <APIException>(...)` — DRF's `exception_handler` formats every `APIException` as `{"detail": str(exc)}`, so the wire response is identical, but the endpoint's return type becomes uniform and clean (no `Response[T] | Response` union with mismatched body shape).

**Why this matters**

When we landed `Response[T]` in #116335 and migrated 43 endpoints in #116433, the try-and-revert pass rejected 33 endpoints largely because of `return Response({"detail": ...}, status=4xx)` patterns. The success TypedDict doesn't have a `"detail"` key. Migrating those endpoints to `Response[T]` requires either a discriminated-union return type (ugly) or converting the error paths to `raise APIException(...)` (clean — exceptions exit through `exception_handler`, not the return type).

This rule identifies the migration targets.

**Inventory across `src/sentry`**

| Status | Count | Migration target |
|---|---|---|
| 400 | 655 | `ValidationError` / `ParseError` / `BadRequest` |
| 404 | 226 | `NotFound` / `ResourceDoesNotExist` |
| 403 | 125 | `PermissionDenied` |
| 500 | 54 | `APIException` default (likely real bugs) |
| 401 | 21 | `NotAuthenticated` / `AuthenticationFailed` |
| 409 | 15 | `ConflictError` |
| 429 | 8 | `Throttled` |
| Other | 17 | subclass `APIException` |

**Total: 1,121 violations across 328 files.**

**Ratchet, not sweep**

Existing offenders are not fixed in this PR. prek runs flake8 on changed files only, so S019 fires only when a dev touches a violating file. That's the natural ratchet — no single huge sweep, but every PR moves the count downward and prevents regressions on touched files.

**Recognized status forms**

```python
Response(..., status=400)                  # → flagged (400)
Response(..., status=status.HTTP_400_*)    # → flagged (400)
Response(<body>, 400)                      # → flagged (positional)
Response(<body>, status.HTTP_400_*)        # → flagged (positional constant)
```

**Skip cases (not flagged)**

- 2xx status (success path)
- Default status (no explicit `status=` arg — defaults to 200)
- Dynamic status (`status=variable`)
- Files in `tests/` (legitimate non-2xx mocking)