### PR TITLE
feat(cells) Allow staff users to create orgs in hidden cells

### DIFF
--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -25,6 +25,7 @@ from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RES
 from sentry.apidocs.examples.user_examples import UserExamples
 from sentry.apidocs.parameters import CursorQueryParam, OrganizationParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
 from sentry.db.models.query import in_iexact
 from sentry.demo_mode.utils import is_demo_user
@@ -92,7 +93,7 @@ class OrganizationPostSerializer(BaseOrganizationSerializer):
             locality = get_locality_by_name(value)
         except CellResolutionError:
             raise serializers.ValidationError(f"Unknown data storage location {value!r}.")
-        if "request" in self.context and self.context["request"].user.is_staff:
+        if "request" in self.context and is_active_staff(self.context["request"]):
             # Staff users are allowed to create orgs in hidden cells/localities.
             return value
         if locality.category != RegionCategory.MULTI_TENANT or not locality.visible:

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -92,6 +92,9 @@ class OrganizationPostSerializer(BaseOrganizationSerializer):
             locality = get_locality_by_name(value)
         except CellResolutionError:
             raise serializers.ValidationError(f"Unknown data storage location {value!r}.")
+        if "request" in self.context and self.context["request"].user.is_staff:
+            # Staff users are allowed to create orgs in hidden cells/localities.
+            return value
         if locality.category != RegionCategory.MULTI_TENANT or not locality.visible:
             raise serializers.ValidationError(f"Unknown data storage location {value!r}.")
         return value

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -300,6 +300,70 @@ class OrganizationsCreateControlTest(OrganizationIndexTest, HybridCloudTestMixin
             owners = [owner.id for owner in org.get_owners()]
             assert [self.user.id] == owners
 
+    def test_staff_user_override_cell_visiblity(self) -> None:
+        cells = [
+            Cell(
+                name="ja",
+                snowflake_id=3,
+                category=RegionCategory.MULTI_TENANT,
+                address="10.0.0.2",
+                visible=False,
+            ),
+            Cell(
+                name="acme",
+                snowflake_id=4,
+                category=RegionCategory.SINGLE_TENANT,
+                address="10.0.0.4",
+                visible=True,
+            ),
+        ]
+
+        localities = [
+            Locality(
+                name="ja",
+                cells=frozenset(["ja"]),
+                category=RegionCategory.MULTI_TENANT,
+                new_org_cell="ja",
+                visible=False,
+            ),
+            Locality(
+                name="acme",
+                cells=frozenset(["acme"]),
+                category=RegionCategory.SINGLE_TENANT,
+                new_org_cell="acme",
+                visible=True,
+            ),
+        ]
+        with get_test_env_directory().swap_state(cells, localities):
+            user = self.create_user("regular@example.com", is_staff=False)
+            staff = self.create_user("staff@example.com", is_staff=True)
+
+            data = {"name": "Sentry ja", "slug": "sentry-ja", "dataStorageLocation": "ja"}
+
+            self.login_as(user)
+            resp = self.get_error_response(**data)
+            assert resp.status_code == 400
+
+            self.login_as(staff)
+            resp = self.get_success_response(**data)
+            assert resp.status_code == 201, "Staff should be able to create orgs in hidden locales"
+
+            data = {"name": "Acme co", "slug": "acme-co", "dataStorageLocation": "acme"}
+
+            self.login_as(user)
+            resp = self.get_error_response(**data)
+            assert resp.status_code == 400
+
+            self.login_as(staff)
+            resp = self.get_success_response(**data)
+            assert resp.status_code == 201, (
+                "Staff should be able to create orgs in hidden st locales"
+            )
+
+            data = {"name": "Denied co", "slug": "denied", "dataStorageLocation": "moon"}
+            resp = self.get_error_response(**data)
+            assert resp.status_code == 400, "Staff cannot create orgs in invalid locales"
+
     @override_options(
         {
             "provision_organization.override.rate": 1.0,

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -344,9 +344,13 @@ class OrganizationsCreateControlTest(OrganizationIndexTest, HybridCloudTestMixin
             resp = self.get_error_response(**data)
             assert resp.status_code == 400
 
-            self.login_as(staff)
+            self.login_as(staff, staff=False)
+            resp = self.get_error_response(**data)
+            assert resp.status_code == 400, "Staff require an active staff session"
+
+            self.login_as(staff, staff=True)
             resp = self.get_success_response(**data)
-            assert resp.status_code == 201, "Staff should be able to create orgs in hidden locales"
+            assert resp.status_code == 201, "Staff can be create orgs in hidden locales"
 
             data = {"name": "Acme co", "slug": "acme-co", "dataStorageLocation": "acme"}
 
@@ -355,6 +359,12 @@ class OrganizationsCreateControlTest(OrganizationIndexTest, HybridCloudTestMixin
             assert resp.status_code == 400
 
             self.login_as(staff)
+            resp = self.get_error_response(**data)
+            assert resp.status_code == 400, (
+                "Staff require an active staff session to create orgs in st locales"
+            )
+
+            self.login_as(staff, staff=True)
             resp = self.get_success_response(**data)
             assert resp.status_code == 201, (
                 "Staff should be able to create orgs in hidden st locales"


### PR DESCRIPTION
Staff users should be allowed to create orgs in hidden locale/cells. We'll use this when we're testing new cells

Fixes INFRENG-325
