### PR TITLE
ref(search): Remove user_impact signal from recommended sort

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -886,11 +886,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "snuba.search.recommended.user-impact-weight",
-    default=0.05,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "snuba.search.recommended.event-volume-weight",
     default=0.20,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -794,10 +794,6 @@ def _recommended_aggregation(
         "0.0))"
     )
 
-    # User impact: ln(uniq(tags[sentry:user]) + 1)/ln(1001) - maps 1→~0, 10→0.33, 100→0.67, 1000→1.0
-    user_impact_weight = options.get("snuba.search.recommended.user-impact-weight")
-    user_impact = "least(1.0, divide(log(plus(uniq(tags[sentry:user]), 1)), log(1001)))"
-
     # Event volume: ln(count() + 1)/ln(10001) - maps 1→~0, 10→0.25, 100→0.50, 1000→0.75, 10000+→1.0
     event_volume_weight = options.get("snuba.search.recommended.event-volume-weight")
     event_volume = "least(1.0, divide(log(plus(count(), 1)), log(10001)))"
@@ -815,11 +811,10 @@ def _recommended_aggregation(
 
     return [
         (
-            f"plus(plus(plus(plus(plus("
+            f"plus(plus(plus(plus("
             f"multiply({recency_weight}, {recency}), "
             f"multiply({spike_weight}, {spike})), "
             f"multiply({severity_weight}, {severity})), "
-            f"multiply({user_impact_weight}, {user_impact})), "
             f"multiply({event_volume_weight}, {event_volume})), "
             f"{type_boost})"
         ),
@@ -851,7 +846,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
     logger = logging.getLogger("sentry.search.postgressnuba")
     dependency_aggregations = {
         "trends": ["last_seen", "times_seen"],
-        "recommended": ["last_seen", "times_seen", "user_count"],
+        "recommended": ["last_seen", "times_seen"],
     }
     postgres_only_fields = {*SKIP_SNUBA_FIELDS, "regressed_in_release"}
     # add specific fields here on top of skip_snuba_fields from the serializer

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3952,59 +3952,6 @@ class EventsRecommendedSortTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin)
         # Fatal event should score higher despite being slightly older
         assert scores[fatal_group.id] > scores[info_group.id]
 
-    def test_recommended_user_impact(self) -> None:
-        base_datetime = before_now(hours=1)
-
-        # Issue affecting many users
-        for i in range(10):
-            self.store_event(
-                data={
-                    "fingerprint": ["many-users-group"],
-                    "event_id": f"a{i:031d}",
-                    "message": "many users",
-                    "timestamp": base_datetime.isoformat(),
-                    "level": "error",
-                    "tags": {"sentry:user": f"user{i}@example.com"},
-                },
-                project_id=self.project.id,
-            )
-        many_users_group = Group.objects.get(
-            project=self.project,
-            message="many users",
-        )
-
-        # Issue affecting one user
-        self.store_event(
-            data={
-                "fingerprint": ["one-user-group"],
-                "event_id": "b" * 32,
-                "message": "one user",
-                "timestamp": base_datetime.isoformat(),
-                "level": "error",
-                "tags": {"sentry:user": "solo@example.com"},
-            },
-            project_id=self.project.id,
-        )
-        one_user_group = Group.objects.get(
-            project=self.project,
-            message="one user",
-        )
-
-        query_executor = self.backend._get_query_executor()
-        results = query_executor.snuba_search(
-            start=None,
-            end=None,
-            project_ids=[self.project.id],
-            environment_ids=[],
-            sort_field="recommended",
-            organization=self.organization,
-            group_ids=[many_users_group.id, one_user_group.id],
-            limit=150,
-            referrer=Referrer.TESTING_TEST,
-        )[0]
-        scores = {gid: score for gid, score in results}
-        assert scores[many_users_group.id] > scores[one_user_group.id]
-
     def test_recommended_issue_platform(self) -> None:
         base_datetime = before_now(hours=1)
 


### PR DESCRIPTION
Remove the `user_impact` signal (`uniq(tags[sentry:user])`) from the
recommended sort formula.

The `uniq(tags[sentry:user])` aggregation requires reading the full tags
array column in ClickHouse, which dominates query I/O — testing in Snuba
Admin showed ~583 MB bytes read with it vs ~12 MB without, a 47x
reduction. The signal only contributed a 0.05 weight to the score and
had negligible impact on ranking quality.