### PR TITLE
chore: fix log statement

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -148,7 +148,7 @@ def make_signed_seer_api_request(
         except ValueError:
             logger.warning(
                 "viewer_context_jwt.no_signing_key",
-                extra={"msg": "No key available to sign viewer context JWT."},
+                extra={"reason": "No key available to sign viewer context JWT."},
             )
         except Exception:
             logger.exception("Failed to encode viewer context JWT for call to Seer.")


### PR DESCRIPTION
## Summary

Fixes a bug where emitting the `viewer_context_jwt.no_signing_key` warning log hard-errors instead of degrading gracefully.

When `SEER_API_SHARED_SECRET` is not configured, `encode_viewer_context` raises `ValueError`, which is meant to be caught and logged as a warning so the request can continue. But the warning passed `extra={"msg": ...}`, and `msg` is a reserved attribute on Python's `LogRecord`. `logging.makeRecord` refuses to overwrite it and raises:

```
KeyError: "Attempt to overwrite 'msg' in LogRecord"
```

So the handler meant to swallow the missing-key case instead threw a new exception that bubbled up as an uncaught 500 on the autofix endpoints.

The fix renames the `extra` key from the reserved `msg` to `reason`.

## Test plan

Hit a Seer-backed endpoint (e.g. autofix) locally without `SEER_API_SHARED_SECRET` set — the request now logs a warning and continues instead of 500ing.