### PR TITLE
feat(msteams): Wire Teams Marketplace installs through the API pipeline modal

### DIFF
--- a/static/app/components/pipeline/integrationMsTeams/index.spec.tsx
+++ b/static/app/components/pipeline/integrationMsTeams/index.spec.tsx
@@ -1,0 +1,36 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {createMakeStepProps} from 'sentry/components/pipeline/testUtils';
+
+import {msTeamsIntegrationPipeline} from '.';
+
+const MsTeamsInstallStep = msTeamsIntegrationPipeline.steps[0].component;
+
+const makeStepProps = createMakeStepProps({totalSteps: 1});
+
+describe('MsTeamsInstallStep', () => {
+  it('auto-advances with the pipeline state and shows a finishing message', () => {
+    const advance = jest.fn();
+    render(
+      <MsTeamsInstallStep
+        {...makeStepProps({
+          stepData: {appDirectoryInstall: true, state: 'pipeline-sig'},
+          advance,
+        })}
+      />
+    );
+
+    expect(advance).toHaveBeenCalledWith({state: 'pipeline-sig'});
+    expect(advance).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByText('Finishing up Microsoft Teams integration installation...')
+    ).toBeInTheDocument();
+  });
+
+  it('does not advance until stepData is available', () => {
+    const advance = jest.fn();
+    render(<MsTeamsInstallStep {...makeStepProps({stepData: null, advance})} />);
+
+    expect(advance).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/components/pipeline/integrationMsTeams/index.tsx
+++ b/static/app/components/pipeline/integrationMsTeams/index.tsx
@@ -1,0 +1,52 @@
+import {useEffect, useRef} from 'react';
+
+import {Text} from '@sentry/scraps/text';
+
+import type {
+  PipelineDefinition,
+  PipelineStepProps,
+} from 'sentry/components/pipeline/types';
+import {pipelineComplete} from 'sentry/components/pipeline/types';
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+type MsTeamsStepData = {
+  appDirectoryInstall: true;
+  state: string;
+};
+
+function MsTeamsInstallStep({
+  stepData,
+  advance,
+}: PipelineStepProps<MsTeamsStepData, {state: string}>) {
+  // MS Teams installs are initiated from the Teams Marketplace, so by the time
+  // the pipeline modal opens all the install data is already bound to pipeline
+  // state. The backend signals this with `appDirectoryInstall` and we advance
+  // immediately with no user interaction. The ref guards against React strict
+  // mode double-firing the effect.
+  const hasAutoAdvanced = useRef(false);
+  useEffect(() => {
+    if (!stepData?.appDirectoryInstall || hasAutoAdvanced.current) {
+      return;
+    }
+    hasAutoAdvanced.current = true;
+    advance({state: stepData.state});
+  }, [stepData, advance]);
+
+  return <Text>{t('Finishing up Microsoft Teams integration installation...')}</Text>;
+}
+
+export const msTeamsIntegrationPipeline = {
+  type: 'integration',
+  provider: 'msteams',
+  actionTitle: t('Installing Microsoft Teams Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'msteams_install',
+      shortDescription: t('Finishing installation'),
+      component: MsTeamsInstallStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -8,6 +8,7 @@ import {discordIntegrationPipeline} from './integrationDiscord';
 import {githubIntegrationPipeline} from './integrationGitHub';
 import {githubEnterpriseIntegrationPipeline} from './integrationGitHubEnterprise';
 import {gitlabIntegrationPipeline} from './integrationGitLab';
+import {msTeamsIntegrationPipeline} from './integrationMsTeams';
 import {opsgenieIntegrationPipeline} from './integrationOpsgenie';
 import {pagerDutyIntegrationPipeline} from './integrationPagerDuty';
 import {perforceIntegrationPipeline} from './integrationPerforce';
@@ -32,6 +33,7 @@ export const PIPELINE_REGISTRY = [
   githubIntegrationPipeline,
   githubEnterpriseIntegrationPipeline,
   gitlabIntegrationPipeline,
+  msTeamsIntegrationPipeline,
   opsgenieIntegrationPipeline,
   pagerDutyIntegrationPipeline,
   perforceIntegrationPipeline,

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -52,6 +52,7 @@ const UNCONDITIONAL_API_PIPELINE_PROVIDERS = [
   'github',
   'github_enterprise',
   'gitlab',
+  'msteams',
   'opsgenie',
   'pagerduty',
   'perforce',

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -77,14 +77,19 @@ function trackExternalAnalytics({
  * Provider-initiated entry points handled here:
  *
  *  - GitHub
- *    `/extensions/github/link/?installationId=…` (redirected from
+ *    `/extensions/github/link/?installationId=...` (redirected from
  *    `/extensions/external-install/github/:installationId`). Drives the
  *    pipeline with `gitHubAppListingParams`.
  *
  *  - Discord
- *    `/extensions/discord/link/?code=…&guild_id=…` (redirected from
+ *    `/extensions/discord/link/?code=...&guild_id=...` (redirected from
  *    `/extensions/discord/configure/`). Drives the pipeline with
  *    `discordAppDirectoryParams`.
+ *
+ *  - Microsoft Teams
+ *    `/extensions/msteams/link/?signed_params=...` (redirected from
+ *    `/extensions/msteams/configure/`). Drives the pipeline with
+ *    `msTeamsParams`.
  *
  *  - Anything else
  *    falls through to {@link finishLegacyInstallation}, which bounces to the
@@ -218,6 +223,20 @@ export default function IntegrationOrganizationLink() {
     return {code, guild_id: guildId, use_configure: '1'};
   }, [integrationSlug, location.query]);
 
+  // Microsoft Teams installs arrive here with `signed_params` in the URL query
+  // (forwarded from `/extensions/msteams/configure/`). The install button uses
+  // it as `initialData` for the pipeline modal.
+  const msTeamsParams = useMemo<Record<string, string> | null>(() => {
+    if (integrationSlug !== 'msteams') {
+      return null;
+    }
+    const signedParams = location.query.signed_params;
+    if (typeof signedParams !== 'string') {
+      return null;
+    }
+    return {signedParams};
+  }, [integrationSlug, location.query]);
+
   // Legacy install path. Redirects to `/extensions/<slug>/configure/`, which
   // runs the Django-rendered `IntegrationExtensionConfigurationView` to drive
   // the install server-side via the legacy pipeline. Used by every provider
@@ -246,7 +265,8 @@ export default function IntegrationOrganizationLink() {
     // Each provider-initiated entry point contributes its own params bag.
     // Whichever one is non-null routes through the API pipeline modal;
     // otherwise we fall back to the legacy server-driven install flow.
-    const urlParams = gitHubAppListingParams ?? discordAppDirectoryParams;
+    const urlParams =
+      gitHubAppListingParams ?? discordAppDirectoryParams ?? msTeamsParams;
     if (urlParams) {
       startFlow({provider, organization, onInstall, urlParams});
       return;
@@ -258,6 +278,7 @@ export default function IntegrationOrganizationLink() {
     organization,
     gitHubAppListingParams,
     discordAppDirectoryParams,
+    msTeamsParams,
     startFlow,
     onInstall,
     finishLegacyInstallation,


### PR DESCRIPTION
[VDY-101: Microsoft Teams: API-driven integration setup](https://linear.app/getsentry/issue/VDY-101/microsoft-teams-api-driven-integration-setup)

When a user installs the Sentry app from the Microsoft Teams Marketplace, the Sentry bot posts a card linking to `/extensions/msteams/configure/` with a signed `signed_params` blob. That forwards to `/extensions/msteams/link/` (the org picker), and from there the install needs to drive the API pipeline modal. This wires up the frontend side:

- Adds `msTeamsParams` in the org-link view, returning `{signedParams}` when `signed_params` is present in the URL query, and routes `handleInstallClick` through it via the existing `gitHubAppListingParams ?? discordAppDirectoryParams ?? msTeamsParams` chain.
- Adds the `integrationMsTeams` pipeline definition. Its single step has no interactive UI; all install data arrives already bound to pipeline state, so it auto-advances when the backend returns `appDirectoryInstall`, rendering a brief "Finishing up..." message (guarded by a ref against React strict-mode double-fire).
- Registers the pipeline and adds `msteams` to `UNCONDITIONAL_API_PIPELINE_PROVIDERS`.

Depends on the backend support (separate PR) and must not deploy before it: the modal calls the API pipeline `initialize` endpoint for `msteams`, which only works once the backend serializer / step / `can_add_externally` changes are live. The `/extensions/msteams/configure/` URL still routes through the legacy server-rendered view until a follow-up swaps it to a redirect.