### PR TITLE
feat(onboarding): Wire ScmIntegrationConnect into single-view project creation

### DIFF
--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -66,6 +66,7 @@ export function ScmCreateProject() {
       setState(s => ({
         ...s,
         selectedRepository: repository,
+        repoStepCompleted: repository ? true : s.repoStepCompleted,
       }));
     },
     [setState]
@@ -76,7 +77,7 @@ export function ScmCreateProject() {
   const handleClearDerivedState = useCallback(() => {}, []);
 
   const showContinueWithoutRepo = !selectedRepository && !repoStepCompleted;
-  const showAllSteps = repoStepCompleted || selectedRepository;
+  const showAllSteps = repoStepCompleted;
 
   return (
     <SentryDocumentTitle title={t('Create a new project')}>

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -1,7 +1,8 @@
 import {Fragment, useCallback} from 'react';
+import {LayoutGroup, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -9,100 +10,176 @@ import {Access} from 'sentry/components/acl/access';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
+import type {Integration, Repository} from 'sentry/types/integrations';
 import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
+import {ScmIntegrationConnect} from 'sentry/views/onboarding/components/scmIntegrationConnect';
+import {useScmProviders} from 'sentry/views/onboarding/components/useScmProviders';
+
+const CREATE_PROJECT_MAX_WIDTH = '760px';
 
 interface WizardState {
   // Flips true on the first meaningful action in section 1 (repo selected
-  // or "Continue without a repo" clicked). Sections 2 and 3 reveal together
-  // when this is true. Decoupled from selection state so later state edits
-  // (de-selecting a repo) do not collapse the rest of the page.
+  // or "Continue without connecting a repo" clicked). Sections 2 and 3
+  // reveal together when this is true. Decoupled from selection state so
+  // later state edits (de-selecting a repo) do not collapse the rest of
+  // the page.
   repoStepCompleted: boolean;
+  selectedIntegration: Integration | undefined;
+  selectedRepository: Repository | undefined;
 }
 
 const INITIAL_STATE: WizardState = {
   repoStepCompleted: false,
+  selectedIntegration: undefined,
+  selectedRepository: undefined,
 };
 
 export function ScmCreateProject() {
   // Session-storage backed so a refresh restores how far the user has
   // progressed. Separate key from new-org onboarding's 'onboarding' key.
-  const [state, setState] = useSessionStorage('project-creation-wizard', INITIAL_STATE);
+  const [{repoStepCompleted, selectedIntegration, selectedRepository}, setState] =
+    useSessionStorage('project-creation-wizard', INITIAL_STATE);
   const canUserCreateProject = useCanCreateProject();
+  // Subscribe so the parent re-renders when integration state changes inside
+  // ScmIntegrationConnect, letting framer-motion's layout="position" siblings
+  // below re-measure and animate position shifts. React Query dedupes with
+  // the child's call.
+  useScmProviders();
 
-  const completeRepoStep = useCallback(() => {
+  const completeRepoStep = () => {
     setState(s => ({...s, repoStepCompleted: true}));
-  }, [setState]);
+  };
+
+  const handleIntegrationChange = useCallback(
+    (integration: Integration | undefined) => {
+      setState(s => ({...s, selectedIntegration: integration}));
+    },
+    [setState]
+  );
+
+  // Selecting a repo is itself a meaningful action, so it also flips the
+  // reveal flag. The "Continue without connecting a repo" path flips the
+  // flag via completeRepoStep below.
+  const handleRepositoryChange = useCallback(
+    (repository: Repository | undefined) => {
+      setState(s => ({
+        ...s,
+        selectedRepository: repository,
+      }));
+    },
+    [setState]
+  );
+
+  // No-op until sections 2 and 3 wire up their own state. VDY-75/76 will
+  // replace this with platform/features/project clearing.
+  const handleClearDerivedState = useCallback(() => {}, []);
+
+  const showContinueWithoutRepo = !selectedRepository && !repoStepCompleted;
+  const showAllSteps = repoStepCompleted || selectedRepository;
 
   return (
     <SentryDocumentTitle title={t('Create a new project')}>
       <Access access={canUserCreateProject ? ['project:read'] : ['project:admin']}>
-        <Stack flex={1} gap="2xl" padding="2xl">
-          <Layout.Title withMargins>{t('Create a new project')}</Layout.Title>
-          <Container maxWidth="760px">
-            <Text as="p" variant="muted">
-              {tct(
-                'Set up a separate project for each part of your application (for example, your API server and frontend client), to quickly pinpoint which part of your application errors are coming from. [link: Read the docs].',
-                {
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/create-new-project/" />
-                  ),
-                }
+        <Stack
+          flexGrow={1}
+          gap="lg"
+          padding="2xl"
+          alignSelf="center"
+          maxWidth={CREATE_PROJECT_MAX_WIDTH}
+        >
+          <LayoutGroup>
+            <Layout.Title withMargins>{t('Create a new project')}</Layout.Title>
+            <Container paddingBottom="lg">
+              <Text as="p" variant="muted">
+                {tct(
+                  'Set up a separate project for each part of your application (for example, your API server and frontend client), to quickly pinpoint which part of your application errors are coming from. [link: Read the docs].',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/create-new-project/" />
+                    ),
+                  }
+                )}
+              </Text>
+            </Container>
+
+            <MotionStack
+              gap="lg"
+              border="primary"
+              radius="md"
+              padding="lg"
+              layout="position"
+            >
+              <Stack gap="md">
+                <Heading as="h2" size="xl">
+                  {t('Create a new project')}
+                </Heading>
+                <Text variant="muted">
+                  {t('Pick a platform, name your project and choose what to monitor.')}
+                </Text>
+              </Stack>
+
+              <ScmIntegrationConnect
+                analyticsFlow="project-creation"
+                selectedIntegration={selectedIntegration}
+                selectedRepository={selectedRepository}
+                onIntegrationChange={handleIntegrationChange}
+                onRepositoryChange={handleRepositoryChange}
+                onClearDerivedState={handleClearDerivedState}
+                maxWidth={CREATE_PROJECT_MAX_WIDTH}
+              />
+              {showContinueWithoutRepo && (
+                <MotionFlex layout="position">
+                  <Button
+                    variant="transparent"
+                    analyticsEventKey="project_creation.scm_connect_skip_clicked"
+                    analyticsEventName="Project Creation: SCM Connect Skip Clicked"
+                    onClick={completeRepoStep}
+                  >
+                    {t('Continue without connecting a repo')}
+                  </Button>
+                </MotionFlex>
               )}
-            </Text>
-          </Container>
+            </MotionStack>
 
-          <ConnectRepositorySection onComplete={completeRepoStep} />
-
-          {state.repoStepCompleted && (
-            <Fragment>
-              <PlatformFeaturesSection />
-              <ProjectDetailsSection />
-            </Fragment>
-          )}
+            {showAllSteps && (
+              <Fragment>
+                <PlatformFeaturesSection />
+                <ProjectDetailsSection />
+              </Fragment>
+            )}
+          </LayoutGroup>
         </Stack>
       </Access>
     </SentryDocumentTitle>
   );
 }
 
-// Placeholder for VDY-74. Will be replaced with <ScmConnect />.
-function ConnectRepositorySection({onComplete}: {onComplete: () => void}) {
-  return (
-    <Stack gap="md">
-      <Heading as="h2" size="xl">
-        {t('Connect a repository')}
-      </Heading>
-      <Text variant="muted">{t('Connect step content goes here (VDY-74).')}</Text>
-      <Button variant="primary" onClick={onComplete}>
-        {t('Continue')}
-      </Button>
-    </Stack>
-  );
-}
-
 // Placeholder for VDY-75. Will be replaced with <ScmPlatformFeatures />.
 function PlatformFeaturesSection() {
   return (
-    <Stack gap="md">
+    <MotionStack layout="position" gap="lg" border="primary" radius="md" padding="lg">
       <Heading as="h2" size="xl">
         {t('Platform & features')}
       </Heading>
       <Text variant="muted">
         {t('Platform and features step content goes here (VDY-75).')}
       </Text>
-    </Stack>
+    </MotionStack>
   );
 }
 
 // Placeholder for VDY-76. Will be replaced with <ScmProjectDetails />.
 function ProjectDetailsSection() {
   return (
-    <Stack gap="md">
+    <MotionStack gap="lg" border="primary" radius="md" padding="lg" layout="position">
       <Heading as="h2" size="xl">
         {t('Project details')}
       </Heading>
       <Text variant="muted">{t('Project details step content goes here (VDY-76).')}</Text>
-    </Stack>
+    </MotionStack>
   );
 }
+
+const MotionStack = motion.create(Stack);
+const MotionFlex = motion.create(Flex);


### PR DESCRIPTION
## TL;DR
Replaces the placeholder section 1 in the SCM-first project creation view with `ScmIntegrationConnect` (the integration-and-repo connection core extracted in PR 3). `analyticsFlow="project-creation"` routes its events through `project_creation.scm_*` keys. The wizard provides its own "Continue without connecting a repo" button below the core for users who do not want to connect a repo; selecting a repo flips the reveal flag eagerly. Sections 2 and 3 remain placeholders pending VDY-75/76.

---

## Stack
- [PR 1](https://github.com/getsentry/sentry/pull/116434): Make decoupled SCM components flow-aware for analytics
- [PR 2](https://github.com/getsentry/sentry/pull/116577): Scaffold SCM-first project creation as a single view
- [PR 3](https://github.com/getsentry/sentry/pull/116581): Extract `ScmIntegrationConnect` from `ScmConnect`
- **PR 4 (this):** Wire `ScmIntegrationConnect` into the single-view scaffold

## Summary
- Replaces the placeholder `ConnectRepositorySection` in `scmCreateProject.tsx` with `<ScmIntegrationConnect analyticsFlow="project-creation" ... />`. None of the onboarding chrome (intro heading, lock/revoke text, benefits grid, Continue button) renders here.
- A small "Continue without connecting a repo" button sits below the core, shown only when no repo is selected. Clicking it fires `project_creation.scm_connect_skip_clicked` and flips `repoStepCompleted`.
- `handleRepositoryChange` wraps the core's `onRepositoryChange` so a non-null repo selection eagerly flips the reveal flag.
- `WizardState` gains `selectedIntegration` and `selectedRepository` so a refresh restores section 1 state.
- `handleClearDerivedState` is a no-op until VDY-75/76 wire platform/features/project state.

## Out of scope
- Wiring `<ScmPlatformFeatures />` and `<ScmProjectDetails />` into sections 2 and 3. VDY-75/76 will pick those up.
- `has_integration` analyticsParam on the skip event. The wizard does not call `useScmProviders` to derive `effectiveIntegration`; if signal demands it later, we can plumb that through.

Refs VDY-74

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint:js` clean on touched files
- [ ] With the experiment flag on, `/projects/new/` renders `ScmIntegrationConnect` in section 1 (no big benefits grid, no onboarding header)
- [ ] Selecting a repo reveals sections 2 and 3 together
- [ ] Clicking "Continue without connecting a repo" reveals sections 2 and 3 with no repo selected and fires `project_creation.scm_connect_skip_clicked`
- [ ] De-selecting a repo afterwards does not collapse sections 2 and 3
- [ ] Refreshing the page restores integration, repo, and revealed-state (sessionStorage round-trip)
- [ ] `project_creation.scm_connect_step_viewed` fires on page load