### PR TITLE
ref(flags): Remove organizations:uptime-response-capture

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -369,8 +369,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:uptime-ai-assertion-suggestions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable task-based retry for out-of-order uptime results
     manager.add("organizations:uptime-backlog-retry", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable storing HTTP response captures for uptime monitor failures
-    manager.add("organizations:uptime-response-capture", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable auto spam classification at User Feedback ingest time
     manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -699,9 +699,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 )
             return
 
-        if result["status"] == CHECKSTATUS_FAILURE and features.has(
-            "organizations:uptime-response-capture", organization
-        ):
+        if result["status"] == CHECKSTATUS_FAILURE:
             create_uptime_response_capture(subscription, result)
 
         if last_update_ms > 0:


### PR DESCRIPTION
Default-removable flag (default=True). Remove the flag registration and flag check, making uptime response capture on failure unconditional.

<!-- Describe your PR here. -->