### PR TITLE
feat(trace-waterfall): Render warning icon with count

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1228,7 +1228,6 @@ export const TraceStylingWrapper = styled('div')`
       min-width: 18px;
       padding: 0 5px 0 5px;
       box-sizing: border-box;
-      border: 1px solid ${p => p.theme.colors.white};
       border-radius: ${p => p.theme.radius.lg};
       color: ${p => p.theme.colors.white};
       z-index: 1;

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -688,7 +688,7 @@ function VerticalTimestampIndicators({
  * emotion's css parsing logic as it is very slow and will cause
  * the scrolling to flicker.
  */
-export const TraceStylingWrapper = styled('div')`
+const TraceStylingWrapper = styled('div')`
   margin: auto;
   overscroll-behavior: none;
   /* eslint-disable-next-line @sentry/scraps/use-semantic-token */

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1272,6 +1272,14 @@ export const TraceStylingWrapper = styled('div')`
       }
     }
 
+    .TraceIconGroupStart {
+      transform: translate(0, -50%) scaleX(var(--inverse-span-scale)) translateZ(0);
+    }
+
+    .TraceIconGroupEnd {
+      transform: translate(-100%, -50%) scaleX(var(--inverse-span-scale)) translateZ(0);
+    }
+
     .TraceIconCount {
       min-width: 8px;
       font-size: ${p => p.theme.font.size.xs};

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -688,7 +688,7 @@ function VerticalTimestampIndicators({
  * emotion's css parsing logic as it is very slow and will cause
  * the scrolling to flicker.
  */
-const TraceStylingWrapper = styled('div')`
+export const TraceStylingWrapper = styled('div')`
   margin: auto;
   overscroll-behavior: none;
   /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
@@ -1215,6 +1215,69 @@ const TraceStylingWrapper = styled('div')`
           transform: translateY(-1px);
         }
       }
+    }
+
+    .TraceIconGroup {
+      position: absolute;
+      top: 50%;
+      transform: translate(-50%, -50%) scaleX(var(--inverse-span-scale)) translateZ(0);
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      height: 18px;
+      min-width: 18px;
+      padding: 0 5px 0 5px;
+      box-sizing: border-box;
+      border: 1px solid ${p => p.theme.colors.white};
+      border-radius: ${p => p.theme.radius.lg};
+      color: ${p => p.theme.colors.white};
+      z-index: 1;
+
+      &.info {
+        background-color: var(--info);
+      }
+      &.warning {
+        background-color: var(--warning);
+      }
+      &.debug {
+        background-color: var(--debug);
+      }
+      &.error,
+      &.fatal {
+        background-color: var(--error);
+      }
+      &.occurrence {
+        background-color: var(--occurrence);
+      }
+      &.default {
+        background-color: var(--default);
+      }
+      &.unknown {
+        background-color: var(--unknown);
+      }
+
+      .TraceIconGlyph {
+        flex: 0 0 auto;
+        width: 12px;
+        height: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      svg {
+        width: 12px;
+        height: 12px;
+        fill: currentColor;
+      }
+    }
+
+    .TraceIconCount {
+      min-width: 8px;
+      font-size: ${p => p.theme.font.size.xs};
+      line-height: 18px;
+      text-align: center;
+      font-variant-numeric: tabular-nums;
     }
 
     .TracePatternContainer {

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import {useTheme, type Theme} from '@emotion/react';
+import {css, useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -56,6 +56,31 @@ import {
 } from './traceState/traceRovingTabIndex';
 import {useTraceState, useTraceStateDispatch} from './traceState/traceStateProvider';
 import type {TraceReducerState} from './traceState';
+
+const traceIssueIconBackgroundStyles = css`
+  &.info {
+    background-color: var(--info);
+  }
+  &.warning {
+    background-color: var(--warning);
+  }
+  &.debug {
+    background-color: var(--debug);
+  }
+  &.error,
+  &.fatal {
+    background-color: var(--error);
+  }
+  &.occurrence {
+    background-color: var(--occurrence);
+  }
+  &.default {
+    background-color: var(--default);
+  }
+  &.unknown {
+    background-color: var(--unknown);
+  }
+`;
 
 function computeNextIndexFromAction(
   current_index: number,
@@ -1170,28 +1195,8 @@ const TraceStylingWrapper = styled('div')`
       justify-content: center;
       z-index: 1;
 
-      &.info {
-        background-color: var(--info);
-      }
-      &.warning {
-        background-color: var(--warning);
-      }
-      &.debug {
-        background-color: var(--debug);
-      }
-      &.error,
-      &.fatal {
-        background-color: var(--error);
-      }
-      &.occurrence {
-        background-color: var(--occurrence);
-      }
-      &.default {
-        background-color: var(--default);
-      }
-      &.unknown {
-        background-color: var(--unknown);
-      }
+      ${traceIssueIconBackgroundStyles}
+
       &.profile {
         background-color: var(--profile);
       }
@@ -1232,28 +1237,7 @@ const TraceStylingWrapper = styled('div')`
       color: ${p => p.theme.colors.white};
       z-index: 1;
 
-      &.info {
-        background-color: var(--info);
-      }
-      &.warning {
-        background-color: var(--warning);
-      }
-      &.debug {
-        background-color: var(--debug);
-      }
-      &.error,
-      &.fatal {
-        background-color: var(--error);
-      }
-      &.occurrence {
-        background-color: var(--occurrence);
-      }
-      &.default {
-        background-color: var(--default);
-      }
-      &.unknown {
-        background-color: var(--unknown);
-      }
+      ${traceIssueIconBackgroundStyles}
 
       .TraceIconGlyph {
         flex: 0 0 auto;

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1272,10 +1272,22 @@ export const TraceStylingWrapper = styled('div')`
     }
 
     .TraceIconGroupStart {
+      transform-origin: left center;
       transform: translate(0, -50%) scaleX(var(--inverse-span-scale)) translateZ(0);
     }
 
     .TraceIconGroupEnd {
+      transform-origin: right center;
+      transform: translate(-100%, -50%) scaleX(var(--inverse-span-scale)) translateZ(0);
+    }
+
+    .TraceIconStart {
+      transform-origin: left center;
+      transform: translate(0, -50%) scaleX(var(--inverse-span-scale)) translateZ(0);
+    }
+
+    .TraceIconEnd {
+      transform-origin: right center;
       transform: translate(-100%, -50%) scaleX(var(--inverse-span-scale)) translateZ(0);
     }
 

--- a/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
+++ b/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
@@ -1,0 +1,143 @@
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+
+export const TRACE_ICON_WIDTH = 18;
+export const TRACE_ICON_GROUP_GLYPH_WIDTH = 12;
+export const TRACE_ICON_GROUP_GAP = 2;
+export const TRACE_ICON_GROUP_HORIZONTAL_PADDING = 10;
+export const TRACE_ICON_GROUP_COUNT_MIN_WIDTH = 8;
+
+export interface RenderableTraceIssue {
+  issue: TraceTree.TraceIssue;
+  additionalIssueCount?: number;
+}
+
+export function getRenderableTraceIssues(
+  node: BaseNode,
+  errors: BaseNode['errors'],
+  occurrences: BaseNode['occurrences']
+): RenderableTraceIssue[] {
+  const directErrors = getDirectErrors(node);
+  const directOccurrences = getDirectOccurrences(node);
+  const childIssues: TraceTree.TraceIssue[] = [];
+  const issues: RenderableTraceIssue[] = [];
+
+  for (const error of errors) {
+    if (directErrors.has(error)) {
+      issues.push({issue: error});
+    } else {
+      childIssues.push(error);
+    }
+  }
+
+  for (const occurrence of occurrences) {
+    if (directOccurrences.has(occurrence)) {
+      issues.push({issue: occurrence});
+    } else {
+      childIssues.push(occurrence);
+    }
+  }
+
+  const childRepresentative = getMostSevereTraceIssue(childIssues);
+  if (childRepresentative) {
+    const additionalIssueCount = childIssues.length - 1;
+    issues.push(
+      additionalIssueCount > 0
+        ? {issue: childRepresentative, additionalIssueCount}
+        : {issue: childRepresentative}
+    );
+  }
+
+  return issues;
+}
+
+export function getDirectErrors(node: BaseNode): Set<TraceTree.TraceErrorIssue> {
+  const errors = new Set<TraceTree.TraceErrorIssue>();
+
+  if (node.value && 'errors' in node.value && Array.isArray(node.value.errors)) {
+    node.value.errors.forEach(error => errors.add(error));
+  }
+
+  return errors;
+}
+
+export function getDirectOccurrences(node: BaseNode): Set<TraceTree.TraceOccurrence> {
+  const occurrences = new Set<TraceTree.TraceOccurrence>();
+
+  if (
+    node.value &&
+    'occurrences' in node.value &&
+    Array.isArray(node.value.occurrences)
+  ) {
+    node.value.occurrences.forEach(occurrence => occurrences.add(occurrence));
+  }
+
+  if (
+    node.value &&
+    'performance_issues' in node.value &&
+    Array.isArray(node.value.performance_issues)
+  ) {
+    node.value.performance_issues.forEach(occurrence => occurrences.add(occurrence));
+  }
+
+  return occurrences;
+}
+
+export function getMostSevereTraceIssue(
+  issues: TraceTree.TraceIssue[]
+): TraceTree.TraceIssue | null {
+  return issues.reduce<TraceTree.TraceIssue | null>((mostSevere, issue) => {
+    if (!mostSevere) {
+      return issue;
+    }
+
+    const severityDiff =
+      getTraceIssueSeverityRank(issue) - getTraceIssueSeverityRank(mostSevere);
+
+    if (severityDiff > 0) {
+      return issue;
+    }
+
+    if (
+      severityDiff === 0 &&
+      getTraceIssueTimestamp(issue, [0, 0]) < getTraceIssueTimestamp(mostSevere, [0, 0])
+    ) {
+      return issue;
+    }
+
+    return mostSevere;
+  }, null);
+}
+
+export function getTraceIssueSeverityRank(issue: TraceTree.TraceIssue): number {
+  switch (issue.level) {
+    case 'fatal':
+      return 5;
+    case 'error':
+      return 4;
+    case 'warning':
+      return 3;
+    case 'info':
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+export function getTraceIssueTimestamp(
+  issue: TraceTree.TraceIssue,
+  nodeSpace: [number, number]
+): number {
+  if ('timestamp' in issue && typeof issue.timestamp === 'number') {
+    return issue.timestamp * 1e3;
+  }
+
+  let startTimestamp: number | undefined;
+  if ('start_timestamp' in issue) {
+    startTimestamp = issue.start_timestamp;
+  } else if ('start' in issue) {
+    startTimestamp = issue.start;
+  }
+
+  return typeof startTimestamp === 'number' ? startTimestamp * 1e3 : nodeSpace[0];
+}

--- a/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
+++ b/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
@@ -68,17 +68,32 @@ export function getTraceIconGroupWidth(
   );
 }
 
+const directErrorsCache = new WeakMap<BaseNode, Set<TraceTree.TraceErrorIssue>>();
+
 export function getDirectErrors(node: BaseNode): Set<TraceTree.TraceErrorIssue> {
+  const cached = directErrorsCache.get(node);
+  if (cached) {
+    return cached;
+  }
+
   const errors = new Set<TraceTree.TraceErrorIssue>();
 
   if (node.value && 'errors' in node.value && Array.isArray(node.value.errors)) {
     node.value.errors.forEach(error => errors.add(error));
   }
 
+  directErrorsCache.set(node, errors);
   return errors;
 }
 
+const directOccurrencesCache = new WeakMap<BaseNode, Set<TraceTree.TraceOccurrence>>();
+
 export function getDirectOccurrences(node: BaseNode): Set<TraceTree.TraceOccurrence> {
+  const cached = directOccurrencesCache.get(node);
+  if (cached) {
+    return cached;
+  }
+
   const occurrences = new Set<TraceTree.TraceOccurrence>();
 
   if (
@@ -97,6 +112,7 @@ export function getDirectOccurrences(node: BaseNode): Set<TraceTree.TraceOccurre
     node.value.performance_issues.forEach(occurrence => occurrences.add(occurrence));
   }
 
+  directOccurrencesCache.set(node, occurrences);
   return occurrences;
 }
 

--- a/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
+++ b/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
@@ -2,6 +2,7 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 
 export const TRACE_ICON_WIDTH = 18;
+// Keep these in sync with the `.TraceIconGroup` CSS in trace.tsx.
 const TRACE_ICON_GROUP_GLYPH_WIDTH = 12;
 const TRACE_ICON_GROUP_GAP = 2;
 const TRACE_ICON_GROUP_HORIZONTAL_PADDING = 10;

--- a/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
+++ b/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
@@ -2,10 +2,10 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 
 export const TRACE_ICON_WIDTH = 18;
-export const TRACE_ICON_GROUP_GLYPH_WIDTH = 12;
-export const TRACE_ICON_GROUP_GAP = 2;
-export const TRACE_ICON_GROUP_HORIZONTAL_PADDING = 10;
-export const TRACE_ICON_GROUP_COUNT_MIN_WIDTH = 8;
+const TRACE_ICON_GROUP_GLYPH_WIDTH = 12;
+const TRACE_ICON_GROUP_GAP = 2;
+const TRACE_ICON_GROUP_HORIZONTAL_PADDING = 10;
+const TRACE_ICON_GROUP_COUNT_MIN_WIDTH = 8;
 
 interface RenderableTraceIssue {
   issue: TraceTree.TraceIssue;

--- a/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
+++ b/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
@@ -7,7 +7,7 @@ export const TRACE_ICON_GROUP_GAP = 2;
 export const TRACE_ICON_GROUP_HORIZONTAL_PADDING = 10;
 export const TRACE_ICON_GROUP_COUNT_MIN_WIDTH = 8;
 
-export interface RenderableTraceIssue {
+interface RenderableTraceIssue {
   issue: TraceTree.TraceIssue;
   additionalIssueCount?: number;
 }
@@ -83,7 +83,7 @@ export function getDirectOccurrences(node: BaseNode): Set<TraceTree.TraceOccurre
   return occurrences;
 }
 
-export function getMostSevereTraceIssue(
+function getMostSevereTraceIssue(
   issues: TraceTree.TraceIssue[]
 ): TraceTree.TraceIssue | null {
   return issues.reduce<TraceTree.TraceIssue | null>((mostSevere, issue) => {
@@ -109,7 +109,7 @@ export function getMostSevereTraceIssue(
   }, null);
 }
 
-export function getTraceIssueSeverityRank(issue: TraceTree.TraceIssue): number {
+function getTraceIssueSeverityRank(issue: TraceTree.TraceIssue): number {
   switch (issue.level) {
     case 'fatal':
       return 5;

--- a/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
+++ b/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
@@ -16,7 +16,8 @@ interface RenderableTraceIssue {
 export function getRenderableTraceIssues(
   node: BaseNode,
   errors: BaseNode['errors'],
-  occurrences: BaseNode['occurrences']
+  occurrences: BaseNode['occurrences'],
+  nodeSpace: [number, number] | null = null
 ): RenderableTraceIssue[] {
   const directErrors = getDirectErrors(node);
   const directOccurrences = getDirectOccurrences(node);
@@ -39,7 +40,7 @@ export function getRenderableTraceIssues(
     }
   }
 
-  const childRepresentative = getMostSevereTraceIssue(childIssues);
+  const childRepresentative = getMostSevereTraceIssue(childIssues, nodeSpace);
   if (childRepresentative) {
     const additionalIssueCount = childIssues.length - 1;
     issues.push(
@@ -118,7 +119,8 @@ export function getDirectOccurrences(node: BaseNode): Set<TraceTree.TraceOccurre
 }
 
 function getMostSevereTraceIssue(
-  issues: TraceTree.TraceIssue[]
+  issues: TraceTree.TraceIssue[],
+  nodeSpace: [number, number] | null
 ): TraceTree.TraceIssue | null {
   return issues.reduce<TraceTree.TraceIssue | null>((mostSevere, issue) => {
     if (!mostSevere) {
@@ -132,11 +134,12 @@ function getMostSevereTraceIssue(
       return issue;
     }
 
-    if (
-      severityDiff === 0 &&
-      getTraceIssueTimestamp(issue, [0, 0]) < getTraceIssueTimestamp(mostSevere, [0, 0])
-    ) {
-      return issue;
+    if (severityDiff === 0 && nodeSpace) {
+      const issueTimestamp = getTraceIssueTimestamp(issue, nodeSpace);
+      const mostSevereTimestamp = getTraceIssueTimestamp(mostSevere, nodeSpace);
+      if (issueTimestamp < mostSevereTimestamp) {
+        return issue;
+      }
     }
 
     return mostSevere;

--- a/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
+++ b/static/app/views/performance/newTraceDetails/traceIssueUtils.ts
@@ -51,6 +51,23 @@ export function getRenderableTraceIssues(
   return issues;
 }
 
+export function getTraceIconGroupWidth(
+  additionalIssueCount: number,
+  measureText: (text: string) => number
+) {
+  const countWidth = Math.max(
+    TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
+    Math.ceil(measureText(String(additionalIssueCount)))
+  );
+
+  return (
+    TRACE_ICON_GROUP_HORIZONTAL_PADDING +
+    TRACE_ICON_GROUP_GLYPH_WIDTH +
+    TRACE_ICON_GROUP_GAP +
+    countWidth
+  );
+}
+
 export function getDirectErrors(node: BaseNode): Set<TraceTree.TraceErrorIssue> {
   const errors = new Set<TraceTree.TraceErrorIssue>();
 

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -529,7 +529,7 @@ describe('VirtualizedViewManger', () => {
       expect(textTransform).toBe(153);
     });
 
-    it('places right-outside text after the start-anchored grouped issue pill for narrow spans', () => {
+    it('keeps grouped issue pill bounds centered when it does not cross the view edge', () => {
       const manager = new VirtualizedViewManager(
         {
           list: {width: 0},
@@ -581,7 +581,130 @@ describe('VirtualizedViewManger', () => {
       );
 
       expect(inside).toBe(0);
-      expect(textTransform).toBe(135);
+      expect(textTransform).toBe(119.5);
+    });
+
+    it('keeps direct issue icon bounds centered when it does not cross the view edge', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(38);
+
+      const directError = {
+        event_id: 'direct-error',
+        issue_id: 1,
+        level: 'warning',
+        start_timestamp: 0.1005,
+      };
+      const node = {
+        value: {errors: [directError], occurrences: []},
+        errors: new Set([directError]),
+        occurrences: new Set(),
+      } as any;
+
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [100, 1],
+        '1.00ms'
+      );
+
+      expect(inside).toBe(0);
+      expect(textTransform).toBe(112.5);
+    });
+
+    it('places right-outside text after a view-edge anchored direct issue icon', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(38);
+
+      const directError = {
+        event_id: 'direct-error',
+        issue_id: 1,
+        level: 'warning',
+        start_timestamp: 0.0005,
+      };
+      const node = {
+        value: {errors: [directError], occurrences: []},
+        errors: new Set([directError]),
+        occurrences: new Set(),
+      } as any;
+
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [0, 1],
+        '1.00ms'
+      );
+
+      expect(inside).toBe(0);
+      expect(textTransform).toBe(21);
+    });
+
+    it('places right-outside text after a view-edge anchored grouped issue pill', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+
+      jest.spyOn(manager.text_measurer, 'measure').mockImplementation(text => {
+        if (text === '2') {
+          return 6.5;
+        }
+        return 38;
+      });
+
+      const childErrorA = {
+        event_id: 'child-error-a',
+        issue_id: 1,
+        level: 'warning',
+        start_timestamp: 0.0005,
+      };
+      const childErrorB = {
+        event_id: 'child-error-b',
+        issue_id: 2,
+        level: 'warning',
+        start_timestamp: 0.0005,
+      };
+      const node = {
+        value: {errors: [], occurrences: []},
+        errors: new Set([childErrorA, childErrorB]),
+        occurrences: new Set(),
+      } as any;
+
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [0, 1],
+        '1.00ms'
+      );
+
+      expect(inside).toBe(0);
+      expect(textTransform).toBe(35);
     });
 
     it('places right-outside text after a start-clamped grouped issue pill', () => {
@@ -630,7 +753,7 @@ describe('VirtualizedViewManger', () => {
       );
 
       expect(inside).toBe(0);
-      expect(textTransform).toBe(135);
+      expect(textTransform).toBe(119);
     });
 
     it('uses ceil(text_width) when placing text inside on the right', () => {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -786,55 +786,6 @@ describe('VirtualizedViewManger', () => {
       expect(textTransform).toBe(35);
     });
 
-    it('places right-outside text after a start-clamped grouped issue pill', () => {
-      const manager = new VirtualizedViewManager(
-        {
-          list: {width: 0},
-          span_list: {width: 1},
-        },
-        new TraceScheduler(),
-        new TraceView(),
-        ThemeFixture()
-      );
-
-      manager.view.setTraceSpace([0, 0, 1000, 1]);
-      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
-
-      jest.spyOn(manager.text_measurer, 'measure').mockImplementation(text => {
-        if (text === '1') {
-          return 6.5;
-        }
-        return 38;
-      });
-
-      const childErrorA = {
-        event_id: 'child-error-a',
-        issue_id: 1,
-        level: 'warning',
-        start_timestamp: 0.09,
-      };
-      const childErrorB = {
-        event_id: 'child-error-b',
-        issue_id: 2,
-        level: 'warning',
-        start_timestamp: 0.09,
-      };
-      const node = {
-        value: {errors: [], occurrences: []},
-        errors: new Set([childErrorA, childErrorB]),
-        occurrences: new Set(),
-      } as any;
-
-      const [inside, textTransform] = manager.computeSpanTextPlacement(
-        node,
-        [100, 1],
-        '1.00ms'
-      );
-
-      expect(inside).toBe(0);
-      expect(textTransform).toBe(119);
-    });
-
     it('uses ceil(text_width) when placing text inside on the right', () => {
       const manager = new VirtualizedViewManager(
         {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -544,7 +544,7 @@ describe('VirtualizedViewManger', () => {
       manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
 
       jest.spyOn(manager.text_measurer, 'measure').mockImplementation(text => {
-        if (text === '3') {
+        if (text === '2') {
           return 6.5;
         }
         return 38;
@@ -673,7 +673,7 @@ describe('VirtualizedViewManger', () => {
       manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
 
       jest.spyOn(manager.text_measurer, 'measure').mockImplementation(text => {
-        if (text === '2') {
+        if (text === '1') {
           return 6.5;
         }
         return 38;
@@ -722,7 +722,7 @@ describe('VirtualizedViewManger', () => {
       manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
 
       jest.spyOn(manager.text_measurer, 'measure').mockImplementation(text => {
-        if (text === '2') {
+        if (text === '1') {
           return 6.5;
         }
         return 38;

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -272,7 +272,7 @@ describe('VirtualizedViewManger', () => {
       manager.view.setTraceView({width: 100, x: 100});
       manager.recomputeSpanToPXMatrix();
 
-      expect(manager.computeTraceIconEdge(109.5, 18)).toBeNull();
+      expect(manager.computeTraceIconPlacement(109.5, 18, [100, 100]).edge).toBeNull();
     });
 
     it('anchors end-clamped icons to the visible trace end in a zoomed view', () => {
@@ -291,7 +291,10 @@ describe('VirtualizedViewManger', () => {
       manager.view.setTraceView({width: 100, x: 100});
       manager.recomputeSpanToPXMatrix();
 
-      expect(manager.computeTraceIconAnchorTimestamp(199.5, 'end')).toBe(200);
+      const placement = manager.computeTraceIconPlacement(199.5, 18, [100, 100]);
+
+      expect(placement.edge).toBe('end');
+      expect(placement.anchorTimestamp).toBe(200);
     });
   });
 

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -251,7 +251,7 @@ describe('VirtualizedViewManger', () => {
       manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
       manager.view.setTraceView({width: 500, x: 500});
 
-      expect(Math.round(manager.transformXFromTimestamp(100))).toBe(-500);
+      expect(Math.round(manager.transformXFromTimestamp(100))).toBe(-1000);
     });
   });
 
@@ -273,6 +273,28 @@ describe('VirtualizedViewManger', () => {
       manager.recomputeSpanToPXMatrix();
 
       expect(manager.computeTraceIconPlacement(109.5, 18, [100, 100]).edge).toBeNull();
+    });
+
+    it('uses current view geometry before the span matrix has been recomputed', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
+      manager.view.setTraceView({width: 100, x: 100});
+
+      const placement = manager.computeTraceIconPlacement(199.5, 18, [100, 100]);
+
+      expect(placement.edge).toBe('end');
+      expect(placement.anchorTimestamp).toBe(200);
+      expect(placement.bounds).toEqual([196.4, 200]);
     });
 
     it('anchors end-clamped icons to the visible trace end in a zoomed view', () => {
@@ -801,7 +823,7 @@ describe('VirtualizedViewManger', () => {
       );
 
       manager.view.setTraceSpace([0, 0, 1000, 1]);
-      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 200, 1], [0, 0, 200, 1]);
       manager.view.setTraceView({width: 100, x: 950});
 
       const measuredWidth = 200.2;

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -255,6 +255,46 @@ describe('VirtualizedViewManger', () => {
     });
   });
 
+  describe('trace issue icon placement', () => {
+    it('does not treat icons away from the physical right edge as end-clamped in a zoomed view', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      manager.view.setTraceView({width: 100, x: 100});
+      manager.recomputeSpanToPXMatrix();
+
+      expect(manager.computeTraceIconEdge(109.5, 18)).toBeNull();
+    });
+
+    it('anchors end-clamped icons to the visible trace end in a zoomed view', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      manager.view.setTraceView({width: 100, x: 100});
+      manager.recomputeSpanToPXMatrix();
+
+      expect(manager.computeTraceIconAnchorTimestamp(199.5, 'end')).toBe(200);
+    });
+  });
+
   describe('horizontal scrolling', () => {
     describe('onWheel (timeline/span durations)', () => {
       it('scrolls horizontally with shift + vertical wheel', () => {
@@ -619,6 +659,45 @@ describe('VirtualizedViewManger', () => {
 
       expect(inside).toBe(0);
       expect(textTransform).toBe(112.5);
+    });
+
+    it('uses the physical viewport edge for issue icon bounds in a zoomed view', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      manager.view.setTraceView({width: 100, x: 100});
+      manager.recomputeSpanToPXMatrix();
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(38);
+
+      const directError = {
+        event_id: 'direct-error',
+        issue_id: 1,
+        level: 'warning',
+        start_timestamp: 0.1095,
+      };
+      const node = {
+        value: {errors: [directError], occurrences: []},
+        errors: new Set([directError]),
+        occurrences: new Set(),
+      } as any;
+
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [109, 1],
+        '1.00ms'
+      );
+
+      expect(inside).toBe(0);
+      expect(textTransform).toBeCloseTo(107);
     });
 
     it('places right-outside text after a view-edge anchored direct issue icon', () => {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -529,7 +529,7 @@ describe('VirtualizedViewManger', () => {
       expect(textTransform).toBe(153);
     });
 
-    it('places right-outside text after the grouped issue pill for narrow spans', () => {
+    it('places right-outside text after the start-anchored grouped issue pill for narrow spans', () => {
       const manager = new VirtualizedViewManager(
         {
           list: {width: 0},
@@ -581,7 +581,56 @@ describe('VirtualizedViewManger', () => {
       );
 
       expect(inside).toBe(0);
-      expect(textTransform).toBe(119.5);
+      expect(textTransform).toBe(135);
+    });
+
+    it('places right-outside text after a start-clamped grouped issue pill', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+
+      jest.spyOn(manager.text_measurer, 'measure').mockImplementation(text => {
+        if (text === '2') {
+          return 6.5;
+        }
+        return 38;
+      });
+
+      const childErrorA = {
+        event_id: 'child-error-a',
+        issue_id: 1,
+        level: 'warning',
+        start_timestamp: 0.09,
+      };
+      const childErrorB = {
+        event_id: 'child-error-b',
+        issue_id: 2,
+        level: 'warning',
+        start_timestamp: 0.09,
+      };
+      const node = {
+        value: {errors: [], occurrences: []},
+        errors: new Set([childErrorA, childErrorB]),
+        occurrences: new Set(),
+      } as any;
+
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [100, 1],
+        '1.00ms'
+      );
+
+      expect(inside).toBe(0);
+      expect(textTransform).toBe(135);
     });
 
     it('uses ceil(text_width) when placing text inside on the right', () => {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -529,6 +529,61 @@ describe('VirtualizedViewManger', () => {
       expect(textTransform).toBe(153);
     });
 
+    it('places right-outside text after the grouped issue pill for narrow spans', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+
+      jest.spyOn(manager.text_measurer, 'measure').mockImplementation(text => {
+        if (text === '3') {
+          return 6.5;
+        }
+        return 38;
+      });
+
+      const childErrorA = {
+        event_id: 'child-error-a',
+        issue_id: 1,
+        level: 'warning',
+        start_timestamp: 0.1005,
+      };
+      const childErrorB = {
+        event_id: 'child-error-b',
+        issue_id: 2,
+        level: 'warning',
+        start_timestamp: 0.1005,
+      };
+      const childErrorC = {
+        event_id: 'child-error-c',
+        issue_id: 3,
+        level: 'warning',
+        start_timestamp: 0.1005,
+      };
+      const node = {
+        value: {errors: [], occurrences: []},
+        errors: new Set([childErrorA, childErrorB, childErrorC]),
+        occurrences: new Set(),
+      } as any;
+
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [100, 1],
+        '1.00ms'
+      );
+
+      expect(inside).toBe(0);
+      expect(textTransform).toBe(119.5);
+    });
+
     it('uses ceil(text_width) when placing text inside on the right', () => {
       const manager = new VirtualizedViewManager(
         {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -9,6 +9,15 @@ import {
   requestAnimationTimeout,
 } from 'sentry/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+import {
+  getRenderableTraceIssues,
+  getTraceIssueTimestamp,
+  TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
+  TRACE_ICON_GROUP_GAP,
+  TRACE_ICON_GROUP_GLYPH_WIDTH,
+  TRACE_ICON_GROUP_HORIZONTAL_PADDING,
+  TRACE_ICON_WIDTH,
+} from 'sentry/views/performance/newTraceDetails/traceIssueUtils';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import {TraceRowWidthMeasurer} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer';
@@ -18,11 +27,6 @@ import type {TraceView} from 'sentry/views/performance/newTraceDetails/traceRend
 import type {TraceScheduler} from './traceScheduler';
 
 const DIVIDER_WIDTH = 6;
-const TRACE_ICON_WIDTH = 18;
-const TRACE_ICON_GROUP_GLYPH_WIDTH = 12;
-const TRACE_ICON_GROUP_GAP = 2;
-const TRACE_ICON_GROUP_HORIZONTAL_PADDING = 10;
-const TRACE_ICON_GROUP_COUNT_MIN_WIDTH = 8;
 
 function easeOutSine(x: number): number {
   return Math.sin((x * Math.PI) / 2);
@@ -1854,141 +1858,6 @@ function getTraceIconBounds(
   }
 
   return [centered_icon_left, centered_icon_right];
-}
-
-interface RenderableTraceIssue {
-  issue: TraceTree.TraceIssue;
-  additionalIssueCount?: number;
-}
-
-function getRenderableTraceIssues(
-  node: BaseNode,
-  errors: BaseNode['errors'],
-  occurrences: BaseNode['occurrences']
-): RenderableTraceIssue[] {
-  const directErrors = getDirectErrors(node);
-  const directOccurrences = getDirectOccurrences(node);
-  const childIssues: TraceTree.TraceIssue[] = [];
-  const issues: RenderableTraceIssue[] = [];
-
-  for (const error of errors) {
-    if (directErrors.has(error)) {
-      issues.push({issue: error});
-    } else {
-      childIssues.push(error);
-    }
-  }
-
-  for (const occurrence of occurrences) {
-    if (directOccurrences.has(occurrence)) {
-      issues.push({issue: occurrence});
-    } else {
-      childIssues.push(occurrence);
-    }
-  }
-
-  const childRepresentative = getMostSevereTraceIssue(childIssues);
-  if (childRepresentative) {
-    const additionalIssueCount = childIssues.length - 1;
-    issues.push(
-      additionalIssueCount > 0
-        ? {issue: childRepresentative, additionalIssueCount}
-        : {issue: childRepresentative}
-    );
-  }
-
-  return issues;
-}
-
-function getDirectErrors(node: BaseNode): Set<TraceTree.TraceErrorIssue> {
-  const errors = new Set<TraceTree.TraceErrorIssue>();
-
-  if (node.value && 'errors' in node.value && Array.isArray(node.value.errors)) {
-    node.value.errors.forEach(error => errors.add(error));
-  }
-
-  return errors;
-}
-
-function getDirectOccurrences(node: BaseNode): Set<TraceTree.TraceOccurrence> {
-  const occurrences = new Set<TraceTree.TraceOccurrence>();
-
-  if (
-    node.value &&
-    'occurrences' in node.value &&
-    Array.isArray(node.value.occurrences)
-  ) {
-    node.value.occurrences.forEach(occurrence => occurrences.add(occurrence));
-  }
-
-  if (
-    node.value &&
-    'performance_issues' in node.value &&
-    Array.isArray(node.value.performance_issues)
-  ) {
-    node.value.performance_issues.forEach(occurrence => occurrences.add(occurrence));
-  }
-
-  return occurrences;
-}
-
-function getMostSevereTraceIssue(
-  issues: TraceTree.TraceIssue[]
-): TraceTree.TraceIssue | null {
-  return issues.reduce<TraceTree.TraceIssue | null>((mostSevere, issue) => {
-    if (!mostSevere) {
-      return issue;
-    }
-
-    const severityDiff =
-      getTraceIssueSeverityRank(issue) - getTraceIssueSeverityRank(mostSevere);
-
-    if (severityDiff > 0) {
-      return issue;
-    }
-
-    if (
-      severityDiff === 0 &&
-      getTraceIssueTimestamp(issue, [0, 0]) < getTraceIssueTimestamp(mostSevere, [0, 0])
-    ) {
-      return issue;
-    }
-
-    return mostSevere;
-  }, null);
-}
-
-function getTraceIssueSeverityRank(issue: TraceTree.TraceIssue): number {
-  switch (issue.level) {
-    case 'fatal':
-      return 5;
-    case 'error':
-      return 4;
-    case 'warning':
-      return 3;
-    case 'info':
-      return 2;
-    default:
-      return 1;
-  }
-}
-
-function getTraceIssueTimestamp(
-  issue: TraceTree.TraceIssue,
-  nodeSpace: [number, number]
-): number {
-  if ('timestamp' in issue && typeof issue.timestamp === 'number') {
-    return issue.timestamp * 1e3;
-  }
-
-  let startTimestamp: number | undefined;
-  if ('start_timestamp' in issue) {
-    startTimestamp = issue.start_timestamp;
-  } else if ('start' in issue) {
-    startTimestamp = issue.start;
-  }
-
-  return typeof startTimestamp === 'number' ? startTimestamp * 1e3 : nodeSpace[0];
 }
 
 function getTraceIconGroupWidth(

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1157,7 +1157,7 @@ export class VirtualizedViewManager {
       return 'start';
     }
 
-    if (x + halfIconWidthPx >= this.view.trace_view.width) {
+    if (x + halfIconWidthPx >= this.view.trace_physical_space.width) {
       return 'end';
     }
 
@@ -1173,11 +1173,7 @@ export class VirtualizedViewManager {
     }
 
     if (edge === 'end') {
-      return (
-        this.view.to_origin +
-        this.view.trace_view.x +
-        this.view.trace_view.width * this.span_to_px[0]
-      );
+      return this.view.to_origin + this.view.trace_view.x + this.view.trace_view.width;
     }
 
     return timestamp;
@@ -1229,9 +1225,7 @@ export class VirtualizedViewManager {
       value => this.text_measurer.measure(value),
       [
         this.view.to_origin + this.view.trace_view.x,
-        this.view.to_origin +
-          this.view.trace_view.x +
-          this.view.trace_view.width * this.span_to_px[0],
+        this.view.to_origin + this.view.trace_view.x + this.view.trace_view.width,
       ]
     );
     const text_left = Math.min(span_space[0], timestamps[0]!);

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1838,7 +1838,8 @@ function getIconTimestamps(
   for (const {issue, additionalIssueCount} of getRenderableTraceIssues(
     node,
     node.errors,
-    node.occurrences
+    node.occurrences,
+    span_space
   )) {
     const icon_width_px =
       additionalIssueCount === undefined

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1792,13 +1792,13 @@ function getIconTimestamps(
 
   let max_icon_width = TRACE_ICON_WIDTH;
 
-  for (const {issue, childIssueCount} of getRenderableTraceIssues(
+  for (const {issue, additionalIssueCount} of getRenderableTraceIssues(
     node,
     node.errors,
     node.occurrences
   )) {
-    const icon_width_px = childIssueCount
-      ? getTraceIconGroupWidth(childIssueCount, measureText)
+    const icon_width_px = additionalIssueCount
+      ? getTraceIconGroupWidth(additionalIssueCount, measureText)
       : TRACE_ICON_WIDTH;
     const icon_width_config_space = icon_width_px * px_to_config_space;
     const timestamp = getTraceIssueTimestamp(issue, span_space);
@@ -1858,7 +1858,7 @@ function getTraceIconBounds(
 
 interface RenderableTraceIssue {
   issue: TraceTree.TraceIssue;
-  childIssueCount?: number;
+  additionalIssueCount?: number;
 }
 
 function getRenderableTraceIssues(
@@ -1889,7 +1889,12 @@ function getRenderableTraceIssues(
 
   const childRepresentative = getMostSevereTraceIssue(childIssues);
   if (childRepresentative) {
-    issues.push({issue: childRepresentative, childIssueCount: childIssues.length});
+    const additionalIssueCount = childIssues.length - 1;
+    issues.push(
+      additionalIssueCount > 0
+        ? {issue: childRepresentative, additionalIssueCount}
+        : {issue: childRepresentative}
+    );
   }
 
   return issues;
@@ -1987,12 +1992,12 @@ function getTraceIssueTimestamp(
 }
 
 function getTraceIconGroupWidth(
-  childIssueCount: number,
+  additionalIssueCount: number,
   measureText: (text: string) => number
 ) {
   const count_width = Math.max(
     TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
-    Math.ceil(measureText(String(childIssueCount)))
+    Math.ceil(measureText(String(additionalIssueCount)))
   );
 
   return (

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -25,6 +25,14 @@ import type {TraceScheduler} from './traceScheduler';
 
 const DIVIDER_WIDTH = 6;
 
+type TraceIconEdge = 'start' | 'end' | null;
+
+interface TraceIconPlacement {
+  anchorTimestamp: number;
+  bounds: [number, number];
+  edge: TraceIconEdge;
+}
+
 function easeOutSine(x: number): number {
   return Math.sin((x * Math.PI) / 2);
 }
@@ -1146,7 +1154,51 @@ export class VirtualizedViewManager {
     return (timestamp - entire_space[0]) / entire_space[1];
   }
 
-  computeTraceIconEdge(timestamp: number, iconWidthPx: number): 'start' | 'end' | null {
+  computeTraceIconPlacement(
+    timestamp: number,
+    iconWidthPx: number,
+    span_space: [number, number]
+  ): TraceIconPlacement {
+    const span_start = span_space[0];
+    const span_end = span_space[0] + span_space[1];
+    const clamped_timestamp = clamp(timestamp, span_start, span_end);
+    const edge = this.computeTraceIconEdge(clamped_timestamp, iconWidthPx);
+    const anchorTimestamp = clamp(
+      this.computeTraceIconAnchorTimestamp(clamped_timestamp, edge),
+      span_start,
+      span_end
+    );
+    const icon_width_config_space = iconWidthPx * this.span_to_px[0];
+
+    if (edge === 'start') {
+      return {
+        edge,
+        anchorTimestamp,
+        bounds: [anchorTimestamp, anchorTimestamp + icon_width_config_space],
+      };
+    }
+
+    if (edge === 'end') {
+      return {
+        edge,
+        anchorTimestamp,
+        bounds: [anchorTimestamp - icon_width_config_space, anchorTimestamp],
+      };
+    }
+
+    const half_icon_width_config_space = icon_width_config_space / 2;
+
+    return {
+      edge,
+      anchorTimestamp,
+      bounds: [
+        anchorTimestamp - half_icon_width_config_space,
+        anchorTimestamp + half_icon_width_config_space,
+      ],
+    };
+  }
+
+  private computeTraceIconEdge(timestamp: number, iconWidthPx: number): TraceIconEdge {
     const halfIconWidthPx = iconWidthPx / 2;
     const x = this.transformXFromTimestamp(timestamp);
 
@@ -1161,9 +1213,9 @@ export class VirtualizedViewManager {
     return null;
   }
 
-  computeTraceIconAnchorTimestamp(
+  private computeTraceIconAnchorTimestamp(
     timestamp: number,
-    edge: 'start' | 'end' | null
+    edge: TraceIconEdge
   ): number {
     if (edge === 'start') {
       return this.view.to_origin + this.view.trace_view.x;
@@ -1218,12 +1270,9 @@ export class VirtualizedViewManager {
     const timestamps = getIconTimestamps(
       node,
       span_space,
-      this.span_to_px[0],
       value => this.text_measurer.measure(value),
-      [
-        this.view.to_origin + this.view.trace_view.x,
-        this.view.to_origin + this.view.trace_view.x + this.view.trace_view.width,
-      ]
+      (timestamp, iconWidthPx) =>
+        this.computeTraceIconPlacement(timestamp, iconWidthPx, span_space)
     );
     const text_left = Math.min(span_space[0], timestamps[0]!);
     const text_right = Math.max(span_space[0] + span_space[1], timestamps[1]!);
@@ -1774,9 +1823,8 @@ export class VirtualizedViewManager {
 function getIconTimestamps(
   node: BaseNode,
   span_space: [number, number],
-  px_to_config_space: number,
   measureText: (text: string) => number,
-  visible_space: [number, number]
+  getTraceIconPlacement: (timestamp: number, iconWidthPx: number) => TraceIconPlacement
 ) {
   let min_icon_timestamp = span_space[0];
   let max_icon_timestamp = span_space[0] + span_space[1];
@@ -1785,7 +1833,7 @@ function getIconTimestamps(
     return [min_icon_timestamp, max_icon_timestamp];
   }
 
-  let max_icon_width = TRACE_ICON_WIDTH;
+  let max_icon_width_config_space = 0;
 
   for (const {issue, additionalIssueCount} of getRenderableTraceIssues(
     node,
@@ -1796,21 +1844,17 @@ function getIconTimestamps(
       additionalIssueCount === undefined
         ? TRACE_ICON_WIDTH
         : getTraceIconGroupWidth(additionalIssueCount, measureText);
-    const icon_width_config_space = icon_width_px * px_to_config_space;
     const timestamp = getTraceIssueTimestamp(issue, span_space);
-    const [icon_left, icon_right] = getTraceIconBounds(
-      timestamp,
-      span_space,
-      visible_space,
-      icon_width_config_space
-    );
+    const {bounds} = getTraceIconPlacement(timestamp, icon_width_px);
+    const [icon_left, icon_right] = bounds;
 
     min_icon_timestamp = Math.min(min_icon_timestamp, icon_left);
     max_icon_timestamp = Math.max(max_icon_timestamp, icon_right);
-    max_icon_width = Math.max(max_icon_width, icon_width_px);
+    max_icon_width_config_space = Math.max(
+      max_icon_width_config_space,
+      icon_right - icon_left
+    );
   }
-
-  const max_icon_width_config_space = max_icon_width * px_to_config_space;
 
   min_icon_timestamp = clamp(
     min_icon_timestamp,
@@ -1824,34 +1868,6 @@ function getIconTimestamps(
   );
 
   return [min_icon_timestamp, max_icon_timestamp];
-}
-
-function getTraceIconBounds(
-  timestamp: number,
-  span_space: [number, number],
-  visible_space: [number, number],
-  icon_width_config_space: number
-): [number, number] {
-  const clamped_timestamp = clamp(
-    timestamp,
-    span_space[0],
-    span_space[0] + span_space[1]
-  );
-  const half_icon_width_config_space = icon_width_config_space / 2;
-  const centered_icon_left = clamped_timestamp - half_icon_width_config_space;
-  const centered_icon_right = clamped_timestamp + half_icon_width_config_space;
-
-  if (centered_icon_left <= visible_space[0]) {
-    const anchor = Math.max(visible_space[0], span_space[0]);
-    return [anchor, anchor + icon_width_config_space];
-  }
-
-  if (centered_icon_right >= visible_space[1]) {
-    const anchor = Math.min(visible_space[1], span_space[0] + span_space[1]);
-    return [anchor - icon_width_config_space, anchor];
-  }
-
-  return [centered_icon_left, centered_icon_right];
 }
 
 /**

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1792,9 +1792,10 @@ function getIconTimestamps(
     node.errors,
     node.occurrences
   )) {
-    const icon_width_px = additionalIssueCount
-      ? getTraceIconGroupWidth(additionalIssueCount, measureText)
-      : TRACE_ICON_WIDTH;
+    const icon_width_px =
+      additionalIssueCount === undefined
+        ? TRACE_ICON_WIDTH
+        : getTraceIconGroupWidth(additionalIssueCount, measureText);
     const icon_width_config_space = icon_width_px * px_to_config_space;
     const timestamp = getTraceIssueTimestamp(issue, span_space);
     const [icon_left, icon_right] = getTraceIconBounds(

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -18,6 +18,11 @@ import type {TraceView} from 'sentry/views/performance/newTraceDetails/traceRend
 import type {TraceScheduler} from './traceScheduler';
 
 const DIVIDER_WIDTH = 6;
+const TRACE_ICON_WIDTH = 18;
+const TRACE_ICON_GROUP_GLYPH_WIDTH = 12;
+const TRACE_ICON_GROUP_GAP = 2;
+const TRACE_ICON_GROUP_HORIZONTAL_PADDING = 10;
+const TRACE_ICON_GROUP_COUNT_MIN_WIDTH = 8;
 
 function easeOutSine(x: number): number {
   return Math.sin((x * Math.PI) / 2);
@@ -1174,13 +1179,14 @@ export class VirtualizedViewManager {
   ): [number, number] {
     const TEXT_PADDING = 3;
 
-    const icon_width_config_space = (18 * this.span_to_px[0]) / 2;
     const text_anchor_left =
       span_space[0] > this.view.to_origin + this.view.trace_space.width * 0.5;
     const text_width = this.text_measurer.measure(text);
     const text_width_ceil = Math.ceil(text_width);
 
-    const timestamps = getIconTimestamps(node, span_space, icon_width_config_space);
+    const timestamps = getIconTimestamps(node, span_space, this.span_to_px[0], value =>
+      this.text_measurer.measure(value)
+    );
     const text_left = Math.min(span_space[0], timestamps[0]!);
     const text_right = Math.max(span_space[0] + span_space[1], timestamps[1]!);
 
@@ -1730,7 +1736,8 @@ export class VirtualizedViewManager {
 function getIconTimestamps(
   node: BaseNode,
   span_space: [number, number],
-  icon_width: number
+  px_to_config_space: number,
+  measureText: (text: string) => number
 ) {
   let min_icon_timestamp = span_space[0];
   let max_icon_timestamp = span_space[0] + span_space[1];
@@ -1739,42 +1746,191 @@ function getIconTimestamps(
     return [min_icon_timestamp, max_icon_timestamp];
   }
 
-  for (const occurrence of node.occurrences) {
-    // Occurences render icons at the start timestamp
-    const start_timestamp =
-      'start_timestamp' in occurrence ? occurrence.start_timestamp : occurrence.start;
-    if (typeof start_timestamp === 'number') {
-      min_icon_timestamp = Math.min(
-        min_icon_timestamp,
-        start_timestamp * 1e3 - icon_width
-      );
-      max_icon_timestamp = Math.max(
-        max_icon_timestamp,
-        start_timestamp * 1e3 + icon_width
-      );
-    }
+  let max_icon_width = TRACE_ICON_WIDTH;
+
+  for (const {issue, childIssueCount} of getRenderableTraceIssues(
+    node,
+    node.errors,
+    node.occurrences
+  )) {
+    const icon_width = childIssueCount
+      ? getTraceIconGroupWidth(childIssueCount, measureText)
+      : TRACE_ICON_WIDTH;
+    const icon_width_config_space = (icon_width * px_to_config_space) / 2;
+    const timestamp = getTraceIssueTimestamp(issue, span_space);
+
+    min_icon_timestamp = Math.min(
+      min_icon_timestamp,
+      timestamp - icon_width_config_space
+    );
+    max_icon_timestamp = Math.max(
+      max_icon_timestamp,
+      timestamp + icon_width_config_space
+    );
+    max_icon_width = Math.max(max_icon_width, icon_width);
   }
 
-  for (const err of node.errors) {
-    const timestamp = 'start_timestamp' in err ? err.start_timestamp : err.timestamp;
-    if (typeof timestamp === 'number') {
-      min_icon_timestamp = Math.min(min_icon_timestamp, timestamp * 1e3 - icon_width);
-      max_icon_timestamp = Math.max(max_icon_timestamp, timestamp * 1e3 + icon_width);
-    }
-  }
+  const max_icon_width_config_space = (max_icon_width * px_to_config_space) / 2;
 
   min_icon_timestamp = clamp(
     min_icon_timestamp,
-    span_space[0] - icon_width,
-    span_space[0] + span_space[1] + icon_width
+    span_space[0] - max_icon_width_config_space,
+    span_space[0] + span_space[1] + max_icon_width_config_space
   );
   max_icon_timestamp = clamp(
     max_icon_timestamp,
-    span_space[0] - icon_width,
-    span_space[0] + span_space[1] + icon_width
+    span_space[0] - max_icon_width_config_space,
+    span_space[0] + span_space[1] + max_icon_width_config_space
   );
 
   return [min_icon_timestamp, max_icon_timestamp];
+}
+
+interface RenderableTraceIssue {
+  issue: TraceTree.TraceIssue;
+  childIssueCount?: number;
+}
+
+function getRenderableTraceIssues(
+  node: BaseNode,
+  errors: BaseNode['errors'],
+  occurrences: BaseNode['occurrences']
+): RenderableTraceIssue[] {
+  const directErrors = getDirectErrors(node);
+  const directOccurrences = getDirectOccurrences(node);
+  const childIssues: TraceTree.TraceIssue[] = [];
+  const issues: RenderableTraceIssue[] = [];
+
+  for (const error of errors) {
+    if (directErrors.has(error)) {
+      issues.push({issue: error});
+    } else {
+      childIssues.push(error);
+    }
+  }
+
+  for (const occurrence of occurrences) {
+    if (directOccurrences.has(occurrence)) {
+      issues.push({issue: occurrence});
+    } else {
+      childIssues.push(occurrence);
+    }
+  }
+
+  const childRepresentative = getMostSevereTraceIssue(childIssues);
+  if (childRepresentative) {
+    issues.push({issue: childRepresentative, childIssueCount: childIssues.length});
+  }
+
+  return issues;
+}
+
+function getDirectErrors(node: BaseNode): Set<TraceTree.TraceErrorIssue> {
+  const errors = new Set<TraceTree.TraceErrorIssue>();
+
+  if (node.value && 'errors' in node.value && Array.isArray(node.value.errors)) {
+    node.value.errors.forEach(error => errors.add(error));
+  }
+
+  return errors;
+}
+
+function getDirectOccurrences(node: BaseNode): Set<TraceTree.TraceOccurrence> {
+  const occurrences = new Set<TraceTree.TraceOccurrence>();
+
+  if (
+    node.value &&
+    'occurrences' in node.value &&
+    Array.isArray(node.value.occurrences)
+  ) {
+    node.value.occurrences.forEach(occurrence => occurrences.add(occurrence));
+  }
+
+  if (
+    node.value &&
+    'performance_issues' in node.value &&
+    Array.isArray(node.value.performance_issues)
+  ) {
+    node.value.performance_issues.forEach(occurrence => occurrences.add(occurrence));
+  }
+
+  return occurrences;
+}
+
+function getMostSevereTraceIssue(
+  issues: TraceTree.TraceIssue[]
+): TraceTree.TraceIssue | null {
+  return issues.reduce<TraceTree.TraceIssue | null>((mostSevere, issue) => {
+    if (!mostSevere) {
+      return issue;
+    }
+
+    const severityDiff =
+      getTraceIssueSeverityRank(issue) - getTraceIssueSeverityRank(mostSevere);
+
+    if (severityDiff > 0) {
+      return issue;
+    }
+
+    if (
+      severityDiff === 0 &&
+      getTraceIssueTimestamp(issue, [0, 0]) < getTraceIssueTimestamp(mostSevere, [0, 0])
+    ) {
+      return issue;
+    }
+
+    return mostSevere;
+  }, null);
+}
+
+function getTraceIssueSeverityRank(issue: TraceTree.TraceIssue): number {
+  switch (issue.level) {
+    case 'fatal':
+      return 5;
+    case 'error':
+      return 4;
+    case 'warning':
+      return 3;
+    case 'info':
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+function getTraceIssueTimestamp(
+  issue: TraceTree.TraceIssue,
+  nodeSpace: [number, number]
+): number {
+  if ('timestamp' in issue && typeof issue.timestamp === 'number') {
+    return issue.timestamp * 1e3;
+  }
+
+  let startTimestamp: number | undefined;
+  if ('start_timestamp' in issue) {
+    startTimestamp = issue.start_timestamp;
+  } else if ('start' in issue) {
+    startTimestamp = issue.start;
+  }
+
+  return typeof startTimestamp === 'number' ? startTimestamp * 1e3 : nodeSpace[0];
+}
+
+function getTraceIconGroupWidth(
+  childIssueCount: number,
+  measureText: (text: string) => number
+) {
+  const count_width = Math.max(
+    TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
+    Math.ceil(measureText(String(childIssueCount)))
+  );
+
+  return (
+    TRACE_ICON_GROUP_HORIZONTAL_PADDING +
+    TRACE_ICON_GROUP_GLYPH_WIDTH +
+    TRACE_ICON_GROUP_GAP +
+    count_width
+  );
 }
 
 /**

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -11,11 +11,8 @@ import {
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import {
   getRenderableTraceIssues,
+  getTraceIconGroupWidth,
   getTraceIssueTimestamp,
-  TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
-  TRACE_ICON_GROUP_GAP,
-  TRACE_ICON_GROUP_GLYPH_WIDTH,
-  TRACE_ICON_GROUP_HORIZONTAL_PADDING,
   TRACE_ICON_WIDTH,
 } from 'sentry/views/performance/newTraceDetails/traceIssueUtils';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
@@ -1852,23 +1849,6 @@ function getTraceIconBounds(
   }
 
   return [centered_icon_left, centered_icon_right];
-}
-
-function getTraceIconGroupWidth(
-  additionalIssueCount: number,
-  measureText: (text: string) => number
-) {
-  const count_width = Math.max(
-    TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
-    Math.ceil(measureText(String(additionalIssueCount)))
-  );
-
-  return (
-    TRACE_ICON_GROUP_HORIZONTAL_PADDING +
-    TRACE_ICON_GROUP_GLYPH_WIDTH +
-    TRACE_ICON_GROUP_GAP +
-    count_width
-  );
 }
 
 /**

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1145,8 +1145,38 @@ export class VirtualizedViewManager {
     return (timestamp - entire_space[0]) / entire_space[1];
   }
 
-  computeConfigSpaceForPixels(px: number): number {
-    return px * this.span_to_px[0];
+  computeTraceIconEdge(timestamp: number, iconWidthPx: number): 'start' | 'end' | null {
+    const halfIconWidthPx = iconWidthPx / 2;
+    const x = this.transformXFromTimestamp(timestamp);
+
+    if (x - halfIconWidthPx <= 0) {
+      return 'start';
+    }
+
+    if (x + halfIconWidthPx >= this.view.trace_view.width) {
+      return 'end';
+    }
+
+    return null;
+  }
+
+  computeTraceIconAnchorTimestamp(
+    timestamp: number,
+    edge: 'start' | 'end' | null
+  ): number {
+    if (edge === 'start') {
+      return this.view.to_origin + this.view.trace_view.x;
+    }
+
+    if (edge === 'end') {
+      return (
+        this.view.to_origin +
+        this.view.trace_view.x +
+        this.view.trace_view.width * this.span_to_px[0]
+      );
+    }
+
+    return timestamp;
   }
 
   recomputeTimelineIntervals() {
@@ -1188,8 +1218,17 @@ export class VirtualizedViewManager {
     const text_width = this.text_measurer.measure(text);
     const text_width_ceil = Math.ceil(text_width);
 
-    const timestamps = getIconTimestamps(node, span_space, this.span_to_px[0], value =>
-      this.text_measurer.measure(value)
+    const timestamps = getIconTimestamps(
+      node,
+      span_space,
+      this.span_to_px[0],
+      value => this.text_measurer.measure(value),
+      [
+        this.view.to_origin + this.view.trace_view.x,
+        this.view.to_origin +
+          this.view.trace_view.x +
+          this.view.trace_view.width * this.span_to_px[0],
+      ]
     );
     const text_left = Math.min(span_space[0], timestamps[0]!);
     const text_right = Math.max(span_space[0] + span_space[1], timestamps[1]!);
@@ -1741,7 +1780,8 @@ function getIconTimestamps(
   node: BaseNode,
   span_space: [number, number],
   px_to_config_space: number,
-  measureText: (text: string) => number
+  measureText: (text: string) => number,
+  visible_space: [number, number]
 ) {
   let min_icon_timestamp = span_space[0];
   let max_icon_timestamp = span_space[0] + span_space[1];
@@ -1762,9 +1802,12 @@ function getIconTimestamps(
       : TRACE_ICON_WIDTH;
     const icon_width_config_space = icon_width_px * px_to_config_space;
     const timestamp = getTraceIssueTimestamp(issue, span_space);
-    const [icon_left, icon_right] = childIssueCount
-      ? getTraceIconGroupBounds(timestamp, span_space, icon_width_config_space)
-      : getTraceIconBounds(timestamp, span_space, icon_width_config_space);
+    const [icon_left, icon_right] = getTraceIconBounds(
+      timestamp,
+      span_space,
+      visible_space,
+      icon_width_config_space
+    );
 
     min_icon_timestamp = Math.min(min_icon_timestamp, icon_left);
     max_icon_timestamp = Math.max(max_icon_timestamp, icon_right);
@@ -1790,6 +1833,7 @@ function getIconTimestamps(
 function getTraceIconBounds(
   timestamp: number,
   span_space: [number, number],
+  visible_space: [number, number],
   icon_width_config_space: number
 ): [number, number] {
   const clamped_timestamp = clamp(
@@ -1798,34 +1842,18 @@ function getTraceIconBounds(
     span_space[0] + span_space[1]
   );
   const half_icon_width_config_space = icon_width_config_space / 2;
+  const centered_icon_left = clamped_timestamp - half_icon_width_config_space;
+  const centered_icon_right = clamped_timestamp + half_icon_width_config_space;
 
-  return [
-    clamped_timestamp - half_icon_width_config_space,
-    clamped_timestamp + half_icon_width_config_space,
-  ];
-}
-
-function getTraceIconGroupBounds(
-  timestamp: number,
-  span_space: [number, number],
-  icon_width_config_space: number
-): [number, number] {
-  const span_start = span_space[0];
-  const span_end = span_space[0] + span_space[1];
-  const half_icon_width_config_space = icon_width_config_space / 2;
-
-  if (timestamp - half_icon_width_config_space <= span_start) {
-    return [span_start, span_start + icon_width_config_space];
+  if (centered_icon_left <= visible_space[0]) {
+    return [visible_space[0], visible_space[0] + icon_width_config_space];
   }
 
-  if (timestamp + half_icon_width_config_space >= span_end) {
-    return [span_end - icon_width_config_space, span_end];
+  if (centered_icon_right >= visible_space[1]) {
+    return [visible_space[1] - icon_width_config_space, visible_space[1]];
   }
 
-  return [
-    timestamp - half_icon_width_config_space,
-    timestamp + half_icon_width_config_space,
-  ];
+  return [centered_icon_left, centered_icon_right];
 }
 
 interface RenderableTraceIssue {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1145,6 +1145,10 @@ export class VirtualizedViewManager {
     return (timestamp - entire_space[0]) / entire_space[1];
   }
 
+  computeConfigSpaceForPixels(px: number): number {
+    return px * this.span_to_px[0];
+  }
+
   recomputeTimelineIntervals() {
     if (this.view.trace_view.width === 0) {
       this.intervals[0] = 0;
@@ -1753,24 +1757,21 @@ function getIconTimestamps(
     node.errors,
     node.occurrences
   )) {
-    const icon_width = childIssueCount
+    const icon_width_px = childIssueCount
       ? getTraceIconGroupWidth(childIssueCount, measureText)
       : TRACE_ICON_WIDTH;
-    const icon_width_config_space = (icon_width * px_to_config_space) / 2;
+    const icon_width_config_space = icon_width_px * px_to_config_space;
     const timestamp = getTraceIssueTimestamp(issue, span_space);
+    const [icon_left, icon_right] = childIssueCount
+      ? getTraceIconGroupBounds(timestamp, span_space, icon_width_config_space)
+      : getTraceIconBounds(timestamp, span_space, icon_width_config_space);
 
-    min_icon_timestamp = Math.min(
-      min_icon_timestamp,
-      timestamp - icon_width_config_space
-    );
-    max_icon_timestamp = Math.max(
-      max_icon_timestamp,
-      timestamp + icon_width_config_space
-    );
-    max_icon_width = Math.max(max_icon_width, icon_width);
+    min_icon_timestamp = Math.min(min_icon_timestamp, icon_left);
+    max_icon_timestamp = Math.max(max_icon_timestamp, icon_right);
+    max_icon_width = Math.max(max_icon_width, icon_width_px);
   }
 
-  const max_icon_width_config_space = (max_icon_width * px_to_config_space) / 2;
+  const max_icon_width_config_space = max_icon_width * px_to_config_space;
 
   min_icon_timestamp = clamp(
     min_icon_timestamp,
@@ -1784,6 +1785,47 @@ function getIconTimestamps(
   );
 
   return [min_icon_timestamp, max_icon_timestamp];
+}
+
+function getTraceIconBounds(
+  timestamp: number,
+  span_space: [number, number],
+  icon_width_config_space: number
+): [number, number] {
+  const clamped_timestamp = clamp(
+    timestamp,
+    span_space[0],
+    span_space[0] + span_space[1]
+  );
+  const half_icon_width_config_space = icon_width_config_space / 2;
+
+  return [
+    clamped_timestamp - half_icon_width_config_space,
+    clamped_timestamp + half_icon_width_config_space,
+  ];
+}
+
+function getTraceIconGroupBounds(
+  timestamp: number,
+  span_space: [number, number],
+  icon_width_config_space: number
+): [number, number] {
+  const span_start = span_space[0];
+  const span_end = span_space[0] + span_space[1];
+  const half_icon_width_config_space = icon_width_config_space / 2;
+
+  if (timestamp - half_icon_width_config_space <= span_start) {
+    return [span_start, span_start + icon_width_config_space];
+  }
+
+  if (timestamp + half_icon_width_config_space >= span_end) {
+    return [span_end - icon_width_config_space, span_end];
+  }
+
+  return [
+    timestamp - half_icon_width_config_space,
+    timestamp + half_icon_width_config_space,
+  ];
 }
 
 interface RenderableTraceIssue {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1842,11 +1842,13 @@ function getTraceIconBounds(
   const centered_icon_right = clamped_timestamp + half_icon_width_config_space;
 
   if (centered_icon_left <= visible_space[0]) {
-    return [visible_space[0], visible_space[0] + icon_width_config_space];
+    const anchor = Math.max(visible_space[0], span_space[0]);
+    return [anchor, anchor + icon_width_config_space];
   }
 
   if (centered_icon_right >= visible_space[1]) {
-    return [visible_space[1] - icon_width_config_space, visible_space[1]];
+    const anchor = Math.min(visible_space[1], span_space[0] + span_space[1]);
+    return [anchor - icon_width_config_space, anchor];
   }
 
   return [centered_icon_left, centered_icon_right];

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -951,23 +951,32 @@ export class VirtualizedViewManager {
     );
   }
 
+  private getConfigSpacePerPx(): number {
+    if (this.view.trace_physical_space.width === 0) {
+      return this.span_to_px[0] || 1;
+    }
+
+    return this.view.trace_view.width / this.view.trace_physical_space.width;
+  }
+
   computeSpanCSSMatrixTransform(
     space: [number, number]
   ): [number, number, number, number, number, number] {
+    const config_space_per_px = this.getConfigSpacePerPx();
     const scale = space[1] / this.view.trace_view.width;
     this.span_matrix[0] = Math.max(
       scale,
-      this.span_to_px[0] / this.view.trace_view.width
+      config_space_per_px / this.view.trace_view.width
     );
     this.span_matrix[4] =
-      (space[0] - this.view.to_origin) / this.span_to_px[0] -
-      this.view.trace_view.x / this.span_to_px[0];
+      (space[0] - this.view.to_origin) / config_space_per_px -
+      this.view.trace_view.x / config_space_per_px;
 
     // if span ends less than 1px before the end of the view, we move it back by 1px and prevent it from being clipped
     if (
       space[0] - this.view.to_origin > this.view.trace_space.width / 2 &&
       (this.view.to_origin + this.view.trace_space.width - space[0] - space[1]) /
-        this.span_to_px[0] <=
+        config_space_per_px <=
         1
     ) {
       // 1px for the span and 1px for the border
@@ -977,8 +986,9 @@ export class VirtualizedViewManager {
   }
 
   transformXFromTimestamp(timestamp: number): number {
+    const config_space_per_px = this.getConfigSpacePerPx();
     return (
-      (timestamp - this.view.to_origin - this.view.trace_view.x) / this.span_to_px[0]
+      (timestamp - this.view.to_origin - this.view.trace_view.x) / config_space_per_px
     );
   }
 
@@ -1168,7 +1178,7 @@ export class VirtualizedViewManager {
       span_start,
       span_end
     );
-    const icon_width_config_space = iconWidthPx * this.span_to_px[0];
+    const icon_width_config_space = iconWidthPx * this.getConfigSpacePerPx();
 
     if (edge === 'start') {
       return {
@@ -1326,7 +1336,8 @@ export class VirtualizedViewManager {
       return text_anchor_left ? [1, window_left] : [1, window_right];
     }
 
-    const full_span_px_width = span_space[1] / this.span_to_px[0];
+    const config_space_per_px = this.getConfigSpacePerPx();
+    const full_span_px_width = span_space[1] / config_space_per_px;
 
     if (text_anchor_left) {
       // While we have space on the left, place the text there
@@ -1335,7 +1346,7 @@ export class VirtualizedViewManager {
       }
 
       const distance = span_right - this.view.trace_view.left;
-      const visible_width = distance / this.span_to_px[0] - TEXT_PADDING;
+      const visible_width = distance / config_space_per_px - TEXT_PADDING;
 
       // If the text fits inside the visible portion of the span, anchor it to the left
       // side of the window so that it is visible while the user pans the view
@@ -1361,7 +1372,7 @@ export class VirtualizedViewManager {
         // origin and check if it fits into the distance of space right edge - span right edge. In practice
         // however, it seems that a magical number works just fine.
         span_right > this.view.trace_space.right * 0.9 &&
-        space_right / this.span_to_px[0] < text_width_ceil
+        space_right / config_space_per_px < text_width_ceil
       ) {
         if (full_span_px_width > text_width_ceil) {
           return [1, right_inside];
@@ -1375,7 +1386,7 @@ export class VirtualizedViewManager {
     if (full_span_px_width > text_width_ceil) {
       const distance = span_right - this.view.trace_view.right;
       const visible_width =
-        (span_space[1] - distance) / this.span_to_px[0] - TEXT_PADDING;
+        (span_space[1] - distance) / config_space_per_px - TEXT_PADDING;
 
       // If the text fits inside the visible portion of the span, anchor it to the right
       // side of the window so that it is visible while the user pans the view
@@ -1405,7 +1416,7 @@ export class VirtualizedViewManager {
     });
 
     // 60px error margin. ~52px is roughly the width of 500.00ms, we add a bit more, to be safe.
-    const error_margin = 60 * this.span_to_px[0];
+    const error_margin = 60 * this.getConfigSpacePerPx();
 
     for (let i = 0; i < this.columns.list.column_refs.length; i++) {
       const span = this.span_bars[i];

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns.spec.tsx
@@ -1,0 +1,61 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import {
+  makeEAPError,
+  makeEAPOccurrence,
+  makeEAPSpan,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
+import {TraceBackgroundPatterns} from 'sentry/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns';
+
+const manager = {
+  computeRelativeLeftPositionFromOrigin: () => 0.5,
+} as unknown as VirtualizedViewManager;
+
+function renderPatterns(node: BaseNode) {
+  return render(
+    <TraceBackgroundPatterns
+      node={node}
+      node_space={[0, 10_000]}
+      errors={node.errors}
+      occurrences={node.occurrences}
+      manager={manager}
+    />
+  );
+}
+
+describe('TraceBackgroundPatterns', () => {
+  it('does not render a colored pattern for child-derived issues', () => {
+    const childError = makeEAPError({event_id: 'child-error', issue_id: 1});
+    const childOccurrence = makeEAPOccurrence({
+      event_id: 'child-occurrence',
+      issue_id: 2,
+    });
+    const node = {
+      value: makeEAPSpan({errors: [], occurrences: []}),
+      errors: new Set([childError]),
+      occurrences: new Set([childOccurrence]),
+    } as unknown as BaseNode;
+
+    renderPatterns(node);
+
+    expect(screen.queryByTestId('trace-issue-pattern')).not.toBeInTheDocument();
+  });
+
+  it('still renders a colored pattern for direct issues', () => {
+    const directOccurrence = makeEAPOccurrence({
+      event_id: 'direct-occurrence',
+      issue_id: 1,
+    });
+    const node = {
+      value: makeEAPSpan({errors: [], occurrences: [directOccurrence]}),
+      errors: new Set(),
+      occurrences: new Set([directOccurrence]),
+    } as unknown as BaseNode;
+
+    renderPatterns(node);
+
+    expect(screen.getByTestId('trace-issue-pattern')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns.tsx
@@ -8,6 +8,10 @@ import {
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
+import {
+  getDirectErrors,
+  getDirectOccurrences,
+} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
 
 const TRACE_ISSUE_SEVERITY_RANK: Record<TraceIssueSeverityClassName, number> = {
   fatal: 0,
@@ -36,31 +40,35 @@ function getMaxIssueSeverity(
 interface BackgroundPatternsProps {
   errors: BaseNode['errors'];
   manager: VirtualizedViewManager;
+  node: BaseNode;
   node_space: [number, number] | null;
   occurrences: BaseNode['occurrences'];
 }
 
 export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
+  const directOccurrences = useMemo(() => getDirectOccurrences(props.node), [props.node]);
+  const directErrors = useMemo(() => getDirectErrors(props.node), [props.node]);
+
   const occurrences = useMemo(() => {
     if (!props.occurrences.size) {
       return [];
     }
 
-    return [...props.occurrences];
-  }, [props.occurrences]);
+    return [...props.occurrences].filter(occurrence => directOccurrences.has(occurrence));
+  }, [props.occurrences, directOccurrences]);
 
   const errors = useMemo(() => {
     if (!props.errors.size) {
       return [];
     }
-    return [...props.errors];
-  }, [props.errors]);
+    return [...props.errors].filter(error => directErrors.has(error));
+  }, [props.errors, directErrors]);
 
   const severity = useMemo(() => {
     return getMaxIssueSeverity(errors, occurrences);
   }, [errors, occurrences]);
 
-  if (!props.occurrences.size && !props.errors.size) {
+  if (!occurrences.length && !errors.length) {
     return null;
   }
 
@@ -72,6 +80,7 @@ export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
     <Fragment>
       {errors.length > 0 ? (
         <div
+          data-test-id="trace-issue-pattern"
           className="TracePatternContainer"
           style={{
             left: 0,
@@ -100,6 +109,7 @@ export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
             return (
               <div
                 key={i}
+                data-test-id="trace-issue-pattern"
                 className="TracePatternContainer"
                 style={{
                   left: left * 100 + '%',

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns.tsx
@@ -5,13 +5,13 @@ import {
   getTraceIssueSeverityClassName,
   type TraceIssueSeverityClassName,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
-import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
-import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
 import {
   getDirectErrors,
   getDirectOccurrences,
-} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
+} from 'sentry/views/performance/newTraceDetails/traceIssueUtils';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
 
 const TRACE_ISSUE_SEVERITY_RANK: Record<TraceIssueSeverityClassName, number> = {
   fatal: 0,

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
@@ -4,10 +4,7 @@ import {formatTraceDuration} from 'sentry/utils/duration/formatTraceDuration';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
 import {TraceBackgroundPatterns} from 'sentry/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns';
-import {
-  TraceErrorIcons,
-  TraceOccurenceIcons,
-} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
+import {TraceIssueIcons} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
 
 interface InvisibleTraceBarProps {
   children: React.ReactNode;
@@ -147,22 +144,18 @@ export function TraceBar(props: TraceBarProps) {
   return (
     <Fragment>
       <div ref={registerSpanBarRef} className="TraceBar">
-        {props.errors.size > 0 ? (
-          <TraceErrorIcons
+        {props.errors.size > 0 || props.occurrences.size > 0 ? (
+          <TraceIssueIcons
+            node={props.node}
             node_space={props.node_space}
             errors={props.errors}
-            manager={props.manager}
-          />
-        ) : null}
-        {props.occurrences.size > 0 ? (
-          <TraceOccurenceIcons
-            node_space={props.node_space}
             occurrences={props.occurrences}
             manager={props.manager}
           />
         ) : null}
         {props.occurrences.size > 0 || props.errors.size > 0 || props.node.hasProfiles ? (
           <TraceBackgroundPatterns
+            node={props.node}
             node_space={props.node_space}
             occurrences={props.occurrences}
             errors={props.errors}
@@ -255,16 +248,11 @@ export function AutogroupedTraceBar(props: AutogroupedTraceBarProps) {
         })}
         {/* Autogrouped bars only render icons. That is because in the case of multiple bars
             with tiny gaps, the background pattern looks broken as it does not repeat nicely */}
-        {props.errors.size > 0 ? (
-          <TraceErrorIcons
+        {props.errors.size > 0 || props.occurrences.size > 0 ? (
+          <TraceIssueIcons
+            node={props.node}
             node_space={props.entire_space}
             errors={props.errors}
-            manager={props.manager}
-          />
-        ) : null}
-        {props.occurrences.size > 0 ? (
-          <TraceOccurenceIcons
-            node_space={props.entire_space}
             occurrences={props.occurrences}
             manager={props.manager}
           />

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
@@ -44,7 +44,7 @@ function renderIcons(node: BaseNode, nodeSpace: [number, number] = [0, 10_000]) 
 }
 
 describe('TraceIssueIcons', () => {
-  it('summarizes child-derived issues into one icon', () => {
+  it('summarizes child-derived issues into one icon with an additional issue count', () => {
     const childErrorA = makeEAPError({event_id: 'child-error-a', issue_id: 1});
     const childErrorB = makeEAPError({event_id: 'child-error-b', issue_id: 2});
     const childOccurrence = makeEAPOccurrence({
@@ -60,10 +60,10 @@ describe('TraceIssueIcons', () => {
     renderIcons(node);
 
     expect(screen.getAllByTestId('trace-issue-icon')).toHaveLength(1);
-    expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('2');
   });
 
-  it('preserves direct issue icons and adds one child-derived issue icon', () => {
+  it('preserves direct issue icons and adds one child-derived issue count', () => {
     const directErrorA = makeEAPError({event_id: 'direct-error-a', issue_id: 1});
     const directErrorB = makeEAPError({event_id: 'direct-error-b', issue_id: 2});
     const childErrorA = makeEAPError({event_id: 'child-error-a', issue_id: 3});
@@ -77,7 +77,23 @@ describe('TraceIssueIcons', () => {
     renderIcons(node);
 
     expect(screen.getAllByTestId('trace-issue-icon')).toHaveLength(3);
-    expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('1');
+  });
+
+  it('renders a single child-derived issue without an extra count', () => {
+    const childError = makeEAPError({event_id: 'child-error', issue_id: 1});
+    const node = {
+      value: makeEAPSpan({errors: [], occurrences: []}),
+      errors: new Set([childError]),
+      occurrences: new Set(),
+    } as unknown as BaseNode;
+
+    renderIcons(node);
+
+    const issueIcon = screen.getByTestId('trace-issue-icon');
+    expect(issueIcon).toHaveClass('TraceIcon');
+    expect(issueIcon).not.toHaveClass('TraceIconGroup');
+    expect(screen.queryByTestId('trace-issue-count')).not.toBeInTheDocument();
   });
 
   it('anchors a start-edge direct issue icon to the span start', () => {
@@ -143,7 +159,7 @@ describe('TraceIssueIcons', () => {
     expect(issueIcon).toHaveClass('TraceIconGroup');
     expect(issueIcon).toHaveClass('TraceIconGroupStart');
     expect(issueIcon).toHaveStyle({left: '0%'});
-    expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('1');
   });
 
   it('anchors a start-clamped child-derived issue pill to the span start', () => {

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
@@ -10,6 +10,7 @@ import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDeta
 import {TraceIssueIcons} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
 
 const manager = {
+  computeConfigSpaceForPixels: (px: number) => px,
   computeRelativeLeftPositionFromOrigin: (
     timestamp: number,
     nodeSpace: [number, number]
@@ -65,7 +66,7 @@ describe('TraceIssueIcons', () => {
     expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('2');
   });
 
-  it('renders the child-derived issue pill for a narrow span duration', () => {
+  it('anchors the child-derived issue pill to the span start for a narrow span duration', () => {
     const childErrorA = makeEAPError({
       event_id: 'child-error-a',
       issue_id: 1,
@@ -86,7 +87,32 @@ describe('TraceIssueIcons', () => {
 
     const issueIcon = screen.getByTestId('trace-issue-icon');
     expect(issueIcon).toHaveClass('TraceIconGroup');
-    expect(issueIcon).toHaveStyle({left: '50%'});
+    expect(issueIcon).toHaveClass('TraceIconGroupStart');
+    expect(issueIcon).toHaveStyle({left: '0%'});
     expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('2');
+  });
+
+  it('anchors a start-clamped child-derived issue pill to the span start', () => {
+    const childErrorA = makeEAPError({
+      event_id: 'child-error-a',
+      issue_id: 1,
+      start_timestamp: 0.9,
+    });
+    const childErrorB = makeEAPError({
+      event_id: 'child-error-b',
+      issue_id: 2,
+      start_timestamp: 0.9,
+    });
+    const node = {
+      value: makeEAPSpan({errors: [], occurrences: []}),
+      errors: new Set([childErrorA, childErrorB]),
+      occurrences: new Set(),
+    } as unknown as BaseNode;
+
+    renderIcons(node, [1000, 1]);
+
+    const issueIcon = screen.getByTestId('trace-issue-icon');
+    expect(issueIcon).toHaveClass('TraceIconGroupStart');
+    expect(issueIcon).toHaveStyle({left: '0%'});
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
@@ -1,0 +1,92 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import {
+  makeEAPError,
+  makeEAPOccurrence,
+  makeEAPSpan,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
+import {TraceIssueIcons} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
+
+const manager = {
+  computeRelativeLeftPositionFromOrigin: (
+    timestamp: number,
+    nodeSpace: [number, number]
+  ) => (timestamp - nodeSpace[0]) / nodeSpace[1],
+} as unknown as VirtualizedViewManager;
+
+function renderIcons(node: BaseNode, nodeSpace: [number, number] = [0, 10_000]) {
+  return render(
+    <TraceIssueIcons
+      node={node}
+      node_space={nodeSpace}
+      errors={node.errors}
+      occurrences={node.occurrences}
+      manager={manager}
+    />
+  );
+}
+
+describe('TraceIssueIcons', () => {
+  it('summarizes child-derived issues into one icon', () => {
+    const childErrorA = makeEAPError({event_id: 'child-error-a', issue_id: 1});
+    const childErrorB = makeEAPError({event_id: 'child-error-b', issue_id: 2});
+    const childOccurrence = makeEAPOccurrence({
+      event_id: 'child-occurrence',
+      issue_id: 3,
+    });
+    const node = {
+      value: makeEAPSpan({errors: [], occurrences: []}),
+      errors: new Set([childErrorA, childErrorB]),
+      occurrences: new Set([childOccurrence]),
+    } as unknown as BaseNode;
+
+    renderIcons(node);
+
+    expect(screen.getAllByTestId('trace-issue-icon')).toHaveLength(1);
+    expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('3');
+  });
+
+  it('preserves direct issue icons and adds one child-derived issue icon', () => {
+    const directErrorA = makeEAPError({event_id: 'direct-error-a', issue_id: 1});
+    const directErrorB = makeEAPError({event_id: 'direct-error-b', issue_id: 2});
+    const childErrorA = makeEAPError({event_id: 'child-error-a', issue_id: 3});
+    const childErrorB = makeEAPError({event_id: 'child-error-b', issue_id: 4});
+    const node = {
+      value: makeEAPSpan({errors: [directErrorA, directErrorB], occurrences: []}),
+      errors: new Set([directErrorA, directErrorB, childErrorA, childErrorB]),
+      occurrences: new Set(),
+    } as unknown as BaseNode;
+
+    renderIcons(node);
+
+    expect(screen.getAllByTestId('trace-issue-icon')).toHaveLength(3);
+    expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('2');
+  });
+
+  it('renders the child-derived issue pill for a narrow span duration', () => {
+    const childErrorA = makeEAPError({
+      event_id: 'child-error-a',
+      issue_id: 1,
+      start_timestamp: 1.0005,
+    });
+    const childErrorB = makeEAPError({
+      event_id: 'child-error-b',
+      issue_id: 2,
+      start_timestamp: 1.0005,
+    });
+    const node = {
+      value: makeEAPSpan({errors: [], occurrences: []}),
+      errors: new Set([childErrorA, childErrorB]),
+      occurrences: new Set(),
+    } as unknown as BaseNode;
+
+    renderIcons(node, [1000, 1]);
+
+    const issueIcon = screen.getByTestId('trace-issue-icon');
+    expect(issueIcon).toHaveClass('TraceIconGroup');
+    expect(issueIcon).toHaveStyle({left: '50%'});
+    expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('2');
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
@@ -29,6 +29,9 @@ const manager = {
     timestamp: number,
     nodeSpace: [number, number]
   ) => (timestamp - nodeSpace[0]) / nodeSpace[1],
+  text_measurer: {
+    measure: jest.fn((text: string) => text.length * 7),
+  },
 } as unknown as VirtualizedViewManager;
 
 function renderIcons(node: BaseNode, nodeSpace: [number, number] = [0, 10_000]) {
@@ -44,6 +47,10 @@ function renderIcons(node: BaseNode, nodeSpace: [number, number] = [0, 10_000]) 
 }
 
 describe('TraceIssueIcons', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('summarizes child-derived issues into one icon with an additional issue count', () => {
     const childErrorA = makeEAPError({event_id: 'child-error-a', issue_id: 1});
     const childErrorB = makeEAPError({event_id: 'child-error-b', issue_id: 2});
@@ -160,6 +167,45 @@ describe('TraceIssueIcons', () => {
     expect(issueIcon).toHaveClass('TraceIconGroupStart');
     expect(issueIcon).toHaveStyle({left: '0%'});
     expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('1');
+  });
+
+  it('uses measured issue count text width for child-derived issue pill edge clamping', () => {
+    const computeTraceIconEdge = jest.fn(() => null);
+    const measuredManager = {
+      ...manager,
+      computeTraceIconEdge,
+      text_measurer: {
+        measure: jest.fn(() => 32),
+      },
+    } as unknown as VirtualizedViewManager;
+    const childErrorA = makeEAPError({
+      event_id: 'child-error-a',
+      issue_id: 1,
+      start_timestamp: 1.04,
+    });
+    const childErrorB = makeEAPError({
+      event_id: 'child-error-b',
+      issue_id: 2,
+      start_timestamp: 1.04,
+    });
+    const node = {
+      value: makeEAPSpan({errors: [], occurrences: []}),
+      errors: new Set([childErrorA, childErrorB]),
+      occurrences: new Set(),
+    } as unknown as BaseNode;
+
+    render(
+      <TraceIssueIcons
+        node={node}
+        node_space={[1000, 100]}
+        errors={node.errors}
+        occurrences={node.occurrences}
+        manager={measuredManager}
+      />
+    );
+
+    expect(measuredManager.text_measurer.measure).toHaveBeenCalledWith('1');
+    expect(computeTraceIconEdge).toHaveBeenCalledWith(1040, 56);
   });
 
   it('anchors a start-clamped child-derived issue pill to the span start', () => {

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
@@ -208,30 +208,6 @@ describe('TraceIssueIcons', () => {
     expect(computeTraceIconEdge).toHaveBeenCalledWith(1040, 56);
   });
 
-  it('anchors a start-clamped child-derived issue pill to the span start', () => {
-    const childErrorA = makeEAPError({
-      event_id: 'child-error-a',
-      issue_id: 1,
-      start_timestamp: 0.9,
-    });
-    const childErrorB = makeEAPError({
-      event_id: 'child-error-b',
-      issue_id: 2,
-      start_timestamp: 0.9,
-    });
-    const node = {
-      value: makeEAPSpan({errors: [], occurrences: []}),
-      errors: new Set([childErrorA, childErrorB]),
-      occurrences: new Set(),
-    } as unknown as BaseNode;
-
-    renderIcons(node, [1000, 1]);
-
-    const issueIcon = screen.getByTestId('trace-issue-icon');
-    expect(issueIcon).toHaveClass('TraceIconGroupStart');
-    expect(issueIcon).toHaveStyle({left: '0%'});
-  });
-
   it('keeps a child-derived issue pill centered when it does not overlap the span edge', () => {
     const childErrorA = makeEAPError({
       event_id: 'child-error-a',

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
@@ -10,20 +10,23 @@ import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDeta
 import {TraceIssueIcons} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
 
 const manager = {
-  computeTraceIconAnchorTimestamp: (timestamp: number, edge: 'start' | 'end' | null) => {
-    if (edge === 'start') {
-      return 1000;
-    }
-    if (edge === 'end') {
-      return 1100;
-    }
-    return timestamp;
-  },
-  computeTraceIconEdge: (timestamp: number) => {
-    if (timestamp < 1009) {
-      return 'start';
-    }
-    return null;
+  computeTraceIconPlacement: (
+    timestamp: number,
+    width: number,
+    nodeSpace: [number, number]
+  ) => {
+    const clampedTimestamp = Math.min(
+      Math.max(timestamp, nodeSpace[0]),
+      nodeSpace[0] + nodeSpace[1]
+    );
+    const edge = clampedTimestamp < 1009 ? 'start' : null;
+    const anchorTimestamp = edge === 'start' ? nodeSpace[0] : clampedTimestamp;
+
+    return {
+      edge,
+      anchorTimestamp,
+      bounds: [anchorTimestamp - width / 2, anchorTimestamp + width / 2],
+    };
   },
   computeRelativeLeftPositionFromOrigin: (
     timestamp: number,
@@ -170,10 +173,16 @@ describe('TraceIssueIcons', () => {
   });
 
   it('uses measured issue count text width for child-derived issue pill edge clamping', () => {
-    const computeTraceIconEdge = jest.fn(() => null);
+    const computeTraceIconPlacement = jest.fn(
+      (timestamp: number, width: number, nodeSpace: [number, number]) => ({
+        edge: null,
+        anchorTimestamp: timestamp,
+        bounds: [nodeSpace[0], nodeSpace[0] + width],
+      })
+    );
     const measuredManager = {
       ...manager,
-      computeTraceIconEdge,
+      computeTraceIconPlacement,
       text_measurer: {
         measure: jest.fn(() => 32),
       },
@@ -205,7 +214,7 @@ describe('TraceIssueIcons', () => {
     );
 
     expect(measuredManager.text_measurer.measure).toHaveBeenCalledWith('1');
-    expect(computeTraceIconEdge).toHaveBeenCalledWith(1040, 56);
+    expect(computeTraceIconPlacement).toHaveBeenCalledWith(1040, 56, [1000, 100]);
   });
 
   it('keeps a child-derived issue pill centered when it does not overlap the span edge', () => {

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.spec.tsx
@@ -10,7 +10,21 @@ import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDeta
 import {TraceIssueIcons} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
 
 const manager = {
-  computeConfigSpaceForPixels: (px: number) => px,
+  computeTraceIconAnchorTimestamp: (timestamp: number, edge: 'start' | 'end' | null) => {
+    if (edge === 'start') {
+      return 1000;
+    }
+    if (edge === 'end') {
+      return 1100;
+    }
+    return timestamp;
+  },
+  computeTraceIconEdge: (timestamp: number) => {
+    if (timestamp < 1009) {
+      return 'start';
+    }
+    return null;
+  },
   computeRelativeLeftPositionFromOrigin: (
     timestamp: number,
     nodeSpace: [number, number]
@@ -66,6 +80,46 @@ describe('TraceIssueIcons', () => {
     expect(screen.getByTestId('trace-issue-count')).toHaveTextContent('2');
   });
 
+  it('anchors a start-edge direct issue icon to the span start', () => {
+    const directError = makeEAPError({
+      event_id: 'direct-error',
+      issue_id: 1,
+      start_timestamp: 1.0005,
+    });
+    const node = {
+      value: makeEAPSpan({errors: [directError], occurrences: []}),
+      errors: new Set([directError]),
+      occurrences: new Set(),
+    } as unknown as BaseNode;
+
+    renderIcons(node, [1000, 1]);
+
+    const issueIcon = screen.getByTestId('trace-issue-icon');
+    expect(issueIcon).toHaveClass('TraceIcon');
+    expect(issueIcon).toHaveClass('TraceIconStart');
+    expect(issueIcon).toHaveStyle({left: '0%'});
+  });
+
+  it('keeps a direct issue icon centered when it does not overlap the span edge', () => {
+    const directError = makeEAPError({
+      event_id: 'direct-error',
+      issue_id: 1,
+      start_timestamp: 1.01,
+    });
+    const node = {
+      value: makeEAPSpan({errors: [directError], occurrences: []}),
+      errors: new Set([directError]),
+      occurrences: new Set(),
+    } as unknown as BaseNode;
+
+    renderIcons(node, [1000, 100]);
+
+    const issueIcon = screen.getByTestId('trace-issue-icon');
+    expect(issueIcon).not.toHaveClass('TraceIconStart');
+    expect(issueIcon).not.toHaveClass('TraceIconEnd');
+    expect(issueIcon).toHaveStyle({left: '10%'});
+  });
+
   it('anchors the child-derived issue pill to the span start for a narrow span duration', () => {
     const childErrorA = makeEAPError({
       event_id: 'child-error-a',
@@ -114,5 +168,30 @@ describe('TraceIssueIcons', () => {
     const issueIcon = screen.getByTestId('trace-issue-icon');
     expect(issueIcon).toHaveClass('TraceIconGroupStart');
     expect(issueIcon).toHaveStyle({left: '0%'});
+  });
+
+  it('keeps a child-derived issue pill centered when it does not overlap the span edge', () => {
+    const childErrorA = makeEAPError({
+      event_id: 'child-error-a',
+      issue_id: 1,
+      start_timestamp: 1.04,
+    });
+    const childErrorB = makeEAPError({
+      event_id: 'child-error-b',
+      issue_id: 2,
+      start_timestamp: 1.04,
+    });
+    const node = {
+      value: makeEAPSpan({errors: [], occurrences: []}),
+      errors: new Set([childErrorA, childErrorB]),
+      occurrences: new Set(),
+    } as unknown as BaseNode;
+
+    renderIcons(node, [1000, 100]);
+
+    const issueIcon = screen.getByTestId('trace-issue-icon');
+    expect(issueIcon).not.toHaveClass('TraceIconGroupStart');
+    expect(issueIcon).not.toHaveClass('TraceIconGroupEnd');
+    expect(issueIcon).toHaveStyle({left: '40%'});
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -21,8 +21,13 @@ interface TraceIssueIconsProps {
 
 export function TraceIssueIcons(props: TraceIssueIconsProps) {
   const issues = useMemo(() => {
-    return getRenderableTraceIssues(props.node, props.errors, props.occurrences);
-  }, [props.node, props.errors, props.occurrences]);
+    return getRenderableTraceIssues(
+      props.node,
+      props.errors,
+      props.occurrences,
+      props.node_space
+    );
+  }, [props.node, props.errors, props.occurrences, props.node_space]);
 
   if (!issues.length || !props.node_space) {
     return null;

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -42,7 +42,7 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
         const timestamp = getTraceIssueTimestamp(issue, node_space);
         const className = getTraceIssueSeverityClassName(issue);
 
-        if (additionalIssueCount) {
+        if (additionalIssueCount !== undefined) {
           const clampedTimestamp = clamp(
             timestamp,
             node_space[0],

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -27,21 +27,23 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
     return getRenderableTraceIssues(props.node, props.errors, props.occurrences);
   }, [props.node, props.errors, props.occurrences]);
 
-  if (!issues.length) {
+  if (!issues.length || !props.node_space) {
     return null;
   }
+
+  const node_space = props.node_space;
 
   return (
     <Fragment>
       {issues.map(({issue, additionalIssueCount}, i) => {
-        const timestamp = getTraceIssueTimestamp(issue, props.node_space!);
+        const timestamp = getTraceIssueTimestamp(issue, node_space);
         const className = getTraceIssueSeverityClassName(issue);
 
         if (additionalIssueCount) {
           const clampedTimestamp = clamp(
             timestamp,
-            props.node_space![0],
-            props.node_space![0] + props.node_space![1]
+            node_space[0],
+            node_space[0] + node_space[1]
           );
           const width = getTraceIconGroupApproximateWidth(additionalIssueCount);
           const edge = props.manager.computeTraceIconEdge(clampedTimestamp, width);
@@ -50,12 +52,12 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
           // into the span so the pill stays flush within the bar (0%-100%).
           const anchorTimestamp = clamp(
             props.manager.computeTraceIconAnchorTimestamp(clampedTimestamp, edge),
-            props.node_space![0],
-            props.node_space![0] + props.node_space![1]
+            node_space[0],
+            node_space[0] + node_space[1]
           );
           const left = props.manager.computeRelativeLeftPositionFromOrigin(
             anchorTimestamp,
-            props.node_space!
+            node_space
           );
 
           return (
@@ -80,8 +82,8 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
 
         const clampedTimestamp = clamp(
           timestamp,
-          props.node_space![0],
-          props.node_space![0] + props.node_space![1]
+          node_space[0],
+          node_space[0] + node_space[1]
         );
         const edge = props.manager.computeTraceIconEdge(
           clampedTimestamp,
@@ -89,12 +91,12 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
         );
         const anchorTimestamp = clamp(
           props.manager.computeTraceIconAnchorTimestamp(clampedTimestamp, edge),
-          props.node_space![0],
-          props.node_space![0] + props.node_space![1]
+          node_space[0],
+          node_space[0] + node_space[1]
         );
         const left = props.manager.computeRelativeLeftPositionFromOrigin(
           anchorTimestamp,
-          props.node_space!
+          node_space
         );
 
         return (

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -3,15 +3,18 @@ import clamp from 'lodash/clamp';
 
 import {getTraceIssueSeverityClassName} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
-import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import {
+  getRenderableTraceIssues,
+  getTraceIssueTimestamp,
+  TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
+  TRACE_ICON_GROUP_GAP,
+  TRACE_ICON_GROUP_GLYPH_WIDTH,
+  TRACE_ICON_GROUP_HORIZONTAL_PADDING,
+  TRACE_ICON_WIDTH,
+} from 'sentry/views/performance/newTraceDetails/traceIssueUtils';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
 
-const TRACE_ICON_WIDTH = 18;
-const TRACE_ICON_GROUP_GLYPH_WIDTH = 12;
-const TRACE_ICON_GROUP_GAP = 2;
-const TRACE_ICON_GROUP_HORIZONTAL_PADDING = 10;
-const TRACE_ICON_GROUP_COUNT_MIN_WIDTH = 8;
 const TRACE_ICON_GROUP_COUNT_APPROXIMATE_CHARACTER_WIDTH = 7;
 
 interface TraceIssueIconsProps {
@@ -115,141 +118,6 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
       })}
     </Fragment>
   );
-}
-
-interface RenderableTraceIssue {
-  issue: TraceTree.TraceIssue;
-  additionalIssueCount?: number;
-}
-
-function getRenderableTraceIssues(
-  node: BaseNode,
-  errors: BaseNode['errors'],
-  occurrences: BaseNode['occurrences']
-): RenderableTraceIssue[] {
-  const directErrors = getDirectErrors(node);
-  const directOccurrences = getDirectOccurrences(node);
-  const childIssues: TraceTree.TraceIssue[] = [];
-  const issues: RenderableTraceIssue[] = [];
-
-  for (const error of errors) {
-    if (directErrors.has(error)) {
-      issues.push({issue: error});
-    } else {
-      childIssues.push(error);
-    }
-  }
-
-  for (const occurrence of occurrences) {
-    if (directOccurrences.has(occurrence)) {
-      issues.push({issue: occurrence});
-    } else {
-      childIssues.push(occurrence);
-    }
-  }
-
-  const childRepresentative = getMostSevereTraceIssue(childIssues);
-  if (childRepresentative) {
-    const additionalIssueCount = childIssues.length - 1;
-    issues.push(
-      additionalIssueCount > 0
-        ? {issue: childRepresentative, additionalIssueCount}
-        : {issue: childRepresentative}
-    );
-  }
-
-  return issues;
-}
-
-export function getDirectErrors(node: BaseNode): Set<TraceTree.TraceErrorIssue> {
-  const errors = new Set<TraceTree.TraceErrorIssue>();
-
-  if (node.value && 'errors' in node.value && Array.isArray(node.value.errors)) {
-    node.value.errors.forEach(error => errors.add(error));
-  }
-
-  return errors;
-}
-
-export function getDirectOccurrences(node: BaseNode): Set<TraceTree.TraceOccurrence> {
-  const occurrences = new Set<TraceTree.TraceOccurrence>();
-
-  if (
-    node.value &&
-    'occurrences' in node.value &&
-    Array.isArray(node.value.occurrences)
-  ) {
-    node.value.occurrences.forEach(occurrence => occurrences.add(occurrence));
-  }
-
-  if (
-    node.value &&
-    'performance_issues' in node.value &&
-    Array.isArray(node.value.performance_issues)
-  ) {
-    node.value.performance_issues.forEach(occurrence => occurrences.add(occurrence));
-  }
-
-  return occurrences;
-}
-
-function getMostSevereTraceIssue(
-  issues: TraceTree.TraceIssue[]
-): TraceTree.TraceIssue | null {
-  return issues.reduce<TraceTree.TraceIssue | null>((mostSevere, issue) => {
-    if (!mostSevere) {
-      return issue;
-    }
-
-    const severityDiff =
-      getTraceIssueSeverityRank(issue) - getTraceIssueSeverityRank(mostSevere);
-
-    if (severityDiff > 0) {
-      return issue;
-    }
-
-    if (
-      severityDiff === 0 &&
-      getTraceIssueTimestamp(issue, [0, 0]) < getTraceIssueTimestamp(mostSevere, [0, 0])
-    ) {
-      return issue;
-    }
-
-    return mostSevere;
-  }, null);
-}
-
-function getTraceIssueSeverityRank(issue: TraceTree.TraceIssue): number {
-  switch (issue.level) {
-    case 'fatal':
-      return 5;
-    case 'error':
-      return 4;
-    case 'warning':
-      return 3;
-    case 'info':
-      return 2;
-    default:
-      return 1;
-  }
-}
-
-function getTraceIssueTimestamp(
-  issue: TraceTree.TraceIssue,
-  nodeSpace: [number, number]
-): number {
-  if ('timestamp' in issue && typeof issue.timestamp === 'number') {
-    return issue.timestamp * 1e3;
-  }
-
-  let startTimestamp: number | undefined;
-  if ('start_timestamp' in issue) {
-    startTimestamp = issue.start_timestamp;
-  } else if ('start' in issue) {
-    startTimestamp = issue.start;
-  }
-
-  return typeof startTimestamp === 'number' ? startTimestamp * 1e3 : nodeSpace[0];
 }
 
 function getTraceIconEdgeClassName(

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -7,6 +7,12 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
 
+const TRACE_ICON_GROUP_GLYPH_WIDTH = 12;
+const TRACE_ICON_GROUP_GAP = 2;
+const TRACE_ICON_GROUP_HORIZONTAL_PADDING = 10;
+const TRACE_ICON_GROUP_COUNT_MIN_WIDTH = 8;
+const TRACE_ICON_GROUP_COUNT_APPROXIMATE_CHARACTER_WIDTH = 7;
+
 interface TraceIssueIconsProps {
   errors: BaseNode['errors'];
   manager: VirtualizedViewManager;
@@ -27,22 +33,32 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
   return (
     <Fragment>
       {issues.map(({issue, childIssueCount}, i) => {
-        const left = props.manager.computeRelativeLeftPositionFromOrigin(
-          clamp(
-            getTraceIssueTimestamp(issue, props.node_space!),
-            props.node_space![0],
-            props.node_space![0] + props.node_space![1]
-          ),
-          props.node_space!
-        );
+        const timestamp = getTraceIssueTimestamp(issue, props.node_space!);
         const className = getTraceIssueSeverityClassName(issue);
 
         if (childIssueCount) {
+          const edge = getTraceIconGroupEdge(
+            timestamp,
+            props.node_space!,
+            props.manager.computeConfigSpaceForPixels(
+              getTraceIconGroupApproximateWidth(childIssueCount)
+            )
+          );
+          const clampedTimestamp = getTraceIconGroupAnchorTimestamp(
+            timestamp,
+            props.node_space!,
+            edge
+          );
+          const left = props.manager.computeRelativeLeftPositionFromOrigin(
+            clampedTimestamp,
+            props.node_space!
+          );
+
           return (
             <div
               key={i}
               data-test-id="trace-issue-icon"
-              className={`TraceIconGroup ${className}`}
+              className={`TraceIconGroup ${className} ${getTraceIconGroupEdgeClassName(edge)}`}
               style={{left: left * 100 + '%'}}
             >
               <span className="TraceIconGlyph">
@@ -54,6 +70,16 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
             </div>
           );
         }
+
+        const clampedTimestamp = clamp(
+          timestamp,
+          props.node_space![0],
+          props.node_space![0] + props.node_space![1]
+        );
+        const left = props.manager.computeRelativeLeftPositionFromOrigin(
+          clampedTimestamp,
+          props.node_space!
+        );
 
         return (
           <div
@@ -198,4 +224,65 @@ function getTraceIssueTimestamp(
   }
 
   return typeof startTimestamp === 'number' ? startTimestamp * 1e3 : nodeSpace[0];
+}
+
+function getTraceIconGroupEdge(
+  timestamp: number,
+  nodeSpace: [number, number],
+  iconWidthConfigSpace: number
+): 'start' | 'end' | null {
+  const clampedTimestamp = clamp(timestamp, nodeSpace[0], nodeSpace[0] + nodeSpace[1]);
+  const halfIconWidthConfigSpace = iconWidthConfigSpace / 2;
+
+  if (clampedTimestamp - halfIconWidthConfigSpace <= nodeSpace[0]) {
+    return 'start';
+  }
+
+  if (clampedTimestamp + halfIconWidthConfigSpace >= nodeSpace[0] + nodeSpace[1]) {
+    return 'end';
+  }
+
+  return null;
+}
+
+function getTraceIconGroupAnchorTimestamp(
+  timestamp: number,
+  nodeSpace: [number, number],
+  edge: 'start' | 'end' | null
+): number {
+  if (edge === 'start') {
+    return nodeSpace[0];
+  }
+
+  if (edge === 'end') {
+    return nodeSpace[0] + nodeSpace[1];
+  }
+
+  return clamp(timestamp, nodeSpace[0], nodeSpace[0] + nodeSpace[1]);
+}
+
+function getTraceIconGroupEdgeClassName(edge: 'start' | 'end' | null): string {
+  if (edge === 'start') {
+    return 'TraceIconGroupStart';
+  }
+
+  if (edge === 'end') {
+    return 'TraceIconGroupEnd';
+  }
+
+  return '';
+}
+
+function getTraceIconGroupApproximateWidth(childIssueCount: number): number {
+  const countWidth = Math.max(
+    TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
+    String(childIssueCount).length * TRACE_ICON_GROUP_COUNT_APPROXIMATE_CHARACTER_WIDTH
+  );
+
+  return (
+    TRACE_ICON_GROUP_HORIZONTAL_PADDING +
+    TRACE_ICON_GROUP_GLYPH_WIDTH +
+    TRACE_ICON_GROUP_GAP +
+    countWidth
+  );
 }

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -3,99 +3,199 @@ import clamp from 'lodash/clamp';
 
 import {getTraceIssueSeverityClassName} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
 
-interface ErrorIconsProps {
+interface TraceIssueIconsProps {
   errors: BaseNode['errors'];
   manager: VirtualizedViewManager;
-  node_space: [number, number] | null;
-}
-
-export function TraceErrorIcons(props: ErrorIconsProps) {
-  const errors = useMemo(() => {
-    return [...props.errors];
-  }, [props.errors]);
-
-  if (!props.errors.size) {
-    return null;
-  }
-
-  return (
-    <Fragment>
-      {errors.map((error, i) => {
-        const timestamp =
-          'start_timestamp' in error ? error.start_timestamp : error.timestamp;
-        // Clamp the error timestamp to the span's timestamp
-        const left = props.manager.computeRelativeLeftPositionFromOrigin(
-          clamp(
-            timestamp ? timestamp * 1e3 : props.node_space![0],
-            props.node_space![0],
-            props.node_space![0] + props.node_space![1]
-          ),
-          props.node_space!
-        );
-
-        return (
-          <div
-            key={i}
-            className={`TraceIcon ${getTraceIssueSeverityClassName(error)}`}
-            style={{left: left * 100 + '%'}}
-          >
-            <TraceIcons.Icon event={error} />
-          </div>
-        );
-      })}
-    </Fragment>
-  );
-}
-
-interface TraceOccurenceIconsProps {
-  manager: VirtualizedViewManager;
+  node: BaseNode;
   node_space: [number, number] | null;
   occurrences: BaseNode['occurrences'];
 }
 
-export function TraceOccurenceIcons(props: TraceOccurenceIconsProps) {
-  const occurrences = useMemo(() => {
-    return [...props.occurrences];
-  }, [props.occurrences]);
+export function TraceIssueIcons(props: TraceIssueIconsProps) {
+  const issues = useMemo(() => {
+    return getRenderableTraceIssues(props.node, props.errors, props.occurrences);
+  }, [props.node, props.errors, props.occurrences]);
 
-  if (!props.occurrences.size) {
+  if (!issues.length) {
     return null;
   }
 
   return (
     <Fragment>
-      {occurrences.map((occurrence, i) => {
-        const occurrence_start_timestamp =
-          'start_timestamp' in occurrence ? occurrence.start_timestamp : occurrence.start;
-        const icon_timestamp =
-          'timestamp' in occurrence && occurrence.timestamp
-            ? occurrence.timestamp * 1e3
-            : occurrence_start_timestamp
-              ? occurrence_start_timestamp * 1e3
-              : props.node_space![0];
-        // Clamp the occurrence's timestamp to the span's timestamp
+      {issues.map(({issue, childIssueCount}, i) => {
         const left = props.manager.computeRelativeLeftPositionFromOrigin(
           clamp(
-            icon_timestamp,
+            getTraceIssueTimestamp(issue, props.node_space!),
             props.node_space![0],
             props.node_space![0] + props.node_space![1]
           ),
           props.node_space!
         );
+        const className = getTraceIssueSeverityClassName(issue);
+
+        if (childIssueCount) {
+          return (
+            <div
+              key={i}
+              data-test-id="trace-issue-icon"
+              className={`TraceIconGroup ${className}`}
+              style={{left: left * 100 + '%'}}
+            >
+              <span className="TraceIconGlyph">
+                <TraceIcons.Icon event={issue} />
+              </span>
+              <span data-test-id="trace-issue-count" className="TraceIconCount">
+                {childIssueCount}
+              </span>
+            </div>
+          );
+        }
 
         return (
           <div
             key={i}
-            className={`TraceIcon ${getTraceIssueSeverityClassName(occurrence)}`}
+            data-test-id="trace-issue-icon"
+            className={`TraceIcon ${className}`}
             style={{left: left * 100 + '%'}}
           >
-            <TraceIcons.Icon event={occurrence} />
+            <TraceIcons.Icon event={issue} />
           </div>
         );
       })}
     </Fragment>
   );
+}
+
+interface RenderableTraceIssue {
+  issue: TraceTree.TraceIssue;
+  childIssueCount?: number;
+}
+
+function getRenderableTraceIssues(
+  node: BaseNode,
+  errors: BaseNode['errors'],
+  occurrences: BaseNode['occurrences']
+): RenderableTraceIssue[] {
+  const directErrors = getDirectErrors(node);
+  const directOccurrences = getDirectOccurrences(node);
+  const childIssues: TraceTree.TraceIssue[] = [];
+  const issues: RenderableTraceIssue[] = [];
+
+  for (const error of errors) {
+    if (directErrors.has(error)) {
+      issues.push({issue: error});
+    } else {
+      childIssues.push(error);
+    }
+  }
+
+  for (const occurrence of occurrences) {
+    if (directOccurrences.has(occurrence)) {
+      issues.push({issue: occurrence});
+    } else {
+      childIssues.push(occurrence);
+    }
+  }
+
+  const childRepresentative = getMostSevereTraceIssue(childIssues);
+  if (childRepresentative) {
+    issues.push({issue: childRepresentative, childIssueCount: childIssues.length});
+  }
+
+  return issues;
+}
+
+export function getDirectErrors(node: BaseNode): Set<TraceTree.TraceErrorIssue> {
+  const errors = new Set<TraceTree.TraceErrorIssue>();
+
+  if (node.value && 'errors' in node.value && Array.isArray(node.value.errors)) {
+    node.value.errors.forEach(error => errors.add(error));
+  }
+
+  return errors;
+}
+
+export function getDirectOccurrences(node: BaseNode): Set<TraceTree.TraceOccurrence> {
+  const occurrences = new Set<TraceTree.TraceOccurrence>();
+
+  if (
+    node.value &&
+    'occurrences' in node.value &&
+    Array.isArray(node.value.occurrences)
+  ) {
+    node.value.occurrences.forEach(occurrence => occurrences.add(occurrence));
+  }
+
+  if (
+    node.value &&
+    'performance_issues' in node.value &&
+    Array.isArray(node.value.performance_issues)
+  ) {
+    node.value.performance_issues.forEach(occurrence => occurrences.add(occurrence));
+  }
+
+  return occurrences;
+}
+
+function getMostSevereTraceIssue(
+  issues: TraceTree.TraceIssue[]
+): TraceTree.TraceIssue | null {
+  return issues.reduce<TraceTree.TraceIssue | null>((mostSevere, issue) => {
+    if (!mostSevere) {
+      return issue;
+    }
+
+    const severityDiff =
+      getTraceIssueSeverityRank(issue) - getTraceIssueSeverityRank(mostSevere);
+
+    if (severityDiff > 0) {
+      return issue;
+    }
+
+    if (
+      severityDiff === 0 &&
+      getTraceIssueTimestamp(issue, [0, 0]) < getTraceIssueTimestamp(mostSevere, [0, 0])
+    ) {
+      return issue;
+    }
+
+    return mostSevere;
+  }, null);
+}
+
+function getTraceIssueSeverityRank(issue: TraceTree.TraceIssue): number {
+  switch (issue.level) {
+    case 'fatal':
+      return 5;
+    case 'error':
+      return 4;
+    case 'warning':
+      return 3;
+    case 'info':
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+function getTraceIssueTimestamp(
+  issue: TraceTree.TraceIssue,
+  nodeSpace: [number, number]
+): number {
+  if ('timestamp' in issue && typeof issue.timestamp === 'number') {
+    return issue.timestamp * 1e3;
+  }
+
+  let startTimestamp: number | undefined;
+  if ('start_timestamp' in issue) {
+    startTimestamp = issue.start_timestamp;
+  } else if ('start' in issue) {
+    startTimestamp = issue.start;
+  }
+
+  return typeof startTimestamp === 'number' ? startTimestamp * 1e3 : nodeSpace[0];
 }

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -7,6 +7,7 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
 
+const TRACE_ICON_WIDTH = 18;
 const TRACE_ICON_GROUP_GLYPH_WIDTH = 12;
 const TRACE_ICON_GROUP_GAP = 2;
 const TRACE_ICON_GROUP_HORIZONTAL_PADDING = 10;
@@ -37,20 +38,19 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
         const className = getTraceIssueSeverityClassName(issue);
 
         if (childIssueCount) {
-          const edge = getTraceIconGroupEdge(
+          const clampedTimestamp = clamp(
             timestamp,
-            props.node_space!,
-            props.manager.computeConfigSpaceForPixels(
-              getTraceIconGroupApproximateWidth(childIssueCount)
-            )
+            props.node_space![0],
+            props.node_space![0] + props.node_space![1]
           );
-          const clampedTimestamp = getTraceIconGroupAnchorTimestamp(
-            timestamp,
-            props.node_space!,
+          const width = getTraceIconGroupApproximateWidth(childIssueCount);
+          const edge = props.manager.computeTraceIconEdge(clampedTimestamp, width);
+          const anchorTimestamp = props.manager.computeTraceIconAnchorTimestamp(
+            clampedTimestamp,
             edge
           );
           const left = props.manager.computeRelativeLeftPositionFromOrigin(
-            clampedTimestamp,
+            anchorTimestamp,
             props.node_space!
           );
 
@@ -58,7 +58,10 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
             <div
               key={i}
               data-test-id="trace-issue-icon"
-              className={`TraceIconGroup ${className} ${getTraceIconGroupEdgeClassName(edge)}`}
+              className={`TraceIconGroup ${className} ${getTraceIconEdgeClassName(
+                edge,
+                'TraceIconGroup'
+              )}`}
               style={{left: left * 100 + '%'}}
             >
               <span className="TraceIconGlyph">
@@ -76,8 +79,16 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
           props.node_space![0],
           props.node_space![0] + props.node_space![1]
         );
-        const left = props.manager.computeRelativeLeftPositionFromOrigin(
+        const edge = props.manager.computeTraceIconEdge(
           clampedTimestamp,
+          TRACE_ICON_WIDTH
+        );
+        const anchorTimestamp = props.manager.computeTraceIconAnchorTimestamp(
+          clampedTimestamp,
+          edge
+        );
+        const left = props.manager.computeRelativeLeftPositionFromOrigin(
+          anchorTimestamp,
           props.node_space!
         );
 
@@ -85,7 +96,10 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
           <div
             key={i}
             data-test-id="trace-issue-icon"
-            className={`TraceIcon ${className}`}
+            className={`TraceIcon ${className} ${getTraceIconEdgeClassName(
+              edge,
+              'TraceIcon'
+            )}`}
             style={{left: left * 100 + '%'}}
           >
             <TraceIcons.Icon event={issue} />
@@ -226,48 +240,16 @@ function getTraceIssueTimestamp(
   return typeof startTimestamp === 'number' ? startTimestamp * 1e3 : nodeSpace[0];
 }
 
-function getTraceIconGroupEdge(
-  timestamp: number,
-  nodeSpace: [number, number],
-  iconWidthConfigSpace: number
-): 'start' | 'end' | null {
-  const clampedTimestamp = clamp(timestamp, nodeSpace[0], nodeSpace[0] + nodeSpace[1]);
-  const halfIconWidthConfigSpace = iconWidthConfigSpace / 2;
-
-  if (clampedTimestamp - halfIconWidthConfigSpace <= nodeSpace[0]) {
-    return 'start';
-  }
-
-  if (clampedTimestamp + halfIconWidthConfigSpace >= nodeSpace[0] + nodeSpace[1]) {
-    return 'end';
-  }
-
-  return null;
-}
-
-function getTraceIconGroupAnchorTimestamp(
-  timestamp: number,
-  nodeSpace: [number, number],
-  edge: 'start' | 'end' | null
-): number {
+function getTraceIconEdgeClassName(
+  edge: 'start' | 'end' | null,
+  baseClassName: 'TraceIcon' | 'TraceIconGroup'
+): string {
   if (edge === 'start') {
-    return nodeSpace[0];
+    return `${baseClassName}Start`;
   }
 
   if (edge === 'end') {
-    return nodeSpace[0] + nodeSpace[1];
-  }
-
-  return clamp(timestamp, nodeSpace[0], nodeSpace[0] + nodeSpace[1]);
-}
-
-function getTraceIconGroupEdgeClassName(edge: 'start' | 'end' | null): string {
-  if (edge === 'start') {
-    return 'TraceIconGroupStart';
-  }
-
-  if (edge === 'end') {
-    return 'TraceIconGroupEnd';
+    return `${baseClassName}End`;
   }
 
   return '';

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -45,9 +45,13 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
           );
           const width = getTraceIconGroupApproximateWidth(additionalIssueCount);
           const edge = props.manager.computeTraceIconEdge(clampedTimestamp, width);
-          const anchorTimestamp = props.manager.computeTraceIconAnchorTimestamp(
-            clampedTimestamp,
-            edge
+          // The anchor timestamp may snap to the visible viewport edge, which can
+          // fall outside the span when the viewport extends past it. Clamp it back
+          // into the span so the pill stays flush within the bar (0%-100%).
+          const anchorTimestamp = clamp(
+            props.manager.computeTraceIconAnchorTimestamp(clampedTimestamp, edge),
+            props.node_space![0],
+            props.node_space![0] + props.node_space![1]
           );
           const left = props.manager.computeRelativeLeftPositionFromOrigin(
             anchorTimestamp,
@@ -83,9 +87,10 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
           clampedTimestamp,
           TRACE_ICON_WIDTH
         );
-        const anchorTimestamp = props.manager.computeTraceIconAnchorTimestamp(
-          clampedTimestamp,
-          edge
+        const anchorTimestamp = clamp(
+          props.manager.computeTraceIconAnchorTimestamp(clampedTimestamp, edge),
+          props.node_space![0],
+          props.node_space![0] + props.node_space![1]
         );
         const left = props.manager.computeRelativeLeftPositionFromOrigin(
           anchorTimestamp,

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -5,17 +5,12 @@ import {getTraceIssueSeverityClassName} from 'sentry/views/performance/newTraceD
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
 import {
   getRenderableTraceIssues,
+  getTraceIconGroupWidth,
   getTraceIssueTimestamp,
-  TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
-  TRACE_ICON_GROUP_GAP,
-  TRACE_ICON_GROUP_GLYPH_WIDTH,
-  TRACE_ICON_GROUP_HORIZONTAL_PADDING,
   TRACE_ICON_WIDTH,
 } from 'sentry/views/performance/newTraceDetails/traceIssueUtils';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
-
-const TRACE_ICON_GROUP_COUNT_APPROXIMATE_CHARACTER_WIDTH = 7;
 
 interface TraceIssueIconsProps {
   errors: BaseNode['errors'];
@@ -48,7 +43,9 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
             node_space[0],
             node_space[0] + node_space[1]
           );
-          const width = getTraceIconGroupApproximateWidth(additionalIssueCount);
+          const width = getTraceIconGroupWidth(additionalIssueCount, text =>
+            props.manager.text_measurer.measure(text)
+          );
           const edge = props.manager.computeTraceIconEdge(clampedTimestamp, width);
           // The anchor timestamp may snap to the visible viewport edge, which can
           // fall outside the span when the viewport extends past it. Clamp it back
@@ -133,19 +130,4 @@ function getTraceIconEdgeClassName(
   }
 
   return '';
-}
-
-function getTraceIconGroupApproximateWidth(additionalIssueCount: number): number {
-  const countWidth = Math.max(
-    TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
-    String(additionalIssueCount).length *
-      TRACE_ICON_GROUP_COUNT_APPROXIMATE_CHARACTER_WIDTH
-  );
-
-  return (
-    TRACE_ICON_GROUP_HORIZONTAL_PADDING +
-    TRACE_ICON_GROUP_GLYPH_WIDTH +
-    TRACE_ICON_GROUP_GAP +
-    countWidth
-  );
 }

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useMemo} from 'react';
-import clamp from 'lodash/clamp';
 
 import {getTraceIssueSeverityClassName} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
@@ -38,22 +37,13 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
         const className = getTraceIssueSeverityClassName(issue);
 
         if (additionalIssueCount !== undefined) {
-          const clampedTimestamp = clamp(
-            timestamp,
-            node_space[0],
-            node_space[0] + node_space[1]
-          );
           const width = getTraceIconGroupWidth(additionalIssueCount, text =>
             props.manager.text_measurer.measure(text)
           );
-          const edge = props.manager.computeTraceIconEdge(clampedTimestamp, width);
-          // The anchor timestamp may snap to the visible viewport edge, which can
-          // fall outside the span when the viewport extends past it. Clamp it back
-          // into the span so the pill stays flush within the bar (0%-100%).
-          const anchorTimestamp = clamp(
-            props.manager.computeTraceIconAnchorTimestamp(clampedTimestamp, edge),
-            node_space[0],
-            node_space[0] + node_space[1]
+          const {edge, anchorTimestamp} = props.manager.computeTraceIconPlacement(
+            timestamp,
+            width,
+            node_space
           );
           const left = props.manager.computeRelativeLeftPositionFromOrigin(
             anchorTimestamp,
@@ -80,19 +70,10 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
           );
         }
 
-        const clampedTimestamp = clamp(
+        const {edge, anchorTimestamp} = props.manager.computeTraceIconPlacement(
           timestamp,
-          node_space[0],
-          node_space[0] + node_space[1]
-        );
-        const edge = props.manager.computeTraceIconEdge(
-          clampedTimestamp,
-          TRACE_ICON_WIDTH
-        );
-        const anchorTimestamp = clamp(
-          props.manager.computeTraceIconAnchorTimestamp(clampedTimestamp, edge),
-          node_space[0],
-          node_space[0] + node_space[1]
+          TRACE_ICON_WIDTH,
+          node_space
         );
         const left = props.manager.computeRelativeLeftPositionFromOrigin(
           anchorTimestamp,

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -33,17 +33,17 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
 
   return (
     <Fragment>
-      {issues.map(({issue, childIssueCount}, i) => {
+      {issues.map(({issue, additionalIssueCount}, i) => {
         const timestamp = getTraceIssueTimestamp(issue, props.node_space!);
         const className = getTraceIssueSeverityClassName(issue);
 
-        if (childIssueCount) {
+        if (additionalIssueCount) {
           const clampedTimestamp = clamp(
             timestamp,
             props.node_space![0],
             props.node_space![0] + props.node_space![1]
           );
-          const width = getTraceIconGroupApproximateWidth(childIssueCount);
+          const width = getTraceIconGroupApproximateWidth(additionalIssueCount);
           const edge = props.manager.computeTraceIconEdge(clampedTimestamp, width);
           const anchorTimestamp = props.manager.computeTraceIconAnchorTimestamp(
             clampedTimestamp,
@@ -68,7 +68,7 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
                 <TraceIcons.Icon event={issue} />
               </span>
               <span data-test-id="trace-issue-count" className="TraceIconCount">
-                {childIssueCount}
+                {additionalIssueCount}
               </span>
             </div>
           );
@@ -112,7 +112,7 @@ export function TraceIssueIcons(props: TraceIssueIconsProps) {
 
 interface RenderableTraceIssue {
   issue: TraceTree.TraceIssue;
-  childIssueCount?: number;
+  additionalIssueCount?: number;
 }
 
 function getRenderableTraceIssues(
@@ -143,7 +143,12 @@ function getRenderableTraceIssues(
 
   const childRepresentative = getMostSevereTraceIssue(childIssues);
   if (childRepresentative) {
-    issues.push({issue: childRepresentative, childIssueCount: childIssues.length});
+    const additionalIssueCount = childIssues.length - 1;
+    issues.push(
+      additionalIssueCount > 0
+        ? {issue: childRepresentative, additionalIssueCount}
+        : {issue: childRepresentative}
+    );
   }
 
   return issues;
@@ -255,10 +260,11 @@ function getTraceIconEdgeClassName(
   return '';
 }
 
-function getTraceIconGroupApproximateWidth(childIssueCount: number): number {
+function getTraceIconGroupApproximateWidth(additionalIssueCount: number): number {
   const countWidth = Math.max(
     TRACE_ICON_GROUP_COUNT_MIN_WIDTH,
-    String(childIssueCount).length * TRACE_ICON_GROUP_COUNT_APPROXIMATE_CHARACTER_WIDTH
+    String(additionalIssueCount).length *
+      TRACE_ICON_GROUP_COUNT_APPROXIMATE_CHARACTER_WIDTH
   );
 
   return (


### PR DESCRIPTION
The goal of this PR is to address an issue where if there we too many warnings in the trace waterfall we would attempt to render all of them in a parent above, example: 

<img width="714" height="337" alt="Screenshot 2026-06-01 at 08 42 55" src="https://github.com/user-attachments/assets/e500c3c1-7e44-4ecb-85fc-5447b93e3d50" />

This PR makes the change so that we now only render one icon with the count next to it:

<img width="730" height="263" alt="Screenshot 2026-06-01 at 09 06 21" src="https://github.com/user-attachments/assets/b81e19d0-544a-49bb-864b-500492ca2f52" />