### PR TITLE
feat(api-docs): publish project profiling profile endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import orjson
 from django.http import HttpResponse
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -11,9 +12,21 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.examples.profiling_examples import ProfilingExamples
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.profiles.utils import get_from_profiling_service, proxy_profiling_service
+
+PROFILE_ID_PATH_PARAM = OpenApiParameter(
+    name="profile_id",
+    location="path",
+    required=True,
+    type=str,
+    description="The ID of the profile. Either a numeric ID or a 32-character hexadecimal string.",
+)
 
 
 class ProjectProfilingBaseEndpoint(ProjectEndpoint):
@@ -23,9 +36,39 @@ class ProjectProfilingBaseEndpoint(ProjectEndpoint):
     }
 
 
+@extend_schema(tags=["Profiling"])
 @cell_silo_endpoint
 class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
+
+    @extend_schema(
+        operation_id="Retrieve a Profile",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            PROFILE_ID_PATH_PARAM,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ProjectProfilingProfileResponse", dict[str, Any]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=ProfilingExamples.PROFILE_DETAILS,
+    )
     def get(self, request: Request, project: Project, profile_id: str) -> HttpResponse:
+        """
+        Retrieve a single profile by its ID.
+
+        The response includes the profile's metadata, its sampled stack data, and the
+        associated release, when one is found.
+
+        Requires profiling to be enabled for the organization.
+        """
         if not features.has("organizations:profiling", project.organization, actor=request.user):
             return Response(status=404)
 

--- a/src/sentry/apidocs/examples/profiling_examples.py
+++ b/src/sentry/apidocs/examples/profiling_examples.py
@@ -110,11 +110,80 @@ FLAMEGRAPH_RESPONSE: dict[str, Any] = {
 }
 
 
+PROFILE_DETAILS_RESPONSE = {
+    "event_id": "9b29bbe17e9d4ee3a6d0fe9b2e8a3b1c",
+    "project_id": 1,
+    "version": "2",
+    "platform": "python",
+    "environment": "production",
+    "received": "2026-04-15T18:22:31.000Z",
+    "timestamp": "2026-04-15T18:22:31.000Z",
+    "release": {
+        "id": 123456,
+        "version": "1.0.0",
+        "status": "open",
+        "shortVersion": "1.0.0",
+        "versionInfo": {
+            "package": None,
+            "version": {"raw": "1.0.0"},
+            "description": "1.0.0",
+            "buildHash": None,
+        },
+        "ref": None,
+        "url": None,
+        "dateReleased": "2026-04-15T18:00:00Z",
+        "dateCreated": "2026-04-15T18:00:00Z",
+        "data": {},
+        "newGroups": 0,
+        "owner": None,
+        "commitCount": 0,
+        "lastCommit": None,
+        "deployCount": 0,
+        "lastDeploy": None,
+        "authors": [],
+        "projects": [
+            {"id": 1, "slug": "my-project", "name": "my-project", "platform": "python"}
+        ],
+        "firstEvent": "2026-04-15T18:05:00Z",
+        "lastEvent": "2026-04-15T18:30:00Z",
+        "currentProjectMeta": {},
+    },
+    "os": {"name": "Linux", "version": "5.15.0", "build_number": ""},
+    "device": {"architecture": "x86_64"},
+    "runtime": {"name": "CPython", "version": "3.13.0"},
+    "profile": {
+        "samples": [
+            {"stack_id": 0, "thread_id": 1, "elapsed_since_start_ns": 1_000_000},
+        ],
+        "stacks": [[0, 1]],
+        "frames": [
+            {"function": "main", "module": "app.main", "in_app": True, "lineno": 10},
+            {"function": "do_work", "module": "app.worker", "in_app": True, "lineno": 42},
+        ],
+        "thread_metadata": {"1": {"name": "MainThread"}},
+    },
+    "transaction": {
+        "name": "GET /api/0/projects/{org}/{proj}/files/dsyms/",
+        "trace_id": "0123456789abcdef0123456789abcdef",
+        "id": "9b29bbe17e9d4ee3a6d0fe9b2e8a3b1c",
+        "active_thread_id": 1,
+    },
+}
+
+
 class ProfilingExamples:
     FLAMEGRAPH = [
         OpenApiExample(
             "Return a flamegraph for the organization",
             value=FLAMEGRAPH_RESPONSE,
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]
+    PROFILE_DETAILS = [
+        OpenApiExample(
+            "Return a single profile by ID",
+            value=PROFILE_DETAILS_RESPONSE,
             response_only=True,
             status_codes=["200"],
         )

--- a/src/sentry/apidocs/examples/profiling_examples.py
+++ b/src/sentry/apidocs/examples/profiling_examples.py
@@ -141,9 +141,7 @@ PROFILE_DETAILS_RESPONSE = {
         "deployCount": 0,
         "lastDeploy": None,
         "authors": [],
-        "projects": [
-            {"id": 1, "slug": "my-project", "name": "my-project", "platform": "python"}
-        ],
+        "projects": [{"id": 1, "slug": "my-project", "name": "my-project", "platform": "python"}],
         "firstEvent": "2026-04-15T18:05:00Z",
         "lastEvent": "2026-04-15T18:30:00Z",
         "currentProjectMeta": {},


### PR DESCRIPTION
Publish `ProjectProfilingProfileEndpoint`, as part of https://www.notion.so/sentry/Supergroup-Ingestion-3678b10e4b5d80e6ac3dd56aec05c03a?source=copy_link. Adds an example of a profiling response.