### PR TITLE
fix(project transfer): Clone shared workflows when transferring project

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -716,15 +716,14 @@ class Project(Model):
         # FK), but Workflows and their DataConditionGroups are organization-scoped, so they need to
         # be moved into the new org explicitly.
         #
-        # Workflows can be shared across multiple projects in the same org (e.g. via DetectorWorkflow
-        # links created by the cron / issue-stream backfills). To keep every workflow in the same org
-        # as the detectors and legacy Rule/AlertRule it fires for, we handle two cases:
+        # Workflows can be shared across multiple projects in the same org if connected to detectors in multiple projects.
+        # To keep every workflow in the same org as the detectors and legacy Rule/AlertRule it fires for, we handle two cases:
         # * A workflow used ONLY by detectors in this project is moved into the new org as-is.
         # * A workflow shared with detectors in other projects is cloned into the new org; we then
-        #   re-point just this project's DetectorWorkflow / AlertRuleWorkflow links onto the clone
+        #   re-point just this project's DetectorWorkflow and AlertRuleWorkflow links onto the clone
         #   and leave the original behind for the projects that remain.
         #
-        # The whole block runs in a transaction so a crash can't leave a half-cloned workflow graph.
+        # The whole block runs in a transaction so a crash can't leave a half-cloned workflow
         detector_ids = list(
             Detector.objects.filter(project_id=self.id).values_list("id", flat=True)
         )

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -49,6 +49,7 @@ from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.snowflake import save_with_snowflake_id, snowflake_id_model
+from sentry.workflow_engine.processors.project_transfer import clone_workflow_to_organization
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,6 @@ if TYPE_CHECKING:
     from sentry.models.options.project_option import ProjectOptionManager
     from sentry.models.organization import Organization
     from sentry.users.models.user import User
-    from sentry.workflow_engine.models import Workflow
 
 # NOTE:
 # - When you modify this list, ensure that the platform IDs listed in "sentry/static/app/data/platforms.tsx" match.
@@ -228,78 +228,6 @@ class ProjectManager(BaseManager["Project"]):
             project_list.append(project)
 
         return sorted(project_list, key=lambda x: x.name.lower())
-
-
-def _clone_workflow_to_organization(
-    workflow: Workflow,
-    organization: Organization,
-    environment_id: int | None,
-) -> Workflow:
-    """Deep-copy a workflow and its condition graph into ``organization``.
-
-    Used by ``Project.transfer_to`` when a workflow is shared with detectors in other
-    projects: the transferring project gets its own copy in the new org while the original
-    is left intact for the projects that remain. The owner team/user is dropped because it
-    won't belong to the new org, and fire history / detector state are not copied.
-    """
-    from sentry.workflow_engine.models import (
-        Action,
-        DataCondition,
-        DataConditionGroup,
-        DataConditionGroupAction,
-        Workflow,
-        WorkflowDataConditionGroup,
-    )
-
-    def clone_condition_group(
-        condition_group: DataConditionGroup,
-    ) -> DataConditionGroup:
-        new_group = DataConditionGroup.objects.create(
-            organization_id=organization.id,
-            logic_type=condition_group.logic_type,
-        )
-        for condition in DataCondition.objects.filter(condition_group=condition_group):
-            DataCondition.objects.create(
-                condition_group=new_group,
-                type=condition.type,
-                comparison=condition.comparison,
-                condition_result=condition.condition_result,
-            )
-        # Actions are not organization-scoped; clone them so the copy is fully isolated
-        # from the original workflow that stays behind in the old org.
-        for group_action in DataConditionGroupAction.objects.filter(
-            condition_group=condition_group
-        ).select_related("action"):
-            action = group_action.action
-            new_action = Action.objects.create(
-                type=action.type,
-                data=action.data,
-                integration_id=action.integration_id,
-                status=action.status,
-                config=action.config,
-            )
-            DataConditionGroupAction.objects.create(condition_group=new_group, action=new_action)
-        return new_group
-
-    when_condition_group = workflow.when_condition_group
-    clone = Workflow.objects.create(
-        organization_id=organization.id,
-        name=workflow.name,
-        enabled=workflow.enabled,
-        config=workflow.config,
-        when_condition_group=(
-            clone_condition_group(when_condition_group)
-            if when_condition_group is not None
-            else None
-        ),
-        environment_id=environment_id,
-    )
-    for workflow_dcg in WorkflowDataConditionGroup.objects.filter(workflow=workflow):
-        WorkflowDataConditionGroup.objects.create(
-            workflow=clone,
-            condition_group=clone_condition_group(workflow_dcg.condition_group),
-        )
-    return clone
 
 
 @snowflake_id_model
@@ -808,7 +736,7 @@ class Project(Model):
                         AlertRule.objects.fetch_for_project(self).values_list("id", flat=True)
                     )
                     for workflow in Workflow.objects.filter(id__in=shared_workflow_ids):
-                        clone = _clone_workflow_to_organization(
+                        clone = clone_workflow_to_organization(
                             workflow,
                             organization,
                             resolve_environment_id(workflow.environment_id),

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -252,10 +252,8 @@ def _clone_workflow_to_organization(
     )
 
     def clone_condition_group(
-        condition_group: DataConditionGroup | None,
-    ) -> DataConditionGroup | None:
-        if condition_group is None:
-            return None
+        condition_group: DataConditionGroup,
+    ) -> DataConditionGroup:
         new_group = DataConditionGroup.objects.create(
             organization_id=organization.id,
             logic_type=condition_group.logic_type,
@@ -283,12 +281,17 @@ def _clone_workflow_to_organization(
             DataConditionGroupAction.objects.create(condition_group=new_group, action=new_action)
         return new_group
 
+    when_condition_group = workflow.when_condition_group
     clone = Workflow.objects.create(
         organization_id=organization.id,
         name=workflow.name,
         enabled=workflow.enabled,
         config=workflow.config,
-        when_condition_group=clone_condition_group(workflow.when_condition_group),
+        when_condition_group=(
+            clone_condition_group(when_condition_group)
+            if when_condition_group is not None
+            else None
+        ),
         environment_id=environment_id,
     )
     for workflow_dcg in WorkflowDataConditionGroup.objects.filter(workflow=workflow):

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -662,7 +662,12 @@ class Project(Model):
             with transaction.atomic(router.db_for_write(Workflow)):
                 # DataSources are 1:1 with their source (e.g. QuerySubscription, Monitor) and are
                 # detector-scoped, so they always transfer.
-                DataSource.objects.filter(detectors__id__in=detector_ids).distinct().update(
+                data_source_ids = list(
+                    DataSource.objects.filter(detectors__id__in=detector_ids)
+                    .distinct()
+                    .values_list("id", flat=True)
+                )
+                DataSource.objects.filter(id__in=data_source_ids).update(
                     organization_id=organization.id
                 )
 
@@ -711,9 +716,16 @@ class Project(Model):
 
                 # DataConditionGroups attached to the moved workflows (the "if" filters, linked via
                 # WorkflowDataConditionGroup) move with them.
-                DataConditionGroup.objects.filter(
-                    workflowdataconditiongroup__workflow_id__in=exclusive_workflow_ids
-                ).distinct().update(organization_id=organization.id)
+                exclusive_condition_group_ids = list(
+                    DataConditionGroup.objects.filter(
+                        workflowdataconditiongroup__workflow_id__in=exclusive_workflow_ids
+                    )
+                    .distinct()
+                    .values_list("id", flat=True)
+                )
+                DataConditionGroup.objects.filter(id__in=exclusive_condition_group_ids).update(
+                    organization_id=organization.id
+                )
 
                 # when_condition_groups of the moved workflows are never shared, so move them too.
                 when_condition_group_ids = (

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from sentry.models.options.project_option import ProjectOptionManager
     from sentry.models.organization import Organization
     from sentry.users.models.user import User
+    from sentry.workflow_engine.models import Workflow
 
 # NOTE:
 # - When you modify this list, ensure that the platform IDs listed in "sentry/static/app/data/platforms.tsx" match.
@@ -227,6 +228,75 @@ class ProjectManager(BaseManager["Project"]):
             project_list.append(project)
 
         return sorted(project_list, key=lambda x: x.name.lower())
+
+
+def _clone_workflow_to_organization(
+    workflow: Workflow,
+    organization: Organization,
+    environment_id: int | None,
+) -> Workflow:
+    """Deep-copy a workflow and its condition graph into ``organization``.
+
+    Used by ``Project.transfer_to`` when a workflow is shared with detectors in other
+    projects: the transferring project gets its own copy in the new org while the original
+    is left intact for the projects that remain. The owner team/user is dropped because it
+    won't belong to the new org, and fire history / detector state are not copied.
+    """
+    from sentry.workflow_engine.models import (
+        Action,
+        DataCondition,
+        DataConditionGroup,
+        DataConditionGroupAction,
+        Workflow,
+        WorkflowDataConditionGroup,
+    )
+
+    def clone_condition_group(
+        condition_group: DataConditionGroup | None,
+    ) -> DataConditionGroup | None:
+        if condition_group is None:
+            return None
+        new_group = DataConditionGroup.objects.create(
+            organization_id=organization.id,
+            logic_type=condition_group.logic_type,
+        )
+        for condition in DataCondition.objects.filter(condition_group=condition_group):
+            DataCondition.objects.create(
+                condition_group=new_group,
+                type=condition.type,
+                comparison=condition.comparison,
+                condition_result=condition.condition_result,
+            )
+        # Actions are not organization-scoped; clone them so the copy is fully isolated
+        # from the original workflow that stays behind in the old org.
+        for group_action in DataConditionGroupAction.objects.filter(
+            condition_group=condition_group
+        ).select_related("action"):
+            action = group_action.action
+            new_action = Action.objects.create(
+                type=action.type,
+                data=action.data,
+                integration_id=action.integration_id,
+                status=action.status,
+                config=action.config,
+            )
+            DataConditionGroupAction.objects.create(condition_group=new_group, action=new_action)
+        return new_group
+
+    clone = Workflow.objects.create(
+        organization_id=organization.id,
+        name=workflow.name,
+        enabled=workflow.enabled,
+        config=workflow.config,
+        when_condition_group=clone_condition_group(workflow.when_condition_group),
+        environment_id=environment_id,
+    )
+    for workflow_dcg in WorkflowDataConditionGroup.objects.filter(workflow=workflow):
+        WorkflowDataConditionGroup.objects.create(
+            workflow=clone,
+            condition_group=clone_condition_group(workflow_dcg.condition_group),
+        )
+    return clone
 
 
 @snowflake_id_model
@@ -506,7 +576,14 @@ class Project(Model):
         from sentry.models.rule import Rule
         from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus
         from sentry.snuba.models import SnubaQuery
-        from sentry.workflow_engine.models import DataConditionGroup, DataSource, Detector, Workflow
+        from sentry.workflow_engine.models import (
+            AlertRuleWorkflow,
+            DataConditionGroup,
+            DataSource,
+            Detector,
+            DetectorWorkflow,
+            Workflow,
+        )
 
         old_org_id = self.organization_id
         org_changed = old_org_id != organization.id
@@ -634,114 +711,140 @@ class Project(Model):
 
         AlertRule.objects.fetch_for_project(self).update(organization=organization)
 
-        # Transfer DataSource, Workflow, and DataConditionGroup objects for Detectors attached to this project.
-        # * DataSources link detectors to their data sources (QuerySubscriptions, Monitors, etc.).
-        # * Workflows are connected to detectors and define what actions to take.
-        # * DataConditionGroups are connected to workflows (unique 1:1 via WorkflowDataConditionGroup).
-        # Since Detectors are project-scoped and their DataSources are project-specific,
-        # we need to update all related organization-scoped workflow_engine models.
+        # Transfer DataSource, Workflow, and DataConditionGroup objects for Detectors attached to
+        # this project. Detectors are project-scoped (they move with the project via their project
+        # FK), but Workflows and their DataConditionGroups are organization-scoped, so they need to
+        # be moved into the new org explicitly.
         #
-        # IMPORTANT: Workflows and DataConditionGroups can be shared across multiple projects
-        # in the same organization. We only transfer them if they're exclusively used by
-        # detectors in this project. Shared workflows remain in the original organization.
-        # There are certainly more correct ways to do this, but this should cover most cases.
-
-        detector_ids = Detector.objects.filter(project_id=self.id).values_list("id", flat=True)
+        # Workflows can be shared across multiple projects in the same org (e.g. via DetectorWorkflow
+        # links created by the cron / issue-stream backfills). To keep every workflow in the same org
+        # as the detectors and legacy Rule/AlertRule it fires for, we handle two cases:
+        # * A workflow used ONLY by detectors in this project is moved into the new org as-is.
+        # * A workflow shared with detectors in other projects is cloned into the new org; we then
+        #   re-point just this project's DetectorWorkflow / AlertRuleWorkflow links onto the clone
+        #   and leave the original behind for the projects that remain.
+        #
+        # The whole block runs in a transaction so a crash can't leave a half-cloned workflow graph.
+        detector_ids = list(
+            Detector.objects.filter(project_id=self.id).values_list("id", flat=True)
+        )
         if detector_ids:
-            # Update DataSources
-            # DataSources are 1:1 with their source (e.g., QuerySubscription) so they always transfer
-            data_source_ids = (
-                DataSource.objects.filter(detectors__id__in=detector_ids)
-                .distinct()
-                .values_list("id", flat=True)
-            )
-            DataSource.objects.filter(id__in=data_source_ids).update(
-                organization_id=organization.id
-            )
-
-            # Update Workflows connected to these detectors
-            # Only transfer workflows that are exclusively used by detectors in this project
-            all_workflow_ids = (
-                Workflow.objects.filter(detectorworkflow__detector_id__in=detector_ids)
-                .distinct()
-                .values_list("id", flat=True)
-            )
-
-            # Find workflows that are ONLY connected to detectors in this project
-            exclusive_workflow_ids = (
-                Workflow.objects.filter(id__in=all_workflow_ids)
-                .annotate(
-                    detector_count=Count("detectorworkflow__detector"),
-                    project_detector_count=Count(
-                        "detectorworkflow__detector",
-                        filter=Q(detectorworkflow__detector_id__in=detector_ids),
-                    ),
+            with transaction.atomic(router.db_for_write(Workflow)):
+                # DataSources are 1:1 with their source (e.g. QuerySubscription, Monitor) and are
+                # detector-scoped, so they always transfer.
+                DataSource.objects.filter(detectors__id__in=detector_ids).distinct().update(
+                    organization_id=organization.id
                 )
-                .filter(detector_count=models.F("project_detector_count"))
-                .values_list("id", flat=True)
-            )
 
-            # Update org and environment references for transferred workflows
-            workflows_with_env = dict(
-                Workflow.objects.filter(
-                    id__in=exclusive_workflow_ids, environment_id__isnull=False
-                ).values_list("id", "environment_id")
-            )
-            for workflow_id, env_id in workflows_with_env.items():
-                Workflow.objects.filter(id=workflow_id).update(
-                    organization_id=organization.id,
-                    environment_id=Environment.get_or_create(
-                        self, name=environment_names.get(env_id)
-                    ).id,
+                all_workflow_ids = set(
+                    Workflow.objects.filter(detectorworkflow__detector_id__in=detector_ids)
+                    .distinct()
+                    .values_list("id", flat=True)
                 )
-            Workflow.objects.filter(id__in=exclusive_workflow_ids).exclude(
-                id__in=workflows_with_env.keys()
-            ).update(organization_id=organization.id)
 
-            # Update DataConditionGroups connected to the transferred workflows
-            # These are linked via WorkflowDataConditionGroup with a unique constraint on condition_group
-            workflow_condition_group_ids = (
+                # Workflows whose detector links are ALL in this project can be moved as-is.
+                exclusive_workflow_ids = set(
+                    Workflow.objects.filter(id__in=all_workflow_ids)
+                    .annotate(
+                        detector_count=Count("detectorworkflow__detector"),
+                        project_detector_count=Count(
+                            "detectorworkflow__detector",
+                            filter=Q(detectorworkflow__detector_id__in=detector_ids),
+                        ),
+                    )
+                    .filter(detector_count=models.F("project_detector_count"))
+                    .values_list("id", flat=True)
+                )
+                shared_workflow_ids = all_workflow_ids - exclusive_workflow_ids
+
+                def resolve_environment_id(environment_id: int | None) -> int | None:
+                    if environment_id is None:
+                        return None
+                    return Environment.get_or_create(
+                        self, name=environment_names.get(environment_id)
+                    ).id
+
+                # Move the exclusive workflows (and their org/environment references) into the new org.
+                workflows_with_env = dict(
+                    Workflow.objects.filter(
+                        id__in=exclusive_workflow_ids, environment_id__isnull=False
+                    ).values_list("id", "environment_id")
+                )
+                for workflow_id, env_id in workflows_with_env.items():
+                    Workflow.objects.filter(id=workflow_id).update(
+                        organization_id=organization.id,
+                        environment_id=resolve_environment_id(env_id),
+                    )
+                Workflow.objects.filter(id__in=exclusive_workflow_ids).exclude(
+                    id__in=workflows_with_env.keys()
+                ).update(organization_id=organization.id)
+
+                # DataConditionGroups attached to the moved workflows (the "if" filters, linked via
+                # WorkflowDataConditionGroup) move with them.
                 DataConditionGroup.objects.filter(
                     workflowdataconditiongroup__workflow_id__in=exclusive_workflow_ids
-                )
-                .distinct()
-                .values_list("id", flat=True)
-            )
-            DataConditionGroup.objects.filter(id__in=workflow_condition_group_ids).update(
-                organization_id=organization.id
-            )
+                ).distinct().update(organization_id=organization.id)
 
-            # Update DataConditionGroups that are directly owned by detectors
-            # These are linked via Detector.workflow_condition_group (unique FK)
-            # and are exclusively owned by the detector, so they always transfer
-            detector_condition_group_ids = (
-                Detector.objects.filter(
-                    id__in=detector_ids, workflow_condition_group_id__isnull=False
+                # when_condition_groups of the moved workflows are never shared, so move them too.
+                when_condition_group_ids = (
+                    Workflow.objects.filter(
+                        id__in=exclusive_workflow_ids, when_condition_group_id__isnull=False
+                    )
+                    .values_list("when_condition_group_id", flat=True)
+                    .distinct()
                 )
-                .values_list("workflow_condition_group_id", flat=True)
-                .distinct()
-            )
-            DataConditionGroup.objects.filter(id__in=detector_condition_group_ids).update(
-                organization_id=organization.id
-            )
-
-            # Update DataConditionGroups used as when_condition_group in transferred workflows
-            # DataConditionGroups are never shared, so transfer all when_condition_groups
-            when_condition_group_ids = (
-                Workflow.objects.filter(
-                    id__in=exclusive_workflow_ids, when_condition_group_id__isnull=False
+                DataConditionGroup.objects.filter(id__in=when_condition_group_ids).update(
+                    organization_id=organization.id
                 )
-                .values_list("when_condition_group_id", flat=True)
-                .distinct()
-            )
-            DataConditionGroup.objects.filter(id__in=when_condition_group_ids).update(
-                organization_id=organization.id
-            )
 
-            # Null out detector owners — the owning team/user won't belong to the new org
-            Detector.objects.filter(id__in=detector_ids).exclude(
-                owner_team_id__isnull=True, owner_user_id__isnull=True
-            ).update(owner_team_id=None, owner_user_id=None)
+                # Clone the shared workflows into the new org and re-point only this project's links.
+                if shared_workflow_ids:
+                    project_rule_ids = list(
+                        Rule.objects.filter(project_id=self.id).values_list("id", flat=True)
+                    )
+                    project_alert_rule_ids = list(
+                        AlertRule.objects.fetch_for_project(self).values_list("id", flat=True)
+                    )
+                    for workflow in Workflow.objects.filter(id__in=shared_workflow_ids):
+                        clone = _clone_workflow_to_organization(
+                            workflow,
+                            organization,
+                            resolve_environment_id(workflow.environment_id),
+                        )
+                        # Detectors are project-scoped and move with this project, so re-point all
+                        # of their workflow links (cron, issue_stream, error, ...) onto the clone.
+                        DetectorWorkflow.objects.filter(
+                            workflow=workflow, detector_id__in=detector_ids
+                        ).update(workflow=clone)
+                        # Re-point the legacy lookups for this project's Rule/AlertRule. Each Rule is
+                        # single-project and AlertRule is functionally single-project, so re-pointing
+                        # this project's rows is unambiguous.
+                        if project_rule_ids:
+                            AlertRuleWorkflow.objects.filter(
+                                workflow=workflow, rule_id__in=project_rule_ids
+                            ).update(workflow=clone)
+                        if project_alert_rule_ids:
+                            AlertRuleWorkflow.objects.filter(
+                                workflow=workflow, alert_rule_id__in=project_alert_rule_ids
+                            ).update(workflow=clone)
+
+                # DataConditionGroups directly owned by detectors (Detector.workflow_condition_group,
+                # a unique FK) are exclusively owned by the detector, so they always transfer.
+                detector_condition_group_ids = (
+                    Detector.objects.filter(
+                        id__in=detector_ids, workflow_condition_group_id__isnull=False
+                    )
+                    .values_list("workflow_condition_group_id", flat=True)
+                    .distinct()
+                )
+                DataConditionGroup.objects.filter(id__in=detector_condition_group_ids).update(
+                    organization_id=organization.id
+                )
+
+                # Null out detector owners — the owning team/user won't belong to the new org.
+                Detector.objects.filter(id__in=detector_ids).exclude(
+                    owner_team_id__isnull=True, owner_user_id__isnull=True
+                ).update(owner_team_id=None, owner_user_id=None)
 
         # Manually move over external issues to the new org
         linked_groups = GroupLink.objects.filter(project_id=self.id).values_list(

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -676,8 +676,8 @@ class Project(Model):
                 all_workflow_ids = set(
                     Workflow.objects.filter(
                         detectorworkflow__detector_id__in=detector_ids,
-                        organization_id=old_org_id,
                     )
+                    .exclude(organization_id=organization.id)
                     .distinct()
                     .values_list("id", flat=True)
                 )

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -49,7 +49,6 @@ from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.snowflake import save_with_snowflake_id, snowflake_id_model
-from sentry.workflow_engine.processors.project_transfer import clone_workflow_to_organization
 
 logger = logging.getLogger(__name__)
 
@@ -515,6 +514,9 @@ class Project(Model):
             DetectorWorkflow,
             Workflow,
         )
+        from sentry.workflow_engine.processors.project_transfer import (
+            clone_workflow_to_organization,
+        )
 
         old_org_id = self.organization_id
         org_changed = old_org_id != organization.id
@@ -672,7 +674,10 @@ class Project(Model):
                 )
 
                 all_workflow_ids = set(
-                    Workflow.objects.filter(detectorworkflow__detector_id__in=detector_ids)
+                    Workflow.objects.filter(
+                        detectorworkflow__detector_id__in=detector_ids,
+                        organization_id=old_org_id,
+                    )
                     .distinct()
                     .values_list("id", flat=True)
                 )
@@ -740,6 +745,9 @@ class Project(Model):
                 )
 
                 # Clone the shared workflows into the new org and re-point only this project's links.
+                # we use DetectorWorkflow to identify Workflows that need to be cloned, but once we clone
+                # we remove the DetectorWorkflow links to the old Workflow so that in a re-run these cloned
+                # workflows will be treated as exclusive and no-op transferred
                 if shared_workflow_ids:
                     project_rule_ids = list(
                         Rule.objects.filter(project_id=self.id).values_list("id", flat=True)

--- a/src/sentry/workflow_engine/processors/project_transfer.py
+++ b/src/sentry/workflow_engine/processors/project_transfer.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+from sentry.db.models import DefaultFieldsModel
+
+if TYPE_CHECKING:
+    from sentry.models.organization import Organization
+    from sentry.workflow_engine.models import Workflow
+
+
+def _simple_shallow_clone[T: DefaultFieldsModel](original: T, **overrides: Any) -> T:
+    new = copy.copy(original)
+    new.pk = None
+    new.id = None
+    for attr, value in overrides.items():
+        setattr(new, attr, value)
+    new.save()
+    return new
+
+
+def clone_workflow_to_organization(
+    workflow: Workflow,
+    destination_organization: Organization,
+    environment_id: int | None,
+) -> Workflow:
+    """Deep-copy a workflow and its condition graph into the destination organization.
+
+    Used by ``Project.transfer_to`` when a workflow is shared with detectors in other
+    projects: the transferring project gets its own copy in the new org while the original
+    is left intact for the projects that remain. The owner team/user is dropped because it
+    won't belong to the new org, and fire history / detector state are not copied.
+    """
+    from sentry.workflow_engine.models import (
+        DataCondition,
+        DataConditionGroup,
+        DataConditionGroupAction,
+        WorkflowDataConditionGroup,
+    )
+
+    def clone_condition_group(
+        condition_group: DataConditionGroup,
+    ) -> DataConditionGroup:
+        new_group = DataConditionGroup.objects.create(
+            organization_id=destination_organization.id,
+            logic_type=condition_group.logic_type,
+        )
+        for condition in DataCondition.objects.filter(condition_group=condition_group):
+            data_condition_overrides = {
+                "condition_group": new_group,
+                "type": condition.type,
+                "comparison": condition.comparison,
+                "condition_result": condition.condition_result,
+            }
+            _simple_shallow_clone(condition, **data_condition_overrides)
+
+        # Actions are not organization-scoped; clone them so the copy is fully isolated
+        # from the original workflow that stays behind in the old org.
+        for group_action in DataConditionGroupAction.objects.filter(
+            condition_group=condition_group
+        ).select_related("action"):
+            action = group_action.action
+            action_overrides = {
+                "type": action.type,
+                "data": action.data,
+                "integration_id": action.integration_id,
+                "status": action.status,
+                "config": action.config,
+            }
+            new_action = _simple_shallow_clone(action, **action_overrides)
+            _simple_shallow_clone(
+                group_action, **{"condition_group": new_group, "action": new_action}
+            )
+        return new_group
+
+    when_condition_group = workflow.when_condition_group
+    workflow_overrides = {
+        "organization_id": destination_organization.id,
+        "name": workflow.name,
+        "enabled": workflow.enabled,
+        "config": workflow.config,
+        "when_condition_group": clone_condition_group(when_condition_group)
+        if when_condition_group is not None
+        else None,
+        "environment_id": environment_id,
+    }
+    new_workflow = _simple_shallow_clone(workflow, **workflow_overrides)
+
+    for workflow_dcg in WorkflowDataConditionGroup.objects.filter(workflow=workflow):
+        _simple_shallow_clone(
+            workflow_dcg,
+            **{
+                "workflow": new_workflow,
+                "condition_group": clone_condition_group(workflow_dcg.condition_group),
+            },
+        )
+
+    return new_workflow

--- a/src/sentry/workflow_engine/processors/project_transfer.py
+++ b/src/sentry/workflow_engine/processors/project_transfer.py
@@ -4,6 +4,12 @@ import copy
 from typing import TYPE_CHECKING, Any
 
 from sentry.db.models import DefaultFieldsModel
+from sentry.workflow_engine.models import (
+    DataCondition,
+    DataConditionGroup,
+    DataConditionGroupAction,
+    WorkflowDataConditionGroup,
+)
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -32,12 +38,6 @@ def clone_workflow_to_organization(
     is left intact for the projects that remain. The owner team/user is dropped because it
     won't belong to the new org, and fire history / detector state are not copied.
     """
-    from sentry.workflow_engine.models import (
-        DataCondition,
-        DataConditionGroup,
-        DataConditionGroupAction,
-        WorkflowDataConditionGroup,
-    )
 
     def clone_condition_group(
         condition_group: DataConditionGroup,

--- a/src/sentry/workflow_engine/processors/project_transfer.py
+++ b/src/sentry/workflow_engine/processors/project_transfer.py
@@ -80,6 +80,10 @@ def clone_workflow_to_organization(
         "name": workflow.name,
         "enabled": workflow.enabled,
         "config": workflow.config,
+        # The owner team/user belongs to the old org, so it won't be valid in the
+        # destination org; drop it rather than carry a dangling reference.
+        "owner_user_id": None,
+        "owner_team_id": None,
         "when_condition_group": clone_condition_group(when_condition_group)
         if when_condition_group is not None
         else None,

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -66,344 +66,6 @@ class ProjectTest(APITestCase, TestCase):
 
         assert list(project.member_set.all()) == []
 
-    def test_transfer_to_organization(self) -> None:
-        from_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        to_org = self.create_organization()
-
-        project = self.create_project(teams=[team])
-        project_other = self.create_project(teams=[team])
-
-        rule = self.create_project_rule(
-            name="Golden Rule",
-            project=project,
-            environment_id=Environment.get_or_create(project, "production").id,
-        )
-        environment_from_new = self.create_environment(organization=from_org)
-        environment_from_existing = self.create_environment(organization=from_org)
-        environment_to_existing = self.create_environment(
-            organization=to_org, name=environment_from_existing.name
-        )
-
-        monitor = Monitor.objects.create(
-            name="test-monitor",
-            slug="test-monitor",
-            organization_id=from_org.id,
-            project_id=project.id,
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
-        )
-
-        monitor_also = Monitor.objects.create(
-            name="test-monitor-also",
-            slug="test-monitor-also",
-            organization_id=from_org.id,
-            project_id=project.id,
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
-        )
-        monitor_env_new = MonitorEnvironment.objects.create(
-            monitor=monitor_also, environment_id=environment_from_new.id
-        )
-        monitor_env_existing = MonitorEnvironment.objects.create(
-            monitor=monitor_also, environment_id=environment_from_existing.id
-        )
-
-        monitor_other = Monitor.objects.create(
-            name="test-monitor-other",
-            slug="test-monitor-other",
-            organization_id=from_org.id,
-            project_id=project_other.id,
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
-        )
-
-        monitor_to = Monitor.objects.create(
-            name="test-monitor",
-            slug="test-monitor",
-            organization_id=to_org.id,
-            project_id=self.create_project(name="other-project").id,
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
-        )
-
-        project.transfer_to(organization=to_org)
-
-        project = Project.objects.get(id=project.id)
-
-        assert project.teams.count() == 0
-        assert project.organization_id == to_org.id
-
-        updated_rule = project.rule_set.get(label="Golden Rule")
-        assert updated_rule.id == rule.id
-        assert updated_rule.environment_id != rule.environment_id
-        assert updated_rule.environment_id == Environment.get_or_create(project, "production").id
-
-        # check to make sure old monitor is scheduled for deletion
-        assert CellScheduledDeletion.objects.filter(
-            object_id=monitor.id, model_name="Monitor"
-        ).exists()
-
-        updated_monitor = Monitor.objects.get(slug="test-monitor-also")
-        assert updated_monitor.id == monitor_also.id
-        assert updated_monitor.organization_id == to_org.id
-        assert updated_monitor.project_id == project.id
-        monitor_env_new.refresh_from_db()
-        environment_to_new = Environment.objects.get(id=monitor_env_new.environment_id)
-        assert environment_to_new.organization_id == to_org.id
-        assert environment_to_new.name == environment_from_new.name
-        monitor_env_existing.refresh_from_db()
-        assert monitor_env_existing.environment_id == environment_to_existing.id
-
-        unmoved_monitor = Monitor.objects.get(slug="test-monitor-other")
-        assert unmoved_monitor.id == monitor_other.id
-        assert unmoved_monitor.organization_id == from_org.id
-        assert unmoved_monitor.project_id == project_other.id
-
-        existing_monitor = Monitor.objects.get(id=monitor_to.id)
-        assert existing_monitor.id == monitor_to.id
-        assert existing_monitor.organization_id == to_org.id
-        assert existing_monitor.project_id == monitor_to.project_id
-
-    def test_transfer_to_organization_slug_collision(self) -> None:
-        from_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        project = self.create_project(teams=[team], slug="matt")
-        to_org = self.create_organization()
-        # conflicting project slug
-        self.create_project(slug="matt", organization=to_org)
-
-        assert Project.objects.filter(organization=to_org).count() == 1
-
-        project.transfer_to(organization=to_org)
-
-        project = Project.objects.get(id=project.id)
-
-        assert project.teams.count() == 0
-        assert project.organization_id == to_org.id
-        assert project.slug != "matt"
-        assert Project.objects.filter(organization=to_org).count() == 2
-        assert Project.objects.filter(organization=from_org).count() == 0
-
-    def test_transfer_to_organization_releases(self) -> None:
-        from_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        to_org = self.create_organization()
-
-        project = self.create_project(teams=[team])
-
-        def project_props(proj: Project):
-            return {
-                "id": proj.id,
-                "slug": proj.slug,
-                "name": proj.name,
-                "forced_color": proj.forced_color,
-                "public": proj.public,
-                "date_added": proj.date_added,
-                "status": proj.status,
-                "first_event": proj.first_event,
-                "flags": proj.flags,
-                "platform": proj.platform,
-            }
-
-        project_before = project_props(project)
-
-        environment = Environment.get_or_create(project, "production")
-        release = Release.get_or_create(project=project, version="1.0")
-
-        ReleaseProjectEnvironment.objects.create(
-            project=project, release=release, environment=environment
-        )
-
-        assert Environment.objects.filter(id=environment.id).exists()
-        assert Environment.objects.filter(organization_id=from_org.id, projects=project).exists()
-
-        assert EnvironmentProject.objects.filter(environment=environment, project=project).exists()
-        assert ReleaseProjectEnvironment.objects.filter(
-            project=project, release=release, environment=environment
-        ).exists()
-        assert ReleaseProject.objects.filter(project=project, release=release).exists()
-
-        project.transfer_to(organization=to_org)
-
-        project = Project.objects.get(id=project.id)
-        project_after = project_props(project)
-
-        assert project_before == project_after
-        assert project.teams.count() == 0
-        assert project.organization_id == to_org.id
-
-        assert Environment.objects.filter(id=environment.id).exists()
-        assert not EnvironmentProject.objects.filter(
-            environment=environment, project=project
-        ).exists()
-        assert not ReleaseProjectEnvironment.objects.filter(
-            project=project, release=release, environment=environment
-        ).exists()
-        assert not ReleaseProject.objects.filter(project=project, release=release).exists()
-
-    def test_delete_on_transfer_repository_project_path_configs(self) -> None:
-        from_org = self.create_organization()
-        to_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        project = self.create_project(teams=[team])
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration, org_integration = self.create_provider_integration_for(
-                from_org, self.user, provider="github"
-            )
-
-        repository = Repository.objects.create(
-            organization_id=from_org.id,
-            name="example-repo",
-            integration_id=integration.id,
-        )
-
-        project_repo, _ = ProjectRepository.objects.get_or_create(
-            project=project,
-            repository=repository,
-            defaults={"source": ProjectRepositorySource.MANUAL},
-        )
-        repository_project_path_config = RepositoryProjectPathConfig.objects.create(
-            organization_integration_id=org_integration.id,
-            organization_id=from_org.id,
-            integration_id=integration.id,
-            stack_root="/app",
-            source_root="/src",
-            default_branch="main",
-            project_repository=project_repo,
-        )
-
-        ProjectCodeOwners.objects.create(
-            project=project,
-            repository_project_path_config=repository_project_path_config,
-            raw="*.py @getsentry/test-team",
-        )
-
-        project.transfer_to(organization=to_org)
-
-        assert RepositoryProjectPathConfig.objects.filter(organization_id=from_org.id).count() == 0
-        assert RepositoryProjectPathConfig.objects.filter(organization_id=to_org.id).count() == 0
-
-        assert (
-            RepositoryProjectPathConfig.objects.filter(
-                project_repository__project_id=project.id
-            ).count()
-            == 0
-        )
-
-        assert ProjectCodeOwners.objects.filter(project_id=project.id).count() == 0
-
-    def test_transfer_to_organization_alert_rules(self) -> None:
-        from_org = self.create_organization()
-        from_user = self.create_user()
-        self.create_member(user=from_user, role="member", organization=from_org)
-        team = self.create_team(organization=from_org)
-        to_org = self.create_organization()
-        to_team = self.create_team(organization=to_org)
-        to_user = self.create_user()
-        self.create_member(user=to_user, role="member", organization=to_org)
-
-        project = self.create_project(teams=[team])
-        environment = Environment.get_or_create(project, "production")
-
-        # should lose their owners
-        alert_rule = self.create_alert_rule(
-            organization=self.organization,
-            projects=[project],
-            owner=Actor.from_identifier(f"team:{team.id}"),
-            environment=environment,
-        )
-        snuba_query = SnubaQuery.objects.filter(id=alert_rule.snuba_query_id).get()
-        rule1 = self.create_project_rule(name="another test rule", project=project, owner_team=team)
-        rule2 = self.create_project_rule(name="rule4", project=project, owner_user_id=from_user.id)
-
-        # should keep their owners
-        rule3 = self.create_project_rule(name="rule2", project=project, owner_team=to_team)
-        rule4 = self.create_project_rule(name="rule3", project=project, owner_user_id=to_user.id)
-
-        assert EnvironmentProject.objects.count() == 1
-        assert snuba_query.environment is not None
-        assert snuba_query.environment.id == environment.id
-
-        project.transfer_to(organization=to_org)
-
-        alert_rule.refresh_from_db()
-        rule1.refresh_from_db()
-        rule2.refresh_from_db()
-        rule3.refresh_from_db()
-        rule4.refresh_from_db()
-        snuba_query.refresh_from_db()
-
-        assert (
-            Environment.objects.exclude(id=environment.id).count() == 1
-        )  # not the same as the from_org env
-        assert EnvironmentProject.objects.count() == 1
-        assert snuba_query.environment != environment
-        assert alert_rule.organization_id == to_org.id
-        assert alert_rule.user_id is None
-        assert alert_rule.team_id is None
-
-        for rule in (rule1, rule2):
-            assert rule.owner_user_id is None
-            assert rule.owner_team_id is None
-
-        assert rule3.owner_user_id is None
-        assert rule3.owner_team_id
-
-        assert rule4.owner_user_id
-        assert rule4.owner_team_id is None
-
-    def test_transfer_to_organization_external_issues(self) -> None:
-        from_org = self.create_organization()
-        to_org = self.create_organization()
-
-        project = self.create_project(organization=from_org)
-        group = self.create_group(project=project)
-        other_project = self.create_project(organization=from_org)
-        other_group = self.create_group(project=other_project)
-
-        self.integration = self.create_integration(
-            organization=self.organization,
-            provider="jira",
-            name="Jira",
-            external_id="jira:1",
-        )
-        ext_issue = ExternalIssue.objects.create(
-            organization_id=from_org.id,
-            integration_id=self.integration.id,
-            key="123",
-        )
-        other_ext_issue = ExternalIssue.objects.create(
-            organization_id=from_org.id,
-            integration_id=self.integration.id,
-            key="124",
-        )
-        group_link = GroupLink.objects.create(
-            group_id=group.id,
-            project_id=group.project_id,
-            linked_type=GroupLink.LinkedType.issue,
-            linked_id=ext_issue.id,
-        )
-        other_group_link = GroupLink.objects.create(
-            group_id=other_group.id,
-            project_id=other_group.project_id,
-            linked_type=GroupLink.LinkedType.issue,
-            linked_id=other_ext_issue.id,
-        )
-
-        project.transfer_to(organization=to_org)
-        project.refresh_from_db()
-        other_project.refresh_from_db()
-        ext_issue.refresh_from_db()
-        other_ext_issue.refresh_from_db()
-        group_link.refresh_from_db()
-        other_group_link.refresh_from_db()
-
-        assert project.organization_id == to_org.id
-        assert ext_issue.organization_id == to_org.id
-        assert group_link.project_id == project.id
-
-        assert other_project.organization_id == from_org.id
-        assert other_ext_issue.organization_id == from_org.id
-        assert other_group_link.project_id == other_project.id
-
     def test_get_absolute_url(self) -> None:
         url = self.project.get_absolute_url()
         assert (
@@ -488,90 +150,414 @@ class ProjectTest(APITestCase, TestCase):
         assert Detector.objects.filter(project=project, type=ErrorGroupType.slug).count() == 1
         assert Detector.objects.filter(project=project, type=IssueStreamGroupType.slug).count() == 1
 
-    def test_transfer_to_organization_with_metric_issue_detector_and_workflow(self) -> None:
-        from_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        to_org = self.create_organization()
-        project = self.create_project(teams=[team])
 
-        detector = self.create_detector(project=project)
-        data_source = self.create_data_source(organization=from_org)
-        data_source.detectors.add(detector)
-        workflow = self.create_workflow(organization=from_org)
-        self.create_detector_workflow(detector=detector, workflow=workflow)
+class TestProjectTransfer(TestCase):
+    def setUp(self) -> None:
+        self.from_org = self.create_organization()
+        self.team = self.create_team(organization=self.from_org)
+        self.to_org = self.create_organization()
+        self.project = self.create_project(teams=[self.team])
 
-        project.transfer_to(organization=to_org)
+        self.detector = self.create_detector(project=self.project)
+        self.data_source = self.create_data_source(organization=self.from_org)
+        self.data_source.detectors.add(self.detector)
+        self.workflow = self.create_workflow(organization=self.from_org)
+        self.create_detector_workflow(detector=self.detector, workflow=self.workflow)
 
-        project.refresh_from_db()
-        detector.refresh_from_db()
-        data_source.refresh_from_db()
-        workflow.refresh_from_db()
-
-        assert project.organization_id == to_org.id
-        assert detector.project_id == project.id
-        assert data_source.organization_id == to_org.id
-        assert workflow.organization_id == to_org.id
-        assert DetectorWorkflow.objects.filter(detector=detector, workflow=workflow).exists()
-
-    def test_transfer_to_organization_with_workflow_data_condition_groups(self) -> None:
-        from_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        to_org = self.create_organization()
-        project = self.create_project(teams=[team])
-
-        detector = self.create_detector(project=project)
-        workflow = self.create_workflow(organization=from_org)
-        self.create_detector_workflow(detector=detector, workflow=workflow)
-        condition_group = self.create_data_condition_group(organization=from_org)
-        self.create_workflow_data_condition_group(
-            workflow=workflow, condition_group=condition_group
+    def test_transfer_to_organization(self) -> None:
+        project_other = self.create_project(teams=[self.team])
+        rule = self.create_project_rule(
+            name="Golden Rule",
+            project=self.project,
+            environment_id=Environment.get_or_create(self.project, "production").id,
+        )
+        environment_from_new = self.create_environment(organization=self.from_org)
+        environment_from_existing = self.create_environment(organization=self.from_org)
+        environment_to_existing = self.create_environment(
+            organization=self.to_org, name=environment_from_existing.name
         )
 
-        project.transfer_to(organization=to_org)
+        monitor = Monitor.objects.create(
+            name="test-monitor",
+            slug="test-monitor",
+            organization_id=self.from_org.id,
+            project_id=self.project.id,
+            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+        )
 
-        project.refresh_from_db()
-        detector.refresh_from_db()
-        workflow.refresh_from_db()
+        monitor_also = Monitor.objects.create(
+            name="test-monitor-also",
+            slug="test-monitor-also",
+            organization_id=self.from_org.id,
+            project_id=self.project.id,
+            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+        )
+        monitor_env_new = MonitorEnvironment.objects.create(
+            monitor=monitor_also, environment_id=environment_from_new.id
+        )
+        monitor_env_existing = MonitorEnvironment.objects.create(
+            monitor=monitor_also, environment_id=environment_from_existing.id
+        )
+
+        monitor_other = Monitor.objects.create(
+            name="test-monitor-other",
+            slug="test-monitor-other",
+            organization_id=self.from_org.id,
+            project_id=project_other.id,
+            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+        )
+
+        monitor_to = Monitor.objects.create(
+            name="test-monitor",
+            slug="test-monitor",
+            organization_id=self.to_org.id,
+            project_id=self.create_project(name="other-project").id,
+            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+        )
+
+        self.project.transfer_to(organization=self.to_org)
+
+        self.project = Project.objects.get(id=self.project.id)
+
+        assert self.project.teams.count() == 0
+        assert self.project.organization_id == self.to_org.id
+
+        updated_rule = self.project.rule_set.get(label="Golden Rule")
+        assert updated_rule.id == rule.id
+        assert updated_rule.environment_id != rule.environment_id
+        assert (
+            updated_rule.environment_id == Environment.get_or_create(self.project, "production").id
+        )
+
+        # check to make sure old monitor is scheduled for deletion
+        assert CellScheduledDeletion.objects.filter(
+            object_id=monitor.id, model_name="Monitor"
+        ).exists()
+
+        updated_monitor = Monitor.objects.get(slug="test-monitor-also")
+        assert updated_monitor.id == monitor_also.id
+        assert updated_monitor.organization_id == self.to_org.id
+        assert updated_monitor.project_id == self.project.id
+        monitor_env_new.refresh_from_db()
+        environment_to_new = Environment.objects.get(id=monitor_env_new.environment_id)
+        assert environment_to_new.organization_id == self.to_org.id
+        assert environment_to_new.name == environment_from_new.name
+        monitor_env_existing.refresh_from_db()
+        assert monitor_env_existing.environment_id == environment_to_existing.id
+
+        unmoved_monitor = Monitor.objects.get(slug="test-monitor-other")
+        assert unmoved_monitor.id == monitor_other.id
+        assert unmoved_monitor.organization_id == self.from_org.id
+        assert unmoved_monitor.project_id == project_other.id
+
+        existing_monitor = Monitor.objects.get(id=monitor_to.id)
+        assert existing_monitor.id == monitor_to.id
+        assert existing_monitor.organization_id == self.to_org.id
+        assert existing_monitor.project_id == monitor_to.project_id
+
+    def test_transfer_to_organization_slug_collision(self) -> None:
+        # conflicting project slug
+        self.create_project(slug="matt", organization=self.to_org)
+
+        assert Project.objects.filter(organization=self.to_org).count() == 1
+
+        self.project.transfer_to(organization=self.to_org)
+
+        self.project = Project.objects.get(id=self.project.id)
+
+        assert self.project.teams.count() == 0
+        assert self.project.organization_id == self.to_org.id
+        assert self.project.slug != "matt"
+        assert Project.objects.filter(organization=self.to_org).count() == 2
+        assert Project.objects.filter(organization=self.from_org).count() == 0
+
+    def test_transfer_to_organization_releases(self) -> None:
+        def project_props(proj: Project):
+            return {
+                "id": proj.id,
+                "slug": proj.slug,
+                "name": proj.name,
+                "forced_color": proj.forced_color,
+                "public": proj.public,
+                "date_added": proj.date_added,
+                "status": proj.status,
+                "first_event": proj.first_event,
+                "flags": proj.flags,
+                "platform": proj.platform,
+            }
+
+        project_before = project_props(self.project)
+
+        environment = Environment.get_or_create(self.project, "production")
+        release = Release.get_or_create(project=self.project, version="1.0")
+
+        ReleaseProjectEnvironment.objects.create(
+            project=self.project, release=release, environment=environment
+        )
+
+        assert Environment.objects.filter(id=environment.id).exists()
+        assert Environment.objects.filter(
+            organization_id=self.from_org.id, projects=self.project
+        ).exists()
+
+        assert EnvironmentProject.objects.filter(
+            environment=environment, project=self.project
+        ).exists()
+        assert ReleaseProjectEnvironment.objects.filter(
+            project=self.project, release=release, environment=environment
+        ).exists()
+        assert ReleaseProject.objects.filter(project=self.project, release=release).exists()
+
+        self.project.transfer_to(organization=self.to_org)
+
+        self.project = Project.objects.get(id=self.project.id)
+        project_after = project_props(self.project)
+
+        assert project_before == project_after
+        assert self.project.teams.count() == 0
+        assert self.project.organization_id == self.to_org.id
+
+        assert Environment.objects.filter(id=environment.id).exists()
+        assert not EnvironmentProject.objects.filter(
+            environment=environment, project=self.project
+        ).exists()
+        assert not ReleaseProjectEnvironment.objects.filter(
+            project=self.project, release=release, environment=environment
+        ).exists()
+        assert not ReleaseProject.objects.filter(project=self.project, release=release).exists()
+
+    def test_delete_on_transfer_repository_project_path_configs(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration, org_integration = self.create_provider_integration_for(
+                self.from_org, self.user, provider="github"
+            )
+
+        repository = Repository.objects.create(
+            organization_id=self.from_org.id,
+            name="example-repo",
+            integration_id=integration.id,
+        )
+
+        project_repo, _ = ProjectRepository.objects.get_or_create(
+            project=self.project,
+            repository=repository,
+            defaults={"source": ProjectRepositorySource.MANUAL},
+        )
+        repository_project_path_config = RepositoryProjectPathConfig.objects.create(
+            organization_integration_id=org_integration.id,
+            organization_id=self.from_org.id,
+            integration_id=integration.id,
+            stack_root="/app",
+            source_root="/src",
+            default_branch="main",
+            project_repository=project_repo,
+        )
+
+        ProjectCodeOwners.objects.create(
+            project=self.project,
+            repository_project_path_config=repository_project_path_config,
+            raw="*.py @getsentry/test-team",
+        )
+
+        self.project.transfer_to(organization=self.to_org)
+
+        assert (
+            RepositoryProjectPathConfig.objects.filter(organization_id=self.from_org.id).count()
+            == 0
+        )
+        assert (
+            RepositoryProjectPathConfig.objects.filter(organization_id=self.to_org.id).count() == 0
+        )
+
+        assert (
+            RepositoryProjectPathConfig.objects.filter(
+                project_repository__project_id=self.project.id
+            ).count()
+            == 0
+        )
+
+        assert ProjectCodeOwners.objects.filter(project_id=self.project.id).count() == 0
+
+    def test_transfer_to_organization_alert_rules(self) -> None:
+        from_user = self.create_user()
+        self.create_member(user=from_user, role="member", organization=self.from_org)
+        to_team = self.create_team(organization=self.to_org)
+        to_user = self.create_user()
+        self.create_member(user=to_user, role="member", organization=self.to_org)
+
+        self.project = self.create_project(teams=[self.team])
+        environment = Environment.get_or_create(self.project, "production")
+
+        # should lose their owners
+        alert_rule = self.create_alert_rule(
+            organization=self.organization,
+            projects=[self.project],
+            owner=Actor.from_identifier(f"team:{self.team.id}"),
+            environment=environment,
+        )
+        snuba_query = SnubaQuery.objects.filter(id=alert_rule.snuba_query_id).get()
+        rule1 = self.create_project_rule(
+            name="another test rule", project=self.project, owner_team=self.team
+        )
+        rule2 = self.create_project_rule(
+            name="rule4", project=self.project, owner_user_id=from_user.id
+        )
+
+        # should keep their owners
+        rule3 = self.create_project_rule(name="rule2", project=self.project, owner_team=to_team)
+        rule4 = self.create_project_rule(
+            name="rule3", project=self.project, owner_user_id=to_user.id
+        )
+
+        assert EnvironmentProject.objects.count() == 1
+        assert snuba_query.environment is not None
+        assert snuba_query.environment.id == environment.id
+
+        self.project.transfer_to(organization=self.to_org)
+
+        alert_rule.refresh_from_db()
+        rule1.refresh_from_db()
+        rule2.refresh_from_db()
+        rule3.refresh_from_db()
+        rule4.refresh_from_db()
+        snuba_query.refresh_from_db()
+
+        assert (
+            Environment.objects.exclude(id=environment.id).count() == 1
+        )  # not the same as the from_org env
+        assert EnvironmentProject.objects.count() == 1
+        assert snuba_query.environment != environment
+        assert alert_rule.organization_id == self.to_org.id
+        assert alert_rule.user_id is None
+        assert alert_rule.team_id is None
+
+        for rule in (rule1, rule2):
+            assert rule.owner_user_id is None
+            assert rule.owner_team_id is None
+
+        assert rule3.owner_user_id is None
+        assert rule3.owner_team_id
+
+        assert rule4.owner_user_id
+        assert rule4.owner_team_id is None
+
+    def test_transfer_to_organization_external_issues(self) -> None:
+        group = self.create_group(project=self.project)
+        other_project = self.create_project(organization=self.from_org)
+        other_group = self.create_group(project=other_project)
+
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="jira",
+            name="Jira",
+            external_id="jira:1",
+        )
+        ext_issue = ExternalIssue.objects.create(
+            organization_id=self.from_org.id,
+            integration_id=self.integration.id,
+            key="123",
+        )
+        other_ext_issue = ExternalIssue.objects.create(
+            organization_id=self.from_org.id,
+            integration_id=self.integration.id,
+            key="124",
+        )
+        group_link = GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=ext_issue.id,
+        )
+        other_group_link = GroupLink.objects.create(
+            group_id=other_group.id,
+            project_id=other_group.project_id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=other_ext_issue.id,
+        )
+
+        self.project.transfer_to(organization=self.to_org)
+        self.project.refresh_from_db()
+        other_project.refresh_from_db()
+        ext_issue.refresh_from_db()
+        other_ext_issue.refresh_from_db()
+        group_link.refresh_from_db()
+        other_group_link.refresh_from_db()
+
+        assert self.project.organization_id == self.to_org.id
+        assert ext_issue.organization_id == self.to_org.id
+        assert group_link.project_id == self.project.id
+
+        assert other_project.organization_id == self.from_org.id
+        assert other_ext_issue.organization_id == self.from_org.id
+        assert other_group_link.project_id == other_project.id
+
+    def test_transfer_to_organization_with_metric_issue_detector_and_workflow(self) -> None:
+        self.project.transfer_to(organization=self.to_org)
+
+        self.project.refresh_from_db()
+        self.detector.refresh_from_db()
+        self.data_source.refresh_from_db()
+        self.workflow.refresh_from_db()
+
+        assert self.project.organization_id == self.to_org.id
+        assert self.detector.project_id == self.project.id
+        assert self.data_source.organization_id == self.to_org.id
+        assert self.workflow.organization_id == self.to_org.id
+        assert DetectorWorkflow.objects.filter(
+            detector=self.detector, workflow=self.workflow
+        ).exists()
+
+    def test_transfer_to_organization_with_workflow_data_condition_groups(self) -> None:
+        condition_group = self.create_data_condition_group(organization=self.from_org)
+        self.create_workflow_data_condition_group(
+            workflow=self.workflow, condition_group=condition_group
+        )
+
+        self.project.transfer_to(organization=self.to_org)
+
+        self.project.refresh_from_db()
+        self.detector.refresh_from_db()
+        self.workflow.refresh_from_db()
         condition_group.refresh_from_db()
 
-        assert project.organization_id == to_org.id
-        assert detector.project_id == project.id
-        assert workflow.organization_id == to_org.id
-        assert condition_group.organization_id == to_org.id
+        assert self.project.organization_id == self.to_org.id
+        assert self.detector.project_id == self.project.id
+        assert self.workflow.organization_id == self.to_org.id
+        assert condition_group.organization_id == self.to_org.id
         wdcg = condition_group.workflowdataconditiongroup_set.first()
         assert wdcg is not None
-        assert wdcg.workflow_id == workflow.id
+        assert wdcg.workflow_id == self.workflow.id
 
     def test_transfer_to_organization_clones_shared_workflows(self) -> None:
-        from_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        to_org = self.create_organization()
-
-        project_a = self.create_project(teams=[team], name="Project A")
-        project_b = self.create_project(teams=[team], organization=from_org, name="Project B")
+        project_a = self.create_project(teams=[self.team], name="Project A")
+        project_b = self.create_project(
+            teams=[self.team], organization=self.from_org, name="Project B"
+        )
 
         detector_a = self.create_detector(project=project_a)
         detector_b = self.create_detector(project=project_b)
 
         # Shared across both projects' detectors, so it must be cloned (not moved) on transfer.
-        shared_workflow = self.create_workflow(organization=from_org, name="Shared Workflow")
+        shared_workflow = self.create_workflow(organization=self.from_org, name="Shared Workflow")
         self.create_detector_workflow(detector=detector_a, workflow=shared_workflow)
         self.create_detector_workflow(detector=detector_b, workflow=shared_workflow)
 
-        exclusive_workflow = self.create_workflow(organization=from_org, name="Exclusive Workflow")
+        exclusive_workflow = self.create_workflow(
+            organization=self.from_org, name="Exclusive Workflow"
+        )
         self.create_detector_workflow(detector=detector_a, workflow=exclusive_workflow)
 
-        shared_dcg = self.create_data_condition_group(organization=from_org)
+        shared_dcg = self.create_data_condition_group(organization=self.from_org)
         self.create_workflow_data_condition_group(
             workflow=shared_workflow, condition_group=shared_dcg
         )
 
-        exclusive_dcg = self.create_data_condition_group(organization=from_org)
+        exclusive_dcg = self.create_data_condition_group(organization=self.from_org)
         self.create_workflow_data_condition_group(
             workflow=exclusive_workflow, condition_group=exclusive_dcg
         )
 
-        project_a.transfer_to(organization=to_org)
+        project_a.transfer_to(organization=self.to_org)
 
         project_a.refresh_from_db()
         project_b.refresh_from_db()
@@ -582,21 +568,21 @@ class ProjectTest(APITestCase, TestCase):
         shared_dcg.refresh_from_db()
         exclusive_dcg.refresh_from_db()
 
-        assert project_a.organization_id == to_org.id
-        assert project_b.organization_id == from_org.id
+        assert project_a.organization_id == self.to_org.id
+        assert project_b.organization_id == self.from_org.id
         assert detector_a.project_id == project_a.id
         assert detector_b.project_id == project_b.id
 
         # The exclusive workflow is moved as-is.
-        assert exclusive_workflow.organization_id == to_org.id
-        assert exclusive_dcg.organization_id == to_org.id
+        assert exclusive_workflow.organization_id == self.to_org.id
+        assert exclusive_dcg.organization_id == self.to_org.id
         assert DetectorWorkflow.objects.filter(
             detector=detector_a, workflow=exclusive_workflow
         ).exists()
 
         # The original shared workflow stays behind for project_b, no longer linked to detector_a.
-        assert shared_workflow.organization_id == from_org.id
-        assert shared_dcg.organization_id == from_org.id
+        assert shared_workflow.organization_id == self.from_org.id
+        assert shared_dcg.organization_id == self.from_org.id
         assert DetectorWorkflow.objects.filter(
             detector=detector_b, workflow=shared_workflow
         ).exists()
@@ -605,7 +591,7 @@ class ProjectTest(APITestCase, TestCase):
         ).exists()
 
         # detector_a is re-pointed onto a clone of the shared workflow that lives in the new org.
-        clone = Workflow.objects.get(organization=to_org, name="Shared Workflow")
+        clone = Workflow.objects.get(organization=self.to_org, name="Shared Workflow")
         assert clone.id != shared_workflow.id
         assert DetectorWorkflow.objects.filter(detector=detector_a, workflow=clone).exists()
 
@@ -616,38 +602,36 @@ class ProjectTest(APITestCase, TestCase):
         assert shared_dcg.id not in clone_condition_group_ids
         assert (
             DataConditionGroup.objects.filter(
-                id__in=clone_condition_group_ids, organization=to_org
+                id__in=clone_condition_group_ids, organization=self.to_org
             ).count()
             == 1
         )
 
     def test_transfer_to_organization_clones_shared_workflow_actions(self) -> None:
-        from_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        to_org = self.create_organization()
-
-        project_a = self.create_project(teams=[team], name="Project A")
-        project_b = self.create_project(teams=[team], organization=from_org, name="Project B")
+        project_a = self.create_project(teams=[self.team], name="Project A")
+        project_b = self.create_project(
+            teams=[self.team], organization=self.from_org, name="Project B"
+        )
 
         detector_a = self.create_detector(project=project_a)
         detector_b = self.create_detector(project=project_b)
 
-        shared_workflow = self.create_workflow(organization=from_org, name="Shared Workflow")
+        shared_workflow = self.create_workflow(organization=self.from_org, name="Shared Workflow")
         self.create_detector_workflow(detector=detector_a, workflow=shared_workflow)
         self.create_detector_workflow(detector=detector_b, workflow=shared_workflow)
 
-        shared_dcg = self.create_data_condition_group(organization=from_org)
+        shared_dcg = self.create_data_condition_group(organization=self.from_org)
         self.create_workflow_data_condition_group(
             workflow=shared_workflow, condition_group=shared_dcg
         )
         action = self.create_action()
         self.create_data_condition_group_action(action=action, condition_group=shared_dcg)
 
-        project_a.transfer_to(organization=to_org)
+        project_a.transfer_to(organization=self.to_org)
 
         # The clone gets its own Action copy; the original Action is untouched and still attached
         # to the workflow that stays behind.
-        clone = Workflow.objects.get(organization=to_org, name="Shared Workflow")
+        clone = Workflow.objects.get(organization=self.to_org, name="Shared Workflow")
         clone_condition_group_ids = WorkflowDataConditionGroup.objects.filter(
             workflow=clone
         ).values_list("condition_group_id", flat=True)
@@ -665,73 +649,100 @@ class ProjectTest(APITestCase, TestCase):
             condition_group=shared_dcg, action=action
         ).exists()
 
+    def test_transfer_to_organization_clones_shared_workflows_is_idempotent(self) -> None:
+        project_a = self.create_project(teams=[self.team], name="Project A")
+        project_b = self.create_project(
+            teams=[self.team], organization=self.from_org, name="Project B"
+        )
+
+        detector_a = self.create_detector(project=project_a)
+        detector_b = self.create_detector(project=project_b)
+
+        shared_workflow = self.create_workflow(organization=self.from_org, name="Shared Workflow")
+        self.create_detector_workflow(detector=detector_a, workflow=shared_workflow)
+        self.create_detector_workflow(detector=detector_b, workflow=shared_workflow)
+
+        shared_dcg = self.create_data_condition_group(organization=self.from_org)
+        self.create_workflow_data_condition_group(
+            workflow=shared_workflow, condition_group=shared_dcg
+        )
+
+        project_a.transfer_to(organization=self.to_org)
+
+        clone = Workflow.objects.get(organization=self.to_org, name="Shared Workflow")
+        clone_condition_group_ids = list(
+            WorkflowDataConditionGroup.objects.filter(workflow=clone).values_list(
+                "condition_group_id", flat=True
+            )
+        )
+
+        # After the first transfer the clone is exclusive to project_a's detector, so a second
+        # transfer should move it as-is without producing another clone or new condition groups.
+        project_a.transfer_to(organization=self.to_org)
+
+        assert (
+            Workflow.objects.filter(organization=self.to_org, name="Shared Workflow").count() == 1
+        )
+        clone.refresh_from_db()
+        assert clone.organization_id == self.to_org.id
+        assert DetectorWorkflow.objects.filter(detector=detector_a, workflow=clone).exists()
+        assert (
+            list(
+                WorkflowDataConditionGroup.objects.filter(workflow=clone).values_list(
+                    "condition_group_id", flat=True
+                )
+            )
+            == clone_condition_group_ids
+        )
+
     def test_transfer_to_organization_with_detector_workflow_condition_group(self) -> None:
-        from_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        to_org = self.create_organization()
-        project = self.create_project(teams=[team])
+        workflow_condition_group = self.create_data_condition_group(organization=self.from_org)
+        self.detector.workflow_condition_group = workflow_condition_group
+        self.detector.save()
 
-        detector = self.create_detector(project=project)
-        workflow_condition_group = self.create_data_condition_group(organization=from_org)
-        detector.workflow_condition_group = workflow_condition_group
-        detector.save()
+        self.project.transfer_to(organization=self.to_org)
 
-        project.transfer_to(organization=to_org)
-
-        project.refresh_from_db()
-        detector.refresh_from_db()
+        self.project.refresh_from_db()
+        self.detector.refresh_from_db()
         workflow_condition_group.refresh_from_db()
 
-        assert project.organization_id == to_org.id
-        assert detector.project_id == project.id
-        assert workflow_condition_group.organization_id == to_org.id
-        assert detector.workflow_condition_group_id == workflow_condition_group.id
+        assert self.project.organization_id == self.to_org.id
+        assert self.detector.project_id == self.project.id
+        assert workflow_condition_group.organization_id == self.to_org.id
+        assert self.detector.workflow_condition_group_id == workflow_condition_group.id
 
     def test_transfer_to_organization_with_workflow_when_condition_groups(self) -> None:
-        from_org = self.create_organization()
-        to_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        project = self.create_project(teams=[team])
-
-        detector = self.create_detector(project=project)
-        when_condition_group = self.create_data_condition_group(organization=from_org)
+        detector = self.create_detector(project=self.project)
+        when_condition_group = self.create_data_condition_group(organization=self.from_org)
         workflow = self.create_workflow(
-            organization=from_org, when_condition_group=when_condition_group
+            organization=self.from_org, when_condition_group=when_condition_group
         )
         self.create_detector_workflow(detector=detector, workflow=workflow)
 
-        project.transfer_to(organization=to_org)
+        self.project.transfer_to(organization=self.to_org)
 
-        project.refresh_from_db()
+        self.project.refresh_from_db()
         detector.refresh_from_db()
         workflow.refresh_from_db()
         when_condition_group.refresh_from_db()
 
-        assert project.organization_id == to_org.id
-        assert detector.project_id == project.id
-        assert workflow.organization_id == to_org.id
-        assert when_condition_group.organization_id == to_org.id
+        assert self.project.organization_id == self.to_org.id
+        assert detector.project_id == self.project.id
+        assert workflow.organization_id == self.to_org.id
+        assert when_condition_group.organization_id == self.to_org.id
 
     def test_transfer_to_organization_updates_workflow_environment(self) -> None:
-        from_org = self.create_organization()
-        to_org = self.create_organization()
-        team = self.create_team(organization=from_org)
-        project = self.create_project(teams=[team])
+        env = self.create_environment(project=self.project, name="production")
+        self.workflow.update(environment_id=env.id)
+        self.project.transfer_to(organization=self.to_org)
 
-        env = self.create_environment(project=project, name="production")
-        detector = self.create_detector(project=project)
-        workflow = self.create_workflow(organization=from_org, environment=env)
-        self.create_detector_workflow(detector=detector, workflow=workflow)
+        self.workflow.refresh_from_db()
 
-        project.transfer_to(organization=to_org)
-
-        workflow.refresh_from_db()
-
-        assert workflow.organization_id == to_org.id
-        assert workflow.environment_id is not None
-        assert workflow.environment_id != env.id
-        new_env = Environment.objects.get(id=workflow.environment_id)
-        assert new_env.organization_id == to_org.id
+        assert self.workflow.organization_id == self.to_org.id
+        assert self.workflow.environment_id is not None
+        assert self.workflow.environment_id != env.id
+        new_env = Environment.objects.get(id=self.workflow.environment_id)
+        assert new_env.organization_id == self.to_org.id
         assert new_env.name == "production"
 
     def test_transfer_to_organization_nulls_detector_owner(self) -> None:

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -538,7 +538,10 @@ class TestProjectTransfer(TestCase):
         detector_b = self.create_detector(project=project_b)
 
         # Shared across both projects' detectors, so it must be cloned (not moved) on transfer.
-        shared_workflow = self.create_workflow(organization=self.from_org, name="Shared Workflow")
+        # The owner belongs to the old org, so the clone must drop it.
+        shared_workflow = self.create_workflow(
+            organization=self.from_org, name="Shared Workflow", owner_team_id=self.team.id
+        )
         self.create_detector_workflow(detector=detector_a, workflow=shared_workflow)
         self.create_detector_workflow(detector=detector_b, workflow=shared_workflow)
 
@@ -580,8 +583,10 @@ class TestProjectTransfer(TestCase):
             detector=detector_a, workflow=exclusive_workflow
         ).exists()
 
-        # The original shared workflow stays behind for project_b, no longer linked to detector_a.
+        # The original shared workflow stays behind for project_b, no longer linked to detector_a,
+        # and keeps its owner.
         assert shared_workflow.organization_id == self.from_org.id
+        assert shared_workflow.owner_team_id == self.team.id
         assert shared_dcg.organization_id == self.from_org.id
         assert DetectorWorkflow.objects.filter(
             detector=detector_b, workflow=shared_workflow
@@ -594,6 +599,10 @@ class TestProjectTransfer(TestCase):
         clone = Workflow.objects.get(organization=self.to_org, name="Shared Workflow")
         assert clone.id != shared_workflow.id
         assert DetectorWorkflow.objects.filter(detector=detector_a, workflow=clone).exists()
+
+        # The owner is dropped on the clone since it belongs to the old org.
+        assert clone.owner_team_id is None
+        assert clone.owner_user_id is None
 
         # The clone has its own condition group in the new org; the original is untouched.
         clone_condition_group_ids = WorkflowDataConditionGroup.objects.filter(

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -256,7 +256,9 @@ class TestProjectTransfer(TestCase):
         assert existing_monitor.project_id == monitor_to.project_id
 
     def test_transfer_to_organization_slug_collision(self) -> None:
-        # conflicting project slug
+        # give the project being transferred a slug that collides with an
+        # existing project in the target org
+        self.project.update(slug="matt")
         self.create_project(slug="matt", organization=self.to_org)
 
         assert Project.objects.filter(organization=self.to_org).count() == 1

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -34,7 +34,15 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.actor import Actor
 from sentry.users.models.user import User
 from sentry.users.models.user_option import UserOption
-from sentry.workflow_engine.models import Detector, DetectorWorkflow
+from sentry.workflow_engine.models import (
+    Action,
+    DataConditionGroup,
+    DataConditionGroupAction,
+    Detector,
+    DetectorWorkflow,
+    Workflow,
+    WorkflowDataConditionGroup,
+)
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
@@ -534,7 +542,7 @@ class ProjectTest(APITestCase, TestCase):
         assert wdcg is not None
         assert wdcg.workflow_id == workflow.id
 
-    def test_transfer_to_organization_does_not_transfer_shared_workflows(self) -> None:
+    def test_transfer_to_organization_clones_shared_workflows(self) -> None:
         from_org = self.create_organization()
         team = self.create_team(organization=from_org)
         to_org = self.create_organization()
@@ -545,6 +553,7 @@ class ProjectTest(APITestCase, TestCase):
         detector_a = self.create_detector(project=project_a)
         detector_b = self.create_detector(project=project_b)
 
+        # Shared across both projects' detectors, so it must be cloned (not moved) on transfer.
         shared_workflow = self.create_workflow(organization=from_org, name="Shared Workflow")
         self.create_detector_workflow(detector=detector_a, workflow=shared_workflow)
         self.create_detector_workflow(detector=detector_b, workflow=shared_workflow)
@@ -577,18 +586,83 @@ class ProjectTest(APITestCase, TestCase):
         assert project_b.organization_id == from_org.id
         assert detector_a.project_id == project_a.id
         assert detector_b.project_id == project_b.id
-        assert shared_workflow.organization_id == from_org.id
+
+        # The exclusive workflow is moved as-is.
         assert exclusive_workflow.organization_id == to_org.id
-        assert shared_dcg.organization_id == from_org.id
         assert exclusive_dcg.organization_id == to_org.id
         assert DetectorWorkflow.objects.filter(
-            detector=detector_a, workflow=shared_workflow
+            detector=detector_a, workflow=exclusive_workflow
         ).exists()
+
+        # The original shared workflow stays behind for project_b, no longer linked to detector_a.
+        assert shared_workflow.organization_id == from_org.id
+        assert shared_dcg.organization_id == from_org.id
         assert DetectorWorkflow.objects.filter(
             detector=detector_b, workflow=shared_workflow
         ).exists()
-        assert DetectorWorkflow.objects.filter(
-            detector=detector_a, workflow=exclusive_workflow
+        assert not DetectorWorkflow.objects.filter(
+            detector=detector_a, workflow=shared_workflow
+        ).exists()
+
+        # detector_a is re-pointed onto a clone of the shared workflow that lives in the new org.
+        clone = Workflow.objects.get(organization=to_org, name="Shared Workflow")
+        assert clone.id != shared_workflow.id
+        assert DetectorWorkflow.objects.filter(detector=detector_a, workflow=clone).exists()
+
+        # The clone has its own condition group in the new org; the original is untouched.
+        clone_condition_group_ids = WorkflowDataConditionGroup.objects.filter(
+            workflow=clone
+        ).values_list("condition_group_id", flat=True)
+        assert shared_dcg.id not in clone_condition_group_ids
+        assert (
+            DataConditionGroup.objects.filter(
+                id__in=clone_condition_group_ids, organization=to_org
+            ).count()
+            == 1
+        )
+
+    def test_transfer_to_organization_clones_shared_workflow_actions(self) -> None:
+        from_org = self.create_organization()
+        team = self.create_team(organization=from_org)
+        to_org = self.create_organization()
+
+        project_a = self.create_project(teams=[team], name="Project A")
+        project_b = self.create_project(teams=[team], organization=from_org, name="Project B")
+
+        detector_a = self.create_detector(project=project_a)
+        detector_b = self.create_detector(project=project_b)
+
+        shared_workflow = self.create_workflow(organization=from_org, name="Shared Workflow")
+        self.create_detector_workflow(detector=detector_a, workflow=shared_workflow)
+        self.create_detector_workflow(detector=detector_b, workflow=shared_workflow)
+
+        shared_dcg = self.create_data_condition_group(organization=from_org)
+        self.create_workflow_data_condition_group(
+            workflow=shared_workflow, condition_group=shared_dcg
+        )
+        action = self.create_action()
+        self.create_data_condition_group_action(action=action, condition_group=shared_dcg)
+
+        project_a.transfer_to(organization=to_org)
+
+        # The clone gets its own Action copy; the original Action is untouched and still attached
+        # to the workflow that stays behind.
+        clone = Workflow.objects.get(organization=to_org, name="Shared Workflow")
+        clone_condition_group_ids = WorkflowDataConditionGroup.objects.filter(
+            workflow=clone
+        ).values_list("condition_group_id", flat=True)
+        clone_actions = Action.objects.filter(
+            dataconditiongroupaction__condition_group_id__in=clone_condition_group_ids
+        )
+        assert clone_actions.count() == 1
+        clone_action = clone_actions.get()
+        assert clone_action.id != action.id
+        assert clone_action.type == action.type
+        assert clone_action.data == action.data
+        assert clone_action.config == action.config
+
+        assert DataConditionGroupAction.objects.filter(
+            condition_group=shared_dcg, action=action
         ).exists()
 
     def test_transfer_to_organization_with_detector_workflow_condition_group(self) -> None:


### PR DESCRIPTION
When a project is transferred to a new organization we move over all of the `Rule` and `AlertRule` objects but don't necessarily move over all the `Workflow` objects. Workflows can be connected to multiple detectors that could be in multiple projects, and if that is the case, we don't transfer them. This leaves us in an inconsistent state because we've dual written most (except for recently created ones) workflows with a rule or alert rule and we've ended up with `AlertRuleWorkflow` rows that reference 2 organizations. When we use that model to look something up, we could end up fetching data from the wrong organization. Previous PRs have added checks against that, but this fixes the project transfer to deeply clone the Workflow if it is shared so that it can live in both organizations and avoid this problem.