### PR TITLE
build(snapshots): Resolve real design-system imports under SSR

### DIFF
--- a/jest.config.snapshots.ts
+++ b/jest.config.snapshots.ts
@@ -69,6 +69,7 @@ const config: Config.InitialOptions = {
 
   transform: {
     '^.+\\.[mc]?[jt]sx?$': ['@swc/jest', swcConfig],
+    '^.+\\.pegjs?$': '<rootDir>/tests/js/jest-pegjs-transform.js',
   },
   transformIgnorePatterns: [
     ESM_NODE_MODULES.length
@@ -76,7 +77,7 @@ const config: Config.InitialOptions = {
       : '/node_modules/',
   ],
 
-  moduleFileExtensions: ['js', 'ts', 'jsx', 'tsx'],
+  moduleFileExtensions: ['js', 'ts', 'jsx', 'tsx', 'pegjs'],
 };
 
 export default config;

--- a/tests/js/sentry-test/snapshots/snapshot-setup.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-setup.ts
@@ -37,10 +37,8 @@ if (globalThis.window === undefined) {
   globalThis.localStorage = localStorageShim as unknown as Storage;
 }
 
-// CompactSelect (and other core components) call `CSS.escape` during render to
-// build option keys. The node SSR environment has no `CSS` global, so provide a
-// minimal shim. The keys we render are simple identifiers, so escaping just the
-// characters that matter for CSS selectors is sufficient.
+// CompactSelect and other core components call `CSS.escape` during render, but
+// the node SSR environment has no `CSS` global. Shim a minimal escape.
 if ((globalThis as any).CSS === undefined) {
   (globalThis as any).CSS = {
     escape: (value: string) => String(value).replace(/[^\w-]/g, '\\$&'),

--- a/tests/js/sentry-test/snapshots/snapshot-setup.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-setup.ts
@@ -36,3 +36,13 @@ if (globalThis.window === undefined) {
 
   globalThis.localStorage = localStorageShim as unknown as Storage;
 }
+
+// CompactSelect (and other core components) call `CSS.escape` during render to
+// build option keys. The node SSR environment has no `CSS` global, so provide a
+// minimal shim. The keys we render are simple identifiers, so escaping just the
+// characters that matter for CSS selectors is sufficient.
+if ((globalThis as any).CSS === undefined) {
+  (globalThis as any).CSS = {
+    escape: (value: string) => String(value).replace(/[^\w-]/g, '\\$&'),
+  };
+}


### PR DESCRIPTION
**PR 2 of 3** in the stack splitting #115893 — base: #116477.

Adds the snapshot-harness plumbing needed to render *real* design-system components (rather than stubs) under the node SSR snapshot environment. No component or test changes here — this is pure test infrastructure, reusable by any snapshot test that pulls in the design system.

### What changes
- **\`jest.config.snapshots.ts\`** — register a \`.pegjs\` transform and add \`pegjs\` to \`moduleFileExtensions\`, so the design-system import chain resolves. (\`tests/js/jest-pegjs-transform.js\` already exists.)
- **\`tests/js/sentry-test/snapshots/snapshot-setup.ts\`** — shim \`CSS.escape\`; \`CompactSelect\` and other core components call it during render, and the node environment has no \`CSS\` global. The shim is guarded by an \`undefined\` check.

### Verification
Existing snapshot suites still pass under the change (verified locally, e.g. \`pnpm snapshots badge\`). The new code paths aren't exercised until PR 3.

### Stack
- PR 1: #116477 — presentational refactor / de-dupe.
- PR 3: the actual toolbar snapshot tests (based on this PR).