### PR TITLE
feat(conversations): Improve freeform search to target conversation fields

### DIFF
--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -84,8 +84,12 @@ function ConversationsOverviewPage() {
         unsetCursor();
       },
       searchSource: 'conversations',
-      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.name'] : undefined,
+      replaceRawSearchKeys: hasRawSearchReplacement
+        ? ['gen_ai.input.messages']
+        : undefined,
       matchKeySuggestions: [
+        {key: 'gen_ai.conversation.id', valuePattern: /^[0-9a-fA-F]{8,32}$/},
+        {key: 'gen_ai.conversation.id', valuePattern: /^resp_/},
         {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
       ],


### PR DESCRIPTION
### **Freeform search targets `gen_ai.input.messages`**

Freeform search in the conversations overview now targets `gen_ai.input.messages` instead of `span.name`, so typing plain text searches conversation message content. This works the same way as message search does for logs.

### **Key suggestions for conversation IDs**

 When input looks like a hex string (8+ characters) or starts with the OpenAI resp_ prefix, the search bar suggests gen_ai.conversation.id as a key, making it easy to look up a specific conversation by ID.

https://github.com/user-attachments/assets/76e846fd-4d6c-4457-b938-da556a0dceea
