### PR TITLE
fix(discover): Link issue event ids directly

### DIFF
--- a/static/app/views/discover/table/index.tsx
+++ b/static/app/views/discover/table/index.tsx
@@ -161,6 +161,7 @@ class Table extends PureComponent<TableProps, TableState> {
     // Note: Event ID or 'id' is added to the fields in the API payload response by default for all non-aggregate queries.
     if (!eventView.hasAggregateField() || apiPayload.field.includes('id')) {
       apiPayload.field.push('trace');
+      apiPayload.field.push('issue.id');
 
       // We need to include the event.type field because we want to
       // route to issue details for error and default event types.

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -561,7 +561,7 @@ describe('TableView > CellActions', () => {
 
     expect(link).toHaveAttribute(
       'href',
-      '/organizations/org-slug/issues/123/events/deadbeef/?project=2&referrer=discover-events-table'
+      '/organizations/org-slug/issues/123/events/deadbeef/?referrer=discover-events-table'
     );
   });
 

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -54,7 +54,11 @@ describe('TableView > CellActions', () => {
 
   const eventView = EventView.fromLocation(location);
 
-  function renderComponent(tableData: TableData, view: EventView) {
+  function renderComponent(
+    tableData: TableData,
+    view: EventView,
+    queryDataset = SavedQueryDatasets.TRANSACTIONS
+  ) {
     return render(
       <TableView
         organization={organization}
@@ -68,7 +72,7 @@ describe('TableView > CellActions', () => {
         measurementKeys={null}
         showTags={false}
         title=""
-        queryDataset={SavedQueryDatasets.TRANSACTIONS}
+        queryDataset={queryDataset}
       />,
       {
         organization,
@@ -80,69 +84,6 @@ describe('TableView > CellActions', () => {
         },
       }
     );
-  }
-
-  function renderIssueEventLink(fields: string[]) {
-    const issueRows: TableData = {
-      meta: {
-        id: 'string',
-        title: 'string',
-        'issue.id': 'integer',
-        'project.name': 'string',
-      },
-      data: [
-        {
-          id: 'deadbeef',
-          title: 'some title',
-          'issue.id': 123,
-          'project.name': 'project-slug',
-        },
-      ],
-    };
-
-    const issueQuery = {
-      id: '42',
-      name: 'best query',
-      field: fields,
-      queryDataset: 'error-events',
-      query: '',
-      project: ['123'],
-      statsPeriod: '14d',
-    };
-
-    const issueLocation = LocationFixture({
-      pathname: '/organizations/org-slug/explore/discover/results/',
-      query: issueQuery,
-    });
-
-    render(
-      <TableView
-        organization={organization}
-        location={issueLocation}
-        eventView={EventView.fromLocation(issueLocation)}
-        isLoading={false}
-        tableData={issueRows}
-        onChangeShowTags={onChangeShowTags}
-        error={null}
-        isFirstPage
-        measurementKeys={null}
-        showTags={false}
-        title=""
-        queryDataset={SavedQueryDatasets.ERRORS}
-      />,
-      {
-        organization,
-        initialRouterConfig: {
-          location: {
-            pathname: issueLocation.pathname,
-            query: issueQuery,
-          },
-        },
-      }
-    );
-
-    const firstRow = screen.getAllByRole('row')[1]!;
-    return within(firstRow).getByTestId('view-event');
   }
 
   async function openContextMenu(cellIndex: number) {
@@ -553,11 +494,24 @@ describe('TableView > CellActions', () => {
     );
   });
 
-  it.each([
-    ['explicit', ['id', 'title']],
-    ['prepended', ['title']],
-  ])('renders %s issue event id links directly to the issue event', (_name, fields) => {
-    const link = renderIssueEventLink(fields);
+  it('renders issue event id links directly to the issue event', () => {
+    const view = EventView.fromLocation(
+      LocationFixture({
+        query: {...locationQuery, field: ['id', 'title']},
+      })
+    );
+    rows.meta = {...rows.meta, id: 'string', 'issue.id': 'integer'};
+    rows.data[0] = {
+      ...rows.data[0]!,
+      id: 'deadbeef',
+      'issue.id': 123,
+      'project.name': 'project-slug',
+    };
+
+    renderComponent(rows, view, SavedQueryDatasets.ERRORS);
+
+    const firstRow = screen.getAllByRole('row')[1]!;
+    const link = within(firstRow).getByTestId('view-event');
 
     expect(link).toHaveAttribute(
       'href',

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -82,6 +82,69 @@ describe('TableView > CellActions', () => {
     );
   }
 
+  function renderIssueEventLink(fields: string[]) {
+    const issueRows: TableData = {
+      meta: {
+        id: 'string',
+        title: 'string',
+        'issue.id': 'integer',
+        'project.name': 'string',
+      },
+      data: [
+        {
+          id: 'deadbeef',
+          title: 'some title',
+          'issue.id': 123,
+          'project.name': 'project-slug',
+        },
+      ],
+    };
+
+    const issueQuery = {
+      id: '42',
+      name: 'best query',
+      field: fields,
+      queryDataset: 'error-events',
+      query: '',
+      project: ['123'],
+      statsPeriod: '14d',
+    };
+
+    const issueLocation = LocationFixture({
+      pathname: '/organizations/org-slug/explore/discover/results/',
+      query: issueQuery,
+    });
+
+    render(
+      <TableView
+        organization={organization}
+        location={issueLocation}
+        eventView={EventView.fromLocation(issueLocation)}
+        isLoading={false}
+        tableData={issueRows}
+        onChangeShowTags={onChangeShowTags}
+        error={null}
+        isFirstPage
+        measurementKeys={null}
+        showTags={false}
+        title=""
+        queryDataset={SavedQueryDatasets.ERRORS}
+      />,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: issueLocation.pathname,
+            query: issueQuery,
+          },
+        },
+      }
+    );
+
+    const firstRow = screen.getAllByRole('row')[1]!;
+    return within(firstRow).getByTestId('view-event');
+  }
+
   async function openContextMenu(cellIndex: number) {
     const firstRow = screen.getAllByRole('row')[1]!;
     const emptyValueCell = within(firstRow).getAllByRole('cell')[cellIndex]!;
@@ -487,6 +550,18 @@ describe('TableView > CellActions', () => {
           '/organizations/org-slug/explore/discover/trace/7fdf8efed85a4f9092507063ced1995b/?.*'
         )
       )
+    );
+  });
+
+  it.each([
+    ['explicit', ['id', 'title']],
+    ['prepended', ['title']],
+  ])('renders %s issue event id links directly to the issue event', (_name, fields) => {
+    const link = renderIssueEventLink(fields);
+
+    expect(link).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/issues/123/events/deadbeef/?project=123&referrer=discover-events-table'
     );
   });
 

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -561,7 +561,7 @@ describe('TableView > CellActions', () => {
 
     expect(link).toHaveAttribute(
       'href',
-      '/organizations/org-slug/issues/123/events/deadbeef/?project=123&referrer=discover-events-table'
+      '/organizations/org-slug/issues/123/events/deadbeef/?project=2&referrer=discover-events-table'
     );
   });
 

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -17,7 +17,6 @@ import {IconStack} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
@@ -194,6 +193,7 @@ export function TableView(props: TableViewProps) {
             isTransactionsDataset,
             location,
             organization,
+            projects,
           })}
         >
           {value}
@@ -309,6 +309,7 @@ export function TableView(props: TableViewProps) {
             isTransactionsDataset,
             location,
             organization,
+            projects,
           })}
         >
           {cell}
@@ -346,10 +347,11 @@ export function TableView(props: TableViewProps) {
         dataRow['max(timestamp)'] ?? dataRow.timestamp
       );
       const dateSelection = eventView.normalizeDateSelection(location);
-      if (dataRow.trace) {
+      const traceSlug = dataRow.trace;
+      if (typeof traceSlug === 'string' && traceSlug) {
         const target = getTraceDetailsUrl({
           organization,
-          traceSlug: String(dataRow.trace),
+          traceSlug,
           dateSelection,
           timestamp,
           location,
@@ -670,23 +672,26 @@ function getEventTarget({
   isTransactionsDataset,
   location,
   organization,
+  projects,
 }: {
   dataRow: TableDataRow;
   eventView: EventView;
   isTransactionsDataset: boolean;
   location: Location;
   organization: Organization;
+  projects: Project[];
 }): LocationDescriptorObject {
   if (dataRow['event.type'] !== 'transaction' && !isTransactionsDataset) {
-    return getIssueEventTarget(dataRow, organization, location);
+    return getIssueEventTarget(dataRow, organization, location, projects);
   }
 
-  if (!dataRow.trace) {
+  const traceSlug = dataRow.trace;
+  if (typeof traceSlug !== 'string' || !traceSlug) {
     throw new Error('Transaction event should always have a trace associated with it.');
   }
 
   return generateLinkToEventInTraceView({
-    traceSlug: String(dataRow.trace),
+    traceSlug,
     eventId: dataRow.id,
     timestamp: dataRow.timestamp,
     organization,
@@ -699,21 +704,22 @@ function getEventTarget({
 function getIssueEventTarget(
   dataRow: TableDataRow,
   organization: Organization,
-  location: Location
+  location: Location,
+  projects: Project[]
 ): LocationDescriptorObject {
   const issueId = dataRow['issue.id'];
+  const project = dataRow.project || dataRow['project.name'];
+  const projectId = projects.find(({slug}) => slug === project)?.id;
 
-  if (defined(issueId)) {
+  if (issueId !== undefined && issueId !== null) {
     return {
       pathname: `/organizations/${organization.slug}/issues/${issueId}/events/${dataRow.id}/`,
       query: {
-        project: location.query.project,
+        project: projectId,
         referrer: 'discover-events-table',
       },
     };
   }
-
-  const project = dataRow.project || dataRow['project.name'];
 
   return {
     // Redirects to the issue group event page via ProjectEventRedirect

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -664,30 +664,77 @@ export function TableView(props: TableViewProps) {
   );
 }
 
+type EventTargetOptions = {
+  dataRow: TableDataRow;
+  eventView: EventView;
+  isTransactionsDataset: boolean;
+  location: Location;
+  organization: Organization;
+};
+
+type TraceEventDataRow = TableDataRow & {
+  timestamp: string | number;
+  trace: string;
+};
+
+type IssueEventDataRow = TableDataRow & {
+  'issue.id': string | number;
+};
+
 function getEventTarget({
   dataRow,
   eventView,
   isTransactionsDataset,
   location,
   organization,
-}: {
-  dataRow: TableDataRow;
-  eventView: EventView;
-  isTransactionsDataset: boolean;
-  location: Location;
-  organization: Organization;
-}): LocationDescriptorObject {
+}: EventTargetOptions): LocationDescriptorObject {
   if (dataRow['event.type'] !== 'transaction' && !isTransactionsDataset) {
-    return getIssueEventTarget(dataRow, organization, location);
+    if (isIssueEventDataRow(dataRow)) {
+      return getIssueEventTarget(dataRow, organization);
+    }
+
+    return getProjectEventRedirectTarget(dataRow, organization, location);
   }
 
-  const traceSlug = dataRow.trace;
-  if (typeof traceSlug !== 'string' || !traceSlug) {
-    throw new Error('Transaction event should always have a trace associated with it.');
+  if (!isTraceEventDataRow(dataRow)) {
+    return getProjectEventRedirectTarget(dataRow, organization, location);
   }
 
+  return getTraceEventTarget(dataRow, organization, location, eventView);
+}
+
+function isIssueEventDataRow(dataRow: TableDataRow): dataRow is IssueEventDataRow {
+  return dataRow['issue.id'] !== undefined && dataRow['issue.id'] !== null;
+}
+
+function isTraceEventDataRow(dataRow: TableDataRow): dataRow is TraceEventDataRow {
+  return (
+    typeof dataRow.trace === 'string' &&
+    dataRow.trace !== '' &&
+    dataRow.timestamp !== undefined
+  );
+}
+
+function getIssueEventTarget(
+  dataRow: IssueEventDataRow,
+  organization: Organization
+): LocationDescriptorObject {
+  return {
+    pathname: `/organizations/${organization.slug}/issues/${dataRow['issue.id']}/events/${dataRow.id}/`,
+    query: {
+      referrer: 'discover-events-table',
+    },
+  };
+}
+
+function getTraceEventTarget(
+  dataRow: TraceEventDataRow,
+  organization: Organization,
+  location: Location,
+  eventView: EventView
+): LocationDescriptorObject {
   return generateLinkToEventInTraceView({
-    traceSlug,
+    traceSlug: dataRow.trace,
     eventId: dataRow.id,
     timestamp: dataRow.timestamp,
     organization,
@@ -697,22 +744,11 @@ function getEventTarget({
   });
 }
 
-function getIssueEventTarget(
+function getProjectEventRedirectTarget(
   dataRow: TableDataRow,
   organization: Organization,
   location: Location
 ): LocationDescriptorObject {
-  const issueId = dataRow['issue.id'];
-
-  if (issueId !== undefined && issueId !== null) {
-    return {
-      pathname: `/organizations/${organization.slug}/issues/${issueId}/events/${dataRow.id}/`,
-      query: {
-        referrer: 'discover-events-table',
-      },
-    };
-  }
-
   const project = dataRow.project || dataRow['project.name'];
 
   return {

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -3,7 +3,7 @@ import {useMatches} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
-import type {Location, LocationDescriptorObject} from 'history';
+import type {Location, LocationDescriptor, LocationDescriptorObject} from 'history';
 
 import {Link} from '@sentry/scraps/link';
 import {useModal} from '@sentry/scraps/modal';
@@ -687,7 +687,7 @@ function getEventTarget({
   isTransactionsDataset,
   location,
   organization,
-}: EventTargetOptions): LocationDescriptorObject {
+}: EventTargetOptions): LocationDescriptor {
   if (dataRow['event.type'] !== 'transaction' && !isTransactionsDataset) {
     if (isIssueEventDataRow(dataRow)) {
       return getIssueEventTarget(dataRow, organization);
@@ -726,7 +726,7 @@ function isTraceEventDataRow(dataRow: TableDataRow): dataRow is TraceEventDataRo
 function getIssueEventTarget(
   dataRow: IssueEventDataRow,
   organization: Organization
-): LocationDescriptorObject {
+): LocationDescriptor {
   return normalizeUrl({
     pathname: `/organizations/${organization.slug}/issues/${dataRow['issue.id']}/events/${dataRow.id}/`,
     query: {
@@ -739,7 +739,7 @@ function getProjectEventRedirectTarget(
   dataRow: TableDataRow,
   organization: Organization,
   location: Location
-): LocationDescriptorObject {
+): LocationDescriptor {
   const project = dataRow.project || dataRow['project.name'];
 
   return {

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -700,7 +700,15 @@ function getEventTarget({
     return getProjectEventRedirectTarget(dataRow, organization, location);
   }
 
-  return getTraceEventTarget(dataRow, organization, location, eventView);
+  return generateLinkToEventInTraceView({
+    traceSlug: dataRow.trace,
+    eventId: dataRow.id,
+    timestamp: dataRow.timestamp,
+    organization,
+    location,
+    eventView,
+    source: TraceViewSources.DISCOVER,
+  });
 }
 
 function isIssueEventDataRow(dataRow: TableDataRow): dataRow is IssueEventDataRow {
@@ -725,23 +733,6 @@ function getIssueEventTarget(
       referrer: 'discover-events-table',
     },
   };
-}
-
-function getTraceEventTarget(
-  dataRow: TraceEventDataRow,
-  organization: Organization,
-  location: Location,
-  eventView: EventView
-): LocationDescriptorObject {
-  return generateLinkToEventInTraceView({
-    traceSlug: dataRow.trace,
-    eventId: dataRow.id,
-    timestamp: dataRow.timestamp,
-    organization,
-    location,
-    eventView,
-    source: TraceViewSources.DISCOVER,
-  });
 }
 
 function getProjectEventRedirectTarget(

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -17,6 +17,7 @@ import {IconStack} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
@@ -184,37 +185,17 @@ export function TableView(props: TableViewProps) {
         value = fieldRenderer(dataRow, {navigate, organization, location, theme});
       }
 
-      let target: any;
-
-      if (dataRow['event.type'] !== 'transaction' && !isTransactionsDataset) {
-        const project = dataRow.project || dataRow['project.name'];
-        target = {
-          // Redirects to the issue group event page via ProjectEventRedirect
-          pathname: normalizeUrl(
-            `/${organization.slug}/${project}/events/${dataRow.id}/`
-          ),
-          query: {...location.query, referrer: 'discover-events-table'},
-        };
-      } else {
-        if (!dataRow.trace) {
-          throw new Error(
-            'Transaction event should always have a trace associated with it.'
-          );
-        }
-
-        target = generateLinkToEventInTraceView({
-          traceSlug: dataRow.trace,
-          eventId: dataRow.id,
-          timestamp: dataRow.timestamp,
-          organization,
-          location,
-          eventView,
-          source: TraceViewSources.DISCOVER,
-        });
-      }
-
       const eventIdLink = (
-        <StyledLink data-test-id="view-event" to={target}>
+        <StyledLink
+          data-test-id="view-event"
+          to={getEventTarget({
+            dataRow,
+            eventView,
+            isTransactionsDataset,
+            location,
+            organization,
+          })}
+        >
           {value}
         </StyledLink>
       );
@@ -319,38 +300,17 @@ export function TableView(props: TableViewProps) {
       queryDataset === SavedQueryDatasets.TRANSACTIONS;
 
     if (columnKey === 'id') {
-      let target: any;
-
-      if (dataRow['event.type'] !== 'transaction' && !isTransactionsDataset) {
-        const project = dataRow.project || dataRow['project.name'];
-
-        target = {
-          // Redirects to the issue group event page via ProjectEventRedirect
-          pathname: normalizeUrl(
-            `/${organization.slug}/${project}/events/${dataRow.id}/`
-          ),
-          query: {...location.query, referrer: 'discover-events-table'},
-        };
-      } else {
-        if (!dataRow.trace) {
-          throw new Error(
-            'Transaction event should always have a trace associated with it.'
-          );
-        }
-
-        target = generateLinkToEventInTraceView({
-          traceSlug: dataRow.trace?.toString(),
-          eventId: dataRow.id,
-          timestamp: dataRow.timestamp!,
-          organization,
-          location,
-          eventView,
-          source: TraceViewSources.DISCOVER,
-        });
-      }
-
       const idLink = (
-        <StyledLink data-test-id="view-event" to={target}>
+        <StyledLink
+          data-test-id="view-event"
+          to={getEventTarget({
+            dataRow,
+            eventView,
+            isTransactionsDataset,
+            location,
+            organization,
+          })}
+        >
           {cell}
         </StyledLink>
       );
@@ -702,6 +662,64 @@ export function TableView(props: TableViewProps) {
       headerButtons={renderHeaderButtons}
     />
   );
+}
+
+function getEventTarget({
+  dataRow,
+  eventView,
+  isTransactionsDataset,
+  location,
+  organization,
+}: {
+  dataRow: TableDataRow;
+  eventView: EventView;
+  isTransactionsDataset: boolean;
+  location: Location;
+  organization: Organization;
+}): LocationDescriptorObject {
+  if (dataRow['event.type'] !== 'transaction' && !isTransactionsDataset) {
+    return getIssueEventTarget(dataRow, organization, location);
+  }
+
+  if (!dataRow.trace) {
+    throw new Error('Transaction event should always have a trace associated with it.');
+  }
+
+  return generateLinkToEventInTraceView({
+    traceSlug: String(dataRow.trace),
+    eventId: dataRow.id,
+    timestamp: dataRow.timestamp,
+    organization,
+    location,
+    eventView,
+    source: TraceViewSources.DISCOVER,
+  });
+}
+
+function getIssueEventTarget(
+  dataRow: TableDataRow,
+  organization: Organization,
+  location: Location
+): LocationDescriptorObject {
+  const issueId = dataRow['issue.id'];
+
+  if (defined(issueId)) {
+    return {
+      pathname: `/organizations/${organization.slug}/issues/${issueId}/events/${dataRow.id}/`,
+      query: {
+        project: location.query.project,
+        referrer: 'discover-events-table',
+      },
+    };
+  }
+
+  const project = dataRow.project || dataRow['project.name'];
+
+  return {
+    // Redirects to the issue group event page via ProjectEventRedirect
+    pathname: normalizeUrl(`/${organization.slug}/${project}/events/${dataRow.id}/`),
+    query: {...location.query, referrer: 'discover-events-table'},
+  };
 }
 
 const PrependHeader = styled('span')`

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -712,7 +712,9 @@ function getEventTarget({
 }
 
 function isIssueEventDataRow(dataRow: TableDataRow): dataRow is IssueEventDataRow {
-  return dataRow['issue.id'] !== undefined && dataRow['issue.id'] !== null;
+  const issueId = dataRow['issue.id'];
+  // Discover coalesces missing issue IDs to 0, so treat 0 as no issue.
+  return issueId !== undefined && issueId !== null && issueId !== 0 && issueId !== '0';
 }
 
 function isTraceEventDataRow(dataRow: TableDataRow): dataRow is TraceEventDataRow {

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -193,7 +193,6 @@ export function TableView(props: TableViewProps) {
             isTransactionsDataset,
             location,
             organization,
-            projects,
           })}
         >
           {value}
@@ -309,7 +308,6 @@ export function TableView(props: TableViewProps) {
             isTransactionsDataset,
             location,
             organization,
-            projects,
           })}
         >
           {cell}
@@ -672,17 +670,15 @@ function getEventTarget({
   isTransactionsDataset,
   location,
   organization,
-  projects,
 }: {
   dataRow: TableDataRow;
   eventView: EventView;
   isTransactionsDataset: boolean;
   location: Location;
   organization: Organization;
-  projects: Project[];
 }): LocationDescriptorObject {
   if (dataRow['event.type'] !== 'transaction' && !isTransactionsDataset) {
-    return getIssueEventTarget(dataRow, organization, location, projects);
+    return getIssueEventTarget(dataRow, organization, location);
   }
 
   const traceSlug = dataRow.trace;
@@ -704,22 +700,20 @@ function getEventTarget({
 function getIssueEventTarget(
   dataRow: TableDataRow,
   organization: Organization,
-  location: Location,
-  projects: Project[]
+  location: Location
 ): LocationDescriptorObject {
   const issueId = dataRow['issue.id'];
-  const project = dataRow.project || dataRow['project.name'];
-  const projectId = projects.find(({slug}) => slug === project)?.id;
 
   if (issueId !== undefined && issueId !== null) {
     return {
       pathname: `/organizations/${organization.slug}/issues/${issueId}/events/${dataRow.id}/`,
       query: {
-        project: projectId,
         referrer: 'discover-events-table',
       },
     };
   }
+
+  const project = dataRow.project || dataRow['project.name'];
 
   return {
     // Redirects to the issue group event page via ProjectEventRedirect

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -727,12 +727,12 @@ function getIssueEventTarget(
   dataRow: IssueEventDataRow,
   organization: Organization
 ): LocationDescriptorObject {
-  return {
+  return normalizeUrl({
     pathname: `/organizations/${organization.slug}/issues/${dataRow['issue.id']}/events/${dataRow.id}/`,
     query: {
       referrer: 'discover-events-table',
     },
-  };
+  });
 }
 
 function getProjectEventRedirectTarget(


### PR DESCRIPTION
Discover was still routing issue event id clicks through the project-event redirect, even when the row already had `issue.id`. That made some issue-event urls messy and left the redirect to clean things up later.

This requests `issue.id` with the hidden link context and builds `/issues/:issueId/events/:eventId/` directly. Keeps the old project redirect fallback for rows that do not have issue context.