### PR TITLE
feat(integrations): Create ExternalActor mappings on new CommitAuthors

### DIFF
--- a/fixtures/github.py
+++ b/fixtures/github.py
@@ -36,6 +36,49 @@ def push_event_with_author(*, name: str, email: str, username: str | None = None
     )
 
 
+def push_event_with_commit_authors(authors: list[dict[str, str | None]]) -> str:
+    """Build a push event body with one distinct commit per provided author.
+
+    Each entry in ``authors`` is a mapping with ``name`` and ``email`` keys and an
+    optional ``username`` key. This is useful for exercising behavior across
+    multiple distinct commits within a single push (e.g. when a later commit for
+    the same email carries a GitHub username the earlier commit was missing).
+
+    Like ``push_event_with_author``, callers are expected to sign the returned
+    body themselves.
+    """
+    commits = []
+    for i, entry in enumerate(authors):
+        author: dict[str, str] = {"name": entry["name"], "email": entry["email"]}  # type: ignore[dict-item]
+        if entry.get("username") is not None:
+            author["username"] = entry["username"]  # type: ignore[assignment]
+        commits.append(
+            {
+                # Commit keys must be unique within a repository.
+                "id": f"{i:040x}",
+                "distinct": True,
+                "message": "Update hello.py",
+                "timestamp": "2015-05-05T19:45:15-04:00",
+                "author": author,
+                "added": [],
+                "removed": [],
+                "modified": ["hello.py"],
+            }
+        )
+    return json.dumps(
+        {
+            "ref": "refs/heads/main",
+            "installation": {"id": 12345},
+            "commits": commits,
+            "repository": {
+                "id": 35129377,
+                "full_name": "baxterthehacker/public-repo",
+                "html_url": "https://github.com/baxterthehacker/public-repo",
+            },
+        }
+    )
+
+
 # we keep this as a raw string as order matters for hmac signing
 PUSH_EVENT_EXAMPLE_INSTALLATION = r"""{
   "ref": "refs/heads/changes",

--- a/fixtures/github.py
+++ b/fixtures/github.py
@@ -1,3 +1,41 @@
+from sentry.utils import json
+
+
+def push_event_with_author(*, name: str, email: str, username: str | None = None) -> str:
+    """Build a minimal push event body with a single commit by the given author.
+
+    Unlike ``PUSH_EVENT_EXAMPLE_INSTALLATION``, this is not a raw string with a precomputed
+    signature: callers are expected to sign the returned body themselves, so field ordering is
+    irrelevant here.
+    """
+    author: dict[str, str] = {"name": name, "email": email}
+    if username is not None:
+        author["username"] = username
+    return json.dumps(
+        {
+            "ref": "refs/heads/main",
+            "installation": {"id": 12345},
+            "commits": [
+                {
+                    "id": "133d60480286590a610a0eb7352ff6e02b9674c4",
+                    "distinct": True,
+                    "message": "Update hello.py",
+                    "timestamp": "2015-05-05T19:45:15-04:00",
+                    "author": author,
+                    "added": [],
+                    "removed": [],
+                    "modified": ["hello.py"],
+                }
+            ],
+            "repository": {
+                "id": 35129377,
+                "full_name": "baxterthehacker/public-repo",
+                "html_url": "https://github.com/baxterthehacker/public-repo",
+            },
+        }
+    )
+
+
 # we keep this as a raw string as order matters for hmac signing
 PUSH_EVENT_EXAMPLE_INSTALLATION = r"""{
   "ref": "refs/heads/changes",

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -367,12 +367,18 @@ class GitHubWebhook(SCMWebhook, ABC):
 
         external_name = f"@{gh_username.lstrip('@')}"
 
+        # GitHub usernames are case-insensitive, and mapping resolution elsewhere
+        # matches on external_name__iexact. Match the same way here so we don't
+        # create a casing-variant duplicate (e.g. @User vs @user) that would split
+        # assignment/codeowner resolution. The __iexact lookup is used only for the
+        # match; the actual (case-preserving) value is written via defaults.
         ExternalActor.objects.get_or_create(
             organization_id=organization.id,
             provider=provider,
-            external_name=external_name,
+            external_name__iexact=external_name,
             user_id=user.id,
             defaults={
+                "external_name": external_name,
                 "integration_id": integration.id,
                 "external_id": str(gh_user_id) if gh_user_id else None,
                 "source": ExternalActorSource.COMMIT_AUTHOR.value,

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -368,18 +368,17 @@ class GitHubWebhook(SCMWebhook, ABC):
 
             external_name = f"@{gh_username.lstrip('@')}"
 
-            with transaction.atomic(router.db_for_write(ExternalActor)):
-                _, created = ExternalActor.objects.get_or_create(
-                    organization_id=organization.id,
-                    provider=provider,
-                    external_name=external_name,
-                    user_id=user.id,
-                    defaults={
-                        "integration_id": integration.id,
-                        "external_id": str(gh_user_id) if gh_user_id else None,
-                        "source": ExternalActorSource.COMMIT_AUTHOR.value,
-                    },
-                )
+            _, created = ExternalActor.objects.get_or_create(
+                organization_id=organization.id,
+                provider=provider,
+                external_name=external_name,
+                user_id=user.id,
+                defaults={
+                    "integration_id": integration.id,
+                    "external_id": str(gh_user_id) if gh_user_id else None,
+                    "source": ExternalActorSource.COMMIT_AUTHOR.value,
+                },
+            )
         except IntegrityError:
             return
         except Exception as e:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -630,13 +630,22 @@ class PushEventWebhook(GitHubWebhook):
             # its optional, lets just throw it out for now
             if len(author_email) > 75:
                 author = None
-            elif author_email not in authors:
-                author, author_created = CommitAuthor.objects.get_or_create(
-                    organization_id=organization.id,
-                    email=author_email,
-                    defaults={"name": commit["author"]["name"][:128]},
-                )
-                authors[author_email] = author
+            else:
+                if author_email not in authors:
+                    author, author_created = CommitAuthor.objects.get_or_create(
+                        organization_id=organization.id,
+                        email=author_email,
+                        defaults={"name": commit["author"]["name"][:128]},
+                    )
+                    authors[author_email] = author
+                else:
+                    # Reuse the author we already resolved earlier in this push. A
+                    # later commit can still carry information (e.g. a GitHub
+                    # username) that the first commit for this email was missing, so
+                    # we continue through the upsert logic below rather than stopping
+                    # here.
+                    author = authors[author_email]
+                    author_created = False
 
                 update_kwargs = {}
 
@@ -658,7 +667,14 @@ class PushEventWebhook(GitHubWebhook):
                     except IntegrityError:
                         pass
 
-                if author_created:
+                # Create the ExternalActor mapping when the author was just created or
+                # when we've only now associated a GitHub username with an existing
+                # author. GitHub omits the commit author's username when the email is
+                # not tied to a GitHub account, so an author created by an earlier
+                # commit (in this push or a previous one) may not gain its username
+                # until a later commit. Gating solely on creation would skip those
+                # authors forever.
+                if author_created or "external_id" in update_kwargs:
                     try:
                         self.maybe_create_external_actor(
                             integration=integration,
@@ -672,8 +688,6 @@ class PushEventWebhook(GitHubWebhook):
                             "github.webhook.external_actor.error",
                             extra={"organization_id": organization.id},
                         )
-            else:
-                author = authors[author_email]
 
             if author:
                 author.preload_users()

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -379,8 +379,6 @@ class GitHubWebhook(SCMWebhook, ABC):
                     "source": ExternalActorSource.COMMIT_AUTHOR.value,
                 },
             )
-        except IntegrityError:
-            return
         except Exception as e:
             # Never let external actor creation disrupt the main webhook flow.
             logger.warning(

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -33,6 +33,7 @@ from sentry.integrations.github.webhook_types import (
     GithubWebhookType,
     InstallationRepositoriesEvent,
 )
+from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.pipeline import ensure_integration
 from sentry.integrations.services.integration.model import (
     RpcIntegration,
@@ -41,7 +42,11 @@ from sentry.integrations.services.integration.model import (
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.services.repository.service import repository_service
 from sentry.integrations.source_code_management.webhook import SCMWebhook
-from sentry.integrations.types import IntegrationProviderSlug
+from sentry.integrations.types import (
+    ExternalActorSource,
+    ExternalProviders,
+    IntegrationProviderSlug,
+)
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.integrations.utils.sync import sync_group_assignee_inbound_by_external_actor
@@ -324,6 +329,67 @@ class GitHubWebhook(SCMWebhook, ABC):
     def get_idp_external_id(self, integration: RpcIntegration, host: str | None = None) -> str:
         return options.get("github-app.id")
 
+    def maybe_create_external_actor(
+        self,
+        *,
+        integration: RpcIntegration,
+        organization: Organization,
+        commit_author: CommitAuthor,
+        gh_username: str | None,
+        gh_user_id: str | int | None = None,
+    ) -> None:
+        """
+        For a newly created CommitAuthor, create the matching GitHub ExternalActor
+        mapping when we can confidently tie the author to a single Sentry user.
+
+        We only create a mapping when:
+        - the commit author has a GitHub username,
+        - the email is not an anonymous GitHub noreply address, and
+        - the email resolves to exactly one verified member of the organization.
+        """
+        try:
+            if not gh_username:
+                return
+
+            if self.is_anonymous_email(commit_author.email):
+                return
+
+            users = commit_author.find_users()
+            # Only create a mapping when the email unambiguously resolves to a
+            # single Sentry user, otherwise we risk linking the wrong account.
+            if len(users) != 1:
+                return
+            user = users[0]
+
+            if integration.provider == IntegrationProviderSlug.GITHUB_ENTERPRISE.value:
+                provider = ExternalProviders.GITHUB_ENTERPRISE.value
+            else:
+                provider = ExternalProviders.GITHUB.value
+
+            external_name = f"@{gh_username.lstrip('@')}"
+
+            with transaction.atomic(router.db_for_write(ExternalActor)):
+                _, created = ExternalActor.objects.get_or_create(
+                    organization_id=organization.id,
+                    provider=provider,
+                    external_name=external_name,
+                    user_id=user.id,
+                    defaults={
+                        "integration_id": integration.id,
+                        "external_id": str(gh_user_id) if gh_user_id else None,
+                        "source": ExternalActorSource.COMMIT_AUTHOR.value,
+                    },
+                )
+        except IntegrityError:
+            return
+        except Exception as e:
+            # Never let external actor creation disrupt the main webhook flow.
+            logger.warning(
+                "github.webhook.external_actor.error",
+                extra={"organization_id": organization.id, "error": str(e)},
+            )
+            return
+
 
 class InstallationEventWebhook(GitHubWebhook):
     """
@@ -570,11 +636,12 @@ class PushEventWebhook(GitHubWebhook):
             if len(author_email) > 75:
                 author = None
             elif author_email not in authors:
-                authors[author_email] = author = CommitAuthor.objects.get_or_create(
+                author, author_created = CommitAuthor.objects.get_or_create(
                     organization_id=organization.id,
                     email=author_email,
                     defaults={"name": commit["author"]["name"][:128]},
-                )[0]
+                )
+                authors[author_email] = author
 
                 update_kwargs = {}
 
@@ -595,6 +662,14 @@ class PushEventWebhook(GitHubWebhook):
                             author.update(**update_kwargs)
                     except IntegrityError:
                         pass
+
+                if author_created:
+                    self.maybe_create_external_actor(
+                        integration=integration,
+                        organization=organization,
+                        commit_author=author,
+                        gh_username=gh_username,
+                    )
             else:
                 author = authors[author_email]
 
@@ -912,7 +987,7 @@ class PullRequestEventWebhook(GitHubWebhook):
                 organization_id=organization.id, external_id=self.get_external_id(user["login"])
             )
         except CommitAuthor.DoesNotExist:
-            author, _created = CommitAuthor.objects.get_or_create(
+            author, author_created = CommitAuthor.objects.get_or_create(
                 organization_id=organization.id,
                 email=author_email,
                 defaults={
@@ -920,6 +995,14 @@ class PullRequestEventWebhook(GitHubWebhook):
                     "external_id": self.get_external_id(user["login"]),
                 },
             )
+            if author_created:
+                self.maybe_create_external_actor(
+                    integration=integration,
+                    organization=organization,
+                    commit_author=author,
+                    gh_username=user["login"],
+                    gh_user_id=user.get("id"),
+                )
 
         author.preload_users()
         try:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -347,45 +347,37 @@ class GitHubWebhook(SCMWebhook, ABC):
         - the email is not an anonymous GitHub noreply address, and
         - the email resolves to exactly one verified member of the organization.
         """
-        try:
-            if not gh_username:
-                return
-
-            if self.is_anonymous_email(commit_author.email):
-                return
-
-            users = commit_author.find_users()
-            # Only create a mapping when the email unambiguously resolves to a
-            # single Sentry user, otherwise we risk linking the wrong account.
-            if len(users) != 1:
-                return
-            user = users[0]
-
-            if integration.provider == IntegrationProviderSlug.GITHUB_ENTERPRISE.value:
-                provider = ExternalProviders.GITHUB_ENTERPRISE.value
-            else:
-                provider = ExternalProviders.GITHUB.value
-
-            external_name = f"@{gh_username.lstrip('@')}"
-
-            _, created = ExternalActor.objects.get_or_create(
-                organization_id=organization.id,
-                provider=provider,
-                external_name=external_name,
-                user_id=user.id,
-                defaults={
-                    "integration_id": integration.id,
-                    "external_id": str(gh_user_id) if gh_user_id else None,
-                    "source": ExternalActorSource.COMMIT_AUTHOR.value,
-                },
-            )
-        except Exception:
-            # Never let external actor creation disrupt the main webhook flow.
-            logger.exception(
-                "github.webhook.external_actor.error",
-                extra={"organization_id": organization.id},
-            )
+        if not gh_username:
             return
+
+        if self.is_anonymous_email(commit_author.email):
+            return
+
+        users = commit_author.find_users()
+        # Only create a mapping when the email unambiguously resolves to a
+        # single Sentry user, otherwise we risk linking the wrong account.
+        if len(users) != 1:
+            return
+        user = users[0]
+
+        if integration.provider == IntegrationProviderSlug.GITHUB_ENTERPRISE.value:
+            provider = ExternalProviders.GITHUB_ENTERPRISE.value
+        else:
+            provider = ExternalProviders.GITHUB.value
+
+        external_name = f"@{gh_username.lstrip('@')}"
+
+        ExternalActor.objects.get_or_create(
+            organization_id=organization.id,
+            provider=provider,
+            external_name=external_name,
+            user_id=user.id,
+            defaults={
+                "integration_id": integration.id,
+                "external_id": str(gh_user_id) if gh_user_id else None,
+                "source": ExternalActorSource.COMMIT_AUTHOR.value,
+            },
+        )
 
 
 class InstallationEventWebhook(GitHubWebhook):
@@ -661,12 +653,19 @@ class PushEventWebhook(GitHubWebhook):
                         pass
 
                 if author_created:
-                    self.maybe_create_external_actor(
-                        integration=integration,
-                        organization=organization,
-                        commit_author=author,
-                        gh_username=gh_username,
-                    )
+                    try:
+                        self.maybe_create_external_actor(
+                            integration=integration,
+                            organization=organization,
+                            commit_author=author,
+                            gh_username=gh_username,
+                        )
+                    except Exception:
+                        # Never let external actor creation disrupt the main webhook flow.
+                        logger.exception(
+                            "github.webhook.external_actor.error",
+                            extra={"organization_id": organization.id},
+                        )
             else:
                 author = authors[author_email]
 
@@ -993,13 +992,20 @@ class PullRequestEventWebhook(GitHubWebhook):
                 },
             )
             if author_created:
-                self.maybe_create_external_actor(
-                    integration=integration,
-                    organization=organization,
-                    commit_author=author,
-                    gh_username=user["login"],
-                    gh_user_id=user.get("id"),
-                )
+                try:
+                    self.maybe_create_external_actor(
+                        integration=integration,
+                        organization=organization,
+                        commit_author=author,
+                        gh_username=user["login"],
+                        gh_user_id=user.get("id"),
+                    )
+                except Exception:
+                    # Never let external actor creation disrupt the main webhook flow.
+                    logger.exception(
+                        "github.webhook.external_actor.error",
+                        extra={"organization_id": organization.id},
+                    )
 
         author.preload_users()
         try:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -379,11 +379,11 @@ class GitHubWebhook(SCMWebhook, ABC):
                     "source": ExternalActorSource.COMMIT_AUTHOR.value,
                 },
             )
-        except Exception as e:
+        except Exception:
             # Never let external actor creation disrupt the main webhook flow.
-            logger.warning(
+            logger.exception(
                 "github.webhook.external_actor.error",
-                extra={"organization_id": organization.id, "error": str(e)},
+                extra={"organization_id": organization.id},
             )
             return
 

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -795,6 +795,34 @@ class PushEventWebhookTest(APITestCase):
         )
 
     @responses.activate
+    def test_does_not_duplicate_external_actor_for_casing_variant(self) -> None:
+        member = self.create_user(email="newdev@example.com")
+        self.create_member(user=member, organization=self.organization)
+        integration = self._setup_github_integration_and_repo()
+
+        # Pre-existing mapping uses a different casing than the webhook payload.
+        existing = ExternalActor.objects.create(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            user_id=member.id,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@NewDev",
+        )
+
+        response = self._send_push_event(
+            push_event_with_author(name="New Dev", email="newdev@example.com", username="newdev")
+        )
+        assert response.status_code == 204
+
+        external_actors = list(
+            ExternalActor.objects.filter(organization_id=self.organization.id, user_id=member.id)
+        )
+        assert len(external_actors) == 1
+        # The original casing is preserved; no casing-variant duplicate is created.
+        assert external_actors[0].id == existing.id
+        assert external_actors[0].external_name == "@NewDev"
+
+    @responses.activate
     @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @patch("sentry.integrations.github.webhook.PushEventWebhook.__call__")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -18,6 +18,7 @@ from fixtures.github import (
     PULL_REQUEST_OPENED_EVENT_EXAMPLE,
     PUSH_EVENT_EXAMPLE_INSTALLATION,
     push_event_with_author,
+    push_event_with_commit_authors,
 )
 from sentry import options
 from sentry.constants import ObjectStatus
@@ -793,6 +794,55 @@ class PushEventWebhookTest(APITestCase):
             ).count()
             == 1
         )
+
+    @responses.activate
+    def test_creates_external_actor_when_username_arrives_in_later_push(self) -> None:
+        member = self.create_user(email="newdev@example.com")
+        self.create_member(user=member, organization=self.organization)
+        self._setup_github_integration_and_repo()
+
+        # GitHub omits the username when the commit email isn't tied to a GitHub
+        # account, so the first push creates the author without one.
+        response = self._send_push_event(
+            push_event_with_author(name="New Dev", email="newdev@example.com")
+        )
+        assert response.status_code == 204
+        assert not ExternalActor.objects.filter(organization_id=self.organization.id).exists()
+
+        # A later push for the same email carries the username; the reused author
+        # must still gain its ExternalActor mapping.
+        response = self._send_push_event(
+            push_event_with_author(name="New Dev", email="newdev@example.com", username="newdev")
+        )
+        assert response.status_code == 204
+
+        external_actors = list(ExternalActor.objects.filter(organization_id=self.organization.id))
+        assert len(external_actors) == 1
+        assert external_actors[0].user_id == member.id
+        assert external_actors[0].external_name == "@newdev"
+
+    @responses.activate
+    def test_creates_external_actor_when_username_arrives_in_later_commit(self) -> None:
+        member = self.create_user(email="newdev@example.com")
+        self.create_member(user=member, organization=self.organization)
+        self._setup_github_integration_and_repo()
+
+        # Within a single push, the first commit lacks the username but a later
+        # commit for the same email includes it.
+        response = self._send_push_event(
+            push_event_with_commit_authors(
+                [
+                    {"name": "New Dev", "email": "newdev@example.com", "username": None},
+                    {"name": "New Dev", "email": "newdev@example.com", "username": "newdev"},
+                ]
+            )
+        )
+        assert response.status_code == 204
+
+        external_actors = list(ExternalActor.objects.filter(organization_id=self.organization.id))
+        assert len(external_actors) == 1
+        assert external_actors[0].user_id == member.id
+        assert external_actors[0].external_name == "@newdev"
 
     @responses.activate
     def test_does_not_duplicate_external_actor_for_casing_variant(self) -> None:

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -25,9 +25,11 @@ from sentry.integrations.github.webhook import (
     InstallationRepositoriesEventWebhook,
 )
 from sentry.integrations.github.webhook_types import InstallationRepositoriesEvent
+from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import ExternalActorSource, ExternalProviders
 from sentry.middleware.integrations.parsers.github import GithubRequestParser
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
@@ -687,6 +689,137 @@ class PushEventWebhookTest(APITestCase):
         )
 
         assert response.status_code == 204
+
+    def _send_push_event(self, body: str):
+        sig1 = GitHubIntegrationsWebhookEndpoint.compute_signature(
+            "sha1", body.encode("utf-8"), self.secret
+        )
+        sig256 = GitHubIntegrationsWebhookEndpoint.compute_signature(
+            "sha256", body.encode("utf-8"), self.secret
+        )
+        return self.client.post(
+            path=self.url,
+            data=body,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE=f"sha1={sig1}",
+            HTTP_X_HUB_SIGNATURE_256=f"sha256={sig256}",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+    def _setup_github_integration_and_repo(self):
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            external_id="35129377",
+            provider="integrations:github",
+            name="baxterthehacker/public-repo",
+        )
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = self.create_integration(
+                organization=self.organization,
+                external_id="12345",
+                provider="github",
+                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
+            )
+            integration.add_organization(self.organization.id, self.user)
+        return integration
+
+    def _push_event_body(self, *, name: str, email: str, username: str | None) -> str:
+        author = {"name": name, "email": email}
+        if username is not None:
+            author["username"] = username
+        return json.dumps(
+            {
+                "ref": "refs/heads/main",
+                "installation": {"id": 12345},
+                "commits": [
+                    {
+                        "id": "133d60480286590a610a0eb7352ff6e02b9674c4",
+                        "distinct": True,
+                        "message": "Update hello.py",
+                        "timestamp": "2015-05-05T19:45:15-04:00",
+                        "author": author,
+                        "added": [],
+                        "removed": [],
+                        "modified": ["hello.py"],
+                    }
+                ],
+                "repository": {
+                    "id": 35129377,
+                    "full_name": "baxterthehacker/public-repo",
+                    "html_url": "https://github.com/baxterthehacker/public-repo",
+                },
+            }
+        )
+
+    @responses.activate
+    def test_creates_external_actor_for_new_commit_author(self) -> None:
+        member = self.create_user(email="newdev@example.com")
+        self.create_member(user=member, organization=self.organization)
+        integration = self._setup_github_integration_and_repo()
+
+        response = self._send_push_event(
+            self._push_event_body(name="New Dev", email="newdev@example.com", username="newdev")
+        )
+        assert response.status_code == 204
+
+        external_actors = list(ExternalActor.objects.filter(organization_id=self.organization.id))
+        assert len(external_actors) == 1
+        external_actor = external_actors[0]
+        assert external_actor.user_id == member.id
+        assert external_actor.external_name == "@newdev"
+        assert external_actor.provider == ExternalProviders.GITHUB.value
+        assert external_actor.integration_id == integration.id
+        assert external_actor.source == ExternalActorSource.COMMIT_AUTHOR.value
+
+    @responses.activate
+    def test_skips_external_actor_for_noreply_email(self) -> None:
+        member = self.create_user(email="newdev@example.com")
+        self.create_member(user=member, organization=self.organization)
+        self._setup_github_integration_and_repo()
+
+        response = self._send_push_event(
+            self._push_event_body(
+                name="New Dev",
+                email="newdev@users.noreply.github.com",
+                username="newdev",
+            )
+        )
+        assert response.status_code == 204
+
+        assert not ExternalActor.objects.filter(organization_id=self.organization.id).exists()
+
+    @responses.activate
+    def test_skips_external_actor_when_email_does_not_match_user(self) -> None:
+        self._setup_github_integration_and_repo()
+
+        response = self._send_push_event(
+            self._push_event_body(
+                name="Stranger", email="stranger@example.com", username="stranger"
+            )
+        )
+        assert response.status_code == 204
+
+        assert not ExternalActor.objects.filter(organization_id=self.organization.id).exists()
+
+    @responses.activate
+    def test_external_actor_creation_is_idempotent(self) -> None:
+        member = self.create_user(email="newdev@example.com")
+        self.create_member(user=member, organization=self.organization)
+        self._setup_github_integration_and_repo()
+
+        body = self._push_event_body(name="New Dev", email="newdev@example.com", username="newdev")
+        assert self._send_push_event(body).status_code == 204
+        # Re-sending creates a new CommitAuthor lookup but must not duplicate the mapping.
+        assert self._send_push_event(body).status_code == 204
+
+        assert (
+            ExternalActor.objects.filter(
+                organization_id=self.organization.id, user_id=member.id
+            ).count()
+            == 1
+        )
 
     @responses.activate
     @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -17,6 +17,7 @@ from fixtures.github import (
     PULL_REQUEST_EDITED_EVENT_EXAMPLE,
     PULL_REQUEST_OPENED_EVENT_EXAMPLE,
     PUSH_EVENT_EXAMPLE_INSTALLATION,
+    push_event_with_author,
 )
 from sentry import options
 from sentry.constants import ObjectStatus
@@ -725,34 +726,6 @@ class PushEventWebhookTest(APITestCase):
             integration.add_organization(self.organization.id, self.user)
         return integration
 
-    def _push_event_body(self, *, name: str, email: str, username: str | None) -> str:
-        author = {"name": name, "email": email}
-        if username is not None:
-            author["username"] = username
-        return json.dumps(
-            {
-                "ref": "refs/heads/main",
-                "installation": {"id": 12345},
-                "commits": [
-                    {
-                        "id": "133d60480286590a610a0eb7352ff6e02b9674c4",
-                        "distinct": True,
-                        "message": "Update hello.py",
-                        "timestamp": "2015-05-05T19:45:15-04:00",
-                        "author": author,
-                        "added": [],
-                        "removed": [],
-                        "modified": ["hello.py"],
-                    }
-                ],
-                "repository": {
-                    "id": 35129377,
-                    "full_name": "baxterthehacker/public-repo",
-                    "html_url": "https://github.com/baxterthehacker/public-repo",
-                },
-            }
-        )
-
     @responses.activate
     def test_creates_external_actor_for_new_commit_author(self) -> None:
         member = self.create_user(email="newdev@example.com")
@@ -760,7 +733,7 @@ class PushEventWebhookTest(APITestCase):
         integration = self._setup_github_integration_and_repo()
 
         response = self._send_push_event(
-            self._push_event_body(name="New Dev", email="newdev@example.com", username="newdev")
+            push_event_with_author(name="New Dev", email="newdev@example.com", username="newdev")
         )
         assert response.status_code == 204
 
@@ -780,7 +753,7 @@ class PushEventWebhookTest(APITestCase):
         self._setup_github_integration_and_repo()
 
         response = self._send_push_event(
-            self._push_event_body(
+            push_event_with_author(
                 name="New Dev",
                 email="newdev@users.noreply.github.com",
                 username="newdev",
@@ -795,7 +768,7 @@ class PushEventWebhookTest(APITestCase):
         self._setup_github_integration_and_repo()
 
         response = self._send_push_event(
-            self._push_event_body(
+            push_event_with_author(
                 name="Stranger", email="stranger@example.com", username="stranger"
             )
         )
@@ -809,7 +782,7 @@ class PushEventWebhookTest(APITestCase):
         self.create_member(user=member, organization=self.organization)
         self._setup_github_integration_and_repo()
 
-        body = self._push_event_body(name="New Dev", email="newdev@example.com", username="newdev")
+        body = push_event_with_author(name="New Dev", email="newdev@example.com", username="newdev")
         assert self._send_push_event(body).status_code == 204
         # Re-sending creates a new CommitAuthor lookup but must not duplicate the mapping.
         assert self._send_push_event(body).status_code == 204


### PR DESCRIPTION
In the github webhook for pushed commits and opened PRs, after we create a new `CommitAuthor` row, also create an `ExternalActor` row if we're able to find a valid Sentry user for the author's email.

Resolves ISWF-2758
