### PR TITLE
feat(seer-activity): Set up the new Seer Activity data condition

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/seer_activity_trigger_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/seer_activity_trigger_handler.py
@@ -1,0 +1,60 @@
+from enum import StrEnum
+from typing import Any
+
+from sentry.models.activity import Activity
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
+
+
+class SeerActivityTriggerStage(StrEnum):
+    """
+    The stages that are configurable options for this SeerActivityTrigger DataCondition.
+    """
+
+    RCA_STARTED = "rca_started"
+    RCA_COMPLETED = "rca_completed"
+    SOLUTION_STARTED = "solution_started"
+    SOLUTION_COMPLETED = "solution_completed"
+    CODING_STARTED = "coding_started"
+    CODING_COMPLETED = "coding_completed"
+    PR_CREATED = "pr_created"
+
+
+SEER_STAGE_TO_ACTIVITY_TYPE: dict[str, int] = {
+    SeerActivityTriggerStage.RCA_STARTED: ActivityType.SEER_RCA_STARTED.value,
+    SeerActivityTriggerStage.RCA_COMPLETED: ActivityType.SEER_RCA_COMPLETED.value,
+    SeerActivityTriggerStage.SOLUTION_STARTED: ActivityType.SEER_SOLUTION_STARTED.value,
+    SeerActivityTriggerStage.SOLUTION_COMPLETED: ActivityType.SEER_SOLUTION_COMPLETED.value,
+    SeerActivityTriggerStage.CODING_STARTED: ActivityType.SEER_CODING_STARTED.value,
+    SeerActivityTriggerStage.CODING_COMPLETED: ActivityType.SEER_CODING_COMPLETED.value,
+    SeerActivityTriggerStage.PR_CREATED: ActivityType.SEER_PR_CREATED.value,
+}
+"""
+Maps the DataCondition's expected stages to their ActivityType (from the Activity model)
+"""
+
+
+class SeerActivityTriggerHandler(DataConditionHandler[WorkflowEventData]):
+    group = DataConditionHandler.Group.WORKFLOW_TRIGGER
+    comparison_json_schema = {
+        "type": "array",
+        "items": {"type": "string", "enum": list(SEER_STAGE_TO_ACTIVITY_TYPE.keys())},
+        "minItems": 1,
+        "uniqueItems": True,
+    }
+
+    @staticmethod
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        event = event_data.event
+        if not isinstance(event, Activity):
+            return False
+
+        if not isinstance(comparison, list):
+            return False
+
+        comparison_activity_types = {
+            SEER_STAGE_TO_ACTIVITY_TYPE[stage]
+            for stage in comparison
+            if stage in SEER_STAGE_TO_ACTIVITY_TYPE
+        }
+        return event.type in comparison_activity_types

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -68,6 +68,9 @@ class Condition(StrEnum):
     # Migration Only
     EVERY_EVENT = "every_event"
 
+    # Activity trigger conditions
+    SEER_ACTIVITY_TRIGGER = "seer_activity_trigger"
+
 
 TRIGGER_CONDITIONS = [
     Condition.FIRST_SEEN_EVENT,

--- a/tests/sentry/workflow_engine/handlers/condition/test_seer_activity_trigger_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_seer_activity_trigger_handler.py
@@ -1,0 +1,102 @@
+import pytest
+from jsonschema import ValidationError
+
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.handlers.condition.seer_activity_trigger_handler import (
+    SeerActivityTriggerHandler,
+    SeerActivityTriggerStage,
+)
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.registry import condition_handler_registry
+from sentry.workflow_engine.types import WorkflowEventData
+from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
+
+
+class TestSeerActivityTriggerHandler(ConditionTestCase):
+    condition = Condition.SEER_ACTIVITY_TRIGGER
+
+    def setUp(self) -> None:
+        super().setUp()
+        # TODO(Leander): Remove after registering
+        condition_handler_registry.registrations[self.condition] = SeerActivityTriggerHandler
+        condition_handler_registry.reverse_lookup[SeerActivityTriggerHandler] = self.condition
+
+        self.dc = self.create_data_condition(
+            type=self.condition,
+            comparison=[SeerActivityTriggerStage.RCA_COMPLETED],
+            condition_result=True,
+        )
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        # TODO(Leander): Remove after registering
+        condition_handler_registry.registrations.pop(self.condition, None)
+        condition_handler_registry.reverse_lookup.pop(SeerActivityTriggerHandler, None)
+
+    def _create_event_data(self, activity_type: ActivityType) -> WorkflowEventData:
+        activity = self.create_group_activity(group=self.group, type=activity_type.value)
+        return WorkflowEventData(event=activity, group=self.group)
+
+    def test_evaluate_value__matching_single_stage(self) -> None:
+        event_data = self._create_event_data(ActivityType.SEER_RCA_COMPLETED)
+        self.assert_passes(self.dc, event_data)
+
+    def test_evaluate_value__non_matching_stage(self) -> None:
+        event_data = self._create_event_data(ActivityType.SEER_RCA_STARTED)
+        self.assert_does_not_pass(self.dc, event_data)
+
+    def test_evaluate_value__matching_multiple_stages(self) -> None:
+        self.dc.update(
+            comparison=[
+                SeerActivityTriggerStage.RCA_STARTED,
+                SeerActivityTriggerStage.CODING_COMPLETED,
+            ]
+        )
+
+        event_data = self._create_event_data(ActivityType.SEER_CODING_COMPLETED)
+        self.assert_passes(self.dc, event_data)
+
+    def test_evaluate_value__all_stages(self) -> None:
+        self.dc.update(comparison=[stage.value for stage in SeerActivityTriggerStage])
+
+        for stage, activity_type_value in [
+            (SeerActivityTriggerStage.RCA_STARTED, ActivityType.SEER_RCA_STARTED),
+            (SeerActivityTriggerStage.RCA_COMPLETED, ActivityType.SEER_RCA_COMPLETED),
+            (SeerActivityTriggerStage.SOLUTION_STARTED, ActivityType.SEER_SOLUTION_STARTED),
+            (SeerActivityTriggerStage.SOLUTION_COMPLETED, ActivityType.SEER_SOLUTION_COMPLETED),
+            (SeerActivityTriggerStage.CODING_STARTED, ActivityType.SEER_CODING_STARTED),
+            (SeerActivityTriggerStage.CODING_COMPLETED, ActivityType.SEER_CODING_COMPLETED),
+            (SeerActivityTriggerStage.PR_CREATED, ActivityType.SEER_PR_CREATED),
+        ]:
+            event_data = self._create_event_data(activity_type_value)
+            self.assert_passes(self.dc, event_data)
+
+    def test_evaluate_value__unrelated_activity_type(self) -> None:
+        event_data = self._create_event_data(ActivityType.SET_RESOLVED)
+        self.assert_does_not_pass(self.dc, event_data)
+
+    def test_evaluate_value__non_activity_event(self) -> None:
+        event_data = WorkflowEventData(event=self.group_event, group=self.group)
+        self.assert_does_not_pass(self.dc, event_data)
+
+    def test_json_schema__valid_single_stage(self) -> None:
+        self.dc.comparison = [SeerActivityTriggerStage.PR_CREATED]
+        self.dc.save()
+
+    def test_json_schema__valid_multiple_stages(self) -> None:
+        self.dc.comparison = [
+            SeerActivityTriggerStage.RCA_STARTED,
+            SeerActivityTriggerStage.CODING_COMPLETED,
+            SeerActivityTriggerStage.PR_CREATED,
+        ]
+        self.dc.save()
+
+    def test_json_schema__empty_array(self) -> None:
+        self.dc.comparison = []
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+    def test_json_schema__invalid_stage_string(self) -> None:
+        self.dc.comparison = ["invalid_stage"]
+        with pytest.raises(ValidationError):
+            self.dc.save()


### PR DESCRIPTION
None of this needs to be flagged since we're not actually registering the handler yet, we just patch it for tests. The next PR will add to the registry but omit it from the endpoint with a feature flag check