### PR TITLE
test(snapshots): Snapshot the snapshots toolbar

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1184,6 +1184,7 @@ export default typescript.config([
           type: 'test-sentry',
           pattern: [
             'static/app/**/*.spec.{ts,js,tsx,jsx}',
+            'static/app/**/*.snapshots.tsx',
             'tests/js/sentry-test/**/*.*',
             'static/app/**/*{t,T}estUtils*.{js,mjs,ts,tsx}',
           ],

--- a/static/app/components/core/badge/badge.snapshots.tsx
+++ b/static/app/components/core/badge/badge.snapshots.tsx
@@ -1,6 +1,6 @@
 import {ThemeProvider} from '@emotion/react';
 
-// eslint-disable-next-line @sentry/scraps/no-core-import -- SSR snapshot needs direct import to avoid barrel re-exports with heavy deps
+// eslint-disable-next-line @sentry/scraps/no-core-import, boundaries/dependencies -- SSR snapshot needs direct import to avoid barrel re-exports with heavy deps
 import {Badge, type BadgeProps} from 'sentry/components/core/badge/badge';
 // eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
@@ -23,10 +23,6 @@ jest.mock('./preprodBuildsTableCommon', () => ({
   ),
 }));
 
-jest.mock('@sentry/scraps/tooltip', () => ({
-  Tooltip: ({children}: {children: React.ReactNode}) => children,
-}));
-
 jest.mock('sentry/components/timeSince', () => ({
   TimeSince: ({date}: {date: string}) => <time dateTime={date}>1 hour ago</time>,
 }));

--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -25,10 +25,6 @@ jest.mock('@sentry/scraps/layout', () => {
   };
 });
 
-jest.mock('@sentry/scraps/tooltip', () => ({
-  Tooltip: ({children}: {children: React.ReactNode}) => children,
-}));
-
 jest.mock('sentry/utils/useCopyToClipboard', () => ({
   useCopyToClipboard: () => ({copy: jest.fn()}),
 }));

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -119,7 +119,7 @@ describe('SnapshotsToolbar', () => {
     it.snapshot.breakpoints(
       ['xs', 'sm', 'md'],
       'all controls',
-      () => (
+      width => (
         <ThemeProvider theme={themes[themeName]}>
           <div style={{width: '100%'}}>
             <SnapshotsToolbarWithControls
@@ -132,6 +132,8 @@ describe('SnapshotsToolbar', () => {
                 onModeChange: noop,
                 overlayColor: '#f55459',
                 onOverlayColorChange: noop,
+                // Mirror production's `showSplit={breakpoints.sm}`.
+                showSplit: width >= parseInt(themes[themeName].breakpoints.sm, 10),
               }}
               solo={{isActive: false, onToggle: noop}}
             />

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -1,6 +1,8 @@
 import {Fragment} from 'react';
 import {ThemeProvider} from '@emotion/react';
 
+import {CompactSelect as mockCompactSelect} from 'sentry-test/snapshots/mocks/compactSelect';
+
 import {Tag} from '@sentry/scraps/badge';
 
 import {t} from 'sentry/locale';
@@ -9,35 +11,7 @@ import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
 
-// Tooltips portal to `document.body` on render, which the SSR snapshot
-// environment (no `document`) can't do. They're hover-only and never visible in
-// a static snapshot, so render the trigger directly.
-jest.mock('@sentry/scraps/tooltip', () => ({
-  Tooltip: ({children}: {children: React.ReactNode}) => children,
-}));
-
-// CompactSelect's overlay control reads `document` during render to compute the
-// dropdown boundary, which the SSR environment can't provide. The dropdown menu
-// is never visible in a static snapshot anyway, so render only its trigger — the
-// real DropdownButton the closed select shows in prod.
-jest.mock('@sentry/scraps/compactSelect', () => {
-  const {DropdownButton} = jest.requireActual('sentry/components/dropdownButton');
-  return {
-    CompactSelect: ({
-      options,
-      value,
-      size,
-    }: {
-      options: Array<{label: React.ReactNode; value: unknown}>;
-      size?: string;
-      value?: unknown;
-    }) => (
-      <DropdownButton size={size}>
-        {options.find(opt => opt.value === value)?.label}
-      </DropdownButton>
-    ),
-  };
-});
+jest.mock('@sentry/scraps/compactSelect', () => ({CompactSelect: mockCompactSelect}));
 
 import {
   ColorPickerButton,
@@ -142,11 +116,12 @@ const noop = () => {};
 
 describe('SnapshotsToolbar', () => {
   describe.each(['light', 'dark'] as const)('%s', themeName => {
-    it.snapshot(
+    it.snapshot.breakpoints(
+      ['xs', 'sm', 'md'],
       'all controls',
       () => (
         <ThemeProvider theme={themes[themeName]}>
-          <div style={{width: 960}}>
+          <div style={{width: '100%'}}>
             <SnapshotsToolbarWithControls
               viewMode="list"
               onViewModeChange={noop}
@@ -163,7 +138,7 @@ describe('SnapshotsToolbar', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {state: 'all-controls', area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -181,7 +156,7 @@ describe('SnapshotsToolbar', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {state: 'no-diff-controls', area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -198,7 +173,7 @@ describe('SnapshotsToolbar', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {state: 'solo-base', area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
 
     it.snapshot(
@@ -210,7 +185,7 @@ describe('SnapshotsToolbar', () => {
           </div>
         </ThemeProvider>
       ),
-      {tags: {state: 'minimal', area: 'snapshots'}}
+      {tags: {area: 'snapshots'}}
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -1,0 +1,216 @@
+import {Fragment} from 'react';
+import {ThemeProvider} from '@emotion/react';
+
+import {Tag} from '@sentry/scraps/badge';
+
+import {t} from 'sentry/locale';
+// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
+import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
+
+import type {DiffMode} from './imageDisplay/diffImageDisplay';
+
+// Tooltips portal to `document.body` on render, which the SSR snapshot
+// environment (no `document`) can't do. They're hover-only and never visible in
+// a static snapshot, so render the trigger directly.
+jest.mock('@sentry/scraps/tooltip', () => ({
+  Tooltip: ({children}: {children: React.ReactNode}) => children,
+}));
+
+// CompactSelect's overlay control reads `document` during render to compute the
+// dropdown boundary, which the SSR environment can't provide. The dropdown menu
+// is never visible in a static snapshot anyway, so render only its trigger — the
+// real DropdownButton the closed select shows in prod.
+jest.mock('@sentry/scraps/compactSelect', () => {
+  const {DropdownButton} = jest.requireActual('sentry/components/dropdownButton');
+  return {
+    CompactSelect: ({
+      options,
+      value,
+      size,
+    }: {
+      options: Array<{label: React.ReactNode; value: unknown}>;
+      size?: string;
+      value?: unknown;
+    }) => (
+      <DropdownButton size={size}>
+        {options.find(opt => opt.value === value)?.label}
+      </DropdownButton>
+    ),
+  };
+});
+
+import {
+  ColorPickerButton,
+  DiffModeToggle,
+  ProgressCounter,
+  ProgressPill,
+  type SortBy,
+  SortDropdown,
+  SoloDiffToggle,
+  ToolbarContainer,
+  ToolbarProgressBar,
+  type ViewMode,
+  ViewModeToggle,
+} from './snapshotsToolbar';
+
+// Test-only convenience wrapper that maps a flat props API onto the slot-based
+// ToolbarContainer, mirroring how SnapshotMainContent composes the real toolbar
+// from the same presentational components in production.
+function SnapshotsToolbarWithControls({
+  viewMode,
+  onViewModeChange,
+  progress,
+  sort,
+  diff,
+  solo,
+}: {
+  onViewModeChange: (mode: ViewMode) => void;
+  viewMode: ViewMode;
+  diff?: {
+    mode: DiffMode;
+    onModeChange: (mode: DiffMode) => void;
+    onOverlayColorChange: (color: string) => void;
+    overlayColor: string;
+    showSplit?: boolean;
+  };
+  progress?: {
+    current: number;
+    percent: number;
+    total: number;
+  };
+  solo?:
+    | 'base'
+    | {
+        isActive: boolean;
+        onToggle: () => void;
+      };
+  sort?: {
+    onChange: (sort: SortBy) => void;
+    value: SortBy;
+  };
+}) {
+  let soloDiffToggle: React.ReactNode = null;
+  if (solo === 'base') {
+    soloDiffToggle = <Tag variant="promotion">{t('Base')}</Tag>;
+  } else if (solo) {
+    soloDiffToggle = (
+      <SoloDiffToggle isSoloView={solo.isActive} onToggleSoloView={solo.onToggle} />
+    );
+  }
+
+  return (
+    <ToolbarContainer
+      toggle={<ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />}
+      sortDropdown={
+        sort ? <SortDropdown value={sort.value} onChange={sort.onChange} /> : null
+      }
+      progressIndicator={
+        progress ? (
+          <ProgressPill>
+            <ToolbarProgressBar value={progress.percent} />
+            <ProgressCounter size="xs" variant="muted">
+              {progress.current}/{progress.total}
+            </ProgressCounter>
+          </ProgressPill>
+        ) : null
+      }
+      diffControls={
+        diff ? (
+          <Fragment>
+            {diff.mode === 'split' && (
+              <ColorPickerButton
+                color={diff.overlayColor}
+                onChange={diff.onOverlayColorChange}
+              />
+            )}
+            <DiffModeToggle
+              diffMode={diff.mode}
+              onDiffModeChange={diff.onModeChange}
+              showSplit={diff.showSplit ?? true}
+            />
+          </Fragment>
+        ) : null
+      }
+      soloDiffToggle={soloDiffToggle}
+    />
+  );
+}
+
+const themes = {light: lightTheme, dark: darkTheme};
+
+const noop = () => {};
+
+describe('SnapshotsToolbar', () => {
+  describe.each(['light', 'dark'] as const)('%s', themeName => {
+    it.snapshot(
+      'all controls',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{width: 960}}>
+            <SnapshotsToolbarWithControls
+              viewMode="list"
+              onViewModeChange={noop}
+              progress={{current: 3, total: 12, percent: 25}}
+              sort={{value: 'diff', onChange: noop}}
+              diff={{
+                mode: 'split',
+                onModeChange: noop,
+                overlayColor: '#f55459',
+                onOverlayColorChange: noop,
+              }}
+              solo={{isActive: false, onToggle: noop}}
+            />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {state: 'all-controls', area: 'snapshots'}}
+    );
+
+    it.snapshot(
+      'no diff controls',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{width: 960}}>
+            <SnapshotsToolbarWithControls
+              viewMode="single"
+              onViewModeChange={noop}
+              progress={{current: 1, total: 5, percent: 0}}
+              sort={{value: 'alpha', onChange: noop}}
+              solo={{isActive: true, onToggle: noop}}
+            />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {state: 'no-diff-controls', area: 'snapshots'}}
+    );
+
+    it.snapshot(
+      'solo base tag',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{width: 960}}>
+            <SnapshotsToolbarWithControls
+              viewMode="list"
+              onViewModeChange={noop}
+              progress={{current: 1, total: 3, percent: 0}}
+              solo="base"
+            />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {state: 'solo-base', area: 'snapshots'}}
+    );
+
+    it.snapshot(
+      'minimal',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{width: 960}}>
+            <SnapshotsToolbarWithControls viewMode="list" onViewModeChange={noop} />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {state: 'minimal', area: 'snapshots'}}
+    );
+  });
+});

--- a/tests/js/sentry-test/snapshots/mocks/compactSelect.tsx
+++ b/tests/js/sentry-test/snapshots/mocks/compactSelect.tsx
@@ -1,0 +1,19 @@
+import type {ComponentProps, ReactNode} from 'react';
+
+import {DropdownButton} from 'sentry/components/dropdownButton';
+
+export function CompactSelect({
+  options,
+  value,
+  size,
+}: {
+  options: Array<{label: ReactNode; value: unknown}>;
+  size?: ComponentProps<typeof DropdownButton>['size'];
+  value?: unknown;
+}) {
+  return (
+    <DropdownButton size={size}>
+      {options.find(opt => opt.value === value)?.label}
+    </DropdownButton>
+  );
+}

--- a/tests/js/sentry-test/snapshots/mocks/tooltip.tsx
+++ b/tests/js/sentry-test/snapshots/mocks/tooltip.tsx
@@ -1,0 +1,5 @@
+import type {ReactNode} from 'react';
+
+export function Tooltip({children}: {children: ReactNode}) {
+  return children;
+}

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -1,10 +1,15 @@
 import type {ReactElement} from 'react';
 
+import {Tooltip as mockTooltip} from 'sentry-test/snapshots/mocks/tooltip';
+
 // eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {lightTheme} from 'sentry/utils/theme/theme';
 
 import {closeBrowser, takeSnapshot} from './snapshot';
 import type {SnapshotTestMetadata} from './snapshot-image-metadata';
+
+// Tooltip portals to document.body, unavailable under SSR; mock globally.
+jest.mock('@sentry/scraps/tooltip', () => ({Tooltip: mockTooltip}));
 
 const BREAKPOINT_WIDTHS = Object.fromEntries(
   Object.entries(lightTheme.breakpoints).map(([k, v]) => [k, parseInt(v, 10)])

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -137,11 +137,12 @@ snapshotTest.each = function snapshotEach<T>(table: T[]) {
 snapshotTest.breakpoints = function snapshotBreakpoints(
   breakpoints: BreakpointName[],
   name: string,
-  renderFn: () => ReactElement,
+  renderFn: (width: number) => ReactElement,
   metadata: SnapshotTestMetadata = {}
 ): void {
   for (const bp of breakpoints) {
-    snapshotTest(name, renderFn, {...metadata, viewport: bp});
+    const width = BREAKPOINT_WIDTHS[bp];
+    snapshotTest(name, () => renderFn(width), {...metadata, viewport: bp});
   }
 };
 
@@ -158,7 +159,7 @@ declare global {
         breakpoints: (
           breakpoints: BreakpointName[],
           name: string,
-          renderFn: () => ReactElement,
+          renderFn: (width: number) => ReactElement,
           metadata?: SnapshotTestMetadata
         ) => void;
         each: <T>(


### PR DESCRIPTION
**PR 3 of 3** in the stack splitting #115893 — base: #116478.

Adds snapshot coverage for the preprod snapshots toolbar, rendering the **real** presentational components from \`snapshotsToolbar.tsx\` (PR 1) via the SSR harness (PR 2).

### What changes
- New **\`snapshotsToolbar.snapshots.tsx\`** — 8 snapshots: four content states (\`all-controls\`, \`no-diff-controls\`, \`solo-base\`, \`minimal\`) × light/dark themes.
- Only the irreducibly DOM-bound \`Tooltip\` (portals to \`document.body\`) and \`CompactSelect\` (reads \`document\` for its overlay) stay mocked — both render their visible trigger so the snapshot still reflects production.
- The test-only \`SnapshotsToolbarWithControls\` composition helper lives **in the test file**, mapping a flat props API onto the slot-based \`ToolbarContainer\`. This keeps the production module free of test-only exports.

### Verification
- \`pnpm snapshots snapshotsToolbar\` — 8/8 pass.
- typecheck, \`lint:js\`, and knip all clean.
- The Sentry "Snapshot Testing" visual check runs in CI on this PR.

### Stack
- PR 1: #116477 — presentational refactor / de-dupe.
- PR 2: #116478 — SSR snapshot-harness plumbing.