### PR TITLE
chore(ACI): Remove usage of workflow engine redirect flag

### DIFF
--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -154,9 +154,7 @@ export function CreateAlertButton({
   const navigate = useNavigate();
   const location = useLocation();
   const {projects} = useProjects();
-  const shouldDirectToMonitors =
-    organization.features.includes('workflow-engine-ui') &&
-    !organization.features.includes('workflow-engine-redirect-opt-out');
+  const shouldDirectToMonitors = organization.features.includes('workflow-engine-ui');
   const defaultButtonLabel = shouldDirectToMonitors
     ? t('Create Monitor')
     : t('Create Alert');

--- a/static/app/views/alerts/workflowEngineRedirects.spec.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.spec.tsx
@@ -9,7 +9,6 @@ import {
 
 import {
   withAutomationDetailsRedirect,
-  withAutomationEditRedirect,
   withDetectorCreateRedirect,
   withDetectorDetailsRedirect,
   withDetectorEditRedirect,
@@ -58,23 +57,6 @@ describe('workflowEngineRedirects', () => {
           makeAutomationDetailsPathname(organization.slug, 'workflow-1')
         );
       });
-    });
-
-    it('renders the wrapped component when redirects are opted out', () => {
-      const organization = OrganizationFixture({
-        slug: 'org-slug',
-        features: ['workflow-engine-ui', 'workflow-engine-redirect-opt-out'],
-      });
-
-      const Wrapped = withAutomationEditRedirect(TestComponent);
-      const initialRouterConfig: RouterConfig = {
-        route: '/organizations/:orgId/alerts/rules/:ruleId/',
-        location: {pathname: `/organizations/${organization.slug}/alerts/rules/1/`},
-      };
-
-      render(<Wrapped />, {organization, initialRouterConfig});
-
-      expect(screen.getByText('Wrapped content')).toBeInTheDocument();
     });
   });
 
@@ -256,68 +238,6 @@ describe('workflowEngineRedirects', () => {
       expect(router.location.pathname).toBe(
         `/organizations/${organization.slug}/alerts/1/`
       );
-    });
-
-    it('does not redirect when workflow-engine-redirect-opt-out flag is enabled', async () => {
-      const organization = OrganizationFixture({
-        slug: 'org-slug',
-        features: ['workflow-engine-ui', 'workflow-engine-redirect-opt-out'],
-      });
-
-      const Wrapped = withDetectorDetailsRedirect(TestComponent);
-
-      const initialRouterConfig: RouterConfig = {
-        route: '/organizations/:orgId/alerts/:ruleId/',
-        location: {pathname: `/organizations/${organization.slug}/alerts/1/`},
-      };
-
-      const {router} = render(<Wrapped />, {organization, initialRouterConfig});
-
-      // Path stays the same and we render the wrapped component
-      await screen.findByText('Wrapped content');
-      expect(router.location.pathname).toBe(
-        `/organizations/${organization.slug}/alerts/1/`
-      );
-    });
-
-    it('does redirect from notification link even when workflow-engine-redirect-opt-out flag is enabled', async () => {
-      const organization = OrganizationFixture({
-        slug: 'org-slug',
-        features: ['workflow-engine-ui', 'workflow-engine-redirect-opt-out'],
-      });
-
-      const Wrapped = withDetectorDetailsRedirect(TestComponent);
-
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/incident-groupopenperiod/`,
-        body: {
-          groupId: 'group-1',
-          incidentId: null,
-          incidentIdentifier: 'alert-1',
-          openPeriodId: 'open-1',
-        },
-        match: [MockApiClient.matchQuery({incident_identifier: 'alert-1'})],
-      });
-
-      const initialRouterConfig: RouterConfig = {
-        route: '/organizations/:orgId/alerts/:ruleId/',
-        location: {
-          pathname: `/organizations/${organization.slug}/alerts/1/`,
-          query: {alert: 'alert-1', notification_uuid: 'notification-uuid'},
-        },
-      };
-
-      const {router} = render(<Wrapped />, {organization, initialRouterConfig});
-
-      await waitFor(() => {
-        expect(router.location.pathname).toBe(
-          `/organizations/${organization.slug}/issues/group-1/`
-        );
-      });
-      expect(router.location.query).toMatchObject({
-        alert: 'alert-1',
-        notification_uuid: 'notification-uuid',
-      });
     });
   });
 

--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -68,11 +68,7 @@ function withRuleRedirect<P extends Record<string, any>>(
     const organization = useOrganization();
     const {ruleId} = useParams();
 
-    const hasRedirectOptOut = organization.features.includes(
-      'workflow-engine-redirect-opt-out'
-    );
-    const shouldRedirect =
-      !hasRedirectOptOut && organization.features.includes('workflow-engine-ui');
+    const shouldRedirect = organization.features.includes('workflow-engine-ui');
 
     const {data: alertRuleWorkflow, isPending} = useApiQuery<AlertRuleWorkflow>(
       [
@@ -118,11 +114,7 @@ function withAlertRuleRedirect<P extends Record<string, any>>(
     const organization = useOrganization();
     const {ruleId, detectorId} = useParams();
 
-    const hasRedirectOptOut = organization.features.includes(
-      'workflow-engine-redirect-opt-out'
-    );
-    const shouldRedirect =
-      !hasRedirectOptOut && organization.features.includes('workflow-engine-ui');
+    const shouldRedirect = organization.features.includes('workflow-engine-ui');
 
     const {data: alertRuleDetector, isPending} = useApiQuery<AlertRuleDetector>(
       [
@@ -203,15 +195,8 @@ export const withDetectorDetailsRedirect = <P extends Record<string, any>>(
     const {ruleId, detectorId} = useParams();
     const location = useLocation();
     const alertId = location.query.alert as string | undefined;
-    const notificationUuid = location.query.notification_uuid;
 
-    const hasWorkflowEngineUI = organization.features.includes('workflow-engine-ui');
-    const hasRedirectOptOut = organization.features.includes(
-      'workflow-engine-redirect-opt-out'
-    );
-    // When clicking from a notification, we never want to opt out of the redirect
-    const optOutOfRedirects = hasRedirectOptOut && !notificationUuid;
-    const shouldRedirect = hasWorkflowEngineUI && !optOutOfRedirects;
+    const shouldRedirect = organization.features.includes('workflow-engine-ui');
 
     if (shouldRedirect) {
       if (alertId) {
@@ -346,11 +331,7 @@ export function withDetectorCreateRedirect<P extends Record<string, any>>(
     const organization = useOrganization();
     const {alertType} = useParams();
 
-    const hasRedirectOptOut = organization.features.includes(
-      'workflow-engine-redirect-opt-out'
-    );
-    const shouldRedirect =
-      !hasRedirectOptOut && organization.features.includes('workflow-engine-ui');
+    const shouldRedirect = organization.features.includes('workflow-engine-ui');
 
     if (shouldRedirect) {
       const detectorType = getDetectionType(alertType);
@@ -373,11 +354,7 @@ export function withOpenPeriodRedirect<P extends Record<string, any>>(
     const location = useLocation();
     const {alertId} = useParams();
 
-    const hasRedirectOptOut = organization.features.includes(
-      'workflow-engine-redirect-opt-out'
-    );
-    const shouldRedirect =
-      !hasRedirectOptOut && organization.features.includes('workflow-engine-ui');
+    const shouldRedirect = organization.features.includes('workflow-engine-ui');
 
     const {data: incidentGroupOpenPeriod, isPending} =
       useApiQuery<IncidentGroupOpenPeriod>(

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -45,11 +45,7 @@ export const automationRoutes: SentryRouteObject = {
 function RedirectToRuleList() {
   const organization = useOrganization();
 
-  const hasRedirectOptOut = organization.features.includes(
-    'workflow-engine-redirect-opt-out'
-  );
-  const shouldRedirect =
-    !hasRedirectOptOut && !organization.features.includes('workflow-engine-ui');
+  const shouldRedirect = !organization.features.includes('workflow-engine-ui');
 
   if (shouldRedirect) {
     return (
@@ -68,11 +64,7 @@ function RedirectToRuleList() {
 function RedirectToNewRule() {
   const organization = useOrganization();
 
-  const hasRedirectOptOut = organization.features.includes(
-    'workflow-engine-redirect-opt-out'
-  );
-  const shouldRedirect =
-    !hasRedirectOptOut && !organization.features.includes('workflow-engine-ui');
+  const shouldRedirect = !organization.features.includes('workflow-engine-ui');
 
   if (shouldRedirect) {
     return (

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -106,10 +106,7 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
   const isSticky = layout === 'sidebar';
 
   const hasWorkflowEngineUI = organization.features.includes('workflow-engine-ui');
-  const hasRedirectOptOut = organization.features.includes(
-    'workflow-engine-redirect-opt-out'
-  );
-  const shouldRedirectToWorkflowEngineUI = !hasRedirectOptOut && hasWorkflowEngineUI;
+  const shouldRedirectToWorkflowEngineUI = hasWorkflowEngineUI;
 
   const alertsLink = shouldRedirectToWorkflowEngineUI
     ? makeAutomationBasePathname(organization.slug)


### PR DESCRIPTION
I don't believe we need this anymore - it was only ever released internally and we are not using the old UI anymore for anything so I think it's safe to remove. 