### PR TITLE
perf(trace): Limit trace issue markers

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1458,6 +1458,22 @@ const TraceStylingWrapper = styled('div')`
     white-space: nowrap;
     font-variant-numeric: tabular-nums;
     position: absolute;
+    z-index: 2;
+
+    &.WithIssueMarkers[data-inside-bar='true'] {
+      --trace-bar-duration-shadow-color: color-mix(
+        in srgb,
+        var(--trace-bar-duration-shadow) 70%,
+        black
+      );
+
+      text-shadow:
+        0 1px 2px var(--trace-bar-duration-shadow-color),
+        0 0 2px var(--trace-bar-duration-shadow-color),
+        1px 0 1px var(--trace-bar-duration-shadow-color),
+        -1px 0 1px var(--trace-bar-duration-shadow-color),
+        0 -1px 1px var(--trace-bar-duration-shadow-color);
+    }
   }
 
   .TraceChildrenCount {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -680,4 +680,33 @@ describe('VirtualizedViewManger', () => {
       expect(textTransform).toBe(manager.transformXFromTimestamp(100.1) + 3);
     });
   });
+
+  describe('drawSpanText', () => {
+    it('marks labels placed inside the span', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 100, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 100, 1], [0, 0, 100, 1]);
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(10);
+
+      const ref = document.createElement('div');
+      const node = {
+        errors: new Set(),
+        occurrences: new Set(),
+        makeBarTextColor: () => 'white',
+      } as any;
+
+      manager.drawSpanText({ref, text: '10ms', space: [0, 100]}, node);
+
+      expect(ref.dataset.insideBar).toBe('true');
+    });
+  });
 });

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1506,6 +1506,7 @@ export class VirtualizedViewManager {
 
     // We don't color the text white for missing instrumentation nodes
     // as the text will be invisible on the light background.
+    span_text.ref.dataset.insideBar = inside ? 'true' : 'false';
     span_text.ref.style.color = node.makeBarTextColor(!!inside, this.theme);
     span_text.ref.style.transform = `translateX(${text_transform}px)`;
   }
@@ -1705,6 +1706,7 @@ export class VirtualizedViewManager {
           return;
         }
 
+        text.ref.dataset.insideBar = inside ? 'true' : 'false';
         text.ref.style.color = inside ? 'white' : '';
         text.ref.style.transform = `translateX(${text_transform}px)`;
       }

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns.tsx
@@ -8,6 +8,7 @@ import {
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
+import {limitTraceIssueMarkers} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
 
 const TRACE_ISSUE_SEVERITY_RANK: Record<TraceIssueSeverityClassName, number> = {
   fatal: 0,
@@ -41,7 +42,7 @@ interface BackgroundPatternsProps {
 }
 
 export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
-  const occurrences = useMemo(() => {
+  const allOccurrences = useMemo(() => {
     if (!props.occurrences.size) {
       return [];
     }
@@ -49,16 +50,24 @@ export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
     return [...props.occurrences];
   }, [props.occurrences]);
 
-  const errors = useMemo(() => {
+  const allErrors = useMemo(() => {
     if (!props.errors.size) {
       return [];
     }
     return [...props.errors];
   }, [props.errors]);
 
+  const occurrences = useMemo(() => {
+    return limitTraceIssueMarkers(allOccurrences);
+  }, [allOccurrences]);
+
+  const errors = useMemo(() => {
+    return limitTraceIssueMarkers(allErrors);
+  }, [allErrors]);
+
   const severity = useMemo(() => {
-    return getMaxIssueSeverity(errors, occurrences);
-  }, [errors, occurrences]);
+    return getMaxIssueSeverity(allErrors, allOccurrences);
+  }, [allErrors, allOccurrences]);
 
   if (!props.occurrences.size && !props.errors.size) {
     return null;
@@ -73,6 +82,7 @@ export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
       {errors.length > 0 ? (
         <div
           className="TracePatternContainer"
+          data-test-id="trace-issue-pattern"
           style={{
             left: 0,
             width: '100%',
@@ -101,6 +111,7 @@ export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
               <div
                 key={i}
                 className="TracePatternContainer"
+                data-test-id="trace-issue-pattern"
                 style={{
                   left: left * 100 + '%',
                   width: (1 - left) * 100 + '%',

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback} from 'react';
+import {Fragment, useCallback, type CSSProperties} from 'react';
 
 import {formatTraceDuration} from 'sentry/utils/duration/formatTraceDuration';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
@@ -110,6 +110,10 @@ interface TraceBarProps {
 
 export function TraceBar(props: TraceBarProps) {
   let duration: string | null = null;
+  const hasIssueMarkers = props.occurrences.size > 0 || props.errors.size > 0;
+  const durationStyle = hasIssueMarkers
+    ? ({'--trace-bar-duration-shadow': props.color} as CSSProperties)
+    : undefined;
 
   if (props.node_space) {
     const precision = props.durationPrecision ?? 2;
@@ -170,7 +174,13 @@ export function TraceBar(props: TraceBarProps) {
           />
         ) : null}
       </div>
-      <div ref={registerSpanBarTextRef} className="TraceBarDuration">
+      <div
+        ref={registerSpanBarTextRef}
+        style={durationStyle}
+        className={
+          hasIssueMarkers ? 'TraceBarDuration WithIssueMarkers' : 'TraceBarDuration'
+        }
+      >
         {duration}
       </div>
     </Fragment>
@@ -190,6 +200,10 @@ interface AutogroupedTraceBarProps {
 
 export function AutogroupedTraceBar(props: AutogroupedTraceBarProps) {
   const duration = props.entire_space ? formatTraceDuration(props.entire_space[1]) : null;
+  const hasIssueMarkers = props.occurrences.size > 0 || props.errors.size > 0;
+  const durationStyle = hasIssueMarkers
+    ? ({'--trace-bar-duration-shadow': props.color} as CSSProperties)
+    : undefined;
 
   const registerInvisibleBarRef = useCallback(
     (ref: HTMLDivElement | null) => {
@@ -270,7 +284,13 @@ export function AutogroupedTraceBar(props: AutogroupedTraceBarProps) {
           />
         ) : null}
       </div>
-      <div ref={registerAutogroupedSpanBarTextRef} className="TraceBarDuration">
+      <div
+        ref={registerAutogroupedSpanBarTextRef}
+        style={durationStyle}
+        className={
+          hasIssueMarkers ? 'TraceBarDuration WithIssueMarkers' : 'TraceBarDuration'
+        }
+      >
         {duration}
       </div>
     </Fragment>

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
@@ -1,0 +1,73 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {makeEAPOccurrence} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
+import {TraceBackgroundPatterns} from 'sentry/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns';
+import {
+  limitTraceIssueMarkers,
+  MAX_TRACE_ISSUE_MARKERS_PER_ROW,
+  TraceOccurenceIcons,
+} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
+
+const manager = {
+  computeRelativeLeftPositionFromOrigin: (
+    timestamp: number,
+    entireSpace: [number, number]
+  ) => {
+    return (timestamp - entireSpace[0]) / entireSpace[1];
+  },
+} as VirtualizedViewManager;
+
+function makeOccurrences(count: number) {
+  return new Set(
+    Array.from({length: count}, (_value, index) =>
+      makeEAPOccurrence({event_id: `occurrence-${index}`, start_timestamp: index})
+    )
+  );
+}
+
+describe('trace issue markers', () => {
+  it('returns all markers when they fit under the limit', () => {
+    const markers = [1, 2, 3];
+
+    expect(limitTraceIssueMarkers(markers)).toBe(markers);
+  });
+
+  it('samples large marker lists while preserving the first and last markers', () => {
+    const markers = Array.from({length: 600}, (_value, index) => index);
+    const limited = limitTraceIssueMarkers(markers);
+
+    expect(limited).toHaveLength(MAX_TRACE_ISSUE_MARKERS_PER_ROW);
+    expect(limited[0]).toBe(0);
+    expect(limited.at(-1)).toBe(599);
+  });
+
+  it('limits rendered occurrence icons', () => {
+    render(
+      <TraceOccurenceIcons
+        node_space={[0, 600_000]}
+        occurrences={makeOccurrences(600)}
+        manager={manager}
+      />
+    );
+
+    expect(screen.getAllByTestId('trace-issue-icon')).toHaveLength(
+      MAX_TRACE_ISSUE_MARKERS_PER_ROW
+    );
+  });
+
+  it('limits rendered occurrence background markers', () => {
+    render(
+      <TraceBackgroundPatterns
+        node_space={[0, 600_000]}
+        occurrences={makeOccurrences(600)}
+        errors={new Set()}
+        manager={manager}
+      />
+    );
+
+    expect(screen.getAllByTestId('trace-issue-pattern')).toHaveLength(
+      MAX_TRACE_ISSUE_MARKERS_PER_ROW
+    );
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -6,6 +6,31 @@ import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
 
+export const MAX_TRACE_ISSUE_MARKERS_PER_ROW = 50;
+
+export function limitTraceIssueMarkers<T>(
+  markers: T[],
+  limit = MAX_TRACE_ISSUE_MARKERS_PER_ROW
+): T[] {
+  if (markers.length <= limit) {
+    return markers;
+  }
+
+  if (limit <= 0) {
+    return [];
+  }
+
+  if (limit === 1) {
+    return [markers[0]!];
+  }
+
+  const step = (markers.length - 1) / (limit - 1);
+
+  return Array.from({length: limit}, (_value, index) => {
+    return markers[Math.round(index * step)]!;
+  });
+}
+
 interface ErrorIconsProps {
   errors: BaseNode['errors'];
   manager: VirtualizedViewManager;
@@ -14,7 +39,7 @@ interface ErrorIconsProps {
 
 export function TraceErrorIcons(props: ErrorIconsProps) {
   const errors = useMemo(() => {
-    return [...props.errors];
+    return limitTraceIssueMarkers([...props.errors]);
   }, [props.errors]);
 
   if (!props.errors.size) {
@@ -40,6 +65,7 @@ export function TraceErrorIcons(props: ErrorIconsProps) {
           <div
             key={i}
             className={`TraceIcon ${getTraceIssueSeverityClassName(error)}`}
+            data-test-id="trace-issue-icon"
             style={{left: left * 100 + '%'}}
           >
             <TraceIcons.Icon event={error} />
@@ -58,7 +84,7 @@ interface TraceOccurenceIconsProps {
 
 export function TraceOccurenceIcons(props: TraceOccurenceIconsProps) {
   const occurrences = useMemo(() => {
-    return [...props.occurrences];
+    return limitTraceIssueMarkers([...props.occurrences]);
   }, [props.occurrences]);
 
   if (!props.occurrences.size) {
@@ -90,6 +116,7 @@ export function TraceOccurenceIcons(props: TraceOccurenceIconsProps) {
           <div
             key={i}
             className={`TraceIcon ${getTraceIssueSeverityClassName(occurrence)}`}
+            data-test-id="trace-issue-icon"
             style={{left: left * 100 + '%'}}
           >
             <TraceIcons.Icon event={occurrence} />


### PR DESCRIPTION
Rows with hundreds of occurrences were rendering one icon and one background marker per issue, which can blow up DOM count in dense traces.

This caps rendered issue markers to a sampled 50 per row while keeping the first and last events so the distribution still reads. Also keeps inside-bar duration labels above markers with a bar-colored shadow so the text doesn't disappear when icons stack underneath it.