### PR TITLE
ref(integrations): Remove `organizations:integrations-github-project-management`

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -134,7 +134,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # API-driven integration setup pipeline (per-provider rollout)
     # ...
     # Project Management Integrations Feature Parity Flags
-    manager.add("organizations:integrations-github-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github_enterprise-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-gitlab-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Temporary: log full Jira Cloud `issue.updated` webhook payloads so we can design project-change link rewriting.


### PR DESCRIPTION
Remove `organizations:integrations-github-project-management`. This flag was registered but has zero usage (no code, frontend, or test references) and is not present in sentry-options-automator.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEALx9J4t3JBPPYcX3KkJN)_