### PR TITLE
ref(gitlab): Backfill repository name to path_with_namespace

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -31,7 +31,7 @@ replays: 0007_organizationmember_replay_access
 
 seer: 0017_drop_old_fk_columns
 
-sentry: 1102_activity_project_type_index
+sentry: 1103_gitlab_repository_name_to_path
 
 social_auth: 0003_social_auth_json_field
 

--- a/src/sentry/migrations/1103_gitlab_repository_name_to_path.py
+++ b/src/sentry/migrations/1103_gitlab_repository_name_to_path.py
@@ -1,0 +1,83 @@
+import logging
+
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+from sentry.new_migrations.migrations import CheckedMigration
+from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
+
+logger = logging.getLogger(__name__)
+
+# Provider string for the GitLab integration (distinct from the legacy
+# "gitlab" plugin, which does not own these Repository rows).
+GITLAB_PROVIDER = "integrations:gitlab"
+
+
+def backfill_gitlab_repository_name(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    """
+    GitLab Repository.name historically stored the display "name_with_namespace"
+    (e.g. "Get Sentry / Example Repo"), which contains spaces and breaks generic
+    code that splits name on "/" to derive owner/repo. The URL slug
+    ("getsentry/example-repo") lives in config["path"]. Align name with the slug,
+    matching GitHub's "owner/repo" convention.
+    """
+    Repository = apps.get_model("sentry", "Repository")
+
+    skipped_missing_path = 0
+    batch: list[object] = []
+
+    for repo in RangeQuerySetWrapperWithProgressBar(
+        Repository.objects.filter(provider=GITLAB_PROVIDER)
+    ):
+        path = (repo.config or {}).get("path")
+        if not path:
+            # Pre-config["path"] rows: leave untouched rather than guess.
+            skipped_missing_path += 1
+            continue
+        if repo.name == path:
+            continue
+        repo.name = path
+        batch.append(repo)
+        if len(batch) >= 1000:
+            Repository.objects.bulk_update(batch, ["name"])
+            batch = []
+
+    if batch:
+        Repository.objects.bulk_update(batch, ["name"])
+
+    if skipped_missing_path:
+        logger.info(
+            "gitlab_repository_name_backfill.skipped_missing_path",
+            extra={"count": skipped_missing_path},
+        )
+
+
+class Migration(CheckedMigration):
+    # This flag is used to mark that a migration shouldn't be automatically run in production.
+    # This should only be used for operations where it's safe to run the migration after your
+    # code has deployed. So this should not be used for most operations that alter the schema
+    # of a table.
+    # Here are some things that make sense to mark as post deployment:
+    # - Large data migrations. Typically we want these to be run manually so that they can be
+    #   monitored and not block the deploy for a long period of time while they run.
+    # - Adding indexes to large tables. Since this can take a long time, we'd generally prefer to
+    #   run this outside deployments so that we don't block them. Note that while adding an index
+    #   is a schema change, it's completely safe to run the operation after the code has deployed.
+    # Once deployed, run these manually via: https://develop.sentry.dev/database-migrations/#migration-deployment
+
+    is_post_deployment = True
+
+    dependencies = [
+        ("sentry", "1102_activity_project_type_index"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_gitlab_repository_name,
+            reverse_code=migrations.RunPython.noop,
+            hints={"tables": ["sentry_repository"]},
+        ),
+    ]

--- a/tests/sentry/migrations/test_1103_gitlab_repository_name_to_path.py
+++ b/tests/sentry/migrations/test_1103_gitlab_repository_name_to_path.py
@@ -1,0 +1,75 @@
+from django.db import router
+
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
+from sentry.testutils.cases import TestMigrations
+from sentry.testutils.silo import assume_test_silo_mode
+
+
+class GitlabRepositoryNameToPathTest(TestMigrations):
+    migrate_from = "1102_activity_project_type_index"
+    migrate_to = "1103_gitlab_repository_name_to_path"
+
+    def setup_before_migration(self, apps):
+        Repository = apps.get_model("sentry", "Repository")
+
+        with (
+            assume_test_silo_mode(SiloMode.MONOLITH),
+            unguarded_write(using=router.db_for_write(Repository)),
+        ):
+            org = self.create_organization()
+            self.org_id = org.id
+
+            # GitLab repo with a display name + path slug in config -> name rewritten.
+            self.display_name_repo = Repository.objects.create(
+                organization_id=org.id,
+                name="Get Sentry / Example Repo",
+                provider="integrations:gitlab",
+                external_id="example.gitlab.com:1",
+                config={"instance": "example.gitlab.com", "path": "getsentry/example-repo"},
+            )
+
+            # GitLab repo already aligned -> left untouched.
+            self.aligned_repo = Repository.objects.create(
+                organization_id=org.id,
+                name="getsentry/already-aligned",
+                provider="integrations:gitlab",
+                external_id="example.gitlab.com:2",
+                config={"instance": "example.gitlab.com", "path": "getsentry/already-aligned"},
+            )
+
+            # GitLab repo missing config["path"] -> left untouched (older row).
+            self.no_path_repo = Repository.objects.create(
+                organization_id=org.id,
+                name="Get Sentry / No Path",
+                provider="integrations:gitlab",
+                external_id="example.gitlab.com:3",
+                config={"instance": "example.gitlab.com"},
+            )
+
+            # Non-GitLab repo -> never touched even with a spaced name + path.
+            self.github_repo = Repository.objects.create(
+                organization_id=org.id,
+                name="getsentry/sentry",
+                provider="integrations:github",
+                external_id="gh:1",
+                config={"path": "should-not-be-used"},
+            )
+
+    def test(self) -> None:
+        Repository = self.apps.get_model("sentry", "Repository")
+
+        with assume_test_silo_mode(SiloMode.MONOLITH):
+            display_name_repo = Repository.objects.get(id=self.display_name_repo.id)
+            aligned_repo = Repository.objects.get(id=self.aligned_repo.id)
+            no_path_repo = Repository.objects.get(id=self.no_path_repo.id)
+            github_repo = Repository.objects.get(id=self.github_repo.id)
+
+        # Rewritten to the path slug; config is otherwise unchanged.
+        assert display_name_repo.name == "getsentry/example-repo"
+        assert display_name_repo.config["path"] == "getsentry/example-repo"
+
+        # Already aligned, missing path, and non-GitLab rows are unchanged.
+        assert aligned_repo.name == "getsentry/already-aligned"
+        assert no_path_repo.name == "Get Sentry / No Path"
+        assert github_repo.name == "getsentry/sentry"


### PR DESCRIPTION
Backfills existing GitLab repositories so `Repository.name` holds the path slug (`getsentry/example-repo`) instead of the display `name_with_namespace` (`Get Sentry / Example Repo`). Generic code splits `Repository.name` on `/` to derive owner/repo, which silently produced garbage for GitLab; the slug already lives in `config["path"]`.

Companion to #116604, which makes newly-added GitLab repos store the path. **Land and deploy #116604 first**, then run this backfill — so new writes are already path-named before/while existing rows are migrated.

**Migration**

Post-deployment data migration (`1103`) that sets `name = config["path"]` for `provider="integrations:gitlab"` rows. Rows missing `config["path"]` (older repos) are skipped and counted, never guessed. Keyed lookups are unaffected: `Repository` uniqueness is `(organization_id, provider, external_id)`, and `name` has no constraint.

`is_post_deployment = True` — run manually per the [migration deployment runbook](https://develop.sentry.dev/database-migrations/#migration-deployment).