### PR TITLE
ref(onboarding): Extract ScmIntegrationConnect from ScmConnect

### DIFF
--- a/static/app/views/onboarding/components/scmIntegrationConnect.tsx
+++ b/static/app/views/onboarding/components/scmIntegrationConnect.tsx
@@ -1,0 +1,131 @@
+import {useCallback, useEffect} from 'react';
+import {motion} from 'framer-motion';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex, Stack, type StackProps} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import type {Integration, Repository} from 'sentry/types/integrations';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
+
+import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+import {ScmProviderPills} from './scmProviderPills';
+import {ScmRepoSelector} from './scmRepoSelector';
+import {useScmPlatformDetection} from './useScmPlatformDetection';
+import {useScmProviders} from './useScmProviders';
+
+const STEP_VIEWED_EVENT = {
+  onboarding: 'onboarding.scm_connect_step_viewed',
+  'project-creation': 'project_creation.scm_connect_step_viewed',
+} as const;
+
+interface ScmIntegrationConnectProps {
+  analyticsFlow: ScmAnalyticsFlow;
+  // Fired once per user-driven repo change so callers can invalidate state
+  // derived from the repo (platform, features, created project). See
+  // ScmRepoSelector for why this is separate from onRepositoryChange.
+  onClearDerivedState: () => void;
+  onIntegrationChange: (integration: Integration | undefined) => void;
+  onRepositoryChange: (repo: Repository | undefined) => void;
+  selectedIntegration: Integration | undefined;
+  selectedRepository: Repository | undefined;
+  maxWidth?: StackProps['maxWidth'];
+}
+
+/**
+ * Core integration-and-repo connection mechanic shared by the SCM connect step
+ * (`ScmConnect`) and the SCM-first project creation surface. Renders the
+ * provider install pills when no integration is connected, or the repo
+ * selector when one is. Owns integration data fetching, platform detection
+ * pre-warming, and the `scm_connect_step_viewed` analytic.
+ *
+ * Does NOT render the connect step's onboarding chrome (intro heading,
+ * lock/revoke text, benefits grid, Continue/Skip footer). Hosts compose the
+ * chrome they need around this component.
+ */
+export function ScmIntegrationConnect({
+  analyticsFlow,
+  onClearDerivedState,
+  onIntegrationChange,
+  onRepositoryChange,
+  selectedIntegration,
+  selectedRepository,
+  maxWidth = SCM_STEP_CONTENT_WIDTH,
+}: ScmIntegrationConnectProps) {
+  const organization = useOrganization();
+  const {
+    scmProviders,
+    isPending,
+    isError,
+    refetch,
+    refetchIntegrations,
+    activeIntegrationExisting,
+  } = useScmProviders();
+
+  // Pre-warm platform detection so results are cached when the user advances
+  useScmPlatformDetection(selectedRepository);
+
+  // Derive integration from explicit selection, falling back to existing
+  const effectiveIntegration = selectedIntegration ?? activeIntegrationExisting;
+
+  useEffect(() => {
+    trackAnalytics(STEP_VIEWED_EVENT[analyticsFlow], {organization});
+  }, [organization, analyticsFlow]);
+
+  const handleInstall = useCallback(
+    (data: Integration) => {
+      onIntegrationChange(data);
+      onRepositoryChange(undefined);
+      refetchIntegrations();
+    },
+    [onIntegrationChange, onRepositoryChange, refetchIntegrations]
+  );
+
+  if (isPending) {
+    return (
+      <Flex justify="center" align="center">
+        <LoadingIndicator mini />
+      </Flex>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Stack gap="lg" align="center">
+        <Text variant="muted">{t('Failed to load integrations.')}</Text>
+        <Button onClick={() => refetch()}>{t('Retry')}</Button>
+      </Stack>
+    );
+  }
+
+  return effectiveIntegration ? (
+    <MotionStack key="with-integration" gap="xl" width="100%" maxWidth={maxWidth}>
+      <Stack gap="md" paddingTop="2xl">
+        <Text variant="secondary" bold size="sm" density="compressed" uppercase>
+          {t(
+            'Connected to %s / %s',
+            effectiveIntegration.provider.name,
+            effectiveIntegration.name
+          )}
+        </Text>
+        <ScmRepoSelector
+          analyticsFlow={analyticsFlow}
+          integration={effectiveIntegration}
+          selectedRepository={selectedRepository}
+          onRepositoryChange={onRepositoryChange}
+          onClearDerivedState={onClearDerivedState}
+        />
+      </Stack>
+    </MotionStack>
+  ) : (
+    <MotionStack key="without-integration" gap="2xl" width="100%" maxWidth={maxWidth}>
+      <ScmProviderPills providers={scmProviders} onInstall={handleInstall} />
+    </MotionStack>
+  );
+}
+
+const MotionStack = motion.create(Stack);

--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -1,4 +1,3 @@
-import {useCallback, useEffect} from 'react';
 import {LayoutGroup, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
@@ -6,17 +5,12 @@ import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconCheckmark, IconClose, IconLock} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Integration, Repository} from 'sentry/types/integrations';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
-import {ScmProviderPills} from './components/scmProviderPills';
-import {ScmRepoSelector} from './components/scmRepoSelector';
+import {ScmIntegrationConnect} from './components/scmIntegrationConnect';
 import {ScmStepHeader} from './components/scmStepHeader';
-import {useScmPlatformDetection} from './components/useScmPlatformDetection';
 import {useScmProviders} from './components/useScmProviders';
 import {SCM_STEP_CONTENT_WIDTH} from './consts';
 import type {StepProps} from './types';
@@ -68,34 +62,12 @@ export function ScmConnect({
   selectedRepository,
   genBackButton,
 }: ScmConnectProps) {
-  const organization = useOrganization();
-  const {
-    scmProviders,
-    isPending,
-    isError,
-    refetch,
-    refetchIntegrations,
-    activeIntegrationExisting,
-  } = useScmProviders();
-
-  // Pre-warm platform detection so results are cached when the user advances
-  useScmPlatformDetection(selectedRepository);
-
-  // Derive integration from explicit selection, falling back to existing
+  // React Query dedupes with ScmIntegrationConnect's call; only the
+  // activeIntegrationExisting fallback is needed here for the footer's
+  // analyticsParams and the "commit auto-detected integration on Continue"
+  // behavior.
+  const {activeIntegrationExisting} = useScmProviders();
   const effectiveIntegration = selectedIntegration ?? activeIntegrationExisting;
-
-  useEffect(() => {
-    trackAnalytics('onboarding.scm_connect_step_viewed', {organization});
-  }, [organization]);
-
-  const handleInstall = useCallback(
-    (data: Integration) => {
-      onIntegrationChange(data);
-      onRepositoryChange(undefined);
-      refetchIntegrations();
-    },
-    [onIntegrationChange, onRepositoryChange, refetchIntegrations]
-  );
 
   return (
     <Flex direction="column" align="center" gap="3xl" flexGrow={1}>
@@ -107,49 +79,14 @@ export function ScmConnect({
       />
 
       <LayoutGroup>
-        {isPending ? (
-          <Flex justify="center" align="center">
-            <LoadingIndicator mini />
-          </Flex>
-        ) : isError ? (
-          <Stack gap="lg" align="center">
-            <Text variant="muted">{t('Failed to load integrations.')}</Text>
-            <Button onClick={() => refetch()}>{t('Retry')}</Button>
-          </Stack>
-        ) : effectiveIntegration ? (
-          <MotionStack
-            key="with-integration"
-            gap="xl"
-            width="100%"
-            maxWidth={SCM_STEP_CONTENT_WIDTH}
-          >
-            <Stack gap="md" paddingTop="2xl">
-              <Text variant="secondary" bold size="sm" density="compressed" uppercase>
-                {t(
-                  'Connected to %s / %s',
-                  effectiveIntegration.provider.name,
-                  effectiveIntegration.name
-                )}
-              </Text>
-              <ScmRepoSelector
-                analyticsFlow="onboarding"
-                integration={effectiveIntegration}
-                selectedRepository={selectedRepository}
-                onRepositoryChange={onRepositoryChange}
-                onClearDerivedState={onClearDerivedState}
-              />
-            </Stack>
-          </MotionStack>
-        ) : (
-          <MotionStack
-            key="without-integration"
-            gap="2xl"
-            width="100%"
-            maxWidth={SCM_STEP_CONTENT_WIDTH}
-          >
-            <ScmProviderPills providers={scmProviders} onInstall={handleInstall} />
-          </MotionStack>
-        )}
+        <ScmIntegrationConnect
+          analyticsFlow="onboarding"
+          onClearDerivedState={onClearDerivedState}
+          onIntegrationChange={onIntegrationChange}
+          onRepositoryChange={onRepositoryChange}
+          selectedIntegration={selectedIntegration}
+          selectedRepository={selectedRepository}
+        />
         <MotionFlex
           layout="position"
           gap="sm"
@@ -247,6 +184,5 @@ export function ScmConnect({
   );
 }
 
-const MotionStack = motion.create(Stack);
 const MotionFlex = motion.create(Flex);
 const MotionGrid = motion.create(Grid);


### PR DESCRIPTION
## TL;DR
Splits `ScmConnect` into a reusable core component (`ScmIntegrationConnect`) and the onboarding chrome that wraps it. The core owns integration data fetching, platform detection pre-warming, the `scm_connect_step_viewed` analytic, and the provider-pills / repo-selector conditional. The `ScmConnect` wrapper keeps the connect-step heading, lock/revoke text, benefits grid, and Continue/Skip footer. No behavior change for onboarding; the extraction unblocks PR 4 in the stack which reuses just the connection mechanic in project creation.

---

## Stack
- [PR 1](https://github.com/getsentry/sentry/pull/116434): Make decoupled SCM components flow-aware for analytics
- [PR 2](https://github.com/getsentry/sentry/pull/116577): Scaffold SCM-first project creation as a single view
- **PR 3 (this):** Extract `ScmIntegrationConnect` from `ScmConnect`
- PR 4 (next): Wire `ScmIntegrationConnect` into the single-view scaffold

## Summary
- New file `static/app/views/onboarding/components/scmIntegrationConnect.tsx` hosts `ScmIntegrationConnect`. Props: `analyticsFlow`, `selectedIntegration`, `selectedRepository`, `onIntegrationChange`, `onRepositoryChange`, `onClearDerivedState`.
- `ScmConnect` now imports and renders `<ScmIntegrationConnect />`. It still calls `useScmProviders()` to derive `effectiveIntegration` for the footer's analyticsParams and the "commit auto-detected integration on Continue" behavior. React Query dedupes with the core's fetch.
- `MotionStack` moves with the core. `MotionFlex` and `MotionGrid` (lock text, info grid, footer) stay in the wrapper. `LayoutGroup` stays in the wrapper, wrapping both the core (as a child) and the wrapper's own motion components, so layout coordination is preserved.
- `STEP_VIEWED_EVENT` moves into the core. Onboarding still fires `onboarding.scm_connect_step_viewed` on mount; project creation will fire `project_creation.scm_connect_step_viewed` once PR 4 wires the core directly.

Refs VDY-74

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint:js` clean on touched files
- [x] `pnpm test-ci` passes on dependent specs (`onboarding.spec.tsx`, `scmPlatformFeatures.spec.tsx`, `scmProjectDetails.spec.tsx`, `scmRepoSelector.spec.tsx`)
- [ ] Onboarding connect step still renders header, integration/repo block, lock text, info grid, and Continue/Skip footer
- [ ] Switching between with-integration and without-integration states still works as before