### PR TITLE
chore(typing): Remove `sentry.search.events.builder.errors` from mypy ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -390,7 +390,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "sentry.api.endpoints.organization_releases",
-    "sentry.search.events.builder.errors",
     "sentry.search.events.builder.metrics",
     "sentry.search.events.datasets.filter_aliases",
     "sentry.snuba.metrics.query_builder",

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -30,7 +30,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.search.events.constants import EQUALITY_OPERATORS, INEQUALITY_OPERATORS
-from sentry.search.events.filter import to_list
+from sentry.search.events.filter import ParsedTerm, to_list
 from sentry.search.utils import (
     DEVICE_CLASS,
     get_teams_for_users,
@@ -352,14 +352,25 @@ def convert_query_values(
 ) -> Sequence[QueryToken]: ...
 
 
+@overload
 def convert_query_values(
-    search_filters: Sequence[QueryToken],
+    search_filters: Sequence[ParsedTerm],
     projects: Sequence[Project],
     user: User | RpcUser | AnonymousUser | None,
     environments: Sequence[Environment] | None,
     value_converters=value_converters,
     allow_aggregate_filters=False,
-) -> Sequence[QueryToken]:
+) -> Sequence[ParsedTerm]: ...
+
+
+def convert_query_values(
+    search_filters: Sequence[QueryToken | str],
+    projects: Sequence[Project],
+    user: User | RpcUser | AnonymousUser | None,
+    environments: Sequence[Environment] | None,
+    value_converters=value_converters,
+    allow_aggregate_filters=False,
+) -> Sequence[QueryToken | str]:
     """
     Accepts a collection of SearchFilter objects and converts their values into
     a specific format, based on converters specified in `value_converters`.
@@ -389,7 +400,12 @@ def convert_query_values(
     @overload
     def convert_search_filter(search_filter: QueryOp, organization: Organization) -> QueryOp: ...
 
-    def convert_search_filter(search_filter: QueryToken, organization: Organization) -> QueryToken:
+    @overload
+    def convert_search_filter(search_filter: str, organization: Organization) -> str: ...
+
+    def convert_search_filter(
+        search_filter: QueryToken | str, organization: Organization
+    ) -> QueryToken | str:
         if isinstance(search_filter, ParenExpression):
             return search_filter._replace(
                 children=[
@@ -421,8 +437,8 @@ def convert_query_values(
         return search_filter
 
     def expand_substatus_query_values(
-        search_filters: Sequence[QueryToken], org: Organization
-    ) -> Sequence[QueryToken]:
+        search_filters: Sequence[QueryToken | str], org: Organization
+    ) -> Sequence[QueryToken | str]:
         first_status_incl = None
         first_status_excl = None
         includes_status_filter = False

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import Sequence
-from typing import cast
 
 from snuba_sdk import (
     AliasedExpression,
@@ -19,7 +17,6 @@ from snuba_sdk import (
     Request,
 )
 
-from sentry.api.event_search import QueryToken
 from sentry.issues.issue_search import convert_query_values, convert_status_value
 from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.builder.discover import (
@@ -43,7 +40,7 @@ class ErrorsQueryBuilderMixin(BaseQueryBuilder):
     def parse_query(self, query: str | None) -> ParsedTerms:
         parsed_terms = super().parse_query(query)
         parsed_terms = convert_query_values(
-            cast("Sequence[QueryToken]", parsed_terms),
+            parsed_terms,
             self.params.projects,
             self.params.user,
             list(filter(None, self.params.environments)),

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Sequence
+from typing import cast
 
 from snuba_sdk import (
     AliasedExpression,
@@ -17,7 +19,9 @@ from snuba_sdk import (
     Request,
 )
 
+from sentry.api.event_search import QueryToken
 from sentry.issues.issue_search import convert_query_values, convert_status_value
+from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.builder.discover import (
     DiscoverQueryBuilder,
     TimeseriesQueryBuilder,
@@ -30,7 +34,7 @@ from sentry.snuba.entity_subscription import ENTITY_TIME_COLUMNS, get_entity_key
 value_converters = {"status": convert_status_value}
 
 
-class ErrorsQueryBuilderMixin:
+class ErrorsQueryBuilderMixin(BaseQueryBuilder):
     def __init__(self, *args, **kwargs):
         self.match = None
         self.entities = set()
@@ -39,7 +43,7 @@ class ErrorsQueryBuilderMixin:
     def parse_query(self, query: str | None) -> ParsedTerms:
         parsed_terms = super().parse_query(query)
         parsed_terms = convert_query_values(
-            parsed_terms,
+            cast("Sequence[QueryToken]", parsed_terms),
             self.params.projects,
             self.params.user,
             list(filter(None, self.params.environments)),

--- a/src/sentry/search/events/datasets/base.py
+++ b/src/sentry/search/events/datasets/base.py
@@ -22,6 +22,7 @@ class DatasetConfig(abc.ABC):
     missing_function_error: ClassVar[type[Exception]] = InvalidSearchQuery
     optimize_wildcard_searches = False
     subscriptables_with_index: set[str] = set()
+    use_entity_prefix_for_fields: bool = False
 
     def __init__(self, builder: BaseQueryBuilder):
         pass


### PR DESCRIPTION
Resolves [ENG-6452](https://linear.app/getsentry/issue/ENG-6452/remove-sentrysearcheventsbuildererrors-from-ignore-list).

Removes `sentry.search.events.builder.errors` from the mypy ignore list.

- Gives `ErrorsQueryBuilderMixin` an explicit base class (`BaseQueryBuilder`) so mypy can resolve attribute accesses and `super()` calls
- Add `use_entity_prefix_for_fields` to `DatasetConfig` base class
- Add a `Sequence[ParsedTerm]` overload to `convert_query_values` (and widen its internal helpers)