### PR TITLE
feat(jira): Wire Marketplace installs through the API pipeline modal

### DIFF
--- a/static/app/components/pipeline/integrationJira/index.spec.tsx
+++ b/static/app/components/pipeline/integrationJira/index.spec.tsx
@@ -1,0 +1,52 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {createMakeStepProps} from 'sentry/components/pipeline/testUtils';
+
+import {jiraIntegrationPipeline} from '.';
+
+const JiraConfirmInstallStep = jiraIntegrationPipeline.steps[0].component;
+
+const makeStepProps = createMakeStepProps({totalSteps: 1});
+
+describe('JiraConfirmInstallStep', () => {
+  const stepData = {
+    baseUrl: 'https://example.atlassian.net',
+    organization: 'My Org',
+    state: 'pipeline-sig',
+  };
+
+  it('renders the workspace, organization, and a warning without auto-advancing', () => {
+    const advance = jest.fn();
+    render(<JiraConfirmInstallStep {...makeStepProps({stepData, advance})} />);
+
+    expect(
+      screen.getByRole('heading', {name: 'Connect Jira to Sentry'})
+    ).toBeInTheDocument();
+    expect(screen.getByText('https://example.atlassian.net')).toBeInTheDocument();
+    expect(screen.getByText(/My Org/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/If you did not start this installation yourself/)
+    ).toBeInTheDocument();
+
+    // No auto-advance: the user must click to confirm.
+    expect(advance).not.toHaveBeenCalled();
+  });
+
+  it('advances with the pipeline state when the install button is clicked', async () => {
+    const advance = jest.fn();
+    render(<JiraConfirmInstallStep {...makeStepProps({stepData, advance})} />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Install Jira integration'}));
+
+    expect(advance).toHaveBeenCalledWith({state: 'pipeline-sig'});
+    expect(advance).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the install button until step data is available', () => {
+    const advance = jest.fn();
+    render(<JiraConfirmInstallStep {...makeStepProps({stepData: null, advance})} />);
+
+    expect(screen.getByRole('button', {name: 'Install Jira integration'})).toBeDisabled();
+    expect(advance).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/components/pipeline/integrationJira/index.tsx
+++ b/static/app/components/pipeline/integrationJira/index.tsx
@@ -1,0 +1,86 @@
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import type {
+  PipelineDefinition,
+  PipelineStepProps,
+} from 'sentry/components/pipeline/types';
+import {pipelineComplete} from 'sentry/components/pipeline/types';
+import {t, tct} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+interface JiraConfirmStepData {
+  baseUrl: string;
+  organization: string;
+  state: string;
+}
+
+function JiraConfirmInstallStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<JiraConfirmStepData, {state: string}>) {
+  // Jira installs are initiated from the Atlassian Marketplace, so the install
+  // data is already bound to pipeline state by the time the modal opens. We do
+  // NOT auto-advance: a copied install link could connect an attacker's Jira
+  // workspace to a victim's org, so we surface the workspace and organization
+  // and require an explicit confirmation before installing.
+  return (
+    <Stack gap="lg" align="start">
+      <Heading as="h3">{t('Connect Jira to Sentry')}</Heading>
+
+      <Text>
+        {tct(
+          'You are about to connect a Jira workspace to the [organization] Sentry organization. Anyone in the organization will be able to create and link Jira issues using this installation.',
+          {
+            organization: (
+              <Text as="span" bold>
+                {stepData?.organization}
+              </Text>
+            ),
+          }
+        )}
+      </Text>
+
+      {stepData?.baseUrl && (
+        <Text>
+          {t('Jira workspace:')}{' '}
+          <Text as="span" bold>
+            {stepData.baseUrl}
+          </Text>
+        </Text>
+      )}
+
+      <Text variant="warning">
+        {t(
+          'If you did not start this installation yourself, do not continue — the link may have been sent to you by someone else.'
+        )}
+      </Text>
+
+      <Button
+        variant="primary"
+        busy={isAdvancing}
+        disabled={!stepData}
+        onClick={() => stepData && advance({state: stepData.state})}
+      >
+        {t('Install Jira integration')}
+      </Button>
+    </Stack>
+  );
+}
+
+export const jiraIntegrationPipeline = {
+  type: 'integration',
+  provider: 'jira',
+  actionTitle: t('Installing Jira Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'jira_confirm_install',
+      shortDescription: t('Confirming installation'),
+      component: JiraConfirmInstallStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -8,6 +8,7 @@ import {discordIntegrationPipeline} from './integrationDiscord';
 import {githubIntegrationPipeline} from './integrationGitHub';
 import {githubEnterpriseIntegrationPipeline} from './integrationGitHubEnterprise';
 import {gitlabIntegrationPipeline} from './integrationGitLab';
+import {jiraIntegrationPipeline} from './integrationJira';
 import {msTeamsIntegrationPipeline} from './integrationMsTeams';
 import {opsgenieIntegrationPipeline} from './integrationOpsgenie';
 import {pagerDutyIntegrationPipeline} from './integrationPagerDuty';
@@ -33,6 +34,7 @@ export const PIPELINE_REGISTRY = [
   githubIntegrationPipeline,
   githubEnterpriseIntegrationPipeline,
   gitlabIntegrationPipeline,
+  jiraIntegrationPipeline,
   msTeamsIntegrationPipeline,
   opsgenieIntegrationPipeline,
   pagerDutyIntegrationPipeline,

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -53,6 +53,7 @@ const UNCONDITIONAL_API_PIPELINE_PROVIDERS = [
   'github',
   'github_enterprise',
   'gitlab',
+  'jira',
   'msteams',
   'opsgenie',
   'pagerduty',

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -91,6 +91,11 @@ function trackExternalAnalytics({
  *    `/extensions/msteams/configure/`). Drives the pipeline with
  *    `msTeamsParams`.
  *
+ *  - Jira
+ *    `/extensions/jira/link/?signed_params=...` (redirected from
+ *    `/extensions/jira/configure/`). Drives the pipeline with
+ *    `jiraParams`.
+ *
  *  - Anything else
  *    falls through to {@link finishLegacyInstallation}, which bounces to the
  *    legacy `/extensions/<slug>/configure/` backend endpoint.
@@ -237,6 +242,20 @@ export default function IntegrationOrganizationLink() {
     return {signedParams};
   }, [integrationSlug, location.query]);
 
+  // Jira Cloud installs arrive here with `signed_params` in the URL query
+  // (forwarded from `/extensions/jira/configure/`). The install button uses it
+  // as `initialData` for the pipeline modal.
+  const jiraParams = useMemo<Record<string, string> | null>(() => {
+    if (integrationSlug !== 'jira') {
+      return null;
+    }
+    const signedParams = location.query.signed_params;
+    if (typeof signedParams !== 'string') {
+      return null;
+    }
+    return {signedParams};
+  }, [integrationSlug, location.query]);
+
   // Legacy install path. Redirects to `/extensions/<slug>/configure/`, which
   // runs the Django-rendered `IntegrationExtensionConfigurationView` to drive
   // the install server-side via the legacy pipeline. Used by every provider
@@ -266,7 +285,7 @@ export default function IntegrationOrganizationLink() {
     // Whichever one is non-null routes through the API pipeline modal;
     // otherwise we fall back to the legacy server-driven install flow.
     const urlParams =
-      gitHubAppListingParams ?? discordAppDirectoryParams ?? msTeamsParams;
+      gitHubAppListingParams ?? discordAppDirectoryParams ?? msTeamsParams ?? jiraParams;
     if (urlParams) {
       startFlow({provider, organization, onInstall, urlParams});
       return;
@@ -279,6 +298,7 @@ export default function IntegrationOrganizationLink() {
     gitHubAppListingParams,
     discordAppDirectoryParams,
     msTeamsParams,
+    jiraParams,
     startFlow,
     onInstall,
     finishLegacyInstallation,


### PR DESCRIPTION
[VDY-123: Jira Cloud: API-driven integration setup](https://linear.app/getsentry/issue/VDY-123/jira-cloud-api-driven-integration-setup)

Drives the Jira Cloud Marketplace install through the API pipeline modal, the same path Discord and MS Teams use. The configure link forwards `signed_params` to the org-link page, which opens the pipeline modal once an organization is chosen.

The Jira step is an interactive confirmation rather than a silent auto-advance: it shows the Jira workspace (`base_url`) and the Sentry organization and requires the user to click "Install Jira integration" before completing. A copied install link could otherwise connect an attacker's Jira workspace to a victim's org, so the screen lets the user catch a mismatch.

- Add the `jiraIntegrationPipeline` confirmation step (`integrationJira/index.tsx`) and register it in the pipeline registry.
- Mark `jira` as an unconditional API pipeline provider.
- Forward `signed_params` from the org-link page via a `jiraParams` memo.

Depends on the backend pipeline support in #116500 — land and deploy that first, since the modal calls the new pipeline API.