### PR TITLE
feat(vercel): Activate the API-driven pipeline for Vercel installs

### DIFF
--- a/static/app/components/pipeline/integrationVercel/index.spec.tsx
+++ b/static/app/components/pipeline/integrationVercel/index.spec.tsx
@@ -1,95 +1,36 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {
-  createMakeStepProps,
-  dispatchPipelineMessage,
-  setupMockPopup,
-} from 'sentry/components/pipeline/testUtils';
+import {createMakeStepProps} from 'sentry/components/pipeline/testUtils';
 
 import {vercelIntegrationPipeline} from '.';
 
-const VercelOAuthLoginStep = vercelIntegrationPipeline.steps[0].component;
+const VercelInstallStep = vercelIntegrationPipeline.steps[0].component;
 
 const makeStepProps = createMakeStepProps({totalSteps: 1});
 
-let mockPopup: Window;
-
-beforeEach(() => {
-  mockPopup = setupMockPopup();
-});
-
-afterEach(() => {
-  jest.restoreAllMocks();
-});
-
-describe('VercelOAuthLoginStep', () => {
-  it('renders the OAuth login step for Vercel', () => {
-    render(
-      <VercelOAuthLoginStep
-        {...makeStepProps({
-          stepData: {oauthUrl: 'https://vercel.com/oauth/authorize'},
-        })}
-      />
-    );
-
-    expect(screen.getByRole('button', {name: 'Authorize Vercel'})).toBeInTheDocument();
-  });
-
-  it('calls advance with code and state on OAuth callback', async () => {
+describe('VercelInstallStep', () => {
+  it('auto-advances with the pipeline state and shows a finishing message', () => {
     const advance = jest.fn();
     render(
-      <VercelOAuthLoginStep
+      <VercelInstallStep
         {...makeStepProps({
-          stepData: {oauthUrl: 'https://vercel.com/oauth/authorize'},
+          stepData: {state: 'pipeline-sig'},
           advance,
         })}
       />
     );
 
-    await userEvent.click(screen.getByRole('button', {name: 'Authorize Vercel'}));
-
-    dispatchPipelineMessage({
-      source: mockPopup,
-      data: {
-        _pipeline_source: 'sentry-pipeline',
-        code: 'auth-code-123',
-        state: 'state-xyz',
-      },
-    });
-
-    expect(advance).toHaveBeenCalledWith({
-      code: 'auth-code-123',
-      state: 'state-xyz',
-    });
+    expect(advance).toHaveBeenCalledWith({state: 'pipeline-sig'});
+    expect(advance).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByText('Finishing up Vercel integration installation...')
+    ).toBeInTheDocument();
   });
 
-  it('shows busy state when isAdvancing is true', () => {
-    render(
-      <VercelOAuthLoginStep
-        {...makeStepProps({
-          stepData: {oauthUrl: 'https://vercel.com/oauth/authorize'},
-          isAdvancing: true,
-        })}
-      />
-    );
+  it('does not advance until stepData is available', () => {
+    const advance = jest.fn();
+    render(<VercelInstallStep {...makeStepProps({stepData: null, advance})} />);
 
-    expect(screen.getByRole('button', {name: 'Authorize Vercel'})).toHaveAttribute(
-      'aria-busy',
-      'true'
-    );
-  });
-
-  it('disables authorize button when oauthUrl is not provided', () => {
-    render(<VercelOAuthLoginStep {...makeStepProps({stepData: {}})} />);
-
-    expect(screen.getByRole('button', {name: 'Authorize Vercel'})).toBeDisabled();
-  });
-
-  it('disables authorize button when isInitializing', () => {
-    render(
-      <VercelOAuthLoginStep {...makeStepProps({stepData: null, isInitializing: true})} />
-    );
-
-    expect(screen.getByRole('button', {name: 'Authorize Vercel'})).toBeDisabled();
+    expect(advance).not.toHaveBeenCalled();
   });
 });

--- a/static/app/components/pipeline/integrationVercel/index.tsx
+++ b/static/app/components/pipeline/integrationVercel/index.tsx
@@ -1,7 +1,7 @@
-import {useCallback} from 'react';
+import {useEffect, useRef} from 'react';
 
-import type {OAuthCallbackData} from 'sentry/components/pipeline/shared/oauthLoginStep';
-import {OAuthLoginStep} from 'sentry/components/pipeline/shared/oauthLoginStep';
+import {Text} from '@sentry/scraps/text';
+
 import type {
   PipelineDefinition,
   PipelineStepProps,
@@ -10,26 +10,25 @@ import {pipelineComplete} from 'sentry/components/pipeline/types';
 import {t} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 
-function VercelOAuthLoginStep({
+function VercelInstallStep({
   stepData,
   advance,
-  isAdvancing,
-}: PipelineStepProps<{oauthUrl?: string}, {code: string; state: string}>) {
-  const handleOAuthCallback = useCallback(
-    (data: OAuthCallbackData) => {
-      advance({code: data.code, state: data.state});
-    },
-    [advance]
-  );
+}: PipelineStepProps<{state: string}, {state: string}>) {
+  // Vercel installs are initiated from the Vercel marketplace, which performs
+  // the OAuth grant and forwards the `code` as initialData. By the time the
+  // modal opens everything the pipeline needs is already bound to state, so we
+  // advance immediately with no user interaction. The ref guards against React
+  // strict mode double-firing the effect.
+  const hasAutoAdvanced = useRef(false);
+  useEffect(() => {
+    if (!stepData?.state || hasAutoAdvanced.current) {
+      return;
+    }
+    hasAutoAdvanced.current = true;
+    advance({state: stepData.state});
+  }, [stepData, advance]);
 
-  return (
-    <OAuthLoginStep
-      oauthUrl={stepData?.oauthUrl}
-      isLoading={isAdvancing}
-      serviceName="Vercel"
-      onOAuthCallback={handleOAuthCallback}
-    />
-  );
+  return <Text>{t('Finishing up Vercel integration installation...')}</Text>;
 }
 
 export const vercelIntegrationPipeline = {
@@ -41,8 +40,8 @@ export const vercelIntegrationPipeline = {
   steps: [
     {
       stepId: 'oauth_login',
-      shortDescription: t('Authorizing via Vercel OAuth'),
-      component: VercelOAuthLoginStep,
+      shortDescription: t('Finishing installation'),
+      component: VercelInstallStep,
     },
   ],
 } as const satisfies PipelineDefinition;

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -60,6 +60,7 @@ const UNCONDITIONAL_API_PIPELINE_PROVIDERS = [
   'perforce',
   'slack',
   'slack_staging',
+  'vercel',
   'vsts',
 ] as const satisfies ReadonlyArray<ProvidersByType['integration']>;
 

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -96,6 +96,11 @@ function trackExternalAnalytics({
  *    `/extensions/jira/configure/`). Drives the pipeline with
  *    `jiraParams`.
  *
+ *  - Vercel
+ *    `/extensions/vercel/link/...` (redirected from
+ *    `/extensions/vercel/configure/`). Drives the pipeline with
+ *    `vercelParams`.
+ *
  *  - Anything else
  *    falls through to {@link finishLegacyInstallation}, which bounces to the
  *    legacy `/extensions/<slug>/configure/` backend endpoint.
@@ -256,6 +261,21 @@ export default function IntegrationOrganizationLink() {
     return {signedParams};
   }, [integrationSlug, location.query]);
 
+  // Vercel marketplace installs arrive here (forwarded from
+  // `/extensions/vercel/configure/`) with the OAuth `code` Vercel already
+  // granted. The install pipeline exchanges that code, so we forward it as
+  // initialData for the modal -- no second authorize round-trip.
+  const vercelParams = useMemo<Record<string, string> | null>(() => {
+    if (integrationSlug !== 'vercel') {
+      return null;
+    }
+    const code = location.query.code;
+    if (typeof code !== 'string') {
+      return null;
+    }
+    return {code};
+  }, [integrationSlug, location.query]);
+
   // Legacy install path. Redirects to `/extensions/<slug>/configure/`, which
   // runs the Django-rendered `IntegrationExtensionConfigurationView` to drive
   // the install server-side via the legacy pipeline. Used by every provider
@@ -285,7 +305,11 @@ export default function IntegrationOrganizationLink() {
     // Whichever one is non-null routes through the API pipeline modal;
     // otherwise we fall back to the legacy server-driven install flow.
     const urlParams =
-      gitHubAppListingParams ?? discordAppDirectoryParams ?? msTeamsParams ?? jiraParams;
+      gitHubAppListingParams ??
+      discordAppDirectoryParams ??
+      msTeamsParams ??
+      jiraParams ??
+      vercelParams;
     if (urlParams) {
       startFlow({provider, organization, onInstall, urlParams});
       return;
@@ -299,6 +323,7 @@ export default function IntegrationOrganizationLink() {
     discordAppDirectoryParams,
     msTeamsParams,
     jiraParams,
+    vercelParams,
     startFlow,
     onInstall,
     finishLegacyInstallation,


### PR DESCRIPTION
Activates the API-driven install pipeline for Vercel and gives the modal step its final, correct shape.

Vercel installs are always initiated from the Vercel marketplace, which performs the OAuth grant and redirects to `/extensions/vercel/link/` with the authorization `code`. So this models Vercel on the marketplace install pattern (MS Teams, Discord App Directory), not the in-app OAuth popup pattern:

- Adds `vercel` to `UNCONDITIONAL_API_PIPELINE_PROVIDERS`.
- `vercelParams` forwards the marketplace `code` as `initialData` into the org-link install dispatch, so the pipeline can exchange it — no second authorize round-trip.
- Rewrites the pipeline step (`integrationVercel`) to a pure auto-advance step (mirrors MS Teams): the install data is already bound to pipeline state by the time the modal opens, so it advances immediately with no user interaction and shows a "Finishing up…" message. Drops the `OAuthLoginStep`/popup (Vercel never needs an authorize popup since the marketplace already granted the code).

Pairs with the backend in #113094 (frontend and backend are not atomically deployed). The configure→`/link/` redirect that fully turns this on lands last, after this is deployed.

Ref [VDY-44](https://linear.app/getsentry/issue/VDY-44/vercel-api-driven-integration-setup)
