### PR TITLE
ref(traces): remove stale events-trace-light frontend references

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -213,13 +213,6 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/events-trace-light/${TRACE_ID}/`,
-    body: trace
-      ? {transactions: [trace], orphan_errors: []}
-      : {transactions: [], orphan_errors: []},
-  });
-
-  MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
     body: [],
   });

--- a/static/app/views/performance/newTraceDetails/traceApi/types.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/types.tsx
@@ -3,7 +3,7 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 
 /**
  * `EventLite` represents the type of a simplified event from
- * the `events-trace` and `events-trace-light` endpoints.
+ * the `events-trace` endpoint.
  */
 type EventLite = {
   event_id: string;


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/116515. Remove references to deprecated endpoint.