### PR TITLE
ref(snapshots): Make the snapshots toolbar presentational and de-duplicate

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -24,7 +24,7 @@ import {
 
 export type DiffMode = 'split' | 'wipe' | 'onion';
 
-export const TRANSPARENT_COLOR = 'transparent';
+const TRANSPARENT_COLOR = 'transparent';
 
 interface DiffImageDisplayProps {
   diffImageBaseUrl: string;

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -1,26 +1,13 @@
 import type React from 'react';
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {useTheme} from '@emotion/react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Container, Flex} from '@sentry/scraps/layout';
-import {SegmentedControl} from '@sentry/scraps/segmentedControl';
-import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {ProgressBar} from 'sentry/components/progressBar';
-import {
-  IconArrow,
-  IconExpand,
-  IconInput,
-  IconList,
-  IconPause,
-  IconStack,
-} from 'sentry/icons';
+import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useBreakpoints} from 'sentry/utils/useBreakpoints';
@@ -28,11 +15,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {DiffStatus, getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
-import {
-  DiffImageDisplay,
-  type DiffMode,
-  TRANSPARENT_COLOR,
-} from './imageDisplay/diffImageDisplay';
+import {DiffImageDisplay, type DiffMode} from './imageDisplay/diffImageDisplay';
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
 import {CardHeader, DarkAware} from './snapshotCards';
 import {SnapshotCardFrame, SnapshotVariantFrame} from './snapshotFrames';
@@ -42,9 +25,19 @@ import {
   SnapshotListView,
   type SnapshotListViewHandle,
 } from './snapshotListView';
-
-type ViewMode = 'single' | 'list';
-type SortBy = 'diff' | 'alpha';
+import {
+  ColorPickerButton,
+  DiffModeToggle,
+  ProgressCounter,
+  ProgressPill,
+  type SortBy,
+  SortDropdown,
+  SoloDiffToggle,
+  ToolbarContainer,
+  ToolbarProgressBar,
+  type ViewMode,
+  ViewModeToggle,
+} from './snapshotsToolbar';
 
 export interface NavButtonRefs {
   next: React.RefObject<HTMLButtonElement | null>;
@@ -109,6 +102,7 @@ export function SnapshotMainContent({
   navButtonRefs,
 }: SnapshotMainContentProps) {
   const organization = useOrganization();
+  const breakpoints = useBreakpoints();
   const [isDark, setIsDark] = useState(false);
   const toggleDark = useCallback(() => setIsDark(v => !v), []);
   const [scrollProgress, setScrollProgress] = useState(0);
@@ -161,8 +155,30 @@ export function SnapshotMainContent({
     [onSelectSnapshot, onViewModeChange]
   );
 
+  const handleViewModeChange = useCallback(
+    (mode: ViewMode) => {
+      onViewModeChange(mode);
+      trackAnalytics('preprod.snapshots.details.view_mode_changed', {
+        organization,
+        view_mode: mode,
+      });
+    },
+    [onViewModeChange, organization]
+  );
+
+  const handleDiffModeChange = useCallback(
+    (mode: DiffMode) => {
+      onDiffModeChange(mode);
+      trackAnalytics('preprod.snapshots.details.diff_mode_changed', {
+        organization,
+        diff_mode: mode,
+      });
+    },
+    [onDiffModeChange, organization]
+  );
+
   const toggle = (
-    <ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
+    <ViewModeToggle viewMode={viewMode} onViewModeChange={handleViewModeChange} />
   );
   const progressIndicator = totalCards > 0 && (
     <ProgressPill>
@@ -182,7 +198,11 @@ export function SnapshotMainContent({
       {diffMode === 'split' && (
         <ColorPickerButton color={overlayColor} onChange={onOverlayColorChange} />
       )}
-      <DiffModeToggle diffMode={diffMode} onDiffModeChange={onDiffModeChange} />
+      <DiffModeToggle
+        diffMode={diffMode}
+        onDiffModeChange={handleDiffModeChange}
+        showSplit={breakpoints.sm}
+      />
     </Fragment>
   ) : null;
   const soloDiffToggle = hasDiffComparison ? (
@@ -562,190 +582,6 @@ function SingleViewLayout({
   );
 }
 
-function SoloDiffToggle({
-  isSoloView,
-  onToggleSoloView,
-}: {
-  isSoloView: boolean;
-  onToggleSoloView: () => void;
-}) {
-  return (
-    <SegmentedControl
-      size="xs"
-      value={isSoloView ? 'head' : 'diff'}
-      aria-label={t('Comparison view')}
-      onChange={value => {
-        if ((value === 'head') !== isSoloView) {
-          onToggleSoloView();
-        }
-      }}
-    >
-      <SegmentedControl.Item key="diff" tooltip={t('Compare with base')}>
-        {t('Diff')}
-      </SegmentedControl.Item>
-      <SegmentedControl.Item key="head" tooltip={t('Head only')}>
-        {t('Head')}
-      </SegmentedControl.Item>
-    </SegmentedControl>
-  );
-}
-
-function ViewModeToggle({
-  viewMode,
-  onViewModeChange,
-}: {
-  onViewModeChange: (mode: ViewMode) => void;
-  viewMode: ViewMode;
-}) {
-  const organization = useOrganization();
-  return (
-    <SegmentedControl
-      size="xs"
-      value={viewMode}
-      onChange={(value: ViewMode) => {
-        onViewModeChange(value);
-        trackAnalytics('preprod.snapshots.details.view_mode_changed', {
-          organization,
-          view_mode: value,
-        });
-      }}
-      aria-label={t('View mode')}
-    >
-      <SegmentedControl.Item
-        key="list"
-        icon={<IconList />}
-        aria-label={t('List view')}
-        tooltip={t('List view (←)')}
-      />
-      <SegmentedControl.Item
-        key="single"
-        icon={<IconExpand />}
-        aria-label={t('Single image view')}
-        tooltip={t('Single image view (→)')}
-      />
-    </SegmentedControl>
-  );
-}
-
-function SortDropdown({
-  value,
-  onChange,
-}: {
-  onChange: (sort: SortBy) => void;
-  value: SortBy;
-}) {
-  return (
-    <CompactSelect
-      size="xs"
-      value={value}
-      onChange={opt => onChange(opt.value)}
-      options={[
-        {value: 'diff' as const, label: t('Diff %')},
-        {value: 'alpha' as const, label: t('A - Z')},
-      ]}
-    />
-  );
-}
-
-function ColorPickerButton({
-  color,
-  onChange,
-}: {
-  color: string;
-  onChange: (color: string) => void;
-}) {
-  const theme = useTheme();
-  const [isOpen, setIsOpen] = useState(false);
-  const pickerRef = useRef<HTMLDivElement>(null);
-  const overlayColors = [TRANSPARENT_COLOR, ...theme.chart.getColorPalette(10)];
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    function handleMouseDown(e: MouseEvent) {
-      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handleMouseDown);
-    return () => document.removeEventListener('mousedown', handleMouseDown);
-  }, [isOpen]);
-
-  return (
-    <ColorPickerWrapper ref={pickerRef}>
-      <Tooltip title={t('Overlay color')} skipWrapper>
-        <ColorTrigger
-          color={color}
-          aria-label={t('Pick overlay color')}
-          onClick={() => setIsOpen(v => !v)}
-        />
-      </Tooltip>
-      {isOpen && (
-        <ColorPickerDropdown>
-          <Flex gap="xs">
-            {overlayColors.map(c => (
-              <ColorSwatch
-                key={c}
-                color={c}
-                selected={color === c}
-                onClick={() => {
-                  onChange(c);
-                  setIsOpen(false);
-                }}
-                aria-label={t('Overlay color %s', c)}
-              />
-            ))}
-          </Flex>
-        </ColorPickerDropdown>
-      )}
-    </ColorPickerWrapper>
-  );
-}
-
-function DiffModeToggle({
-  diffMode,
-  onDiffModeChange,
-}: {
-  diffMode: DiffMode;
-  onDiffModeChange: (mode: DiffMode) => void;
-}) {
-  const organization = useOrganization();
-  const breakpoints = useBreakpoints();
-  const handleChange = (value: DiffMode) => {
-    onDiffModeChange(value);
-    trackAnalytics('preprod.snapshots.details.diff_mode_changed', {
-      organization,
-      diff_mode: value,
-    });
-  };
-
-  return (
-    <SegmentedControl size="xs" value={diffMode} onChange={handleChange}>
-      {breakpoints.sm ? (
-        <SegmentedControl.Item
-          key="split"
-          icon={<IconPause />}
-          aria-label={t('Split')}
-          tooltip={t('Split')}
-        />
-      ) : null}
-      <SegmentedControl.Item
-        key="wipe"
-        icon={<IconInput />}
-        aria-label={t('Wipe')}
-        tooltip={t('Wipe')}
-      />
-      <SegmentedControl.Item
-        key="onion"
-        icon={<IconStack />}
-        aria-label={t('Onion')}
-        tooltip={t('Onion')}
-      />
-    </SegmentedControl>
-  );
-}
-
 const SingleViewScroll = styled('div')`
   flex: 1 1 0;
   min-height: 0;
@@ -785,134 +621,3 @@ const NavGutter = styled('div')`
     }
   }
 `;
-
-const ColorPickerWrapper = styled('div')`
-  position: relative;
-  display: flex;
-  align-items: center;
-`;
-
-const ColorPickerDropdown = styled('div')`
-  position: absolute;
-  top: 100%;
-  right: 0;
-  margin-top: ${p => p.theme.space.xs};
-  padding: ${p => p.theme.space.sm};
-  background: ${p => p.theme.tokens.background.primary};
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  box-shadow: ${p => p.theme.shadow.high};
-  z-index: ${p => p.theme.zIndex.dropdown};
-`;
-
-const ColorTrigger = styled('button')<{color: string}>`
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  cursor: pointer;
-  border: 2px solid ${p => p.theme.tokens.border.primary};
-  background-color: ${p => (p.color === TRANSPARENT_COLOR ? 'transparent' : p.color)};
-  padding: 0;
-  ${p =>
-    p.color === TRANSPARENT_COLOR &&
-    css`
-      /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
-      background-image: linear-gradient(
-        to top right,
-        transparent calc(50% - 2px),
-        ${p.theme.tokens.content.danger} calc(50% - 1px),
-        ${p.theme.tokens.content.danger} calc(50% + 1px),
-        transparent calc(50% + 2px)
-      );
-    `}
-
-  &:hover {
-    border-color: ${p => p.theme.tokens.border.accent};
-  }
-`;
-
-const ProgressPill = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.sm};
-`;
-
-const ProgressCounter = styled(Text)`
-  white-space: nowrap;
-  font-family: ${p => p.theme.font.family.mono};
-`;
-
-const ToolbarProgressBar = styled(ProgressBar)`
-  width: 50px;
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    display: none;
-  }
-`;
-
-const ColorSwatch = styled('button')<{color: string; selected: boolean}>`
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  cursor: pointer;
-  border: 2px solid
-    ${p => (p.selected ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
-  background-color: ${p => (p.color === TRANSPARENT_COLOR ? 'transparent' : p.color)};
-  padding: 0;
-  outline: ${p => (p.selected ? `2px solid ${p.theme.tokens.focus.default}` : 'none')};
-  outline-offset: 1px;
-  ${p =>
-    p.color === TRANSPARENT_COLOR &&
-    css`
-      /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
-      background-image: linear-gradient(
-        to top right,
-        transparent calc(50% - 1.5px),
-        ${p.theme.tokens.content.danger} calc(50% - 0.5px),
-        ${p.theme.tokens.content.danger} calc(50% + 0.5px),
-        transparent calc(50% + 1.5px)
-      );
-    `}
-`;
-
-function ToolbarContainer({
-  toggle,
-  sortDropdown,
-  progressIndicator,
-  diffControls,
-  soloDiffToggle,
-}: {
-  toggle: React.ReactNode;
-  diffControls?: React.ReactNode;
-  progressIndicator?: React.ReactNode;
-  soloDiffToggle?: React.ReactNode;
-  sortDropdown?: React.ReactNode;
-}) {
-  return (
-    <Fragment>
-      <Flex
-        align="center"
-        justify="between"
-        gap="md"
-        padding={{xs: 'md xl', md: 'md xl md 0'}}
-        background="primary"
-        onClick={e => e.stopPropagation()}
-      >
-        <Flex align="center" gap="md">
-          {toggle}
-          {sortDropdown}
-          {progressIndicator}
-        </Flex>
-        <Flex align="center" gap="md">
-          {diffControls && (
-            <Flex align="center" gap="sm">
-              {diffControls}
-            </Flex>
-          )}
-          <Flex display={{'2xs': 'none', xs: 'none', sm: 'flex'}}>{soloDiffToggle}</Flex>
-        </Flex>
-      </Flex>
-      <Separator orientation="horizontal" />
-    </Fragment>
-  );
-}

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -1,0 +1,324 @@
+import type React from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
+import {css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Flex} from '@sentry/scraps/layout';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
+import {Separator} from '@sentry/scraps/separator';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {ProgressBar} from 'sentry/components/progressBar';
+import {IconExpand, IconInput, IconList, IconPause, IconStack} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+import type {DiffMode} from './imageDisplay/diffImageDisplay';
+
+const TRANSPARENT_COLOR = 'transparent';
+
+export type ViewMode = 'single' | 'list';
+export type SortBy = 'diff' | 'alpha';
+
+interface ToolbarContainerProps {
+  toggle: React.ReactNode;
+  diffControls?: React.ReactNode;
+  progressIndicator?: React.ReactNode;
+  soloDiffToggle?: React.ReactNode;
+  sortDropdown?: React.ReactNode;
+}
+
+export function ToolbarContainer({
+  toggle,
+  sortDropdown,
+  progressIndicator,
+  diffControls,
+  soloDiffToggle,
+}: ToolbarContainerProps) {
+  return (
+    <Fragment>
+      <Flex
+        align="center"
+        justify="between"
+        gap="md"
+        padding={{xs: 'md xl', md: 'md xl md 0'}}
+        background="primary"
+        onClick={e => e.stopPropagation()}
+      >
+        <Flex align="center" gap="md">
+          {toggle}
+          {sortDropdown}
+          {progressIndicator}
+        </Flex>
+        <Flex align="center" gap="md">
+          {diffControls && (
+            <Flex align="center" gap="sm">
+              {diffControls}
+            </Flex>
+          )}
+          <Flex display={{'2xs': 'none', xs: 'none', sm: 'flex'}}>{soloDiffToggle}</Flex>
+        </Flex>
+      </Flex>
+      <Separator orientation="horizontal" />
+    </Fragment>
+  );
+}
+
+export function SoloDiffToggle({
+  isSoloView,
+  onToggleSoloView,
+}: {
+  isSoloView: boolean;
+  onToggleSoloView: () => void;
+}) {
+  return (
+    <SegmentedControl
+      size="xs"
+      value={isSoloView ? 'head' : 'diff'}
+      aria-label={t('Comparison view')}
+      onChange={value => {
+        if ((value === 'head') !== isSoloView) {
+          onToggleSoloView();
+        }
+      }}
+    >
+      <SegmentedControl.Item key="diff" tooltip={t('Compare with base')}>
+        {t('Diff')}
+      </SegmentedControl.Item>
+      <SegmentedControl.Item key="head" tooltip={t('Head only')}>
+        {t('Head')}
+      </SegmentedControl.Item>
+    </SegmentedControl>
+  );
+}
+
+export function ViewModeToggle({
+  viewMode,
+  onViewModeChange,
+}: {
+  onViewModeChange: (mode: ViewMode) => void;
+  viewMode: ViewMode;
+}) {
+  return (
+    <SegmentedControl
+      size="xs"
+      value={viewMode}
+      onChange={onViewModeChange}
+      aria-label={t('View mode')}
+    >
+      <SegmentedControl.Item
+        key="list"
+        icon={<IconList />}
+        aria-label={t('List view')}
+        tooltip={t('List view (←)')}
+      />
+      <SegmentedControl.Item
+        key="single"
+        icon={<IconExpand />}
+        aria-label={t('Single image view')}
+        tooltip={t('Single image view (→)')}
+      />
+    </SegmentedControl>
+  );
+}
+
+export function SortDropdown({
+  value,
+  onChange,
+}: {
+  onChange: (sort: SortBy) => void;
+  value: SortBy;
+}) {
+  return (
+    <CompactSelect
+      size="xs"
+      value={value}
+      onChange={opt => onChange(opt.value)}
+      options={[
+        {value: 'diff' as const, label: t('Diff %')},
+        {value: 'alpha' as const, label: t('A - Z')},
+      ]}
+    />
+  );
+}
+
+export function ColorPickerButton({
+  color,
+  onChange,
+}: {
+  color: string;
+  onChange: (color: string) => void;
+}) {
+  const theme = useTheme();
+  const [isOpen, setIsOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+  const overlayColors = [TRANSPARENT_COLOR, ...theme.chart.getColorPalette(10)];
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    function handleMouseDown(e: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [isOpen]);
+
+  return (
+    <ColorPickerWrapper ref={pickerRef}>
+      <Tooltip title={t('Overlay color')} skipWrapper>
+        <ColorTrigger
+          color={color}
+          aria-label={t('Pick overlay color')}
+          onClick={() => setIsOpen(v => !v)}
+        />
+      </Tooltip>
+      {isOpen && (
+        <ColorPickerDropdown>
+          <Flex gap="xs">
+            {overlayColors.map(c => (
+              <ColorSwatch
+                key={c}
+                color={c}
+                selected={color === c}
+                onClick={() => {
+                  onChange(c);
+                  setIsOpen(false);
+                }}
+                aria-label={t('Overlay color %s', c)}
+              />
+            ))}
+          </Flex>
+        </ColorPickerDropdown>
+      )}
+    </ColorPickerWrapper>
+  );
+}
+
+export function DiffModeToggle({
+  diffMode,
+  onDiffModeChange,
+  showSplit,
+}: {
+  diffMode: DiffMode;
+  onDiffModeChange: (mode: DiffMode) => void;
+  showSplit: boolean;
+}) {
+  return (
+    <SegmentedControl size="xs" value={diffMode} onChange={onDiffModeChange}>
+      {showSplit ? (
+        <SegmentedControl.Item
+          key="split"
+          icon={<IconPause />}
+          aria-label={t('Split')}
+          tooltip={t('Split')}
+        />
+      ) : null}
+      <SegmentedControl.Item
+        key="wipe"
+        icon={<IconInput />}
+        aria-label={t('Wipe')}
+        tooltip={t('Wipe')}
+      />
+      <SegmentedControl.Item
+        key="onion"
+        icon={<IconStack />}
+        aria-label={t('Onion')}
+        tooltip={t('Onion')}
+      />
+    </SegmentedControl>
+  );
+}
+
+const ColorPickerWrapper = styled('div')`
+  position: relative;
+  display: flex;
+  align-items: center;
+`;
+
+const ColorPickerDropdown = styled('div')`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: ${p => p.theme.space.xs};
+  padding: ${p => p.theme.space.sm};
+  background: ${p => p.theme.tokens.background.primary};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  box-shadow: ${p => p.theme.shadow.high};
+  z-index: ${p => p.theme.zIndex.dropdown};
+`;
+
+const ColorTrigger = styled('button')<{color: string}>`
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid ${p => p.theme.tokens.border.primary};
+  background-color: ${p => (p.color === TRANSPARENT_COLOR ? 'transparent' : p.color)};
+  padding: 0;
+  ${p =>
+    p.color === TRANSPARENT_COLOR &&
+    css`
+      /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
+      background-image: linear-gradient(
+        to top right,
+        transparent calc(50% - 2px),
+        ${p.theme.tokens.content.danger} calc(50% - 1px),
+        ${p.theme.tokens.content.danger} calc(50% + 1px),
+        transparent calc(50% + 2px)
+      );
+    `}
+
+  &:hover {
+    border-color: ${p => p.theme.tokens.border.accent};
+  }
+`;
+
+export const ProgressPill = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.sm};
+`;
+
+export const ProgressCounter = styled(Text)`
+  white-space: nowrap;
+  font-family: ${p => p.theme.font.family.mono};
+`;
+
+export const ToolbarProgressBar = styled(ProgressBar)`
+  width: 50px;
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    display: none;
+  }
+`;
+
+const ColorSwatch = styled('button')<{color: string; selected: boolean}>`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid
+    ${p => (p.selected ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
+  background-color: ${p => (p.color === TRANSPARENT_COLOR ? 'transparent' : p.color)};
+  padding: 0;
+  outline: ${p => (p.selected ? `2px solid ${p.theme.tokens.focus.default}` : 'none')};
+  outline-offset: 1px;
+  ${p =>
+    p.color === TRANSPARENT_COLOR &&
+    css`
+      /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
+      background-image: linear-gradient(
+        to top right,
+        transparent calc(50% - 1.5px),
+        ${p.theme.tokens.content.danger} calc(50% - 0.5px),
+        ${p.theme.tokens.content.danger} calc(50% + 0.5px),
+        transparent calc(50% + 1.5px)
+      );
+    `}
+`;


### PR DESCRIPTION
First of a 3-PR stack splitting #115893. **PR 1 of 3** — base: \`master\`.

Refactors the preprod snapshots toolbar so it can be rendered in isolation, without touching production behavior.

### What changes
- Extracts the toolbar components into a dedicated **\`snapshotsToolbar.tsx\`** module and makes them purely presentational.
- **\`DiffModeToggle\`** now takes a \`showSplit\` prop instead of calling \`useBreakpoints()\` itself. The view-mode / diff-mode toggles no longer call \`useOrganization()\` / \`trackAnalytics\` — that wiring moves up into \`SnapshotMainContent\`, which passes \`breakpoints.sm\` and fires analytics from its \`onChange\` handlers.
- **\`snapshotMainContent.tsx\`** imports the shared components instead of defining its own copies, removing the duplication.
- Drops the now-unused \`export\` on \`TRANSPARENT_COLOR\` in \`diffImageDisplay.tsx\` (still used internally; no external importer remains after the de-dupe).

### Behavior
No production behavior change intended. The old \`DiffModeToggle\` did \`const breakpoints = useBreakpoints(); breakpoints.sm ? …\`, which is exactly what \`showSplit={breakpoints.sm}\` now passes.

### Follow-ups in the stack
- PR 2: snapshot-harness plumbing to render real design-system components under SSR.
- PR 3: the actual toolbar snapshot tests.