### PR TITLE
chore(billing): Bump sentry-protos to 0.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.0.13",
-  "sentry-protos>=0.17.0",
+  "sentry-protos>=0.18.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2439,7 +2439,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.1.27" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.0.13" },
-    { name = "sentry-protos", specifier = ">=0.17.0" },
+    { name = "sentry-protos", specifier = ">=0.18.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.20.0" },
@@ -2623,7 +2623,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.17.0"
+version = "0.18.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2631,7 +2631,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.17.0-py3-none-any.whl", hash = "sha256:e5a7c320678a6204cfa6e8a8981952e8dd1080131de076c5cec8702a24f62d7d" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.18.0-py3-none-any.whl", hash = "sha256:ceb0fee695ef69939346b217a84e1b5e656e7f4a080e65005c54125314e7618f" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `sentry-protos` from `0.17.0` to `0.18.0`
- **0.18.0**: (billing) Add `GrantSource`, `source` field, and `GetEffectiveGrants` protos ([sentry-protos#268](https://github.com/getsentry/sentry-protos/pull/268))

All changes are additive — no breaking changes.
