### PR TITLE
ref(flags): Remove organizations:processing-error-analytics

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1120,9 +1120,7 @@ def _eventstream_insert_many(jobs: Sequence[Job]) -> None:
         # so new-customer cohorts are fully observable; 1% otherwise.
         processing_errors = job["data"].get("errors", [])
         event = job["event"]
-        if processing_errors and features.has(
-            "organizations:processing-error-analytics", event.project.organization
-        ):
+        if processing_errors:
             org_age = datetime.now(timezone.utc) - event.project.organization.date_added
             sample_rate = 1.0 if org_age < timedelta(days=30) else 0.01
             if random.random() < sample_rate:

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -218,8 +218,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:relay-new-error-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Add a random trace ID to events that lack one in Relay.
     manager.add("organizations:relay-default-trace-id", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enables recording processing errors to analytics for product validation
-    manager.add("organizations:processing-error-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     manager.add("organizations:processing-errors-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:sourcemap-issue-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable profiling

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -4456,10 +4456,7 @@ class EventProcessingErrorAnalyticsTest(TestCase, SnubaTestCase):
     def test_validation_errors_recorded_to_analytics(self, mock_random: mock.MagicMock) -> None:
         """Test that validation errors from normalization are also recorded."""
         mock_random.return_value = 0.001
-        with (
-            self.feature("organizations:processing-error-analytics"),
-            mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record,
-        ):
+        with mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record:
             # Create an event with a future timestamp, which produces a validation error
             future = timezone.now() + timedelta(minutes=10)
             event = self.store_event(
@@ -4498,10 +4495,7 @@ class EventProcessingErrorAnalyticsTest(TestCase, SnubaTestCase):
         self.organization.date_added = timezone.now() - timedelta(days=60)
         self.organization.save()
         mock_random.return_value = 0.001
-        with (
-            self.feature("organizations:processing-error-analytics"),
-            mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record,
-        ):
+        with mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record:
             future = timezone.now() + timedelta(minutes=10)
             event = self.store_event(
                 data=make_event(
@@ -4539,10 +4533,7 @@ class EventProcessingErrorAnalyticsTest(TestCase, SnubaTestCase):
         self.organization.date_added = timezone.now() - timedelta(days=60)
         self.organization.save()
         mock_random.return_value = 0.5
-        with (
-            self.feature("organizations:processing-error-analytics"),
-            mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record,
-        ):
+        with mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record:
             # Create an event with a future timestamp, which produces a validation error
             future = timezone.now() + timedelta(minutes=10)
             self.store_event(
@@ -4566,40 +4557,10 @@ class EventProcessingErrorAnalyticsTest(TestCase, SnubaTestCase):
     ) -> None:
         """Test that analytics is not recorded when there are no processing errors."""
         mock_random.return_value = 0.001
-        with (
-            self.feature("organizations:processing-error-analytics"),
-            mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record,
-        ):
+        with mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record:
             self.store_event(
                 data=make_event(platform="python"),
                 project_id=self.project.id,
-            )
-            processing_error_calls = [
-                call
-                for call in spy_analytics_record.call_args_list
-                if isinstance(call[0][0], EventProcessingErrorRecorded)
-            ]
-            assert len(processing_error_calls) == 0
-
-    @mock.patch("sentry.event_manager.random.random")
-    def test_processing_errors_not_recorded_when_feature_disabled(
-        self, mock_random: mock.MagicMock
-    ) -> None:
-        """Test that analytics is not recorded when feature flag is disabled."""
-        mock_random.return_value = 0.001
-        with (
-            self.feature({"organizations:processing-error-analytics": False}),
-            mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record,
-        ):
-            # Create an event with a future timestamp, which produces a validation error
-            future = timezone.now() + timedelta(minutes=10)
-            self.store_event(
-                data=make_event(
-                    platform="python",
-                    timestamp=future.isoformat(),
-                ),
-                project_id=self.project.id,
-                assert_no_errors=False,
             )
             processing_error_calls = [
                 call


### PR DESCRIPTION
Default-removable flag (default=True). Remove the flag registration and all flag checks, making processing error analytics recording unconditional. Remove the now-irrelevant feature-disabled test.

