### PR TITLE
ref(api-docs): add `EventAttachmentSerializerResponse` type and example

### DIFF
--- a/src/sentry/api/serializers/models/eventattachment.py
+++ b/src/sentry/api/serializers/models/eventattachment.py
@@ -1,13 +1,27 @@
 import mimetypes
+from datetime import datetime
+from typing import TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.models.eventattachment import EventAttachment
 from sentry.models.files.file import File
 
 
+class EventAttachmentSerializerResponse(TypedDict):
+    id: str
+    event_id: str
+    type: str
+    name: str
+    mimetype: str | None
+    dateCreated: datetime
+    size: int
+    headers: dict[str, str | None]
+    sha1: str | None
+
+
 @register(EventAttachment)
 class EventAttachmentSerializer(Serializer):
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs) -> EventAttachmentSerializerResponse:
         content_type = obj.content_type
         size = obj.size or 0
         sha1 = obj.sha1

--- a/src/sentry/apidocs/examples/event_attachment_examples.py
+++ b/src/sentry/apidocs/examples/event_attachment_examples.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+
+from drf_spectacular.utils import OpenApiExample
+
+from sentry.api.serializers.models.eventattachment import EventAttachmentSerializerResponse
+
+SCREENSHOT_ATTACHMENT: EventAttachmentSerializerResponse = {
+    "id": "1234",
+    "event_id": "9b29bbe17e9d4ee3a6d0fe9b2e8a3b1c",
+    "type": "event.attachment",
+    "name": "screenshot.png",
+    "mimetype": "image/png",
+    "dateCreated": datetime.fromisoformat("2026-04-15T18:22:31.000000Z"),
+    "size": 248137,
+    "headers": {"Content-Type": "image/png"},
+    "sha1": "d3f299af02d6abbe92dd8368bab781824a9702ed",
+}
+
+VIEW_HIERARCHY_ATTACHMENT: EventAttachmentSerializerResponse = {
+    "id": "1235",
+    "event_id": "9b29bbe17e9d4ee3a6d0fe9b2e8a3b1c",
+    "type": "event.view_hierarchy",
+    "name": "view-hierarchy.json",
+    "mimetype": "application/json",
+    "dateCreated": datetime.fromisoformat("2026-04-15T18:22:31.000000Z"),
+    "size": 8421,
+    "headers": {"Content-Type": "application/json"},
+    "sha1": "fa0a5fad9e64129f6b5f60cca3a5b8c9b8a1a3a0",
+}
+
+
+class EventAttachmentExamples:
+    LIST_EVENT_ATTACHMENTS = [
+        OpenApiExample(
+            "Return a list of attachments for an event",
+            value=[SCREENSHOT_ATTACHMENT, VIEW_HIERARCHY_ATTACHMENT],
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]
+    EVENT_ATTACHMENT_DETAILS = [
+        OpenApiExample(
+            "Return a single event attachment",
+            value=SCREENSHOT_ATTACHMENT,
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]


### PR DESCRIPTION
Add types and example for the event attachments endpoint, in preparation for publishing it. 