### PR TITLE
ref(trace-waterfall): drop deprecated aliases from trace meta endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_meta.py
+++ b/src/sentry/api/endpoints/organization_trace_meta.py
@@ -44,15 +44,6 @@ class SerializedResponse(TypedDict, total=False):
     transactionChildCountMap: SnubaData
     spansCountMap: dict[str, int]
 
-    # These are deprecated
-    logs: int
-    errors: int
-    performance_issues: int
-    span_count: int
-    transaction_child_count_map: SnubaData
-    span_count_map: dict[str, int]
-    uptime_checks: int  # Only present when include_uptime is True
-
 
 def extract_uptime_count(uptime_result: list[TraceItemTableResponse]) -> int:
     """Safely extract uptime count from query result."""
@@ -282,31 +273,21 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsEndpointBase):
             "spansCountMap": {
                 row["span.op"]: row["count()"] for row in results["spans_op_count"]["data"]
             },
-            # these are deprecated
-            "logs": results["logs_meta"]["data"][0].get("count()") or 0,
-            "errors": errors_count,
-            "performance_issues": perf_issues,
-            "span_count": results["spans_meta"]["data"][0].get("count()") or 0,
-            "transaction_child_count_map": results["transaction_children"]["data"],
-            "span_count_map": {
-                row["span.op"]: row["count()"] for row in results["spans_op_count"]["data"]
-            },
         }
 
         sentry_sdk.metrics.distribution(
             "performance.trace.logs.count",
-            response["logs"],
+            response["logsCount"],
         )
         sentry_sdk.metrics.distribution(
             "performance.trace.span.count",
-            response["span_count"],
+            response["spansCount"],
         )
         sentry_sdk.metrics.distribution(
             "performance.trace.errors.count",
-            response["errors"],
+            response["errorsCount"],
         )
 
         if uptime_count is not None:
-            response["uptime_checks"] = uptime_count
             response["uptimeCount"] = uptime_count
         return response

--- a/tests/snuba/api/endpoints/test_organization_trace_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_meta.py
@@ -69,7 +69,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         assert data["spansCount"] == 0
         assert data["spansCountMap"] == {}
         assert data["metricsCount"] == 0
-        assert "uptime_checks" not in data  # Should not be present without include_uptime param
+        assert "uptimeCount" not in data  # Should not be present without include_uptime param
 
         # Invalid trace id
         with pytest.raises(NoReverseMatch):
@@ -309,7 +309,7 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
         return self.create_eap_uptime_result(**defaults)
 
     def test_trace_meta_without_uptime_param(self) -> None:
-        """Test that uptime_checks field is NOT present when include_uptime is not set"""
+        """Test that uptimeCount field is NOT present when include_uptime is not set"""
         self.load_trace()
         uptime_result = self.create_uptime_check()
         self.store_eap_items([uptime_result])
@@ -322,13 +322,13 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
 
         assert response.status_code == 200
         data = response.data
-        assert "uptime_checks" not in data
-        assert data["errors"] == 0
-        assert data["performance_issues"] == 2
-        assert data["span_count"] == 19
+        assert "uptimeCount" not in data
+        assert data["errorsCount"] == 0
+        assert data["performanceIssuesCount"] == 2
+        assert data["spansCount"] == 19
 
     def test_trace_meta_with_uptime_param(self) -> None:
-        """Test that uptime_checks shows correct count when include_uptime=1"""
+        """Test that uptimeCount shows correct count when include_uptime=1"""
         self.load_trace()
 
         uptime_results = [
@@ -347,14 +347,14 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
 
         assert response.status_code == 200
         data = response.data
-        assert "uptime_checks" in data
-        assert data["uptime_checks"] == 3
-        assert data["errors"] == 0
-        assert data["performance_issues"] == 2
-        assert data["span_count"] == 19
+        assert "uptimeCount" in data
+        assert data["uptimeCount"] == 3
+        assert data["errorsCount"] == 0
+        assert data["performanceIssuesCount"] == 2
+        assert data["spansCount"] == 19
 
     def test_trace_meta_no_uptime_results(self) -> None:
-        """Test that uptime_checks is 0 when there are no uptime results"""
+        """Test that uptimeCount is 0 when there are no uptime results"""
         self.load_trace()
 
         with self.feature(self.FEATURES):
@@ -366,11 +366,11 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
 
         assert response.status_code == 200
         data = response.data
-        assert "uptime_checks" in data
-        assert data["uptime_checks"] == 0
-        assert data["errors"] == 0
-        assert data["performance_issues"] == 2
-        assert data["span_count"] == 19
+        assert "uptimeCount" in data
+        assert data["uptimeCount"] == 0
+        assert data["errorsCount"] == 0
+        assert data["performanceIssuesCount"] == 2
+        assert data["spansCount"] == 19
 
     def test_trace_meta_different_trace_id(self) -> None:
         """Test that uptime results from different traces are not counted"""
@@ -387,5 +387,5 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
             )
         assert response.status_code == 200
         data = response.data
-        assert "uptime_checks" in data
-        assert data["uptime_checks"] == 0
+        assert "uptimeCount" in data
+        assert data["uptimeCount"] == 0


### PR DESCRIPTION
Remove deprecated fields from this endpoint from https://github.com/getsentry/sentry/pull/115107. This makes publishing it a little cleaner: https://github.com/getsentry/sentry/pull/116445. Frontend already only uses the non-deprecated versions.