### PR TITLE
chore(issues): Add fallback event components codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -214,6 +214,9 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /src/sentry/tasks/post_process.py                        @getsentry/issue-detection-backend
 ## Issue Detection Lower Priority
 
+## Event components fallback so more specific rules can take precedence
+/static/app/components/events/                           @getsentry/issue-workflow
+
 ## Hybrid Cloud
 /src/sentry/silo/                                        @getsentry/hybrid-cloud
 /src/sentry/hybridcloud/                                 @getsentry/hybrid-cloud
@@ -347,7 +350,6 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/views/performance/                                            @getsentry/data-browsing
 /static/app/components/performance/                                       @getsentry/data-browsing
 /static/app/utils/performance/                                            @getsentry/data-browsing
-/static/app/components/events/groupingInfo                                @getsentry/data-browsing
 /static/app/components/events/interfaces/spans/                           @getsentry/data-browsing
 /static/app/components/events/viewHierarchy/*                             @getsentry/data-browsing
 /static/app/components/searchQueryBuilder/                                @getsentry/data-browsing
@@ -439,7 +441,6 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/analyticsArea.spec.tsx  @getsentry/app-frontend
 /static/app/components/analyticsArea.tsx       @getsentry/app-frontend
 /static/app/components/loading/                @getsentry/app-frontend
-/static/app/components/events/interfaces/      @getsentry/app-frontend
 /static/app/components/forms/                  @getsentry/app-frontend
 /static/app/components/featureShowcase.mdx     @getsentry/app-frontend
 /static/app/components/featureShowcase.spec.tsx @getsentry/app-frontend
@@ -691,9 +692,6 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/tasks/unmerge.py                                @getsentry/issue-detection-backend
 /src/sentry/tasks/weekly_escalating_forecast.py             @getsentry/issue-detection-backend
 /src/sentry/tasks/llm_issue_detection/                      @getsentry/issue-detection-backend
-/static/app/components/events/contexts/                     @getsentry/issue-workflow
-/static/app/components/events/eventTags/                    @getsentry/issue-workflow
-/static/app/components/events/highlights/                   @getsentry/issue-workflow
 /static/app/components/issues/                              @getsentry/issue-workflow
 /static/app/components/stackTrace/                          @getsentry/issue-workflow
 /static/app/components/stream/supergroups/                  @getsentry/issue-detection-frontend
@@ -704,8 +702,6 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/views/issueDetails/                             @getsentry/issue-workflow
 /static/app/views/nav/secondary/sections/issues/            @getsentry/issue-workflow
 /static/app/views/sharedGroupDetails/                       @getsentry/issue-workflow
-/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx @getsentry/issue-detection-frontend
-/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx   @getsentry/issue-workflow
 /tests/sentry/deletions/test_group.py                       @getsentry/issue-detection-backend
 /tests/sentry/event_manager/                                @getsentry/issue-detection-backend
 /tests/sentry/grouping/                                     @getsentry/issue-detection-backend


### PR DESCRIPTION
for components that are not specifically owned by a team further down in the codeowners, fallback to the issue-workflow team.