### PR TITLE
chore(ci): Skip broken trace item detail tests

### DIFF
--- a/tests/sentry/api/endpoints/test_project_trace_item_details.py
+++ b/tests/sentry/api/endpoints/test_project_trace_item_details.py
@@ -4,6 +4,7 @@ from sentry.api.endpoints.project_trace_item_details import convert_rpc_attribut
 from sentry.search.eap.types import SupportedTraceItemType
 
 
+@pytest.mark.skip(reason="Skipping due to broken CI 05-29-2026")
 def test_convert_rpc_attribute_to_json_serializes_known_string_array_without_array_flag() -> None:
     result = convert_rpc_attribute_to_json(
         [
@@ -54,6 +55,7 @@ def test_convert_rpc_attribute_to_json_hides_non_replacement_array_without_array
     assert result == []
 
 
+@pytest.mark.skip(reason="Skipping due to broken CI 05-29-2026")
 def test_convert_rpc_attribute_to_json_exposes_array_with_array_flag() -> None:
     result = convert_rpc_attribute_to_json(
         [
@@ -114,6 +116,7 @@ class TestReplacementAttributeFiltering:
         assert "gen_ai.usage.prompt_tokens" in names
         assert "gen_ai.usage.input_tokens" not in names
 
+    @pytest.mark.skip(reason="Skipping due to broken CI 05-29-2026")
     def test_replacement_array_shown_when_no_deprecated_source(self) -> None:
         result = convert_rpc_attribute_to_json(
             [


### PR DESCRIPTION
## Summary
- Skip 3 tests in `test_project_trace_item_details.py` that are broken as of 05-29-2026
- `test_convert_rpc_attribute_to_json_serializes_known_string_array_without_array_flag`
- `test_convert_rpc_attribute_to_json_exposes_array_with_array_flag`
- `TestReplacementAttributeFiltering::test_replacement_array_shown_when_no_deprecated_source`

## Test plan
- CI should pass with these tests skipped


Will continue root causing and follow up with the relevant parties to ensure the real cause is addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)