### PR TITLE
feat(performance): Add trace stack span evidence

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -32,6 +32,14 @@ describe('SpanEvidenceKeyValueList', () => {
     });
 
     parentSpan.addChild({
+      startTimestamp: 0.005,
+      endTimestamp: 0.01,
+      op: 'db',
+      description: 'SELECT * FROM authors WHERE id = %s',
+      problemSpan: ProblemSpan.CAUSE,
+    });
+
+    parentSpan.addChild({
       startTimestamp: 0.01,
       endTimestamp: 2.1,
       op: 'db',
@@ -69,15 +77,40 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         '/organizations/org-slug/insights/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29'
       );
-      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
-        'href',
-        '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=4'
-      );
+      expect(screen.getAllByRole('button', {name: 'View Full Trace'})).toEqual([
+        expect.objectContaining({
+          href: expect.stringContaining(
+            '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=4'
+          ),
+        }),
+        expect.objectContaining({
+          href: expect.stringContaining(
+            '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=4'
+          ),
+        }),
+      ]);
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
       expect(
         screen.getByTestId('span-evidence-key-value-list.parent-span')
       ).toHaveTextContent('http.server');
+      expect(screen.getByRole('cell', {name: 'Preceding Span'})).toBeInTheDocument();
+      expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+        'Repeating DB Queries (2)'
+      );
+      expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+        /SELECT \*\s+FROM books/
+      );
+      expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+        'Preceding Span'
+      );
+      expect(screen.getByRole('button', {name: 'Show preceding span'})).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+      expect(
+        screen.getByTestId('span-evidence-trace-stack.transaction')
+      ).toHaveTextContent('/');
 
       expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
       expect(
@@ -143,15 +176,29 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         '/organizations/org-slug/insights/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29'
       );
-      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
-        'href',
-        '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=4'
-      );
+      expect(screen.getAllByRole('button', {name: 'View Full Trace'})).toEqual([
+        expect.objectContaining({
+          href: expect.stringContaining(
+            '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=4'
+          ),
+        }),
+        expect.objectContaining({
+          href: expect.stringContaining(
+            '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=4'
+          ),
+        }),
+      ]);
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
       expect(
         screen.getByTestId('span-evidence-key-value-list.parent-span')
       ).toHaveTextContent('http.server');
+      expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+        'Repeating DB Queries (2)'
+      );
+      expect(
+        screen.getByTestId('span-evidence-trace-stack.transaction')
+      ).toHaveTextContent('/');
 
       expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
       expect(
@@ -225,15 +272,29 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         '/organizations/org-slug/insights/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29'
       );
-      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
-        'href',
-        '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=4'
-      );
+      expect(screen.getAllByRole('button', {name: 'View Full Trace'})).toEqual([
+        expect.objectContaining({
+          href: expect.stringContaining(
+            '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=4'
+          ),
+        }),
+        expect.objectContaining({
+          href: expect.stringContaining(
+            '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=4'
+          ),
+        }),
+      ]);
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
       expect(
         screen.getByTestId('span-evidence-key-value-list.parent-span')
       ).toHaveTextContent('http.server');
+      expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+        'Repeating DB Queries (2)'
+      );
+      expect(
+        screen.getByTestId('span-evidence-trace-stack.transaction')
+      ).toHaveTextContent('/');
 
       expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
       expect(
@@ -475,6 +536,10 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId(/span-evidence-key-value-list.repeating-spans/)
       ).toHaveTextContent('/user/*/book/?book_id=*');
+      expect(screen.getByRole('cell', {name: 'Trace Path'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.trace-path')
+      ).toHaveTextContent('/ → pageload → Repeating API Calls (2)');
 
       expect(screen.getByRole('cell', {name: 'Query Parameters'})).toBeInTheDocument();
 
@@ -594,31 +659,28 @@ describe('SpanEvidenceKeyValueList', () => {
     const parentSpan = new MockSpan({
       startTimestamp: 0,
       endTimestamp: 200,
-      op: 'pageload',
+      op: 'function',
+      description: 'LinkCatalog',
       problemSpan: ProblemSpan.PARENT,
     });
 
     parentSpan.addChild({
+      startTimestamp: 1,
+      endTimestamp: 300,
+      op: 'function',
+      description: 'LinkCatalogStore',
+    });
+
+    parentSpan.children[0]!.addChild({
       startTimestamp: 10,
       endTimestamp: 10100,
       op: 'db',
       description: 'SELECT pokemon FROM pokedex',
       problemSpan: ProblemSpan.OFFENDER,
     });
-    parentSpan.children[0]!.span.data = {
-      'code.filepath': '/app/pokedex/queries.py',
-      'code.function': 'fetchPokemon',
-      'code.lineno': 42,
-    };
-
     builder.addSpan(parentSpan);
 
     it('Renders relevant fields', () => {
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/dashboards/',
-        body: [],
-      });
-
       render(
         <SpanEvidenceKeyValueList
           event={builder.getEventFixture()}
@@ -641,29 +703,45 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         '/organizations/org-slug/insights/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29'
       );
-      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
-        'href',
-        '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=10100'
+      expect(screen.getAllByRole('button', {name: 'View Full Trace'})).toEqual([
+        expect.objectContaining({
+          href: expect.stringContaining(
+            '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=10100'
+          ),
+        }),
+        expect.objectContaining({
+          href: expect.stringContaining(
+            '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=10100'
+          ),
+        }),
+      ]);
+      expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+        'Transaction/'
+      );
+      expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+        'FunctionLinkCatalog'
+      );
+      expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+        'FunctionLinkCatalogStore'
+      );
+      expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+        'Slow DB Query'
+      );
+      expect(screen.getByRole('button', {name: 'Hide slow DB query'})).toHaveAttribute(
+        'aria-expanded',
+        'true'
       );
 
-      expect(screen.getByRole('cell', {name: 'Slow DB Query'})).toBeInTheDocument();
-      expect(
-        screen.getByTestId('span-evidence-key-value-list.slow-db-query')
-      ).toHaveTextContent('SELECT pokemon FROM pokedex');
-      expect(
-        screen.getByTestId('span-evidence-key-value-list.slow-db-query')
-      ).toHaveTextContent('/app/pokedex/queries.py in fetchPokemon at line 42');
+      expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+        /SELECT pokemon\s+FROM pokedex/
+      );
+      expect(screen.queryByRole('cell', {name: 'Slow DB Query'})).not.toBeInTheDocument();
       expect(screen.getByRole('cell', {name: 'Duration Impact'})).toBeInTheDocument();
-
-      expect(screen.getByRole('link', {name: 'More Samples'})).toBeInTheDocument();
+      expect(screen.queryByRole('cell', {name: 'Trace Path'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', {name: 'More Samples'})).not.toBeInTheDocument();
     });
 
-    it('renders span-specific missing query source copy', () => {
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/dashboards/',
-        body: [],
-      });
-
+    it('renders without query source copy when code location is missing', () => {
       const builderWithoutCodeLocation = new TransactionEventBuilder(
         'a1',
         '/',
@@ -700,13 +778,10 @@ describe('SpanEvidenceKeyValueList', () => {
         }
       );
 
-      const slowDbQuery = screen.getByTestId(
-        'span-evidence-key-value-list.slow-db-query'
-      );
+      const slowDbQuery = screen.getByTestId('span-evidence-trace-stack-example');
 
-      expect(slowDbQuery).toHaveTextContent(
-        'Query source is not available for this span.'
-      );
+      expect(slowDbQuery).toHaveTextContent(/SELECT pokemon\s+FROM pokedex/);
+      expect(slowDbQuery).not.toHaveTextContent('Query source is not available');
       expect(slowDbQuery).not.toHaveTextContent('selected date range');
     });
   });
@@ -760,6 +835,10 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.slow-resource-span')
       ).toHaveTextContent('resource.script - https://example.com/resource.js');
+      expect(screen.getByRole('cell', {name: 'Trace Path'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.trace-path')
+      ).toHaveTextContent('/ → Slow Resource Span');
 
       expect(screen.getByRole('cell', {name: 'FCP Delay'})).toBeInTheDocument();
       expect(
@@ -824,6 +903,10 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.slow-resource-span')
       ).toHaveTextContent('resource.script - https://example.com/resource.js');
+      expect(screen.getByRole('cell', {name: 'Trace Path'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.trace-path')
+      ).toHaveTextContent('/ → Slow Resource Span');
 
       expect(screen.getByRole('cell', {name: 'Asset Size'})).toBeInTheDocument();
       expect(
@@ -926,6 +1009,10 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.large-http-payload-span')
       ).toHaveTextContent('http.client - https://example.com/api/users');
+      expect(screen.getByRole('cell', {name: 'Trace Path'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.trace-path')
+      ).toHaveTextContent('/ → Large HTTP Payload Span');
 
       expect(screen.getByRole('cell', {name: 'Payload Size'})).toBeInTheDocument();
       expect(

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -8,13 +8,15 @@ import mapValues from 'lodash/mapValues';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ClippedBox} from 'sentry/components/clippedBox';
 import {getKeyValueListData as getRegressionIssueKeyValueList} from 'sentry/components/events/eventStatisticalDetector/eventRegressionSummary';
 import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
+import {makeTracePathRow} from 'sentry/components/events/interfaces/performance/spanEvidenceTracePath';
+import {SpanEvidenceTraceStack} from 'sentry/components/events/interfaces/performance/spanEvidenceTraceStack';
 import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
 import type {
   ProcessedSpanType,
@@ -26,7 +28,6 @@ import {
   SpanSubTimingName,
 } from 'sentry/components/events/interfaces/spans/utils';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
-import {IconGraph} from 'sentry/icons/iconGraph';
 import {t} from 'sentry/locale';
 import type {Entry, EntryRequest, Event, EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
@@ -45,16 +46,6 @@ import {SQLishFormatter} from 'sentry/utils/sqlish';
 import {safeURL} from 'sentry/utils/url/safeURL';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {
-  MissingFrame,
-  StackTraceMiniFrame,
-} from 'sentry/views/insights/database/components/stackTraceMiniFrame';
-import {SpanFields} from 'sentry/views/insights/types';
-import {SpanSummaryLink} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/components/spanSummaryLink';
-import {
-  getSearchInExploreTarget,
-  TraceDrawerActionKind,
-} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils/getPerformanceDuration';
 
@@ -137,17 +128,22 @@ function LargeHTTPPayloadSpanEvidence({
   projectSlug,
   location,
 }: SpanEvidenceKeyValueListProps) {
+  const offendingSpan = offendingSpans[0]!;
+
   return (
     <PresortedKeyValueList
-      data={[
-        makeTransactionNameRow(event, organization, location, projectSlug),
-        makeRow(t('Large HTTP Payload Span'), getSpanEvidenceValue(offendingSpans[0]!)),
-        makeRow(
-          t('Payload Size'),
-          getSpanFieldBytes(offendingSpans[0]!, 'http.response_content_length') ??
-            getSpanFieldBytes(offendingSpans[0]!, 'Encoded Body Size')
-        ),
-      ].filter(Boolean)}
+      data={
+        [
+          makeTransactionNameRow(event, organization, location, projectSlug),
+          makeTracePathRow(event, offendingSpan, t('Large HTTP Payload Span')),
+          makeRow(t('Large HTTP Payload Span'), getSpanEvidenceValue(offendingSpan)),
+          makeRow(
+            t('Payload Size'),
+            getSpanFieldBytes(offendingSpan, 'http.response_content_length') ??
+              getSpanFieldBytes(offendingSpan, 'Encoded Body Size')
+          ),
+        ].filter(Boolean) as KeyValueListData
+      }
     />
   );
 }
@@ -191,27 +187,43 @@ function NPlusOneDBQueriesSpanEvidence({
     );
   const evidenceData = event?.occurrence?.evidenceData ?? {};
   const patternSize = evidenceData.patternSize ?? 0;
+  const precedingSpan = causeSpans[0];
 
   return (
-    <PresortedKeyValueList
-      data={
-        [
-          makeTransactionNameRow(event, organization, location, projectSlug),
-          parentSpan ? makeRow(t('Parent Span'), getSpanEvidenceValue(parentSpan)) : null,
-          causeSpans.length > 0
-            ? makeRow(t('Preceding Span'), getSpanEvidenceValue(causeSpans[0]!))
-            : null,
-          ...repeatingSpanRows,
-          patternSize > 0 ? makeRow(t('Pattern Size'), patternSize) : null,
-        ].filter(Boolean) as KeyValueListData
-      }
-    />
+    <Stack gap="md">
+      <SpanEvidenceTraceStack
+        event={event}
+        location={location}
+        organization={organization}
+        parentSpan={parentSpan}
+        offendingSpans={dbSpans}
+        patternSize={patternSize}
+        precedingSpan={precedingSpan}
+        projectSlug={projectSlug}
+      />
+      <PresortedKeyValueList
+        data={
+          [
+            makeTransactionNameRow(event, organization, location, projectSlug),
+            parentSpan
+              ? makeRow(t('Parent Span'), getSpanEvidenceValue(parentSpan))
+              : null,
+            causeSpans.length > 0
+              ? makeRow(t('Preceding Span'), getSpanEvidenceValue(causeSpans[0]!))
+              : null,
+            ...repeatingSpanRows,
+            patternSize > 0 ? makeRow(t('Pattern Size'), patternSize) : null,
+          ].filter(Boolean) as KeyValueListData
+        }
+      />
+    </Stack>
   );
 }
 
 function NPlusOneAPICallsSpanEvidence({
   event,
   offendingSpans,
+  parentSpan,
   organization,
   projectSlug,
   location,
@@ -226,12 +238,22 @@ function NPlusOneAPICallsSpanEvidence({
   const pathParameters = evidenceData.pathParameters ?? [];
   const commonPathPrefix =
     occurrence?.subtitle ?? formatBasePath(offendingSpans[0]!, baseURL);
+  const tracePathSpan = parentSpan ?? offendingSpans[0];
+  const tracePathRow = tracePathSpan
+    ? makeTracePathRow(
+        event,
+        tracePathSpan,
+        parentSpan ? undefined : t('Repeating API Calls (%s)', offendingSpans.length),
+        parentSpan ? t('Repeating API Calls (%s)', offendingSpans.length) : undefined
+      )
+    : null;
 
   return (
     <PresortedKeyValueList
       data={
         [
           makeTransactionNameRow(event, organization, location, projectSlug),
+          tracePathRow,
           commonPathPrefix
             ? makeRow(
                 t('Repeating Spans (%s)', offendingSpans.length),
@@ -503,70 +525,28 @@ function SlowDBQueryEvidence({
   location,
 }: SpanEvidenceKeyValueListProps) {
   const span = offendingSpans[0]!;
-  const sentryTags = 'sentry_tags' in span ? span.sentry_tags : undefined;
-  const groupHash = sentryTags?.group ?? span.hash ?? '';
-  const hasExplore = organization.features.includes('visibility-explore-view');
-
-  const queryValue = (
-    <QueryCard>
-      <Stack minWidth={0}>
-        <NoPaddingClippedBox clipHeight={200}>
-          <StyledCodeSnippet language="sql">
-            {formatter.toString(span.description ?? '')}
-          </StyledCodeSnippet>
-        </NoPaddingClippedBox>
-        {span.data?.['code.filepath'] ? (
-          <StackTraceMiniFrame
-            projectId={event.projectID}
-            event={event}
-            frame={{
-              filename: span.data['code.filepath'],
-              lineNo: span.data['code.lineno'],
-              function: span.data['code.function'],
-            }}
-          />
-        ) : (
-          <MissingFrame source="span" />
-        )}
-      </Stack>
-      <Flex gap="md" padding="md lg" borderTop="muted">
-        <SpanSummaryLink
-          op={span.op}
-          category={sentryTags?.category}
-          group={groupHash}
-          project_id={event.projectID}
-          organization={organization}
-        />
-        {hasExplore && span.description && (
-          <Link
-            to={getSearchInExploreTarget(
-              organization,
-              location,
-              event.projectID,
-              SpanFields.SPAN_DESCRIPTION,
-              span.description,
-              TraceDrawerActionKind.INCLUDE
-            )}
-          >
-            <Flex align="center" gap="xs">
-              <IconGraph type="scatter" size="xs" />
-              {t('More Samples')}
-            </Flex>
-          </Link>
-        )}
-      </Flex>
-    </QueryCard>
-  );
 
   return (
-    <KeyValueList
-      shouldSort={false}
-      data={[
-        makeTransactionNameRow(event, organization, location, projectSlug),
-        makeRow(t('Duration Impact'), getSingleSpanDurationImpact(event, span)),
-        makeRow(t('Slow DB Query'), queryValue),
-      ]}
-    />
+    <Stack gap="md">
+      <SpanEvidenceTraceStack
+        collapseEvidenceLabel={t('Hide slow DB query')}
+        event={event}
+        evidenceTitle={t('Slow DB Query')}
+        expandEvidenceLabel={t('Show slow DB query')}
+        location={location}
+        organization={organization}
+        offendingSpans={[span]}
+        projectSlug={projectSlug}
+        sqlStatements={span.description ? [span.description] : []}
+      />
+      <KeyValueList
+        shouldSort={false}
+        data={[
+          makeTransactionNameRow(event, organization, location, projectSlug),
+          makeRow(t('Duration Impact'), getSingleSpanDurationImpact(event, span)),
+        ]}
+      />
+    </Stack>
   );
 }
 
@@ -581,18 +561,24 @@ function RenderBlockingAssetSpanEvidence({
 
   return (
     <PresortedKeyValueList
-      data={[
-        makeTransactionNameRow(event, organization, location, projectSlug),
-        makeRow(t('Slow Resource Span'), getSpanEvidenceValue(offendingSpan!)),
-        makeRow(
-          t('FCP Delay'),
-          formatDelay(
-            getSpanDuration(offendingSpan!),
-            event.measurements?.fcp?.value ?? 0
-          )
-        ),
-        makeRow(t('Duration Impact'), getSingleSpanDurationImpact(event, offendingSpan!)),
-      ]}
+      data={
+        [
+          makeTransactionNameRow(event, organization, location, projectSlug),
+          makeTracePathRow(event, offendingSpan!, t('Slow Resource Span')),
+          makeRow(t('Slow Resource Span'), getSpanEvidenceValue(offendingSpan!)),
+          makeRow(
+            t('FCP Delay'),
+            formatDelay(
+              getSpanDuration(offendingSpan!),
+              event.measurements?.fcp?.value ?? 0
+            )
+          ),
+          makeRow(
+            t('Duration Impact'),
+            getSingleSpanDurationImpact(event, offendingSpan!)
+          ),
+        ].filter(Boolean) as KeyValueListData
+      }
     />
   );
 }
@@ -604,21 +590,26 @@ function UncompressedAssetSpanEvidence({
   projectSlug,
   location,
 }: SpanEvidenceKeyValueListProps) {
+  const offendingSpan = offendingSpans[0]!;
+
   return (
     <PresortedKeyValueList
-      data={[
-        makeTransactionNameRow(event, organization, location, projectSlug),
-        makeRow(t('Slow Resource Span'), getSpanEvidenceValue(offendingSpans[0]!)),
-        makeRow(
-          t('Asset Size'),
-          getSpanFieldBytes(offendingSpans[0]!, 'http.response_content_length') ??
-            getSpanFieldBytes(offendingSpans[0]!, 'Encoded Body Size')
-        ),
-        makeRow(
-          t('Duration Impact'),
-          getSingleSpanDurationImpact(event, offendingSpans[0]!)
-        ),
-      ]}
+      data={
+        [
+          makeTransactionNameRow(event, organization, location, projectSlug),
+          makeTracePathRow(event, offendingSpan, t('Slow Resource Span')),
+          makeRow(t('Slow Resource Span'), getSpanEvidenceValue(offendingSpan)),
+          makeRow(
+            t('Asset Size'),
+            getSpanFieldBytes(offendingSpan, 'http.response_content_length') ??
+              getSpanFieldBytes(offendingSpan, 'Encoded Body Size')
+          ),
+          makeRow(
+            t('Duration Impact'),
+            getSingleSpanDurationImpact(event, offendingSpan)
+          ),
+        ].filter(Boolean) as KeyValueListData
+      }
     />
   );
 }
@@ -923,14 +914,4 @@ function formatBasePath(span: Span, baseURL?: string): string {
 
 const NoPaddingClippedBox = styled(ClippedBox)`
   padding: 0;
-`;
-
-const QueryCard = styled('div')`
-  border-radius: ${p => p.theme.radius.md};
-  overflow: hidden;
-  border: 1px solid ${p => p.theme.tokens.border.secondary};
-  pre {
-    margin: 0 !important;
-    padding-top: ${p => p.theme.space.md} !important;
-  }
 `;

--- a/static/app/components/events/interfaces/performance/spanEvidenceTracePath.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceTracePath.spec.tsx
@@ -1,0 +1,71 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  MockSpan,
+  ProblemSpan,
+  TransactionEventBuilder,
+} from 'sentry-test/performance/utils';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {IssueType} from 'sentry/types/group';
+
+import {SpanEvidenceKeyValueList} from './spanEvidenceKeyValueList';
+
+describe('spanEvidenceTracePath', () => {
+  it('collapses long trace paths', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      body: [],
+    });
+
+    const builder = new TransactionEventBuilder(
+      'a1',
+      '/',
+      IssueType.PERFORMANCE_SLOW_DB_QUERY
+    );
+
+    const rootSpan = new MockSpan({
+      startTimestamp: 0,
+      endTimestamp: 100,
+      op: 'function',
+      description: 'LinkCatalog',
+    });
+    let currentSpan = rootSpan;
+
+    for (let i = 1; i <= 5; i++) {
+      currentSpan.addChild({
+        startTimestamp: i,
+        endTimestamp: 100 + i,
+        op: 'function',
+        description: `Layer ${i}`,
+      });
+      currentSpan = currentSpan.children[0]!;
+    }
+
+    currentSpan.addChild({
+      startTimestamp: 10,
+      endTimestamp: 10100,
+      op: 'db',
+      description: 'SELECT pokemon FROM pokedex',
+      problemSpan: ProblemSpan.OFFENDER,
+    });
+
+    builder.addSpan(rootSpan);
+
+    render(<SpanEvidenceKeyValueList event={builder.getEventFixture()} />, {
+      organization: OrganizationFixture({
+        features: ['visibility-explore-view'],
+      }),
+    });
+
+    const tracePath = screen.getByTestId('span-evidence-key-value-list.trace-path');
+
+    expect(tracePath).toHaveTextContent('… 3 spans hidden');
+    expect(tracePath).not.toHaveTextContent('Layer 2');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Show full path'}));
+
+    expect(tracePath).toHaveTextContent('Layer 2');
+    expect(tracePath).not.toHaveTextContent('… 3 spans hidden');
+  });
+});

--- a/static/app/components/events/interfaces/performance/spanEvidenceTracePath.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceTracePath.tsx
@@ -1,0 +1,221 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+
+import type {
+  RawSpanType,
+  TraceContextSpanProxy,
+} from 'sentry/components/events/interfaces/spans/types';
+import {t} from 'sentry/locale';
+import type {Entry, EntrySpans, EventTransaction} from 'sentry/types/event';
+import {EntryType} from 'sentry/types/event';
+import type {KeyValueListDataItem} from 'sentry/types/group';
+
+const TEST_ID_NAMESPACE = 'span-evidence-key-value-list';
+const MAX_VISIBLE_TRACE_PATH_LINES = 6;
+
+export type SpanEvidenceTraceSpan = (RawSpanType | TraceContextSpanProxy) & {
+  data?: any;
+  start_timestamp?: number;
+  timestamp?: number;
+};
+
+export type TracePathLine = {
+  depth: number;
+  label: string;
+  kindLabel?: string;
+};
+
+export function makeTracePathRow(
+  event: EventTransaction,
+  targetSpan: SpanEvidenceTraceSpan,
+  targetSpanLabel?: string,
+  appendedLabel?: string
+): KeyValueListDataItem | null {
+  const tracePathLines = getTracePathLines(event, targetSpan, targetSpanLabel);
+
+  if (!tracePathLines) {
+    return null;
+  }
+
+  if (appendedLabel) {
+    const lastLine = tracePathLines[tracePathLines.length - 1]!;
+    tracePathLines.push({
+      depth: lastLine.depth + 1,
+      kindLabel: t('Evidence'),
+      label: appendedLabel,
+    });
+  }
+
+  return {
+    key: 'trace-path',
+    subject: t('Trace Path'),
+    value: <TracePath lines={tracePathLines} />,
+    subjectDataTestId: `${TEST_ID_NAMESPACE}.trace-path`,
+  };
+}
+
+const isSpanEntry = (entry: Entry): entry is EntrySpans => {
+  return entry.type === EntryType.SPANS;
+};
+
+export function getTracePathLines(
+  event: EventTransaction,
+  targetSpan: SpanEvidenceTraceSpan,
+  targetSpanLabel?: string
+): TracePathLine[] | null {
+  const traceContext = event.contexts?.trace;
+  const traceRootSpanId = traceContext?.span_id;
+  const spanEntry = event.entries.find(isSpanEntry);
+  const spans: SpanEvidenceTraceSpan[] = [...(spanEntry?.data ?? [])];
+
+  if (traceContext) {
+    spans.push(traceContext as TraceContextSpanProxy);
+  }
+
+  const spansById = new Map(spans.map(span => [span.span_id, span]));
+  const path: SpanEvidenceTraceSpan[] = [];
+  const visitedSpanIds = new Set<string>();
+  let currentSpan: SpanEvidenceTraceSpan | undefined = targetSpan;
+
+  while (currentSpan && !visitedSpanIds.has(currentSpan.span_id)) {
+    visitedSpanIds.add(currentSpan.span_id);
+    path.unshift(currentSpan);
+
+    if (currentSpan.span_id === traceRootSpanId || !currentSpan.parent_span_id) {
+      break;
+    }
+
+    currentSpan = spansById.get(currentSpan.parent_span_id);
+  }
+
+  const spanLines = path
+    .filter(span => span.span_id !== traceRootSpanId)
+    .map(
+      span =>
+        ({
+          kindLabel: getTracePathSpanKindLabel(span),
+          label:
+            span.span_id === targetSpan.span_id && targetSpanLabel
+              ? targetSpanLabel
+              : getTracePathSpanLabel(span),
+        }) satisfies Pick<TracePathLine, 'kindLabel' | 'label'>
+    );
+
+  if (spanLines.length === 0) {
+    return null;
+  }
+
+  return [{kindLabel: t('Transaction'), label: event.title}, ...spanLines].map(
+    (line, depth) => ({...line, depth})
+  );
+}
+
+function getTracePathSpanKindLabel(span: SpanEvidenceTraceSpan): string {
+  const op = span.op ?? '';
+
+  if (op.startsWith('db')) {
+    return t('Database');
+  }
+
+  if (op === 'http.server') {
+    return t('HTTP Server');
+  }
+
+  if (op.startsWith('http')) {
+    return t('HTTP Client');
+  }
+
+  if (op.startsWith('resource')) {
+    return t('Resource');
+  }
+
+  if (op.includes('function')) {
+    return t('Function');
+  }
+
+  if (op.includes('middleware')) {
+    return t('Middleware');
+  }
+
+  if (op.includes('rpc')) {
+    return t('RPC');
+  }
+
+  if (op.includes('cache')) {
+    return t('Cache');
+  }
+
+  return t('Span');
+}
+
+function getTracePathSpanLabel(span: SpanEvidenceTraceSpan): string {
+  const label = span.description ?? span.op ?? span.span_id;
+  const normalizedLabel = String(label).replace(/\s+/g, ' ').trim();
+  const maxLength = 160;
+
+  if (normalizedLabel.length <= maxLength) {
+    return normalizedLabel;
+  }
+
+  return `${normalizedLabel.slice(0, maxLength - 1)}…`;
+}
+
+function TracePath({lines}: {lines: TracePathLine[]}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const shouldCollapse = lines.length > MAX_VISIBLE_TRACE_PATH_LINES;
+  const visibleLines =
+    shouldCollapse && !isExpanded ? getCollapsedTracePathLines(lines) : lines;
+
+  return (
+    <TracePathContainer gap="xs" align="start">
+      <TracePathPre>
+        {visibleLines.map(line => (
+          <Fragment key={`${line.depth}-${line.label}`}>
+            {formatTracePathLine(line)}
+            {'\n'}
+          </Fragment>
+        ))}
+      </TracePathPre>
+      {shouldCollapse ? (
+        <Button
+          size="xs"
+          variant="link"
+          onClick={() => setIsExpanded(expanded => !expanded)}
+        >
+          {isExpanded ? t('Show less') : t('Show full path')}
+        </Button>
+      ) : null}
+    </TracePathContainer>
+  );
+}
+
+function getCollapsedTracePathLines(lines: TracePathLine[]): TracePathLine[] {
+  const head = lines.slice(0, 2);
+  const tail = lines.slice(-3);
+  const hiddenCount = lines.length - head.length - tail.length;
+
+  return [
+    ...head,
+    {depth: head.length, label: t('… %s spans hidden', hiddenCount)},
+    ...tail,
+  ];
+}
+
+function formatTracePathLine({depth, label}: TracePathLine): string {
+  return `${depth === 0 ? '' : `${'  '.repeat(depth)}→ `}${label}`;
+}
+
+const TracePathContainer = styled(Stack)`
+  width: 100%;
+`;
+
+const TracePathPre = styled('pre')`
+  margin: 0;
+  width: 100%;
+  box-sizing: border-box;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+`;

--- a/static/app/components/events/interfaces/performance/spanEvidenceTraceStack.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceTraceStack.spec.tsx
@@ -1,0 +1,203 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  MockSpan,
+  ProblemSpan,
+  TransactionEventBuilder,
+} from 'sentry-test/performance/utils';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {EntrySpans} from 'sentry/types/event';
+import {EntryType} from 'sentry/types/event';
+import {IssueType} from 'sentry/types/group';
+
+import {SpanEvidenceTraceStack} from './spanEvidenceTraceStack';
+
+describe('SpanEvidenceTraceStack', () => {
+  it('renders an interactive evidence stack for a slow db query', async () => {
+    const builder = new TransactionEventBuilder(
+      'a1',
+      '/',
+      IssueType.PERFORMANCE_SLOW_DB_QUERY
+    );
+    builder.getEventFixture().projectID = '123';
+
+    const parentSpan = new MockSpan({
+      startTimestamp: 0,
+      endTimestamp: 0.2,
+      op: 'function',
+      description: 'LinkCatalog',
+      problemSpan: ProblemSpan.PARENT,
+    });
+
+    parentSpan.addChild({
+      startTimestamp: 0.01,
+      endTimestamp: 4,
+      op: 'db',
+      description: 'SELECT pokemon FROM pokedex',
+      problemSpan: ProblemSpan.OFFENDER,
+    });
+
+    builder.addSpan(parentSpan);
+
+    const event = builder.getEventFixture();
+    const spanEntry = event.entries.find(
+      (entry): entry is EntrySpans => entry.type === EntryType.SPANS
+    )!;
+
+    render(
+      <SpanEvidenceTraceStack
+        collapseEvidenceLabel="Hide slow DB query"
+        event={event}
+        evidenceTitle="Slow DB Query"
+        expandEvidenceLabel="Show slow DB query"
+        location={LocationFixture()}
+        organization={OrganizationFixture()}
+        offendingSpans={[spanEntry.data[1]!]}
+        projectSlug="project"
+        sqlStatements={['SELECT pokemon FROM pokedex']}
+      />
+    );
+
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      'Transaction/'
+    );
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      'FunctionLinkCatalog'
+    );
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      'Slow DB Query'
+    );
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      /SELECT pokemon\s+FROM pokedex/
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Hide slow DB query'}));
+
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).not.toHaveTextContent(
+      /SELECT pokemon\s+FROM pokedex/
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Show slow DB query'}));
+
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      /SELECT pokemon\s+FROM pokedex/
+    );
+  });
+
+  it('renders an interactive evidence stack for repeated db queries', async () => {
+    const builder = new TransactionEventBuilder(
+      'a1',
+      '/',
+      IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES
+    );
+    builder.getEventFixture().projectID = '123';
+
+    const parentSpan = new MockSpan({
+      startTimestamp: 0,
+      endTimestamp: 0.2,
+      op: 'function',
+      description: 'LinkCatalogStore',
+      problemSpan: ProblemSpan.PARENT,
+    });
+
+    parentSpan.addChild({
+      startTimestamp: 0.005,
+      endTimestamp: 0.01,
+      op: 'db',
+      description: 'SELECT * FROM authors WHERE id = %s',
+      problemSpan: ProblemSpan.CAUSE,
+    });
+    parentSpan.addChild({
+      startTimestamp: 0.01,
+      endTimestamp: 2.1,
+      op: 'db',
+      description: 'SELECT * FROM books',
+      hash: 'aaa',
+      problemSpan: ProblemSpan.OFFENDER,
+    });
+    parentSpan.addChild({
+      startTimestamp: 2.1,
+      endTimestamp: 4,
+      op: 'db',
+      description: 'SELECT * FROM books',
+      hash: 'aaa',
+      problemSpan: ProblemSpan.OFFENDER,
+    });
+
+    builder.addSpan(parentSpan);
+
+    const event = builder.getEventFixture();
+    const spanEntry = event.entries.find(
+      (entry): entry is EntrySpans => entry.type === EntryType.SPANS
+    )!;
+
+    render(
+      <SpanEvidenceTraceStack
+        event={event}
+        location={LocationFixture()}
+        organization={OrganizationFixture()}
+        parentSpan={spanEntry.data[0]}
+        offendingSpans={[spanEntry.data[2]!, spanEntry.data[3]!]}
+        patternSize={2}
+        precedingSpan={spanEntry.data[1]}
+        projectSlug="project"
+      />
+    );
+
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      'Repeating DB Queries (2)'
+    );
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      'Transaction/'
+    );
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      'FunctionLinkCatalogStore'
+    );
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      'Repeating DB Queries (2)'
+    );
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      'Pattern Size 2'
+    );
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      'Preceding Span'
+    );
+    expect(screen.queryByText('Operation')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('SELECT * FROM authors WHERE id = %s')
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('link', {name: '/'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/insights/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29'
+    );
+    expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/traces/trace/8cbbc19c0f54447ab702f00263262726/?eventId=a1&statsPeriod=14d&timestamp=4'
+    );
+
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      /SELECT \*\s+FROM books/
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Show preceding span'}));
+
+    expect(screen.queryByText('Operation')).not.toBeInTheDocument();
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      /SELECT \*\s+FROM authors\s+WHERE id = %s/
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Hide repeated queries'}));
+
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).not.toHaveTextContent(
+      /SELECT \*\s+FROM books/
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Show repeated queries'}));
+
+    expect(screen.getByTestId('span-evidence-trace-stack-example')).toHaveTextContent(
+      /SELECT \*\s+FROM books/
+    );
+  });
+});

--- a/static/app/components/events/interfaces/performance/spanEvidenceTraceStack.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceTraceStack.tsx
@@ -1,0 +1,457 @@
+import type {ReactNode} from 'react';
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+import type {Location} from 'history';
+
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {CodeBlock} from '@sentry/scraps/code';
+import {Flex} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {IconChevron, IconWarning} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {EventTransaction} from 'sentry/types/event';
+import type {Organization} from 'sentry/types/organization';
+import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
+import {SQLishFormatter} from 'sentry/utils/sqlish';
+import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
+
+import {
+  getTracePathLines,
+  type SpanEvidenceTraceSpan,
+  type TracePathLine,
+} from './spanEvidenceTracePath';
+
+const formatter = new SQLishFormatter();
+
+type SpanEvidenceTraceStackProps = {
+  event: EventTransaction;
+  offendingSpans: SpanEvidenceTraceSpan[];
+  organization: Organization;
+  collapseEvidenceLabel?: string;
+  evidenceBadges?: ReactNode[];
+  evidenceTitle?: string;
+  expandEvidenceLabel?: string;
+  location?: Location;
+  parentSpan?: SpanEvidenceTraceSpan | null;
+  patternSize?: number;
+  precedingSpan?: SpanEvidenceTraceSpan | null;
+  projectSlug?: string;
+  sqlStatements?: string[];
+};
+
+export function SpanEvidenceTraceStack({
+  event,
+  collapseEvidenceLabel,
+  evidenceBadges,
+  evidenceTitle,
+  expandEvidenceLabel,
+  offendingSpans,
+  organization,
+  location,
+  parentSpan,
+  patternSize,
+  precedingSpan,
+  projectSlug,
+  sqlStatements,
+}: SpanEvidenceTraceStackProps) {
+  const targetSpan = parentSpan ?? offendingSpans[0];
+
+  if (!targetSpan) {
+    return null;
+  }
+
+  const terminalLabel =
+    evidenceTitle ?? t('Repeating DB Queries (%s)', offendingSpans.length);
+  const tracePathLines =
+    getTracePathLines(event, targetSpan, parentSpan ? undefined : terminalLabel) ?? [];
+
+  if (parentSpan && tracePathLines.length > 0) {
+    const lastLine = tracePathLines[tracePathLines.length - 1]!;
+    tracePathLines.push({
+      depth: lastLine.depth + 1,
+      kindLabel: t('Evidence'),
+      label: terminalLabel,
+    });
+  }
+
+  const evidenceSqlStatements = Array.from(
+    new Set(
+      (sqlStatements ?? offendingSpans.map(span => span.description)).filter(Boolean)
+    )
+  ) as string[];
+  const metadataBadges =
+    evidenceBadges ??
+    [
+      patternSize ? t('Pattern Size %s', patternSize) : null,
+      evidenceSqlStatements.length > 1
+        ? t('%s query shapes', evidenceSqlStatements.length)
+        : null,
+    ].filter(Boolean);
+
+  if (tracePathLines.length === 0) {
+    return null;
+  }
+
+  return (
+    <TraceStack data-test-id="span-evidence-trace-stack-example">
+      {tracePathLines.map((line, index) => {
+        if (index === 0) {
+          return (
+            <TransactionFrame
+              key={`${line.depth}-${line.label}`}
+              event={event}
+              location={location}
+              organization={organization}
+              line={line}
+              projectSlug={projectSlug}
+            />
+          );
+        }
+
+        const isTerminal = index === tracePathLines.length - 1;
+
+        if (isTerminal) {
+          return (
+            <Fragment key={`${line.depth}-${line.label}`}>
+              {precedingSpan ? (
+                <ExpandablePrecedingSpanFrame depth={line.depth} span={precedingSpan} />
+              ) : null}
+              <ExpandableEvidenceFrame
+                collapseLabel={collapseEvidenceLabel}
+                expandLabel={expandEvidenceLabel}
+                line={line}
+                metadataBadges={metadataBadges}
+                sqlStatements={evidenceSqlStatements}
+              />
+            </Fragment>
+          );
+        }
+
+        return <TraceFrame key={`${line.depth}-${line.label}`} line={line} />;
+      })}
+    </TraceStack>
+  );
+}
+
+function ExpandablePrecedingSpanFrame({
+  depth,
+  span,
+}: {
+  depth: number;
+  span: SpanEvidenceTraceSpan;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const isDatabaseSpan = span.op?.startsWith('db');
+
+  return (
+    <EvidenceFrame>
+      <EvidenceHeadingRow depth={depth}>
+        <ChevronSlot>
+          <ArrowMarker>→</ArrowMarker>
+        </ChevronSlot>
+        <EvidenceHeading as="div" bold size="sm">
+          {t('Preceding Span')}
+        </EvidenceHeading>
+        <Button
+          size="zero"
+          variant="transparent"
+          aria-label={isExpanded ? t('Hide preceding span') : t('Show preceding span')}
+          aria-expanded={isExpanded}
+          onClick={() => setIsExpanded(expanded => !expanded)}
+        >
+          <IconChevron direction={isExpanded ? 'down' : 'right'} size="xs" />
+        </Button>
+      </EvidenceHeadingRow>
+      {isExpanded ? (
+        <EvidencePanel>
+          {isDatabaseSpan && span.description ? (
+            <StyledCodeBlock language="sql">
+              {formatter.toString(span.description)}
+            </StyledCodeBlock>
+          ) : span.description ? (
+            <SpanDetails>
+              <InlineLabel as="span" size="sm" variant="muted">
+                {t('Description')}
+              </InlineLabel>
+              {span.description}
+            </SpanDetails>
+          ) : (
+            <SpanDetails>
+              <InlineLabel as="span" size="sm" variant="muted">
+                {t('Span ID')}
+              </InlineLabel>
+              {span.span_id}
+            </SpanDetails>
+          )}
+        </EvidencePanel>
+      ) : null}
+    </EvidenceFrame>
+  );
+}
+
+function TransactionFrame({
+  event,
+  location,
+  organization,
+  line,
+  projectSlug,
+}: {
+  event: EventTransaction;
+  line: TracePathLine;
+  organization: Organization;
+  location?: Location;
+  projectSlug?: string;
+}) {
+  const transactionSummaryLocation = transactionSummaryRouteWithQuery({
+    organization,
+    projectID: event.projectID,
+    transaction: event.title,
+    query: {},
+  });
+
+  const traceSlug = event.contexts?.trace?.trace_id ?? '';
+  const eventDetailsLocation =
+    location && projectSlug
+      ? generateLinkToEventInTraceView({
+          traceSlug,
+          eventId: event.eventID,
+          timestamp: event.endTimestamp ?? '',
+          location,
+          organization,
+        })
+      : null;
+
+  return (
+    <TransactionRow
+      depth={line.depth}
+      data-test-id="span-evidence-trace-stack.transaction"
+    >
+      <TransactionLabel align="center" gap="xs">
+        <InlineLabel as="span" size="sm" variant="muted">
+          {line.kindLabel ?? t('Transaction')}
+        </InlineLabel>
+        <TransactionNameText as="span" ellipsis size="sm" title={line.label}>
+          <Link to={transactionSummaryLocation}>{line.label}</Link>
+        </TransactionNameText>
+      </TransactionLabel>
+      {eventDetailsLocation ? (
+        <LinkButton size="xs" to={eventDetailsLocation}>
+          {t('View Full Trace')}
+        </LinkButton>
+      ) : null}
+    </TransactionRow>
+  );
+}
+
+function TraceFrame({line}: {line: TracePathLine}) {
+  return (
+    <FrameRow depth={line.depth}>
+      <ChevronSlot>
+        <ArrowMarker>→</ArrowMarker>
+      </ChevronSlot>
+      <FrameLabel as="div" size="sm">
+        <InlineLabel as="span" size="sm" variant="muted">
+          {line.kindLabel ?? t('Span')}
+        </InlineLabel>
+        {line.label}
+      </FrameLabel>
+    </FrameRow>
+  );
+}
+
+function ExpandableEvidenceFrame({
+  collapseLabel,
+  expandLabel,
+  line,
+  metadataBadges,
+  sqlStatements,
+}: {
+  line: TracePathLine;
+  metadataBadges: ReactNode[];
+  sqlStatements: string[];
+  collapseLabel?: string;
+  expandLabel?: string;
+}) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const hideLabel = collapseLabel ?? t('Hide repeated queries');
+  const showLabel = expandLabel ?? t('Show repeated queries');
+
+  return (
+    <EvidenceFrame>
+      <EvidenceHeadingRow depth={line.depth}>
+        <ChevronSlot>
+          <IconWarning size="xs" variant="warning" />
+        </ChevronSlot>
+        <EvidenceHeading as="div" bold size="sm">
+          {line.label}
+        </EvidenceHeading>
+        {metadataBadges.map((badge, index) => (
+          <MetadataBadge key={index}>{badge}</MetadataBadge>
+        ))}
+        <Button
+          size="zero"
+          variant="transparent"
+          aria-label={isExpanded ? hideLabel : showLabel}
+          aria-expanded={isExpanded}
+          onClick={() => setIsExpanded(expanded => !expanded)}
+        >
+          <IconChevron direction={isExpanded ? 'down' : 'right'} size="xs" />
+        </Button>
+      </EvidenceHeadingRow>
+      {isExpanded ? (
+        <EvidencePanel>
+          <QueryList>
+            {sqlStatements.map(query => (
+              <QueryShape key={query}>
+                <StyledCodeBlock language="sql">
+                  {formatter.toString(query)}
+                </StyledCodeBlock>
+              </QueryShape>
+            ))}
+          </QueryList>
+        </EvidencePanel>
+      ) : null}
+    </EvidenceFrame>
+  );
+}
+
+const INDENT_WIDTH = 18;
+const BASE_ROW_PADDING = 2;
+
+const TraceStack = styled('div')`
+  border: 1px solid ${p => p.theme.tokens.border.secondary};
+  border-radius: ${p => p.theme.radius.md};
+  overflow: hidden;
+
+  > * + * {
+    border-top: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+`;
+
+const EvidenceFrame = styled('div')`
+  background: ${p => p.theme.tokens.background.primary};
+`;
+
+const FrameRow = styled(Flex)<{depth: number}>`
+  align-items: center;
+  gap: ${p => p.theme.space.sm};
+  min-height: 30px;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
+  padding-left: ${p => `${BASE_ROW_PADDING + p.depth * INDENT_WIDTH}px`};
+`;
+
+const TransactionRow = styled(FrameRow)`
+  padding-left: ${p => p.theme.space.md};
+`;
+
+const EvidenceHeadingRow = styled(FrameRow)`
+  min-height: 34px;
+  padding-top: ${p => p.theme.space.xs};
+  padding-bottom: ${p => p.theme.space.xs};
+`;
+
+const ChevronSlot = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  min-width: 16px;
+`;
+
+const ArrowMarker = styled('span')`
+  color: ${p => p.theme.tokens.content.muted};
+  font-size: ${p => p.theme.font.size.sm};
+  line-height: 1;
+`;
+
+const FrameLabel = styled(Text)`
+  min-width: 0;
+  flex: 1;
+  overflow-wrap: anywhere;
+`;
+
+const EvidenceHeading = styled(FrameLabel)`
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+`;
+
+const TransactionLabel = styled(Flex)`
+  min-width: 0;
+  flex: 1;
+`;
+
+const TransactionNameText = styled(Text)`
+  min-width: 0;
+  flex: 1;
+`;
+
+const InlineLabel = styled(Text)`
+  flex-shrink: 0;
+  font-weight: ${p => p.theme.font.weight.normal};
+  margin-right: ${p => p.theme.space.xs};
+`;
+
+const MetadataBadge = styled('div')`
+  flex-shrink: 0;
+  color: ${p => p.theme.tokens.content.muted};
+  font-size: ${p => p.theme.font.size.xs};
+  font-weight: ${p => p.theme.font.weight.normal};
+  line-height: 1;
+  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
+  border: 1px solid ${p => p.theme.tokens.border.secondary};
+  border-radius: ${p => p.theme.radius.sm};
+  background: ${p => p.theme.tokens.background.primary};
+`;
+
+const EvidencePanel = styled('div')`
+  padding: ${p => p.theme.space.sm};
+  border-top: 1px solid ${p => p.theme.tokens.border.secondary};
+  background: ${p => p.theme.tokens.background.secondary};
+`;
+
+const QueryList = styled('div')`
+  > * + * {
+    margin-top: ${p => p.theme.space.sm};
+    padding-top: ${p => p.theme.space.sm};
+    border-top: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+`;
+
+const QueryShape = styled('div')`
+  min-width: 0;
+`;
+
+const SpanDetails = styled('div')`
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: ${p => p.theme.font.size.sm};
+
+  & + & {
+    margin-top: ${p => p.theme.space.xs};
+  }
+`;
+
+const StyledCodeBlock = styled(CodeBlock)`
+  min-width: 0;
+
+  > div:last-child {
+    overflow-x: hidden;
+  }
+
+  pre {
+    margin: 0 !important;
+    padding: ${p => p.theme.space.sm} !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  pre,
+  code {
+    line-height: 18px;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+`;


### PR DESCRIPTION
Adds a reusable trace path helper and an interactive trace stack for performance span evidence. N+1 DB and slow DB issues can now show the path from transaction down to the relevant span, with expandable formatted SQL for the evidence.

Also keeps the old key/value evidence around underneath for now while we try the stack-style version.

<img width="1050" height="436" alt="image" src="https://github.com/user-attachments/assets/48a47de9-6b63-4915-827e-42b7edf907e4" />
