### PR TITLE
feat(onboarding): Scaffold SCM-first project creation as a single view

### DIFF
--- a/static/app/views/projectInstall/newProject.tsx
+++ b/static/app/views/projectInstall/newProject.tsx
@@ -3,10 +3,21 @@ import styled from '@emotion/styled';
 import {Stack} from '@sentry/scraps/layout';
 
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {useExperiment} from 'sentry/utils/useExperiment';
 
 import {CreateProject} from './createProject';
+import {ScmCreateProject} from './scmCreateProject';
 
 function NewProject() {
+  const {inExperiment: hasScmProjectCreation} = useExperiment({
+    feature: 'onboarding-scm-project-creation-experiment',
+    reportExposure: true,
+  });
+
+  if (hasScmProjectCreation) {
+    return <ScmCreateProject />;
+  }
+
   return (
     <SentryDocumentTitle>
       <Stack flex={1}>

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -1,0 +1,108 @@
+import {Fragment, useCallback} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Container, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {Access} from 'sentry/components/acl/access';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {t, tct} from 'sentry/locale';
+import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
+import {useSessionStorage} from 'sentry/utils/useSessionStorage';
+
+interface WizardState {
+  // Flips true on the first meaningful action in section 1 (repo selected
+  // or "Continue without a repo" clicked). Sections 2 and 3 reveal together
+  // when this is true. Decoupled from selection state so later state edits
+  // (de-selecting a repo) do not collapse the rest of the page.
+  repoStepCompleted: boolean;
+}
+
+const INITIAL_STATE: WizardState = {
+  repoStepCompleted: false,
+};
+
+export function ScmCreateProject() {
+  // Session-storage backed so a refresh restores how far the user has
+  // progressed. Separate key from new-org onboarding's 'onboarding' key.
+  const [state, setState] = useSessionStorage('project-creation-wizard', INITIAL_STATE);
+  const canUserCreateProject = useCanCreateProject();
+
+  const completeRepoStep = useCallback(() => {
+    setState(s => ({...s, repoStepCompleted: true}));
+  }, [setState]);
+
+  return (
+    <SentryDocumentTitle title={t('Create a new project')}>
+      <Access access={canUserCreateProject ? ['project:read'] : ['project:admin']}>
+        <Stack flex={1} gap="2xl" padding="2xl">
+          <Layout.Title withMargins>{t('Create a new project')}</Layout.Title>
+          <Container maxWidth="760px">
+            <Text as="p" variant="muted">
+              {tct(
+                'Set up a separate project for each part of your application (for example, your API server and frontend client), to quickly pinpoint which part of your application errors are coming from. [link: Read the docs].',
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/create-new-project/" />
+                  ),
+                }
+              )}
+            </Text>
+          </Container>
+
+          <ConnectRepositorySection onComplete={completeRepoStep} />
+
+          {state.repoStepCompleted && (
+            <Fragment>
+              <PlatformFeaturesSection />
+              <ProjectDetailsSection />
+            </Fragment>
+          )}
+        </Stack>
+      </Access>
+    </SentryDocumentTitle>
+  );
+}
+
+// Placeholder for VDY-74. Will be replaced with <ScmConnect />.
+function ConnectRepositorySection({onComplete}: {onComplete: () => void}) {
+  return (
+    <Stack gap="md">
+      <Heading as="h2" size="xl">
+        {t('Connect a repository')}
+      </Heading>
+      <Text variant="muted">{t('Connect step content goes here (VDY-74).')}</Text>
+      <Button variant="primary" onClick={onComplete}>
+        {t('Continue')}
+      </Button>
+    </Stack>
+  );
+}
+
+// Placeholder for VDY-75. Will be replaced with <ScmPlatformFeatures />.
+function PlatformFeaturesSection() {
+  return (
+    <Stack gap="md">
+      <Heading as="h2" size="xl">
+        {t('Platform & features')}
+      </Heading>
+      <Text variant="muted">
+        {t('Platform and features step content goes here (VDY-75).')}
+      </Text>
+    </Stack>
+  );
+}
+
+// Placeholder for VDY-76. Will be replaced with <ScmProjectDetails />.
+function ProjectDetailsSection() {
+  return (
+    <Stack gap="md">
+      <Heading as="h2" size="xl">
+        {t('Project details')}
+      </Heading>
+      <Text variant="muted">{t('Project details step content goes here (VDY-76).')}</Text>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## TL;DR
Scaffolds the SCM-first project creation surface at `/projects/new/` as a single view with progressive disclosure. Section 1 (Connect a repository) is always visible. Sections 2 and 3 (Platform & features, Project details) reveal together once a meaningful action is taken on section 1. Gated on `organizations:onboarding-scm-project-creation-experiment`. Orgs not in the experiment see the legacy `CreateProject` form. Section bodies are placeholders; VDY-74/75/76 will wire the decoupled SCM components from VDY-72.

---

## Stack
- [PR 1](https://github.com/getsentry/sentry/pull/116434): Make decoupled SCM components flow-aware for analytics (base)
- **PR 2 (this):** Scaffold SCM-first project creation as a single view
- PR 3 (next): Wire `ScmConnect` into the single-view scaffold (VDY-74)

## Summary
- Adds `ScmCreateProject` at `static/app/views/projectInstall/scmCreateProject.tsx`. Single view, no `:step` route param, no `useNavigate`, no `Stepper`.
- Wizard state lives in `useSessionStorage` under the key `project-creation-wizard`, separate from new-org onboarding's `onboarding` key so the two flows do not collide. A single `repoStepCompleted` boolean drives the reveal.
- Section 1 always renders. Sections 2 and 3 render together when `repoStepCompleted` is true. The flag is decoupled from selection state, so de-selecting a repo later does not collapse the rest of the page.
- `newProject.tsx` gates on the experiment and dispatches to `ScmCreateProject` when in the experiment, else falls through to the existing `CreateProject` form. No route changes; the existing `/projects/new/` route handles everything.
- Section bodies are placeholders. Section 1 has a temporary Continue button so the disclosure is testable; that button goes away when VDY-74 wires up `<ScmConnect />`.

## Out of scope
- Wiring `<ScmConnect />`, `<ScmPlatformFeatures />`, `<ScmProjectDetails />` into the three sections. VDY-74/75/76 will pick those up.
- Funnel construction in Amplitude. BI work.

Refs VDY-73

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint:js` clean on touched files
- [ ] With the experiment flag on locally, `/projects/new/` renders the single-view scaffold with only section 1 on first load
- [ ] Clicking the placeholder Continue button on section 1 reveals sections 2 and 3 together
- [ ] Refreshing the page preserves the revealed sections (sessionStorage round-trip)
- [ ] With the flag off, `/projects/new/` renders the legacy `CreateProject` form unchanged