### PR TITLE
ref(night-shift): Use default autofix model for night-shift runs

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -343,7 +343,6 @@ def run_night_shift_execution(
         results = _run_autofix_for_candidates(
             run=run,
             candidates=candidates,
-            options=resolved_options,
             stopping_point_by_project_id=stopping_point_by_project_id,
             log_extra=log_extra,
         )
@@ -493,7 +492,6 @@ def _get_eligible_projects(
 def _run_autofix_for_candidates(
     run: SeerNightShiftRun,
     candidates: Sequence[TriageResult],
-    options: SeerNightShiftRunOptions,
     stopping_point_by_project_id: Mapping[int, AutofixStoppingPoint],
     log_extra: dict[str, object],
 ) -> list[SeerNightShiftRunResult]:
@@ -534,8 +532,6 @@ def _run_autofix_for_candidates(
                 step=AutofixStep.ROOT_CAUSE,
                 referrer=referrer,
                 stopping_point=stopping_point,
-                intelligence_level=options["intelligence_level"],
-                reasoning_effort=options["reasoning_effort"],
                 user_context=user_context,
             )
         except Exception:

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -458,21 +458,6 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
         assert mock_trigger.call_args.kwargs["stopping_point"] == AutofixStoppingPoint.SOLUTION
 
-    def test_forwards_reasoning_effort_to_trigger(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        self._make_eligible(project)
-
-        group = self._store_event_and_update_group(
-            project, "fixable", seer_fixability_score=0.9, times_seen=5
-        )
-
-        with self._patched_night_shift([(group.id, "autofix")]) as (mock_trigger, _):
-            run_night_shift_for_org(org.id, options={"reasoning_effort": "low"})
-
-        mock_trigger.assert_called_once()
-        assert mock_trigger.call_args.kwargs["reasoning_effort"] == "low"
-
     def test_dry_run_skips_autofix(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)


### PR DESCRIPTION
Night-shift was the only autofix invoker that forwarded an explicit `intelligence_level` and `reasoning_effort` (both `"high"`) to `trigger_autofix_agent`. Every other invoker — the group autofix endpoint, the issue-summary auto-trigger, the on-completion pipeline, and Slack — relies on the defaults: `intelligence_level="medium"` and the per-step `reasoning_effort` from the step config.

This drops the explicit arguments from the night-shift autofix call so its runs use the same model as all other invokers.

The night-shift triage step still honors the configured `intelligence_level` and `reasoning_effort` options; only the autofix invocation changes.



Agent transcript: https://claudescope.sentry.dev/share/p8XAfGYOrDo-lObjRdup6LquAGyi4CNn3M0hGLD_HDo