### PR TITLE
chore(dashboards): Remove transaction widget explore flag

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -672,8 +672,7 @@ describe('Dashboards > WidgetCard', () => {
         widgetLimitReached={false}
         isPreview
         widgetLegendState={widgetLegendState}
-      />,
-      ['transaction-widget-deprecation-explore-view']
+      />
     );
 
     expect(await screen.findByLabelText('Widget warnings')).toBeInTheDocument();

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -57,7 +57,6 @@ export const useTransactionsDeprecationWarning = ({
   // memoize the URL to avoid recalculating it on every render
   const exploreUrl = useMemo(() => {
     if (
-      !organization.features.includes('transaction-widget-deprecation-explore-view') ||
       widget.widgetType !== WidgetType.TRANSACTIONS ||
       !widget.exploreUrls ||
       widget.exploreUrls.length === 0


### PR DESCRIPTION
Make the transaction widget deprecation Explore warning the default now that the frontend flag is fully rolled out.