### PR TITLE
fix(segment-enrichment): Propagate conventional user attributes

### DIFF
--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -17,16 +17,6 @@ from sentry.spans.consumers.process_segments.types import (
 # is taken from `extract_shared_tags` in Relay.
 SHARED_SENTRY_ATTRIBUTES = (
     ATTRIBUTE_NAMES.SENTRY_RELEASE,
-    "sentry.user",
-    "sentry.user.id",
-    "sentry.user.ip",
-    "sentry.user.username",
-    "sentry.user.email",
-    "sentry.user.geo.city",
-    "sentry.user.geo.country_code",
-    "sentry.user.geo.region",
-    "sentry.user.geo.subdivision",
-    "sentry.user.geo.subregion",
     ATTRIBUTE_NAMES.SENTRY_ENVIRONMENT,
     ATTRIBUTE_NAMES.SENTRY_TRANSACTION,
     "sentry.transaction.method",
@@ -42,6 +32,28 @@ SHARED_SENTRY_ATTRIBUTES = (
     ATTRIBUTE_NAMES.SENTRY_PLATFORM,
     "sentry.thread.id",
     "sentry.thread.name",
+    # Current user attributes
+    ATTRIBUTE_NAMES.USER_EMAIL,
+    ATTRIBUTE_NAMES.USER_GEO_CITY,
+    ATTRIBUTE_NAMES.USER_GEO_COUNTRY_CODE,
+    ATTRIBUTE_NAMES.USER_GEO_REGION,
+    ATTRIBUTE_NAMES.USER_GEO_SUBDIVISION,
+    ATTRIBUTE_NAMES.USER_ID,
+    ATTRIBUTE_NAMES.USER_IP_ADDRESS,
+    ATTRIBUTE_NAMES.USER_NAME,
+    # Legacy user attributes, taken from sentry_tags.
+    # TODO(mjq): Remove these once everything is switched over to the new
+    # conventional attribute names. See BROWSE-535.
+    "sentry.user",
+    "sentry.user.id",
+    "sentry.user.ip",
+    "sentry.user.username",
+    "sentry.user.email",
+    "sentry.user.geo.city",
+    "sentry.user.geo.country_code",
+    "sentry.user.geo.region",
+    "sentry.user.geo.subdivision",
+    "sentry.user.geo.subregion",
 )
 
 # The name of the main thread used to infer the `main_thread` flag in spans from

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -1,5 +1,6 @@
 from typing import cast
 
+from sentry_conventions.attributes import ATTRIBUTE_NAMES
 from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
 from sentry.spans.consumers.process_segments.enrichment import (
@@ -512,6 +513,77 @@ def _mock_performance_issue_span(is_segment, attributes, **fields) -> SpanEvent:
             **fields,
         },
     )
+
+
+def test_conventional_user_attributes_propagated_to_child_spans() -> None:
+    """New conventional user attributes (user.email, user.id, etc.) are propagated
+    from the segment span to child spans that don't already have them."""
+    user_attrs = {
+        ATTRIBUTE_NAMES.USER_EMAIL: {"type": "string", "value": "user@example.com"},
+        ATTRIBUTE_NAMES.USER_ID: {"type": "string", "value": "12345"},
+        ATTRIBUTE_NAMES.USER_IP_ADDRESS: {"type": "string", "value": "203.0.113.1"},
+        ATTRIBUTE_NAMES.USER_NAME: {"type": "string", "value": "testuser"},
+        ATTRIBUTE_NAMES.USER_GEO_CITY: {"type": "string", "value": "San Francisco"},
+        ATTRIBUTE_NAMES.USER_GEO_COUNTRY_CODE: {"type": "string", "value": "US"},
+        ATTRIBUTE_NAMES.USER_GEO_REGION: {"type": "string", "value": "CA"},
+        ATTRIBUTE_NAMES.USER_GEO_SUBDIVISION: {"type": "string", "value": "San Francisco"},
+    }
+
+    segment = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        attributes=user_attrs,
+    )
+    child = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+    )
+
+    _, enriched = TreeEnricher.enrich_spans([segment, child])
+
+    enriched_child = enriched[1]
+    for attr_name, attr in user_attrs.items():
+        assert attribute_value(enriched_child, attr_name) == attr["value"], (
+            f"{attr_name} not propagated to child"
+        )
+
+
+def test_conventional_user_attributes_not_overwritten_on_child() -> None:
+    """If a child span already has a conventional user attribute, the segment
+    value must not overwrite it."""
+    segment = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        attributes={
+            ATTRIBUTE_NAMES.USER_EMAIL: {"type": "string", "value": "segment@example.com"},
+            ATTRIBUTE_NAMES.USER_ID: {"type": "string", "value": "111"},
+        },
+    )
+    child = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+        attributes={
+            ATTRIBUTE_NAMES.USER_EMAIL: {"type": "string", "value": "child@example.com"},
+        },
+    )
+
+    _, enriched = TreeEnricher.enrich_spans([segment, child])
+
+    enriched_child = enriched[1]
+    assert attribute_value(enriched_child, ATTRIBUTE_NAMES.USER_EMAIL) == "child@example.com"
+    assert attribute_value(enriched_child, ATTRIBUTE_NAMES.USER_ID) == "111"
 
 
 def test_enrich_gen_ai_agent_name_from_immediate_parent() -> None:


### PR DESCRIPTION
Currently v1 (transaction-based) spans send user attributes in `sentry.user.*` attributes, while v2 (streaming) spans send user attributes in conventions-defined `user.*` attributes. Only the v1 attributes are currently propagated, meaning that child spans from span streaming SDKs are missing user info.

We can use our conventions' deprecation mechanism (https://github.com/getsentry/sentry-conventions/pull/406) to make queries backwards compatible, but that doesn't affect segment enrichment which reads data directly from spans.

For now, propagate both the old v1 user attributes and the new v2 user attributes to children. Once that's done, EAP's attribute coalescing (via above deprecation PR) will take care of the rest.

Next steps will be to clean up our use of the v1 `sentry.user.*` attributes in Relay and Sentry, at which point we can stop propagating them. (That work is tracked in BROWSE-535).

Fixes BROWSE-532.

---

🤖: Claude Code (Opus 4.6) used to generate the tests. I made the code changes and reviewed the tests. Words my own.
