### PR TITLE
feat(issues): Refine low-value span configuration UI

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
@@ -32,9 +32,7 @@ describe('LowValueSpanIssueDetails', () => {
 
     expect(screen.getByText('Problem')).toBeInTheDocument();
     expect(screen.getByText('Troubleshooting')).toBeInTheDocument();
-    expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(
-      0
-    );
+    expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(0);
     expect(screen.getByText('60,000')).toBeInTheDocument();
     expect(screen.getByText('$12.34')).toBeInTheDocument();
     expect(screen.queryByText('Value score')).not.toBeInTheDocument();

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
@@ -13,9 +13,10 @@ describe('LowValueSpanIssueDetails', () => {
         event={EventFixture({
           occurrence: {
             evidenceData: {
-              op: 'function',
-              description: 'compute_checksum',
-              count: 1234,
+              span_op: 'function',
+              span_description: 'compute_checksum',
+              span_count: 1234,
+              extrapolated_count: 60_000,
               value_score: 0.15,
               avg_duration_ms: 0.4,
               estimated_cost_usd: 12.34,
@@ -32,6 +33,7 @@ describe('LowValueSpanIssueDetails', () => {
     expect(screen.getByText('Problem')).toBeInTheDocument();
     expect(screen.getByText('Troubleshooting')).toBeInTheDocument();
     expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(0);
+    expect(screen.getByText('60,000')).toBeInTheDocument();
     expect(screen.getByText('$12.34')).toBeInTheDocument();
     expect(screen.queryByText('Value score')).not.toBeInTheDocument();
     expect(screen.queryByText('15%')).not.toBeInTheDocument();

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
@@ -41,12 +41,15 @@ describe('LowValueSpanIssueDetails', () => {
     expect(screen.queryByText('Impact')).not.toBeInTheDocument();
   });
 
-  it('only reads the backend evidence field names', () => {
+  it('only reads the new backend evidence field names', () => {
     render(
       <LowValueSpanIssueDetails
         event={EventFixture({
           occurrence: {
             evidenceData: {
+              op: 'function',
+              description: 'compute_checksum',
+              count: 1234,
               spanOp: 'function',
               spanDescription: 'compute_checksum',
               seenCount: 1234,

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
@@ -32,7 +32,9 @@ describe('LowValueSpanIssueDetails', () => {
 
     expect(screen.getByText('Problem')).toBeInTheDocument();
     expect(screen.getByText('Troubleshooting')).toBeInTheDocument();
-    expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(
+      0
+    );
     expect(screen.getByText('60,000')).toBeInTheDocument();
     expect(screen.getByText('$12.34')).toBeInTheDocument();
     expect(screen.queryByText('Value score')).not.toBeInTheDocument();

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.spec.tsx
@@ -6,10 +6,12 @@ import type {LowValueSpanEvidenceData} from './types';
 const evidenceData: LowValueSpanEvidenceData = {
   op: 'function',
   description: 'compute_checksum',
-  count: 1234,
+  spanCount: 1234,
+  extrapolatedCount: 60_000,
   avgDurationMs: 0.4,
   estimatedCostUsd: 12.34,
   sdkName: 'sentry.javascript.nextjs',
+  spanOrigin: 'auto',
 };
 
 describe('LowValueSpanIssues ProblemSection', () => {
@@ -17,18 +19,28 @@ describe('LowValueSpanIssues ProblemSection', () => {
     render(<ProblemSection evidenceData={evidenceData} />);
 
     expect(screen.getByText('Problem')).toBeInTheDocument();
-    expect(screen.getByText('function')).toBeInTheDocument();
     expect(screen.getByText('function - compute_checksum')).toBeInTheDocument();
-    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText('Span count')).toBeInTheDocument();
+    expect(screen.getByText('60,000')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('More information')).toHaveLength(2);
     expect(screen.getByText('Estimated cost')).toBeInTheDocument();
     expect(screen.getByText('$12.34')).toBeInTheDocument();
-    expect(
-      screen.getByLabelText('More information', {
-        selector: '[aria-label="More information"]',
-      })
-    ).toBeInTheDocument();
     expect(screen.getByText('<1ms')).toBeInTheDocument();
-    expect(screen.getByText('sentry.javascript.nextjs')).toBeInTheDocument();
+    expect(screen.queryByText('sentry.javascript.nextjs')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the sampled span count when extrapolated count is unavailable', () => {
+    render(
+      <ProblemSection
+        evidenceData={{
+          ...evidenceData,
+          extrapolatedCount: null,
+        }}
+      />
+    );
+
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('More information')).toHaveLength(1);
   });
 
   it('does not render estimated cost when unavailable', () => {

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
@@ -1,6 +1,5 @@
 import type {ReactNode} from 'react';
 
-import {InlineCode} from '@sentry/scraps/code';
 import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -32,16 +31,16 @@ function DetailRow({label, value}: {label: string; value: ReactNode}) {
 export function ProblemSection({evidenceData}: ProblemSectionProps) {
   const hasEstimatedCost =
     evidenceData.estimatedCostUsd !== null && evidenceData.estimatedCostUsd > 0;
+  const spanCount = evidenceData.extrapolatedCount ?? evidenceData.spanCount;
 
   return (
     <Stack gap="lg" padding="lg">
       <Flex align="baseline" gap="sm" wrap="wrap">
         <Heading as="h3">{t('Problem')}</Heading>
-        {evidenceData.op && <InlineCode>{evidenceData.op}</InlineCode>}
       </Flex>
       <Text>
         {t(
-          'Sentry detected a span that appears frequently but adds low-value telemetry. It can make traces noisier and increase stored span volume without adding useful debugging context.'
+          'Sentry found a frequently created span that adds little value. It can make traces harder to read and increase stored span volume.'
         )}
       </Text>
       <Text>
@@ -50,7 +49,20 @@ export function ProblemSection({evidenceData}: ProblemSectionProps) {
         })}
       </Text>
       <Stack gap="xs">
-        <DetailRow label={t('Seen')} value={formatCount(evidenceData.count)} />
+        <Flex align="baseline" gap="sm" wrap="wrap">
+          <Text variant="muted">{t('Span count')}</Text>
+          <Flex align="center" gap="xs">
+            <Text>{formatCount(spanCount)}</Text>
+            {evidenceData.extrapolatedCount !== null && (
+              <InfoTip
+                size="xs"
+                title={t(
+                  'This monthly volume is extrapolated from a recent sample of this span, so it may not match the final span volume for the billing period.'
+                )}
+              />
+            )}
+          </Flex>
+        </Flex>
         {hasEstimatedCost && (
           <Flex align="baseline" gap="sm" wrap="wrap">
             <Text variant="muted">{t('Estimated cost')}</Text>
@@ -69,12 +81,6 @@ export function ProblemSection({evidenceData}: ProblemSectionProps) {
           label={t('Average duration')}
           value={formatDurationMs(evidenceData.avgDurationMs)}
         />
-        {evidenceData.sdkName && (
-          <DetailRow
-            label={t('SDK')}
-            value={<InlineCode>{evidenceData.sdkName}</InlineCode>}
-          />
-        )}
       </Stack>
     </Stack>
   );

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
@@ -6,25 +6,49 @@ import type {LowValueSpanEvidenceData} from './types';
 const baseEvidenceData: LowValueSpanEvidenceData = {
   op: 'function',
   description: 'compute_checksum',
-  count: 1234,
+  spanCount: 1234,
+  extrapolatedCount: 60_000,
   avgDurationMs: 0.4,
   estimatedCostUsd: 12.34,
   sdkName: 'sentry.javascript.nextjs',
+  spanOrigin: 'auto',
 };
 
 describe('LowValueSpanIssues TroubleshootingSection', () => {
-  it('renders the two troubleshooting paths', () => {
+  it('renders automatic instrumentation guidance for auto spans', () => {
     render(<TroubleshootingSection evidenceData={baseEvidenceData} />);
 
     expect(screen.getByText('Troubleshooting')).toBeInTheDocument();
-    expect(screen.getByText('1. Find where the span is created')).toBeInTheDocument();
+    expect(screen.getByText('ignoreSpans')).toBeInTheDocument();
+    expect(screen.queryByText('function - compute_checksum')).not.toBeInTheDocument();
+    expect(screen.queryByText('sentry.javascript.nextjs')).not.toBeInTheDocument();
     expect(
-      screen.getByText('2. Remove custom instrumentation when possible')
-    ).toBeInTheDocument();
+      screen.queryByText('1. Find the custom span')
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText('3. Filter automatic instrumentation exactly')
+      screen.queryByText('2. Remove or replace the span')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders manual instrumentation guidance only for manual spans', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={{
+          ...baseEvidenceData,
+          spanOrigin: 'manual',
+        }}
+      />
+    );
+
+    expect(screen.getByText('1. Find the custom span')).toBeInTheDocument();
+    expect(screen.getByText('2. Remove or replace the span')).toBeInTheDocument();
+    expect(
+      screen.getByText(/delete the custom span line/)
     ).toBeInTheDocument();
-    expect(screen.getByText('function - compute_checksum')).toBeInTheDocument();
+    expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(0);
+    expect(screen.queryByText('sentry.javascript.nextjs')).not.toBeInTheDocument();
+    expect(screen.queryByText('ignoreSpans')).not.toBeInTheDocument();
+    expect(screen.queryByText('before_send_transaction')).not.toBeInTheDocument();
   });
 
   it('recommends JavaScript span filtering and mentions beforeSendSpan', () => {
@@ -62,8 +86,22 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
     );
 
     expect(
-      screen.getByText(/Check your SDK tracing options and add an exact-match filter/)
+      screen.getByText(/Add an exact-match span filter/)
     ).toBeInTheDocument();
     expect(screen.queryByText(/beforeSendTransaction/)).not.toBeInTheDocument();
+  });
+
+  it('treats missing span origin as automatic instrumentation', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={{
+          ...baseEvidenceData,
+          spanOrigin: null,
+        }}
+      />
+    );
+
+    expect(screen.getByText('ignoreSpans')).toBeInTheDocument();
+    expect(screen.queryByText('1. Find the custom span')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
@@ -22,12 +22,8 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
     expect(screen.getByText('ignoreSpans')).toBeInTheDocument();
     expect(screen.queryByText('function - compute_checksum')).not.toBeInTheDocument();
     expect(screen.queryByText('sentry.javascript.nextjs')).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('1. Find the custom span')
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('2. Remove or replace the span')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('1. Find the custom span')).not.toBeInTheDocument();
+    expect(screen.queryByText('2. Remove or replace the span')).not.toBeInTheDocument();
   });
 
   it('renders manual instrumentation guidance only for manual spans', () => {
@@ -42,12 +38,8 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
 
     expect(screen.getByText('1. Find the custom span')).toBeInTheDocument();
     expect(screen.getByText('2. Remove or replace the span')).toBeInTheDocument();
-    expect(
-      screen.getByText(/delete the custom span line/)
-    ).toBeInTheDocument();
-    expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(
-      0
-    );
+    expect(screen.getByText(/delete the custom span line/)).toBeInTheDocument();
+    expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(0);
     expect(screen.queryByText('sentry.javascript.nextjs')).not.toBeInTheDocument();
     expect(screen.queryByText('ignoreSpans')).not.toBeInTheDocument();
     expect(screen.queryByText('before_send_transaction')).not.toBeInTheDocument();
@@ -74,9 +66,7 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
 
     expect(screen.getByText('before_send_transaction')).toBeInTheDocument();
     expect(screen.getAllByText(/event\["spans"\]/).length).toBeGreaterThan(0);
-    expect(
-      screen.getByText(/span.get\("op"\) == "function"/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/span.get\("op"\) == "function"/)).toBeInTheDocument();
   });
 
   it('renders generic guidance when the SDK is unavailable', () => {
@@ -89,9 +79,7 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
       />
     );
 
-    expect(
-      screen.getByText(/Add an exact-match span filter/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Add an exact-match span filter/)).toBeInTheDocument();
     expect(screen.queryByText(/beforeSendTransaction/)).not.toBeInTheDocument();
   });
 

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
@@ -45,7 +45,9 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
     expect(
       screen.getByText(/delete the custom span line/)
     ).toBeInTheDocument();
-    expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(
+      0
+    );
     expect(screen.queryByText('sentry.javascript.nextjs')).not.toBeInTheDocument();
     expect(screen.queryByText('ignoreSpans')).not.toBeInTheDocument();
     expect(screen.queryByText('before_send_transaction')).not.toBeInTheDocument();
@@ -72,7 +74,9 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
 
     expect(screen.getByText('before_send_transaction')).toBeInTheDocument();
     expect(screen.getAllByText(/event\["spans"\]/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/span.get\("op"\) == "function"/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/span.get\("op"\) == "function"/)
+    ).toBeInTheDocument();
   });
 
   it('renders generic guidance when the SDK is unavailable', () => {

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
@@ -30,13 +30,10 @@ function AutomaticInstrumentationFix({
     return (
       <Stack gap="md">
         <Text>
-          {tct(
-            'Use [hook] to remove matching spans from [spans].',
-            {
-              hook: <InlineCode>before_send_transaction</InlineCode>,
-              spans: <InlineCode>event["spans"]</InlineCode>,
-            }
-          )}
+          {tct('Use [hook] to remove matching spans from [spans].', {
+            hook: <InlineCode>before_send_transaction</InlineCode>,
+            spans: <InlineCode>event["spans"]</InlineCode>,
+          })}
         </Text>
         <CodeBlock language="python">
           {getPythonSpanFilterSnippet(evidenceData)}
@@ -81,9 +78,7 @@ function ManualInstrumentationFix({
 }) {
   return (
     <Stack gap="md">
-      <Text>
-        {t('This appears to come from custom instrumentation in your code.')}
-      </Text>
+      <Text>{t('This appears to come from custom instrumentation in your code.')}</Text>
       <Stack gap="xs">
         <Heading as="h4">{t('1. Find the custom span')}</Heading>
         <Text>

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
@@ -31,7 +31,7 @@ function AutomaticInstrumentationFix({
       <Stack gap="md">
         <Text>
           {tct(
-            'For Python automatic instrumentation, use [hook] to remove matching spans from [spans].',
+            'Use [hook] to remove matching spans from [spans].',
             {
               hook: <InlineCode>before_send_transaction</InlineCode>,
               spans: <InlineCode>event["spans"]</InlineCode>,
@@ -50,7 +50,7 @@ function AutomaticInstrumentationFix({
       <Stack gap="md">
         <Text>
           {tct(
-            'For JavaScript automatic instrumentation, use [ignoreSpans] to drop this exact span before it is sent. Use [beforeSendSpan] only if you need to transform span data instead of dropping it.',
+            'Use [ignoreSpans] to drop this exact span. Use [beforeSendSpan] only when you need to change span data.',
             {
               beforeSendSpan: <InlineCode>beforeSendSpan</InlineCode>,
               ignoreSpans: <InlineCode>ignoreSpans</InlineCode>,
@@ -67,57 +67,77 @@ function AutomaticInstrumentationFix({
   return (
     <Text>
       {tct(
-        'Check your SDK tracing options and add an exact-match filter for [span]. Filter only this operation and description so useful spans with similar names keep flowing.',
+        'Add an exact-match span filter for [span]. Match both operation and description so similar useful spans still get sent.',
         {span: <SpanCode>{getSpanLabel(evidenceData)}</SpanCode>}
       )}
     </Text>
   );
 }
 
-export function TroubleshootingSection({evidenceData}: TroubleshootingSectionProps) {
+function ManualInstrumentationFix({
+  evidenceData,
+}: {
+  evidenceData: LowValueSpanEvidenceData;
+}) {
   return (
-    <Stack gap="lg" padding="lg">
-      <Heading as="h3">{t('Troubleshooting')}</Heading>
+    <Stack gap="md">
+      <Text>
+        {t('This appears to come from custom instrumentation in your code.')}
+      </Text>
+      <Stack gap="xs">
+        <Heading as="h4">{t('1. Find the custom span')}</Heading>
+        <Text>
+          {tct('Search your codebase for [span].', {
+            span: <SpanCode>{getSpanLabel(evidenceData)}</SpanCode>,
+          })}
+        </Text>
+      </Stack>
+      <Stack gap="xs">
+        <Heading as="h4">{t('2. Remove or replace the span')}</Heading>
+        <Text>
+          {t(
+            'If this span is not useful for debugging, delete the custom span line or replace it with a more meaningful span.'
+          )}
+        </Text>
+      </Stack>
+    </Stack>
+  );
+}
+
+function AutomaticInstrumentationTroubleshooting({
+  evidenceData,
+}: {
+  evidenceData: LowValueSpanEvidenceData;
+}) {
+  return (
+    <Stack gap="md">
       <Text>
         {t(
-          'Start by confirming whether this span is created by custom code or by SDK automatic instrumentation. Then remove it at the source or filter the exact span before it is sent.'
+          'This appears to come from SDK automatic instrumentation. Filter the exact operation and description before the span is sent.'
         )}
       </Text>
-      <Stack gap="md">
-        <Stack gap="xs">
-          <Heading as="h4">{t('1. Find where the span is created')}</Heading>
-          <Text>
-            {tct('Search for code or SDK configuration that creates [span].', {
-              span: <SpanCode>{getSpanLabel(evidenceData)}</SpanCode>,
-            })}
-          </Text>
-          {evidenceData.sdkName && (
-            <Text>
-              {tct('The latest evidence points to the [sdk] SDK.', {
-                sdk: <InlineCode>{evidenceData.sdkName}</InlineCode>,
-              })}
-            </Text>
-          )}
-        </Stack>
-        <Stack gap="xs">
-          <Heading as="h4">{t('2. Remove custom instrumentation when possible')}</Heading>
-          <Text>
-            {t(
-              'If this span is manually instrumented and does not describe work you need for debugging, delete the custom span creation line or replace it with a more meaningful span.'
-            )}
-          </Text>
-        </Stack>
-        <Stack gap="xs">
-          <Heading as="h4">{t('3. Filter automatic instrumentation exactly')}</Heading>
-          <AutomaticInstrumentationFix evidenceData={evidenceData} />
-        </Stack>
-      </Stack>
+      <AutomaticInstrumentationFix evidenceData={evidenceData} />
       <Flex align="center" gap="xs">
         <IconDocs size="xs" />
         <ExternalLink href={getSpanFilteringDocsUrl(evidenceData)}>
           {t('Read the SDK filtering docs')}
         </ExternalLink>
       </Flex>
+    </Stack>
+  );
+}
+
+export function TroubleshootingSection({evidenceData}: TroubleshootingSectionProps) {
+  const isManualInstrumentation = evidenceData.spanOrigin === 'manual';
+
+  return (
+    <Stack gap="lg" padding="lg">
+      <Heading as="h3">{t('Troubleshooting')}</Heading>
+      {isManualInstrumentation ? (
+        <ManualInstrumentationFix evidenceData={evidenceData} />
+      ) : (
+        <AutomaticInstrumentationTroubleshooting evidenceData={evidenceData} />
+      )}
     </Stack>
   );
 }

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/types.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/types.ts
@@ -2,11 +2,13 @@ import type {EventOccurrence} from 'sentry/types/event';
 
 export interface LowValueSpanEvidenceData {
   avgDurationMs: number | null;
-  count: number | null;
   description: string | null;
   estimatedCostUsd: number | null;
+  extrapolatedCount: number | null;
   op: string | null;
   sdkName: string | null;
+  spanCount: number | null;
+  spanOrigin: string | null;
 }
 
 function getStringValue(value: unknown): string | null {
@@ -21,11 +23,13 @@ export function getLowValueSpanEvidenceData(
   evidenceData: EventOccurrence['evidenceData'] | null | undefined
 ): LowValueSpanEvidenceData {
   return {
-    op: getStringValue(evidenceData?.op),
-    description: getStringValue(evidenceData?.description),
-    count: getNumberValue(evidenceData?.count),
+    op: getStringValue(evidenceData?.op ?? evidenceData?.span_op),
+    description: getStringValue(evidenceData?.description ?? evidenceData?.span_description),
+    spanCount: getNumberValue(evidenceData?.span_count ?? evidenceData?.count),
+    extrapolatedCount: getNumberValue(evidenceData?.extrapolated_count),
     avgDurationMs: getNumberValue(evidenceData?.avg_duration_ms),
     estimatedCostUsd: getNumberValue(evidenceData?.estimated_cost_usd),
     sdkName: getStringValue(evidenceData?.sdk_name),
+    spanOrigin: getStringValue(evidenceData?.span_origin),
   };
 }

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/types.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/types.ts
@@ -23,9 +23,9 @@ export function getLowValueSpanEvidenceData(
   evidenceData: EventOccurrence['evidenceData'] | null | undefined
 ): LowValueSpanEvidenceData {
   return {
-    op: getStringValue(evidenceData?.op ?? evidenceData?.span_op),
-    description: getStringValue(evidenceData?.description ?? evidenceData?.span_description),
-    spanCount: getNumberValue(evidenceData?.span_count ?? evidenceData?.count),
+    op: getStringValue(evidenceData?.span_op),
+    description: getStringValue(evidenceData?.span_description),
+    spanCount: getNumberValue(evidenceData?.span_count),
     extrapolatedCount: getNumberValue(evidenceData?.extrapolated_count),
     avgDurationMs: getNumberValue(evidenceData?.avg_duration_ms),
     estimatedCostUsd: getNumberValue(evidenceData?.estimated_cost_usd),


### PR DESCRIPTION
Refine the low-value span configuration issue details UI to use the updated evidence contract and reduce repeated metadata. The problem section now shows the extrapolated monthly span count with an explanation tooltip, while troubleshooting branches on `span_origin` so manual spans show removal steps and automatic spans show filtering guidance.

**Evidence Contract**

Reads `span_op`, `span_description`, `span_count`, `extrapolated_count`, and `span_origin` from the low-value span issue evidence data.


<img width="1403" height="587" alt="Screenshot 2026-05-29 at 09 25 04" src="https://github.com/user-attachments/assets/c164815f-fa4e-42ed-ab4a-6d28c037d456" />

<img width="1403" height="689" alt="Screenshot 2026-05-29 at 09 26 31" src="https://github.com/user-attachments/assets/631e92f5-0fd4-4f58-81b4-ad30d5f604d1" />


Required: [getsentry/getsentry#20456](https://github.com/getsentry/getsentry/pull/20456)
Closes TET-2402