### PR TITLE
fix(cells) Add flag and display name for us2

### DIFF
--- a/static/app/utils/regions/index.tsx
+++ b/static/app/utils/regions/index.tsx
@@ -5,28 +5,29 @@ import type {Region} from 'sentry/types/system';
 
 const RegionDisplayName: Record<string, string> = {
   US: t('United States of America (US)'),
+  US2: t('United States of America (US2)'),
   DE: t('European Union (EU)'),
 };
 
-enum RegionFlagIndicator {
-  US = '🇺🇸',
-  DE = '🇪🇺',
-}
+const RegionFlagIndicator: Record<string, string> = {
+  US: '🇺🇸',
+  US2: '🇺🇸',
+  DE: '🇪🇺',
+};
 
 interface RegionData {
   displayName: string;
   name: string;
   url: string;
-  flag?: RegionFlagIndicator;
+  flag?: string;
 }
 
 function getRegionDisplayName(region: Region): string {
   return RegionDisplayName[region.name.toUpperCase()] ?? region.name;
 }
 
-function getRegionFlagIndicator(region: Region): RegionFlagIndicator | undefined {
+function getRegionFlagIndicator(region: Region): string | undefined {
   const regionName = region.name.toUpperCase();
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   return RegionFlagIndicator[regionName];
 }
 


### PR DESCRIPTION
After orgs are created in us2 we should display similar copy in organization settings to what is shown for US orgs.

<img width="972" height="364" alt="Screenshot 2026-05-29 at 3 03 23 PM" src="https://github.com/user-attachments/assets/52b98eb9-7bd1-401d-bd09-bb2f47903c00" />

Fixes PRODENG-1457
