### PR TITLE
ref(seer): use get_group_list helper in supergroups-by-group endpoint

### DIFF
--- a/src/sentry/api/helpers/group_index/__init__.py
+++ b/src/sentry/api/helpers/group_index/__init__.py
@@ -24,11 +24,13 @@ __all__ = (
     "BULK_MUTATION_LIMIT",
     "SEARCH_MAX_HITS",
     "delete_group_list",
+    "get_group_list",
     "update_groups",
 )
 
 from .delete import *  # NOQA
 from .delete import delete_group_list
 from .index import *  # NOQA
+from .lookup import get_group_list
 from .update import *  # NOQA
 from .update import update_groups

--- a/src/sentry/api/helpers/group_index/lookup.py
+++ b/src/sentry/api/helpers/group_index/lookup.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sentry.models.group import Group
+from sentry.models.project import Project
+
+
+def get_group_list(
+    organization_id: int,
+    projects: Sequence[Project],
+    group_ids: Sequence[int | str],
+) -> list[Group]:
+    """
+    Gets group list based on provided filters.
+
+    Args:
+        organization_id: ID of the organization
+        projects: Sequence of projects to filter groups by
+        group_ids: Sequence of specific group IDs to fetch
+
+    Returns: List of Group objects filtered to only valid groups in the org/projects
+    """
+    groups: list[Group] = []
+    # Convert all group IDs to integers and filter out any non-integer values
+    group_ids_int = [int(gid) for gid in group_ids if str(gid).isdigit()]
+    if group_ids_int:
+        return list(
+            Group.objects.filter(
+                project__organization_id=organization_id, project__in=projects, id__in=group_ids_int
+            ).select_related("project")
+        )
+    else:
+        project_ids = {p.id for p in projects}
+        for group_id in group_ids:
+            if isinstance(group_id, str):
+                try:
+                    group = Group.objects.by_qualified_short_id(organization_id, group_id)
+                except Group.DoesNotExist:
+                    continue
+                if group.project_id in project_ids:
+                    groups.append(group)
+
+    return groups

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -61,6 +61,7 @@ from sentry.users.services.user_option import user_option_service
 from sentry.utils import metrics
 
 from . import ACTIVITIES_COUNT, BULK_MUTATION_LIMIT, SearchFunction, delete_group_list
+from .lookup import get_group_list
 from .validators import GroupValidator, ValidationError
 
 logger = logging.getLogger(__name__)
@@ -323,44 +324,6 @@ def validate_request(
         if not serializer.is_valid():
             raise serializers.ValidationError(serializer.errors)
     return serializer
-
-
-def get_group_list(
-    organization_id: int,
-    projects: Sequence[Project],
-    group_ids: Sequence[int | str],
-) -> list[Group]:
-    """
-    Gets group list based on provided filters.
-
-    Args:
-        organization_id: ID of the organization
-        projects: Sequence of projects to filter groups by
-        group_ids: Sequence of specific group IDs to fetch
-
-    Returns: List of Group objects filtered to only valid groups in the org/projects
-    """
-    groups: list[Group] = []
-    # Convert all group IDs to integers and filter out any non-integer values
-    group_ids_int = [int(gid) for gid in group_ids if str(gid).isdigit()]
-    if group_ids_int:
-        return list(
-            Group.objects.filter(
-                project__organization_id=organization_id, project__in=projects, id__in=group_ids_int
-            ).select_related("project")
-        )
-    else:
-        project_ids = {p.id for p in projects}
-        for group_id in group_ids:
-            if isinstance(group_id, str):
-                try:
-                    group = Group.objects.by_qualified_short_id(organization_id, group_id)
-                except Group.DoesNotExist:
-                    continue
-                if group.project_id in project_ids:
-                    groups.append(group)
-
-    return groups
 
 
 def handle_resolve_in_release(

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
@@ -12,9 +12,10 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.helpers.group_index.update import get_group_list
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
-from sentry.models.group import STATUS_QUERY_CHOICES, Group
+from sentry.models.group import STATUS_QUERY_CHOICES
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organization import Organization
 from sentry.models.team import Team
@@ -72,12 +73,8 @@ class OrganizationSupergroupsByGroupEndpoint(OrganizationEndpoint):
                 status=status_codes.HTTP_400_BAD_REQUEST,
             )
 
-        valid_group_ids = set(
-            Group.objects.filter(
-                id__in=group_ids,
-                project__organization=organization,
-            ).values_list("id", flat=True)
-        )
+        projects = self.get_projects(request, organization)
+        valid_group_ids = {g.id for g in get_group_list(organization.id, projects, group_ids)}
         group_ids = [gid for gid in group_ids if gid in valid_group_ids]
 
         if not group_ids:
@@ -98,13 +95,11 @@ class OrganizationSupergroupsByGroupEndpoint(OrganizationEndpoint):
             return Response({"data": data["data"], "meta": {"estimated": True}})
 
         if status_param:
-            matching_ids = set(
-                Group.objects.filter(
-                    id__in=all_response_group_ids,
-                    project__organization=organization,
-                    status=STATUS_QUERY_CHOICES[status_param],
-                ).values_list("id", flat=True)
-            )
+            matching_ids = {
+                g.id
+                for g in get_group_list(organization.id, projects, list(all_response_group_ids))
+                if g.status == STATUS_QUERY_CHOICES[status_param]
+            }
 
             for sg in data["data"]:
                 sg["group_ids"] = [gid for gid in sg["group_ids"] if gid in matching_ids]

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
@@ -12,7 +12,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
-from sentry.api.helpers.group_index.update import get_group_list
+from sentry.api.helpers.group_index import get_group_list
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.models.group import STATUS_QUERY_CHOICES

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -9,10 +9,13 @@ from rest_framework.request import Request
 
 from sentry.analytics.events.advanced_search_feature_gated import AdvancedSearchFeatureGateEvent
 from sentry.analytics.events.manual_issue_assignment import ManualIssueAssignment
-from sentry.api.helpers.group_index import update_groups, validate_search_filter_permissions
+from sentry.api.helpers.group_index import (
+    get_group_list,
+    update_groups,
+    validate_search_filter_permissions,
+)
 from sentry.api.helpers.group_index.delete import schedule_tasks_to_delete_groups
 from sentry.api.helpers.group_index.update import (
-    get_group_list,
     get_semver_releases,
     greatest_semver_release,
     handle_assigned_to,

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
@@ -9,6 +9,7 @@ from sentry.models.group import GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.seer.supergroups.endpoints import organization_supergroups_by_group
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import cell_silo_test
 
 
 def mock_seer_response(data: dict[str, Any]) -> MagicMock:
@@ -18,6 +19,7 @@ def mock_seer_response(data: dict[str, Any]) -> MagicMock:
     return response
 
 
+@cell_silo_test
 class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-supergroups-by-group"
 
@@ -188,6 +190,63 @@ class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
         sg = response.data["data"][0]
         assert "assignees" not in sg
         assert self.resolved_group.id in sg["group_ids"]
+
+    def test_returns_404_when_all_groups_are_in_inaccessible_projects(self):
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        member_user = self.create_user()
+        self.create_member(organization=self.organization, user=member_user, role="member")
+
+        other_project = self.create_project(organization=self.organization)
+        inaccessible_group = self.create_group(project=other_project)
+
+        self.login_as(member_user)
+
+        with self.feature("organizations:top-issues-ui"):
+            self.get_error_response(
+                self.organization.slug,
+                group_id=[inaccessible_group.id],
+                status_code=404,
+            )
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_filters_out_groups_from_inaccessible_projects(self, mock_seer):
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        member_user = self.create_user()
+        member_team = self.create_team(organization=self.organization)
+        self.create_member(
+            organization=self.organization,
+            user=member_user,
+            role="member",
+            teams=[member_team],
+        )
+        self.project.add_team(member_team)
+
+        accessible_group = self.create_group(project=self.project)
+
+        other_project = self.create_project(organization=self.organization)
+        inaccessible_group = self.create_group(project=other_project)
+
+        mock_seer.return_value = mock_seer_response(
+            {"data": [{"id": 1, "group_ids": [accessible_group.id], "title": "sg"}]}
+        )
+
+        self.login_as(member_user)
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(
+                self.organization.slug,
+                group_id=[accessible_group.id, inaccessible_group.id],
+            )
+
+        seer_call_body = mock_seer.call_args[0][0]
+        assert accessible_group.id in seer_call_body["group_ids"]
+        assert inaccessible_group.id not in seer_call_body["group_ids"]
+
+        assert len(response.data["data"]) == 1
 
     @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
     def test_assignee_summary_tolerates_missing_actor(self, mock_seer):


### PR DESCRIPTION
The `OrganizationSupergroupsByGroupEndpoint` was using inline `Group.objects.filter` calls to validate and filter group IDs. This refactors it to use the existing `get_group_list` helper from `sentry.api.helpers.group_index`, which is the canonical pattern for this kind of scoped group lookup (see `api/helpers/group_index/update.py` line 275 for the existing usage).

`get_group_list` previously lived in `group_index/update.py` — a large mutation-focused module with heavy dependencies. Since the function is a pure read with minimal dependencies (`Group`, `Project`, `Sequence`), it has been extracted into a new `group_index/lookup.py`. This avoids a circular-import risk (`update.py` ← `index.py` ← `__init__.py` ← `update.py`) and gives the function a proper home as a first-class export of the package via `__init__.__all__`.

`update.py` now imports `get_group_list` from `.lookup`; no behaviour change for existing callers.

Test coverage for the endpoint has been expanded and `@cell_silo_test` has been added to the test class to match the endpoint's `@cell_silo_endpoint` decorator.

Refs AIML-2879