### PR TITLE
ref(gitlab): Store repository name as path_with_namespace

### DIFF
--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -46,7 +46,11 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
         self, organization: RpcOrganization, data: Mapping[str, Any]
     ) -> RepositoryConfig:
         return {
-            "name": data["name"],
+            # Store the path_with_namespace (e.g. "group/project") as the repo
+            # name, matching GitHub's "owner/repo" convention. Generic code splits
+            # name on "/" to derive owner/repo; the display name_with_namespace
+            # contains spaces and breaks that. The slug also lives in config["path"].
+            "name": data["path"],
             "external_id": data["external_id"],
             "url": data["url"],
             "config": {

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -165,8 +165,14 @@ class GitlabWebhook(SCMWebhook, ABC):
         url_from_event = project["web_url"]
         path_from_event = project["path_with_namespace"]
 
-        if repo.url != url_from_event or repo.config.get("path") != path_from_event:
+        if (
+            repo.url != url_from_event
+            or repo.config.get("path") != path_from_event
+            or repo.name != path_from_event
+        ):
+            # Keep name == path_with_namespace so generic owner/repo parsing works.
             repo.update(
+                name=path_from_event,
                 url=url_from_event,
                 config=dict(repo.config, path=path_from_event),
             )

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -87,7 +87,7 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             provider=self.provider_name,
             external_id=external_id,
         )
-        assert repo.name == repository_config["name_with_namespace"]
+        assert repo.name == repository_config["path_with_namespace"]
         assert repo.url == repository_config["web_url"]
         assert repo.integration_id == self.integration.id
         assert repo.config == {

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -376,7 +376,7 @@ class WebhookTest(GitLabTestCase):
         # merge_request event is dispatched into it with the expected context.
         assert handle_merge_request_event in MergeEventWebhook.WEBHOOK_EVENT_PROCESSORS
 
-        self.create_gitlab_repo("getsentry/sentry")
+        self.create_gitlab_repo("cool-group/sentry")
 
         # wraps the real handler so it still runs while we record the invocation
         spy = MagicMock(wraps=handle_merge_request_event)
@@ -395,7 +395,7 @@ class WebhookTest(GitLabTestCase):
         assert call_kwargs["event"]["object_attributes"]["action"] == "open"
         assert call_kwargs["integration"].id == self.integration.id
         assert call_kwargs["organization"].id == self.organization.id
-        assert call_kwargs["repo"].name == "getsentry/sentry"
+        assert call_kwargs["repo"].name == "cool-group/sentry"
 
     def test_merge_event_create_pull_request(self) -> None:
         self.create_gitlab_repo("getsentry/sentry")
@@ -465,9 +465,10 @@ class WebhookTest(GitLabTestCase):
 
         assert response.status_code == 204
 
-        # path has been updated
+        # path (and name, kept in sync) have been updated
         repo_out_of_date_path.refresh_from_db()
         assert repo_out_of_date_path.config["path"] == "cool-group/sentry"
+        assert repo_out_of_date_path.name == "cool-group/sentry"
 
     def test_update_repo_url(self) -> None:
         repo_out_of_date_url = self.create_gitlab_repo(


### PR DESCRIPTION
We have been saving GitLab's repository display name for `Repository.name` - which has spaces and potential casing differences. A slug-like "path" is also saved in `Repository.config`. I'm proposing we migrate to using the slug for name for GitLab to be consistent with GitHub. We do have another scm provider (VSTS) that does not adhere to the same "<owner>/<repo>" format and whose `name` contains spaces, so something else to consider.

Anyway the root problem is that when we use Seer, it will suggest the repo name, and it's usually in the slug format. We then have to look-up the repo's external id via repo name (slugified), which does not get matched when using GitLab as its `name` in the db contains spaces. We already have [a PR](https://github.com/getsentry/seer/pull/6722) to normalize this look-up, so this migration is not explicitly needed.

This also presents a problem on the frontend as we use this name to create URLs.

[Backfill PR here](https://github.com/getsentry/sentry/pull/116610)

## Slop

GitLab `Repository.name` historically stored the display `name_with_namespace` (e.g. `Get Sentry / Example Repo`), which contains spaces and a ` / ` separator. Generic, provider-agnostic code splits `Repository.name` on `/` to derive owner/repo (Seer project repos, autofix, code review), which silently produced garbage for GitLab. This stores the URL slug already kept in `config["path"]` as `name`, matching how GitHub stores `name`.

This PR changes behavior for **newly added** GitLab repositories only. A follow-up backfills existing rows: #116610

**Behavior change**

```text
# Before
Repository.name   = "Get Sentry / Example Repo"
Repository.config = {"path": "getsentry/example-repo", ...}

# After
Repository.name   = "getsentry/example-repo"
Repository.config = {"path": "getsentry/example-repo", ...}
```

The display name is dropped (not preserved), for consistency with GitHub. If we wanted to keep display name, we could add a new `config.display_name` property.

`build_repository_config` stores `path_with_namespace` as `name`, and the webhook's `update_repo_data` keeps `name` in sync on GitLab-side project renames.

**Unaffected paths (clanker verified)**

Ticket/issue linking does not read `Repository.name` (`ExternalIssue.key` uses `path_with_namespace`, parsed from the key string). Historical commits link by `repository_id`, not name. The legacy `gitlab` plugin (provider `gitlab`) is unaffected. On the Seer side, GitLab repos are accessed by `external_id` (code review path); the name-keyed codebase index is GitHub-only, so no Seer state is stranded.