### PR TITLE
ref(eap): make trace item attributes alias test less fragile

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -889,27 +889,21 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
 
         response = self.do_request(query={"attributeType": "string", "substringMatch": "span.op"})
         assert response.status_code == 200, response.content
-
         keys = {item["key"] for item in response.data}
-        assert len(keys) == 1
         assert "span.op" in keys
+        assert "transaction.op" not in keys
+        assert "sentry.op" not in keys
 
         response = self.do_request(query={"attributeType": "string", "substringMatch": "op"})
         assert response.status_code == 200, response.content
-
         keys = {item["key"] for item in response.data}
-        assert len(keys) == 4
-        assert "transaction.op" in keys
-        assert "span.op" in keys
-        # These two are unrelated, but happen to match.
-        assert "db.operation" in keys
-        assert "db.operation.name" in keys
+        assert {"span.op", "transaction.op"}.issubset(keys)
+        assert "sentry.op" not in keys
 
         response = self.do_request(query={"attributeType": "string", "substringMatch": "sentry.op"})
         assert response.status_code == 200, response.content
-
         keys = {item["key"] for item in response.data}
-        assert len(keys) == 0
+        assert "sentry.op" not in keys
 
     def test_aliased_attribute_project(self) -> None:
         span1 = self.create_span(


### PR DESCRIPTION
`OrganizationTraceItemAttributesEndpointSpansTest::test_aliased_attribute` in `tests/snuba/api/endpoints/test_organization_trace_item_attributes.py` revealed itself to be fragile in #116509, when adding new attributes suddenly broke its assertions around `op` aliases:

https://github.com/getsentry/sentry/blob/61bc60a3e716563ca3bdc1dc0cd0f17114666408/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py#L904-L906

Update the test to be less fragile, focusing on the presence or absence of `op` aliases rather than complete `keys` results.