### PR TITLE
ref(scm): Remove /rate-limit endpoint from internal rate-limit computation

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -40,7 +40,9 @@ from sentry.integrations.source_code_management.status_check import StatusCheckC
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders, IntegrationProviderSlug
 from sentry.models.pullrequest import PullRequest, PullRequestComment
 from sentry.models.repository import Repository
+from sentry.net.http import SafeSession
 from sentry.scm.private.rate_limit import DynamicRateLimiter, RedisRateLimitProvider
+from sentry.shared_integrations.client.base import SessionSettings
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import (
     ApiConflictError,
@@ -1135,6 +1137,10 @@ GITHUB_RATE_LIMIT_CAPACITY = "x-ratelimit-limit"
 GITHUB_RATE_LIMIT_USED = "x-ratelimit-used"
 GITHUB_RATE_LIMIT_RESET = "x-ratelimit-reset"
 
+# Requests to this resource do not count against GitHub's primary rate limit, so our
+# internal rate limiter ignores them. https://docs.github.com/en/rest/rate-limit
+GITHUB_RATE_LIMIT_RESOURCE_PATH = "/rate_limit"
+
 
 class GitHubApiClient(GitHubBaseClient):
     """
@@ -1190,7 +1196,15 @@ class GitHubApiClient(GitHubBaseClient):
         finally:
             self.__referrer = prev
 
-    def _do_send(self, *args, **kwargs) -> Response:
+    def _do_send(
+        self, session: SafeSession, request: PreparedRequest, session_settings: SessionSettings
+    ) -> Response:
+        # The rate-limit resource is not itself rate limited by GitHub, so we skip the internal
+        # rate limiter entirely. Counting these requests would both consume quota we don't owe and
+        # pollute the recorded capacity with the rate-limit resource's own (unrelated) headers.
+        if request.path_url.partition("?")[0] == GITHUB_RATE_LIMIT_RESOURCE_PATH:
+            return super()._do_send(session, request, session_settings)
+
         is_rate_limited = False
         try:
             if self.__rate_limiter.is_rate_limited(self.__referrer):
@@ -1202,7 +1216,7 @@ class GitHubApiClient(GitHubBaseClient):
             # Something went really wrong. Let's not be instrusive. We'll fail silently instead.
             sentry_sdk.capture_exception(e)
 
-        response = super()._do_send(*args, **kwargs)
+        response = super()._do_send(session, request, session_settings)
 
         try:
             capacity = int(response.headers[GITHUB_RATE_LIMIT_CAPACITY])

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -24,6 +24,7 @@ from sentry.integrations.source_code_management.commit_context import (
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.pullrequest import PullRequest, PullRequestComment
 from sentry.models.repository import Repository
+from sentry.scm.private.rate_limit import DynamicRateLimiter
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.shared_integrations.response.base import BaseApiResponse
 from sentry.silo.base import SiloMode
@@ -104,6 +105,59 @@ class GitHubApiClientTest(TestCase):
     def test_get_rate_limit_non_existent_resource(self) -> None:
         with pytest.raises(AssertionError):
             self.github_client.get_rate_limit("foo")
+
+    @responses.activate
+    def test_internal_rate_limiter_ignores_get_rate_limit(self) -> None:
+        """
+        The /rate_limit resource does not count against GitHub's primary rate limit, so the
+        internal rate limiter must neither consult its quota nor record capacity from the
+        (unrelated) headers on its response.
+        """
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/rate_limit",
+            json={
+                "resources": {
+                    "core": {"limit": 5000, "remaining": 4999, "reset": 1372700873, "used": 1},
+                },
+            },
+            headers={"x-ratelimit-limit": "5000"},
+        )
+
+        with (
+            mock.patch.object(DynamicRateLimiter, "is_rate_limited") as mock_is_rate_limited,
+            mock.patch.object(DynamicRateLimiter, "set_total_capacity") as mock_set_capacity,
+            mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1"),
+        ):
+            self.github_client.get_rate_limit()
+
+        mock_is_rate_limited.assert_not_called()
+        mock_set_capacity.assert_not_called()
+
+    @responses.activate
+    def test_internal_rate_limiter_applies_to_other_endpoints(self) -> None:
+        """
+        Requests to resources other than /rate_limit must still flow through the internal rate
+        limiter so quota is tracked and capacity is recorded.
+        """
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/commits",
+            json=[],
+            headers={"x-ratelimit-limit": "5000"},
+        )
+
+        with (
+            mock.patch.object(
+                DynamicRateLimiter, "is_rate_limited", return_value=False
+            ) as mock_is_rate_limited,
+            mock.patch.object(DynamicRateLimiter, "set_total_capacity") as mock_set_capacity,
+            mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1"),
+        ):
+            self.github_client.get_commits(self.repo.name)
+
+        mock_is_rate_limited.assert_called_once()
+        mock_set_capacity.assert_called_once_with(capacity=5000)
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate


### PR DESCRIPTION
Improves internal rate-limit accuracy.