### PR TITLE
ref(explore): Remove raw search replacement flag checks

### DIFF
--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -72,10 +72,6 @@ function ConversationsOverviewPage() {
     'boolean'
   );
 
-  const hasRawSearchReplacement = organization.features.includes(
-    'search-query-builder-raw-search-replacement'
-  );
-
   const searchQueryBuilderProps: UseSpanSearchQueryBuilderProps = useMemo(
     () => ({
       initialQuery: searchQuery ?? '',
@@ -84,9 +80,7 @@ function ConversationsOverviewPage() {
         unsetCursor();
       },
       searchSource: 'conversations',
-      replaceRawSearchKeys: hasRawSearchReplacement
-        ? ['gen_ai.conversation.id', 'gen_ai.input.messages']
-        : undefined,
+      replaceRawSearchKeys: ['gen_ai.conversation.id', 'gen_ai.input.messages'],
       matchKeySuggestions: [
         {key: 'gen_ai.conversation.id', valuePattern: /^[0-9a-fA-F]{8,32}$/},
         {key: 'gen_ai.conversation.id', valuePattern: /^resp_/},
@@ -94,7 +88,7 @@ function ConversationsOverviewPage() {
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
       ],
     }),
-    [hasRawSearchReplacement, searchQuery, setSearchQuery, unsetCursor]
+    [searchQuery, setSearchQuery, unsetCursor]
   );
 
   const {spanSearchQueryBuilderProviderProps, spanSearchQueryBuilderProps} =

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -3,7 +3,6 @@ import {useCallback, useMemo} from 'react';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import type {TagCollection} from 'sentry/types/group';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {
   useTraceItemSearchQueryBuilderProps,
@@ -38,10 +37,6 @@ export function useLogsSearchQueryBuilderProps({
   const fields = useQueryParamsFields();
   const setQueryParams = useSetQueryParams();
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
-  const organization = useOrganization();
-  const hasRawSearchReplacement = organization.features.includes(
-    'search-query-builder-raw-search-replacement'
-  );
 
   const onSearch = useCallback(
     (newQuery: string) => {
@@ -85,7 +80,7 @@ export function useLogsSearchQueryBuilderProps({
       stringSecondaryAliases,
       caseInsensitive,
       onCaseInsensitiveClick: setCaseInsensitive,
-      replaceRawSearchKeys: hasRawSearchReplacement ? ['message'] : undefined,
+      replaceRawSearchKeys: ['message'],
       matchKeySuggestions: [{key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/}],
       hiddenAttributeKeys: HiddenLogSearchFields,
     }),
@@ -93,7 +88,6 @@ export function useLogsSearchQueryBuilderProps({
       booleanAttributes,
       booleanSecondaryAliases,
       caseInsensitive,
-      hasRawSearchReplacement,
       initialQuery,
       numberAttributes,
       numberSecondaryAliases,

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
@@ -5,7 +5,6 @@ import {
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
   type AggregationKey,
 } from 'sentry/utils/fields';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   TraceItemSearchQueryBuilder,
   useTraceItemSearchQueryBuilderProps,
@@ -31,10 +30,6 @@ export const SpansTabCrossEventSearchBar = memo(
     const mode = useQueryParamsMode();
     const crossEvents = useQueryParamsCrossEvents();
     const setCrossEvents = useSetQueryParamsCrossEvents();
-    const organization = useOrganization();
-    const hasRawSearchReplacement = organization.features.includes(
-      'search-query-builder-raw-search-replacement'
-    );
 
     const traceItemType =
       type === 'logs' ? TraceItemDataset.LOGS : TraceItemDataset.SPANS;
@@ -87,17 +82,12 @@ export const SpansTabCrossEventSearchBar = memo(
         booleanSecondaryAliases,
         numberSecondaryAliases,
         stringSecondaryAliases,
-        replaceRawSearchKeys: hasRawSearchReplacement
-          ? type === 'logs'
-            ? ['message']
-            : ['span.description']
-          : undefined,
+        replaceRawSearchKeys: type === 'logs' ? ['message'] : ['span.description'],
       }),
       [
         booleanAttributes,
         booleanSecondaryAliases,
         crossEvents,
-        hasRawSearchReplacement,
         index,
         mode,
         numberSecondaryAliases,

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -24,7 +24,6 @@ import {
   type AggregationKey,
 } from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {SchemaHintsList} from 'sentry/views/explore/components/schemaHints/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
@@ -77,11 +76,6 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
   const {selection} = usePageFilters();
 
-  const organization = useOrganization();
-  const hasRawSearchReplacement = organization.features.includes(
-    'search-query-builder-raw-search-replacement'
-  );
-
   const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
   const hasAbsoluteDateSelection = Boolean(
     selection.datetime.start && selection.datetime.end && !selection.datetime.period
@@ -128,7 +122,7 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
           : undefined,
       supportedAggregates:
         mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
-      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.description'] : undefined,
+      replaceRawSearchKeys: ['span.description'],
       matchKeySuggestions: [
         {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
@@ -140,7 +134,6 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
       booleanAttributes,
       caseInsensitive,
       fields,
-      hasRawSearchReplacement,
       mode,
       numberAttributes,
       oldSearch,


### PR DESCRIPTION
Raw search key replacement is now always enabled in the Explore spans, logs, and conversations search builders now that the rollout is complete.