### PR TITLE
feat(repositories): Auto-link new projects to repos via name matching

### DIFF
--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -298,7 +298,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
         self,
         *,
         organization_id: int,
-        repo_ids: list[int],
+        repo_ids: list[int] | None = None,
         project_ids: list[int] | None = None,
     ) -> int:
         try:

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -299,9 +299,10 @@ class DatabaseBackedRepositoryService(RepositoryService):
         *,
         organization_id: int,
         repo_ids: list[int],
+        project_ids: list[int] | None = None,
     ) -> int:
         try:
             organization = Organization.objects.get(id=organization_id)
         except Organization.DoesNotExist:
             return 0
-        return auto_link_repos_by_name(organization, repo_ids)
+        return auto_link_repos_by_name(organization, repo_ids, project_ids=project_ids)

--- a/src/sentry/integrations/services/repository/service.py
+++ b/src/sentry/integrations/services/repository/service.py
@@ -150,7 +150,7 @@ class RepositoryService(RpcService):
         self,
         *,
         organization_id: int,
-        repo_ids: list[int],
+        repo_ids: list[int] | None = None,
         project_ids: list[int] | None = None,
     ) -> int:
         """
@@ -158,6 +158,8 @@ class RepositoryService(RpcService):
         Only creates links when neither the repo nor the project
         already has a ProjectRepository row.
 
+        If repo_ids is provided, only consider those repos. Otherwise all
+        unlinked repos in the org are considered.
         If project_ids is provided, only consider those projects.
 
         Returns the number of links created.

--- a/src/sentry/integrations/services/repository/service.py
+++ b/src/sentry/integrations/services/repository/service.py
@@ -151,11 +151,14 @@ class RepositoryService(RpcService):
         *,
         organization_id: int,
         repo_ids: list[int],
+        project_ids: list[int] | None = None,
     ) -> int:
         """
         Auto-link repositories to projects based on name matching.
         Only creates links when neither the repo nor the project
         already has a ProjectRepository row.
+
+        If project_ids is provided, only consider those projects.
 
         Returns the number of links created.
         """

--- a/src/sentry/integrations/source_code_management/auto_link_repos.py
+++ b/src/sentry/integrations/source_code_management/auto_link_repos.py
@@ -47,6 +47,7 @@ def get_repo_name_candidates(repo_name: str) -> list[str]:
 def auto_link_repos_by_name(
     organization: Organization | RpcOrganization,
     repo_ids: Sequence[int],
+    project_ids: Sequence[int] | None = None,
 ) -> int:
     """
     Auto-link repositories to projects by matching repo name suffix to project slug.
@@ -57,6 +58,7 @@ def auto_link_repos_by_name(
     Constraints:
     - The repo must not already be linked to any project.
     - The project must not already have any ProjectRepository link.
+    - If project_ids is provided, only consider those projects.
 
     Returns the number of links created
     """
@@ -74,15 +76,15 @@ def auto_link_repos_by_name(
         status=ObjectStatus.ACTIVE,
     ).exclude(Exists(ProjectRepository.objects.filter(repository_id=OuterRef("id"))))
 
+    project_qs = Project.objects.filter(
+        organization_id=organization.id,
+        status=ObjectStatus.ACTIVE,
+    ).exclude(Exists(ProjectRepository.objects.filter(project_id=OuterRef("id"))))
+    if project_ids is not None:
+        project_qs = project_qs.filter(id__in=project_ids)
+
     unlinked_projects_by_slug: dict[str, tuple[int, str]] = {}
-    for p_id, slug in (
-        Project.objects.filter(
-            organization_id=organization.id,
-            status=ObjectStatus.ACTIVE,
-        )
-        .exclude(Exists(ProjectRepository.objects.filter(project_id=OuterRef("id"))))
-        .values_list("id", "slug")
-    ):
+    for p_id, slug in project_qs.values_list("id", "slug"):
         unlinked_projects_by_slug[slug] = (p_id, slug)
 
     if not unlinked_projects_by_slug:
@@ -132,3 +134,21 @@ def auto_link_repos_by_name(
                 created += 1
 
     return created
+
+
+def auto_link_repos_on_project_create(project: Project, **kwargs: object) -> None:
+    """
+    Signal receiver for project_created. Finds all unlinked repos in the
+    org and tries to match them to the newly created project by name.
+    """
+    organization = project.organization
+    repo_ids = list(
+        Repository.objects.filter(
+            organization_id=organization.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        .exclude(Exists(ProjectRepository.objects.filter(repository_id=OuterRef("id"))))
+        .values_list("id", flat=True)
+    )
+    if repo_ids:
+        auto_link_repos_by_name(organization, repo_ids, project_ids=[project.id])

--- a/src/sentry/integrations/source_code_management/auto_link_repos.py
+++ b/src/sentry/integrations/source_code_management/auto_link_repos.py
@@ -46,7 +46,7 @@ def get_repo_name_candidates(repo_name: str) -> list[str]:
 
 def auto_link_repos_by_name(
     organization: Organization | RpcOrganization,
-    repo_ids: Sequence[int],
+    repo_ids: Sequence[int] | None = None,
     project_ids: Sequence[int] | None = None,
 ) -> int:
     """
@@ -58,23 +58,23 @@ def auto_link_repos_by_name(
     Constraints:
     - The repo must not already be linked to any project.
     - The project must not already have any ProjectRepository link.
+    - If repo_ids is provided, only consider those repos. Otherwise all unlinked
+      repos in the org are considered.
     - If project_ids is provided, only consider those projects.
 
     Returns the number of links created
     """
-    if not repo_ids:
-        return 0
-
     if not features.has("organizations:auto-link-repos-by-name", organization):
         return 0
 
     dry_run = options.get("repository.auto-link-by-name-dry-run")
 
-    repos = Repository.objects.filter(
-        id__in=repo_ids,
+    repo_qs = Repository.objects.filter(
         organization_id=organization.id,
         status=ObjectStatus.ACTIVE,
     ).exclude(Exists(ProjectRepository.objects.filter(repository_id=OuterRef("id"))))
+    if repo_ids is not None:
+        repo_qs = repo_qs.filter(id__in=repo_ids)
 
     project_qs = Project.objects.filter(
         organization_id=organization.id,
@@ -91,7 +91,7 @@ def auto_link_repos_by_name(
         return 0
 
     created = 0
-    for repo in repos:
+    for repo in repo_qs:
         project_id: int | None = None
         project_slug: str | None = None
         for candidate in get_repo_name_candidates(repo.name):
@@ -138,17 +138,7 @@ def auto_link_repos_by_name(
 
 def auto_link_repos_on_project_create(project: Project, **kwargs: object) -> None:
     """
-    Signal receiver for project_created. Finds all unlinked repos in the
-    org and tries to match them to the newly created project by name.
+    Signal receiver for project_created. Tries to match all unlinked repos
+    in the org to the newly created project by name.
     """
-    organization = project.organization
-    repo_ids = list(
-        Repository.objects.filter(
-            organization_id=organization.id,
-            status=ObjectStatus.ACTIVE,
-        )
-        .exclude(Exists(ProjectRepository.objects.filter(repository_id=OuterRef("id"))))
-        .values_list("id", flat=True)
-    )
-    if repo_ids:
-        auto_link_repos_by_name(organization, repo_ids, project_ids=[project.id])
+    auto_link_repos_by_name(project.organization, project_ids=[project.id])

--- a/src/sentry/integrations/source_code_management/receivers.py
+++ b/src/sentry/integrations/source_code_management/receivers.py
@@ -1,0 +1,10 @@
+from sentry.integrations.source_code_management.auto_link_repos import (
+    auto_link_repos_on_project_create,
+)
+from sentry.signals import project_created
+
+project_created.connect(
+    auto_link_repos_on_project_create,
+    weak=False,
+    dispatch_uid="auto_link_repos_on_project_create",
+)

--- a/src/sentry/receivers/__init__.py
+++ b/src/sentry/receivers/__init__.py
@@ -1,3 +1,5 @@
+import sentry.integrations.source_code_management.receivers  # noqa: F401,E402
+
 from .analytics import *  # noqa: F401,F403
 from .auth import *  # noqa: F401,F403
 from .core import *  # noqa: F401,F403

--- a/tests/sentry/integrations/source_code_management/test_auto_link_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_auto_link_repos.py
@@ -1,6 +1,7 @@
 from sentry.constants import ObjectStatus
 from sentry.integrations.source_code_management.auto_link_repos import (
     auto_link_repos_by_name,
+    auto_link_repos_on_project_create,
     get_repo_name_candidates,
 )
 from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
@@ -219,3 +220,68 @@ class AutoLinkReposByNameTest(TestCase):
             ProjectRepository.objects.filter(project=self.project, repository=self.repo).count()
             == 1
         )
+
+
+class AutoLinkReposOnProjectCreateTest(TestCase):
+    def test_links_matching_repo_on_project_create(self) -> None:
+        org = self.create_organization()
+        Repository.objects.create(
+            organization_id=org.id,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
+        )
+        project = self.create_project(organization=org, slug="sentry")
+
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            auto_link_repos_on_project_create(project)
+
+        assert ProjectRepository.objects.filter(
+            project=project,
+            source=ProjectRepositorySource.AUTO_NAME_MATCH,
+        ).exists()
+
+    def test_skips_when_no_matching_repo(self) -> None:
+        org = self.create_organization()
+        Repository.objects.create(
+            organization_id=org.id,
+            name="getsentry/relay",
+            provider="integrations:github",
+            external_id="456",
+        )
+        project = self.create_project(organization=org, slug="sentry")
+
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            auto_link_repos_on_project_create(project)
+
+        assert not ProjectRepository.objects.filter(project=project).exists()
+
+    def test_skips_already_linked_repos(self) -> None:
+        org = self.create_organization()
+        repo = Repository.objects.create(
+            organization_id=org.id,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
+        )
+        other_project = self.create_project(organization=org, slug="other")
+        ProjectRepository.objects.create(
+            project=other_project,
+            repository=repo,
+            source=ProjectRepositorySource.MANUAL,
+        )
+        project = self.create_project(organization=org, slug="sentry")
+
+        with (
+            self.feature("organizations:auto-link-repos-by-name"),
+            self.options({"repository.auto-link-by-name-dry-run": False}),
+        ):
+            auto_link_repos_on_project_create(project)
+
+        assert not ProjectRepository.objects.filter(project=project).exists()


### PR DESCRIPTION
When we create new projects, if repositories exist in the organization we should attempt to match them to a project.
