### PR TITLE
feat(onboarding): Wire ScmPlatformFeaturesCore into single-view project creation

### DIFF
--- a/static/app/components/onboarding/onboardingContext.spec.tsx
+++ b/static/app/components/onboarding/onboardingContext.spec.tsx
@@ -1,0 +1,76 @@
+import {RepositoryFixture} from 'sentry-fixture/repository';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  OnboardingContextProvider,
+  useOnboardingContext,
+} from 'sentry/components/onboarding/onboardingContext';
+
+const platform = {
+  key: 'javascript-nextjs' as const,
+  name: 'Next.js',
+  language: 'javascript',
+  type: 'framework' as const,
+  link: null,
+  category: 'browser' as const,
+};
+
+function StateConsumer() {
+  const {selectedRepository, selectedPlatform, selectedFeatures} = useOnboardingContext();
+  return (
+    <div>
+      <div>{selectedRepository ? `repo:${selectedRepository.id}` : 'no-repo'}</div>
+      <div>{selectedPlatform ? `platform:${selectedPlatform.key}` : 'no-platform'}</div>
+      <div>
+        {selectedFeatures ? `features:${selectedFeatures.length}` : 'no-features'}
+      </div>
+    </div>
+  );
+}
+
+describe('OnboardingContextProvider', () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('drops a stale optimistic repository and its derived state on load', async () => {
+    // An optimistic repo (empty id) persisted mid-resolution can never fetch
+    // detection. Dropping it must also clear the repo-derived platform and
+    // features so the platform step doesn't show a platform with no repo.
+    render(
+      <OnboardingContextProvider
+        initialValue={{
+          selectedRepository: RepositoryFixture({id: ''}),
+          selectedPlatform: platform,
+          selectedFeatures: [ProductSolution.ERROR_MONITORING],
+        }}
+      >
+        <StateConsumer />
+      </OnboardingContextProvider>
+    );
+
+    expect(await screen.findByText('no-repo')).toBeInTheDocument();
+    expect(screen.getByText('no-platform')).toBeInTheDocument();
+    expect(screen.getByText('no-features')).toBeInTheDocument();
+  });
+
+  it('keeps a resolved repository and its derived state on load', () => {
+    render(
+      <OnboardingContextProvider
+        initialValue={{
+          selectedRepository: RepositoryFixture({id: '42'}),
+          selectedPlatform: platform,
+          selectedFeatures: [ProductSolution.ERROR_MONITORING],
+        }}
+      >
+        <StateConsumer />
+      </OnboardingContextProvider>
+    );
+
+    expect(screen.getByText('repo:42')).toBeInTheDocument();
+    expect(screen.getByText('platform:javascript-nextjs')).toBeInTheDocument();
+    expect(screen.getByText('features:1')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useMemo} from 'react';
+import {createContext, useContext, useEffect, useMemo, useRef} from 'react';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {Integration, Repository} from 'sentry/types/integrations';
@@ -76,6 +76,29 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
     'onboarding',
     initialValue
   );
+
+  // An optimistic repo (empty id, see useScmRepoSelection) persisted by a
+  // refresh mid-resolution can never fetch detection and would hold the
+  // platform step in a permanent spinner. Drop it once on load, also clearing
+  // the repo-derived state so the platform step doesn't show a platform with no
+  // connected repo (mirrors clearDerivedState on a repo change). Live in-session
+  // optimistic selections arrive after mount and keep their loading state.
+  const hadStaleRepoOnLoad = useRef(
+    !!onboarding?.selectedRepository && !onboarding.selectedRepository.id
+  );
+  useEffect(() => {
+    if (hadStaleRepoOnLoad.current) {
+      hadStaleRepoOnLoad.current = false;
+      setOnboarding(prev => ({
+        ...prev,
+        selectedRepository: undefined,
+        selectedPlatform: undefined,
+        selectedFeatures: undefined,
+        createdProjectSlug: undefined,
+        projectDetailsForm: undefined,
+      }));
+    }
+  }, [setOnboarding]);
 
   const contextValue = useMemo(
     () => ({

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -100,6 +100,15 @@ export function ScmPlatformFeaturesCore({
 
   const [showManualPicker, setShowManualPicker] = useState(false);
 
+  // Reset the manual-picker toggle when the user changes repositories so
+  // the freshly-detected platforms for the new repo are surfaced instead
+  // of leaving the manual picker visible from the prior repo. Keyed on
+  // externalId since it is stable across the optimistic -> resolved
+  // transition for a given selection.
+  useEffect(() => {
+    setShowManualPicker(false);
+  }, [selectedRepository?.externalId]);
+
   useEffect(() => {
     trackAnalytics(STEP_VIEWED_EVENT[analyticsFlow], {organization});
   }, [organization, analyticsFlow]);

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -99,14 +99,17 @@ export function ScmPlatformFeaturesCore({
   const {meta: featureMeta, isLoading: isFeatureMetaLoading} = useScmFeatureMeta();
 
   const [showManualPicker, setShowManualPicker] = useState(false);
+  // Guards the auto-detect analytics event below so it fires once per repo.
+  const autoDetectionTrackedRef = useRef(false);
 
-  // Reset the manual-picker toggle when the user changes repositories so
-  // the freshly-detected platforms for the new repo are surfaced instead
-  // of leaving the manual picker visible from the prior repo. Keyed on
-  // externalId since it is stable across the optimistic -> resolved
-  // transition for a given selection.
+  // Reset repo-derived state when the user changes repositories: surface the
+  // freshly-detected platforms for the new repo instead of leaving the manual
+  // picker visible, and re-arm the auto-detect analytics event so it can fire
+  // for the new repo. Keyed on externalId since it is stable across the
+  // optimistic -> resolved transition for a given selection.
   useEffect(() => {
     setShowManualPicker(false);
+    autoDetectionTrackedRef.current = false;
   }, [selectedRepository?.externalId]);
 
   useEffect(() => {
@@ -154,11 +157,11 @@ export function ScmPlatformFeaturesCore({
 
   const currentPlatformName = getPlatformName(currentPlatformKey);
 
-  // Fire scm_platform_selected once when detection auto-resolves a platform
-  // and the user hasn't explicitly chosen one. Otherwise a user who accepts
-  // the recommendation and clicks Continue never emits the event, leaving
-  // the funnel without a platform-selected step.
-  const autoDetectionTrackedRef = useRef(false);
+  // Fire scm_platform_selected once per repo when detection auto-resolves a
+  // platform and the user hasn't explicitly chosen one. Otherwise a user who
+  // accepts the recommendation and clicks Continue never emits the event,
+  // leaving the funnel without a platform-selected step. The ref is re-armed
+  // on repo change above so a switch to a new repo fires the event again.
   useEffect(() => {
     if (
       autoDetectionTrackedRef.current ||

--- a/static/app/views/onboarding/components/useScmPlatformDetection.ts
+++ b/static/app/views/onboarding/components/useScmPlatformDetection.ts
@@ -23,15 +23,16 @@ export function useScmPlatformDetection(repository: Repository | undefined) {
   const organization = useOrganization();
   const repoId = repository?.id;
   const isSupported = repository?.provider.id === SUPPORTED_PROVIDER;
+  // Empty id means we have an optimistic repo from useScmRepoSelection;
+  // the resolved repo with a real id arrives via a subsequent onSelect
+  // call. The query can only fetch once we have a real id.
+  const canFetch = !!(repoId && isSupported);
 
   const query = useQuery(
     apiOptions.as<PlatformDetectionResponse>()(
       '/organizations/$organizationIdOrSlug/repos/$repoId/platforms/',
       {
-        path:
-          repoId && isSupported
-            ? {organizationIdOrSlug: organization.slug, repoId}
-            : skipToken,
+        path: canFetch ? {organizationIdOrSlug: organization.slug, repoId} : skipToken,
         staleTime: 30_000,
       }
     )
@@ -39,9 +40,12 @@ export function useScmPlatformDetection(repository: Repository | undefined) {
 
   return {
     detectedPlatforms: query.data?.platforms ?? [],
-    // Use isLoading so that disabled queries (non-GitHub providers)
-    // report false instead of the idle-pending state.
-    isPending: query.isLoading,
+    // True whenever a supported repo is in flight, including the optimistic
+    // phase before the real id resolves. Consumers gate UI on this; using
+    // `query.isLoading` alone misses both the skipToken→enabled transition
+    // gap and the optimistic-id window. Unsupported providers or no repo
+    // still report false so the manual-picker fallback can show.
+    isPending: !!repository && isSupported && !query.data && !query.isError,
     isError: query.isError,
   };
 }

--- a/static/app/views/onboarding/components/useScmPlatformDetection.ts
+++ b/static/app/views/onboarding/components/useScmPlatformDetection.ts
@@ -40,11 +40,13 @@ export function useScmPlatformDetection(repository: Repository | undefined) {
 
   return {
     detectedPlatforms: query.data?.platforms ?? [],
-    // True whenever a supported repo is in flight, including the optimistic
-    // phase before the real id resolves. Consumers gate UI on this; using
-    // `query.isLoading` alone misses both the skipToken→enabled transition
-    // gap and the optimistic-id window. Unsupported providers or no repo
-    // still report false so the manual-picker fallback can show.
+    // A supported repo without a result yet is loading, including the
+    // optimistic phase before the real id resolves (so the platform step shows
+    // a spinner rather than flashing the manual picker) and the skipToken→
+    // enabled gap before `query.isLoading` flips. Unsupported providers or no
+    // repo report false. State owners drop a stale optimistic repo (empty id)
+    // on load so a refresh mid-resolution can't strand this as a permanent
+    // spinner.
     isPending: !!repository && isSupported && !query.data && !query.isError,
     isError: query.isError,
   };

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -31,7 +31,13 @@ function buildOptimisticRepo(
     externalSlug: repo.identifier,
     url: '',
     provider: {
-      id: integration.provider.key,
+      // Match the format the backend returns for real Repository records
+      // (see the create call below — `integrations:<provider.key>`). Without
+      // the prefix, downstream consumers that compare against
+      // `'integrations:github'` (e.g. useScmPlatformDetection) fail to
+      // recognize the optimistic repo during the brief window before the
+      // resolved record replaces it.
+      id: `integrations:${integration.provider.key}`,
       name: integration.provider.name,
     },
     status: RepositoryStatus.ACTIVE,

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -523,6 +523,59 @@ describe('ScmPlatformFeatures', () => {
       expect(detectedCalls).toHaveLength(1);
     });
 
+    it('re-fires the auto-detected event after switching repositories', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {platforms: [DetectedPlatformFixture()]},
+      });
+      const otherRepository = RepositoryFixture({
+        id: '99',
+        externalId: '99',
+        provider: {id: 'integrations:github', name: 'GitHub'},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/99/platforms/`,
+        body: {
+          platforms: [
+            DetectedPlatformFixture({platform: 'python-django', language: 'Python'}),
+          ],
+        },
+      });
+
+      const {rerender} = render(
+        <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
+        {organization}
+      );
+
+      // First repo auto-detects Next.js and fires the detected event once.
+      await screen.findByRole('heading', {level: 3, name: 'Available with Next.js'});
+      expect(
+        trackAnalyticsSpy.mock.calls.filter(
+          ([event, params]) =>
+            event === 'onboarding.scm_platform_selected' &&
+            params.platform === 'javascript-nextjs' &&
+            params.source === 'detected'
+        )
+      ).toHaveLength(1);
+
+      // Switching repos re-arms the guard so the new repo's detected platform
+      // fires the event again instead of being silently skipped.
+      rerender(
+        <ScmPlatformFeatures {...defaultProps({selectedRepository: otherRepository})} />
+      );
+
+      await waitFor(() => {
+        expect(
+          trackAnalyticsSpy.mock.calls.filter(
+            ([event, params]) =>
+              event === 'onboarding.scm_platform_selected' &&
+              params.platform === 'python-django' &&
+              params.source === 'detected'
+          )
+        ).toHaveLength(1);
+      });
+    });
+
     it('fires feature toggled event when toggling a feature', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/repos/42/platforms/`,

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback} from 'react';
+import {Fragment, useCallback, useEffect, useRef} from 'react';
 import {LayoutGroup, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
@@ -56,6 +56,27 @@ export function ScmCreateProject() {
     },
     setState,
   ] = useSessionStorage('project-creation-wizard', INITIAL_STATE);
+
+  // An optimistic repo (empty id, see useScmRepoSelection) persisted by a
+  // refresh mid-resolution can never fetch detection and would hold the
+  // platform step in a permanent spinner. Drop it once on load, also clearing
+  // the repo-derived platform/features so section 2 doesn't show a platform
+  // with no connected repo (mirrors handleClearDerivedState on a repo change).
+  // Live in-session optimistic selections arrive after mount and keep their
+  // loading state.
+  const hadStaleRepoOnLoad = useRef(!!selectedRepository && !selectedRepository.id);
+  useEffect(() => {
+    if (hadStaleRepoOnLoad.current) {
+      hadStaleRepoOnLoad.current = false;
+      setState(s => ({
+        ...s,
+        selectedRepository: undefined,
+        selectedPlatform: undefined,
+        selectedFeatures: undefined,
+      }));
+    }
+  }, [setState]);
+
   const canUserCreateProject = useCanCreateProject();
   // Subscribe so the parent re-renders when integration state changes inside
   // ScmIntegrationConnect, letting framer-motion's layout="position" siblings

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -17,6 +17,7 @@ import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 import {ScmIntegrationConnect} from 'sentry/views/onboarding/components/scmIntegrationConnect';
 import {ScmPlatformFeaturesCore} from 'sentry/views/onboarding/components/scmPlatformFeaturesCore';
+import {useScmPlatformDetection} from 'sentry/views/onboarding/components/useScmPlatformDetection';
 import {useScmProviders} from 'sentry/views/onboarding/components/useScmProviders';
 
 const CREATE_PROJECT_MAX_WIDTH = '760px';
@@ -61,6 +62,8 @@ export function ScmCreateProject() {
   // below re-measure and animate position shifts. React Query dedupes with
   // the child's call.
   useScmProviders();
+
+  useScmPlatformDetection(selectedRepository);
 
   const completeRepoStep = () => {
     setState(s => ({...s, repoStepCompleted: true}));

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -8,12 +8,15 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {Access} from 'sentry/components/acl/access';
 import * as Layout from 'sentry/components/layouts/thirds';
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {Integration, Repository} from 'sentry/types/integrations';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 import {ScmIntegrationConnect} from 'sentry/views/onboarding/components/scmIntegrationConnect';
+import {ScmPlatformFeaturesCore} from 'sentry/views/onboarding/components/scmPlatformFeaturesCore';
 import {useScmProviders} from 'sentry/views/onboarding/components/useScmProviders';
 
 const CREATE_PROJECT_MAX_WIDTH = '760px';
@@ -25,21 +28,33 @@ interface WizardState {
   // later state edits (de-selecting a repo) do not collapse the rest of
   // the page.
   repoStepCompleted: boolean;
+  selectedFeatures: ProductSolution[] | undefined;
   selectedIntegration: Integration | undefined;
+  selectedPlatform: OnboardingSelectedSDK | undefined;
   selectedRepository: Repository | undefined;
 }
 
 const INITIAL_STATE: WizardState = {
   repoStepCompleted: false,
+  selectedFeatures: undefined,
   selectedIntegration: undefined,
+  selectedPlatform: undefined,
   selectedRepository: undefined,
 };
 
 export function ScmCreateProject() {
   // Session-storage backed so a refresh restores how far the user has
   // progressed. Separate key from new-org onboarding's 'onboarding' key.
-  const [{repoStepCompleted, selectedIntegration, selectedRepository}, setState] =
-    useSessionStorage('project-creation-wizard', INITIAL_STATE);
+  const [
+    {
+      repoStepCompleted,
+      selectedFeatures,
+      selectedIntegration,
+      selectedPlatform,
+      selectedRepository,
+    },
+    setState,
+  ] = useSessionStorage('project-creation-wizard', INITIAL_STATE);
   const canUserCreateProject = useCanCreateProject();
   // Subscribe so the parent re-renders when integration state changes inside
   // ScmIntegrationConnect, letting framer-motion's layout="position" siblings
@@ -72,9 +87,34 @@ export function ScmCreateProject() {
     [setState]
   );
 
-  // No-op until sections 2 and 3 wire up their own state. VDY-75/76 will
-  // replace this with platform/features/project clearing.
-  const handleClearDerivedState = useCallback(() => {}, []);
+  const handlePlatformChange = useCallback(
+    (platform: OnboardingSelectedSDK | undefined) => {
+      setState(s => ({...s, selectedPlatform: platform}));
+    },
+    [setState]
+  );
+
+  const handleFeaturesChange = useCallback(
+    (features: ProductSolution[] | undefined) => {
+      setState(s => ({...s, selectedFeatures: features}));
+    },
+    [setState]
+  );
+
+  // Clear state derived from the repository when the repo changes. Platform
+  // and features are repo-dependent (auto-detection seeds them). VDY-76 will
+  // extend this to clear the project-details form too.
+  const handleClearDerivedState = useCallback(() => {
+    setState(s => ({
+      ...s,
+      selectedPlatform: undefined,
+      selectedFeatures: undefined,
+    }));
+  }, [setState]);
+
+  // Clear the project-details form when the platform changes. VDY-76 will
+  // wire this up to actual project-details state.
+  const handleClearProjectDetailsForm = useCallback(() => {}, []);
 
   const showContinueWithoutRepo = !selectedRepository && !repoStepCompleted;
   const showAllSteps = repoStepCompleted;
@@ -145,7 +185,31 @@ export function ScmCreateProject() {
 
             {showAllSteps && (
               <Fragment>
-                <PlatformFeaturesSection />
+                <MotionStack
+                  layout="position"
+                  gap="lg"
+                  border="primary"
+                  radius="md"
+                  padding="lg"
+                >
+                  <Stack gap="md">
+                    <Heading as="h2" size="xl">
+                      {t('Platform & features')}
+                    </Heading>
+                    <Text variant="muted">
+                      {t('Choose a platform and configure what to monitor.')}
+                    </Text>
+                  </Stack>
+                  <ScmPlatformFeaturesCore
+                    analyticsFlow="project-creation"
+                    selectedRepository={selectedRepository}
+                    selectedPlatform={selectedPlatform}
+                    selectedFeatures={selectedFeatures}
+                    onPlatformChange={handlePlatformChange}
+                    onFeaturesChange={handleFeaturesChange}
+                    onClearProjectDetailsForm={handleClearProjectDetailsForm}
+                  />
+                </MotionStack>
                 <ProjectDetailsSection />
               </Fragment>
             )}
@@ -153,20 +217,6 @@ export function ScmCreateProject() {
         </Stack>
       </Access>
     </SentryDocumentTitle>
-  );
-}
-
-// Placeholder for VDY-75. Will be replaced with <ScmPlatformFeatures />.
-function PlatformFeaturesSection() {
-  return (
-    <MotionStack layout="position" gap="lg" border="primary" radius="md" padding="lg">
-      <Heading as="h2" size="xl">
-        {t('Platform & features')}
-      </Heading>
-      <Text variant="muted">
-        {t('Platform and features step content goes here (VDY-75).')}
-      </Text>
-    </MotionStack>
   );
 }
 

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -184,6 +184,180 @@ class ScmOnboardingTest(AcceptanceTestCase):
                 self.org, active_project_ids=[project.id], deleted_project_ids=[]
             )
 
+    def test_scm_onboarding_reload_restores_connected_repo(self) -> None:
+        """Reloading the platform-features step restores the connected repo from
+        session storage and re-runs detection. Guards the stale-optimistic-repo
+        cleanup on load against dropping a resolved repo (real id): if it did,
+        the auto-detected section would be replaced by the manual picker."""
+        self.create_github_integration()
+
+        mock_repos = [
+            {
+                "name": "sentry",
+                "identifier": "getsentry/sentry",
+                "default_branch": "master",
+                "external_id": "12345",
+            },
+        ]
+        mock_platforms = [
+            {
+                "platform": "python-django",
+                "language": "Python",
+                "bytes": 50000,
+                "confidence": "high",
+                "priority": 1,
+            }
+        ]
+
+        with (
+            self.feature(
+                {
+                    "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": True,
+                    "organizations:integrations-github-platform-detection": True,
+                }
+            ),
+            mock.patch(
+                "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+                return_value=mock_repos,
+            ),
+            mock.patch(
+                "sentry.integrations.github.repository.GitHubRepositoryProvider._validate_repo",
+                return_value={"id": "12345"},
+            ),
+            mock.patch(
+                "sentry.integrations.api.endpoints.organization_repository_platforms.detect_platforms",
+                return_value=mock_platforms,
+            ),
+        ):
+            self.start_onboarding()
+
+            # Connect a repo and advance to the platform-features step.
+            self.browser.wait_until(xpath='//*[contains(text(), "Connected to")]')
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("sentry")
+            self.browser.wait_until('[data-test-id="menu-list-item-label"]')
+            self.browser.click('[data-test-id="menu-list-item-label"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until(
+                xpath='//*[contains(text(), "Auto-detected from your repository")]'
+            )
+            self.browser.wait_until('[role="radio"]')
+
+            # Reload the step. The connected repo (real id) must survive the
+            # session restore so detection re-runs and the auto-detected section
+            # renders again rather than falling back to the manual picker.
+            self.browser.get(f"/onboarding/{self.org.slug}/scm-platform-features/")
+
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until(
+                xpath='//*[contains(text(), "Auto-detected from your repository")]'
+            )
+            self.browser.wait_until('[role="radio"]')
+
+    def test_scm_onboarding_switch_repo_updates_detection(self) -> None:
+        """Switching the connected repo re-runs detection for the new repo and
+        does not leak the previous repo's detected platform."""
+        self.create_github_integration()
+
+        mock_repos = [
+            {
+                "name": "sentry",
+                "identifier": "getsentry/sentry",
+                "default_branch": "master",
+                "external_id": "11111",
+            },
+            {
+                "name": "frontend",
+                "identifier": "getsentry/frontend",
+                "default_branch": "main",
+                "external_id": "22222",
+            },
+        ]
+
+        # Key off "frontend" — a substring unique to the second repo — so the
+        # match holds whether detect_platforms/_validate_repo receive the repo
+        # name or the identifier.
+        def platforms_for(client: object, repo: str) -> list[dict[str, object]]:
+            if "frontend" in repo:
+                return [
+                    {
+                        "platform": "javascript-react",
+                        "language": "JavaScript",
+                        "bytes": 50000,
+                        "confidence": "high",
+                        "priority": 1,
+                    }
+                ]
+            return [
+                {
+                    "platform": "python-django",
+                    "language": "Python",
+                    "bytes": 50000,
+                    "confidence": "high",
+                    "priority": 1,
+                }
+            ]
+
+        def validate_for(client: object, installation: object, repo: str) -> dict[str, str]:
+            return {"id": "22222" if "frontend" in repo else "11111"}
+
+        with (
+            self.feature(
+                {
+                    "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": True,
+                    "organizations:integrations-github-platform-detection": True,
+                }
+            ),
+            mock.patch(
+                "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+                return_value=mock_repos,
+            ),
+            mock.patch(
+                "sentry.integrations.github.repository.GitHubRepositoryProvider._validate_repo",
+                side_effect=validate_for,
+            ),
+            mock.patch(
+                "sentry.integrations.api.endpoints.organization_repository_platforms.detect_platforms",
+                side_effect=platforms_for,
+            ),
+        ):
+            self.start_onboarding()
+
+            # Connect the first repo; detection resolves to Django.
+            self.browser.wait_until(xpath='//*[contains(text(), "Connected to")]')
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("sentry")
+            self.browser.wait_until('[data-test-id="menu-list-item-label"]')
+            self.browser.click('[data-test-id="menu-list-item-label"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until(xpath='//*[@role="radio"][contains(., "Django")]')
+
+            # Go back and switch to the second repo; detection must re-run for it.
+            self.browser.click('[aria-label="Back"]')
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-connect"]')
+            # Don't click the input: the selected repo's SingleValueLabel overlays
+            # it and intercepts the click. send_keys focuses and filters directly,
+            # matching the initial-selection path above.
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("frontend")
+            self.browser.wait_until('[data-test-id="menu-list-item-label"]')
+            self.browser.click('[data-test-id="menu-list-item-label"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            # New repo's platform is detected; the previous repo's is not shown.
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until(xpath='//*[@role="radio"][contains(., "React")]')
+            self.browser.wait_until_not(xpath='//*[@role="radio"][contains(., "Django")]')
+
     def test_scm_onboarding_skip_integration(self) -> None:
         """Skip flow: welcome → skip connect → manual platform → create project."""
         with self.feature(


### PR DESCRIPTION
## TL;DR
Wires `ScmPlatformFeaturesCore` (extracted in PR 5) into section 2 of the SCM-first project creation wizard. The placeholder `PlatformFeaturesSection` is replaced by the real component, wrapped in the same bordered-card chrome as section 1, with `analyticsFlow="project-creation"` routing events through the `project_creation.scm_*` keys. Section 3 stays as a placeholder pending VDY-76.

---

## Stack
- [PR 1](https://github.com/getsentry/sentry/pull/116434): `ScmAnalyticsFlow` + project_creation event registry
- [PR 2](https://github.com/getsentry/sentry/pull/116577): Single-view scaffold
- [PR 3](https://github.com/getsentry/sentry/pull/116581): Extract `ScmIntegrationConnect`
- [PR 4](https://github.com/getsentry/sentry/pull/116582): Wire `ScmIntegrationConnect`
- [PR 5](https://github.com/getsentry/sentry/pull/116624): Extract `ScmPlatformFeaturesCore`
- **PR 6 (this):** Wire `ScmPlatformFeaturesCore` into section 2

## Summary
- Replaces the placeholder `PlatformFeaturesSection` with `<ScmPlatformFeaturesCore analyticsFlow="project-creation" .../>`, wrapped in a `MotionStack` with `border="primary" radius="md" padding="lg"` to match section 1's card look. A "Platform & features" heading and short description sit above the core.
- `WizardState` gains `selectedPlatform: OnboardingSelectedSDK | undefined` and `selectedFeatures: ProductSolution[] | undefined` so a refresh restores section 2's state through sessionStorage.
- `handlePlatformChange` and `handleFeaturesChange` propagate user selections back into state.
- `handleClearDerivedState` now clears `selectedPlatform` and `selectedFeatures` (in addition to its previous no-op) so changing the repo resets section 2's derived state. The core's contract for repo re-selection.
- `handleClearProjectDetailsForm` stays a no-op until VDY-76 wires up project-details state.
- Section 3 (`ProjectDetailsSection`) is still a placeholder. VDY-76 will replace it.

## Out of scope
- Wiring `ScmProjectDetails` (or its future extracted core) into section 3. VDY-76 will pick that up.
- Per-section progressive disclosure between sections 2 and 3. Per the design decision, both reveal together when `repoStepCompleted` flips.

Refs VDY-75

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint:js\` clean on touched file
- [ ] With the experiment flag on, after completing section 1, section 2 renders \`ScmPlatformFeaturesCore\` inside the bordered card
- [ ] With a repo connected, auto-detected platform cards appear and clicking one fires \`project_creation.scm_platform_selected\` with \`source: 'detected'\`
- [ ] Without a repo (skip path), the manual picker shows and selecting fires \`project_creation.scm_platform_selected\` with \`source: 'manual'\`
- [ ] Toggling a feature fires \`project_creation.scm_platform_feature_toggled\`
- [ ] Changing the repo in section 1 clears \`selectedPlatform\` and \`selectedFeatures\` (section 2 resets)
- [ ] \`project_creation.scm_platform_features_step_viewed\` fires when section 2 mounts (i.e. after \`repoStepCompleted\` flips)