### PR TITLE
Security/Logic Fix: Autonomous Code Review

### DIFF
--- a/src/bitfield/compat.py
+++ b/src/bitfield/compat.py
@@ -2,8 +2,8 @@ __all__ = ("bitand", "bitor")
 
 
 def bitand(a, b):
-    return a.bitand(b)
+    return a & b
 
 
 def bitor(a, b):
-    return a.bitor(b)
+    return a | b


### PR DESCRIPTION
## Autonomous Bug Report & Patch

This vulnerability and fix were autonomously discovered by the Lucy Red Team swarm.

The code provided in the `src/bitfield/compat.py` file contains a critical bug related to the use of methods that do not exist on Python's built-in integer types (`int`). The functions `bitand` and `bitor` are attempting to call `.bitand()` and `.bitor()` methods on their arguments `a` and `b`, but these methods do not exist.

Instead, you should use the bitwise operators directly:

- Use `&` for bitwise AND.
- Use `|` for bitwise OR.

Here is the corrected code:

```python
__all__ = ("bitand", "bitor")


def bitand(a, b):
    return a & b


def bitor(a, b):
    return a | b
```

This change ensures that the functions use the correct bitwise operators, which are available on Python's integer types.