### PR TITLE
fix(issues): Make linked issue metadata clickable

### DIFF
--- a/static/app/components/groupMetaRow.tsx
+++ b/static/app/components/groupMetaRow.tsx
@@ -147,6 +147,8 @@ const GroupExtra = styled('div')`
   grid-auto-flow: column dense;
   justify-content: start;
   align-items: center;
+  position: relative;
+  z-index: 1;
   color: ${p => p.theme.tokens.content.secondary};
   font-size: ${p => p.theme.font.size.sm};
   white-space: nowrap;
@@ -200,6 +202,11 @@ const CommentsLink = styled(Link)`
 
 const Annotation = styled('span')`
   a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 20px;
+    margin: -2px;
+    padding: 2px;
     color: ${p => p.theme.tokens.content.secondary};
   }
 

--- a/static/app/components/groupMetaRow.tsx
+++ b/static/app/components/groupMetaRow.tsx
@@ -202,11 +202,6 @@ const CommentsLink = styled(Link)`
 
 const Annotation = styled('span')`
   a {
-    display: inline-flex;
-    align-items: center;
-    min-height: 20px;
-    margin: -2px;
-    padding: 2px;
     color: ${p => p.theme.tokens.content.secondary};
   }
 


### PR DESCRIPTION
Issue stream rows use the title link as a full-row click target. Linked issue annotations like Asana were sitting underneath that overlay.

fixes JAVASCRIPT-3A34