### PR TITLE
feat(seer): Add flag to roll out structured page context to all orgs

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -261,6 +261,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-night-shift-settings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable context engine for Seer Agent
     manager.add("organizations:seer-explorer-context-engine", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Roll out structured LLM page context on STRUCTURED_CONTEXT_ROUTES to all orgs
+    manager.add("organizations:seer-explorer-structured-context-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable context engine experimental contexts
     manager.add("organizations:context-engine-experiments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable frontend override for context engine (only for AI/ML/Reasoning platform team)


### PR DESCRIPTION
+ Register organizations:seer-explorer-structured-context-rollout so the Seer Explorer frontend can gate STRUCTURED_CONTEXT_ROUTES on a single dedicated flag. This enables a controlled FlagPole percentage rollout (10/40/100%) of the structured LLM page context to all orgs, replacing the previous OR of broad "has Seer" flags that left no rollout knob.