### PR TITLE
fix(eventstream): Guard against None entries in exception values list

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -347,7 +347,9 @@ def _extract_exception(
 ) -> Mapping[str, int | list[str | int | bool | None]]:
     out: dict[str, int | list[Any]] = {}
 
-    exceptions = event_data.get("exception", {}).get("values", [])
+    exceptions = [
+        exc for exc in event_data.get("exception", {}).get("values", []) if exc is not None
+    ]
     # So, logically, each exception here is basically a mapping of data.
     # Most notable in that mapping is frames, which is itself a mapping of frame data.
     # NOW! EAP currently doesn't support mappings. So what we do here is instead build
@@ -371,8 +373,6 @@ def _extract_exception(
     frame_linenos = []
     frame_stack_levels = []
     for stack_level, stack in enumerate(exceptions):
-        if stack is None:
-            continue
         stack_types.append(stack.get("type"))
         stack_values.append(stack.get("value"))
         stack_mechanism_types.append(get_path(stack, "mechanism", "type"))

--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -348,7 +348,7 @@ def _extract_exception(
     out: dict[str, int | list[Any]] = {}
 
     exceptions = [
-        exc for exc in event_data.get("exception", {}).get("values", []) if exc is not None
+        exc for exc in event_data.get("exception", {}).get("values", []) or [] if exc is not None
     ]
     # So, logically, each exception here is basically a mapping of data.
     # Most notable in that mapping is frames, which is itself a mapping of frame data.

--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -371,6 +371,8 @@ def _extract_exception(
     frame_linenos = []
     frame_stack_levels = []
     for stack_level, stack in enumerate(exceptions):
+        if stack is None:
+            continue
         stack_types.append(stack.get("type"))
         stack_values.append(stack.get("value"))
         stack_mechanism_types.append(get_path(stack, "mechanism", "type"))


### PR DESCRIPTION
Guard against `None` entries in `exception.values` when extracting exception
data for the eventstream/EAP pipeline.

Some events have `None` entries in their `exception.values` list. When
`_extract_exception` iterates over this list, it calls `.get("type")` on
`None`, causing `AttributeError: 'NoneType' object has no attribute 'get'`.

The fix filters `None` entries out of the exceptions list before iteration
rather than skipping inside the loop. This keeps `exception_count`,
`stack_level` indices, and the parallel `stack_*` arrays consistent. Also
adds `or []` to handle the case where `"values"` is explicitly `None`.

Fixes SENTRY-FOR-SENTRY-2T8