### PR TITLE
feat(api): Add [T] to 33 Serializer subclasses

### DIFF
--- a/src/sentry/api/serializers/models/auth_provider.py
+++ b/src/sentry/api/serializers/models/auth_provider.py
@@ -28,7 +28,7 @@ class AuthProviderDict(TypedDict):
 
 
 @register(AuthProvider)
-class AuthProviderSerializer(Serializer):
+class AuthProviderSerializer(Serializer[AuthProviderDict]):
     def serialize(
         self,
         obj: AuthProvider | RpcAuthProvider,

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -115,7 +115,7 @@ class DashboardPermissionsResponse(TypedDict):
 
 
 @register(DashboardWidget)
-class DashboardWidgetSerializer(Serializer):
+class DashboardWidgetSerializer(Serializer[DashboardWidgetResponse]):
     def get_attrs(self, item_list, user, **kwargs):
         result = {}
         data_sources = serialize(
@@ -362,7 +362,7 @@ class DashboardWidgetSerializer(Serializer):
 
 
 @register(DashboardWidgetQueryOnDemand)
-class DashboardWidgetQueryOnDemandSerializer(Serializer):
+class DashboardWidgetQueryOnDemandSerializer(Serializer[OnDemandResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> OnDemandResponse:
         return {
             "enabled": obj.extraction_enabled(),
@@ -372,7 +372,7 @@ class DashboardWidgetQueryOnDemandSerializer(Serializer):
 
 
 @register(DashboardWidgetQuery)
-class DashboardWidgetQuerySerializer(Serializer):
+class DashboardWidgetQuerySerializer(Serializer[DashboardWidgetQueryResponse]):
     def get_attrs(self, item_list, user, **kwargs):
         result = {}
 
@@ -425,7 +425,7 @@ class DashboardWidgetQuerySerializer(Serializer):
 
 
 @register(DashboardPermissions)
-class DashboardPermissionsSerializer(Serializer):
+class DashboardPermissionsSerializer(Serializer[DashboardPermissionsResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardPermissionsResponse:
         return {
             "isEditableByEveryone": obj.is_editable_by_everyone,
@@ -691,7 +691,7 @@ class DashboardRevisionResponse(TypedDict):
 
 
 @register(DashboardRevision)
-class DashboardRevisionSerializer(Serializer):
+class DashboardRevisionSerializer(Serializer[DashboardRevisionResponse]):
     def get_attrs(self, item_list, user, **kwargs):
         user_ids = [r.created_by_id for r in item_list if r.created_by_id is not None]
         users_by_id = {

--- a/src/sentry/api/serializers/models/debug_file.py
+++ b/src/sentry/api/serializers/models/debug_file.py
@@ -21,7 +21,7 @@ class DebugFileSerializerResponse(TypedDict):
 
 
 @register(ProjectDebugFile)
-class DebugFileSerializer(Serializer):
+class DebugFileSerializer(Serializer[DebugFileSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> DebugFileSerializerResponse:
         return {
             "id": str(obj.id),

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -45,7 +45,7 @@ class DiscoverSavedQueryResponse(DiscoverSavedQueryResponseOptional):
 
 
 @register(DiscoverSavedQuery)
-class DiscoverSavedQueryModelSerializer(Serializer):
+class DiscoverSavedQueryModelSerializer(Serializer[DiscoverSavedQueryResponse]):
     def partial_serialize_explore_query(self, query: ExploreSavedQuery) -> dict:
         query_keys = [
             "environment",

--- a/src/sentry/api/serializers/models/environment.py
+++ b/src/sentry/api/serializers/models/environment.py
@@ -22,7 +22,7 @@ class EnvironmentSerializer(Serializer[EnvironmentSerializerResponse]):
 
 
 @register(EnvironmentProject)
-class EnvironmentProjectSerializer(Serializer):
+class EnvironmentProjectSerializer(Serializer[EnvironmentProjectSerializerResponse]):
     def serialize(
         self, obj: EnvironmentProject, attrs, user, **kwargs
     ) -> EnvironmentProjectSerializerResponse:

--- a/src/sentry/api/serializers/models/eventattachment.py
+++ b/src/sentry/api/serializers/models/eventattachment.py
@@ -20,7 +20,7 @@ class EventAttachmentSerializerResponse(TypedDict):
 
 
 @register(EventAttachment)
-class EventAttachmentSerializer(Serializer):
+class EventAttachmentSerializer(Serializer[EventAttachmentSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> EventAttachmentSerializerResponse:
         content_type = obj.content_type
         size = obj.size or 0

--- a/src/sentry/api/serializers/models/eventuser.py
+++ b/src/sentry/api/serializers/models/eventuser.py
@@ -19,7 +19,7 @@ class EventUserSerializerResponse(TypedDict):
 
 
 @register(EventUser)
-class EventUserSerializer(Serializer):
+class EventUserSerializer(Serializer[EventUserSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> EventUserSerializerResponse:
         return {
             "id": str(obj.id) if obj.id is not None else obj.id,

--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -66,7 +66,7 @@ class ExploreSavedQueryResponse(ExploreSavedQueryResponseOptional):
 
 
 @register(ExploreSavedQuery)
-class ExploreSavedQueryModelSerializer(Serializer):
+class ExploreSavedQueryModelSerializer(Serializer[ExploreSavedQueryResponse]):
     def get_attrs(self, item_list, user, **kwargs):
         result: defaultdict[str, dict] = defaultdict(lambda: {"created_by": {}})
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -1203,7 +1203,7 @@ class SimpleGroupSerializerResponse(TypedDict):
     lastSeen: datetime | None
 
 
-class SimpleGroupSerializer(Serializer):
+class SimpleGroupSerializer(Serializer[SimpleGroupSerializerResponse]):
     """
     A serializer that only returns the most basic information about a group.
     It should make minimal queries to the database.

--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -29,7 +29,7 @@ class GroupSearchViewSerializerResponse(TypedDict):
 
 
 @register(GroupSearchView)
-class GroupSearchViewSerializer(Serializer):
+class GroupSearchViewSerializer(Serializer[GroupSearchViewSerializerResponse]):
     def __init__(self, *args, **kwargs):
         self.organization = kwargs.pop("organization", None)
         super().__init__(*args, **kwargs)

--- a/src/sentry/api/serializers/models/groupsearchviewstarred.py
+++ b/src/sentry/api/serializers/models/groupsearchviewstarred.py
@@ -22,7 +22,7 @@ class GroupSearchViewStarredSerializerResponse(TypedDict):
 
 
 @register(GroupSearchViewStarred)
-class GroupSearchViewStarredSerializer(Serializer):
+class GroupSearchViewStarredSerializer(Serializer[GroupSearchViewStarredSerializerResponse]):
     def __init__(self, *args, **kwargs):
         self.organization = kwargs.pop("organization", None)
         super().__init__(*args, **kwargs)

--- a/src/sentry/api/serializers/models/incidentactivity.py
+++ b/src/sentry/api/serializers/models/incidentactivity.py
@@ -23,7 +23,7 @@ class IncidentActivitySerializerResponse(TypedDict):
 
 
 @register(IncidentActivity)
-class IncidentActivitySerializer(Serializer):
+class IncidentActivitySerializer(Serializer[IncidentActivitySerializerResponse]):
     def get_attrs(self, item_list, user, **kwargs):
         prefetch_related_objects(item_list, "incident__organization")
         serialized_users = user_service.serialize_many(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -305,7 +305,7 @@ class ControlSiloOrganizationSerializerResponse(TypedDict):
     name: str
 
 
-class ControlSiloOrganizationSerializer(Serializer):
+class ControlSiloOrganizationSerializer(Serializer[ControlSiloOrganizationSerializerResponse]):
     def serialize(
         self,
         obj: RpcOrganizationSummary,
@@ -340,7 +340,9 @@ class ControlSiloOrganizationMappingSerializerResponse(TypedDict):
     hasAuthProvider: bool
 
 
-class ControlSiloOrganizationMappingSerializer(Serializer):
+class ControlSiloOrganizationMappingSerializer(
+    Serializer[ControlSiloOrganizationMappingSerializerResponse]
+):
     _AVATAR_TYPE_BY_ID: ClassVar[dict[int, str]] = dict(OrganizationAvatar.AVATAR_TYPES)
 
     def get_attrs(
@@ -409,7 +411,7 @@ class ControlSiloOrganizationMappingSerializer(Serializer):
 
 
 @register(Organization)
-class OrganizationSummarySerializer(Serializer):
+class OrganizationSummarySerializer(Serializer[OrganizationSummarySerializerResponse]):
     def get_attrs(
         self, item_list: Sequence[Organization], user: User | RpcUser | AnonymousUser, **kwargs: Any
     ) -> MutableMapping[Organization, MutableMapping[str, Any]]:
@@ -596,7 +598,7 @@ class _OnboardingTasksAttrs(TypedDict):
 
 
 @register(OrganizationOnboardingTask)
-class OnboardingTasksSerializer(Serializer):
+class OnboardingTasksSerializer(Serializer[OnboardingTasksSerializerResponse]):
     def get_attrs(
         self,
         item_list: Sequence[OrganizationOnboardingTask],

--- a/src/sentry/api/serializers/models/organization_member/scim.py
+++ b/src/sentry/api/serializers/models/organization_member/scim.py
@@ -8,7 +8,7 @@ from sentry.models.organizationmember import OrganizationMember
 from .response import OrganizationMemberSCIMSerializerResponse
 
 
-class OrganizationMemberSCIMSerializer(Serializer):
+class OrganizationMemberSCIMSerializer(Serializer[OrganizationMemberSCIMSerializerResponse]):
     def __init__(self, expand: Sequence[str] | None = None) -> None:
         self.expand = expand or []
 

--- a/src/sentry/api/serializers/models/organizationmemberinvite.py
+++ b/src/sentry/api/serializers/models/organizationmemberinvite.py
@@ -14,7 +14,7 @@ from sentry.users.services.user.service import user_service
 
 
 @register(OrganizationMemberInvite)
-class OrganizationMemberInviteSerializer(Serializer):
+class OrganizationMemberInviteSerializer(Serializer[OrganizationMemberInviteResponse]):
     def get_attrs(
         self,
         item_list: Sequence[OrganizationMemberInvite],

--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -67,7 +67,7 @@ class ProjectKeySerializerResponse(TypedDict):
 
 
 @register(ProjectKey)
-class ProjectKeySerializer(Serializer):
+class ProjectKeySerializer(Serializer[ProjectKeySerializerResponse]):
     def serialize(
         self, obj: ProjectKey, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> ProjectKeySerializerResponse:

--- a/src/sentry/api/serializers/models/projectownership.py
+++ b/src/sentry/api/serializers/models/projectownership.py
@@ -41,7 +41,7 @@ class ProjectOwnershipResponse(ProjectOwnershipResponseOptional):
 
 
 @register(ProjectOwnership)
-class ProjectOwnershipSerializer(Serializer):
+class ProjectOwnershipSerializer(Serializer[ProjectOwnershipResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> ProjectOwnershipResponse:
         assignment = (
             "Auto Assign to Suspect Commits"

--- a/src/sentry/api/serializers/models/pullrequest.py
+++ b/src/sentry/api/serializers/models/pullrequest.py
@@ -33,7 +33,7 @@ def get_users_for_pull_requests(item_list, user=None):
 
 
 @register(PullRequest)
-class PullRequestSerializer(Serializer):
+class PullRequestSerializer(Serializer[PullRequestSerializerResponse]):
     def get_attrs(self, item_list, user, **kwargs):
         users_by_author = get_users_for_pull_requests(item_list, user)
         repositories = list(Repository.objects.filter(id__in=[c.repository_id for c in item_list]))

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -26,7 +26,7 @@ class RepositorySerializerResponse(TypedDict, total=False):
 
 
 @register(RepositorySettings)
-class RepositorySettingsSerializer(Serializer):
+class RepositorySettingsSerializer(Serializer[RepositorySettingsSerializerResponse]):
     def serialize(
         self, obj: RepositorySettings, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> RepositorySettingsSerializerResponse:
@@ -37,7 +37,7 @@ class RepositorySettingsSerializer(Serializer):
 
 
 @register(Repository)
-class RepositorySerializer(Serializer):
+class RepositorySerializer(Serializer[RepositorySerializerResponse]):
     def __init__(self, expand: Sequence[str] | None = None) -> None:
         super().__init__()
         self.expand = expand or []

--- a/src/sentry/api/serializers/models/role.py
+++ b/src/sentry/api/serializers/models/role.py
@@ -51,7 +51,7 @@ def _serialize_base_role(
     }
 
 
-class OrganizationRoleSerializer(Serializer):
+class OrganizationRoleSerializer(Serializer[OrganizationRoleSerializerResponse]):
     def __init__(self, **kwargs):
         """
         Remove this when deleting "organizations:team-roles" flag
@@ -76,7 +76,7 @@ class OrganizationRoleSerializer(Serializer):
         }
 
 
-class TeamRoleSerializer(Serializer):
+class TeamRoleSerializer(Serializer[TeamRoleSerializerResponse]):
     def __init__(self, **kwargs):
         """
         Remove this when deleting "organizations:team-roles" flag

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -42,7 +42,7 @@ class SeerNightShiftRunResponse(TypedDict):
 
 
 @register(SeerNightShiftRun)
-class SeerNightShiftRunSerializer(Serializer):
+class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
     def get_attrs(
         self, item_list: Sequence[SeerNightShiftRun], user: Any, **kwargs: Any
     ) -> dict[SeerNightShiftRun, dict[str, Any]]:

--- a/src/sentry/api/serializers/models/userrollback.py
+++ b/src/sentry/api/serializers/models/userrollback.py
@@ -20,7 +20,7 @@ class RollbackSerializerResponse(TypedDict):
     data: dict  # JSON Blob
 
 
-class UserRollbackSerializer(Serializer):
+class UserRollbackSerializer(Serializer[RollbackSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> RollbackSerializerResponse:
         rollback_org = kwargs.get("rollback_org")
 


### PR DESCRIPTION
Foundation for typed-body flow on the Serializer side. Every `Serializer`
subclass that already annotates `def serialize(...) -> XResponse:`
declares its base as `Serializer[XResponse]`, so call sites that pass
`serializer=FooSer()` get the typed return through mypy's overload
chain instead of `Any`.

Builds on #116538's `Serializer[T]` generic. Sibling to a follow-up
PR that uses these typed serializers for endpoint annotation migrations.

**Subset selection — 33 of 43 candidates**

A per-file try-and-revert against full-tree mypy (matching CI's
`files = ["."]`) picked the safe subset. The 10 rejected serializers
have consumers that:

- Add keys to the result not present in the TypedDict
  (e.g. `data["stats"] = ...` after `ProjectSerializer`)
- Delete required keys from the result
  (e.g. `del result["conditions"]` in `RuleSerializer` tests)
- Pass the serializer to typed-context sites expecting a different `T`
  (e.g. `CommitSerializer` to a `MutableMapping[str, Any]`-expecting helper)

Surfacing those is a feature of the new typing — they're latent
TypedDict drift the migration would catch. Each gets its own
follow-up PR.

Rejected for follow-up:

```
EventSerializer, ProjectSerializer, ActorSerializer,
BaseTeamSerializer/TeamSCIMSerializer, CommitSerializer,
UserReportSerializer, RuleSerializer, ReleaseSerializer/GroupEventReleaseSerializer,
OrganizationMemberSerializer
```

**No runtime change**

Unchanged: serializer method bodies, instance behavior, registry
registration, OpenAPI emission (`make build-api-docs` byte-identical
to master). The `TypeVar` default `Any` preserves behavior for every
caller that doesn't pass `serializer=` explicitly. The new check only
fires for callers that opt in.

**Verification**

- `.venv/bin/mypy` (full-tree, 8037 files): clean
- `prek run -q` on touched files: clean
- structural linter (#116496): clean
- `make build-api-docs`: byte-identical to master