### PR TITLE
fix(dynamic-sampling): exclude zero-volume projects from project balancing

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -38,15 +38,17 @@ def run_project_balancing(
     config: BaseDynamicSamplingConfiguration, project_volumes: list[ProjectVolume]
 ) -> list[RebalancedItem]:
     sample_rate = cast(float, config.get_sample_rate())
-    counts_by_project = {project.id: 0 for project in config.projects}
+    project_ids = {project.id for project in config.projects}
+    counts_by_project: dict[int, int] = {}
     for project_volume in project_volumes:
-        if project_volume.project_id in counts_by_project:
+        if project_volume.project_id in project_ids and project_volume.total > 0:
             counts_by_project[project_volume.project_id] = project_volume.total
     return ProjectsRebalancingModel().run(
         ProjectsRebalancingInput(
             classes=[
-                RebalancedItem(id=project_id, count=count)
-                for project_id, count in counts_by_project.items()
+                RebalancedItem(id=project.id, count=counts_by_project[project.id])
+                for project in config.projects
+                if project.id in counts_by_project
             ],
             sample_rate=sample_rate,
         )

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -41,20 +41,27 @@ class ProjectBalancingCalculationsTest(TestCase):
         org = self.create_organization()
         project_with_volume = self.create_project(organization=org)
         project_without_volume = self.create_project(organization=org)
+        other_project = self.create_project()
         config = Mock()
         config.organization = org
         config.projects = [project_with_volume, project_without_volume]
         config.get_sample_rate.return_value = 0.5
         rebalanced_projects = [
             RebalancedItem(id=project_with_volume.id, count=100, new_sample_rate=0.25),
-            RebalancedItem(id=project_without_volume.id, count=0, new_sample_rate=1.0),
         ]
 
         with patch(
             "sentry.dynamic_sampling.per_org.calculations.ProjectsRebalancingModel.run",
             return_value=rebalanced_projects,
         ) as model_run:
-            result = run_project_balancing(config, [_project_volume(project_with_volume.id)])
+            result = run_project_balancing(
+                config,
+                [
+                    _project_volume(project_with_volume.id),
+                    _project_volume(project_without_volume.id, total=0, keep=0),
+                    _project_volume(other_project.id),
+                ],
+            )
 
         model_run.assert_called_once()
         model_input = model_run.call_args.args[-1]
@@ -62,7 +69,6 @@ class ProjectBalancingCalculationsTest(TestCase):
         assert model_input.sample_rate == 0.5
         assert model_input.classes == [
             RebalancedItem(id=project_with_volume.id, count=100),
-            RebalancedItem(id=project_without_volume.id, count=0),
         ]
         assert result == rebalanced_projects
 


### PR DESCRIPTION
- We do this in the old pipeline, do it in the new one as well for consistency

Closes TET-2427