### PR TITLE
fix(issues): Read low-value span evidence as camelCase

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
@@ -13,14 +13,17 @@ describe('LowValueSpanIssueDetails', () => {
         event={EventFixture({
           occurrence: {
             evidenceData: {
-              span_op: 'function',
-              span_description: 'compute_checksum',
-              span_count: 1234,
-              extrapolated_count: 60_000,
-              value_score: 0.15,
-              avg_duration_ms: 0.4,
-              estimated_cost_usd: 12.34,
-              sdk_name: 'sentry.javascript.nextjs',
+              analysisEnd: '2026-06-01T07:32:25.403623+00:00',
+              analysisStart: '2026-06-01T01:32:25.403623+00:00',
+              avgDurationMs: 0.4,
+              count: 1234,
+              description: 'compute_checksum',
+              estimatedCostUsd: 12.34,
+              extrapolatedCount: 60_000,
+              op: 'function',
+              sdkName: 'sentry.javascript.nextjs',
+              spanOrigin: 'auto',
+              valueScore: 0.15,
             },
             type: 13002,
           },
@@ -39,35 +42,5 @@ describe('LowValueSpanIssueDetails', () => {
     expect(screen.queryByText('15%')).not.toBeInTheDocument();
     expect(screen.queryByText('Diagnosis')).not.toBeInTheDocument();
     expect(screen.queryByText('Impact')).not.toBeInTheDocument();
-  });
-
-  it('only reads the new backend evidence field names', () => {
-    render(
-      <LowValueSpanIssueDetails
-        event={EventFixture({
-          occurrence: {
-            evidenceData: {
-              op: 'function',
-              description: 'compute_checksum',
-              count: 1234,
-              spanOp: 'function',
-              spanDescription: 'compute_checksum',
-              seenCount: 1234,
-              avgDurationMs: 0.4,
-              estimatedCostUsd: 12.34,
-              sdkName: 'sentry.javascript.nextjs',
-            },
-            type: 13002,
-          },
-        })}
-        group={GroupFixture()}
-        project={ProjectFixture()}
-      />
-    );
-
-    expect(screen.getAllByText('Unknown span').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Unknown').length).toBeGreaterThan(0);
-    expect(screen.queryByText('function - compute_checksum')).not.toBeInTheDocument();
-    expect(screen.queryByText('$12.34')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.spec.tsx
@@ -6,7 +6,7 @@ import type {LowValueSpanEvidenceData} from './types';
 const evidenceData: LowValueSpanEvidenceData = {
   op: 'function',
   description: 'compute_checksum',
-  spanCount: 1234,
+  count: 1234,
   extrapolatedCount: 60_000,
   avgDurationMs: 0.4,
   estimatedCostUsd: 12.34,

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
@@ -31,7 +31,7 @@ function DetailRow({label, value}: {label: string; value: ReactNode}) {
 export function ProblemSection({evidenceData}: ProblemSectionProps) {
   const hasEstimatedCost =
     evidenceData.estimatedCostUsd !== null && evidenceData.estimatedCostUsd > 0;
-  const spanCount = evidenceData.extrapolatedCount ?? evidenceData.spanCount;
+  const spanCount = evidenceData.extrapolatedCount ?? evidenceData.count;
 
   return (
     <Stack gap="lg" padding="lg">

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
@@ -6,7 +6,7 @@ import type {LowValueSpanEvidenceData} from './types';
 const baseEvidenceData: LowValueSpanEvidenceData = {
   op: 'function',
   description: 'compute_checksum',
-  spanCount: 1234,
+  count: 1234,
   extrapolatedCount: 60_000,
   avgDurationMs: 0.4,
   estimatedCostUsd: 12.34,

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/types.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/types.ts
@@ -2,14 +2,28 @@ import type {EventOccurrence} from 'sentry/types/event';
 
 export interface LowValueSpanEvidenceData {
   avgDurationMs: number | null;
+  count: number | null;
   description: string | null;
   estimatedCostUsd: number | null;
   extrapolatedCount: number | null;
   op: string | null;
   sdkName: string | null;
-  spanCount: number | null;
   spanOrigin: string | null;
 }
+
+type LowValueSpanEvidencePayload = Partial<{
+  analysisEnd: unknown;
+  analysisStart: unknown;
+  avgDurationMs: unknown;
+  count: unknown;
+  description: unknown;
+  estimatedCostUsd: unknown;
+  extrapolatedCount: unknown;
+  op: unknown;
+  sdkName: unknown;
+  spanOrigin: unknown;
+  valueScore: unknown;
+}>;
 
 function getStringValue(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
@@ -22,14 +36,16 @@ function getNumberValue(value: unknown): number | null {
 export function getLowValueSpanEvidenceData(
   evidenceData: EventOccurrence['evidenceData'] | null | undefined
 ): LowValueSpanEvidenceData {
+  const data = evidenceData as LowValueSpanEvidencePayload | null | undefined;
+
   return {
-    op: getStringValue(evidenceData?.span_op),
-    description: getStringValue(evidenceData?.span_description),
-    spanCount: getNumberValue(evidenceData?.span_count),
-    extrapolatedCount: getNumberValue(evidenceData?.extrapolated_count),
-    avgDurationMs: getNumberValue(evidenceData?.avg_duration_ms),
-    estimatedCostUsd: getNumberValue(evidenceData?.estimated_cost_usd),
-    sdkName: getStringValue(evidenceData?.sdk_name),
-    spanOrigin: getStringValue(evidenceData?.span_origin),
+    op: getStringValue(data?.op),
+    description: getStringValue(data?.description),
+    count: getNumberValue(data?.count),
+    extrapolatedCount: getNumberValue(data?.extrapolatedCount),
+    avgDurationMs: getNumberValue(data?.avgDurationMs),
+    estimatedCostUsd: getNumberValue(data?.estimatedCostUsd),
+    sdkName: getStringValue(data?.sdkName),
+    spanOrigin: getStringValue(data?.spanOrigin),
   };
 }


### PR DESCRIPTION
Low-value span configuration issues now read the camelCase evidenceData payload returned by the backend. This fixes the issue UI rendering Unknown values when the response contains fields such as count, extrapolatedCount, avgDurationMs, and estimatedCostUsd.

Refs TET-2430