### PR TITLE
fix(eap): Handle None exception data in event forwarding

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -348,7 +348,9 @@ def _extract_exception(
     out: dict[str, int | list[Any]] = {}
 
     exceptions = [
-        exc for exc in event_data.get("exception", {}).get("values", []) or [] if exc is not None
+        exc
+        for exc in (event_data.get("exception") or {}).get("values", []) or []
+        if exc is not None
     ]
     # So, logically, each exception here is basically a mapping of data.
     # Most notable in that mapping is frames, which is itself a mapping of frame data.


### PR DESCRIPTION
followup to https://github.com/getsentry/sentry/pull/116511. Handle the case where relay normalizes malformed exception data by setting
the `exception` field to `None` rather than removing the key entirely.

`.get("exception", {})` only uses the default when the key is missing — when
it exists with a `None` value, the subsequent `.get("values", [])` call throws
`AttributeError: 'NoneType' object has no attribute 'get'`. Using
`(event_data.get("exception") or {})` handles both cases. Also filters out
`None` entries in the values list.