### PR TITLE
feat(repositories): Auto-link repos to projects by name matching

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -54,6 +54,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:trace-item-details-array-fields", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the cron job to auto-enable codecov integrations.
     manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    # Auto-link repos to projects by matching repo name suffix to project slug
+    manager.add("organizations:auto-link-repos-by-name", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enabled for orgs that participated in the code review beta
     manager.add("organizations:code-review-beta", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable A/B testing experiments for code review (org eligibility)

--- a/src/sentry/integrations/github/tasks/link_all_repos.py
+++ b/src/sentry/integrations/github/tasks/link_all_repos.py
@@ -6,6 +6,7 @@ from taskbroker_client.retry import Retry
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.services.repository.service import repository_service
 from sentry.integrations.source_code_management.metrics import (
     LinkAllReposHaltReason,
     SCMIntegrationInteractionEvent,
@@ -90,11 +91,17 @@ def link_all_repos(
                 missing_repos.append(repo)
                 continue
 
-        _created_repos, _reactivated_repos, existing_repos = (
+        created_repos, _reactivated_repos, existing_repos = (
             integration_repo_provider.create_repositories(
                 configs=repo_configs, organization=rpc_org
             )
         )
+
+        if created_repos:
+            repository_service.auto_link_repos_by_name(
+                organization_id=rpc_org.id, repo_ids=[r.id for r in created_repos]
+            )
+
         if existing_repos:
             lifecycle.record_halt(
                 str(LinkAllReposHaltReason.REPOSITORY_NOT_CREATED),

--- a/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
+++ b/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
@@ -132,6 +132,11 @@ def _sync_repos_for_org(
             )
             changed = bool(created_repos or reactivated_repos)
 
+            if created_repos:
+                repository_service.auto_link_repos_by_name(
+                    organization_id=rpc_org.id, repo_ids=[r.id for r in created_repos]
+                )
+
             for created_repo in created_repos:
                 log_repo_change(
                     event_name="REPO_ADDED",

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -14,9 +14,11 @@ from sentry.integrations.models.repository_project_path_config import Repository
 from sentry.integrations.services.repository import RepositoryService, RpcRepository
 from sentry.integrations.services.repository.model import RpcCreateRepository
 from sentry.integrations.services.repository.serial import serialize_repository
+from sentry.integrations.source_code_management.auto_link_repos import auto_link_repos_by_name
 from sentry.models.code_review_event import CodeReviewEvent
 from sentry.models.commit import Commit
 from sentry.models.options.project_option import ProjectOption
+from sentry.models.organization import Organization
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.projectrepository import ProjectRepository
 from sentry.models.pullrequest import PullRequest
@@ -291,3 +293,14 @@ class DatabaseBackedRepositoryService(RepositoryService):
             integration_id=integration_id,
             organization_id=organization_id,
         )
+
+    def auto_link_repos_by_name(
+        self,
+        *,
+        organization_id: int,
+        repo_ids: list[int],
+    ) -> int:
+        organization = Organization.objects.filter(id=organization_id).first()
+        if organization is None:
+            return 0
+        return auto_link_repos_by_name(organization, repo_ids)

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -300,7 +300,8 @@ class DatabaseBackedRepositoryService(RepositoryService):
         organization_id: int,
         repo_ids: list[int],
     ) -> int:
-        organization = Organization.objects.filter(id=organization_id).first()
-        if organization is None:
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
             return 0
         return auto_link_repos_by_name(organization, repo_ids)

--- a/src/sentry/integrations/services/repository/service.py
+++ b/src/sentry/integrations/services/repository/service.py
@@ -144,5 +144,21 @@ class RepositoryService(RpcService):
         This is used when sync settings change and webhooks need to be updated.
         """
 
+    @cell_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def auto_link_repos_by_name(
+        self,
+        *,
+        organization_id: int,
+        repo_ids: list[int],
+    ) -> int:
+        """
+        Auto-link repositories to projects based on name matching.
+        Only creates links when neither the repo nor the project
+        already has a ProjectRepository row.
+
+        Returns the number of links created.
+        """
+
 
 repository_service = RepositoryService.create_delegation()

--- a/src/sentry/integrations/source_code_management/auto_link_repos.py
+++ b/src/sentry/integrations/source_code_management/auto_link_repos.py
@@ -75,7 +75,7 @@ def auto_link_repos_by_name(
     ).exclude(Exists(ProjectRepository.objects.filter(repository_id=OuterRef("id"))))
 
     unlinked_projects_by_slug: dict[str, tuple[int, str]] = {}
-    for project_id, slug in (
+    for p_id, slug in (
         Project.objects.filter(
             organization_id=organization.id,
             status=ObjectStatus.ACTIVE,
@@ -83,15 +83,15 @@ def auto_link_repos_by_name(
         .exclude(Exists(ProjectRepository.objects.filter(project_id=OuterRef("id"))))
         .values_list("id", "slug")
     ):
-        unlinked_projects_by_slug[slug] = (project_id, slug)
+        unlinked_projects_by_slug[slug] = (p_id, slug)
 
     if not unlinked_projects_by_slug:
         return 0
 
     created = 0
     for repo in repos:
-        project_id = None
-        project_slug = None
+        project_id: int | None = None
+        project_slug: str | None = None
         for candidate in get_repo_name_candidates(repo.name):
             if candidate in unlinked_projects_by_slug:
                 project_id, project_slug = unlinked_projects_by_slug.pop(candidate)

--- a/src/sentry/integrations/source_code_management/auto_link_repos.py
+++ b/src/sentry/integrations/source_code_management/auto_link_repos.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+from django.db.models import Exists, OuterRef
+from django.utils.text import slugify
+
+from sentry import features, options
+from sentry.constants import ObjectStatus
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
+from sentry.models.repository import Repository
+from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+
+def get_repo_name_candidates(repo_name: str) -> list[str]:
+    """
+    Return a list of slug candidates to match against project slugs,
+    in priority order.
+
+    Splits the repo name on `/`, slugifies each part individually,
+    then returns the last part (repo basename) first, followed by
+    the full slugified path joined with hyphens.
+
+    Examples:
+        "getsentry/sentry"          -> ["sentry", "getsentry-sentry"]
+        "getsentry / sentry"        -> ["sentry", "getsentry-sentry"]
+        "My Project/My Repo"        -> ["my-repo", "my-project-my-repo"]
+        "GetSentry/Sentry-Backend"  -> ["sentry-backend", "getsentry-sentry-backend"]
+        "sentry-backend"            -> ["sentry-backend"]
+    """
+    parts = [slugify(part.strip()) for part in repo_name.split("/") if part.strip()]
+    parts = [p for p in parts if p]
+    if not parts:
+        return []
+    candidates = [parts[-1]]
+    if len(parts) > 1:
+        candidates.append("-".join(parts))
+    return candidates
+
+
+def auto_link_repos_by_name(
+    organization: Organization | RpcOrganization,
+    repo_ids: Sequence[int],
+) -> int:
+    """
+    Auto-link repositories to projects by matching repo name suffix to project slug.
+
+    For each given repo, attempt to match its name suffix to a project slug
+    in the same organization and create a ProjectRepository link.
+
+    Constraints:
+    - The repo must not already be linked to any project.
+    - The project must not already have any ProjectRepository link.
+
+    Returns the number of links created
+    """
+    if not repo_ids:
+        return 0
+
+    if not features.has("organizations:auto-link-repos-by-name", organization):
+        return 0
+
+    dry_run = options.get("repository.auto-link-by-name-dry-run")
+
+    repos = Repository.objects.filter(
+        id__in=repo_ids,
+        organization_id=organization.id,
+        status=ObjectStatus.ACTIVE,
+    ).exclude(Exists(ProjectRepository.objects.filter(repository_id=OuterRef("id"))))
+
+    unlinked_projects_by_slug: dict[str, tuple[int, str]] = {}
+    for project_id, slug in (
+        Project.objects.filter(
+            organization_id=organization.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        .exclude(Exists(ProjectRepository.objects.filter(project_id=OuterRef("id"))))
+        .values_list("id", "slug")
+    ):
+        unlinked_projects_by_slug[slug] = (project_id, slug)
+
+    if not unlinked_projects_by_slug:
+        return 0
+
+    created = 0
+    for repo in repos:
+        project_id = None
+        project_slug = None
+        for candidate in get_repo_name_candidates(repo.name):
+            if candidate in unlinked_projects_by_slug:
+                project_id, project_slug = unlinked_projects_by_slug.pop(candidate)
+                break
+        if project_id is None:
+            continue
+
+        if dry_run:
+            logger.info(
+                "auto_link_repos_by_name.dry_run_match",
+                extra={
+                    "organization_id": organization.id,
+                    "repository_id": repo.id,
+                    "repository_name": repo.name,
+                    "project_id": project_id,
+                    "project_slug": project_slug,
+                },
+            )
+            metrics.incr("auto_link_repos_by_name.dry_run_match", sample_rate=1.0)
+        else:
+            _, was_created = ProjectRepository.objects.get_or_create(
+                project_id=project_id,
+                repository=repo,
+                defaults={"source": ProjectRepositorySource.AUTO_NAME_MATCH},
+            )
+            if was_created:
+                logger.info(
+                    "auto_link_repos_by_name.linked",
+                    extra={
+                        "organization_id": organization.id,
+                        "repository_id": repo.id,
+                        "repository_name": repo.name,
+                        "project_id": project_id,
+                        "project_slug": project_slug,
+                    },
+                )
+                metrics.incr("auto_link_repos_by_name.linked", sample_rate=1.0)
+                created += 1
+
+    return created

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -432,6 +432,11 @@ def create_repos_batch(
             provider=provider_key,
         )
 
+    if created_repos:
+        repository_service.auto_link_repos_by_name(
+            organization_id=rpc_org.id, repo_ids=[r.id for r in created_repos]
+        )
+
 
 @instrumented_task(
     name="sentry.integrations.source_code_management.sync_repos.disable_repos_batch",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3738,3 +3738,11 @@ register(
     type=Bool,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# When True, auto-link-repos-by-name logs matches but does not create ProjectRepository rows.
+register(
+    "repository.auto-link-by-name-dry-run",
+    default=True,
+    type=Bool,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/integrations/source_code_management/test_auto_link_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_auto_link_repos.py
@@ -36,6 +36,21 @@ class GetRepoNameCandidatesTest(TestCase):
     def test_empty_string(self) -> None:
         assert get_repo_name_candidates("") == []
 
+    def test_dots_in_name(self) -> None:
+        assert get_repo_name_candidates("my-org/my.repo.name") == [
+            "myreponame",
+            "my-org-myreponame",
+        ]
+
+    def test_underscores(self) -> None:
+        assert get_repo_name_candidates("org/my_repo") == ["my_repo", "org-my_repo"]
+
+    def test_trailing_slash(self) -> None:
+        assert get_repo_name_candidates("org/repo/") == ["repo", "org-repo"]
+
+    def test_only_slashes(self) -> None:
+        assert get_repo_name_candidates("///") == []
+
 
 class AutoLinkReposByNameTest(TestCase):
     def setUp(self) -> None:

--- a/tests/sentry/integrations/source_code_management/test_auto_link_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_auto_link_repos.py
@@ -1,0 +1,206 @@
+from sentry.constants import ObjectStatus
+from sentry.integrations.source_code_management.auto_link_repos import (
+    auto_link_repos_by_name,
+    get_repo_name_candidates,
+)
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
+from sentry.models.repository import Repository
+from sentry.testutils.cases import TestCase
+
+
+class GetRepoNameCandidatesTest(TestCase):
+    def test_github_format(self) -> None:
+        assert get_repo_name_candidates("getsentry/sentry") == ["sentry", "getsentry-sentry"]
+
+    def test_gitlab_format_spaces_around_slash(self) -> None:
+        assert get_repo_name_candidates("getsentry / sentry") == ["sentry", "getsentry-sentry"]
+
+    def test_bitbucket_server_display_names(self) -> None:
+        assert get_repo_name_candidates("My Project/My Repo") == [
+            "my-repo",
+            "my-project-my-repo",
+        ]
+
+    def test_mixed_case(self) -> None:
+        assert get_repo_name_candidates("GetSentry/Sentry-Backend") == [
+            "sentry-backend",
+            "getsentry-sentry-backend",
+        ]
+
+    def test_no_slash(self) -> None:
+        assert get_repo_name_candidates("sentry-backend") == ["sentry-backend"]
+
+    def test_nested_groups(self) -> None:
+        assert get_repo_name_candidates("org/group/repo") == ["repo", "org-group-repo"]
+
+    def test_empty_string(self) -> None:
+        assert get_repo_name_candidates("") == []
+
+
+class AutoLinkReposByNameTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.org = self.create_organization()
+        self.project = self.create_project(organization=self.org, slug="sentry")
+        self.repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
+        )
+
+    def test_links_matching_repo_to_project(self) -> None:
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            created = auto_link_repos_by_name(self.org, [self.repo.id])
+
+        assert created == 1
+        pr = ProjectRepository.objects.get(project=self.project, repository=self.repo)
+        assert pr.source == ProjectRepositorySource.AUTO_NAME_MATCH
+
+    def test_dry_run_does_not_create(self) -> None:
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": True}),
+        ):
+            created = auto_link_repos_by_name(self.org, [self.repo.id])
+
+        assert created == 0
+        assert not ProjectRepository.objects.filter(
+            project=self.project, repository=self.repo
+        ).exists()
+
+    def test_skips_when_flag_disabled(self) -> None:
+        with self.options({"repository.auto-link-by-name-dry-run": False}):
+            created = auto_link_repos_by_name(self.org, [self.repo.id])
+
+        assert created == 0
+
+    def test_skips_repo_already_linked(self) -> None:
+        ProjectRepository.objects.create(
+            project=self.create_project(organization=self.org, slug="other"),
+            repository=self.repo,
+            source=ProjectRepositorySource.MANUAL,
+        )
+
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            created = auto_link_repos_by_name(self.org, [self.repo.id])
+
+        assert created == 0
+
+    def test_skips_project_already_has_link(self) -> None:
+        other_repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name="getsentry/other",
+            provider="integrations:github",
+            external_id="456",
+        )
+        ProjectRepository.objects.create(
+            project=self.project,
+            repository=other_repo,
+            source=ProjectRepositorySource.MANUAL,
+        )
+
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            created = auto_link_repos_by_name(self.org, [self.repo.id])
+
+        assert created == 0
+
+    def test_no_match_when_names_differ(self) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name="getsentry/relay",
+            provider="integrations:github",
+            external_id="789",
+        )
+
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            created = auto_link_repos_by_name(self.org, [repo.id])
+
+        assert created == 0
+
+    def test_skips_inactive_repos(self) -> None:
+        self.repo.status = ObjectStatus.HIDDEN
+        self.repo.save()
+
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            created = auto_link_repos_by_name(self.org, [self.repo.id])
+
+        assert created == 0
+
+    def test_multiple_repos_multiple_projects(self) -> None:
+        project2 = self.create_project(organization=self.org, slug="relay")
+        repo2 = Repository.objects.create(
+            organization_id=self.org.id,
+            name="getsentry/relay",
+            provider="integrations:github",
+            external_id="456",
+        )
+
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            created = auto_link_repos_by_name(self.org, [self.repo.id, repo2.id])
+
+        assert created == 2
+        assert ProjectRepository.objects.filter(project=self.project, repository=self.repo).exists()
+        assert ProjectRepository.objects.filter(project=project2, repository=repo2).exists()
+
+    def test_matches_second_candidate(self) -> None:
+        project = self.create_project(organization=self.org, slug="getsentry-sentry")
+        repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="999",
+        )
+        # self.project has slug="sentry" which would match the first candidate,
+        # but it already has a link so it's excluded
+        ProjectRepository.objects.create(
+            project=self.project,
+            repository=self.repo,
+            source=ProjectRepositorySource.MANUAL,
+        )
+
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            created = auto_link_repos_by_name(self.org, [repo.id])
+
+        assert created == 1
+        pr = ProjectRepository.objects.get(project=project, repository=repo)
+        assert pr.source == ProjectRepositorySource.AUTO_NAME_MATCH
+
+    def test_empty_repo_ids(self) -> None:
+        created = auto_link_repos_by_name(self.org, [])
+        assert created == 0
+
+    def test_idempotent(self) -> None:
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            auto_link_repos_by_name(self.org, [self.repo.id])
+            created = auto_link_repos_by_name(self.org, [self.repo.id])
+
+        assert created == 0
+        assert (
+            ProjectRepository.objects.filter(project=self.project, repository=self.repo).count()
+            == 1
+        )

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -90,6 +90,30 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
             assert entries.count() == 2
 
     @responses.activate
+    def test_creates_new_repos_with_auto_link(self, _: MagicMock) -> None:
+        from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            self.create_project(organization=self.organization, slug="sentry")
+
+        self._add_repos_response([{"id": 1, "full_name": "getsentry/sentry", "name": "sentry"}])
+
+        with (
+            self.tasks(),
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            sync_repos_for_org(self.oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            repo = Repository.objects.get(organization_id=self.organization.id, external_id="1")
+            assert ProjectRepository.objects.filter(
+                repository=repo,
+                source=ProjectRepositorySource.AUTO_NAME_MATCH,
+                project__slug="sentry",
+            ).exists()
+
+    @responses.activate
     def test_disables_removed_repos(self, _: MagicMock) -> None:
         with assume_test_silo_mode(SiloMode.CELL):
             repo = Repository.objects.create(


### PR DESCRIPTION
When new Repository rows are created automatically, match the repo's base name against project slugs in the same org. If matched and neither side already has a link, create a ProjectRepository with source=AUTO_NAME_MATCH.

This includes a dry-run mode so that we can test things out first.
<!-- Describe your PR here. -->