### PR TITLE
feat(issue-details): Enable Autofix for low-value spans

### DIFF
--- a/static/app/utils/issueTypeConfig/configurationIssuesConfig.tsx
+++ b/static/app/utils/issueTypeConfig/configurationIssuesConfig.tsx
@@ -14,6 +14,11 @@ const staticConfigurationIssueDetails = {
   },
 };
 
+const lowValueSpanConfigurationIssueDetails = {
+  ...staticConfigurationIssueDetails,
+  autofix: true,
+};
+
 export const configurationIssuesConfig: IssueCategoryConfigMapping = {
   _categoryDefaults: {
     actions: {
@@ -65,5 +70,5 @@ export const configurationIssuesConfig: IssueCategoryConfigMapping = {
     groupingInfo: {enabled: false},
   },
   [IssueType.SOURCEMAP_CONFIGURATION]: staticConfigurationIssueDetails,
-  [IssueType.LOW_VALUE_SPAN_CONFIGURATION]: staticConfigurationIssueDetails,
+  [IssueType.LOW_VALUE_SPAN_CONFIGURATION]: lowValueSpanConfigurationIssueDetails,
 };


### PR DESCRIPTION
Enable Seer Autofix for low-value span configuration issues.

Low-value span issues now opt into the issue detail Autofix surface while keeping the existing static configuration issue details behavior.