### PR TITLE
feat(msteams): Support installing through the API pipeline modal

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -228,6 +228,17 @@ class IntegrationProvider(PipelineProvider["IntegrationPipeline"], abc.ABC):
     can_add = True
     """whether or not the integration installation be initiated from Sentry"""
 
+    can_add_externally = False
+    """
+    Marks providers whose install is initiated from the third party's app
+    directory or marketplace (e.g. Discord's App Directory, the GitHub App
+    listing, the Teams Marketplace) and completed through the pipeline modal.
+
+    For providers that also set `can_add = False`, hiding the in-app install
+    button because the install can only start from the third party, this is
+    what lets the pipeline endpoint accept the externally-initiated install.
+    """
+
     allow_multiple = True
     """whether multiple installations of this integration are allowed per organization"""
 

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -227,6 +227,7 @@ class DiscordOAuthApiStep:
 class DiscordIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.DISCORD.value
     name = "Discord"
+    can_add_externally = True
     metadata = metadata
     integration_cls = DiscordIntegration
     features = frozenset([IntegrationFeatures.CHAT_UNFURL, IntegrationFeatures.ALERT_RULE])

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -693,6 +693,7 @@ def process_api_error(e: ApiError) -> list[dict[str, Any]] | None:
 class GitHubIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.GITHUB.value
     name = "GitHub"
+    can_add_externally = True
     metadata = metadata
     integration_cls: type[IntegrationInstallation] = GitHubIntegration
     features = frozenset(

--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, TypedDict
 
+from django.core.signing import BadSignature, SignatureExpired
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+from rest_framework.fields import CharField
 
 from sentry import options
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
@@ -19,6 +23,7 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.msteams.card_builder.block import AdaptiveCard
+from sentry.integrations.msteams.constants import SALT
 from sentry.integrations.msteams.metrics import translate_msteams_api_error
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.types import IntegrationProviderSlug
@@ -28,14 +33,19 @@ from sentry.notifications.platform.provider import (
 )
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils.signing import unsign
 
 from .card_builder.installation import (
     build_personal_installation_confirmation_message,
     build_team_installation_confirmation_message,
 )
 from .client import MsTeamsClient, get_token_data
+
+# 24 hours to finish installation
+INSTALL_EXPIRATION_TIME = 60 * 60 * 24
 
 logger = logging.getLogger("sentry.integrations.msteams")
 
@@ -105,10 +115,76 @@ class MsTeamsIntegration(IntegrationInstallation, IntegrationNotificationClient)
         raise NotImplementedError("Threading is not supported for Microsoft Teams")
 
 
+class MsTeamsInstallParams(TypedDict):
+    """The payload the Sentry-Teams bot signs into `signed_params`."""
+
+    external_id: str
+    external_name: str
+    service_url: str
+    user_id: str
+    conversation_id: str
+    tenant_id: str
+    installation_type: str
+
+
+class MsTeamsInitialDataSerializer(CamelSnakeSerializer):
+    """Initial pipeline data for Microsoft Teams installs.
+
+    The Sentry bot in Teams renders a card with a single `signed_params` blob
+    (see MsTeamsInstallParams). We unsign it here so each field is bound to
+    top-level pipeline state individually.
+    """
+
+    signed_params = CharField(required=True)
+
+    def validate(self, attrs: dict[str, Any]) -> MsTeamsInstallParams:
+        try:
+            return unsign(attrs["signed_params"], max_age=INSTALL_EXPIRATION_TIME, salt=SALT)
+        except SignatureExpired:
+            raise serializers.ValidationError("Installation link expired")
+        except BadSignature:
+            raise serializers.ValidationError("Invalid installation link")
+
+
+class MsTeamsAdvanceSerializer(CamelSnakeSerializer):
+    state = CharField(required=True)
+
+
+class MsTeamsApiStep:
+    """Install step for Microsoft Teams.
+
+    All install data arrives bound to pipeline state via initialData, so this
+    step has no UI of its own. It signals the frontend to auto-advance, which
+    triggers `build_integration` to run on the already-bound state.
+    """
+
+    step_name = "msteams_install"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        return {
+            "appDirectoryInstall": True,
+            "state": pipeline.signature,
+        }
+
+    def get_serializer_cls(self) -> type:
+        return MsTeamsAdvanceSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, str],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        if validated_data["state"] != pipeline.signature:
+            return PipelineStepResult.error("An error occurred while validating your request.")
+        return PipelineStepResult.advance()
+
+
 class MsTeamsIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.MSTEAMS.value
     name = "Microsoft Teams"
     can_add = False
+    can_add_externally = True
     metadata = metadata
     integration_cls = MsTeamsIntegration
     features = frozenset([IntegrationFeatures.CHAT_UNFURL, IntegrationFeatures.ALERT_RULE])
@@ -116,8 +192,19 @@ class MsTeamsIntegrationProvider(IntegrationProvider):
     def get_pipeline_views(self) -> Sequence[PipelineView[IntegrationPipeline]]:
         return [MsTeamsPipelineView()]
 
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [MsTeamsApiStep()]
+
+    def get_initial_data_serializer_cls(self) -> type[MsTeamsInitialDataSerializer]:
+        return MsTeamsInitialDataSerializer
+
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        data = state[self.key]
+        # Legacy installs (server-rendered configure view) bind everything under
+        # `state["msteams"]`; the API pipeline binds each field top-level. Read
+        # the nested blob if present, else fall back to top-level state.
+        # TODO: drop the `state[self.key]` fallback once the legacy configure
+        # view is removed.
+        data = state.get(self.key) or state
         external_id = data["external_id"]
         external_name = data["external_name"]
         service_url = data["service_url"]

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -96,7 +96,7 @@ def initialize_integration_pipeline(
             % "\n".join(is_feature_enabled)
         )
 
-    if not pipeline.provider.can_add:
+    if not pipeline.provider.can_add and not pipeline.provider.can_add_externally:
         raise IntegrationPipelineError("Integration cannot be added.", not_found=True)
 
     pipeline.initialize()

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -1,19 +1,23 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlencode
 
 import pytest
 import responses
+from django.urls import reverse
 
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.msteams.constants import SALT
 from sentry.integrations.msteams.integration import MsTeamsIntegration, MsTeamsIntegrationProvider
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
     NotificationProviderKey,
     NotificationTargetResourceType,
 )
 from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigurationError
-from sentry.testutils.cases import IntegrationTestCase, TestCase
+from sentry.testutils.cases import APITestCase, IntegrationTestCase, TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 from sentry.utils.signing import sign
@@ -118,6 +122,137 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
     @responses.activate
     def test_personal_installation(self) -> None:
         self.assert_setup_flow(installation_type="tenant")
+
+
+@control_silo_test
+class MsTeamsApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+    provider = MsTeamsIntegrationProvider
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.start_time = 1594768808
+        self.install_params = {
+            "external_id": team_id,
+            "external_name": "my_team",
+            "service_url": "https://smba.trafficmanager.net/amer/",
+            "user_id": user_id,
+            "conversation_id": team_id,
+            "tenant_id": tenant_id,
+        }
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self, initial_data: dict[str, Any] | None = None) -> Any:
+        payload: dict[str, Any] = {"action": "initialize", "provider": self.provider.key}
+        if initial_data is not None:
+            payload["initialData"] = initial_data
+        return self.client.post(self._get_pipeline_url(), data=payload, format="json")
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _signed_params(self, installation_type: str) -> str:
+        return sign(salt=SALT, **{**self.install_params, "installation_type": installation_type})
+
+    @responses.activate
+    def test_initialize_returns_auto_advance_data(self) -> None:
+        resp = self._initialize_pipeline(initial_data={"signedParams": self._signed_params("team")})
+        assert resp.status_code == 200
+        assert resp.data["step"] == "msteams_install"
+        data = resp.data["data"]
+        assert data["appDirectoryInstall"] is True
+        assert "state" in data
+
+    @responses.activate
+    def test_initialize_expired_signature(self) -> None:
+        with patch("sentry.integrations.msteams.integration.INSTALL_EXPIRATION_TIME", -1):
+            resp = self._initialize_pipeline(
+                initial_data={"signedParams": self._signed_params("team")}
+            )
+        assert resp.status_code == 400
+
+    @responses.activate
+    def test_initialize_tampered_signature(self) -> None:
+        # Signed with a different salt, so unsigning with SALT raises
+        # BadSignature rather than SignatureExpired.
+        tampered = sign(salt="not-the-msteams-salt", **self.install_params)
+        resp = self._initialize_pipeline(initial_data={"signedParams": tampered})
+        assert resp.status_code == 400
+
+    def _complete_install(self, installation_type: str) -> str:
+        """Run the full API pipeline and return the post-install card body."""
+        responses.add(
+            responses.POST,
+            "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
+            json={"expires_in": 86399, "access_token": "my_token"},
+        )
+        responses.add(
+            responses.POST,
+            "https://smba.trafficmanager.net/amer/v3/conversations/%s/activities" % team_id,
+            json={},
+        )
+
+        with patch("time.time") as mock_time:
+            mock_time.return_value = self.start_time
+
+            resp = self._initialize_pipeline(
+                initial_data={"signedParams": self._signed_params(installation_type)}
+            )
+            pipeline_signature = resp.data["data"]["state"]
+
+            resp = self._advance_step({"state": pipeline_signature})
+
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        token_body = responses.calls[0].request.body
+        assert token_body == urlencode(
+            {
+                "client_id": "msteams-client-id",
+                "client_secret": "msteams-client-secret",
+                "grant_type": "client_credentials",
+                "scope": "https://api.botframework.com/.default",
+            }
+        )
+
+        integration = Integration.objects.get(provider=self.provider.key)
+        assert integration.external_id == team_id
+        assert integration.name == "my_team"
+        assert integration.metadata == {
+            "access_token": "my_token",
+            "service_url": "https://smba.trafficmanager.net/amer/",
+            "expires_at": self.start_time + 86399 - 60 * 5,
+            "installation_type": installation_type,
+            "tenant_id": tenant_id,
+        }
+        assert OrganizationIntegration.objects.filter(
+            integration=integration, organization_id=self.organization.id
+        ).exists()
+
+        return responses.calls[1].request.body.decode("utf-8")
+
+    @responses.activate
+    def test_team_installation(self) -> None:
+        post_install_body = self._complete_install(installation_type="team")
+        assert f"organizations/{self.organization.slug}/alerts/rules/" in post_install_body
+        assert self.organization.name in post_install_body
+
+    @responses.activate
+    def test_personal_installation(self) -> None:
+        post_install_body = self._complete_install(installation_type="tenant")
+        assert "Personal installation successful" in post_install_body
+        assert "/settings/account/notifications" in post_install_body
 
 
 @control_silo_test


### PR DESCRIPTION
[VDY-101: Microsoft Teams: API-driven integration setup](https://linear.app/getsentry/issue/VDY-101/microsoft-teams-api-driven-integration-setup)

Adds the API-mode pipeline machinery for Microsoft Teams alongside the existing server-rendered configure flow, without changing the entry point yet. This is the first of three deploy-safe steps: the legacy `MsTeamsExtensionConfigurationView` and the `/extensions/msteams/configure/` URL are left untouched, so nothing changes for users until the frontend can drive the modal and the configure URL is later swapped to a redirect.

- `MsTeamsInitialDataSerializer` unsigns the bot's `signed_params` blob and binds each field to top-level pipeline state.
- `MsTeamsApiStep` has no interactive UI; it signals the frontend to auto-advance, which runs `build_integration` on the bound state.
- `build_integration` now reads top-level state, falling back to the nested `state["msteams"]` the legacy view binds, so both flows work during the transition.

Also adds a `can_add_externally` marker to `IntegrationProvider` for integrations whose install is initiated from the third party's app directory or marketplace and completed through the pipeline modal. MS Teams sets `can_add = False` to hide the in-app install button, so the pipeline endpoint needs this opt-in to allow the externally-initiated install. The other already-external providers (Discord, GitHub, and GitHub Enterprise via subclassing) are marked for consistency; it's a no-op for them since they're `can_add = True`.

Note: mypy will be red until #116486 (typing `utils.signing.unsign` as `Any`) merges, since the serializer's `validate()` returns a `TypedDict` from `unsign()`. The frontend follow-up is #116488.