### PR TITLE
feat(api-docs): publish organization profile chunks endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -189,9 +189,58 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
         )
 
 
+PROFILER_ID_QUERY_PARAM = OpenApiParameter(
+    name="profiler_id",
+    location="query",
+    required=True,
+    type=str,
+    description="The continuous-profiler ID to fetch chunks for.",
+)
+
+CHUNKS_PROJECT_PARAM = OpenApiParameter(
+    name="project",
+    location="query",
+    required=True,
+    type=int,
+    description="The ID of the project to fetch chunks for. Exactly one project must be specified.",
+)
+
+
+@extend_schema(tags=["Profiling"])
 @cell_silo_endpoint
 class OrganizationProfilingChunksEndpoint(OrganizationProfilingBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
+
+    @extend_schema(
+        operation_id="Retrieve Profile Chunks for an Organization",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            CHUNKS_PROJECT_PARAM,
+            GlobalParams.STATS_PERIOD,
+            GlobalParams.START,
+            GlobalParams.END,
+            PROFILER_ID_QUERY_PARAM,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "OrganizationProfilingChunksResponse", dict[str, Any]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=ProfilingExamples.PROFILE_CHUNKS,
+    )
     def get(self, request: Request, organization: Organization) -> HttpResponse:
+        """
+        Retrieve continuous profiling data for a profiler over a time range.
+
+        Exactly one project must be specified via the `project` query parameter.
+
+        Requires continuous profiling to be enabled for the organization.
+        """
         if not features.has("organizations:continuous-profiling", organization, actor=request.user):
             return Response(status=404)
 

--- a/src/sentry/apidocs/examples/profiling_examples.py
+++ b/src/sentry/apidocs/examples/profiling_examples.py
@@ -169,6 +169,38 @@ PROFILE_DETAILS_RESPONSE = {
 }
 
 
+PROFILE_CHUNKS_RESPONSE = {
+    "chunk": {
+        "chunk_id": "0123456789abcdef0123456789abcdef",
+        "profiler_id": "fedcba9876543210fedcba9876543210",
+        "project_id": 1,
+        "organization_id": 1,
+        "environment": "production",
+        "platform": "python",
+        "release": "1.0.0",
+        "received": 1_779_957_840.0,
+        "retention_days": 30,
+        "version": "2",
+        "profile": {
+            "samples": [
+                {
+                    "stack_id": 0,
+                    "thread_id": "1",
+                    "timestamp": 1_779_957_840.0,
+                },
+            ],
+            "stacks": [[0, 1]],
+            "frames": [
+                {"function": "main", "module": "app.main", "in_app": True, "lineno": 10},
+                {"function": "do_work", "module": "app.worker", "in_app": True, "lineno": 42},
+            ],
+            "thread_metadata": {"1": {"name": "MainThread"}},
+        },
+    },
+    "debug_chunk_ids": ["0123456789abcdef0123456789abcdef"],
+}
+
+
 class ProfilingExamples:
     FLAMEGRAPH = [
         OpenApiExample(
@@ -182,6 +214,14 @@ class ProfilingExamples:
         OpenApiExample(
             "Return a single profile by ID",
             value=PROFILE_DETAILS_RESPONSE,
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]
+    PROFILE_CHUNKS = [
+        OpenApiExample(
+            "Return continuous-profile chunks for a profiler",
+            value=PROFILE_CHUNKS_RESPONSE,
             response_only=True,
             status_codes=["200"],
         )


### PR DESCRIPTION
Publish `OrganizationProfilingChunksEndpoint`, as part of https://linear.app/getsentry/project/api-docs-for-agents-c7863fd8bbe0/overview.