### PR TITLE
fix(deletions): Avoid cross-table JOIN in `GroupEnvironment` bulk delete during org deletion

### DIFF
--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -63,13 +63,18 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
         # via the ORM, Django cascades to GroupEnvironment (on_delete=CASCADE, db_constraint=False)
         # and fires a post_delete signal per row. For large orgs this causes the deletion task
         # to time out. Bulk-deleting GroupEnvironment first avoids that cascade entirely.
-        relations.append(
-            ModelRelation(
-                GroupEnvironment,
-                {"environment__organization_id": instance.id},
-                task=BulkModelDeletionTask,
-            )
+        # Resolve env IDs upfront to avoid a cross-table JOIN that times out for large orgs.
+        env_ids = list(
+            Environment.objects.filter(organization_id=instance.id).values_list("id", flat=True)
         )
+        if env_ids:
+            relations.append(
+                ModelRelation(
+                    GroupEnvironment,
+                    {"environment_id__in": env_ids},
+                    task=BulkModelDeletionTask,
+                )
+            )
 
         post_environment_models = (
             Environment,

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -1,5 +1,7 @@
 from collections.abc import Sequence
 
+from django.db import router
+
 from sentry.deletions.base import (
     BaseRelation,
     BulkModelDeletionTask,
@@ -10,6 +12,8 @@ from sentry.models.organization import Organization, OrganizationStatus
 from sentry.organizations.services.organization_actions.impl import (
     update_organization_with_outbox_message,
 )
+from sentry.silo.safety import unguarded_write
+from sentry.utils.query import bulk_delete_objects
 
 
 class OrganizationDeletionTask(ModelDeletionTask[Organization]):
@@ -63,18 +67,13 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
         # via the ORM, Django cascades to GroupEnvironment (on_delete=CASCADE, db_constraint=False)
         # and fires a post_delete signal per row. For large orgs this causes the deletion task
         # to time out. Bulk-deleting GroupEnvironment first avoids that cascade entirely.
-        # Resolve env IDs upfront to avoid a cross-table JOIN that times out for large orgs.
-        env_ids = list(
-            Environment.objects.filter(organization_id=instance.id).values_list("id", flat=True)
-        )
-        if env_ids:
-            relations.append(
-                ModelRelation(
-                    GroupEnvironment,
-                    {"environment_id__in": env_ids},
-                    task=BulkModelDeletionTask,
-                )
+        relations.append(
+            ModelRelation(
+                GroupEnvironment,
+                {"environment__organization_id": instance.id},
+                task=GroupEnvironmentBulkDeletionTask,
             )
+        )
 
         post_environment_models = (
             Environment,
@@ -108,3 +107,39 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
                     org_id=instance.id,
                     update_data={"status": OrganizationStatus.DELETION_IN_PROGRESS},
                 )
+
+
+class GroupEnvironmentBulkDeletionTask(BulkModelDeletionTask):
+    """
+    Deletes GroupEnvironment rows by resolving environment IDs first to avoid
+    a cross-table JOIN that times out for large orgs.
+    """
+
+    def _delete_instance_bulk(self) -> bool:
+        from sentry.models.environment import Environment
+
+        org_id = self.query["environment__organization_id"]
+        env_ids = list(
+            Environment.objects.filter(organization_id=org_id).values_list("id", flat=True)
+        )
+        if not env_ids:
+            return False
+        try:
+            with unguarded_write(using=router.db_for_write(self.model)):
+                return bulk_delete_objects(
+                    model=self.model,
+                    limit=self.chunk_size,
+                    transaction_id=self.transaction_id,
+                    environment_id__in=env_ids,
+                )
+        finally:
+            model_name = self.model.__name__
+            self.logger.info(
+                f"object.delete.bulk_executed ({model_name})",
+                extra={
+                    "transaction_id": self.transaction_id,
+                    "app_label": self.model._meta.app_label,
+                    "model": model_name,
+                    **self.query,
+                },
+            )

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -8,6 +8,7 @@ from sentry.deletions.base import (
     ModelDeletionTask,
     ModelRelation,
 )
+from sentry.models.environment import Environment
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.organizations.services.organization_actions.impl import (
@@ -36,7 +37,6 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
         from sentry.models.artifactbundle import ArtifactBundle
         from sentry.models.commitauthor import CommitAuthor
         from sentry.models.dashboard import Dashboard
-        from sentry.models.environment import Environment
         from sentry.models.organizationmember import OrganizationMember
         from sentry.models.project import Project
         from sentry.models.promptsactivity import PromptsActivity
@@ -112,21 +112,27 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
 class GroupEnvironmentBulkDeletionTask(BulkModelDeletionTask[GroupEnvironment]):
     """
     Deletes GroupEnvironment rows by resolving environment IDs first to avoid
-    a cross-table JOIN that times out for large orgs.
+    a cross-table JOIN that times out for large orgs. Pages through environment
+    IDs in batches to stay under PostgreSQL's 32k placeholder limit.
     """
 
-    def _delete_instance_bulk(self) -> bool:
-        from sentry.models.environment import Environment
+    ENV_ID_BATCH_SIZE = 10_000
+    _last_env_id = 0
 
+    def _delete_instance_bulk(self) -> bool:
         org_id = self.query["environment__organization_id"]
+
         env_ids = list(
-            Environment.objects.filter(organization_id=org_id).values_list("id", flat=True)
+            Environment.objects.filter(organization_id=org_id, id__gt=self._last_env_id)
+            .order_by("id")
+            .values_list("id", flat=True)[: self.ENV_ID_BATCH_SIZE]
         )
         if not env_ids:
             return False
+
         try:
             with unguarded_write(using=router.db_for_write(self.model)):
-                return bulk_delete_objects(
+                has_more_rows = bulk_delete_objects(
                     model=self.model,
                     limit=self.chunk_size,
                     transaction_id=self.transaction_id,
@@ -143,3 +149,8 @@ class GroupEnvironmentBulkDeletionTask(BulkModelDeletionTask[GroupEnvironment]):
                     **self.query,
                 },
             )
+
+        if not has_more_rows:
+            self._last_env_id = env_ids[-1]
+
+        return True

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -8,6 +8,7 @@ from sentry.deletions.base import (
     ModelDeletionTask,
     ModelRelation,
 )
+from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.organizations.services.organization_actions.impl import (
     update_organization_with_outbox_message,
@@ -36,7 +37,6 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
         from sentry.models.commitauthor import CommitAuthor
         from sentry.models.dashboard import Dashboard
         from sentry.models.environment import Environment
-        from sentry.models.groupenvironment import GroupEnvironment
         from sentry.models.organizationmember import OrganizationMember
         from sentry.models.project import Project
         from sentry.models.promptsactivity import PromptsActivity
@@ -109,7 +109,7 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
                 )
 
 
-class GroupEnvironmentBulkDeletionTask(BulkModelDeletionTask):
+class GroupEnvironmentBulkDeletionTask(BulkModelDeletionTask[GroupEnvironment]):
     """
     Deletes GroupEnvironment rows by resolving environment IDs first to avoid
     a cross-table JOIN that times out for large orgs.

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -128,6 +128,7 @@ class GroupEnvironmentBulkDeletionTask(BulkModelDeletionTask[GroupEnvironment]):
             .values_list("id", flat=True)[: self.ENV_ID_BATCH_SIZE]
         )
         if not env_ids:
+            self._last_env_id = 0
             return False
 
         try:

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -382,19 +382,34 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin, BaseWork
         # Environment deletion. Without the explicit GroupEnvironment child relation in
         # OrganizationDeletionTask, Django's ORM cascade from environment.delete() fires a
         # post_delete signal per GroupEnvironment row, which causes timeouts at scale.
+        # Uses multiple environments to exercise the environment_id__in query.
         from django.db import connection
 
         org = self.create_organization(name="test")
         project = self.create_project(organization=org)
-        env = Environment.objects.create(organization_id=org.id, name="production")
-        group = Group.objects.create(project=project)
-        group_env = GroupEnvironment.objects.create(group=group, environment=env)
+        env_prod = Environment.objects.create(organization_id=org.id, name="production")
+        env_staging = Environment.objects.create(organization_id=org.id, name="staging")
+        env_dev = Environment.objects.create(organization_id=org.id, name="development")
+        group1 = Group.objects.create(project=project)
+        group2 = Group.objects.create(project=project)
+        group_env1 = GroupEnvironment.objects.create(group=group1, environment=env_prod)
+        group_env2 = GroupEnvironment.objects.create(group=group1, environment=env_staging)
+        group_env3 = GroupEnvironment.objects.create(group=group2, environment=env_prod)
+        group_env4 = GroupEnvironment.objects.create(group=group2, environment=env_dev)
 
-        # Delete the group via raw SQL to bypass Django's ORM cascade, leaving the
-        # GroupEnvironment row orphaned (no parent group) — this is the production scenario.
+        # Delete the groups via raw SQL to bypass Django's ORM cascade, leaving the
+        # GroupEnvironment rows orphaned (no parent group) — this is the production scenario.
         with connection.cursor() as cursor:
-            cursor.execute("DELETE FROM sentry_groupedmessage WHERE id = %s", [group.id])
-        assert GroupEnvironment.objects.filter(id=group_env.id).exists()
+            cursor.execute(
+                "DELETE FROM sentry_groupedmessage WHERE id IN (%s, %s)",
+                [group1.id, group2.id],
+            )
+        assert (
+            GroupEnvironment.objects.filter(
+                id__in=[group_env1.id, group_env2.id, group_env3.id, group_env4.id]
+            ).count()
+            == 4
+        )
 
         org.update(status=OrganizationStatus.PENDING_DELETION)
         self.ScheduledDeletion.schedule(instance=org, days=0)
@@ -403,8 +418,10 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin, BaseWork
             run_scheduled_deletions()
 
         assert not Organization.objects.filter(id=org.id).exists()
-        assert not Environment.objects.filter(id=env.id).exists()
-        assert not GroupEnvironment.objects.filter(id=group_env.id).exists()
+        assert not Environment.objects.filter(organization_id=org.id).exists()
+        assert not GroupEnvironment.objects.filter(
+            id__in=[group_env1.id, group_env2.id, group_env3.id, group_env4.id]
+        ).exists()
 
     def test_workflow_engine_cleanup(self) -> None:
         org = self.create_organization(name="test")

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 from uuid import uuid4
 
+from django.db import connection
+
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 from sentry.incidents.grouptype import MetricIssue
@@ -383,7 +385,6 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin, BaseWork
         # OrganizationDeletionTask, Django's ORM cascade from environment.delete() fires a
         # post_delete signal per GroupEnvironment row, which causes timeouts at scale.
         # Uses multiple environments to exercise the environment_id__in query.
-        from django.db import connection
 
         org = self.create_organization(name="test")
         project = self.create_project(organization=org)
@@ -422,6 +423,37 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin, BaseWork
         assert not GroupEnvironment.objects.filter(
             id__in=[group_env1.id, group_env2.id, group_env3.id, group_env4.id]
         ).exists()
+
+    def test_orphan_group_environment_batched_cleanup(self) -> None:
+        org = self.create_organization(name="test")
+        project = self.create_project(organization=org)
+        envs = [
+            Environment.objects.create(organization_id=org.id, name=f"env-{i}") for i in range(5)
+        ]
+        group = Group.objects.create(project=project)
+        group_envs = [GroupEnvironment.objects.create(group=group, environment=env) for env in envs]
+
+        with connection.cursor() as cursor:
+            cursor.execute("DELETE FROM sentry_groupedmessage WHERE id = %s", [group.id])
+
+        group_env_ids = [ge.id for ge in group_envs]
+        assert GroupEnvironment.objects.filter(id__in=group_env_ids).count() == 5
+
+        org.update(status=OrganizationStatus.PENDING_DELETION)
+        self.ScheduledDeletion.schedule(instance=org, days=0)
+
+        with (
+            patch(
+                "sentry.deletions.defaults.organization.GroupEnvironmentBulkDeletionTask.ENV_ID_BATCH_SIZE",
+                2,
+            ),
+            self.tasks(),
+        ):
+            run_scheduled_deletions()
+
+        assert not Organization.objects.filter(id=org.id).exists()
+        assert not Environment.objects.filter(organization_id=org.id).exists()
+        assert not GroupEnvironment.objects.filter(id__in=group_env_ids).exists()
 
     def test_workflow_engine_cleanup(self) -> None:
         org = self.create_organization(name="test")


### PR DESCRIPTION
Resolves [SENTRY-5HEP](https://sentry.sentry.io/issues/7220419831/?project=1).

The `GroupEnvironment` bulk delete during organization deletion uses a `{"environment__organization_id": org_id}` filter, which requires an expensive JOIN query for large orgs, causing the deletion to silently fail and retry indefinitely. This PR replaces the cross-table JOIN with a two-step approach: resolve environment IDs upfront, then delete with a flat `environment_id__in` filter. This produces a simple indexed query with no JOIN.

This PR also expands the regression test to cover multiple environments and orphaned rows across them, exercising the `IN` clause.