### PR TITLE
ref(webhooks): Hide PLUGIN action type from available actions endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
@@ -162,7 +162,10 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
                         )
                     )
 
-            # add all other action types (EMAIL, PLUGIN, etc.)
+            elif action_type == Action.Type.PLUGIN:
+                continue
+
+            # add all other action types (EMAIL, etc.)
             else:
                 actions.append(
                     serialize(
@@ -173,11 +176,7 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
         actions.sort(
             key=lambda x: (
                 x["handlerGroup"],
-                (
-                    0
-                    if x["type"] in [Action.Type.EMAIL, Action.Type.PLUGIN, Action.Type.WEBHOOK]
-                    else 1
-                ),
+                (0 if x["type"] in [Action.Type.EMAIL, Action.Type.WEBHOOK] else 1),
                 x["type"],
                 (x["sentryApp"].get("name", "") if x.get("sentryApp") else ""),
             )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
@@ -477,7 +477,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             self.organization.slug,
             status_code=200,
         )
-        assert len(response.data) == 8
+        assert len(response.data) == 7
         assert response.data == [
             # notification actions, sorted alphabetically with email first
             {
@@ -495,13 +495,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
                     {"id": str(self.slack_integration.id), "name": self.slack_integration.name}
                 ],
             },
-            # other actions, non sentry app actions first then sentry apps sorted alphabetically by name
-            {
-                "type": Action.Type.PLUGIN,
-                "handlerGroup": ActionHandler.Group.OTHER.value,
-                "configSchema": {},
-                "dataSchema": {},
-            },
+            # other actions — PLUGIN is registered but hidden from available actions
             # webhook action should include sentry apps without components
             {
                 "type": Action.Type.WEBHOOK,


### PR DESCRIPTION
Filters `Action.Type.PLUGIN` out of the available actions, preventing new PLUGIN actions from being created in the alerts UI. Since we don't want to support plugins in the future, except for the webhooks one but that can be set via the explicit WebHooks action

