### PR TITLE
feat(api): Add Serializer[T] generic; pilot on environments

### DIFF
--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
-from typing import Any, TypeVar
+from typing import Any, Generic, TypeVar, overload
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
@@ -13,6 +13,15 @@ from sentry.users.services.user.model import RpcUser
 logger = logging.getLogger(__name__)
 
 K = TypeVar("K")
+# Default `T` to `Any` (not `Mapping[str, Any]`) so unmigrated serializers
+# preserve the historical caller behavior: `serialize(obj, user, FooSerializer())`
+# returns `Any` when `FooSerializer` has no `[T]` parameter, and downstream
+# code can mutate the result (`data["key"] = ...`) without type errors. The
+# `Any` default opts callers out of the new type check until the serializer
+# is migrated.
+T = TypeVar("T", default=Any)
+
+_User = User | RpcUser | AnonymousUser | None
 
 registry: MutableMapping[Any, Any] = {}
 
@@ -27,9 +36,62 @@ def register(type: Any) -> Callable[[type[K]], type[K]]:
     return wrapped
 
 
+# Overload order matters: the no-serializer / `serializer=None` path comes
+# first so the registry-lookup case keeps returning `Any` (preserves the
+# historical behavior of every existing call site that doesn't pass a
+# serializer). The typed overloads only fire when an explicit `Serializer[T]`
+# instance is passed.
+#
+# Note: there is a known soundness gap when a falsy non-sequence value
+# (literal `None`, `0`, `False`, `""`) is passed alongside a typed
+# `Serializer[T]`. Runtime short-circuits and returns the input as-is
+# (documented contract — see `assert serialize(None) is None` in
+# `test_base.py`), but the typed `object → T` overload promises `T`. A
+# dedicated `objects: None → None` overload was tried and reverted: it
+# polluted real `X | None` call sites with `T | None` returns, breaking
+# 2+ files in the wider mypy run. No real Sentry caller passes literal
+# `None` to a typed serializer; callers that pass `X | None` narrow
+# before the call site.
+@overload
+def serialize(
+    objects: Any,
+    user: _User = ...,
+    serializer: None = ...,
+    **kwargs: Any,
+) -> Any: ...
+@overload
+def serialize(
+    objects: Sequence[Any],
+    user: _User = ...,
+    *,
+    serializer: Serializer[T],
+    **kwargs: Any,
+) -> list[T]: ...
+@overload
+def serialize(
+    objects: Sequence[Any],
+    user: _User,
+    serializer: Serializer[T],
+    **kwargs: Any,
+) -> list[T]: ...
+@overload
+def serialize(
+    objects: object,
+    user: _User = ...,
+    *,
+    serializer: Serializer[T],
+    **kwargs: Any,
+) -> T: ...
+@overload
+def serialize(
+    objects: object,
+    user: _User,
+    serializer: Serializer[T],
+    **kwargs: Any,
+) -> T: ...
 def serialize(
     objects: Any | Sequence[Any],
-    user: User | RpcUser | AnonymousUser | None = None,
+    user: _User = None,
     serializer: Any | None = None,
     **kwargs: Any,
 ) -> Any:
@@ -80,8 +142,22 @@ def serialize(
             return [serializer(o, attrs=attrs.get(o, {}), user=user, **kwargs) for o in objects]
 
 
-class Serializer:
-    """A Serializer class contains the logic to serialize a specific type of object."""
+class Serializer(Generic[T]):
+    """A Serializer class contains the logic to serialize a specific type of object.
+
+    Subclasses declare the shape they emit by parameterizing the base, e.g.
+    ``class FooSerializer(Serializer[FooResponse]):``. Unparameterized
+    subclasses (``class FooSerializer(Serializer):``) keep ``T`` at its
+    default of ``Mapping[str, Any]`` — the historical return shape.
+
+    Mypy uses ``T`` to propagate the typed output through ``__call__`` /
+    ``serialize`` and the top-level ``serialize(...)`` helper's overloads.
+    Runtime behavior is unchanged: the base ``serialize`` is a no-op returning
+    ``{}``; ``__call__`` returns ``None`` when ``obj is None`` and on
+    ``_serialize`` exceptions. Those ``None`` / ``{}`` returns are widened
+    from ``T`` via ``# type: ignore[return-value]`` — concrete subclasses
+    override ``serialize`` with a real body that genuinely returns ``T``.
+    """
 
     def __call__(
         self,
@@ -89,10 +165,10 @@ class Serializer:
         attrs: Mapping[Any, Any],
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
-    ) -> Mapping[str, Any] | None:
+    ) -> T:
         """See documentation for `serialize`."""
         if obj is None:
-            return None
+            return None  # type: ignore[return-value]
         return self._serialize(obj, attrs, user, **kwargs)
 
     def get_attrs(
@@ -114,12 +190,12 @@ class Serializer:
         attrs: Mapping[Any, Any],
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
-    ) -> Mapping[str, Any] | None:
+    ) -> T:
         try:
             return self.serialize(obj, attrs, user, **kwargs)
         except Exception:
             logger.exception("Failed to serialize", extra={"instance": obj})
-            return None
+            return None  # type: ignore[return-value]
 
     def serialize(
         self,
@@ -127,7 +203,7 @@ class Serializer:
         attrs: Mapping[Any, Any],
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
-    ) -> Mapping[str, Any]:
+    ) -> T:
         """
         Convert an arbitrary python object `obj` to an object that only contains primitives.
 
@@ -137,4 +213,4 @@ class Serializer:
         :param kwargs: Any
         :returns A serialized version of `obj`.
         """
-        return {}
+        return {}  # type: ignore[return-value]

--- a/src/sentry/api/serializers/models/environment.py
+++ b/src/sentry/api/serializers/models/environment.py
@@ -16,7 +16,7 @@ class EnvironmentProjectSerializerResponse(TypedDict):
 
 
 @register(Environment)
-class EnvironmentSerializer(Serializer):
+class EnvironmentSerializer(Serializer[EnvironmentSerializerResponse]):
     def serialize(self, obj: Environment, attrs, user, **kwargs) -> EnvironmentSerializerResponse:
         return {"id": str(obj.id), "name": obj.name}
 

--- a/src/sentry/core/endpoints/organization_environments.py
+++ b/src/sentry/core/endpoints/organization_environments.py
@@ -1,4 +1,5 @@
 from drf_spectacular.utils import extend_schema
+from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -8,7 +9,10 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.helpers.environments import environment_visibility_filter_options
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.environment import EnvironmentSerializerResponse
+from sentry.api.serializers.models.environment import (
+    EnvironmentSerializer,
+    EnvironmentSerializerResponse,
+)
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
 from sentry.apidocs.examples.environment_examples import EnvironmentExamples
 from sentry.apidocs.parameters import EnvironmentParams, GlobalParams
@@ -37,17 +41,16 @@ class OrganizationEnvironmentsEndpoint(OrganizationEndpoint):
         },
         examples=EnvironmentExamples.GET_ORGANIZATION_ENVIRONMENTS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[EnvironmentSerializerResponse]]:
         """
         Lists an organization's environments.
         """
         visibility = request.GET.get("visibility", "visible")
         if visibility not in environment_visibility_filter_options:
-            return Response(
-                {
-                    "detail": f"Invalid value for 'visibility', valid values are: {sorted(environment_visibility_filter_options.keys())!r}"
-                },
-                status=400,
+            raise ParseError(
+                f"Invalid value for 'visibility', valid values are: {sorted(environment_visibility_filter_options.keys())!r}"
             )
         environment_projects = EnvironmentProject.objects.filter(
             project__in=self.get_projects(request, organization)
@@ -67,4 +70,4 @@ class OrganizationEnvironmentsEndpoint(OrganizationEndpoint):
             )
             .order_by("name")
         )
-        return Response(serialize(list(queryset), request.user))
+        return Response(serialize(list(queryset), request.user, EnvironmentSerializer()))


### PR DESCRIPTION
Make `sentry.api.serializers.Serializer` statically generic over its
serialized output type, so `Response(serialize(obj, user, FooSerializer()))`
type-checks against `Response[T]` end-to-end. Builds on the `Response[T]`
work in #116335 / #116433 / #116496 — closes the gap where
`serialize()`'s `-> Any` return defeated the new mypy plugin's body check.

**Opt-in per serializer, no churn for unmigrated ones**

`T = TypeVar("T", default=Any)` means `class FooSerializer(Serializer):`
keeps returning `Any` from the helper's perspective — every existing
call site is unaffected, including those that mutate the result
(`data["key"] = ...`). The new check fires only for serializers that
explicitly opt in by declaring `Serializer[FooResponse]`.

**Pilot: `EnvironmentSerializer` + `OrganizationEnvironmentsEndpoint`**

```python
# src/sentry/api/serializers/models/environment.py
class EnvironmentSerializer(Serializer[EnvironmentSerializerResponse]):
    ...

# src/sentry/core/endpoints/organization_environments.py
def get(
    self, request: Request, organization: Organization
) -> Response[list[EnvironmentSerializerResponse]]:
    ...
    return Response(serialize(list(queryset), request.user, EnvironmentSerializer()))
```

The 400 inline-validation `Response({"detail": ...}, status=400)`
converts to `raise ParseError(...)` so the return type is single-armed
— same pattern as the earlier `Response[T]` cluster work. DRF's
exception handler produces the same `{"detail": "..."}` body at
runtime; existing test assertions pass unchanged.

**Drift caught at both ends**

Verified synthetically. With the pilot serializer declared
`Serializer[EnvironmentSerializerResponse]`:

- Returning a wrong-shape body from the endpoint produces:
  `Missing keys ("id", "name") for TypedDict` +
  `Extra key "wrong" for TypedDict`.
- Declaring the serializer with a mismatched base produces both
  `Return type ... incompatible with return type ... in supertype` (at
  the serializer) and `Argument 3 to "serialize" has incompatible type
  ... expected "Serializer[EnvironmentSerializerResponse]"` (at the
  endpoint).

**No stub file — typing lives in `base.py`**

Two `.pyi` placements were tried during development:
`fixtures/stubs-for-mypy/sentry/api/serializers/base.pyi` and sibling
`src/sentry/api/serializers/base.pyi`. Both rejected: mypy ignores
stubs for internal modules when CI's `files = ["."]` puts the `.py` in
the check set. The runtime file is the single source of truth.
`@overload` decorators on `serialize()` provide the typed shape; the
no-serializer overload comes first to preserve `Any` for the
registry-lookup path. Three `# type: ignore[return-value]` on the base
`Serializer` method bodies cover the placeholder `return None` /
`return {}` cases — concrete subclasses override with real bodies that
satisfy `T`.

**Deferred**

- Extending the structural linter (#116496) to resolve
  `responses={200: FooSerializer}` to `T` via `Serializer[T]` bases.
  Useful once a handful of serializers are migrated; the bare class
  references continue to be skipped silently for now.
- Cluster migrations of additional serializers + endpoints.
- Kwargs-divergent serializers (e.g. `IssueEventSerializer` returning
  different shapes for different call args) stay un-generic.