### PR TITLE
fix(discover): Link issue event ids directly

### DIFF
--- a/static/app/views/discover/table/index.tsx
+++ b/static/app/views/discover/table/index.tsx
@@ -161,6 +161,7 @@ class Table extends PureComponent<TableProps, TableState> {
     // Note: Event ID or 'id' is added to the fields in the API payload response by default for all non-aggregate queries.
     if (!eventView.hasAggregateField() || apiPayload.field.includes('id')) {
       apiPayload.field.push('trace');
+      apiPayload.field.push('issue.id');
 
       // We need to include the event.type field because we want to
       // route to issue details for error and default event types.

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -54,7 +54,11 @@ describe('TableView > CellActions', () => {
 
   const eventView = EventView.fromLocation(location);
 
-  function renderComponent(tableData: TableData, view: EventView) {
+  function renderComponent(
+    tableData: TableData,
+    view: EventView,
+    queryDataset = SavedQueryDatasets.TRANSACTIONS
+  ) {
     return render(
       <TableView
         organization={organization}
@@ -68,7 +72,7 @@ describe('TableView > CellActions', () => {
         measurementKeys={null}
         showTags={false}
         title=""
-        queryDataset={SavedQueryDatasets.TRANSACTIONS}
+        queryDataset={queryDataset}
       />,
       {
         organization,
@@ -487,6 +491,31 @@ describe('TableView > CellActions', () => {
           '/organizations/org-slug/explore/discover/trace/7fdf8efed85a4f9092507063ced1995b/?.*'
         )
       )
+    );
+  });
+
+  it('renders issue event id links directly to the issue event', () => {
+    const view = EventView.fromLocation(
+      LocationFixture({
+        query: {...locationQuery, field: ['id', 'title']},
+      })
+    );
+    rows.meta = {...rows.meta, id: 'string', 'issue.id': 'integer'};
+    rows.data[0] = {
+      ...rows.data[0]!,
+      id: 'deadbeef',
+      'issue.id': 123,
+      'project.name': 'project-slug',
+    };
+
+    renderComponent(rows, view, SavedQueryDatasets.ERRORS);
+
+    const firstRow = screen.getAllByRole('row')[1]!;
+    const link = within(firstRow).getByTestId('view-event');
+
+    expect(link).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/issues/123/events/deadbeef/?referrer=discover-events-table'
     );
   });
 

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -3,7 +3,7 @@ import {useMatches} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
-import type {Location, LocationDescriptorObject} from 'history';
+import type {Location, LocationDescriptor, LocationDescriptorObject} from 'history';
 
 import {Link} from '@sentry/scraps/link';
 import {useModal} from '@sentry/scraps/modal';
@@ -184,37 +184,17 @@ export function TableView(props: TableViewProps) {
         value = fieldRenderer(dataRow, {navigate, organization, location, theme});
       }
 
-      let target: any;
-
-      if (dataRow['event.type'] !== 'transaction' && !isTransactionsDataset) {
-        const project = dataRow.project || dataRow['project.name'];
-        target = {
-          // Redirects to the issue group event page via ProjectEventRedirect
-          pathname: normalizeUrl(
-            `/${organization.slug}/${project}/events/${dataRow.id}/`
-          ),
-          query: {...location.query, referrer: 'discover-events-table'},
-        };
-      } else {
-        if (!dataRow.trace) {
-          throw new Error(
-            'Transaction event should always have a trace associated with it.'
-          );
-        }
-
-        target = generateLinkToEventInTraceView({
-          traceSlug: dataRow.trace,
-          eventId: dataRow.id,
-          timestamp: dataRow.timestamp,
-          organization,
-          location,
-          eventView,
-          source: TraceViewSources.DISCOVER,
-        });
-      }
-
       const eventIdLink = (
-        <StyledLink data-test-id="view-event" to={target}>
+        <StyledLink
+          data-test-id="view-event"
+          to={getEventTarget({
+            dataRow,
+            eventView,
+            isTransactionsDataset,
+            location,
+            organization,
+          })}
+        >
           {value}
         </StyledLink>
       );
@@ -319,38 +299,17 @@ export function TableView(props: TableViewProps) {
       queryDataset === SavedQueryDatasets.TRANSACTIONS;
 
     if (columnKey === 'id') {
-      let target: any;
-
-      if (dataRow['event.type'] !== 'transaction' && !isTransactionsDataset) {
-        const project = dataRow.project || dataRow['project.name'];
-
-        target = {
-          // Redirects to the issue group event page via ProjectEventRedirect
-          pathname: normalizeUrl(
-            `/${organization.slug}/${project}/events/${dataRow.id}/`
-          ),
-          query: {...location.query, referrer: 'discover-events-table'},
-        };
-      } else {
-        if (!dataRow.trace) {
-          throw new Error(
-            'Transaction event should always have a trace associated with it.'
-          );
-        }
-
-        target = generateLinkToEventInTraceView({
-          traceSlug: dataRow.trace?.toString(),
-          eventId: dataRow.id,
-          timestamp: dataRow.timestamp!,
-          organization,
-          location,
-          eventView,
-          source: TraceViewSources.DISCOVER,
-        });
-      }
-
       const idLink = (
-        <StyledLink data-test-id="view-event" to={target}>
+        <StyledLink
+          data-test-id="view-event"
+          to={getEventTarget({
+            dataRow,
+            eventView,
+            isTransactionsDataset,
+            location,
+            organization,
+          })}
+        >
           {cell}
         </StyledLink>
       );
@@ -386,10 +345,11 @@ export function TableView(props: TableViewProps) {
         dataRow['max(timestamp)'] ?? dataRow.timestamp
       );
       const dateSelection = eventView.normalizeDateSelection(location);
-      if (dataRow.trace) {
+      const traceSlug = dataRow.trace;
+      if (typeof traceSlug === 'string' && traceSlug) {
         const target = getTraceDetailsUrl({
           organization,
-          traceSlug: String(dataRow.trace),
+          traceSlug,
           dateSelection,
           timestamp,
           location,
@@ -702,6 +662,93 @@ export function TableView(props: TableViewProps) {
       headerButtons={renderHeaderButtons}
     />
   );
+}
+
+type EventTargetOptions = {
+  dataRow: TableDataRow;
+  eventView: EventView;
+  isTransactionsDataset: boolean;
+  location: Location;
+  organization: Organization;
+};
+
+type TraceEventDataRow = TableDataRow & {
+  timestamp: string | number;
+  trace: string;
+};
+
+type IssueEventDataRow = TableDataRow & {
+  'issue.id': string | number;
+};
+
+function getEventTarget({
+  dataRow,
+  eventView,
+  isTransactionsDataset,
+  location,
+  organization,
+}: EventTargetOptions): LocationDescriptor {
+  if (dataRow['event.type'] !== 'transaction' && !isTransactionsDataset) {
+    if (isIssueEventDataRow(dataRow)) {
+      return getIssueEventTarget(dataRow, organization);
+    }
+
+    return getProjectEventRedirectTarget(dataRow, organization, location);
+  }
+
+  if (!isTraceEventDataRow(dataRow)) {
+    return getProjectEventRedirectTarget(dataRow, organization, location);
+  }
+
+  return generateLinkToEventInTraceView({
+    traceSlug: dataRow.trace,
+    eventId: dataRow.id,
+    timestamp: dataRow.timestamp,
+    organization,
+    location,
+    eventView,
+    source: TraceViewSources.DISCOVER,
+  });
+}
+
+function isIssueEventDataRow(dataRow: TableDataRow): dataRow is IssueEventDataRow {
+  const issueId = dataRow['issue.id'];
+  // Discover coalesces missing issue IDs to 0, so treat 0 as no issue.
+  return issueId !== undefined && issueId !== null && issueId !== 0 && issueId !== '0';
+}
+
+function isTraceEventDataRow(dataRow: TableDataRow): dataRow is TraceEventDataRow {
+  return (
+    typeof dataRow.trace === 'string' &&
+    dataRow.trace !== '' &&
+    dataRow.timestamp !== undefined
+  );
+}
+
+function getIssueEventTarget(
+  dataRow: IssueEventDataRow,
+  organization: Organization
+): LocationDescriptor {
+  return normalizeUrl({
+    pathname: `/organizations/${organization.slug}/issues/${dataRow['issue.id']}/events/${dataRow.id}/`,
+    query: {
+      referrer: 'discover-events-table',
+    },
+  });
+}
+
+function getProjectEventRedirectTarget(
+  dataRow: TableDataRow,
+  organization: Organization,
+  location: Location
+): LocationDescriptor {
+  const project = dataRow.project || dataRow['project.name'];
+
+  return {
+    // Redirects to the issue group event page via ProjectEventRedirect
+    pathname: normalizeUrl(`/${organization.slug}/${project}/events/${dataRow.id}/`),
+    query: {...location.query, referrer: 'discover-events-table'},
+  };
 }
 
 const PrependHeader = styled('span')`


### PR DESCRIPTION
Recreates #116485 against master. The previous PR was accidentally based on another dev branch.

Discover was still routing issue event id clicks through the project-event redirect, even when the row already had `issue.id`. That made some issue-event urls messy and left the redirect to clean things up later.

This requests `issue.id` with the hidden link context and builds the issue event url directly. Keeps the old project redirect fallback for rows that do not have issue context.