### PR TITLE
feat(seer): Gate structured context routes on rollout flag

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -119,7 +119,7 @@ describe('useSeerExplorer', () => {
         getPageReferrer: () => '/dashboard/:dashboardId/',
       });
       const org = OrganizationFixture({
-        features: ['seer-explorer', 'seer-explorer-context-engine'],
+        features: ['seer-explorer', 'seer-explorer-structured-context-rollout'],
       });
       MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/seer/explorer-chat/`,
@@ -163,7 +163,7 @@ describe('useSeerExplorer', () => {
         getPageReferrer: () => route,
       });
       const org = OrganizationFixture({
-        features: ['seer-explorer', 'seer-explorer-context-engine'],
+        features: ['seer-explorer', 'seer-explorer-structured-context-rollout'],
       });
       MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/seer/explorer-chat/`,
@@ -199,7 +199,7 @@ describe('useSeerExplorer', () => {
         getPageReferrer: () => '/monitors/mobile-builds/',
       });
       const org = OrganizationFixture({
-        features: ['seer-explorer', 'seer-explorer-context-engine'],
+        features: ['seer-explorer', 'seer-explorer-structured-context-rollout'],
       });
       MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/seer/explorer-chat/`,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -72,9 +72,7 @@ function supportsStructuredContext(
 ): boolean {
   if (STRUCTURED_CONTEXT_ROUTES.has(referrer)) {
     return (
-      organization?.features.includes('seat-based-seer-enabled') === true ||
-      organization?.features.includes('seer-added') === true ||
-      organization?.features.includes('seer-explorer-context-engine') === true
+      organization?.features.includes('seer-explorer-structured-context-rollout') === true
     );
   }
   if (NEW_STRUCTURED_CONTEXT_ROUTES.has(referrer)) {


### PR DESCRIPTION
+ Gate STRUCTURED_CONTEXT_ROUTES on the dedicated
seer-explorer-structured-context-rollout flag instead of the previous OR of broad "has Seer" flags (seat-based-seer-enabled, seer-added, seer-explorer-context-engine). The old OR left structured context on at ~100% for Seer orgs with no controllable rollout knob; the single flag lets us ramp structured page context to all orgs via FlagPole.
