### PR TITLE
chore(webhooks): Remove raise that short circuit url sending

### DIFF
--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -144,7 +144,6 @@ class WebHooksPlugin(notify.NotificationPlugin):
                     tags={"outcome": LegacyWebhookOutcome.ERROR},
                     sample_rate=1.0,
                 )
-                raise
             except (ConnectionError, ReadTimeout):
                 metrics.incr(
                     "legacy_webhook.plugin.send",


### PR DESCRIPTION
There's a small discrepancy rn where the number of webhooks being sent via task is > the number of plugin webhooks......
I'm kinda trial and erroring rn, and I think this could be one of the spots since we short circuit if 1 url is bad