### PR TITLE
ref(github-enterprise): Remove fully-GA github.com source flag registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -128,8 +128,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:scm-repositories-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:github-repo-auto-sync-webhook", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:integrations-slack-staging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable GitHub Enterprise to accept github.com as a valid Installation URL
-    manager.add("organizations:github-enterprise-github-com-source", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # API-driven integration setup pipeline (per-provider rollout)
     # ...
     # Project Management Integrations Feature Parity Flags


### PR DESCRIPTION
Final step of the three-PR flagpole removal for `organizations:github-enterprise-github-com-source`. Drop the `manager.add(...)` registration (and its comment) from `src/sentry/features/temporary.py`.

Sequence:
1. #116385 — remove the `features.has(...)` call sites + tests (backend)
2. getsentry/sentry-options-automator#7964 — remove the flagpole config block
3. This PR — remove the registration

⚠️ **Do not merge until #7964 has merged AND deployed.** Landing this earlier would log warnings about an unknown feature key from the still-live options config.