### PR TITLE
chore(seer-activity): update the data condition endpoint with the new condition

### DIFF
--- a/src/sentry/workflow_engine/apps.py
+++ b/src/sentry/workflow_engine/apps.py
@@ -6,7 +6,7 @@ class Config(AppConfig):
 
     def ready(self) -> None:
         # Import items that use registries or respond to events
-        import sentry.workflow_engine.handlers  # NOQA
+        import sentry.workflow_engine.handlers.condition  # NOQA
+        import sentry.workflow_engine.handlers.workflow  # NOQA
         import sentry.workflow_engine.receivers  # NOQA
-        import sentry.workflow_engine.handlers.workflow.workflow_activity_handlers  # NOQA
         from sentry.workflow_engine.endpoints import serializers  # NOQA

--- a/src/sentry/workflow_engine/endpoints/organization_data_condition_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_data_condition_index.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -22,7 +23,7 @@ from sentry.workflow_engine.endpoints.serializers.data_condition_handler_seriali
     DataConditionHandlerResponse,
     DataConditionHandlerSerializer,
 )
-from sentry.workflow_engine.models.data_condition import LEGACY_CONDITIONS
+from sentry.workflow_engine.models.data_condition import LEGACY_CONDITIONS, Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler
 
@@ -66,6 +67,11 @@ class OrganizationDataConditionIndexEndpoint(OrganizationEndpoint):
         data_conditions = []
 
         for condition_type, handler in condition_handler_registry.registrations.items():
+            if condition_type == Condition.SEER_ACTIVITY_TRIGGER and not features.has(
+                "organizations:workflow-engine-evaluate-seer-activities", organization
+            ):
+                continue
+
             if condition_type not in LEGACY_CONDITIONS and handler.group == group:
                 serialized = serialize(
                     handler,

--- a/src/sentry/workflow_engine/handlers/__init__.py
+++ b/src/sentry/workflow_engine/handlers/__init__.py
@@ -1,9 +1,0 @@
-# Export any handlers we want to include into the registry
-__all__ = [
-    "EventCreatedByDetectorConditionHandler",
-    "EventSeenCountConditionHandler",
-    "workflow_status_update_handler",
-]
-
-from .condition import EventCreatedByDetectorConditionHandler, EventSeenCountConditionHandler
-from .workflow import workflow_status_update_handler

--- a/src/sentry/workflow_engine/handlers/condition/__init__.py
+++ b/src/sentry/workflow_engine/handlers/condition/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "PercentSessionsPercentHandler",
     "ReappearedEventConditionHandler",
     "RegressionEventConditionHandler",
+    "SeerActivityTriggerHandler",
     "TaggedEventConditionHandler",
 ]
 
@@ -51,4 +52,5 @@ from .level_handler import LevelConditionHandler
 from .new_high_priority_issue_handler import NewHighPriorityIssueConditionHandler
 from .reappeared_event_handler import ReappearedEventConditionHandler
 from .regression_event_handler import RegressionEventConditionHandler
+from .seer_activity_trigger_handler import SeerActivityTriggerHandler
 from .tagged_event_handler import TaggedEventConditionHandler

--- a/src/sentry/workflow_engine/handlers/condition/seer_activity_trigger_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/seer_activity_trigger_handler.py
@@ -3,6 +3,8 @@ from typing import Any
 
 from sentry.models.activity import Activity
 from sentry.types.activity import ActivityType
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
@@ -34,6 +36,7 @@ Maps the DataCondition's expected stages to their ActivityType (from the Activit
 """
 
 
+@condition_handler_registry.register(Condition.SEER_ACTIVITY_TRIGGER)
 class SeerActivityTriggerHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {

--- a/src/sentry/workflow_engine/handlers/workflow/__init__.py
+++ b/src/sentry/workflow_engine/handlers/workflow/__init__.py
@@ -1,3 +1,7 @@
+from .workflow_activity_handlers import seer_activity_handler
 from .workflow_status_update_handler import workflow_status_update_handler
 
-__all__ = ["workflow_status_update_handler"]
+__all__ = [
+    "seer_activity_handler",
+    "workflow_status_update_handler",
+]

--- a/tests/sentry/workflow_engine/endpoints/test_organization_data_condition_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_data_condition_index.py
@@ -3,6 +3,7 @@ from typing import Any
 from unittest.mock import patch
 
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import cell_silo_test
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.models.data_condition import Condition
@@ -128,3 +129,34 @@ class OrganizationDataConditionIndexBaseTest(OrganizationDataConditionAPITestCas
 
     def test_no_group(self) -> None:
         self.get_error_response(self.organization.slug, status_code=400)
+
+    def test_seer_activity_trigger_hidden_without_feature(self) -> None:
+        @self.registry.register(Condition.SEER_ACTIVITY_TRIGGER)
+        @dataclass(frozen=True)
+        class TestSeerActivityTrigger(DataConditionHandler[dict[str, str]]):
+            group = DataConditionHandler.Group.WORKFLOW_TRIGGER
+            comparison_json_schema = {"type": "array", "items": {"type": "string"}}
+
+        response = self.get_success_response(
+            self.organization.slug,
+            group=DataConditionHandler.Group.WORKFLOW_TRIGGER,
+            status_code=200,
+        )
+        condition_types = [item["type"] for item in response.data]
+        assert Condition.SEER_ACTIVITY_TRIGGER.value not in condition_types
+
+    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
+    def test_seer_activity_trigger_shown_with_feature(self) -> None:
+        @self.registry.register(Condition.SEER_ACTIVITY_TRIGGER)
+        @dataclass(frozen=True)
+        class TestSeerActivityTrigger(DataConditionHandler[dict[str, str]]):
+            group = DataConditionHandler.Group.WORKFLOW_TRIGGER
+            comparison_json_schema = {"type": "array", "items": {"type": "string"}}
+
+        response = self.get_success_response(
+            self.organization.slug,
+            group=DataConditionHandler.Group.WORKFLOW_TRIGGER,
+            status_code=200,
+        )
+        condition_types = [item["type"] for item in response.data]
+        assert Condition.SEER_ACTIVITY_TRIGGER.value in condition_types

--- a/tests/sentry/workflow_engine/handlers/condition/test_seer_activity_trigger_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_seer_activity_trigger_handler.py
@@ -3,11 +3,9 @@ from jsonschema import ValidationError
 
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.handlers.condition.seer_activity_trigger_handler import (
-    SeerActivityTriggerHandler,
     SeerActivityTriggerStage,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
@@ -17,21 +15,11 @@ class TestSeerActivityTriggerHandler(ConditionTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        # TODO(Leander): Remove after registering
-        condition_handler_registry.registrations[self.condition] = SeerActivityTriggerHandler
-        condition_handler_registry.reverse_lookup[SeerActivityTriggerHandler] = self.condition
-
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison=[SeerActivityTriggerStage.RCA_COMPLETED],
             condition_result=True,
         )
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        # TODO(Leander): Remove after registering
-        condition_handler_registry.registrations.pop(self.condition, None)
-        condition_handler_registry.reverse_lookup.pop(SeerActivityTriggerHandler, None)
 
     def _create_event_data(self, activity_type: ActivityType) -> WorkflowEventData:
         activity = self.create_group_activity(group=self.group, type=activity_type.value)


### PR DESCRIPTION
Registers the new data condition and omits it from the endpoint after checking if the org has the feature flag to access it.
Simplifies how the registries are imported as well.