### PR TITLE
fix(webhooks): Check webhooks:enabled in new webhook path

### DIFF
--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -135,6 +135,10 @@ def send_legacy_webhooks_for_invocation(invocation: ActionInvocation) -> None:
     from sentry.sentry_apps.services.legacy_webhook.tasks import send_legacy_webhook_task
 
     project = invocation.detector.project
+    enabled = ProjectOption.objects.get_value(project, "webhooks:enabled", default=False)
+    if not enabled:
+        return
+
     urls_raw = ProjectOption.objects.get_value(project, "webhooks:urls", default="")
     urls = split_urls(urls_raw)
     if not urls:

--- a/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
+++ b/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
@@ -227,6 +227,23 @@ class TestWebhookActionHandlerExecute(BaseWorkflowTest):
         mock_sentry_app.assert_not_called()
 
     @responses.activate
+    @with_feature(
+        {
+            "organizations:legacy-webhook-new-path": True,
+            "organizations:legacy-webhook-disable-old-path": True,
+        }
+    )
+    def test_new_path_disabled_webhooks_does_not_send(self) -> None:
+        responses.add(responses.POST, "http://example.com/hook")
+        webhook_plugin = plugins.get("webhooks")
+        webhook_plugin.set_option("enabled", False, self.project)
+
+        with self.tasks():
+            WebhookActionHandler.execute(self.invocation)
+
+        assert len(responses.calls) == 0
+
+    @responses.activate
     @mock.patch(
         "sentry.notifications.notification_action.action_handler_registry.webhook_handler.execute_via_group_type_registry",
         side_effect=Exception("legacy path error"),

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_service.py
@@ -97,6 +97,7 @@ class TestSendLegacyWebhooksForInvocation(BaseWorkflowTest):
         "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
     )
     def test_dispatches_task_per_url(self, mock_task: mock.MagicMock) -> None:
+        ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
         ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://a.com\nhttp://b.com")
 
         send_legacy_webhooks_for_invocation(self.invocation)
@@ -109,6 +110,29 @@ class TestSendLegacyWebhooksForInvocation(BaseWorkflowTest):
         "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
     )
     def test_no_urls_configured_is_noop(self, mock_task: mock.MagicMock) -> None:
+        ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
+
+        send_legacy_webhooks_for_invocation(self.invocation)
+
+        assert mock_task.delay.call_count == 0
+
+    @mock.patch(
+        "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
+    )
+    def test_webhooks_disabled_is_noop(self, mock_task: mock.MagicMock) -> None:
+        ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://a.com")
+
+        send_legacy_webhooks_for_invocation(self.invocation)
+
+        assert mock_task.delay.call_count == 0
+
+    @mock.patch(
+        "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
+    )
+    def test_webhooks_explicitly_disabled_is_noop(self, mock_task: mock.MagicMock) -> None:
+        ProjectOption.objects.set_value(self.project, "webhooks:enabled", False)
+        ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://a.com")
+
         send_legacy_webhooks_for_invocation(self.invocation)
 
         assert mock_task.delay.call_count == 0
@@ -117,6 +141,7 @@ class TestSendLegacyWebhooksForInvocation(BaseWorkflowTest):
         "sentry.sentry_apps.services.legacy_webhook.tasks.send_legacy_webhook_task",
     )
     def test_triggering_rules_uses_workflow_name(self, mock_task: mock.MagicMock) -> None:
+        ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
         ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://a.com")
 
         send_legacy_webhooks_for_invocation(self.invocation)
@@ -133,6 +158,7 @@ class TestSendLegacyWebhooksForInvocation(BaseWorkflowTest):
         rule.save()
         self.create_alert_rule_workflow(rule_id=rule.id, workflow=self.workflow)
 
+        ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
         ProjectOption.objects.set_value(self.project, "webhooks:urls", "http://a.com")
 
         send_legacy_webhooks_for_invocation(self.invocation)


### PR DESCRIPTION
Since we want to maintain the parity of being able to enable/disable legacy_webhooks on a per project basis we need to add back the gate that checks the webhooks:enabled ProjectOption