### PR TITLE
ref(onboarding): Extract ScmPlatformFeaturesCore from ScmPlatformFeatures

### DIFF
--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -20,7 +20,7 @@ import {IconBroadcast, IconBusiness, IconGeneric} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
-import type {PlatformKey} from 'sentry/types/project';
+import type {PlatformKey} from 'sentry/types/platform';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDisabledGamingPlatform} from 'sentry/utils/platform';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -1,0 +1,535 @@
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {motion} from 'framer-motion';
+import {PlatformIcon} from 'platformicons';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
+import {Select} from '@sentry/scraps/select';
+import {Text} from '@sentry/scraps/text';
+
+import {closeModal, openConsoleModal} from 'sentry/actionCreators/modal';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getDisabledProducts,
+  platformProductAvailability,
+} from 'sentry/components/onboarding/productSelection';
+import {PLATFORM_PRODUCT_INFO} from 'sentry/data/platformProductInfo.generated';
+import {IconBroadcast, IconBusiness, IconGeneric} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import type {Repository} from 'sentry/types/integrations';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import type {PlatformKey} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {isDisabledGamingPlatform} from 'sentry/utils/platform';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+import {ScmFeatureInfoCards} from './scmFeatureInfoCards';
+import {ScmFeatureSelectionCards} from './scmFeatureSelectionCards';
+import {ScmPlatformCard} from './scmPlatformCard';
+import {
+  FEATURE_DISPLAY_ORDER,
+  getPlatformInfo,
+  getPlatformName,
+  platformOptions,
+  type ResolvedPlatform,
+  shouldSuggestFramework,
+  toSelectedSdk,
+} from './scmPlatformHelpers';
+import {ScmSearchControl} from './scmSearchControl';
+import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
+import {useScmFeatureMeta} from './useScmFeatureMeta';
+import {useScmPlatformDetection} from './useScmPlatformDetection';
+
+const STEP_VIEWED_EVENT = {
+  onboarding: 'onboarding.scm_platform_features_step_viewed',
+  'project-creation': 'project_creation.scm_platform_features_step_viewed',
+} as const;
+const PLATFORM_SELECTED_EVENT = {
+  onboarding: 'onboarding.scm_platform_selected',
+  'project-creation': 'project_creation.scm_platform_selected',
+} as const;
+const FEATURE_TOGGLED_EVENT = {
+  onboarding: 'onboarding.scm_platform_feature_toggled',
+  'project-creation': 'project_creation.scm_platform_feature_toggled',
+} as const;
+const CHANGE_PLATFORM_CLICKED_EVENT = {
+  onboarding: 'onboarding.scm_platform_change_platform_clicked',
+  'project-creation': 'project_creation.scm_platform_change_platform_clicked',
+} as const;
+
+interface ScmPlatformFeaturesCoreProps {
+  analyticsFlow: ScmAnalyticsFlow;
+  onClearProjectDetailsForm: () => void;
+  onFeaturesChange: (features: ProductSolution[] | undefined) => void;
+  onPlatformChange: (platform: OnboardingSelectedSDK | undefined) => void;
+  selectedFeatures: ProductSolution[] | undefined;
+  selectedPlatform: OnboardingSelectedSDK | undefined;
+  selectedRepository: Repository | undefined;
+}
+
+/**
+ * Core platform-and-features selection slice shared by the SCM onboarding
+ * step (`ScmPlatformFeatures`) and the SCM-first project creation surface.
+ * Renders the auto-detected platform cards (when an SCM repo is connected
+ * and platforms were detected), the manual platform search dropdown, and
+ * the feature selection / info cards. Owns platform detection, feature
+ * metadata fetching, manual-picker toggle state, and the platform-selected
+ * / feature-toggled / step-viewed / change-platform analytics.
+ *
+ * Does NOT render the step's surrounding chrome (page heading, "Choose
+ * your SDK" subheading and description, Back / Continue footer). Hosts
+ * compose the chrome they need around this component.
+ */
+export function ScmPlatformFeaturesCore({
+  analyticsFlow,
+  onClearProjectDetailsForm,
+  onFeaturesChange,
+  onPlatformChange,
+  selectedFeatures,
+  selectedPlatform,
+  selectedRepository,
+}: ScmPlatformFeaturesCoreProps) {
+  const {openModal} = useModal();
+  const organization = useOrganization();
+  // Fetch feature meta at step entry so billing-config is in flight (or cached)
+  // before the user reaches the feature cards below.
+  const {meta: featureMeta, isLoading: isFeatureMetaLoading} = useScmFeatureMeta();
+
+  const [showManualPicker, setShowManualPicker] = useState(false);
+
+  useEffect(() => {
+    trackAnalytics(STEP_VIEWED_EVENT[analyticsFlow], {organization});
+  }, [organization, analyticsFlow]);
+
+  const setPlatform = useCallback(
+    (platformKey: PlatformKey) => {
+      const info = getPlatformInfo(platformKey);
+      if (info) {
+        onPlatformChange(toSelectedSdk(info));
+      }
+    },
+    [onPlatformChange]
+  );
+
+  const hasScmConnected = !!selectedRepository;
+
+  const {
+    detectedPlatforms,
+    isPending: isDetecting,
+    isError: isDetectionError,
+  } = useScmPlatformDetection(selectedRepository);
+
+  const currentFeatures = useMemo(
+    () => selectedFeatures ?? [ProductSolution.ERROR_MONITORING],
+    [selectedFeatures]
+  );
+
+  const resolvedPlatforms = useMemo(
+    () =>
+      detectedPlatforms.reduce<ResolvedPlatform[]>((acc, detected) => {
+        const info = getPlatformInfo(detected.platform);
+        if (info) {
+          acc.push({...detected, info});
+        }
+        return acc;
+      }, []),
+    [detectedPlatforms]
+  );
+
+  const detectedPlatformKey = resolvedPlatforms[0]?.platform;
+  // Derive platform from explicit selection, falling back to first detected
+  const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
+
+  const currentPlatformName = getPlatformName(currentPlatformKey);
+
+  // Fire scm_platform_selected once when detection auto-resolves a platform
+  // and the user hasn't explicitly chosen one. Otherwise a user who accepts
+  // the recommendation and clicks Continue never emits the event, leaving
+  // the funnel without a platform-selected step.
+  const autoDetectionTrackedRef = useRef(false);
+  useEffect(() => {
+    if (
+      autoDetectionTrackedRef.current ||
+      !detectedPlatformKey ||
+      selectedPlatform?.key
+    ) {
+      return;
+    }
+    autoDetectionTrackedRef.current = true;
+    trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
+      organization,
+      platform: detectedPlatformKey,
+      source: 'detected',
+    });
+  }, [detectedPlatformKey, selectedPlatform?.key, organization, analyticsFlow]);
+
+  // Wizard-driven platforms render an informational variant since the wizard CLI
+  // owns product configuration and toggles aren't actionable.
+  const featureMode = useMemo<'toggleable' | 'informational' | 'none'>(() => {
+    if (!currentPlatformKey) {
+      return 'none';
+    }
+    if (currentPlatformKey in platformProductAvailability) {
+      return 'toggleable';
+    }
+    if (currentPlatformKey in PLATFORM_PRODUCT_INFO) {
+      return 'informational';
+    }
+    return 'none';
+  }, [currentPlatformKey]);
+
+  const availableFeatures = useMemo(() => {
+    if (!currentPlatformKey || featureMode === 'none') {
+      return [];
+    }
+    const sourceProducts =
+      featureMode === 'toggleable'
+        ? platformProductAvailability[currentPlatformKey]
+        : PLATFORM_PRODUCT_INFO[currentPlatformKey];
+    const features = new Set<ProductSolution>([
+      ProductSolution.ERROR_MONITORING,
+      ...(sourceProducts ?? []),
+    ]);
+    return FEATURE_DISPLAY_ORDER.filter(f => features.has(f));
+  }, [currentPlatformKey, featureMode]);
+
+  const disabledProducts = useMemo(
+    () => getDisabledProducts(organization),
+    [organization]
+  );
+
+  const handleToggleFeature = useCallback(
+    (feature: ProductSolution) => {
+      if (disabledProducts[feature]) {
+        disabledProducts[feature]?.onClick?.();
+        return;
+      }
+
+      const wasEnabled = currentFeatures.includes(feature);
+      const newFeatures = new Set(
+        wasEnabled
+          ? currentFeatures.filter(f => f !== feature)
+          : [...currentFeatures, feature]
+      );
+
+      // Profiling requires tracing — mirror the constraint from ProductSelection
+      if (availableFeatures.includes(ProductSolution.PROFILING)) {
+        if (
+          feature === ProductSolution.PROFILING &&
+          newFeatures.has(ProductSolution.PROFILING)
+        ) {
+          newFeatures.add(ProductSolution.PERFORMANCE_MONITORING);
+        } else if (
+          feature === ProductSolution.PERFORMANCE_MONITORING &&
+          !newFeatures.has(ProductSolution.PERFORMANCE_MONITORING)
+        ) {
+          newFeatures.delete(ProductSolution.PROFILING);
+        }
+      }
+
+      onFeaturesChange(Array.from(newFeatures));
+
+      trackAnalytics(FEATURE_TOGGLED_EVENT[analyticsFlow], {
+        organization,
+        feature,
+        enabled: !wasEnabled,
+        platform: currentPlatformKey ?? '',
+      });
+    },
+    [
+      currentFeatures,
+      onFeaturesChange,
+      disabledProducts,
+      availableFeatures,
+      organization,
+      currentPlatformKey,
+      analyticsFlow,
+    ]
+  );
+
+  const applyPlatformSelection = (sdk: OnboardingSelectedSDK) => {
+    onPlatformChange(sdk);
+    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+    onClearProjectDetailsForm();
+  };
+
+  const handleManualPlatformSelect = async (option: {value: string}) => {
+    const platformKey = option.value as PlatformKey;
+    if (platformKey === selectedPlatform?.key) {
+      return;
+    }
+
+    // Block disabled gaming/console platforms
+    const platformInfo = getPlatformInfo(platformKey);
+    if (
+      platformInfo &&
+      isDisabledGamingPlatform({
+        platform: platformInfo,
+        enabledConsolePlatforms: organization.enabledConsolePlatforms,
+      })
+    ) {
+      openConsoleModal({
+        organization,
+        selectedPlatform: toSelectedSdk(platformInfo),
+        origin: 'onboarding',
+      });
+      return;
+    }
+
+    // For base languages (JavaScript, Python, etc.), show a modal suggesting
+    // specific frameworks — matching the legacy onboarding behavior.
+    if (platformInfo && shouldSuggestFramework(platformKey)) {
+      const baseSdk = toSelectedSdk(platformInfo);
+
+      const {FrameworkSuggestionModal, modalCss} =
+        await import('sentry/components/onboarding/frameworkSuggestionModal');
+
+      openModal(
+        deps => (
+          <FrameworkSuggestionModal
+            {...deps}
+            organization={organization}
+            selectedPlatform={baseSdk}
+            onConfigure={selectedFramework => {
+              applyPlatformSelection(selectedFramework);
+              closeModal();
+            }}
+            onSkip={() => {
+              applyPlatformSelection(baseSdk);
+              closeModal();
+            }}
+            newOrg
+            hasScmOnboarding
+          />
+        ),
+        {modalCss}
+      );
+      return;
+    }
+
+    setPlatform(platformKey);
+    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+    onClearProjectDetailsForm();
+
+    trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
+      organization,
+      platform: platformKey,
+      source: 'manual',
+    });
+  };
+
+  const handleSelectDetectedPlatform = (platformKey: PlatformKey) => {
+    if (platformKey === selectedPlatform?.key) {
+      return;
+    }
+    setPlatform(platformKey);
+    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+    onClearProjectDetailsForm();
+
+    trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
+      organization,
+      platform: platformKey,
+      source: 'detected',
+    });
+  };
+
+  function handleChangePlatformClick() {
+    setShowManualPicker(true);
+    if (!isDetecting) {
+      trackAnalytics(CHANGE_PLATFORM_CLICKED_EVENT[analyticsFlow], {
+        organization,
+      });
+    }
+  }
+
+  function handleBackToRecommended() {
+    setShowManualPicker(false);
+    if (detectedPlatformKey) {
+      setPlatform(detectedPlatformKey);
+      onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+      onClearProjectDetailsForm();
+    }
+  }
+
+  // Ensure the selected platform is always present in the dropdown options
+  // so the Select can resolve and display it. When the framework suggestion
+  // modal picks a key not in the static list, prepend it.
+  const manualPickerOptions = useMemo(() => {
+    const key = currentPlatformKey;
+    if (!key || platformOptions.some(o => o.value === key)) {
+      return platformOptions;
+    }
+    const info = getPlatformInfo(key);
+    if (!info) {
+      return platformOptions;
+    }
+    return [
+      {
+        value: info.id,
+        label: info.name,
+        textValue: `${info.name} ${info.id}`,
+        leadingItems: <PlatformIcon platform={info.id} size={16} />,
+      },
+      ...platformOptions,
+    ];
+  }, [currentPlatformKey]);
+
+  // If the user previously selected a platform manually (not in the detected
+  // list), show the manual picker so their selection is visible.
+  const currentPlatformIsDetected = resolvedPlatforms.some(
+    p => p.platform === currentPlatformKey
+  );
+  const hasDetectedPlatforms = resolvedPlatforms.length > 0 || isDetecting;
+  // Fall through to manual picker on detection error
+  const showDetectedPlatforms =
+    hasScmConnected &&
+    !showManualPicker &&
+    !isDetectionError &&
+    hasDetectedPlatforms &&
+    (!currentPlatformKey || currentPlatformIsDetected);
+
+  return (
+    <Fragment>
+      {showDetectedPlatforms ? (
+        <MotionStack
+          key="detected"
+          initial={{opacity: 0}}
+          animate={{opacity: 1}}
+          gap="md"
+          width="100%"
+        >
+          <Flex justify="between" align="center">
+            <Flex align="center" gap="sm">
+              <IconBroadcast size="sm" variant="secondary" />
+              <Text variant="secondary" bold size="sm" density="comfortable" uppercase>
+                {t('Auto-detected from your repository')}
+              </Text>
+            </Flex>
+            <Button size="xs" variant="link" onClick={handleChangePlatformClick}>
+              {isDetecting
+                ? t('Skip detection and select manually')
+                : t("Doesn't look right? Change platform")}
+            </Button>
+          </Flex>
+          <Stack gap="lg" width="100%">
+            {isDetecting ? (
+              <Flex justify="center">
+                <LoadingIndicator mini />
+              </Flex>
+            ) : (
+              <Grid
+                columns={{
+                  xs: '1fr',
+                  md: `repeat(${resolvedPlatforms.length}, minmax(200px, 1fr))`,
+                }}
+                width="100%"
+                justify="center"
+                gap="md"
+                role="radiogroup"
+              >
+                {resolvedPlatforms.map(({platform, info}) => (
+                  <ScmPlatformCard
+                    key={platform}
+                    platform={platform}
+                    name={info.name}
+                    type={info.type}
+                    isSelected={currentPlatformKey === platform}
+                    onClick={() => handleSelectDetectedPlatform(platform)}
+                  />
+                ))}
+              </Grid>
+            )}
+          </Stack>
+        </MotionStack>
+      ) : (
+        <MotionStack
+          key="manual"
+          gap="md"
+          width="100%"
+          initial={{opacity: 0}}
+          animate={{opacity: 1}}
+        >
+          <Flex justify="between" align="center">
+            <Flex align="center" gap="sm">
+              <IconGeneric size="sm" variant="secondary" />
+              <Text variant="secondary" bold size="sm" density="comfortable" uppercase>
+                {t('Select a platform')}
+              </Text>
+            </Flex>
+            {hasScmConnected && !isDetectionError && hasDetectedPlatforms && (
+              <Button size="xs" variant="link" onClick={handleBackToRecommended}>
+                {t('Back to recommended platforms')}
+              </Button>
+            )}
+          </Flex>
+          <Select<(typeof platformOptions)[number]>
+            placeholder={t('Search SDKs...')}
+            options={manualPickerOptions}
+            value={currentPlatformKey ?? null}
+            onChange={option => {
+              if (option) {
+                handleManualPlatformSelect(option);
+              }
+            }}
+            searchable
+            components={{
+              Control: ScmSearchControl,
+              MenuList: ScmVirtualizedMenuList,
+            }}
+            styles={{container: base => ({...base, width: '100%'})}}
+          />
+        </MotionStack>
+      )}
+      {featureMode !== 'none' && (
+        <MotionStack layout="position" width="100%">
+          <Stack gap="2xl" paddingTop="xs">
+            <Flex
+              padding="lg"
+              background="secondary"
+              border="secondary"
+              radius="md"
+              gap="lg"
+            >
+              <IconBusiness size="lg" variant="accent" />
+              <Text size="md" density="comfortable">
+                {tct(
+                  'You’ve got [bold:unlimited volume for 14 days] to try out everything. After that, free plan volumes apply ⋅ No credit card required',
+                  {
+                    bold: (
+                      <Text as="span" bold variant="accent">
+                        {null}
+                      </Text>
+                    ),
+                  }
+                )}
+              </Text>
+            </Flex>
+            {featureMode === 'toggleable' ? (
+              <ScmFeatureSelectionCards
+                availableFeatures={availableFeatures}
+                selectedFeatures={currentFeatures}
+                disabledProducts={disabledProducts}
+                onToggleFeature={handleToggleFeature}
+                featureMeta={featureMeta}
+                isVolumeLoading={isFeatureMetaLoading}
+              />
+            ) : (
+              <ScmFeatureInfoCards
+                availableFeatures={availableFeatures}
+                disabledProducts={disabledProducts}
+                featureMeta={featureMeta}
+                platformName={currentPlatformName}
+                isVolumeLoading={isFeatureMetaLoading}
+              />
+            )}
+          </Stack>
+        </MotionStack>
+      )}
+    </Fragment>
+  );
+}
+
+const MotionStack = motion.create(Stack);

--- a/static/app/views/onboarding/components/scmPlatformHelpers.tsx
+++ b/static/app/views/onboarding/components/scmPlatformHelpers.tsx
@@ -4,7 +4,8 @@ import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggesti
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {platforms} from 'sentry/data/platforms';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
-import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
+import type {PlatformKey} from 'sentry/types/platform';
+import type {PlatformIntegration} from 'sentry/types/project';
 
 import type {DetectedPlatform} from './useScmPlatformDetection';
 

--- a/static/app/views/onboarding/components/scmPlatformHelpers.tsx
+++ b/static/app/views/onboarding/components/scmPlatformHelpers.tsx
@@ -1,0 +1,61 @@
+import {PlatformIcon} from 'platformicons';
+
+import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {platforms} from 'sentry/data/platforms';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
+
+import type {DetectedPlatform} from './useScmPlatformDetection';
+
+export interface ResolvedPlatform extends DetectedPlatform {
+  info: PlatformIntegration;
+}
+
+export const FEATURE_DISPLAY_ORDER: ProductSolution[] = [
+  ProductSolution.ERROR_MONITORING,
+  ProductSolution.LOGS,
+  ProductSolution.SESSION_REPLAY,
+  ProductSolution.PERFORMANCE_MONITORING,
+  ProductSolution.PROFILING,
+  ProductSolution.METRICS,
+];
+
+const platformsByKey = new Map(platforms.map(p => [p.id, p]));
+
+export const getPlatformInfo = (key: PlatformKey) => platformsByKey.get(key);
+
+export const platformOptions = platforms.map(platform => ({
+  value: platform.id,
+  label: platform.name,
+  textValue: `${platform.name} ${platform.id}`,
+  leadingItems: <PlatformIcon platform={platform.id} size={16} />,
+}));
+
+export function toSelectedSdk(info: PlatformIntegration): OnboardingSelectedSDK {
+  return {
+    key: info.id,
+    name: info.name,
+    language: info.language,
+    type: info.type,
+    link: info.link,
+    // PlatformIntegration doesn't carry a category — 'all' is the most
+    // neutral value and avoids implying a specific picker category.
+    category: 'all',
+  };
+}
+
+export function shouldSuggestFramework(platformKey: PlatformKey): boolean {
+  const info = getPlatformInfo(platformKey);
+  return (
+    info?.type === 'language' &&
+    Object.values(SupportedLanguages).includes(info.language as SupportedLanguages)
+  );
+}
+
+export function getPlatformName(platformKey: PlatformKey | undefined) {
+  if (!platformKey) {
+    return;
+  }
+  return getPlatformInfo(platformKey)?.name;
+}

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,105 +1,28 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import {LayoutGroup, motion} from 'framer-motion';
-import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
-import {useModal} from '@sentry/scraps/modal';
-import {Select} from '@sentry/scraps/select';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {closeModal, openConsoleModal} from 'sentry/actionCreators/modal';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {
-  getDisabledProducts,
-  platformProductAvailability,
-} from 'sentry/components/onboarding/productSelection';
 import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
-import {PLATFORM_PRODUCT_INFO} from 'sentry/data/platformProductInfo.generated';
-import {platforms} from 'sentry/data/platforms';
-import {IconBroadcast, IconBusiness, IconGeneric} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {Team} from 'sentry/types/organization';
-import type {PlatformKey} from 'sentry/types/platform';
-import type {PlatformIntegration} from 'sentry/types/project';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import {isDisabledGamingPlatform} from 'sentry/utils/platform';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
-import {ScmFeatureInfoCards} from 'sentry/views/onboarding/components/scmFeatureInfoCards';
-import {ScmFeatureSelectionCards} from 'sentry/views/onboarding/components/scmFeatureSelectionCards';
-import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCard';
-import {useScmFeatureMeta} from 'sentry/views/onboarding/components/useScmFeatureMeta';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
-import {ScmSearchControl} from './components/scmSearchControl';
-import {ScmVirtualizedMenuList} from './components/scmVirtualizedMenuList';
-import {
-  useScmPlatformDetection,
-  type DetectedPlatform,
-} from './components/useScmPlatformDetection';
+import {ScmPlatformFeaturesCore} from './components/scmPlatformFeaturesCore';
+import {getPlatformInfo, toSelectedSdk} from './components/scmPlatformHelpers';
+import {useScmPlatformDetection} from './components/useScmPlatformDetection';
 import type {StepProps} from './types';
-
-interface ResolvedPlatform extends DetectedPlatform {
-  info: PlatformIntegration;
-}
-
-const FEATURE_DISPLAY_ORDER: ProductSolution[] = [
-  ProductSolution.ERROR_MONITORING,
-  ProductSolution.LOGS,
-  ProductSolution.SESSION_REPLAY,
-  ProductSolution.PERFORMANCE_MONITORING,
-  ProductSolution.PROFILING,
-  ProductSolution.METRICS,
-];
-
-const platformsByKey = new Map(platforms.map(p => [p.id, p]));
-
-const getPlatformInfo = (key: PlatformKey) => platformsByKey.get(key);
-
-const platformOptions = platforms.map(platform => ({
-  value: platform.id,
-  label: platform.name,
-  textValue: `${platform.name} ${platform.id}`,
-  leadingItems: <PlatformIcon platform={platform.id} size={16} />,
-}));
-
-function toSelectedSdk(info: PlatformIntegration): OnboardingSelectedSDK {
-  return {
-    key: info.id,
-    name: info.name,
-    language: info.language,
-    type: info.type,
-    link: info.link,
-    // PlatformIntegration doesn't carry a category — 'all' is the most
-    // neutral value and avoids implying a specific picker category.
-    category: 'all',
-  };
-}
-
-function shouldSuggestFramework(platformKey: PlatformKey): boolean {
-  const info = getPlatformInfo(platformKey);
-  return (
-    info?.type === 'language' &&
-    Object.values(SupportedLanguages).includes(info.language as SupportedLanguages)
-  );
-}
-
-function getPlatformName(platformKey: PlatformKey | undefined) {
-  if (!platformKey) {
-    return;
-  }
-  return getPlatformInfo(platformKey)?.name;
-}
 
 interface ScmPlatformFeaturesProps {
   createdProjectSlug: string | undefined;
@@ -126,16 +49,11 @@ export function ScmPlatformFeatures({
   selectedRepository,
   genBackButton,
 }: ScmPlatformFeaturesProps) {
-  const {openModal} = useModal();
-
   const organization = useOrganization();
 
   const {teams, fetching: isLoadingTeams} = useTeams();
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const createProject = useCreateProject();
-  // Fetch feature meta at step entry so billing-config is in flight (or cached)
-  // before the user reaches the feature cards below.
-  const {meta: featureMeta, isLoading: isFeatureMetaLoading} = useScmFeatureMeta();
   // Exposure is reported upstream in onboarding.tsx when the user enters SCM
   // onboarding; skip it here to avoid double-counting on step mount.
   const {inExperiment: hasProjectDetailsStep} = useExperiment({
@@ -143,260 +61,25 @@ export function ScmPlatformFeatures({
     reportExposure: false,
   });
 
-  const [showManualPicker, setShowManualPicker] = useState(false);
-
-  useEffect(() => {
-    trackAnalytics('onboarding.scm_platform_features_step_viewed', {organization});
-  }, [organization]);
-
-  const setPlatform = useCallback(
-    (platformKey: PlatformKey) => {
-      const info = getPlatformInfo(platformKey);
-      if (info) {
-        onPlatformChange(toSelectedSdk(info));
-      }
-    },
-    [onPlatformChange]
-  );
-
-  const hasScmConnected = !!selectedRepository;
-
-  const {
-    detectedPlatforms,
-    isPending: isDetecting,
-    isError: isDetectionError,
-  } = useScmPlatformDetection(selectedRepository);
-
-  const currentFeatures = useMemo(
-    () => selectedFeatures ?? [ProductSolution.ERROR_MONITORING],
-    [selectedFeatures]
-  );
-
-  const resolvedPlatforms = useMemo(
-    () =>
-      detectedPlatforms.reduce<ResolvedPlatform[]>((acc, detected) => {
-        const info = getPlatformInfo(detected.platform);
-        if (info) {
-          acc.push({...detected, info});
-        }
-        return acc;
-      }, []),
-    [detectedPlatforms]
-  );
-
-  const detectedPlatformKey = resolvedPlatforms[0]?.platform;
-  // Derive platform from explicit selection, falling back to first detected
+  // React Query dedupes with the core's call; we only need detectedPlatformKey
+  // here so handleContinue's auto-create path can fall back to the
+  // auto-detected platform when the user clicks Continue without an explicit
+  // selection.
+  const {detectedPlatforms} = useScmPlatformDetection(selectedRepository);
+  const detectedPlatformKey = detectedPlatforms[0]?.platform;
   const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
 
-  const currentPlatformName = getPlatformName(currentPlatformKey);
+  const currentFeatures = selectedFeatures ?? [ProductSolution.ERROR_MONITORING];
 
-  // Fire scm_platform_selected once when detection auto-resolves a platform
-  // and the user hasn't explicitly chosen one. Otherwise a user who accepts
-  // the recommendation and clicks Continue never emits the event, leaving
-  // the funnel without a platform-selected step.
-  const autoDetectionTrackedRef = useRef(false);
-  useEffect(() => {
-    if (
-      autoDetectionTrackedRef.current ||
-      !detectedPlatformKey ||
-      selectedPlatform?.key
-    ) {
+  const setPlatform = (platformKey: typeof currentPlatformKey) => {
+    if (!platformKey) {
       return;
     }
-    autoDetectionTrackedRef.current = true;
-    trackAnalytics('onboarding.scm_platform_selected', {
-      organization,
-      platform: detectedPlatformKey,
-      source: 'detected',
-    });
-  }, [detectedPlatformKey, selectedPlatform?.key, organization]);
-
-  // Wizard-driven platforms render an informational variant since the wizard CLI
-  // owns product configuration and toggles aren't actionable.
-  const featureMode = useMemo<'toggleable' | 'informational' | 'none'>(() => {
-    if (!currentPlatformKey) {
-      return 'none';
+    const info = getPlatformInfo(platformKey);
+    if (info) {
+      onPlatformChange(toSelectedSdk(info));
     }
-    if (currentPlatformKey in platformProductAvailability) {
-      return 'toggleable';
-    }
-    if (currentPlatformKey in PLATFORM_PRODUCT_INFO) {
-      return 'informational';
-    }
-    return 'none';
-  }, [currentPlatformKey]);
-
-  const availableFeatures = useMemo(() => {
-    if (!currentPlatformKey || featureMode === 'none') {
-      return [];
-    }
-    const sourceProducts =
-      featureMode === 'toggleable'
-        ? platformProductAvailability[currentPlatformKey]
-        : PLATFORM_PRODUCT_INFO[currentPlatformKey];
-    const features = new Set<ProductSolution>([
-      ProductSolution.ERROR_MONITORING,
-      ...(sourceProducts ?? []),
-    ]);
-    return FEATURE_DISPLAY_ORDER.filter(f => features.has(f));
-  }, [currentPlatformKey, featureMode]);
-
-  const disabledProducts = useMemo(
-    () => getDisabledProducts(organization),
-    [organization]
-  );
-
-  const handleToggleFeature = useCallback(
-    (feature: ProductSolution) => {
-      if (disabledProducts[feature]) {
-        disabledProducts[feature]?.onClick?.();
-        return;
-      }
-
-      const wasEnabled = currentFeatures.includes(feature);
-      const newFeatures = new Set(
-        wasEnabled
-          ? currentFeatures.filter(f => f !== feature)
-          : [...currentFeatures, feature]
-      );
-
-      // Profiling requires tracing — mirror the constraint from ProductSelection
-      if (availableFeatures.includes(ProductSolution.PROFILING)) {
-        if (
-          feature === ProductSolution.PROFILING &&
-          newFeatures.has(ProductSolution.PROFILING)
-        ) {
-          newFeatures.add(ProductSolution.PERFORMANCE_MONITORING);
-        } else if (
-          feature === ProductSolution.PERFORMANCE_MONITORING &&
-          !newFeatures.has(ProductSolution.PERFORMANCE_MONITORING)
-        ) {
-          newFeatures.delete(ProductSolution.PROFILING);
-        }
-      }
-
-      onFeaturesChange(Array.from(newFeatures));
-
-      trackAnalytics('onboarding.scm_platform_feature_toggled', {
-        organization,
-        feature,
-        enabled: !wasEnabled,
-        platform: currentPlatformKey ?? '',
-      });
-    },
-    [
-      currentFeatures,
-      onFeaturesChange,
-      disabledProducts,
-      availableFeatures,
-      organization,
-      currentPlatformKey,
-    ]
-  );
-
-  const applyPlatformSelection = (sdk: OnboardingSelectedSDK) => {
-    onPlatformChange(sdk);
-    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
-    onClearProjectDetailsForm();
   };
-
-  const handleManualPlatformSelect = async (option: {value: string}) => {
-    const platformKey = option.value as PlatformKey;
-    if (platformKey === selectedPlatform?.key) {
-      return;
-    }
-
-    // Block disabled gaming/console platforms
-    const platformInfo = getPlatformInfo(platformKey);
-    if (
-      platformInfo &&
-      isDisabledGamingPlatform({
-        platform: platformInfo,
-        enabledConsolePlatforms: organization.enabledConsolePlatforms,
-      })
-    ) {
-      openConsoleModal({
-        organization,
-        selectedPlatform: toSelectedSdk(platformInfo),
-        origin: 'onboarding',
-      });
-      return;
-    }
-
-    // For base languages (JavaScript, Python, etc.), show a modal suggesting
-    // specific frameworks — matching the legacy onboarding behavior.
-    if (platformInfo && shouldSuggestFramework(platformKey)) {
-      const baseSdk = toSelectedSdk(platformInfo);
-
-      const {FrameworkSuggestionModal, modalCss} =
-        await import('sentry/components/onboarding/frameworkSuggestionModal');
-
-      openModal(
-        deps => (
-          <FrameworkSuggestionModal
-            {...deps}
-            organization={organization}
-            selectedPlatform={baseSdk}
-            onConfigure={selectedFramework => {
-              applyPlatformSelection(selectedFramework);
-              closeModal();
-            }}
-            onSkip={() => {
-              applyPlatformSelection(baseSdk);
-              closeModal();
-            }}
-            newOrg
-            hasScmOnboarding
-          />
-        ),
-        {modalCss}
-      );
-      return;
-    }
-
-    setPlatform(platformKey);
-    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
-    onClearProjectDetailsForm();
-
-    trackAnalytics('onboarding.scm_platform_selected', {
-      organization,
-      platform: platformKey,
-      source: 'manual',
-    });
-  };
-
-  const handleSelectDetectedPlatform = (platformKey: PlatformKey) => {
-    if (platformKey === selectedPlatform?.key) {
-      return;
-    }
-    setPlatform(platformKey);
-    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
-    onClearProjectDetailsForm();
-
-    trackAnalytics('onboarding.scm_platform_selected', {
-      organization,
-      platform: platformKey,
-      source: 'detected',
-    });
-  };
-
-  function handleChangePlatformClick() {
-    setShowManualPicker(true);
-    if (!isDetecting) {
-      trackAnalytics('onboarding.scm_platform_change_platform_clicked', {
-        organization,
-      });
-    }
-  }
-
-  function handleBackToRecommended() {
-    setShowManualPicker(false);
-    if (detectedPlatformKey) {
-      setPlatform(detectedPlatformKey);
-      onFeaturesChange([ProductSolution.ERROR_MONITORING]);
-      onClearProjectDetailsForm();
-    }
-  }
 
   const existingProject = createdProjectSlug
     ? projects.find(p => p.slug === createdProjectSlug)
@@ -475,43 +158,6 @@ export function ScmPlatformFeatures({
     onComplete();
   }
 
-  // Ensure the selected platform is always present in the dropdown options
-  // so the Select can resolve and display it. When the framework suggestion
-  // modal picks a key not in the static list, prepend it.
-  const manualPickerOptions = useMemo(() => {
-    const key = currentPlatformKey;
-    if (!key || platformOptions.some(o => o.value === key)) {
-      return platformOptions;
-    }
-    const info = getPlatformInfo(key);
-    if (!info) {
-      return platformOptions;
-    }
-    return [
-      {
-        value: info.id,
-        label: info.name,
-        textValue: `${info.name} ${info.id}`,
-        leadingItems: <PlatformIcon platform={info.id} size={16} />,
-      },
-      ...platformOptions,
-    ];
-  }, [currentPlatformKey]);
-
-  // If the user previously selected a platform manually (not in the detected
-  // list), show the manual picker so their selection is visible.
-  const currentPlatformIsDetected = resolvedPlatforms.some(
-    p => p.platform === currentPlatformKey
-  );
-  const hasDetectedPlatforms = resolvedPlatforms.length > 0 || isDetecting;
-  // Fall through to manual picker on detection error
-  const showDetectedPlatforms =
-    hasScmConnected &&
-    !showManualPicker &&
-    !isDetectionError &&
-    hasDetectedPlatforms &&
-    (!currentPlatformKey || currentPlatformIsDetected);
-
   return (
     <Flex direction="column" align="center" gap="2xl" flexGrow={1}>
       <Stack gap="3xl" maxWidth={SCM_STEP_CONTENT_WIDTH}>
@@ -531,153 +177,15 @@ export function ScmPlatformFeatures({
               </Text>
             </Container>
           </Stack>
-          {showDetectedPlatforms ? (
-            <MotionStack
-              key="detected"
-              initial={{opacity: 0}}
-              animate={{opacity: 1}}
-              gap="md"
-              width="100%"
-            >
-              <Flex justify="between" align="center">
-                <Flex align="center" gap="sm">
-                  <IconBroadcast size="sm" variant="secondary" />
-                  <Text
-                    variant="secondary"
-                    bold
-                    size="sm"
-                    density="comfortable"
-                    uppercase
-                  >
-                    {t('Auto-detected from your repository')}
-                  </Text>
-                </Flex>
-                <Button size="xs" variant="link" onClick={handleChangePlatformClick}>
-                  {isDetecting
-                    ? t('Skip detection and select manually')
-                    : t("Doesn't look right? Change platform")}
-                </Button>
-              </Flex>
-              <Stack gap="lg" width="100%">
-                {isDetecting ? (
-                  <Flex justify="center">
-                    <LoadingIndicator mini />
-                  </Flex>
-                ) : (
-                  <Grid
-                    columns={{
-                      xs: '1fr',
-                      md: `repeat(${resolvedPlatforms.length}, minmax(200px, 1fr))`,
-                    }}
-                    width="100%"
-                    justify="center"
-                    gap="md"
-                    role="radiogroup"
-                  >
-                    {resolvedPlatforms.map(({platform, info}) => (
-                      <ScmPlatformCard
-                        key={platform}
-                        platform={platform}
-                        name={info.name}
-                        type={info.type}
-                        isSelected={currentPlatformKey === platform}
-                        onClick={() => handleSelectDetectedPlatform(platform)}
-                      />
-                    ))}
-                  </Grid>
-                )}
-              </Stack>
-            </MotionStack>
-          ) : (
-            <MotionStack
-              key="manual"
-              gap="md"
-              width="100%"
-              initial={{opacity: 0}}
-              animate={{opacity: 1}}
-            >
-              <Flex justify="between" align="center">
-                <Flex align="center" gap="sm">
-                  <IconGeneric size="sm" variant="secondary" />
-                  <Text
-                    variant="secondary"
-                    bold
-                    size="sm"
-                    density="comfortable"
-                    uppercase
-                  >
-                    {t('Select a platform')}
-                  </Text>
-                </Flex>
-                {hasScmConnected && !isDetectionError && hasDetectedPlatforms && (
-                  <Button size="xs" variant="link" onClick={handleBackToRecommended}>
-                    {t('Back to recommended platforms')}
-                  </Button>
-                )}
-              </Flex>
-              <Select<(typeof platformOptions)[number]>
-                placeholder={t('Search SDKs...')}
-                options={manualPickerOptions}
-                value={currentPlatformKey ?? null}
-                onChange={option => {
-                  if (option) {
-                    handleManualPlatformSelect(option);
-                  }
-                }}
-                searchable
-                components={{
-                  Control: ScmSearchControl,
-                  MenuList: ScmVirtualizedMenuList,
-                }}
-                styles={{container: base => ({...base, width: '100%'})}}
-              />
-            </MotionStack>
-          )}
-          {featureMode !== 'none' && (
-            <MotionStack layout="position" width="100%">
-              <Stack gap="2xl" paddingTop="xs">
-                <Flex
-                  padding="lg"
-                  background="secondary"
-                  border="secondary"
-                  radius="md"
-                  gap="lg"
-                >
-                  <IconBusiness size="lg" variant="accent" />
-                  <Text size="md" density="comfortable">
-                    {tct(
-                      'You’ve got [bold:unlimited volume for 14 days] to try out everything. After that, free plan volumes apply ⋅ No credit card required',
-                      {
-                        bold: (
-                          <Text as="span" bold variant="accent">
-                            {null}
-                          </Text>
-                        ),
-                      }
-                    )}
-                  </Text>
-                </Flex>
-                {featureMode === 'toggleable' ? (
-                  <ScmFeatureSelectionCards
-                    availableFeatures={availableFeatures}
-                    selectedFeatures={currentFeatures}
-                    disabledProducts={disabledProducts}
-                    onToggleFeature={handleToggleFeature}
-                    featureMeta={featureMeta}
-                    isVolumeLoading={isFeatureMetaLoading}
-                  />
-                ) : (
-                  <ScmFeatureInfoCards
-                    availableFeatures={availableFeatures}
-                    disabledProducts={disabledProducts}
-                    featureMeta={featureMeta}
-                    platformName={currentPlatformName}
-                    isVolumeLoading={isFeatureMetaLoading}
-                  />
-                )}
-              </Stack>
-            </MotionStack>
-          )}
+          <ScmPlatformFeaturesCore
+            analyticsFlow="onboarding"
+            selectedRepository={selectedRepository}
+            selectedPlatform={selectedPlatform}
+            selectedFeatures={selectedFeatures}
+            onPlatformChange={onPlatformChange}
+            onFeaturesChange={onFeaturesChange}
+            onClearProjectDetailsForm={onClearProjectDetailsForm}
+          />
           <MotionFlex
             layout="position"
             align="center"
@@ -693,7 +201,6 @@ export function ScmPlatformFeatures({
                 analyticsEventName="Onboarding: SCM Platform Features Continue Clicked"
                 analyticsParams={{
                   platform: currentPlatformKey ?? '',
-                  source: showDetectedPlatforms ? 'detected' : 'manual',
                   features: currentFeatures,
                 }}
                 onClick={handleContinue}
@@ -712,5 +219,4 @@ export function ScmPlatformFeatures({
   );
 }
 
-const MotionStack = motion.create(Stack);
 const MotionFlex = motion.create(Flex);

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -66,7 +66,13 @@ export function ScmPlatformFeatures({
   // auto-detected platform when the user clicks Continue without an explicit
   // selection.
   const {detectedPlatforms} = useScmPlatformDetection(selectedRepository);
-  const detectedPlatformKey = detectedPlatforms[0]?.platform;
+  // Mirror the core's filtering: only fall back to a detected platform the
+  // client recognizes. An unknown key from detection would otherwise enable
+  // Continue while handleContinue's getPlatformInfo lookup returns undefined,
+  // stranding the user on a no-op click.
+  const detectedPlatformKey = detectedPlatforms.find(p =>
+    getPlatformInfo(p.platform)
+  )?.platform;
   const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
 
   const currentFeatures = selectedFeatures ?? [ProductSolution.ERROR_MONITORING];


### PR DESCRIPTION
## TL;DR
Splits `ScmPlatformFeatures` into a reusable platform-and-features selection core (`ScmPlatformFeaturesCore`) and the onboarding chrome that wraps it. The core owns platform detection, feature metadata, the manual-picker toggle, all selection/toggle handlers, and the `step_viewed` / `platform_selected` / `feature_toggled` / `change_platform_clicked` analytics. The wrapper keeps the page headings, the Continue button, and the auto-create-on-skip-project-details path. Behavior preserved (modulo a small analyticsParam drop noted below); the existing 26 spec tests pass unchanged.

This is the VDY-75 equivalent of PR 3's `ScmIntegrationConnect` extraction. The future wiring PR will consume `ScmPlatformFeaturesCore` from `scmCreateProject` for section 2 of the single-view wizard.

---

## Stack
- [PR 1](https://github.com/getsentry/sentry/pull/116434): `ScmAnalyticsFlow` + project_creation event registry
- [PR 2](https://github.com/getsentry/sentry/pull/116577): Single-view scaffold
- [PR 3](https://github.com/getsentry/sentry/pull/116581): Extract `ScmIntegrationConnect`
- [PR 4](https://github.com/getsentry/sentry/pull/116582): Wire `ScmIntegrationConnect`
- **PR 5 (this):** Extract `ScmPlatformFeaturesCore`
- PR 6 (next): Wire `ScmPlatformFeaturesCore` into section 2 (VDY-75 wiring)

## Summary
- New `static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx` owns the platform-and-features selection slice (auto-detected cards or manual picker + feature selection/info cards + the "unlimited volume" promo card). Props: `analyticsFlow`, `selectedRepository`, `selectedPlatform`, `selectedFeatures`, `onPlatformChange`, `onFeaturesChange`, `onClearProjectDetailsForm`.
- New `static/app/views/onboarding/components/scmPlatformHelpers.tsx` holds shared constants and helpers (`FEATURE_DISPLAY_ORDER`, `getPlatformInfo`, `getPlatformName`, `platformOptions`, `toSelectedSdk`, `shouldSuggestFramework`, `ResolvedPlatform`) so both the wrapper and the core can import without a circular dependency.
- `ScmPlatformFeatures` (wrapper) now imports and renders `<ScmPlatformFeaturesCore analyticsFlow="onboarding" .../>`. It still calls `useScmPlatformDetection` to derive `currentPlatformKey` for `handleContinue`'s auto-create path (React Query dedupes with the core's call).
- The Continue button's `analyticsParams` drop the `source: 'detected' | 'manual'` field, since that lived in core-internal state and is already captured by per-selection `scm_platform_selected` events.
- All 26 existing `scmPlatformFeatures.spec.tsx` tests pass unchanged; broader onboarding specs (`onboarding.spec.tsx`, `scmProjectDetails.spec.tsx`, `scmRepoSelector.spec.tsx`) also clean.

## Out of scope
- Wiring `ScmPlatformFeaturesCore` into `scmCreateProject`. PR 6 will pick that up.

Refs VDY-75

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint:js\` clean on touched files
- [x] \`pnpm test-ci scmPlatformFeatures.spec.tsx\` (26 tests, all pass)
- [x] \`pnpm test-ci onboarding.spec.tsx scmProjectDetails.spec.tsx scmRepoSelector.spec.tsx\` (59 tests, all pass)
- [ ] In onboarding, the platform-features step renders identically: detected cards when SCM connected and platforms detected, manual picker otherwise, feature cards below, Continue footer
- [ ] Selecting an auto-detected card or picking from manual fires \`onboarding.scm_platform_selected\` with the right \`source\`
- [ ] Toggling a feature fires \`onboarding.scm_platform_feature_toggled\`
- [ ] Clicking Continue fires \`onboarding.scm_platform_features_continue_clicked\` (without \`source\` param, with \`platform\` and \`features\`)