### PR TITLE
ref(slack): Remove assistant:write OAuth scope from Slack integration

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -344,7 +344,6 @@ class SlackIntegrationProvider(IntegrationProvider):
             "chat:write.customize",
             "commands",
             SlackScope.APP_MENTIONS_READ,
-            SlackScope.ASSISTANT_WRITE,
         ]
     )
     # Stage new scopes here to test them via SlackStagingIntegrationProvider


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR removes the `assistant:write` OAuth scope from the Slack integration's requested scopes during installation.

## Context

The assistant feature has been removed from Sentry's Slack app, so we no longer need to request the `assistant:write` scope when users install the integration.

## Changes

- Removed `SlackScope.ASSISTANT_WRITE` from `identity_oauth_scopes` in `SlackIntegrationProvider`

## Behavior

- **New installations**: Will not request or receive the `assistant:write` scope
- **Existing installations**: Will continue to work with their existing scopes. The code that uses assistant functionality (`set_thread_status`, `set_suggested_prompts`) already has defensive error handling and will gracefully handle missing scopes.

## Testing

The existing test suite covers:
- OAuth scope verification in `test_integration.py::test_initialize_pipeline`
- Defensive behavior when the scope is missing (tests set scopes in metadata)

Related to: #inc-2211
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0B7AMW5XL6/p1780319812860829?thread_ts=1780319812.860829&cid=C0B7AMW5XL6)

<div><a href="https://cursor.com/agents/bc-d59dd21c-3ae5-5e0e-9638-f805395d6efa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d59dd21c-3ae5-5e0e-9638-f805395d6efa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

