### PR TITLE
feat(api-docs): publish organization trace endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -1,28 +1,84 @@
 import sentry_sdk
 from django.http import HttpRequest, HttpResponse
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors, update_snuba_params_with_timestamp
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.examples.trace_examples import TraceExamples
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.search.events.types import SnubaParams
-from sentry.snuba.trace import SerializedEvent, query_trace_data
+from sentry.snuba.trace import (
+    SerializedEvent,
+    SerializedIssue,
+    SerializedSpan,
+    SerializedUptimeCheck,
+    query_trace_data,
+)
 from sentry.utils.validators import is_event_id
 
+TRACE_ID_PATH_PARAM = OpenApiParameter(
+    name="trace_id",
+    location="path",
+    required=True,
+    type=str,
+    description="The ID of the trace, a 32-character hexadecimal string.",
+)
 
+REFERRER_QUERY_PARAM = OpenApiParameter(
+    name="referrer",
+    location="query",
+    required=False,
+    type=str,
+    description="Internal referrer identifier used for query tracing. Most clients can omit this.",
+)
+
+ERROR_ID_QUERY_PARAM = OpenApiParameter(
+    name="errorId",
+    location="query",
+    required=False,
+    type=str,
+    description="A 32-character hexadecimal event ID to bias the trace results toward including.",
+)
+
+ADDITIONAL_ATTRIBUTES_PARAM = OpenApiParameter(
+    name="additional_attributes",
+    location="query",
+    required=False,
+    many=True,
+    type=str,
+    description="Additional span attributes to include on each event. Repeat to request multiple.",
+)
+
+INCLUDE_UPTIME_PARAM = OpenApiParameter(
+    name="include_uptime",
+    location="query",
+    required=False,
+    type=str,
+    enum=["0", "1"],
+    description="Set to `1` to include uptime check results in the trace. Defaults to `0`.",
+)
+
+
+@extend_schema(tags=["Discover"])
 @cell_silo_endpoint
 class OrganizationTraceEndpoint(OrganizationEventsEndpointBase):
     """Replaces OrganizationEventsTraceEndpoint"""
 
+    owner = ApiOwner.EXPLORE
     publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PUBLIC,
     }
 
     def get_projects(
@@ -69,7 +125,38 @@ class OrganizationTraceEndpoint(OrganizationEventsEndpointBase):
             organization=organization,
         )
 
+    @extend_schema(
+        operation_id="Retrieve a Trace",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            TRACE_ID_PATH_PARAM,
+            GlobalParams.STATS_PERIOD,
+            GlobalParams.START,
+            GlobalParams.END,
+            REFERRER_QUERY_PARAM,
+            ERROR_ID_QUERY_PARAM,
+            ADDITIONAL_ATTRIBUTES_PARAM,
+            INCLUDE_UPTIME_PARAM,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "OrganizationTraceResponse",
+                list[SerializedSpan | SerializedIssue | SerializedUptimeCheck],
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=TraceExamples.TRACE,
+    )
     def get(self, request: Request, organization: Organization, trace_id: str) -> HttpResponse:
+        """
+        Retrieve the spans, errors, and (optionally) uptime checks that make up a single trace.
+
+        The response is a list of top-level events; each item may have nested `children`, `errors`,
+        and `occurrences` arrays representing related items. Top-level entries are spans by default
+        and may also be uptime checks when `include_uptime=1` is passed.
+        """
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/apidocs/examples/trace_examples.py
+++ b/src/sentry/apidocs/examples/trace_examples.py
@@ -20,11 +20,44 @@ TRACE_META: OrganizationTraceMetaResponse = {
 }
 
 
+TRACE_SPAN = {
+    "event_id": "0123456789abcdef0123456789abcdef",
+    "event_type": "span",
+    "transaction_id": "280027d94f30428c83a2de46f932612a",
+    "project_id": 4505281256090153,
+    "project_slug": "javascript",
+    "transaction": "POST /api/0/projects/{org}/{proj}/events/{event_id}/attachments/",
+    "description": "POST /api/0/projects/{org}/{proj}/events/{event_id}/attachments/",
+    "op": "http.server",
+    "name": "http.server",
+    "parent_span_id": None,
+    "profile_id": "",
+    "profiler_id": "",
+    "sdk_name": "sentry.python",
+    "is_transaction": True,
+    "start_timestamp": "2026-04-15T18:22:31.000000Z",
+    "end_timestamp": "2026-04-15T18:22:31.250000Z",
+    "duration": 250.0,
+    "measurements": {},
+    "children": [],
+    "errors": [],
+    "occurrences": [],
+}
+
+
 class TraceExamples:
     TRACE_META = [
         OpenApiExample(
             "Return aggregate metadata for a trace",
             value=TRACE_META,
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]
+    TRACE = [
+        OpenApiExample(
+            "Return the spans, errors, and occurrences of a trace",
+            value=[TRACE_SPAN],
             response_only=True,
             status_codes=["200"],
         )

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -66,7 +66,7 @@ class SerializedIssue(SerializedEvent):
     end_timestamp: NotRequired[float]
     culprit: str | None
     short_id: str | None
-    issue_type: str
+    issue_type: int
 
 
 class SerializedSpan(SerializedEvent):


### PR DESCRIPTION
Publish `OrganizationTraceEndpoint`, as part of https://linear.app/getsentry/project/api-docs-for-agents-c7863fd8bbe0/overview. This primarily involves defining the query parameters via `extend_schema` and adding an example.