### PR TITLE
feat(jira): Support installing through the API pipeline modal

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -7,14 +7,20 @@ from collections.abc import Mapping, Sequence
 from operator import attrgetter
 from typing import Any, NoReturn, TypedDict
 
+import orjson
 import sentry_sdk
 from django.conf import settings
+from django.core.signing import BadSignature, SignatureExpired
 from django.db.models import QuerySet
+from django.http.request import HttpRequest
 from django.urls import reverse
 from django.utils.functional import classproperty
 from django.utils.translation import gettext as _
+from rest_framework import serializers
+from rest_framework.fields import CharField
 
 from sentry import features
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
@@ -24,6 +30,7 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.jira.models.create_issue_metadata import JiraIssueTypeMetadata
 from sentry.integrations.jira.tasks import migrate_issues
+from sentry.integrations.jira.views import SALT
 from sentry.integrations.mixins.issues import (
     MAX_CHAR,
     IntegrationSyncTargetNotFound,
@@ -38,7 +45,8 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import (
     ApiError,
@@ -55,6 +63,7 @@ from sentry.users.models.identity import Identity
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
+from sentry.utils.signing import unsign
 from sentry.utils.strings import truncatechars
 
 from .client import JiraCloudClient
@@ -1204,6 +1213,85 @@ class JiraIntegration(IssueSyncIntegration):
             return None
 
 
+# 24 hours to finish installation
+INSTALL_EXPIRATION_TIME = 60 * 60 * 24
+
+
+class JiraInstallParams(TypedDict):
+    """Decoded contents of the `signed_params` blob from a Marketplace install.
+
+    The Jira UI hook (`JiraSentryInstallationView`) signs the integration's
+    `external_id` plus a JSON-encoded `metadata` payload into the configure
+    link. We decode `metadata` back into a dict here so it can be bound to
+    pipeline state and consumed by `build_integration`.
+    """
+
+    external_id: str
+    metadata: dict[str, Any]
+
+
+class JiraInitialDataSerializer(CamelSnakeSerializer):
+    """Initial pipeline data for Jira Cloud Marketplace installs.
+
+    The configure link carries a single `signed_params` blob. We unsign it and
+    bind `external_id` and the decoded `metadata` dict to top-level pipeline
+    state so the confirmation step and `build_integration` can read them.
+    """
+
+    signed_params = CharField(required=True)
+
+    def validate(self, attrs: dict[str, Any]) -> JiraInstallParams:
+        try:
+            decoded = unsign(attrs["signed_params"], max_age=INSTALL_EXPIRATION_TIME, salt=SALT)
+        except SignatureExpired:
+            raise serializers.ValidationError("Installation link expired")
+        except BadSignature:
+            raise serializers.ValidationError("Invalid installation link")
+
+        return {
+            "external_id": decoded["external_id"],
+            "metadata": orjson.loads(decoded["metadata"]),
+        }
+
+
+class JiraConfirmSerializer(CamelSnakeSerializer):
+    state = CharField(required=True)
+
+
+class JiraConfirmInstallStep:
+    """Confirmation step for Jira Cloud Marketplace installs.
+
+    Shows an interactive confirmation screen before completing the install,
+    rather than auto-advancing. A copied install link could otherwise connect
+    an attacker's Jira workspace to a victim's Sentry organization, so we
+    surface the Jira workspace and Sentry organization for the user to verify
+    before they commit.
+    """
+
+    step_name = "jira_confirm_install"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        metadata = pipeline.fetch_state("metadata") or {}
+        return {
+            "baseUrl": metadata.get("base_url", ""),
+            "organization": pipeline.organization.name if pipeline.organization else "",
+            "state": pipeline.signature,
+        }
+
+    def get_serializer_cls(self) -> type:
+        return JiraConfirmSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, str],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        if validated_data["state"] != pipeline.signature:
+            return PipelineStepResult.error("An error occurred while validating your request.")
+        return PipelineStepResult.advance()
+
+
 class JiraIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.JIRA.value
     name = "Jira"
@@ -1219,17 +1307,34 @@ class JiraIntegrationProvider(IntegrationProvider):
     )
 
     can_add = False
+    can_add_externally = True
 
     def get_pipeline_views(self) -> list[PipelineView[IntegrationPipeline]]:
         return []
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [JiraConfirmInstallStep()]
+
+    def get_initial_data_serializer_cls(self) -> type[JiraInitialDataSerializer]:
+        return JiraInitialDataSerializer
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
         # Most information is not available during integration installation,
         # since the integration won't have been fully configured on JIRA's side
         # yet, we can't make API calls for more details like the server name or
         # Icon.
-        # two ways build_integration can be called
-        if state.get(IntegrationProviderSlug.JIRA.value):
+        #
+        # build_integration is reached three ways:
+        #  - the API pipeline binds the decoded Marketplace params to top-level
+        #    state (`external_id` + `metadata`),
+        #  - the legacy configure view nests the same params under the provider
+        #    key (`state["jira"]`),
+        #  - the `installed` webhook passes the raw Atlassian payload
+        #    (`clientKey`, `oauthClientId`, ...).
+        if "external_id" in state and "metadata" in state:
+            external_id = state["external_id"]
+            metadata = state["metadata"]
+        elif state.get(IntegrationProviderSlug.JIRA.value):
             metadata = state[IntegrationProviderSlug.JIRA.value]["metadata"]
             external_id = state[IntegrationProviderSlug.JIRA.value]["external_id"]
         else:

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -92,11 +92,16 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
                 )
 
             # Bind iss to whichever value build_integration will persist as
-            # Integration.external_id. Branch on state["jira"] (the parent
-            # dict) to match build_integration exactly — branching on the
-            # inner external_id's truthiness diverges when it's empty.
+            # Integration.external_id, mirroring its branch order exactly. The
+            # request body is attacker-controlled and not covered by the JWT, so
+            # the issuer must be validated against the same external_id we store;
+            # otherwise a valid token for one tenant could install an integration
+            # keyed to another tenant. Branch on the parent dicts (not the inner
+            # external_id's truthiness, which diverges when it's empty).
             jira_state = state.get(IntegrationProviderSlug.JIRA.value)
-            if jira_state:
+            if "external_id" in state and "metadata" in state:
+                expected_external_id = state.get("external_id")
+            elif jira_state:
                 expected_external_id = jira_state.get("external_id")
             else:
                 expected_external_id = state.get("clientKey")

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -256,6 +256,34 @@ class JiraInstalledTest(APITestCase):
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @responses.activate
+    def test_rejects_when_top_level_external_id_does_not_match_jwt_iss(
+        self, mock_record_event: MagicMock
+    ) -> None:
+        self.add_response()
+
+        # JWT is signed by tenant `it2may+cody` (self.external_id) and clientKey
+        # matches it, but the body injects a top-level external_id + metadata for
+        # a different tenant. build_integration prefers that top-level pair (the
+        # shape the API pipeline binds), so the issuer check must validate
+        # against it rather than clientKey — otherwise a valid token for one
+        # tenant could persist a row keyed to another tenant.
+        body = dict(self.body())
+        body.pop("jira", None)
+        body["external_id"] = "some-other-tenant"
+        body["metadata"] = {"base_url": "https://attacker.example"}
+        self.get_error_response(
+            **body,
+            extra_headers=dict(HTTP_AUTHORIZATION="JWT " + self.jwt_token_cdn()),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+        assert not Integration.objects.filter(
+            provider="jira", external_id="some-other-tenant"
+        ).exists()
+        assert_halt_metric(mock_record_event, "JWT iss does not match clientKey")
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @responses.activate
     def test_rejects_when_jira_external_id_is_empty(self, mock_record_event: MagicMock) -> None:
         self.add_response()
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from typing import Any
 from unittest import mock
 from unittest.mock import patch
 
@@ -16,6 +17,7 @@ from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupmeta import GroupMeta
@@ -1661,3 +1663,88 @@ class JiraInstallationTest(IntegrationTestCase):
 
     def test_installation(self) -> None:
         self.assert_setup_flow()
+
+
+@control_silo_test
+class JiraApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+    provider = JiraIntegrationProvider
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.external_id = "my-external-id"
+        self.metadata = {
+            "oauth_client_id": "oauth-client-id",
+            "shared_secret": "a-super-secret-key-from-atlassian",
+            "base_url": "https://example.atlassian.net",
+            "domain_name": "example.atlassian.net",
+        }
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self, initial_data: dict[str, Any] | None = None) -> Any:
+        payload: dict[str, Any] = {"action": "initialize", "provider": self.provider.key}
+        if initial_data is not None:
+            payload["initialData"] = initial_data
+        return self.client.post(self._get_pipeline_url(), data=payload, format="json")
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _signed_params(self) -> str:
+        return sign(salt=SALT, external_id=self.external_id, metadata=json.dumps(self.metadata))
+
+    def test_initialize_returns_confirmation_data(self) -> None:
+        resp = self._initialize_pipeline(initial_data={"signedParams": self._signed_params()})
+        assert resp.status_code == 200
+        assert resp.data["step"] == "jira_confirm_install"
+        data = resp.data["data"]
+        assert data["baseUrl"] == "https://example.atlassian.net"
+        assert data["organization"] == self.organization.name
+        assert "state" in data
+        # Confirmation step does not auto-advance.
+        assert "appDirectoryInstall" not in data
+        assert not Integration.objects.filter(provider=self.provider.key).exists()
+
+    def test_initialize_expired_signature(self) -> None:
+        with patch("sentry.integrations.jira.integration.INSTALL_EXPIRATION_TIME", -1):
+            resp = self._initialize_pipeline(initial_data={"signedParams": self._signed_params()})
+        assert resp.status_code == 400
+
+    def test_initialize_tampered_signature(self) -> None:
+        # Signed with a different salt, so unsigning with SALT raises
+        # BadSignature rather than SignatureExpired.
+        tampered = sign(
+            salt="not-the-jira-salt",
+            external_id=self.external_id,
+            metadata=json.dumps(self.metadata),
+        )
+        resp = self._initialize_pipeline(initial_data={"signedParams": tampered})
+        assert resp.status_code == 400
+
+    def test_advance_with_invalid_state_errors(self) -> None:
+        self._initialize_pipeline(initial_data={"signedParams": self._signed_params()})
+        resp = self._advance_step({"state": "not-the-pipeline-signature"})
+        assert resp.status_code == 400
+        assert not Integration.objects.filter(provider=self.provider.key).exists()
+
+    def test_install(self) -> None:
+        resp = self._initialize_pipeline(initial_data={"signedParams": self._signed_params()})
+        pipeline_signature = resp.data["data"]["state"]
+
+        resp = self._advance_step({"state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider=self.provider.key)
+        assert integration.external_id == self.external_id
+        assert integration.metadata == self.metadata
+        assert OrganizationIntegration.objects.filter(
+            integration=integration, organization_id=self.organization.id
+        ).exists()


### PR DESCRIPTION
[VDY-123: Jira Cloud: API-driven integration setup](https://linear.app/getsentry/issue/VDY-123/jira-cloud-api-driven-integration-setup)

Adds the API-mode pipeline machinery for Jira Cloud alongside the existing server-rendered configure flow, without changing the entry point yet. This is the first of three deploy-safe steps: the legacy `JiraExtensionConfigurationView` and the `/extensions/jira/configure/` URL are left untouched, so nothing changes for users until the frontend can drive the modal and the configure URL is later swapped to a redirect.

- `JiraInitialDataSerializer` unsigns the Marketplace `signed_params` blob, decodes the nested `metadata` JSON, and binds `external_id` and `metadata` to top-level pipeline state.
- Unlike MS Teams, which auto-advances silently, `JiraConfirmInstallStep` is an interactive confirmation step: it exposes the Jira workspace (`base_url`) and the Sentry organization so the user can verify them before completing the install. A copied install link could otherwise connect an attacker's Jira workspace to a victim's org, so the confirmation screen lets the user catch a mismatch. The frontend follow-up renders this step; this PR only adds the backend `get_step_data` / `handle_post`.
- `build_integration` now reads top-level state, falling back to the nested `state["jira"]` the legacy view binds. The `installed` webhook's raw Atlassian payload path (`clientKey`, `oauthClientId`, ...) is preserved.

Also sets `can_add_externally` so the externally-initiated Marketplace install is allowed through the pipeline endpoint while `can_add = False` keeps the in-app install button hidden — matching the MS Teams backend.

Follows the same three-PR structure as MS Teams (#116490): backend (this PR) → frontend → backend cleanup (swap the configure URL to a redirect and drop the legacy view).