### PR TITLE
fix(replays): Stop page reloads on initial tab change

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -1,6 +1,8 @@
+import type {OnUrlUpdateFunction} from 'nuqs/adapters/testing';
 import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
+import {SentryNuqsTestingAdapter} from 'sentry-test/nuqsTestingAdapter';
 import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 import {setWindowLocation} from 'sentry-test/utils';
 
@@ -149,5 +151,41 @@ describe('useActiveReplayTab', () => {
         t_main: 'network',
       });
     });
+  });
+
+  it('should update the tab query parameter shallowly', async () => {
+    const onUrlUpdate = jest.fn<
+      ReturnType<OnUrlUpdateFunction>,
+      Parameters<OnUrlUpdateFunction>
+    >();
+
+    const {result, router} = renderHookWithProviders(useActiveReplayTab, {
+      initialProps: {},
+      initialRouterConfig: {
+        location: {pathname: '/mock-pathname/', query: {}},
+      },
+      organization: OrganizationFixture({features: []}),
+      additionalWrapper: ({children}) => (
+        <SentryNuqsTestingAdapter
+          defaultOptions={{shallow: false}}
+          onUrlUpdate={onUrlUpdate}
+        >
+          {children}
+        </SentryNuqsTestingAdapter>
+      ),
+    });
+
+    act(() => result.current.setActiveTab('network'));
+
+    await waitFor(() => {
+      expect(router.location.query.t_main).toBe('network');
+    });
+
+    expect(onUrlUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryString: '?t_main=network',
+        options: expect.objectContaining({shallow: true}),
+      })
+    );
   });
 });

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -58,7 +58,9 @@ export function useActiveReplayTab({isVideoReplay = false}: {isVideoReplay?: boo
 
   const [tabParam, setTabParam] = useQueryState(
     't_main',
-    tabKeyParser.withDefault(defaultTab).withOptions({clearOnDefault: false})
+    tabKeyParser
+      .withDefault(defaultTab)
+      .withOptions({clearOnDefault: false, shallow: true})
   );
 
   return {


### PR DESCRIPTION
Seems to be an issue with nuqs on the initial tab change doing a fairly hefty page reload. To resolve this issue, we need to make the change "shallow".

Closes JAVASCRIPT-3A1R