### PR TITLE
feat(issues): Add issue.agent search filter

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -952,6 +952,7 @@ SKIP_SNUBA_FIELDS = frozenset(
         "issue.type",
         "issue.seer_actionability",
         "issue.seer_last_run",
+        "issue.agent",
     )
 )
 

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -41,6 +41,7 @@ from sentry.search.utils import (
     parse_user_value,
 )
 from sentry.seer.autofix.constants import FixabilityScoreThresholds
+from sentry.types.activity import ActivityType
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, PriorityLevel
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -262,6 +263,29 @@ def convert_seer_actionability_value(
     return results
 
 
+ISSUE_AGENT_TO_ACTIVITY_TYPES: dict[str, list[int]] = {
+    "has_root_cause": [ActivityType.SEER_RCA_COMPLETED.value],
+    "has_plan": [ActivityType.SEER_SOLUTION_COMPLETED.value],
+    "has_code_changes": [ActivityType.SEER_CODING_COMPLETED.value],
+    "pr_created": [ActivityType.SEER_PR_CREATED.value],
+}
+
+
+def convert_issue_agent_value(
+    value: Iterable[str],
+    projects: Sequence[Project],
+    user: User,
+    environments: Sequence[Environment] | None,
+) -> list[int]:
+    results: list[int] = []
+    for status in value:
+        activity_types = ISSUE_AGENT_TO_ACTIVITY_TYPES.get(status)
+        if not activity_types:
+            raise InvalidSearchQuery(f"Invalid issue.agent value of '{status}'")
+        results.extend(activity_types)
+    return results
+
+
 def convert_detector_value(
     value: Iterable[str],
     projects: Sequence[Project],
@@ -287,6 +311,7 @@ value_converters: Mapping[str, ValueConverter] = {
     "device.class": convert_device_class_value,
     "substatus": convert_substatus_value,
     "issue.seer_actionability": convert_seer_actionability_value,
+    "issue.agent": convert_issue_agent_value,
     "detector": convert_detector_value,  # TODO - delete this once the UI has been updated
     "monitor": convert_detector_value,
 }

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -16,6 +16,7 @@ from sentry import quotas
 from sentry.api.event_search import SearchFilter
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.exceptions import InvalidSearchQuery
+from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
@@ -244,6 +245,15 @@ def regressed_in_release_filter(versions: Sequence[str], projects: Sequence[Proj
             status=GroupHistoryStatus.REGRESSED,
             project__in=projects,
         ).values_list("group_id", flat=True),
+    )
+
+
+def issue_agent_filter(activity_types: list[int], projects: Sequence[Project]) -> Q:
+    return Q(
+        id__in=Activity.objects.filter(
+            project__in=projects,
+            type__in=activity_types,
+        ).values_list("group_id", flat=True)
     )
 
 
@@ -595,6 +605,9 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "issue.type": QCallbackCondition(lambda types: Q(type__in=types)),
             "issue.priority": QCallbackCondition(lambda priorities: Q(priority__in=priorities)),
             "issue.seer_actionability": QCallbackCondition(seer_actionability_filter),
+            "issue.agent": QCallbackCondition(
+                functools.partial(issue_agent_filter, projects=projects)
+            ),
             "issue.seer_last_run": ScalarCondition("seer_explorer_autofix_last_triggered"),
             "issue.id": QCallbackCondition(
                 lambda ids: Q(id__in=[int(v) for v in (ids if isinstance(ids, list) else [ids])])

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -13,6 +13,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.grouptype import registry as GROUP_TYPE_REGISTRY
 from sentry.issues.issue_search import (
+    ISSUE_AGENT_TO_ACTIVITY_TYPES,
     convert_actor_or_none_value,
     convert_category_value,
     convert_device_class_value,
@@ -343,6 +344,25 @@ class ConvertSeerActionabilityValueTest(TestCase):
 
     def test_invalid(self) -> None:
         filters = [SearchFilter(SearchKey("issue.seer_actionability"), "=", SearchValue("wrong"))]
+        with pytest.raises(InvalidSearchQuery):
+            convert_query_values(filters, [self.project], self.user, None)
+
+
+class ConvertIssueAgentValueTest(TestCase):
+    def test_valid(self) -> None:
+        for status, activity_types in ISSUE_AGENT_TO_ACTIVITY_TYPES.items():
+            filters = [
+                SearchFilter(
+                    SearchKey("issue.agent"),
+                    "=",
+                    SearchValue([status]),
+                )
+            ]
+            result = convert_query_values(filters, [self.project], self.user, None)
+            assert result[0].value.raw_value == activity_types
+
+    def test_invalid(self) -> None:
+        filters = [SearchFilter(SearchKey("issue.agent"), "=", SearchValue("wrong"))]
         with pytest.raises(InvalidSearchQuery):
             convert_query_values(filters, [self.project], self.user, None)
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -32,6 +32,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus, PriorityLevel
 from sentry.utils import snuba
 from sentry.utils.snuba import SENTRY_SNUBA_MAP
@@ -1072,6 +1073,32 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             environments=[self.environments["staging"]], search_filter_query="is:linked"
         )
         assert set(results) == {linked_group2}
+
+    def test_issue_agent(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_RCA_COMPLETED.value)
+        self.create_group_activity(group=self.group2, type=ActivityType.SEER_PR_CREATED.value)
+
+        results = self.make_query(search_filter_query="issue.agent:has_root_cause")
+        assert set(results) == {self.group1}
+
+        results = self.make_query(search_filter_query="issue.agent:pr_created")
+        assert set(results) == {self.group2}
+
+        results = self.make_query(search_filter_query="issue.agent:has_plan")
+        assert set(results) == set()
+
+    def test_issue_agent_multiple_values(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_RCA_COMPLETED.value)
+        self.create_group_activity(group=self.group2, type=ActivityType.SEER_PR_CREATED.value)
+
+        results = self.make_query(search_filter_query="issue.agent:[has_root_cause, pr_created]")
+        assert set(results) == {self.group1, self.group2}
+
+    def test_issue_agent_negation(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_RCA_COMPLETED.value)
+
+        results = self.make_query(search_filter_query="!issue.agent:has_root_cause")
+        assert set(results) == {self.group2}
 
     def test_unassigned(self) -> None:
         results = self.make_query(search_filter_query="is:unassigned")


### PR DESCRIPTION
Ref ISWF-2760

Adds an `issue.agent` search filter so you can find issues by Seer activity. The value maps to the relevant `Activity` types: `has_root_cause` (SEER_RCA_COMPLETED), `has_plan` (SEER_SOLUTION_COMPLETED), `has_code_changes` (SEER_CODING_COMPLETED), and `pr_created` (SEER_PR_CREATED).

This filter is experimental and subject to change, it will not be documented until we're confident on the exact naming, fields, and behavior. But I did not find a reason for us to feature flag it in the meantime.

A new index was added in a previous PR to allow this to run performantly: https://github.com/getsentry/sentry/pull/116524