### PR TITLE
fix(eap): Recognize `normalize` deprecations in attribute mapping

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -533,7 +533,7 @@ def _update_attribute_definitions_with_deprecations(
         if (
             deprecation is None
             or deprecation.replacement is None
-            or deprecation.status != DeprecationStatus.BACKFILL
+            or deprecation.status not in (DeprecationStatus.BACKFILL, DeprecationStatus.NORMALIZE)
         ):
             continue
 

--- a/tests/sentry/api/endpoints/test_project_trace_item_details.py
+++ b/tests/sentry/api/endpoints/test_project_trace_item_details.py
@@ -4,7 +4,6 @@ from sentry.api.endpoints.project_trace_item_details import convert_rpc_attribut
 from sentry.search.eap.types import SupportedTraceItemType
 
 
-@pytest.mark.skip(reason="Skipping due to broken CI 05-29-2026")
 def test_convert_rpc_attribute_to_json_serializes_known_string_array_without_array_flag() -> None:
     result = convert_rpc_attribute_to_json(
         [
@@ -53,7 +52,6 @@ def test_convert_rpc_attribute_to_json_hides_non_replacement_array_without_array
     assert result == []
 
 
-@pytest.mark.skip(reason="Skipping due to broken CI 05-29-2026")
 def test_convert_rpc_attribute_to_json_exposes_array_with_array_flag() -> None:
     result = convert_rpc_attribute_to_json(
         [
@@ -111,7 +109,6 @@ class TestReplacementAttributeFiltering:
         assert "gen_ai.usage.prompt_tokens" in names
         assert "gen_ai.usage.input_tokens" not in names
 
-    @pytest.mark.skip(reason="Skipping due to broken CI 05-29-2026")
     def test_replacement_array_shown_when_no_deprecated_source(self) -> None:
         result = convert_rpc_attribute_to_json(
             [

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -1036,14 +1036,18 @@ class SearchResolverColumnTest(TestCase):
         assert (resolved_column, virtual_context) == (p95_column, p95_context)
 
 
-def _make_deprecated_metadata(attr_type: AttributeType, replacement: str) -> AttributeMetadata:
+def _make_deprecated_metadata(
+    attr_type: AttributeType,
+    replacement: str,
+    status: DeprecationStatus = DeprecationStatus.BACKFILL,
+) -> AttributeMetadata:
     return AttributeMetadata(
         brief="",
         type=attr_type,
         pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        deprecation=DeprecationInfo(replacement=replacement, status=DeprecationStatus.BACKFILL),
+        deprecation=DeprecationInfo(replacement=replacement, status=status),
     )
 
 
@@ -1249,3 +1253,50 @@ def test_deprecated_attribute_normalizes_supported_convention_attribute_types() 
 
     assert attribute_definitions["old_double"].search_type == "number"
     assert attribute_definitions["new_double"].search_type == "number"
+
+
+def test_normalize_deprecated_attributes_resolve_to_replacement() -> None:
+    attribute_definitions: dict[str, ResolvedAttribute] = {}
+
+    _update_attribute_definitions_with_deprecations(
+        attribute_definitions,
+        {
+            "old_attr": _make_deprecated_metadata(
+                AttributeType.STRING, "new_attr", status=DeprecationStatus.NORMALIZE
+            ),
+        },
+    )
+
+    assert "old_attr" in attribute_definitions
+    assert attribute_definitions["old_attr"].replacement == "new_attr"
+    assert attribute_definitions["old_attr"].deprecation_status == "normalize"
+    assert "new_attr" in attribute_definitions
+    assert attribute_definitions["new_attr"].search_type == "string"
+
+
+def test_normalize_deprecated_attribute_preserves_existing_definition() -> None:
+    attribute_definitions = {
+        "gen_ai.request.messages": ResolvedAttribute(
+            public_alias="gen_ai.request.messages",
+            internal_name="gen_ai.request.messages",
+            search_type="string",
+        ),
+    }
+
+    _update_attribute_definitions_with_deprecations(
+        attribute_definitions,
+        {
+            "gen_ai.request.messages": _make_deprecated_metadata(
+                AttributeType.STRING, "gen_ai.input.messages", status=DeprecationStatus.NORMALIZE
+            ),
+        },
+    )
+
+    deprecated_attr = attribute_definitions["gen_ai.request.messages"]
+    replacement_attr = attribute_definitions["gen_ai.input.messages"]
+
+    assert deprecated_attr.replacement == "gen_ai.input.messages"
+    assert deprecated_attr.deprecation_status == "normalize"
+    assert replacement_attr.public_alias == "gen_ai.input.messages"
+    assert replacement_attr.internal_name == "gen_ai.input.messages"
+    assert replacement_attr.search_type == "string"

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -898,9 +898,12 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.content
 
         keys = {item["key"] for item in response.data}
-        assert len(keys) == 2
+        assert len(keys) == 4
         assert "transaction.op" in keys
         assert "span.op" in keys
+        # These two are unrelated, but happen to match.
+        assert "db.operation" in keys
+        assert "db.operation.name" in keys
 
         response = self.do_request(query={"attributeType": "string", "substringMatch": "sentry.op"})
         assert response.status_code == 200, response.content


### PR DESCRIPTION
Okay, here goes.

#116399 broke 3 tests in [tests/sentry/api/endpoints/test_project_trace_item_details.py](https://github.com/getsentry/sentry/blob/master/tests/sentry/api/endpoints/test_project_trace_item_details.py), breaking CI:

1. [`test_convert_rpc_attribute_to_json_serializes_known_string_array_without_array_flag`](https://github.com/getsentry/sentry/blob/297a20eaa5c960b6cc53f0291296c56a29432861/tests/sentry/api/endpoints/test_project_trace_item_details.py#L8-L25)
2. [`test_convert_rpc_attribute_to_json_exposes_array_with_array_flag `](https://github.com/getsentry/sentry/blob/297a20eaa5c960b6cc53f0291296c56a29432861/tests/sentry/api/endpoints/test_project_trace_item_details.py#L57-L75)
3. [`TestReplacementAttributeFiltering::test_replacement_array_shown_when_no_deprecated_source`](https://github.com/getsentry/sentry/blob/297a20eaa5c960b6cc53f0291296c56a29432861/tests/sentry/api/endpoints/test_project_trace_item_details.py#L115-L127)

These all test the [very fiddly logic in `ProjectTraceItemDetailsEndpoint` around arrays](https://github.com/getsentry/sentry/blob/297a20eaa5c960b6cc53f0291296c56a29432861/src/sentry/api/endpoints/project_trace_item_details.py#L138-L158). Dig through enough indirection and you'll find that said logic depends on attribute info (especially deprecation metadata) being included in the relevant `<type>_ATTRIBUTE_DEFINITIONS` list (e.g. [`SPAN_ATTRIBUTE_DEFINITIONS`](https://github.com/getsentry/sentry/blob/297a20eaa5c960b6cc53f0291296c56a29432861/src/sentry/search/eap/spans/attributes.py#L39) for spans).

When #116399 changed our data source for deprecations, it picked up a convention update that wasn't reflected in the old static deprecation JSON, changing 8 `gen_ai.*` spans from `backfill` deprecations to `normalize` deprecations. However, [only `backfill` deprecations get included in `SPAN_ATTRIBUTE_DEFINITIONS` lists](https://github.com/getsentry/sentry/blob/297a20eaa5c960b6cc53f0291296c56a29432861/src/sentry/search/eap/spans/attributes.py#L536) - so the definitions disappeared, breaking the logic the tests depended on.

Frankly: all this code needs a major rethink. The `<type>_ATTRIBUTE_DEFINITIONS` lists are now heavily overloaded, acting as public search aliases, type definitions (often duplicating conventions), conventional attributes themselves, and their deprecation aliases. On top of that, the whole `backfill` vs `normalize` thing is poorly defined between conventions, Relay and Sentry. This is going to be a constant source of bugs until this is untangled.

_But_, this has to get fixed now and can't wait for all that heavy lifting. So I made the change that seems least likely to have a blast radius: processing `normalize` deprecated attributes the same way we do `backfill` ones. This only affects the 8 `gen_ai.*` attributes plus 2 more (`db.operation` and `db.statement`), and fixes the failing tests.

Fixes BROWSE-536.

---

🤖 Claude Code (Opus 4.6) used heavily to understand WTF is going on. I wrote the code change, Claude wrote the tests, I reviewed. All words mine.