### PR TITLE
fix: Trigger ad-hoc explorer index runs

### DIFF
--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -30,6 +30,7 @@ from sentry.models.authproviderreplica import AuthProviderReplica
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.receivers.outbox import maybe_process_tombstone
+from sentry.seer.agent.client import _trigger_explorer_indexes_if_needed
 from sentry.seer.agent.client_utils import AgentChatRequest, make_agent_chat_request
 from sentry.seer.autofix.utils import make_autofix_start_request
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
@@ -278,6 +279,19 @@ def handle_seer_run_create(object_identifier: int, payload: Any, **kwds: Any) ->
     run.seer_run_state_id = run_id
     run.mirror_status = SeerRunMirrorStatus.LIVE
     run.save(update_fields=["seer_run_state_id", "mirror_status"])
+
+    if run_type == SeerRunType.EXPLORER:
+        try:
+            _trigger_explorer_indexes_if_needed(
+                run.organization_id,
+                data.get("has_explorer_index"),
+                data.get("has_org_project_context"),
+            )
+        except Exception:
+            logger.exception(
+                "seer_run_create.explorer_index_trigger_failed",
+                extra={"run_id": run.id},
+            )
 
 
 def _mark_seer_run_failed(run: SeerRun, event: str, **extra: Any) -> None:

--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -12,6 +12,7 @@ import json  # noqa: S003 - urllib3 raises stdlib JSONDecodeError, not simplejso
 import logging
 from typing import Any, assert_never, cast
 
+from django.db import router, transaction
 from django.dispatch import receiver
 
 from sentry.audit_log.services.log import AuditLogEvent, UserIpEvent, log_rpc_service
@@ -281,17 +282,25 @@ def handle_seer_run_create(object_identifier: int, payload: Any, **kwds: Any) ->
     run.save(update_fields=["seer_run_state_id", "mirror_status"])
 
     if run_type == SeerRunType.EXPLORER:
-        try:
-            _trigger_explorer_indexes_if_needed(
-                run.organization_id,
-                data.get("has_explorer_index"),
-                data.get("has_org_project_context"),
-            )
-        except Exception:
-            logger.exception(
-                "seer_run_create.explorer_index_trigger_failed",
-                extra={"run_id": run.id},
-            )
+        organization_id = run.organization_id
+        has_explorer_index = data.get("has_explorer_index")
+        has_org_project_context = data.get("has_org_project_context")
+        run_id = run.id
+
+        def _trigger_on_commit() -> None:
+            try:
+                _trigger_explorer_indexes_if_needed(
+                    organization_id,
+                    has_explorer_index,
+                    has_org_project_context,
+                )
+            except Exception:
+                logger.exception(
+                    "seer_run_create.explorer_index_trigger_failed",
+                    extra={"run_id": run_id},
+                )
+
+        transaction.on_commit(_trigger_on_commit, using=router.db_for_write(SeerRun))
 
 
 def _mark_seer_run_failed(run: SeerRun, event: str, **extra: Any) -> None:

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -57,6 +57,47 @@ from sentry.utils import metrics
 logger = logging.getLogger(__name__)
 
 
+def _trigger_explorer_indexes_if_needed(
+    organization_id: int,
+    has_explorer_index: bool | None,
+    has_org_project_context: bool | None,
+) -> None:
+    """Trigger explorer indexing for the org if Seer reports missing indexes."""
+    if options.get("seer.explorer_index.killswitch.enable"):
+        logger.info("seer.explorer_index.killswitch.enable flag enabled, skipping")
+        return
+
+    logger.info(
+        "Maybe trigger explorer index tasks",
+        extra={
+            "organization_id": organization_id,
+            "has_explorer_index": has_explorer_index,
+            "has_org_project_context": has_org_project_context,
+        },
+    )
+    if has_explorer_index is False:
+        projects = list(
+            Project.objects.filter(
+                organization_id=organization_id,
+                status=ObjectStatus.ACTIVE,
+            )
+        )
+
+        projects_batch = [(p.id, organization_id) for p in projects if p.flags.has_transactions]
+
+        if projects_batch:
+            for _ in dispatch_explorer_index_projects(iter(projects_batch), django_timezone.now()):
+                pass
+
+    if has_org_project_context is False:
+        logger.info(
+            "Dispatching context engine index tasks",
+            extra={"organization_id": organization_id},
+        )
+        index_org_project_knowledge.apply_async(args=[organization_id])
+        build_service_map.apply_async(args=[organization_id])
+
+
 def _has_context_engine(
     organization: Organization, user: User | RpcUser | AnonymousUser | None
 ) -> bool:
@@ -455,44 +496,9 @@ class SeerAgentClient:
         has_explorer_index: bool | None,
         has_org_project_context: bool | None,
     ) -> None:
-        """Trigger explorer indexing for the org if Seer reports missing indexes."""
-        if options.get("seer.explorer_index.killswitch.enable"):
-            logger.info("seer.explorer_index.killswitch.enable flag enabled, skipping")
-            return
-
-        logger.info(
-            "Maybe trigger explorer index tasks",
-            extra={
-                "organization_id": self.organization.id,
-                "has_explorer_index": has_explorer_index,
-                "has_org_project_context": has_org_project_context,
-            },
+        _trigger_explorer_indexes_if_needed(
+            self.organization.id, has_explorer_index, has_org_project_context
         )
-        if has_explorer_index is False:
-            projects = list(
-                Project.objects.filter(
-                    organization_id=self.organization.id,
-                    status=ObjectStatus.ACTIVE,
-                )
-            )
-
-            projects_batch = [
-                (p.id, self.organization.id) for p in projects if p.flags.has_transactions
-            ]
-
-            if projects_batch:
-                for _ in dispatch_explorer_index_projects(
-                    iter(projects_batch), django_timezone.now()
-                ):
-                    pass
-
-        if has_org_project_context is False:
-            logger.info(
-                "Dispatching context engine index tasks",
-                extra={"organization_id": self.organization.id},
-            )
-            index_org_project_knowledge.apply_async(args=[self.organization.id])
-            build_service_map.apply_async(args=[self.organization.id])
 
     def continue_run(
         self,

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -482,23 +482,16 @@ class SeerAgentClient:
         result = response.json()
 
         try:
-            self._maybe_trigger_explorer_index_for_new_run(
-                result.get("has_explorer_index"),
-                result.get("has_org_project_context"),
+            _trigger_explorer_indexes_if_needed(
+                self.organization.id,
+                has_explorer_index=result.get("has_explorer_index"),
+                has_org_project_context=result.get("has_org_project_context"),
             )
+
         except Exception as e:
             sentry_sdk.capture_exception(e)
 
         return result["run_id"]
-
-    def _maybe_trigger_explorer_index_for_new_run(
-        self,
-        has_explorer_index: bool | None,
-        has_org_project_context: bool | None,
-    ) -> None:
-        _trigger_explorer_indexes_if_needed(
-            self.organization.id, has_explorer_index, has_org_project_context
-        )
 
     def continue_run(
         self,

--- a/src/sentry/tasks/seer/explorer_index.py
+++ b/src/sentry/tasks/seer/explorer_index.py
@@ -18,7 +18,7 @@ from sentry.seer.signed_seer_api import (
     make_agent_index_request,
 )
 from sentry.tasks.base import instrumented_task
-from sentry.tasks.statistical_detectors import compute_delay
+from sentry.tasks.utils import compute_delay
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.query import RangeQuerySetWrapper
 

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -5,7 +5,6 @@ from collections.abc import Generator, Iterable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-import sentry_sdk
 from django.utils import timezone as django_timezone
 from snuba_sdk import (
     And,
@@ -59,6 +58,7 @@ from sentry.statistical_detectors.issue_platform_adapter import (
 from sentry.statistical_detectors.redis import RedisDetectorStore
 from sentry.statistical_detectors.store import DetectorStore
 from sentry.tasks.base import instrumented_task
+from sentry.tasks.utils import compute_delay
 from sentry.taskworker.namespaces import performance_tasks, profiling_tasks
 from sentry.utils import json, metrics
 from sentry.utils.iterators import chunked
@@ -75,9 +75,6 @@ TRANSACTIONS_PER_PROJECT = 50
 TRANSACTIONS_PER_BATCH = 1_000
 PROJECTS_PER_BATCH = 1_000
 TIMESERIES_PER_BATCH = 10
-RUN_FREQUENCY = timedelta(hours=1)  # runs hourly
-# pick a prime number so when it wraps around, it doesn't over lap
-DISPATCH_STEP = timedelta(seconds=17)
 
 
 def get_performance_issue_settings(projects: list[Project]):
@@ -126,27 +123,6 @@ def run_detection() -> None:
     # make sure to consume the generator
     for _ in projects:
         pass
-
-
-def compute_delay(
-    timestamp: datetime,
-    batch_index: int,
-    duration: timedelta = RUN_FREQUENCY,
-    step: timedelta = DISPATCH_STEP,
-) -> int:
-    now = django_timezone.now()
-
-    if now - timestamp > duration:
-        sentry_sdk.capture_message("Statistical detectors task not dispatched within duration.")
-
-    start = now.replace(minute=0, second=0, microsecond=0)
-    end = start + duration
-
-    remaining = end - now.replace(microsecond=0)
-    # ensure there is some padding before the end of the duration
-    remaining -= step
-
-    return batch_index * int(step.total_seconds()) % int(remaining.total_seconds())
 
 
 def dispatch_performance_projects(

--- a/src/sentry/tasks/utils.py
+++ b/src/sentry/tasks/utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import sentry_sdk
+from django.utils import timezone as django_timezone
+
+# These defaults match the statistical detectors hourly run cadence and are
+# intentionally kept as module-level constants so callers that share the same
+# dispatch rhythm (e.g. seer explorer indexing) can import them directly.
+RUN_FREQUENCY = timedelta(hours=1)
+DISPATCH_STEP = timedelta(seconds=17)
+
+
+def compute_delay(
+    timestamp: datetime,
+    batch_index: int,
+    duration: timedelta = RUN_FREQUENCY,
+    step: timedelta = DISPATCH_STEP,
+) -> int:
+    now = django_timezone.now()
+
+    if now - timestamp > duration:
+        sentry_sdk.capture_message("Statistical detectors task not dispatched within duration.")
+
+    start = now.replace(minute=0, second=0, microsecond=0)
+    end = start + duration
+
+    remaining = end - now.replace(microsecond=0)
+    # ensure there is some padding before the end of the duration
+    remaining -= step
+
+    return batch_index * int(step.total_seconds()) % int(remaining.total_seconds())

--- a/tests/sentry/receivers/outbox/test_cell.py
+++ b/tests/sentry/receivers/outbox/test_cell.py
@@ -286,3 +286,50 @@ class HandleSeerRunCreateTest(TestCase):
         run.refresh_from_db()
         assert run.mirror_status == SeerRunMirrorStatus.FAILED
         assert run.seer_run_state_id is None
+
+    @patch("sentry.receivers.outbox.cell._trigger_explorer_indexes_if_needed")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    def test_explorer_calls_index_trigger_with_response_flags(
+        self, mock_request: Mock, mock_trigger: Mock
+    ) -> None:
+        mock_request.return_value = Mock(
+            status=200,
+            json=Mock(
+                return_value={
+                    "run_id": 99,
+                    "has_explorer_index": False,
+                    "has_org_project_context": False,
+                }
+            ),
+        )
+        run = self.create_seer_run(type=SeerRunType.EXPLORER)
+
+        handle_seer_run_create(
+            object_identifier=run.id,
+            payload=self._make_payload(),
+            shard_identifier=run.id,
+        )
+
+        run.refresh_from_db()
+        assert run.seer_run_state_id == 99
+        assert run.mirror_status == SeerRunMirrorStatus.LIVE
+        mock_trigger.assert_called_once_with(run.organization_id, False, False)
+
+    @patch("sentry.receivers.outbox.cell._trigger_explorer_indexes_if_needed")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    def test_explorer_index_trigger_exception_does_not_fail_run(
+        self, mock_request: Mock, mock_trigger: Mock
+    ) -> None:
+        mock_request.return_value = Mock(status=200, json=Mock(return_value={"run_id": 99}))
+        mock_trigger.side_effect = RuntimeError("boom")
+        run = self.create_seer_run(type=SeerRunType.EXPLORER)
+
+        handle_seer_run_create(
+            object_identifier=run.id,
+            payload=self._make_payload(),
+            shard_identifier=run.id,
+        )
+
+        run.refresh_from_db()
+        assert run.seer_run_state_id == 99
+        assert run.mirror_status == SeerRunMirrorStatus.LIVE


### PR DESCRIPTION
The `organizations:seer-run-mirror-explorer` on SeerAgentClient.start_run meant
we weren't triggering the ad-hoc create explorer index tasks. This PR now calls the
index build tasks for explorer runs.

`compute_delay` was causing a circular import - so just moved that to a utils file