### PR TITLE
feat(gitlab): track contributor seat on merge request opened

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -348,9 +348,12 @@ class MergeEventWebhook(GitlabWebhook):
     """
 
     EVENT_TYPE = IntegrationWebhookEventType.MERGE_REQUEST
+    # Order matters: seed OrganizationContributors before the code-review
+    # handler runs preflight, otherwise the first MR open from a new
+    # contributor would be denied with ORG_CONTRIBUTOR_NOT_FOUND.
     WEBHOOK_EVENT_PROCESSORS = (
-        handle_merge_request_event,
         track_gitlab_contributor_seat_processor,
+        handle_merge_request_event,
     )
 
     def __call__(self, event: Mapping[str, Any], **kwargs):

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -39,6 +39,9 @@ from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.seer.code_review.webhooks.merge_request import handle_merge_request_event
+from sentry.seer.code_review.webhooks.seat_tracking import (
+    track_gitlab_contributor_seat_processor,
+)
 from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.webhooks")
@@ -345,7 +348,10 @@ class MergeEventWebhook(GitlabWebhook):
     """
 
     EVENT_TYPE = IntegrationWebhookEventType.MERGE_REQUEST
-    WEBHOOK_EVENT_PROCESSORS = (handle_merge_request_event,)
+    WEBHOOK_EVENT_PROCESSORS = (
+        handle_merge_request_event,
+        track_gitlab_contributor_seat_processor,
+    )
 
     def __call__(self, event: Mapping[str, Any], **kwargs):
         if not (

--- a/src/sentry/seer/code_review/webhooks/seat_tracking.py
+++ b/src/sentry/seer/code_review/webhooks/seat_tracking.py
@@ -1,14 +1,22 @@
 """
 GitLab merge_request webhook processor that seeds OrganizationContributors so
 seat-based Seer billing works once an org is moved onto
-``organizations:seat-based-seer-enabled``.
+``organizations:seat-based-seer-enabled``. Same goal as GitHub's
+``track_contributor_seat`` call in ``PullRequestEventWebhook._handle`` (see
+``sentry/integrations/github/webhook.py``), but uses different idempotency
+mechanics:
 
-Mirrors the GitHub side, where ``track_contributor_seat`` runs from the
-``pull_request opened`` webhook (see
-``sentry/integrations/github/webhook.py``). Only fires on MR-open events
-(GitLab's ``object_attributes.action == "open"``); the GitLab merge_request
-webhook also delivers update/close/merge events that should not seed a
-contributor.
+- GitHub guards the call with ``if created:`` from
+  ``PullRequest.objects.update_or_create``, so re-delivery of the same
+  ``pull_request opened`` event is a no-op once the PR row exists.
+- GitLab's ``MergeEventWebhook.__call__`` discards the ``created`` return and
+  calls ``_handle`` for every action, so the processor cannot rely on DB state.
+  Instead we (a) filter on ``object_attributes.action == "open"`` (the GitLab
+  analog of GitHub's "opened") and (b) record a short-lived Redis key per
+  ``(org, repo, MR iid)`` to drop re-deliveries within the TTL window. GitLab
+  redelivers merge_request hooks on response timeout and the endpoint also
+  dispatches each payload once per installed organization; both can otherwise
+  cause ``num_actions`` to be incremented multiple times for a single MR-open.
 
 Gated by ``organizations:seer-code-review-gitlab`` — the same cohort flag
 ``handle_merge_request_event`` uses — so seeding only happens for orgs that
@@ -16,6 +24,20 @@ are already opted in to GitLab code review. The downstream call to
 ``should_increment_contributor_seat`` additionally requires
 ``organizations:seat-based-seer-enabled`` before any row is actually written
 or a seat is assigned.
+
+``MergeEventWebhook.WEBHOOK_EVENT_PROCESSORS`` registers this processor
+**before** ``handle_merge_request_event`` so the contributor row exists when
+the code-review handler's preflight billing check runs. Without that
+ordering, the first MR open from a new contributor would be denied with
+``ORG_CONTRIBUTOR_NOT_FOUND`` even though the same delivery seeds the row
+seconds later.
+
+Known gap: ``MergeEventWebhook.__call__`` short-circuits before ``_handle``
+when the payload is missing ``last_commit`` or the author's email
+(``test_merge_event_no_last_commit``). In that case this processor never
+runs, so the MR author is not seeded. Subsequent ``update`` events for the
+same MR do not fire the processor either (the action filter is ``"open"``).
+Tracked on SCM-99 as a follow-up.
 """
 
 from __future__ import annotations
@@ -30,8 +52,30 @@ from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.seer.code_review.contributor_seats import track_contributor_seat
+from sentry.utils.redis import redis_clusters
 
 logger = logging.getLogger(__name__)
+
+# Mirrors the dedup pattern in ``merge_request.py``. Distinct prefix so seat
+# tracking and code-review dispatch don't share a namespace.
+SEAT_SEEN_KEY_PREFIX = "webhook:gitlab:seat_tracking:"
+SEAT_SEEN_TTL_SECONDS = 20
+
+
+def _is_duplicate_delivery(seen_key: str) -> bool:
+    """
+    True if a delivery with this key was already processed within the TTL window.
+
+    On Redis errors we return False (process anyway) — double-counting once is
+    preferable to losing seat tracking entirely.
+    """
+    try:
+        cluster = redis_clusters.get("default")
+        is_first_time_seen = cluster.set(seen_key, "1", ex=SEAT_SEEN_TTL_SECONDS, nx=True)
+    except Exception:
+        logger.warning("gitlab.webhook.seat_tracking.mark_seen_failed")
+        return False
+    return not is_first_time_seen
 
 
 def track_gitlab_contributor_seat_processor(
@@ -54,11 +98,17 @@ def track_gitlab_contributor_seat_processor(
     try:
         user_id = object_attributes["author_id"]
         user_username = event["user"]["username"]
+        iid = object_attributes["iid"]
     except KeyError as e:
         logger.warning(
             "gitlab.webhook.seat_tracking.missing-author-data",
             extra={"integration_id": integration.id, "error": str(e)},
         )
+        return
+
+    seen_key = f"{SEAT_SEEN_KEY_PREFIX}{organization.id}:{repo.id}:{iid}"
+    if _is_duplicate_delivery(seen_key):
+        logger.info("gitlab.webhook.seat_tracking.duplicate_delivery_skipped")
         return
 
     try:

--- a/src/sentry/seer/code_review/webhooks/seat_tracking.py
+++ b/src/sentry/seer/code_review/webhooks/seat_tracking.py
@@ -106,14 +106,17 @@ def track_gitlab_contributor_seat_processor(
         )
         return
 
-    seen_key = f"{SEAT_SEEN_KEY_PREFIX}{organization.id}:{repo.id}:{iid}"
-    if _is_duplicate_delivery(seen_key):
-        logger.info("gitlab.webhook.seat_tracking.duplicate_delivery_skipped")
-        return
-
+    # Resolve the Organization before marking the delivery as seen so a missing
+    # org does not poison the dedup window and block GitLab redeliveries from
+    # seeding the contributor later.
     try:
         org = Organization.objects.get_from_cache(id=organization.id)
     except Organization.DoesNotExist:
+        return
+
+    seen_key = f"{SEAT_SEEN_KEY_PREFIX}{organization.id}:{repo.id}:{iid}"
+    if _is_duplicate_delivery(seen_key):
+        logger.info("gitlab.webhook.seat_tracking.duplicate_delivery_skipped")
         return
 
     track_contributor_seat(

--- a/src/sentry/seer/code_review/webhooks/seat_tracking.py
+++ b/src/sentry/seer/code_review/webhooks/seat_tracking.py
@@ -26,6 +26,7 @@ from typing import Any
 
 from sentry import features
 from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.seer.code_review.contributor_seats import track_contributor_seat
@@ -60,8 +61,13 @@ def track_gitlab_contributor_seat_processor(
         )
         return
 
+    try:
+        org = Organization.objects.get_from_cache(id=organization.id)
+    except Organization.DoesNotExist:
+        return
+
     track_contributor_seat(
-        organization=organization,
+        organization=org,
         repo=repo,
         integration_id=integration.id,
         user_id=user_id,

--- a/src/sentry/seer/code_review/webhooks/seat_tracking.py
+++ b/src/sentry/seer/code_review/webhooks/seat_tracking.py
@@ -1,0 +1,70 @@
+"""
+GitLab merge_request webhook processor that seeds OrganizationContributors so
+seat-based Seer billing works once an org is moved onto
+``organizations:seat-based-seer-enabled``.
+
+Mirrors the GitHub side, where ``track_contributor_seat`` runs from the
+``pull_request opened`` webhook (see
+``sentry/integrations/github/webhook.py``). Only fires on MR-open events
+(GitLab's ``object_attributes.action == "open"``); the GitLab merge_request
+webhook also delivers update/close/merge events that should not seed a
+contributor.
+
+Gated by ``organizations:seer-code-review-gitlab`` — the same cohort flag
+``handle_merge_request_event`` uses — so seeding only happens for orgs that
+are already opted in to GitLab code review. The downstream call to
+``should_increment_contributor_seat`` additionally requires
+``organizations:seat-based-seer-enabled`` before any row is actually written
+or a seat is assigned.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from sentry import features
+from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.models.repository import Repository
+from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.seer.code_review.contributor_seats import track_contributor_seat
+
+logger = logging.getLogger(__name__)
+
+
+def track_gitlab_contributor_seat_processor(
+    *,
+    event: Mapping[str, Any],
+    organization: RpcOrganization,
+    repo: Repository,
+    integration: RpcIntegration | None = None,
+    **kwargs: Any,
+) -> None:
+    if integration is None:
+        return
+    if not features.has("organizations:seer-code-review-gitlab", organization):
+        return
+
+    object_attributes = event.get("object_attributes") or {}
+    if object_attributes.get("action") != "open":
+        return
+
+    try:
+        user_id = object_attributes["author_id"]
+        user_username = event["user"]["username"]
+    except KeyError as e:
+        logger.warning(
+            "gitlab.webhook.seat_tracking.missing-author-data",
+            extra={"integration_id": integration.id, "error": str(e)},
+        )
+        return
+
+    track_contributor_seat(
+        organization=organization,
+        repo=repo,
+        integration_id=integration.id,
+        user_id=user_id,
+        user_username=user_username,
+        provider="gitlab",
+    )

--- a/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
+++ b/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
@@ -1,0 +1,97 @@
+from typing import Any
+from unittest.mock import patch
+
+import orjson
+
+from fixtures.gitlab import MERGE_REQUEST_OPENED_EVENT, GitLabTestCase
+from sentry.models.organization import Organization
+from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.seer.code_review.webhooks.seat_tracking import (
+    track_gitlab_contributor_seat_processor,
+)
+from sentry.testutils.helpers.features import with_feature
+
+
+def _make_event(action: str = "open", **overrides: object) -> dict[str, Any]:
+    event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+    event["object_attributes"]["action"] = action
+    for key, value in overrides.items():
+        event["object_attributes"][key] = value
+    return event
+
+
+def _rpc_org(org: Organization) -> RpcOrganization:
+    return RpcOrganization(id=org.id, slug=org.slug, name=org.name)
+
+
+class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.create_gitlab_repo("getsentry/sentry")
+        self.rpc_organization = _rpc_org(self.organization)
+
+    def _call(self, event: dict[str, Any] | None = None) -> None:
+        track_gitlab_contributor_seat_processor(
+            event=event if event is not None else _make_event(),
+            organization=self.rpc_organization,
+            repo=self.repo,
+            integration=self.integration,
+        )
+
+    @with_feature("organizations:seer-code-review-gitlab")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_calls_track_contributor_seat_on_open(self, mock_track: Any) -> None:
+        self._call()
+
+        mock_track.assert_called_once()
+        kwargs = mock_track.call_args.kwargs
+        assert kwargs["organization"].id == self.organization.id
+        assert kwargs["repo"].id == self.repo.id
+        assert kwargs["integration_id"] == self.integration.id
+        assert kwargs["user_id"] == 51
+        assert kwargs["user_username"] == "root"
+        assert kwargs["provider"] == "gitlab"
+
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_no_call_without_cohort_flag(self, mock_track: Any) -> None:
+        self._call()
+        mock_track.assert_not_called()
+
+    @with_feature("organizations:seer-code-review-gitlab")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_no_call_on_update_action(self, mock_track: Any) -> None:
+        self._call(event=_make_event(action="update"))
+        mock_track.assert_not_called()
+
+    @with_feature("organizations:seer-code-review-gitlab")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_no_call_on_close_action(self, mock_track: Any) -> None:
+        self._call(event=_make_event(action="close"))
+        mock_track.assert_not_called()
+
+    @with_feature("organizations:seer-code-review-gitlab")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_no_call_without_integration(self, mock_track: Any) -> None:
+        track_gitlab_contributor_seat_processor(
+            event=_make_event(),
+            organization=self.rpc_organization,
+            repo=self.repo,
+            integration=None,
+        )
+        mock_track.assert_not_called()
+
+    @with_feature("organizations:seer-code-review-gitlab")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_no_call_when_author_id_missing(self, mock_track: Any) -> None:
+        event = _make_event()
+        del event["object_attributes"]["author_id"]
+        self._call(event=event)
+        mock_track.assert_not_called()
+
+    @with_feature("organizations:seer-code-review-gitlab")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_no_call_when_username_missing(self, mock_track: Any) -> None:
+        event = _make_event()
+        del event["user"]["username"]
+        self._call(event=event)
+        mock_track.assert_not_called()

--- a/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
+++ b/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
@@ -139,3 +139,26 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
 
         self._call(event=event)
         assert mock_track.call_count == 2
+
+    @with_feature("organizations:seer-code-review-gitlab")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_missing_organization_does_not_poison_dedup(self, mock_track: Any) -> None:
+        # If the Organization can't be resolved, no Redis key is set, so a
+        # subsequent delivery for a valid org with the same key shape still
+        # has a chance to seed the contributor.
+        event = _make_event()
+        iid = event["object_attributes"]["iid"]
+        seen_key = f"{SEAT_SEEN_KEY_PREFIX}{self.organization.id}:{self.repo.id}:{iid}"
+
+        with patch(
+            "sentry.seer.code_review.webhooks.seat_tracking.Organization.objects.get_from_cache",
+            side_effect=Organization.DoesNotExist,
+        ):
+            self._call(event=event)
+
+        mock_track.assert_not_called()
+        assert redis_clusters.get("default").get(seen_key) is None
+
+        # Now the lookup succeeds — the same delivery should proceed.
+        self._call(event=event)
+        mock_track.assert_called_once()

--- a/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
+++ b/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
@@ -4,12 +4,28 @@ from unittest.mock import patch
 import orjson
 
 from fixtures.gitlab import MERGE_REQUEST_OPENED_EVENT, GitLabTestCase
+from sentry.integrations.gitlab.webhooks import MergeEventWebhook
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.seer.code_review.webhooks.merge_request import handle_merge_request_event
 from sentry.seer.code_review.webhooks.seat_tracking import (
+    SEAT_SEEN_KEY_PREFIX,
     track_gitlab_contributor_seat_processor,
 )
 from sentry.testutils.helpers.features import with_feature
+from sentry.utils.redis import redis_clusters
+
+
+def test_processor_runs_before_code_review_handler() -> None:
+    # Order matters: the seat processor must run before
+    # handle_merge_request_event, otherwise preflight billing finds no
+    # contributor row and denies the first MR open from a new author.
+    processors = MergeEventWebhook.WEBHOOK_EVENT_PROCESSORS
+    assert track_gitlab_contributor_seat_processor in processors
+    assert handle_merge_request_event in processors
+    assert processors.index(track_gitlab_contributor_seat_processor) < processors.index(
+        handle_merge_request_event
+    )
 
 
 def _make_event(action: str = "open", **overrides: object) -> dict[str, Any]:
@@ -95,3 +111,31 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
         del event["user"]["username"]
         self._call(event=event)
         mock_track.assert_not_called()
+
+    @with_feature("organizations:seer-code-review-gitlab")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_duplicate_delivery_within_window_skipped(self, mock_track: Any) -> None:
+        # GitLab redelivers webhooks on response timeout, and the endpoint
+        # dispatches each payload once per installed organization. Both can
+        # otherwise cause num_actions to be incremented multiple times for a
+        # single MR-open. The Redis TTL key per (org, repo, MR iid) deduplicates.
+        event = _make_event()
+        self._call(event=event)
+        self._call(event=event)
+
+        mock_track.assert_called_once()
+
+    @with_feature("organizations:seer-code-review-gitlab")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_duplicate_delivery_after_ttl_processes_again(self, mock_track: Any) -> None:
+        event = _make_event()
+        self._call(event=event)
+        assert mock_track.call_count == 1
+
+        # Simulate TTL expiry so the same delivery can be processed again.
+        iid = event["object_attributes"]["iid"]
+        seen_key = f"{SEAT_SEEN_KEY_PREFIX}{self.organization.id}:{self.repo.id}:{iid}"
+        redis_clusters.get("default").delete(seen_key)
+
+        self._call(event=event)
+        assert mock_track.call_count == 2


### PR DESCRIPTION
Seeds `OrganizationContributors` when a GitLab merge request is opened, so seat-based Seer billing works once an org is moved onto `organizations:seat-based-seer-enabled`. Mirrors the GitHub side, where `track_contributor_seat` fires from the `pull_request opened` webhook (`src/sentry/integrations/github/webhook.py`).

Implemented as a `WebhookProcessor` registered on `MergeEventWebhook` so errors are isolated per-processor by the existing `_handle` loop. Action filtered to `"open"` only — GitLab's merge_request event also delivers update / close / merge actions that should not seed a contributor.

Gating:
- `organizations:seer-code-review-gitlab` — the same cohort flag `handle_merge_request_event` uses, so seat seeding only happens for orgs that are already opted in to GitLab code review.
- `organizations:seat-based-seer-enabled` — checked inside the downstream `should_increment_contributor_seat`. Required before any row is actually written or a seat is assigned.

This supersedes #116305, which was opened against the pre-#116317 webhook shape and is no longer rebaseable.

Once this lands, the gap documented in `src/sentry/seer/code_review/webhooks/merge_request.py`'s module docstring ("Code review does not fire in production yet: GitLab contributors are never seeded") closes, and the only remaining blocker before billing flips on is the per-org subscription option (`SubscriptionOptions.SEER_USER_ENABLED`) gating `seat-based-seer-enabled`.

Refs SCM-99