### PR TITLE
feat(conversations): Add conversation ID to freeform search suggestions

### DIFF
--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -85,7 +85,7 @@ function ConversationsOverviewPage() {
       },
       searchSource: 'conversations',
       replaceRawSearchKeys: hasRawSearchReplacement
-        ? ['gen_ai.input.messages']
+        ? ['gen_ai.conversation.id', 'gen_ai.input.messages']
         : undefined,
       matchKeySuggestions: [
         {key: 'gen_ai.conversation.id', valuePattern: /^[0-9a-fA-F]{8,32}$/},


### PR DESCRIPTION
Add `gen_ai.conversation.id` as a `replaceRawSearchKeys` entry so the search dropdown suggests contains/is filters for conversation IDs alongside input messages.

Refs TET-2425