### PR TITLE
ref(logs): Add superuser only log json debug button

### DIFF
--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -326,12 +326,10 @@ export const LogRowContent = memo(function LogRowContent({
   const logTimestampSeconds = isRegularLogResponseItem(dataRow)
     ? getLogRowTimestampMillis(dataRow) / 1000
     : null;
-  const traceId = String(dataRow[OurLogKnownFieldKey.TRACE_ID] ?? '');
-
   const {hoverProps, traceItemMeta} = usePrefetchTraceItemDetailsOnHover({
     traceItemId: rowId,
     projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
-    traceId,
+    traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID]),
     traceItemType: TraceItemDataset.LOGS,
     referrer: 'api.explore.log-item-details',
     timestamp: logTimestampSeconds,
@@ -477,12 +475,12 @@ export const LogRowContent = memo(function LogRowContent({
 
           const extraMenuItems =
             field === OurLogKnownFieldKey.MESSAGE
-              ? (getExploreSimilarSpansMenuItems({
+              ? getExploreSimilarSpansMenuItems({
                   message: value,
                   organization,
                   selection,
                   showExploreSimilarSpansLink,
-                }) ?? [])
+                })
               : undefined;
 
           if (!defined(value)) {
@@ -742,6 +740,7 @@ function LogRowDetails({
         >
           <LogRowDetailsActions
             fullLogDataResult={fullLogDataResult}
+            projectSlug={projectSlug}
             tableDataRow={dataRow}
           />
         </LogDetailTableActionsCell>
@@ -787,18 +786,17 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
 
 function LogRowDetailsActions({
   fullLogDataResult,
+  projectSlug,
   tableDataRow,
 }: {
   fullLogDataResult: UseQueryResult<TraceItemDetailsResponse>;
+  projectSlug: string;
   tableDataRow: LogTableRowItem;
 }) {
   const {data, isPending, isError} = fullLogDataResult;
   const isFrozen = useLogsFrozenIsFrozen();
   const organization = useOrganization();
   const user = useUser();
-  const project = useProjectFromId({
-    project_id: String(tableDataRow[OurLogKnownFieldKey.PROJECT_ID] ?? ''),
-  });
   const showFilterButtons = !isFrozen;
 
   const {copy} = useCopyToClipboard();
@@ -807,7 +805,7 @@ function LogRowDetailsActions({
   const json = useMemo(() => ourlogToJson(data), [data]);
   let logDebugEndpoint: string | undefined;
 
-  if (user.isSuperuser && project?.slug && isRegularLogResponseItem(tableDataRow)) {
+  if (user.isSuperuser && projectSlug && isRegularLogResponseItem(tableDataRow)) {
     const logId = String(tableDataRow[OurLogKnownFieldKey.ID] ?? '');
     const traceId = String(tableDataRow[OurLogKnownFieldKey.TRACE_ID] ?? '');
 
@@ -819,7 +817,7 @@ function LogRowDetailsActions({
         timestamp: String(Math.trunc(getLogRowTimestampMillis(tableDataRow) / 1000)),
       });
 
-      logDebugEndpoint = `/api/0/projects/${organization.slug}/${project.slug}/trace-items/${logId}/?${query}`;
+      logDebugEndpoint = `/api/0/projects/${organization.slug}/${projectSlug}/trace-items/${logId}/?${query}`;
     }
   }
 

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -28,6 +28,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {defined, escapeDoubleQuotes} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {FieldValueType} from 'sentry/utils/fields';
@@ -817,7 +818,16 @@ function LogRowDetailsActions({
         timestamp: String(Math.trunc(getLogRowTimestampMillis(tableDataRow) / 1000)),
       });
 
-      logDebugEndpoint = `/api/0/projects/${organization.slug}/${projectSlug}/trace-items/${logId}/?${query}`;
+      logDebugEndpoint = `/api/0${getApiUrl(
+        '/projects/$organizationIdOrSlug/$projectIdOrSlug/trace-items/$itemId/',
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            projectIdOrSlug: projectSlug,
+            itemId: logId,
+          },
+        }
+      )}?${query}`;
     }
   }
 

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -29,6 +29,7 @@ import type {Organization} from 'sentry/types/organization';
 import {defined, escapeDoubleQuotes} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {normalizeTimestampToSeconds} from 'sentry/utils/dates';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {FieldValueType} from 'sentry/utils/fields';
@@ -807,15 +808,17 @@ function LogRowDetailsActions({
   let logDebugEndpoint: string | undefined;
 
   if (user.isSuperuser && projectSlug && isRegularLogResponseItem(tableDataRow)) {
-    const logId = String(tableDataRow[OurLogKnownFieldKey.ID] ?? '');
-    const traceId = String(tableDataRow[OurLogKnownFieldKey.TRACE_ID] ?? '');
+    const logId = tableDataRow[OurLogKnownFieldKey.ID] ?? '';
+    const traceId = tableDataRow[OurLogKnownFieldKey.TRACE_ID] ?? '';
 
     if (logId && traceId) {
       const query = new URLSearchParams({
         item_type: TraceItemDataset.LOGS,
         trace_id: traceId,
         debug: 'true',
-        timestamp: String(Math.trunc(getLogRowTimestampMillis(tableDataRow) / 1000)),
+        timestamp: String(
+          normalizeTimestampToSeconds(getLogRowTimestampMillis(tableDataRow))
+        ),
       });
 
       logDebugEndpoint = `/api/0${getApiUrl(

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -5,7 +5,7 @@ import type {UseQueryResult} from '@tanstack/react-query';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
@@ -14,7 +14,14 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
-import {IconAdd, IconJson, IconPin, IconSubtract, IconWarning} from 'sentry/icons';
+import {
+  IconAdd,
+  IconJson,
+  IconPin,
+  IconSubtract,
+  IconTerminal,
+  IconWarning,
+} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
@@ -220,7 +227,6 @@ export const LogRowContent = memo(function LogRowContent({
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
-  const user = useUser();
   const {selection} = usePageFilters();
   const fields = useQueryParamsFields();
   const projects = useProjects();
@@ -321,25 +327,6 @@ export const LogRowContent = memo(function LogRowContent({
     ? getLogRowTimestampMillis(dataRow) / 1000
     : null;
   const traceId = String(dataRow[OurLogKnownFieldKey.TRACE_ID] ?? '');
-  let logDebugEndpointMenuItem: MenuItemProps | undefined;
-
-  if (user.isSuperuser && !isPseudoRow && projectSlug && rowId && traceId) {
-    const query = new URLSearchParams({
-      item_type: TraceItemDataset.LOGS,
-      trace_id: traceId,
-      debug: 'true',
-    });
-
-    if (defined(logTimestampSeconds)) {
-      query.set('timestamp', String(Math.trunc(logTimestampSeconds)));
-    }
-
-    logDebugEndpointMenuItem = {
-      key: 'log-debug-endpoint',
-      label: t('Log JSON'),
-      externalHref: `/api/0/projects/${organization.slug}/${projectSlug}/trace-items/${rowId}/?${query}`,
-    };
-  }
 
   const {hoverProps, traceItemMeta} = usePrefetchTraceItemDetailsOnHover({
     traceItemId: rowId,
@@ -496,11 +483,7 @@ export const LogRowContent = memo(function LogRowContent({
                   selection,
                   showExploreSimilarSpansLink,
                 }) ?? [])
-              : [];
-
-          if (logDebugEndpointMenuItem) {
-            extraMenuItems.push(logDebugEndpointMenuItem);
-          }
+              : undefined;
 
           if (!defined(value)) {
             return (
@@ -812,12 +795,33 @@ function LogRowDetailsActions({
   const {data, isPending, isError} = fullLogDataResult;
   const isFrozen = useLogsFrozenIsFrozen();
   const organization = useOrganization();
+  const user = useUser();
+  const project = useProjectFromId({
+    project_id: String(tableDataRow[OurLogKnownFieldKey.PROJECT_ID] ?? ''),
+  });
   const showFilterButtons = !isFrozen;
 
   const {copy} = useCopyToClipboard();
 
   // Memoize in case we are attempting to copy large JSON objects.
   const json = useMemo(() => ourlogToJson(data), [data]);
+  let logDebugEndpoint: string | undefined;
+
+  if (user.isSuperuser && project?.slug && isRegularLogResponseItem(tableDataRow)) {
+    const logId = String(tableDataRow[OurLogKnownFieldKey.ID] ?? '');
+    const traceId = String(tableDataRow[OurLogKnownFieldKey.TRACE_ID] ?? '');
+
+    if (logId && traceId) {
+      const query = new URLSearchParams({
+        item_type: TraceItemDataset.LOGS,
+        trace_id: traceId,
+        debug: 'true',
+        timestamp: String(Math.trunc(getLogRowTimestampMillis(tableDataRow) / 1000)),
+      });
+
+      logDebugEndpoint = `/api/0/projects/${organization.slug}/${project.slug}/trace-items/${logId}/?${query}`;
+    }
+  }
 
   const betterCopyToClipboard = () => {
     if (!json) {
@@ -851,6 +855,16 @@ function LogRowDetailsActions({
         >
           {t('Copy as JSON')}
         </Button>
+        {logDebugEndpoint ? (
+          <LinkButton
+            variant="transparent"
+            size="sm"
+            href={logDebugEndpoint}
+            icon={<IconTerminal />}
+          >
+            {t('Debug JSON')}
+          </LinkButton>
+        ) : null}
       </LogDetailTableActionsButtonBar>
     </Fragment>
   );

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -30,6 +30,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {useProjects} from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
 import {
   Actions,
   ActionTriggerType,
@@ -219,6 +220,7 @@ export const LogRowContent = memo(function LogRowContent({
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
+  const user = useUser();
   const {selection} = usePageFilters();
   const fields = useQueryParamsFields();
   const projects = useProjects();
@@ -318,10 +320,31 @@ export const LogRowContent = memo(function LogRowContent({
   const logTimestampSeconds = isRegularLogResponseItem(dataRow)
     ? getLogRowTimestampMillis(dataRow) / 1000
     : null;
+  const traceId = String(dataRow[OurLogKnownFieldKey.TRACE_ID] ?? '');
+  let logDebugEndpointMenuItem: MenuItemProps | undefined;
+
+  if (user.isSuperuser && !isPseudoRow && projectSlug && rowId && traceId) {
+    const query = new URLSearchParams({
+      item_type: TraceItemDataset.LOGS,
+      trace_id: traceId,
+      debug: 'true',
+    });
+
+    if (defined(logTimestampSeconds)) {
+      query.set('timestamp', String(Math.trunc(logTimestampSeconds)));
+    }
+
+    logDebugEndpointMenuItem = {
+      key: 'log-debug-endpoint',
+      label: t('Log JSON'),
+      externalHref: `/api/0/projects/${organization.slug}/${projectSlug}/trace-items/${rowId}/?${query}`,
+    };
+  }
+
   const {hoverProps, traceItemMeta} = usePrefetchTraceItemDetailsOnHover({
     traceItemId: rowId,
     projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
-    traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID]),
+    traceId,
     traceItemType: TraceItemDataset.LOGS,
     referrer: 'api.explore.log-item-details',
     timestamp: logTimestampSeconds,
@@ -467,13 +490,17 @@ export const LogRowContent = memo(function LogRowContent({
 
           const extraMenuItems =
             field === OurLogKnownFieldKey.MESSAGE
-              ? getExploreSimilarSpansMenuItems({
+              ? (getExploreSimilarSpansMenuItems({
                   message: value,
                   organization,
                   selection,
                   showExploreSimilarSpansLink,
-                })
-              : undefined;
+                }) ?? [])
+              : [];
+
+          if (logDebugEndpointMenuItem) {
+            extraMenuItems.push(logDebugEndpointMenuItem);
+          }
 
           if (!defined(value)) {
             return (


### PR DESCRIPTION
Like #116131 for logs, bottom right of the expanded view:

<img width="1511" height="481" alt="image" src="https://github.com/user-attachments/assets/f72bfbc1-3f65-4c6d-b23a-07d0cc5a131a" />

