### PR TITLE
feat(api-docs): publish event attachment details endpoint

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -1,6 +1,7 @@
 import posixpath
 
 from django.http import StreamingHttpResponse
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -10,6 +11,11 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.eventattachment import EventAttachmentSerializerResponse
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.examples.event_attachment_examples import EventAttachmentExamples
+from sentry.apidocs.parameters import EventParams, GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.superuser import superuser_has_permission
 from sentry.auth.system import is_system_auth
 from sentry.constants import ATTACHMENTS_ROLE_DEFAULT
@@ -19,6 +25,14 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.objectstore import parse_accept_encoding
 from sentry.services import eventstore
 from sentry.types.activity import ActivityType
+
+ATTACHMENT_ID_PARAM = OpenApiParameter(
+    name="attachment_id",
+    location="path",
+    required=True,
+    type=str,
+    description="The numeric ID of the attachment, as returned from the attachments list endpoint.",
+)
 
 
 class EventAttachmentDetailsPermission(ProjectPermission):
@@ -49,12 +63,13 @@ class EventAttachmentDetailsPermission(ProjectPermission):
         return om_role.priority >= required_role.priority
 
 
+@extend_schema(tags=["Events"])
 @cell_silo_endpoint
 class EventAttachmentDetailsEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_INGEST
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
-        "GET": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (EventAttachmentDetailsPermission,)
 
@@ -76,20 +91,31 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
         response["Content-Disposition"] = f'attachment; filename="{name}"'
         return response
 
+    @extend_schema(
+        operation_id="Retrieve an Event Attachment",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            EventParams.EVENT_ID,
+            ATTACHMENT_ID_PARAM,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "EventAttachmentDetailsResponse", EventAttachmentSerializerResponse
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=EventAttachmentExamples.EVENT_ATTACHMENT_DETAILS,
+    )
     def get(
         self, request: Request, project, event_id, attachment_id
     ) -> Response | StreamingHttpResponse:
         """
-        Retrieve an Attachment
-        ``````````````````````
+        Retrieve metadata for a single attachment on an event.
 
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          issues belong to.
-        :pparam string project_id_or_slug: the id or slug of the project the event
-                                     belongs to.
-        :pparam string event_id: the id of the event.
-        :pparam string attachment_id: the id of the attachment.
-        :auth: required
+        Requires the `event-attachments` organization feature.
         """
         if not features.has(
             "organizations:event-attachments", project.organization, actor=request.user

--- a/tests/apidocs/endpoints/events/test_event_attachment_details.py
+++ b/tests/apidocs/endpoints/events/test_event_attachment_details.py
@@ -1,0 +1,43 @@
+from django.test.client import RequestFactory
+from django.urls import reverse
+
+from fixtures.apidocs_test_case import APIDocsTestCase
+from sentry.models.eventattachment import EventAttachment
+from sentry.testutils.helpers.datetime import before_now
+
+
+class ProjectEventAttachmentDetailsDocs(APIDocsTestCase):
+    def setUp(self) -> None:
+        event = self.store_event(
+            data={"fingerprint": ["group1"], "timestamp": before_now(minutes=1).isoformat()},
+            project_id=self.project.id,
+        )
+        attachment = EventAttachment.objects.create(
+            project_id=event.project_id,
+            event_id=event.event_id,
+            type="event.attachment",
+            name="hello.png",
+            content_type="image/png",
+            size=18,
+            sha1="d3f299af02d6abbe92dd8368bab781824a9702ed",
+            blob_path=":File contents here",
+        )
+
+        self.url = reverse(
+            "sentry-api-0-event-attachment-details",
+            kwargs={
+                "organization_id_or_slug": self.project.organization.slug,
+                "project_id_or_slug": self.project.slug,
+                "event_id": event.event_id,
+                "attachment_id": attachment.id,
+            },
+        )
+
+        self.login_as(user=self.user)
+
+    def test_get(self) -> None:
+        with self.feature("organizations:event-attachments"):
+            response = self.client.get(self.url)
+        request = RequestFactory().get(self.url)
+
+        self.validate_schema(request, response)


### PR DESCRIPTION
Publishes `EventAttachmentDetailsEndpoint` as part of https://linear.app/getsentry/project/api-docs-for-agents-c7863fd8bbe0/overview. 