### PR TITLE
feat(apidocs): Support union Response[T] annotations in structural linter

### DIFF
--- a/src/sentry/apidocs/_check_response_annotation_matches_schema.py
+++ b/src/sentry/apidocs/_check_response_annotation_matches_schema.py
@@ -1,15 +1,31 @@
-"""Lint: assert decorator-T equals annotation-T for typed endpoint responses.
+"""Lint: assert decorator's declared `T`s match the method's `Response[T]` annotation.
 
 For each method decorated with
-    @extend_schema(responses={N: inline_sentry_response_serializer("Name", T_decl)})
+    @extend_schema(responses={N: inline_sentry_response_serializer("Name", T_decl), ...})
 and annotated
     -> Response[T_annot]
-this linter asserts that `T_decl == T_annot` (AST-level name equality) for the
-2xx-status entry. mypy enforces body-vs-annotation; this linter enforces
-decorator-vs-annotation. Together they close the schema/runtime drift gap.
+or, when the endpoint exposes multiple typed response shapes,
+    -> Response[T_success] | Response[T_error_400] | ...
 
-Plain `-> Response` annotations are skipped (unmigrated endpoints). Decorator
-entries that are canned constants (e.g. `RESPONSE_BAD_REQUEST`) are skipped.
+this linter asserts that the *set* of `T`s declared by
+`inline_sentry_response_serializer(...)` entries in the decorator equals the set of
+`T`s in the annotation's union arms. Names are compared verbatim — no
+normalization, no convention-based pairing. mypy enforces body-vs-annotation;
+this linter enforces decorator-vs-annotation.
+
+The status-code-to-`T` linkage is intentionally not enforced — mypy can't model
+it, and broad `except APIException` catches would lose the linkage anyway.
+
+Skipped silently (no diagnostic):
+  - Plain `-> Response` annotations (the unmigrated state).
+  - Methods with no `@extend_schema` decorator.
+  - Decorator entries that aren't `inline_sentry_response_serializer(...)` —
+    direct serializer-class references (`MonitorSerializer`),
+    `OpenApiResponse(...)` wrappers, `RESPONSE_*` canned constants, `None`,
+    raw `dict`, etc. These don't carry a statically-resolvable `T` for the
+    linter to compare; either migrate them to
+    `inline_sentry_response_serializer(...)` or wait for the generic
+    `Serializer[T]` refactor.
 
 Invoke as:
     python -m sentry.apidocs._check_response_annotation_matches_schema [paths...]
@@ -38,8 +54,6 @@ DEFAULT_PATHS = (
     "src/sentry/uptime/endpoints",
 )
 
-SUCCESS_STATUSES = frozenset(range(200, 300))
-
 
 @dataclass(frozen=True)
 class Mismatch:
@@ -47,14 +61,15 @@ class Mismatch:
     line: int
     cls: str
     method: str
-    status: int
-    decl: str
-    annot: str
+    decl: frozenset[str]
+    annot: frozenset[str]
 
     def __str__(self) -> str:
+        decl = ", ".join(sorted(self.decl)) or "<none>"
+        annot = ", ".join(sorted(self.annot)) or "<none>"
         return (
-            f"{self.path}:{self.line} {self.cls}.{self.method} status={self.status}: "
-            f"decorator declares `{self.decl}`, annotation declares `{self.annot}`"
+            f"{self.path}:{self.line} {self.cls}.{self.method}: "
+            f"decorator declares {{{decl}}}, annotation declares {{{annot}}}"
         )
 
 
@@ -69,27 +84,50 @@ def _name_of(node: ast.expr) -> str:
     return ast.unparse(node)
 
 
-def _extract_decorator_responses(
-    decorator: ast.expr,
-) -> dict[int, ast.expr]:
-    """For `@extend_schema(responses={N: inline_sentry_response_serializer("X", T)})`,
-    return {N: T_expr} for entries that use `inline_sentry_response_serializer`.
-    Skips canned constants and non-2xx entries that don't carry a body schema.
+def _is_response_subscript(node: ast.expr) -> ast.expr | None:
+    """If `node` is `Response[T]` (or `rest_framework.response.Response[T]`),
+    return the `T` expression. Otherwise return None."""
+    if not isinstance(node, ast.Subscript):
+        return None
+    val = node.value
+    if isinstance(val, ast.Name) and val.id == "Response":
+        return node.slice
+    if isinstance(val, ast.Attribute) and val.attr == "Response":
+        return node.slice
+    return None
+
+
+def _extract_decorator_response_Ts(decorator: ast.expr) -> list[ast.expr]:
+    """From `@extend_schema(responses={N: inline_sentry_response_serializer("X", T), ...})`,
+    return every `T` expression. Only this explicit form is recognized — it's the
+    one shape where the linter has a real handle on what the typed schema is.
+
+    Skipped silently (no extractable T):
+      - Direct serializer-class references (e.g. `MonitorSerializer`). These
+        carry a typed output by sentry convention but no statically-resolvable
+        link to a TypedDict. Either migrate the entry to
+        `inline_sentry_response_serializer(...)`, or wait for the generic-
+        `Serializer[T]` refactor to land — both give the linter a real handle.
+      - Canned `RESPONSE_*` constants (no T — error responses, untyped body).
+      - `OpenApiResponse(...)` wrappers.
+      - `None`, raw `dict`, etc.
+
+    Status code is intentionally ignored — see module docstring.
     """
     if not isinstance(decorator, ast.Call):
-        return {}
+        return []
     func = decorator.func
-    if not (isinstance(func, ast.Name) and func.id == "extend_schema"):
-        if not (isinstance(func, ast.Attribute) and func.attr == "extend_schema"):
-            return {}
+    if not (
+        (isinstance(func, ast.Name) and func.id == "extend_schema")
+        or (isinstance(func, ast.Attribute) and func.attr == "extend_schema")
+    ):
+        return []
     responses_kw = next((kw for kw in decorator.keywords if kw.arg == "responses"), None)
     if responses_kw is None or not isinstance(responses_kw.value, ast.Dict):
-        return {}
-    out: dict[int, ast.expr] = {}
+        return []
+    out: list[ast.expr] = []
     for key, val in zip(responses_kw.value.keys, responses_kw.value.values):
         if not isinstance(key, ast.Constant) or not isinstance(key.value, int):
-            continue
-        if key.value not in SUCCESS_STATUSES:
             continue
         if not isinstance(val, ast.Call):
             continue
@@ -99,25 +137,44 @@ def _extract_decorator_responses(
         ) or (
             isinstance(func_v, ast.Attribute) and func_v.attr == "inline_sentry_response_serializer"
         )
-        if not is_inline or len(val.args) < 2:
-            continue
-        out[key.value] = val.args[1]
+        if is_inline and len(val.args) >= 2:
+            out.append(val.args[1])
     return out
 
 
-def _extract_response_annotation_T(returns: ast.expr | None) -> ast.expr | None:
-    """If the return annotation is `Response[T]`, return the T expr. Else None
-    (which means: skip this method — it's either unmigrated or non-Response).
+def _extract_response_annotation_Ts(returns: ast.expr | None) -> list[ast.expr] | None:
+    """Parse the return annotation and return the list of `T` expressions that appear
+    inside `Response[...]` (handling both single `Response[T]` and union
+    `Response[T_a] | Response[T_b]` forms).
+
+    Returns:
+      - `None` if the annotation is not a `Response[T]` (or union thereof) — that's
+        the unmigrated state; the method is skipped.
+      - A non-empty list of `T` AST expressions otherwise.
     """
     if returns is None:
         return None
-    if isinstance(returns, ast.Subscript):
-        val = returns.value
-        if isinstance(val, ast.Name) and val.id == "Response":
-            return returns.slice
-        if isinstance(val, ast.Attribute) and val.attr == "Response":
-            return returns.slice
-    return None
+
+    # Collect every leaf of a union, then check each is `Response[T]`.
+    arms: list[ast.expr] = []
+    pending: list[ast.expr] = [returns]
+    while pending:
+        node = pending.pop()
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+            pending.append(node.left)
+            pending.append(node.right)
+        else:
+            arms.append(node)
+
+    extracted: list[ast.expr] = []
+    for arm in arms:
+        T = _is_response_subscript(arm)
+        if T is None:
+            # If any arm is `Response` (bare, unparameterized) or some other type,
+            # we can't meaningfully compare — treat this as unmigrated.
+            return None
+        extracted.append(T)
+    return extracted or None
 
 
 def _iter_methods(tree: ast.Module) -> Iterator[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef]]:
@@ -141,32 +198,30 @@ def check_file(path: Path) -> list[Mismatch]:
 
     mismatches: list[Mismatch] = []
     for cls_name, method in _iter_methods(tree):
-        annot_T = _extract_response_annotation_T(method.returns)
-        if annot_T is None:
+        annot_Ts = _extract_response_annotation_Ts(method.returns)
+        if annot_Ts is None:
             continue
-        annot_name = _name_of(annot_T)
 
-        decl_by_status: dict[int, ast.expr] = {}
+        decl_Ts: list[ast.expr] = []
         for dec in method.decorator_list:
-            decl_by_status.update(_extract_decorator_responses(dec))
+            decl_Ts.extend(_extract_decorator_response_Ts(dec))
 
-        if not decl_by_status:
+        if not decl_Ts:
             continue
 
-        for status, decl_expr in decl_by_status.items():
-            decl_name = _name_of(decl_expr)
-            if decl_name != annot_name:
-                mismatches.append(
-                    Mismatch(
-                        path=path,
-                        line=method.lineno,
-                        cls=cls_name,
-                        method=method.name,
-                        status=status,
-                        decl=decl_name,
-                        annot=annot_name,
-                    )
+        decl_set = frozenset(_name_of(t) for t in decl_Ts)
+        annot_set = frozenset(_name_of(t) for t in annot_Ts)
+        if decl_set != annot_set:
+            mismatches.append(
+                Mismatch(
+                    path=path,
+                    line=method.lineno,
+                    cls=cls_name,
+                    method=method.name,
+                    decl=decl_set,
+                    annot=annot_set,
                 )
+            )
     return mismatches
 
 
@@ -189,9 +244,9 @@ def main(argv: list[str]) -> int:
         sys.stdout.write(f"{m}\n")
     if all_mismatches:
         sys.stderr.write(
-            f"\n{len(all_mismatches)} mismatch(es) — decorator's "
-            "`inline_sentry_response_serializer(name, T)` must match the "
-            "method's `-> Response[T]` annotation.\n",
+            f"\n{len(all_mismatches)} mismatch(es) — the set of `T`s declared by "
+            "`inline_sentry_response_serializer(...)` in `@extend_schema` must "
+            "equal the set of `T`s in the `Response[T]` (or union) annotation.\n",
         )
         return 1
     return 0

--- a/tests/sentry/apidocs/test_check_response_annotation_matches_schema.py
+++ b/tests/sentry/apidocs/test_check_response_annotation_matches_schema.py
@@ -67,9 +67,8 @@ class FooEndpoint:
     m = mismatches[0]
     assert m.cls == "FooEndpoint"
     assert m.method == "get"
-    assert m.status == 200
-    assert m.decl == "FooResponse"
-    assert m.annot == "BarResponse"
+    assert m.decl == frozenset({"FooResponse"})
+    assert m.annot == frozenset({"BarResponse"})
 
 
 def test_unmigrated_endpoint_skipped() -> None:
@@ -109,9 +108,8 @@ class FooEndpoint:
 
 
 def test_canned_response_constant_skipped() -> None:
-    """Non-inline_sentry_response_serializer entries (e.g. RESPONSE_BAD_REQUEST)
-    are not comparable and must not produce false positives.
-    """
+    """Non-`inline_sentry_response_serializer` entries (e.g. RESPONSE_BAD_REQUEST)
+    are not comparable and must not produce false positives."""
     source = """
 from typing import TypedDict
 from drf_spectacular.utils import extend_schema
@@ -135,10 +133,36 @@ class FooEndpoint:
     assert _run(source) == []
 
 
-def test_only_2xx_entries_compared() -> None:
-    """Even if a 4xx/5xx entry used inline_sentry_response_serializer (unusual),
-    it should not be compared to the success-path annotation.
-    """
+def test_union_annotation_matches_multi_status_decorator() -> None:
+    """Union return type matching a decorator with multiple typed responses."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class ErrorBody(TypedDict):
+    detail: str
+
+class FooEndpoint:
+    @extend_schema(
+        responses={
+            200: inline_sentry_response_serializer("Foo", FooResponse),
+            400: inline_sentry_response_serializer("Err", ErrorBody),
+        },
+    )
+    def get(self) -> Response[FooResponse] | Response[ErrorBody]:
+        return Response({"x": 1})
+"""
+    assert _run(source) == []
+
+
+def test_union_annotation_missing_decorator_T_fires() -> None:
+    """If the decorator declares two typed responses but the annotation only
+    covers one, the set-equality check must fail."""
     source = """
 from typing import TypedDict
 from drf_spectacular.utils import extend_schema
@@ -159,6 +183,87 @@ class FooEndpoint:
         },
     )
     def get(self) -> Response[FooResponse]:
+        return Response({"x": 1})
+"""
+    mismatches = _run(source)
+    assert len(mismatches) == 1
+    assert mismatches[0].decl == frozenset({"FooResponse", "ErrorBody"})
+    assert mismatches[0].annot == frozenset({"FooResponse"})
+
+
+def test_annotation_has_extra_T_not_in_decorator_fires() -> None:
+    """If the annotation union declares a `T` that the decorator doesn't, fail."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class GhostResponse(TypedDict):
+    y: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response[FooResponse] | Response[GhostResponse]:
+        return Response({"x": 1})
+"""
+    mismatches = _run(source)
+    assert len(mismatches) == 1
+    assert mismatches[0].decl == frozenset({"FooResponse"})
+    assert mismatches[0].annot == frozenset({"FooResponse", "GhostResponse"})
+
+
+def test_multi_2xx_decorator_with_union_annotation() -> None:
+    """Multiple 2xx schemas (e.g. 200 + 201) with a union annotation covering both."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class GetResponse(TypedDict):
+    x: int
+
+class CreatedResponse(TypedDict):
+    id: str
+
+class FooEndpoint:
+    @extend_schema(
+        responses={
+            200: inline_sentry_response_serializer("Foo", GetResponse),
+            201: inline_sentry_response_serializer("FooCreated", CreatedResponse),
+        },
+    )
+    def post(self) -> Response[GetResponse] | Response[CreatedResponse]:
+        return Response({"x": 1})
+"""
+    assert _run(source) == []
+
+
+def test_union_with_non_response_arm_skipped() -> None:
+    """If the union contains an arm that isn't `Response[T]` (e.g. a bare
+    `HttpResponse`), the method is treated as unmigrated and skipped — there's
+    no clean comparison to make."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from django.http import HttpResponse
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response[FooResponse] | HttpResponse:
         return Response({"x": 1})
 """
     assert _run(source) == []
@@ -186,14 +291,12 @@ class FooEndpoint:
 """
     mismatches = _run(source)
     assert len(mismatches) == 1
-    assert mismatches[0].decl == "FooResponse"
-    assert mismatches[0].annot == "BarResponse"
+    assert mismatches[0].decl == frozenset({"FooResponse"})
+    assert mismatches[0].annot == frozenset({"BarResponse"})
 
 
 def test_dotted_response_annotation_handled() -> None:
-    """Some files write the annotation as `rest_framework.response.Response[T]`.
-    The linter must extract T from both `Name` and `Attribute` forms.
-    """
+    """Some files write the annotation as `rest_framework.response.Response[T]`."""
     source = """
 from typing import TypedDict
 import rest_framework.response
@@ -215,8 +318,8 @@ class FooEndpoint:
 """
     mismatches = _run(source)
     assert len(mismatches) == 1
-    assert mismatches[0].decl == "FooResponse"
-    assert mismatches[0].annot == "BarResponse"
+    assert mismatches[0].decl == frozenset({"FooResponse"})
+    assert mismatches[0].annot == frozenset({"BarResponse"})
 
 
 def test_main_returns_zero_on_clean(tmp_path: Path) -> None:
@@ -268,3 +371,49 @@ class FooEndpoint:
     assert "FooResponse" in captured.out
     assert "BarResponse" in captured.out
     assert "mismatch" in captured.err
+
+
+def test_direct_serializer_class_reference_skipped() -> None:
+    """Decorator entries that are bare class references (e.g. `MonitorSerializer`)
+    carry a typed output by sentry convention but no statically-resolvable link
+    to a TypedDict. The linter skips them silently — neither false-positives nor
+    false-negatives. Resolving these waits on the generic-`Serializer[T]`
+    refactor, or on migrating the entry to `inline_sentry_response_serializer`.
+    """
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+
+class MonitorSerializer: ...
+
+class MonitorSerializerResponse(TypedDict):
+    id: str
+
+class MonitorEndpoint:
+    @extend_schema(responses={200: MonitorSerializer})
+    def get(self) -> Response[MonitorSerializerResponse]:
+        return Response({"id": "x"})
+"""
+    assert _run(source) == []
+
+
+def test_openapi_response_wrapper_skipped() -> None:
+    """`OpenApiResponse(...)` and similar wrappers don't carry a comparable T —
+    skip silently."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: OpenApiResponse(description="ok")},
+    )
+    def get(self) -> Response[FooResponse]:
+        return Response({"x": 1})
+"""
+    assert _run(source) == []


### PR DESCRIPTION
Extend the structural linter at `src/sentry/apidocs/_check_response_annotation_matches_schema.py` to support union return annotations and compare against decorator response entries at every status code (not just 2xx).

This unblocks endpoints that want to type both their success and error response bodies — `-> Response[FooResponse] | Response[ErrorBody]` with corresponding decorator entries — and removes the artificial 2xx restriction from before.

## What changed

| Aspect | Before | After |
|---|---|---|
| Annotation forms | `Response[T]` only | `Response[T]` and `Response[T_a] \| Response[T_b] \| ...` |
| Decorator status range | 2xx entries only | All status codes |
| Decorator shape recognized | `inline_sentry_response_serializer("Name", T)` | unchanged |
| Comparison | T-name equality (single) | Set equality on raw T names |
| Name handling | Verbatim | Verbatim (no normalization, no convention pairing) |

## What is intentionally still skipped (no diagnostic, no false positive)

- Plain `-> Response` annotations (the unmigrated state).
- Methods with no `@extend_schema` decorator.
- Decorator entries that aren't `inline_sentry_response_serializer(...)`. This includes:
  - Direct serializer-class references like `MonitorSerializer` — these carry a typed output by sentry convention but no statically-resolvable link to a `TypedDict`. The right path for these is either migrating the entry to `inline_sentry_response_serializer(...)`, or waiting for a generic-`Serializer[T]` refactor where the linter can read the parameter directly from the class.
  - `OpenApiResponse(...)` wrappers.
  - `RESPONSE_*` canned constants (error documentation, no body type).
  - `None`, raw `dict`, etc.
- Union arms that aren't `Response[T]` (e.g. `Response[T] | HttpResponse`).

In all those cases the linter exits clean — it neither false-positives nor gives a misleading guess.

## Status-code-to-T linkage is intentionally not enforced

mypy can't model the link (the status code is runtime data), and broad `except APIException` patterns would lose it anyway. Endpoints needing strict status↔T guarantees should `raise <APIException>(...)` for error paths so the success-path return is uniquely typed.

## Worked examples

**Single T (unchanged from prior behavior):**
```python
@extend_schema(responses={200: inline_sentry_response_serializer("Foo", FooResponse)})
def get(...) -> Response[FooResponse]:
    ...
# pass: decorator set {FooResponse} == annotation set {FooResponse}
```

**Union with success + typed error:**
```python
@extend_schema(
    responses={
        200: inline_sentry_response_serializer("Foo", FooResponse),
        400: inline_sentry_response_serializer("Err", ErrorBody),
    },
)
def get(...) -> Response[FooResponse] | Response[ErrorBody]:
    ...
# pass: sets {FooResponse, ErrorBody} match
```

**Drift — annotation missing a decorator-declared T:**
```python
@extend_schema(
    responses={
        200: inline_sentry_response_serializer("Foo", FooResponse),
        400: inline_sentry_response_serializer("Err", ErrorBody),
    },
)
def get(...) -> Response[FooResponse]:
    ...
# fail: decorator {FooResponse, ErrorBody} != annotation {FooResponse}
```

## Tests

16 cases in `tests/sentry/apidocs/test_check_response_annotation_matches_schema.py`:

- Single-T match / mismatch
- Union annotation matching multi-status decorator (both arms typed)
- Annotation missing a decorator-declared T (set inequality)
- Annotation containing extra T not in decorator (set inequality)
- Multiple 2xx schemas (200 + 201) matched by union
- Unmigrated `-> Response` skipped
- Method without `@extend_schema` skipped
- `RESPONSE_*` canned constant skipped
- Direct serializer-class reference skipped (waiting on generic Serializer[T])
- `OpenApiResponse(...)` wrapper skipped
- Union arm that isn't `Response[T]` skipped
- Async methods
- Dotted annotation form (`rest_framework.response.Response[T]`)
- `main()` exit codes (zero on clean, nonzero on mismatch)

Full src/sentry run: clean. The 43 endpoints already opted into `Response[T]` (#116335, #116433) continue to pass.

## Follow-up paths (out of scope for this PR)

A survey of all 862 `responses={N: ...}` entries in `src/sentry` showed that ~97 use direct serializer-class references (about as common as `inline_sentry_response_serializer`). The linter doesn't help these endpoints today. Two ways to bring them into coverage later:
- **Migrate** each to `inline_sentry_response_serializer("Name", FooResponse)` with an explicit paired TypedDict.
- **Make sentry's `Serializer` generic** in its output type (`Serializer[T]`), so the linter can extract T directly from the class's bases. This eliminates the need for any naming convention.

Either path gives the linter a real handle. This PR doesn't attempt to bridge it with name heuristics — those were considered and rejected as brittle.