### PR TITLE
feat(search): Add pluggable Postgres-data sort framework for issue search

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -6,6 +6,7 @@ import time
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from datetime import datetime, timedelta
 from enum import Enum, auto
 from hashlib import md5
@@ -78,6 +79,24 @@ DEFAULT_TRENDS_WEIGHTS: TrendsSortWeights = {
 class Clauses(Enum):
     HAVING = auto()
     WHERE = auto()
+
+
+@dataclass(frozen=True)
+class PostgresSortStrategy:
+    """A sort strategy that uses Postgres Group model data, optionally combined with Snuba."""
+
+    postgres_fields: dict[str, str]
+    snuba_aggregations: list[str] = dataclass_field(default_factory=list)
+    score_fn: Callable[[dict[str, Any]], int] = lambda data: 0
+    field_resolvers: dict[str, Callable[[Organization, Any], str]] | None = None
+    exclude_null_postgres: bool = True
+    snuba_fallback: str | None = None
+
+
+def _datetime_to_ms(dt: datetime | None) -> int:
+    if dt is None:
+        return 0
+    return int(float(dt.strftime("%s.%f")) * 1000)
 
 
 # we cannot use snuba for these fields because they require a join with tables that don't exist there
@@ -583,7 +602,9 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         return _run_snuba_query()
 
     def has_sort_strategy(self, sort_by: str) -> bool:
-        return sort_by in self.sort_strategies.keys()
+        return sort_by in self.sort_strategies or sort_by in getattr(
+            self, "postgres_sort_strategies", {}
+        )
 
 
 def trends_aggregation(
@@ -884,6 +905,236 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
     def dataset(self) -> Dataset:
         return Dataset.Events
 
+    @property
+    def postgres_sort_strategies(self) -> dict[str, PostgresSortStrategy]:
+        return {}
+
+    def _apply_type_visibility_filter(
+        self,
+        group_queryset: BaseQuerySet,
+        search_filters: Sequence[SearchFilter] | None,
+    ) -> BaseQuerySet:
+        from sentry.issues.search import group_types_from
+
+        visible_type_ids = group_types_from(search_filters)
+        return group_queryset.filter(type__in=visible_type_ids)
+
+    def _resolve_pg_sort_fields(
+        self,
+        strategy: PostgresSortStrategy,
+        organization: Organization,
+        actor: Any | None,
+    ) -> dict[str, str]:
+        resolved: dict[str, str] = {}
+        for logical_name, default_field in strategy.postgres_fields.items():
+            if strategy.field_resolvers and logical_name in strategy.field_resolvers:
+                resolved[logical_name] = strategy.field_resolvers[logical_name](organization, actor)
+            else:
+                resolved[logical_name] = default_field
+        return resolved
+
+    def _pure_postgres_sort(
+        self,
+        strategy: PostgresSortStrategy,
+        field_name: str,
+        group_queryset: BaseQuerySet,
+        search_filters: Sequence[SearchFilter] | None,
+        limit: int,
+        cursor: Cursor | None,
+        count_hits: bool,
+        paginator_options: Mapping[str, Any],
+        max_hits: int | None,
+    ) -> CursorResult[Group]:
+        group_queryset = self._apply_type_visibility_filter(group_queryset, search_filters)
+        if strategy.exclude_null_postgres:
+            group_queryset = group_queryset.filter(**{f"{field_name}__isnull": False})
+        group_queryset = group_queryset.using_replica().order_by(f"-{field_name}")
+        paginator = DateTimePaginator(group_queryset, f"-{field_name}", **paginator_options)
+        return paginator.get_result(limit, cursor, count_hits=count_hits, max_hits=max_hits)
+
+    def _execute_postgres_sort(
+        self,
+        strategy: PostgresSortStrategy,
+        sort_by: str,
+        group_queryset: BaseQuerySet,
+        projects: Sequence[Project],
+        environments: Sequence[Environment] | None,
+        search_filters: Sequence[SearchFilter] | None,
+        limit: int,
+        cursor: Cursor | None,
+        count_hits: bool,
+        paginator_options: Mapping[str, Any],
+        max_hits: int | None,
+        actor: Any | None,
+        start: datetime,
+        end: datetime,
+        *,
+        referrer: str,
+    ) -> CursorResult[Group] | None:
+        """Execute a sort using Postgres data, with optional Snuba filtering/aggregation.
+
+        Returns None to signal the caller should fall back to the Snuba-only path.
+        """
+        from sentry.exceptions import InvalidSearchQuery
+
+        organization = projects[0].organization
+        resolved_fields = self._resolve_pg_sort_fields(strategy, organization, actor)
+
+        group_queryset = self._apply_type_visibility_filter(group_queryset, search_filters)
+        if strategy.exclude_null_postgres:
+            for model_field in resolved_fields.values():
+                group_queryset = group_queryset.filter(**{f"{model_field}__isnull": False})
+
+        has_snuba_filters = bool(
+            [
+                sf
+                for sf in (search_filters or ())
+                if sf.key.name not in self.postgres_only_fields.union({"date", "timestamp"})
+            ]
+        )
+
+        max_candidates = options.get("snuba.search.max-pre-snuba-candidates")
+        candidate_ids = list(
+            group_queryset.using_replica().values_list("id", flat=True)[: max_candidates + 1]
+        )
+
+        if not candidate_ids:
+            return self.empty_result
+
+        if len(candidate_ids) > max_candidates:
+            if strategy.snuba_fallback and strategy.snuba_fallback in self.sort_strategies:
+                return None
+            raise InvalidSearchQuery(
+                f"Sort by '{sort_by}' requires more specific filters. "
+                "Try adding 'is:unresolved', 'assigned:me', or project filters."
+            )
+
+        snuba_data: dict[int, dict[str, Any]] = {}
+
+        if has_snuba_filters and strategy.snuba_aggregations:
+            snuba_data = self._snuba_search_raw(
+                start=start,
+                end=end,
+                project_ids=[p.id for p in projects],
+                environment_ids=[env.id for env in environments] if environments else None,
+                organization=organization,
+                required_aggregations=strategy.snuba_aggregations,
+                group_ids=candidate_ids,
+                search_filters=search_filters,
+                actor=actor,
+                referrer=referrer,
+            )
+            candidate_ids = list(snuba_data.keys())
+        elif has_snuba_filters:
+            snuba_groups, _ = self.snuba_search(
+                start=start,
+                end=end,
+                project_ids=[p.id for p in projects],
+                environment_ids=[env.id for env in environments] if environments else None,
+                organization=organization,
+                sort_field="last_seen",
+                cursor=None,
+                group_ids=candidate_ids,
+                limit=len(candidate_ids),
+                offset=0,
+                search_filters=search_filters,
+                referrer=referrer,
+                actor=actor,
+            )
+            candidate_ids = [gid for gid, _ in snuba_groups]
+        elif strategy.snuba_aggregations:
+            snuba_data = self._snuba_search_raw(
+                start=start,
+                end=end,
+                project_ids=[p.id for p in projects],
+                environment_ids=[env.id for env in environments] if environments else None,
+                organization=organization,
+                required_aggregations=strategy.snuba_aggregations,
+                group_ids=candidate_ids,
+                search_filters=search_filters,
+                actor=actor,
+                referrer=referrer,
+            )
+            candidate_ids = list(snuba_data.keys())
+
+        if not candidate_ids:
+            return self.empty_result
+
+        pg_value_fields = list(resolved_fields.values())
+        logical_names = list(resolved_fields.keys())
+        pg_rows = (
+            group_queryset.filter(id__in=candidate_ids)
+            .using_replica()
+            .values_list("id", *pg_value_fields)
+        )
+        pg_data: dict[int, dict[str, Any]] = {}
+        for row in pg_rows:
+            gid = row[0]
+            pg_data[gid] = {logical_names[i]: row[i + 1] for i in range(len(logical_names))}
+
+        scored_groups: list[tuple[int, int]] = []
+        for gid in candidate_ids:
+            pg_values = pg_data.get(gid)
+            if pg_values is None:
+                continue
+            merged = {**pg_values, **snuba_data.get(gid, {})}
+            try:
+                score = strategy.score_fn(merged)
+            except (TypeError, KeyError):
+                continue
+            scored_groups.append((score, gid))
+
+        if not scored_groups:
+            return self.empty_result
+
+        paginator_results = SequencePaginator(
+            scored_groups, reverse=True, **paginator_options
+        ).get_result(limit, cursor, count_hits=count_hits, max_hits=max_hits)
+
+        groups = Group.objects.in_bulk(paginator_results.results)
+        paginator_results.results = [groups[k] for k in paginator_results.results if k in groups]
+        return paginator_results
+
+    def _snuba_search_raw(
+        self,
+        start: datetime,
+        end: datetime,
+        project_ids: Sequence[int],
+        environment_ids: Sequence[int] | None,
+        organization: Organization,
+        required_aggregations: list[str],
+        group_ids: Sequence[int],
+        search_filters: Sequence[SearchFilter] | None = None,
+        actor: Any | None = None,
+        *,
+        referrer: str,
+    ) -> dict[int, dict[str, Any]]:
+        """Like snuba_search(), but returns raw aggregation values per group."""
+        snuba_groups, _ = self.snuba_search(
+            start=start,
+            end=end,
+            project_ids=project_ids,
+            environment_ids=environment_ids,
+            organization=organization,
+            sort_field="last_seen",
+            cursor=None,
+            group_ids=list(group_ids),
+            limit=len(group_ids),
+            offset=0,
+            search_filters=search_filters,
+            referrer=referrer,
+            actor=actor,
+        )
+        if not snuba_groups:
+            return {}
+
+        # TODO: Extract shared plumbing from snuba_search() to return all
+        # requested aggregation columns, not just the sort score.
+        result: dict[int, dict[str, Any]] = {}
+        for gid, score in snuba_groups:
+            result[gid] = {"last_seen": score}
+        return result
+
     def query(
         self,
         projects: Sequence[Project],
@@ -951,6 +1202,65 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             # in the future we should find a way to notify the user that their search
             # is invalid.
             return self.empty_result
+
+        pg_strategy = self.postgres_sort_strategies.get(sort_by)
+        if pg_strategy is not None:
+            has_snuba_filters = bool(
+                [
+                    sf
+                    for sf in (search_filters or ())
+                    if sf.key.name not in self.postgres_only_fields.union({"date", "timestamp"})
+                ]
+            )
+
+            if not pg_strategy.snuba_aggregations and not has_snuba_filters:
+                organization = projects[0].organization
+                resolved = self._resolve_pg_sort_fields(pg_strategy, organization, actor)
+                first_field = next(iter(resolved.values()))
+                result = self._pure_postgres_sort(
+                    strategy=pg_strategy,
+                    field_name=first_field,
+                    group_queryset=group_queryset,
+                    search_filters=search_filters,
+                    limit=limit,
+                    cursor=cursor,
+                    count_hits=count_hits,
+                    paginator_options=paginator_options,
+                    max_hits=max_hits,
+                )
+                metrics.timing(
+                    "snuba.search.query",
+                    (timezone.now() - now).total_seconds(),
+                    tags={"postgres_only": True, "sort": sort_by},
+                )
+                return result
+
+            result = self._execute_postgres_sort(
+                strategy=pg_strategy,
+                sort_by=sort_by,
+                group_queryset=group_queryset,
+                projects=projects,
+                environments=environments,
+                search_filters=search_filters,
+                limit=limit,
+                cursor=cursor,
+                count_hits=count_hits,
+                paginator_options=paginator_options,
+                max_hits=max_hits,
+                actor=actor,
+                start=start,
+                end=end,
+                referrer=referrer,
+            )
+            if result is not None:
+                metrics.timing(
+                    "snuba.search.query",
+                    (timezone.now() - now).total_seconds(),
+                    tags={"postgres_only": False, "sort": sort_by},
+                )
+                return result
+            # Fall through to Snuba path with fallback sort
+            sort_by = pg_strategy.snuba_fallback or sort_by
 
         # If the requested sort is `date` (`last_seen`) and there
         # are no other Snuba-based search predicates, we can simply

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -14,6 +14,7 @@ from math import floor
 from typing import Any, TypedDict, cast
 
 import sentry_sdk
+from django.db.models import DateTimeField
 from django.utils import timezone
 from snuba_sdk.query import Query
 
@@ -941,7 +942,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         group_queryset = group_queryset.using_replica().order_by(f"-{field_name}")
         # DateTimePaginator encodes the cursor as a millisecond integer, which only works
         # for datetime columns. Numeric columns carry their value directly via Paginator.
-        is_datetime = Group._meta.get_field(field_name).get_internal_type() == "DateTimeField"
+        is_datetime = isinstance(Group._meta.get_field(field_name), DateTimeField)
         paginator_cls = DateTimePaginator if is_datetime else Paginator
         paginator = paginator_cls(group_queryset, f"-{field_name}", **paginator_options)
         return paginator.get_result(limit, cursor, count_hits=count_hits, max_hits=max_hits)
@@ -1068,7 +1069,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             for name, resolver in strategy.signal_resolvers.items()
         }
 
-        scored_groups: list[tuple[float, int]] = []
+        scored_groups: list[tuple[Any, int]] = []
         for gid in candidate_ids:
             pg_values = pg_data.get(gid)
             if pg_values is None:

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -87,10 +87,14 @@ class PostgresSortStrategy:
 
     postgres_fields: dict[str, str]
     snuba_aggregations: list[str] = dataclass_field(default_factory=list)
-    score_fn: Callable[[dict[str, Any]], int] = lambda data: 0
-    field_resolvers: dict[str, Callable[[Organization, Any], str]] | None = None
+    # Computed signals that aren't a single Group column (e.g. assignment affinity).
+    # Each resolver is called once in bulk with (actor, organization, group_ids) and
+    # returns {group_id: value}; the value is merged into the score_fn dict under its key.
+    signal_resolvers: dict[str, Callable[[Any, Organization, list[int]], dict[int, Any]]] = (
+        dataclass_field(default_factory=dict)
+    )
+    score_fn: Callable[[dict[str, Any]], float] = lambda data: 0.0
     exclude_null_postgres: bool = True
-    snuba_fallback: str | None = None
 
 
 def _datetime_to_ms(dt: datetime | None) -> int:
@@ -919,20 +923,6 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         visible_type_ids = group_types_from(search_filters)
         return group_queryset.filter(type__in=visible_type_ids)
 
-    def _resolve_pg_sort_fields(
-        self,
-        strategy: PostgresSortStrategy,
-        organization: Organization,
-        actor: Any | None,
-    ) -> dict[str, str]:
-        resolved: dict[str, str] = {}
-        for logical_name, default_field in strategy.postgres_fields.items():
-            if strategy.field_resolvers and logical_name in strategy.field_resolvers:
-                resolved[logical_name] = strategy.field_resolvers[logical_name](organization, actor)
-            else:
-                resolved[logical_name] = default_field
-        return resolved
-
     def _pure_postgres_sort(
         self,
         strategy: PostgresSortStrategy,
@@ -949,7 +939,11 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         if strategy.exclude_null_postgres:
             group_queryset = group_queryset.filter(**{f"{field_name}__isnull": False})
         group_queryset = group_queryset.using_replica().order_by(f"-{field_name}")
-        paginator = DateTimePaginator(group_queryset, f"-{field_name}", **paginator_options)
+        # DateTimePaginator encodes the cursor as a millisecond integer, which only works
+        # for datetime columns. Numeric columns carry their value directly via Paginator.
+        is_datetime = Group._meta.get_field(field_name).get_internal_type() == "DateTimeField"
+        paginator_cls = DateTimePaginator if is_datetime else Paginator
+        paginator = paginator_cls(group_queryset, f"-{field_name}", **paginator_options)
         return paginator.get_result(limit, cursor, count_hits=count_hits, max_hits=max_hits)
 
     def _execute_postgres_sort(
@@ -973,12 +967,11 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
     ) -> CursorResult[Group] | None:
         """Execute a sort using Postgres data, with optional Snuba filtering/aggregation.
 
-        Returns None to signal the caller should fall back to the Snuba-only path.
+        Returns None to signal the caller should fall back to the Snuba-only path (e.g.
+        when there are too many candidates to score in memory).
         """
-        from sentry.exceptions import InvalidSearchQuery
-
         organization = projects[0].organization
-        resolved_fields = self._resolve_pg_sort_fields(strategy, organization, actor)
+        resolved_fields = strategy.postgres_fields
 
         group_queryset = self._apply_type_visibility_filter(group_queryset, search_filters)
         if strategy.exclude_null_postgres:
@@ -1002,12 +995,9 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             return self.empty_result
 
         if len(candidate_ids) > max_candidates:
-            if strategy.snuba_fallback and strategy.snuba_fallback in self.sort_strategies:
-                return None
-            raise InvalidSearchQuery(
-                f"Sort by '{sort_by}' requires more specific filters. "
-                "Try adding 'is:unresolved', 'assigned:me', or project filters."
-            )
+            # Too many candidates to score in memory. Signal the caller to fall through
+            # to the Snuba chunked path, which can paginate without an in-memory bound.
+            return None
 
         snuba_data: dict[int, dict[str, Any]] = {}
 
@@ -1072,12 +1062,21 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             gid = row[0]
             pg_data[gid] = {logical_names[i]: row[i + 1] for i in range(len(logical_names))}
 
-        scored_groups: list[tuple[int, int]] = []
+        # Each signal resolver runs once over all candidates, returning {group_id: value}.
+        signal_data: dict[str, dict[int, Any]] = {
+            name: resolver(actor, organization, candidate_ids)
+            for name, resolver in strategy.signal_resolvers.items()
+        }
+
+        scored_groups: list[tuple[float, int]] = []
         for gid in candidate_ids:
             pg_values = pg_data.get(gid)
             if pg_values is None:
                 continue
             merged = {**pg_values, **snuba_data.get(gid, {})}
+            for name, values in signal_data.items():
+                if gid in values:
+                    merged[name] = values[gid]
             try:
                 score = strategy.score_fn(merged)
             except (TypeError, KeyError):
@@ -1215,12 +1214,11 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
 
             if (
                 not pg_strategy.snuba_aggregations
+                and not pg_strategy.signal_resolvers
                 and not has_snuba_filters
                 and len(pg_strategy.postgres_fields) == 1
             ):
-                organization = projects[0].organization
-                resolved = self._resolve_pg_sort_fields(pg_strategy, organization, actor)
-                first_field = next(iter(resolved.values()))
+                first_field = next(iter(pg_strategy.postgres_fields.values()))
                 result = self._pure_postgres_sort(
                     strategy=pg_strategy,
                     field_name=first_field,
@@ -1263,8 +1261,10 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                     tags={"postgres_only": False, "sort": sort_by},
                 )
                 return pg_result
-            # Fall through to Snuba path with fallback sort
-            sort_by = pg_strategy.snuba_fallback or sort_by
+            # Overflow: too many candidates to score in memory. Fall through to the Snuba
+            # chunked path. If this sort has no Snuba-only equivalent, fall back to `date`.
+            if sort_by not in self.sort_strategies:
+                sort_by = "date"
 
         # If the requested sort is `date` (`last_seen`) and there
         # are no other Snuba-based search predicates, we can simply

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1213,7 +1213,11 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 ]
             )
 
-            if not pg_strategy.snuba_aggregations and not has_snuba_filters:
+            if (
+                not pg_strategy.snuba_aggregations
+                and not has_snuba_filters
+                and len(pg_strategy.postgres_fields) == 1
+            ):
                 organization = projects[0].organization
                 resolved = self._resolve_pg_sort_fields(pg_strategy, organization, actor)
                 first_field = next(iter(resolved.values()))
@@ -1235,7 +1239,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 )
                 return result
 
-            result = self._execute_postgres_sort(
+            pg_result = self._execute_postgres_sort(
                 strategy=pg_strategy,
                 sort_by=sort_by,
                 group_queryset=group_queryset,
@@ -1252,13 +1256,13 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 end=end,
                 referrer=referrer,
             )
-            if result is not None:
+            if pg_result is not None:
                 metrics.timing(
                     "snuba.search.query",
                     (timezone.now() - now).total_seconds(),
                     tags={"postgres_only": False, "sort": sort_by},
                 )
-                return result
+                return pg_result
             # Fall through to Snuba path with fallback sort
             sort_by = pg_strategy.snuba_fallback or sort_by
 

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -7,7 +7,6 @@ from unittest import mock
 import pytest
 from django.utils import timezone
 
-from sentry.exceptions import InvalidSearchQuery
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.issue_search import convert_query_values, parse_search_query
 from sentry.models.group import Group, GroupStatus
@@ -57,9 +56,8 @@ class TestPostgresSortStrategy(TestCase):
     def test_defaults(self):
         s = PostgresSortStrategy(postgres_fields={"ts": "last_seen"})
         assert s.snuba_aggregations == []
-        assert s.field_resolvers is None
+        assert s.signal_resolvers == {}
         assert s.exclude_null_postgres is True
-        assert s.snuba_fallback is None
 
     def test_frozen(self):
         s = PostgresSortStrategy(postgres_fields={"ts": "last_seen"})
@@ -85,28 +83,6 @@ class TestHasSortStrategy(TestCase):
         with _patch_pg_strategies({"custom": _ts_strategy()}):
             assert executor.has_sort_strategy("custom") is True
             assert executor.has_sort_strategy("date") is True
-
-
-class TestResolveFields(TestCase):
-    def test_default_fields(self):
-        executor = PostgresSnubaQueryExecutor()
-        strategy = PostgresSortStrategy(postgres_fields={"ts": "last_seen", "prio": "priority"})
-        org = self.create_organization()
-        assert executor._resolve_pg_sort_fields(strategy, org, None) == {
-            "ts": "last_seen",
-            "prio": "priority",
-        }
-
-    def test_field_resolver_overrides(self):
-        executor = PostgresSnubaQueryExecutor()
-        strategy = PostgresSortStrategy(
-            postgres_fields={"ts": "default_field", "prio": "priority"},
-            field_resolvers={"ts": lambda org, actor: "resolved_field"},
-        )
-        org = self.create_organization()
-        resolved = executor._resolve_pg_sort_fields(strategy, org, None)
-        assert resolved["ts"] == "resolved_field"
-        assert resolved["prio"] == "priority"
 
 
 class PostgresSortTestBase(TestCase, SnubaTestCase):
@@ -206,6 +182,15 @@ class TestPurePostgresSort(PostgresSortTestBase):
                 assert len(results) == 3
                 assert not snuba_spy.called
 
+    def test_numeric_column_ordering(self):
+        for group, score in zip(self.groups, [0.1, 0.9, 0.5]):
+            group.seer_fixability_score = score
+            group.save()
+        strategy = PostgresSortStrategy(postgres_fields={"fix": "seer_fixability_score"})
+        with _patch_pg_strategies({"test_sort": strategy}):
+            results = list(self.make_query("test_sort"))
+        assert results == [self.groups[1], self.groups[2], self.groups[0]]
+
 
 class TestExecutePostgresSort(PostgresSortTestBase):
     def test_snuba_filter_narrows_candidates(self):
@@ -232,6 +217,17 @@ class TestExecutePostgresSort(PostgresSortTestBase):
         with _patch_pg_strategies({"test_sort": strategy}):
             results = list(self.make_query("test_sort", query="issue"))
         assert len(results) == 3
+
+    def test_signal_resolver_influences_score(self):
+        boosted = self.groups[0].id
+        strategy = _ts_strategy(
+            signal_resolvers={"boost": lambda actor, org, gids: {boosted: 1}},
+            score_fn=lambda data: data.get("boost", 0) * 10**15 + _datetime_to_ms(data["ts"]),
+        )
+        with _patch_pg_strategies({"test_sort": strategy}):
+            results = list(self.make_query("test_sort"))
+        # groups[0] is the oldest (normally last) but the boost floats it to the top.
+        assert results == [self.groups[0], self.groups[2], self.groups[1]]
 
     def test_cursor_pagination_with_snuba_filter(self):
         for i in range(5):
@@ -264,51 +260,24 @@ class TestExecutePostgresSort(PostgresSortTestBase):
 
 
 class TestFallbackBehavior(PostgresSortTestBase):
-    def test_fallback_to_snuba_sort(self):
-        """When _execute_postgres_sort returns None, falls through to Snuba path."""
-        strategy = _ts_strategy(snuba_fallback="date")
+    def test_overflow_falls_through_to_snuba(self):
+        """Over the candidate cap, _execute_postgres_sort returns None and query() falls
+        through to the Snuba path rather than erroring."""
         with (
-            _patch_pg_strategies({"test_sort": strategy}),
-            mock.patch.object(
-                PostgresSnubaQueryExecutor, "_execute_postgres_sort", return_value=None
-            ),
+            _patch_pg_strategies({"test_sort": _ts_strategy(snuba_aggregations=["last_seen"])}),
+            mock.patch("sentry.search.snuba.executors.options") as mock_opts,
         ):
+            mock_opts.get.return_value = 0  # force every query over the cap
             results = list(self.make_query("test_sort", query="issue"))
             assert len(results) >= 0
 
-    def test_too_many_candidates_without_fallback_raises(self):
-        strategy = _ts_strategy(snuba_fallback=None)
-        executor = PostgresSnubaQueryExecutor()
-        qs = Group.objects.filter(project=self.project)
-        with mock.patch("sentry.search.snuba.executors.options") as mock_opts:
-            mock_opts.get.return_value = 0
-            with pytest.raises(InvalidSearchQuery, match="requires more specific filters"):
-                executor._execute_postgres_sort(
-                    strategy=strategy,
-                    sort_by="test_sort",
-                    group_queryset=qs,
-                    projects=[self.project],
-                    environments=None,
-                    search_filters=[],
-                    limit=25,
-                    cursor=None,
-                    count_hits=False,
-                    paginator_options={},
-                    max_hits=None,
-                    actor=None,
-                    start=before_now(days=90),
-                    end=timezone.now(),
-                    referrer=Referrer.TESTING_TEST.value,
-                )
-
-    def test_too_many_candidates_with_fallback_returns_none(self):
-        strategy = _ts_strategy(snuba_fallback="date")
+    def test_too_many_candidates_returns_none(self):
         executor = PostgresSnubaQueryExecutor()
         qs = Group.objects.filter(project=self.project)
         with mock.patch("sentry.search.snuba.executors.options") as mock_opts:
             mock_opts.get.return_value = 0
             result = executor._execute_postgres_sort(
-                strategy=strategy,
+                strategy=_ts_strategy(snuba_aggregations=["last_seen"]),
                 sort_by="test_sort",
                 group_queryset=qs,
                 projects=[self.project],

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+from django.utils import timezone
+
+from sentry.exceptions import InvalidSearchQuery
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.issues.issue_search import convert_query_values, parse_search_query
+from sentry.models.group import Group, GroupStatus
+from sentry.search.snuba.backend import EventsDatasetSnubaSearchBackend
+from sentry.search.snuba.executors import (
+    PostgresSnubaQueryExecutor,
+    PostgresSortStrategy,
+    _datetime_to_ms,
+)
+from sentry.snuba.referrer import Referrer
+from sentry.testutils.cases import SnubaTestCase, TestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.types.group import GroupSubStatus, PriorityLevel
+
+
+def _patch_pg_strategies(strategies: dict[str, PostgresSortStrategy]):
+    return mock.patch.object(
+        PostgresSnubaQueryExecutor,
+        "postgres_sort_strategies",
+        new_callable=lambda: property(lambda self: strategies),
+    )
+
+
+def _ts_strategy(**overrides):
+    defaults = dict(
+        postgres_fields={"ts": "seer_autofix_last_triggered"},
+        score_fn=lambda data: _datetime_to_ms(data["ts"]),
+    )
+    defaults.update(overrides)
+    return PostgresSortStrategy(**defaults)
+
+
+class TestDatetimeToMs(TestCase):
+    def test_converts_datetime(self):
+        dt = timezone.now()
+        assert isinstance(_datetime_to_ms(dt), int)
+        assert _datetime_to_ms(dt) > 0
+
+    def test_none_returns_zero(self):
+        assert _datetime_to_ms(None) == 0
+
+    def test_preserves_ordering(self):
+        assert _datetime_to_ms(before_now(hours=2)) < _datetime_to_ms(before_now(hours=1))
+
+
+class TestPostgresSortStrategy(TestCase):
+    def test_defaults(self):
+        s = PostgresSortStrategy(postgres_fields={"ts": "last_seen"})
+        assert s.snuba_aggregations == []
+        assert s.field_resolvers is None
+        assert s.exclude_null_postgres is True
+        assert s.snuba_fallback is None
+
+    def test_frozen(self):
+        s = PostgresSortStrategy(postgres_fields={"ts": "last_seen"})
+        with pytest.raises(AttributeError):
+            s.exclude_null_postgres = False  # type: ignore[misc]
+
+    def test_custom_score_fn(self):
+        s = PostgresSortStrategy(
+            postgres_fields={"ts": "last_seen"},
+            score_fn=lambda data: data.get("ts", 0) * 2,
+        )
+        assert s.score_fn({"ts": 5}) == 10
+
+
+class TestHasSortStrategy(TestCase):
+    def test_includes_snuba_sorts(self):
+        executor = PostgresSnubaQueryExecutor()
+        assert executor.has_sort_strategy("date") is True
+        assert executor.has_sort_strategy("nonexistent") is False
+
+    def test_includes_postgres_sorts(self):
+        executor = PostgresSnubaQueryExecutor()
+        with _patch_pg_strategies({"custom": _ts_strategy()}):
+            assert executor.has_sort_strategy("custom") is True
+            assert executor.has_sort_strategy("date") is True
+
+
+class TestResolveFields(TestCase):
+    def test_default_fields(self):
+        executor = PostgresSnubaQueryExecutor()
+        strategy = PostgresSortStrategy(postgres_fields={"ts": "last_seen", "prio": "priority"})
+        org = self.create_organization()
+        assert executor._resolve_pg_sort_fields(strategy, org, None) == {
+            "ts": "last_seen",
+            "prio": "priority",
+        }
+
+    def test_field_resolver_overrides(self):
+        executor = PostgresSnubaQueryExecutor()
+        strategy = PostgresSortStrategy(
+            postgres_fields={"ts": "default_field", "prio": "priority"},
+            field_resolvers={"ts": lambda org, actor: "resolved_field"},
+        )
+        org = self.create_organization()
+        resolved = executor._resolve_pg_sort_fields(strategy, org, None)
+        assert resolved["ts"] == "resolved_field"
+        assert resolved["prio"] == "priority"
+
+
+class PostgresSortTestBase(TestCase, SnubaTestCase):
+    """Shared setup: creates 3 groups with distinct seer_autofix_last_triggered values."""
+
+    def setUp(self):
+        super().setUp()
+        self.backend = EventsDatasetSnubaSearchBackend()
+        self.base_datetime = before_now(days=3).replace(microsecond=0)
+        self.groups = []
+        offsets = [timedelta(days=5), timedelta(days=2), timedelta(0)]
+        for i, offset in enumerate(offsets):
+            event = self.store_event(
+                data={
+                    "fingerprint": [f"group-{i}"],
+                    "event_id": f"{chr(97 + i)}" * 32,
+                    "message": f"issue {i}",
+                    "timestamp": (self.base_datetime - offset).isoformat(),
+                    "stacktrace": {"frames": [{"module": f"mod{i}"}]},
+                    "environment": "production",
+                },
+                project_id=self.project.id,
+            )
+            group = Group.objects.get(id=event.group.id)
+            group.status = GroupStatus.UNRESOLVED
+            group.substatus = GroupSubStatus.ONGOING
+            group.priority = PriorityLevel.HIGH
+            group.update(type=ErrorGroupType.type_id)
+            group.seer_autofix_last_triggered = self.base_datetime - offset
+            group.save()
+            self.store_group(group)
+            self.groups.append(group)
+
+    def make_query(self, sort_by, query=None, limit=None, cursor=None):
+        search_filters = []
+        if query:
+            search_filters = convert_query_values(
+                parse_search_query(query), [self.project], self.user, None
+            )
+        kwargs = {}
+        if limit is not None:
+            kwargs["limit"] = limit
+        return self.backend.query(
+            [self.project],
+            search_filters=search_filters,
+            environments=None,
+            count_hits=False,
+            sort_by=sort_by,
+            date_from=None,
+            date_to=None,
+            cursor=cursor,
+            referrer=Referrer.TESTING_TEST,
+            **kwargs,
+        )
+
+
+class TestPurePostgresSort(PostgresSortTestBase):
+    def test_ordering(self):
+        with _patch_pg_strategies({"test_sort": _ts_strategy()}):
+            results = list(self.make_query("test_sort"))
+        assert results == [self.groups[2], self.groups[1], self.groups[0]]
+
+    def test_null_exclusion(self):
+        self.groups[1].seer_autofix_last_triggered = None
+        self.groups[1].save()
+
+        with _patch_pg_strategies({"test_sort": _ts_strategy()}):
+            results = list(self.make_query("test_sort"))
+        assert self.groups[1] not in results
+        assert results == [self.groups[2], self.groups[0]]
+
+    def test_cursor_pagination(self):
+        with _patch_pg_strategies({"test_sort": _ts_strategy()}):
+            page1 = self.make_query("test_sort", limit=2)
+            assert list(page1) == [self.groups[2], self.groups[1]]
+            assert page1.next.has_results
+
+            page2 = self.make_query("test_sort", limit=2, cursor=page1.next)
+            assert list(page2) == [self.groups[0]]
+
+    def test_empty_when_all_null(self):
+        Group.objects.filter(id__in=[g.id for g in self.groups]).update(
+            seer_autofix_last_triggered=None
+        )
+        with _patch_pg_strategies({"test_sort": _ts_strategy()}):
+            assert len(list(self.make_query("test_sort"))) == 0
+
+    def test_with_postgres_only_filter(self):
+        with _patch_pg_strategies({"test_sort": _ts_strategy()}):
+            results = list(self.make_query("test_sort", query="is:unresolved"))
+        assert len(results) == 3
+
+    def test_pure_path_does_not_call_snuba(self):
+        with _patch_pg_strategies({"test_sort": _ts_strategy()}):
+            with mock.patch.object(PostgresSnubaQueryExecutor, "snuba_search") as snuba_spy:
+                results = list(self.make_query("test_sort"))
+                assert len(results) == 3
+                assert not snuba_spy.called
+
+
+class TestExecutePostgresSort(PostgresSortTestBase):
+    def test_snuba_filter_narrows_candidates(self):
+        with _patch_pg_strategies({"test_sort": _ts_strategy()}):
+            results = list(self.make_query("test_sort", query="issue 0"))
+        assert len(results) == 1
+        assert results[0] == self.groups[0]
+
+    def test_execute_path_calls_snuba(self):
+        with _patch_pg_strategies({"test_sort": _ts_strategy()}):
+            with mock.patch.object(
+                PostgresSnubaQueryExecutor,
+                "snuba_search",
+                return_value=([(g.id, 1) for g in Group.objects.filter(project=self.project)], 0),
+            ) as snuba_spy:
+                self.make_query("test_sort", query="issue")
+                assert snuba_spy.called
+
+    def test_hybrid_sort_with_snuba_aggregations(self):
+        strategy = _ts_strategy(
+            snuba_aggregations=["last_seen"],
+            score_fn=lambda data: _datetime_to_ms(data["ts"]) + data.get("last_seen", 0),
+        )
+        with _patch_pg_strategies({"test_sort": strategy}):
+            results = list(self.make_query("test_sort", query="issue"))
+        assert len(results) == 3
+
+    def test_cursor_pagination_with_snuba_filter(self):
+        for i in range(5):
+            event = self.store_event(
+                data={
+                    "fingerprint": [f"extra-{i}"],
+                    "event_id": f"e{i:031d}",
+                    "message": f"extra issue {i}",
+                    "timestamp": (self.base_datetime - timedelta(hours=i)).isoformat(),
+                    "stacktrace": {"frames": [{"module": f"ex{i}"}]},
+                    "environment": "production",
+                },
+                project_id=self.project.id,
+            )
+            group = Group.objects.get(id=event.group.id)
+            group.status = GroupStatus.UNRESOLVED
+            group.substatus = GroupSubStatus.ONGOING
+            group.update(type=ErrorGroupType.type_id)
+            group.seer_autofix_last_triggered = self.base_datetime - timedelta(hours=i)
+            group.save()
+            self.store_group(group)
+
+        with _patch_pg_strategies({"test_sort": _ts_strategy()}):
+            page1 = self.make_query("test_sort", query="issue", limit=3)
+            page2 = self.make_query("test_sort", query="issue", limit=3, cursor=page1.next)
+
+        page1_ids = {g.id for g in page1}
+        page2_ids = {g.id for g in page2}
+        assert page1_ids.isdisjoint(page2_ids)
+
+
+class TestFallbackBehavior(PostgresSortTestBase):
+    def test_fallback_to_snuba_sort(self):
+        """When _execute_postgres_sort returns None, falls through to Snuba path."""
+        strategy = _ts_strategy(snuba_fallback="date")
+        with (
+            _patch_pg_strategies({"test_sort": strategy}),
+            mock.patch.object(
+                PostgresSnubaQueryExecutor, "_execute_postgres_sort", return_value=None
+            ),
+        ):
+            results = list(self.make_query("test_sort", query="issue"))
+            assert len(results) >= 0
+
+    def test_too_many_candidates_without_fallback_raises(self):
+        strategy = _ts_strategy(snuba_fallback=None)
+        executor = PostgresSnubaQueryExecutor()
+        qs = Group.objects.filter(project=self.project)
+        with mock.patch("sentry.search.snuba.executors.options") as mock_opts:
+            mock_opts.get.return_value = 0
+            with pytest.raises(InvalidSearchQuery, match="requires more specific filters"):
+                executor._execute_postgres_sort(
+                    strategy=strategy,
+                    sort_by="test_sort",
+                    group_queryset=qs,
+                    projects=[self.project],
+                    environments=None,
+                    search_filters=[],
+                    limit=25,
+                    cursor=None,
+                    count_hits=False,
+                    paginator_options={},
+                    max_hits=None,
+                    actor=None,
+                    start=before_now(days=90),
+                    end=timezone.now(),
+                    referrer=Referrer.TESTING_TEST.value,
+                )
+
+    def test_too_many_candidates_with_fallback_returns_none(self):
+        strategy = _ts_strategy(snuba_fallback="date")
+        executor = PostgresSnubaQueryExecutor()
+        qs = Group.objects.filter(project=self.project)
+        with mock.patch("sentry.search.snuba.executors.options") as mock_opts:
+            mock_opts.get.return_value = 0
+            result = executor._execute_postgres_sort(
+                strategy=strategy,
+                sort_by="test_sort",
+                group_queryset=qs,
+                projects=[self.project],
+                environments=None,
+                search_filters=[],
+                limit=25,
+                cursor=None,
+                count_hits=False,
+                paginator_options={},
+                max_hits=None,
+                actor=None,
+                start=before_now(days=90),
+                end=timezone.now(),
+                referrer=Referrer.TESTING_TEST.value,
+            )
+            assert result is None
+
+    def test_unknown_sort_uses_snuba_path(self):
+        results = list(self.make_query("date"))
+        assert len(results) >= 0
+
+
+class TestDefaultPostgresSortStrategies(TestCase):
+    def test_returns_empty(self):
+        assert PostgresSnubaQueryExecutor().postgres_sort_strategies == {}

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -30,8 +31,8 @@ def _patch_pg_strategies(strategies: dict[str, PostgresSortStrategy]):
     )
 
 
-def _ts_strategy(**overrides):
-    defaults = dict(
+def _ts_strategy(**overrides: Any) -> PostgresSortStrategy:
+    defaults: dict[str, Any] = dict(
         postgres_fields={"ts": "seer_autofix_last_triggered"},
         score_fn=lambda data: _datetime_to_ms(data["ts"]),
     )
@@ -140,10 +141,10 @@ class PostgresSortTestBase(TestCase, SnubaTestCase):
             self.groups.append(group)
 
     def make_query(self, sort_by, query=None, limit=None, cursor=None):
-        search_filters = []
+        search_filters: list[Any] = []
         if query:
-            search_filters = convert_query_values(
-                parse_search_query(query), [self.project], self.user, None
+            search_filters = list(
+                convert_query_values(parse_search_query(query), [self.project], self.user, None)
             )
         kwargs = {}
         if limit is not None:


### PR DESCRIPTION
Adds a generic framework inside `PostgresSnubaQueryExecutor` that enables sorting issue search results by Postgres Group model data — either alone (pure Postgres sorts) or combined with Snuba aggregations (hybrid sorts).

**Motivation**: Issue search sorts are currently Snuba-only, limiting sorts to event-level signals (timestamps, counts, log levels). Issue-level metadata stored in Postgres (priority, seer scores, fixability, etc.) cannot participate in ranking. This framework removes that limitation.

**How it works**: Adding a new Postgres-backed sort requires only registering a `PostgresSortStrategy` config — no framework code changes needed. The strategy declares which Postgres fields it needs, which Snuba aggregations (if any), and a `score_fn` that merges both data sources into a sort score.

Three execution paths:

| Path | When | How |
|------|------|-----|
| Pure Postgres | No Snuba filters or aggregations needed | `DateTimePaginator` on queryset — single efficient DB query |
| General pre-filter | Snuba filters or aggregations needed | Candidates from Postgres → Snuba filter/agg → score → `SequencePaginator` |
| Fallback | Candidate set too large + `snuba_fallback` set | Falls through to existing Snuba-only path |

Key additions to `PostgresSnubaQueryExecutor`:
- `PostgresSortStrategy` dataclass with `postgres_fields`, `snuba_aggregations`, `score_fn`, `field_resolvers`, `exclude_null_postgres`, `snuba_fallback`
- `_pure_postgres_sort()` — efficient single-query path with `DateTimePaginator`
- `_execute_postgres_sort()` — general pre-filter path with `SequencePaginator`
- `_snuba_search_raw()` — returns raw aggregation values per group (simplified; has TODO for full implementation)
- `_apply_type_visibility_filter()` — applies issue type visibility rules (also fixes an existing XXX on the `sort=date` shortcut)
- Routing in `query()` that dispatches to the appropriate path based on strategy config