### PR TITLE
fix(sdk-crash): Ignore CoreData tracker as only SDK frame

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -159,6 +159,14 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                     module_pattern="*",
                     function_pattern="**SentryCrashExceptionApplicationHelper _crashOnException**",
                 ),
+                # SentryCoreDataSwizzlingHelper sets up the swizzle that routes through
+                # SentryCoreDataTracker. It always appears alongside the tracker frame and
+                # never causes crashes itself, so it is unconditionally ignored to avoid
+                # inflating the conditional SDK frame count in the detector.
+                FunctionAndModulePattern(
+                    module_pattern="*",
+                    function_pattern="**SentryCoreDataSwizzlingHelper**",
+                ),
             },
             sdk_crash_ignore_when_only_sdk_frame_matchers={
                 # SentrySwizzleWrapper is used for method swizzling to intercept UI events.
@@ -168,19 +176,14 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                     module_pattern="*",
                     function_pattern="**SentrySwizzleWrapper**",
                 ),
-                # SentryCoreDataTracker and SentryCoreDataSwizzlingHelper swizzle
-                # NSManagedObjectContext save:/executeFetchRequest: to add tracing spans.
-                # The swizzled methods transparently call the original implementation.
+                # SentryCoreDataTracker swizzles NSManagedObjectContext save:/executeFetchRequest:
+                # to add tracing spans. It transparently calls the original implementation.
                 # Crashes inside CoreData internals (e.g., doesNotRecognizeSelector: during
                 # merge policy resolution or validation logging) are app-level CoreData
                 # misconfigurations, not SDK bugs.
                 FunctionAndModulePattern(
                     module_pattern="*",
                     function_pattern="**SentryCoreDataTracker**",
-                ),
-                FunctionAndModulePattern(
-                    module_pattern="*",
-                    function_pattern="**SentryCoreDataSwizzlingHelper**",
                 ),
             },
         )

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -168,6 +168,20 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                     module_pattern="*",
                     function_pattern="**SentrySwizzleWrapper**",
                 ),
+                # SentryCoreDataTracker and SentryCoreDataSwizzlingHelper swizzle
+                # NSManagedObjectContext save:/executeFetchRequest: to add tracing spans.
+                # The swizzled methods transparently call the original implementation.
+                # Crashes inside CoreData internals (e.g., doesNotRecognizeSelector: during
+                # merge policy resolution or validation logging) are app-level CoreData
+                # misconfigurations, not SDK bugs.
+                FunctionAndModulePattern(
+                    module_pattern="*",
+                    function_pattern="**SentryCoreDataTracker**",
+                ),
+                FunctionAndModulePattern(
+                    module_pattern="*",
+                    function_pattern="**SentryCoreDataSwizzlingHelper**",
+                ),
             },
         )
         configs.append(cocoa_config)

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_cocoa.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_cocoa.py
@@ -905,6 +905,7 @@ class CocoaSDKSwizzleWrapperTestMixin(BaseSDKCrashDetectionMixin):
         )
 
 
+@patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection.sdk_crash_reporter")
 class CocoaSDKCoreDataTrackerTestMixin(BaseSDKCrashDetectionMixin):
     """Tests for SentryCoreDataTracker/SentryCoreDataSwizzlingHelper conditional SDK crash detection.
 

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_cocoa.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_cocoa.py
@@ -905,12 +905,131 @@ class CocoaSDKSwizzleWrapperTestMixin(BaseSDKCrashDetectionMixin):
         )
 
 
+class CocoaSDKCoreDataTrackerTestMixin(BaseSDKCrashDetectionMixin):
+    """Tests for SentryCoreDataTracker/SentryCoreDataSwizzlingHelper conditional SDK crash detection.
+
+    These frames swizzle NSManagedObjectContext save:/executeFetchRequest: to add tracing spans.
+    Crashes inside CoreData internals (e.g., doesNotRecognizeSelector: during merge policy
+    resolution) are app-level misconfigurations, not SDK bugs.
+
+    Note: Frames are ordered from oldest (caller) to youngest (exception).
+    """
+
+    def test_core_data_tracker_only_sdk_frames_not_reported(
+        self, mock_sdk_crash_reporter: MagicMock
+    ) -> None:
+        """
+        SentryCoreDataTracker and SentryCoreDataSwizzlingHelper are the only SDK frames.
+        The crash is inside CoreData internals, not caused by the SDK.
+        """
+        frames = [
+            {
+                "function": "start_wqthread",
+                "package": "/usr/lib/system/libsystem_pthread.dylib",
+                "in_app": False,
+            },
+            {
+                "function": "developerSubmittedBlockToNSManagedObjectContextPerform",
+                "package": "/System/Library/Frameworks/CoreData.framework/CoreData",
+                "in_app": False,
+            },
+            {
+                "function": "__52+[SentryCoreDataSwizzlingHelper swizzleWithTracker:]_block_invoke_2.19",
+                "package": "/private/var/containers/Bundle/Application/59E988EF-46DB-4C75-8E08-10C27DC3E90E/iOS-Swift.app/Frameworks/Sentry.framework/Sentry",
+                "in_app": False,
+            },
+            {
+                "function": "-[SentryCoreDataTracker managedObjectContext:save:originalImp:]",
+                "package": "/private/var/containers/Bundle/Application/59E988EF-46DB-4C75-8E08-10C27DC3E90E/iOS-Swift.app/Frameworks/Sentry.framework/Sentry",
+                "in_app": False,
+            },
+            {
+                "function": "-[NSManagedObjectContext save:]",
+                "package": "/System/Library/Frameworks/CoreData.framework/CoreData",
+                "in_app": False,
+            },
+            {
+                "function": "-[NSMergePolicy resolveConstraintConflicts:error:]",
+                "package": "/System/Library/Frameworks/CoreData.framework/CoreData",
+                "in_app": False,
+            },
+            {
+                "function": "-[NSObject(NSObject) doesNotRecognizeSelector:]",
+                "package": "/usr/lib/libobjc.A.dylib",
+                "in_app": False,
+            },
+            {
+                "function": "objc_exception_throw",
+                "package": "/usr/lib/libobjc.A.dylib",
+                "in_app": False,
+            },
+            {
+                "function": "__exceptionPreprocess",
+                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+                "in_app": False,
+            },
+        ]
+
+        self.execute_test(
+            get_crash_event_with_frames(frames),
+            False,
+            mock_sdk_crash_reporter,
+        )
+
+    def test_core_data_tracker_with_other_sdk_frame_reported(
+        self, mock_sdk_crash_reporter: MagicMock
+    ) -> None:
+        """
+        SentryCoreDataTracker is in the stack, but there's another non-instrumentation SDK frame.
+        This IS an SDK crash.
+        """
+        frames = [
+            {
+                "function": "developerSubmittedBlockToNSManagedObjectContextPerform",
+                "package": "/System/Library/Frameworks/CoreData.framework/CoreData",
+                "in_app": False,
+            },
+            {
+                "function": "__52+[SentryCoreDataSwizzlingHelper swizzleWithTracker:]_block_invoke_2.19",
+                "package": "/private/var/containers/Bundle/Application/59E988EF-46DB-4C75-8E08-10C27DC3E90E/iOS-Swift.app/Frameworks/Sentry.framework/Sentry",
+                "in_app": False,
+            },
+            {
+                "function": "-[SentryCoreDataTracker managedObjectContext:save:originalImp:]",
+                "package": "/private/var/containers/Bundle/Application/59E988EF-46DB-4C75-8E08-10C27DC3E90E/iOS-Swift.app/Frameworks/Sentry.framework/Sentry",
+                "in_app": False,
+            },
+            {
+                "function": "-[SentryHub captureEvent:]",
+                "package": "/private/var/containers/Bundle/Application/59E988EF-46DB-4C75-8E08-10C27DC3E90E/iOS-Swift.app/Frameworks/Sentry.framework/Sentry",
+                "in_app": False,
+            },
+            {
+                "function": "objc_exception_throw",
+                "package": "/usr/lib/libobjc.A.dylib",
+                "in_app": False,
+            },
+            {
+                "function": "__exceptionPreprocess",
+                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+                "in_app": False,
+            },
+        ]
+
+        self.execute_test(
+            get_crash_event_with_frames(frames),
+            True,
+            mock_sdk_crash_reporter,
+        )
+
+
 class SDKCrashDetectionCocoaTest(
     TestCase,
     CococaSDKFilenameTestMixin,
     CococaSDKFramesTestMixin,
     CococaSDKFunctionTestMixin,
     CocoaSDKSwizzleWrapperTestMixin,
+    CocoaSDKCoreDataTrackerTestMixin,
 ):
     def create_event(self, data, project_id, assert_no_errors=True):
         return self.store_event(data=data, project_id=project_id, assert_no_errors=assert_no_errors)


### PR DESCRIPTION
## Summary

Adds `SentryCoreDataTracker` and `SentryCoreDataSwizzlingHelper` to the Cocoa SDK's `sdk_crash_ignore_when_only_sdk_frame_matchers`, preventing false-positive SDK crash reports when these instrumentation frames are the only SDK frames in the stack.

## Context

[SDK-CRASHES-COCOA-59A](https://sentry.sentry.io/issues/SDK-CRASHES-COCOA-59A) has 50K+ occurrences of `NSInvalidArgumentException` (`doesNotRecognizeSelector:`) where the crash originates inside CoreData internals — merge policy constraint resolution or validation logging — not in our SDK code. Our CoreData swizzling transparently wraps `save:`/`executeFetchRequest:` with tracing spans and calls the original implementation unchanged. The crashes would occur identically without our swizzling.

This follows the same pattern as the existing `SentrySwizzleWrapper` exclusion.

## Changes

- **Config**: Added two `FunctionAndModulePattern` entries for `SentryCoreDataTracker` and `SentryCoreDataSwizzlingHelper`
- **Tests**: Added `CocoaSDKCoreDataTrackerTestMixin` with two tests:
  - CoreData tracker frames as only SDK frames → not reported
  - CoreData tracker frames with another real SDK frame → still reported

Fixes SDK-CRASHES-COCOA-59A

#skip-changelog