### PR TITLE
ref(span consumer): Use new reference to transaction name

### DIFF
--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -18,7 +18,7 @@ from sentry.spans.consumers.process_segments.types import (
 SHARED_SENTRY_ATTRIBUTES = (
     ATTRIBUTE_NAMES.SENTRY_RELEASE,
     ATTRIBUTE_NAMES.SENTRY_ENVIRONMENT,
-    ATTRIBUTE_NAMES.SENTRY_TRANSACTION,
+    ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME,
     "sentry.transaction.method",
     "sentry.transaction.op",
     "sentry.trace.status",

--- a/src/sentry/spans/consumers/process_segments/shim.py
+++ b/src/sentry/spans/consumers/process_segments/shim.py
@@ -79,7 +79,7 @@ def build_shim_event_data(
         },
         "event_id": uuid.uuid4().hex,
         "project_id": segment_span["project_id"],
-        "transaction": attribute_value(segment_span, ATTRIBUTE_NAMES.SENTRY_TRANSACTION),
+        "transaction": attribute_value(segment_span, ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME),
         "release": attribute_value(segment_span, ATTRIBUTE_NAMES.SENTRY_RELEASE),
         "dist": attribute_value(segment_span, ATTRIBUTE_NAMES.SENTRY_DIST),
         "environment": attribute_value(segment_span, ATTRIBUTE_NAMES.SENTRY_ENVIRONMENT),

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -3,6 +3,8 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any, NotRequired, Optional, TypedDict
 
+from sentry_conventions.attributes import ATTRIBUTE_NAMES
+
 from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.spans.grouping.utils import Hash, parse_fingerprint_var
 from sentry.utils import urls
@@ -58,7 +60,8 @@ class SpanGroupingStrategy:
         # fingerprinting if the span doesn't have a transaction.
         if (
             span.get("is_segment")
-            and (transaction := attribute_value(span, "sentry.transaction")) is not None
+            and (transaction := attribute_value(span, ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME))
+            is not None
         ):
             result = Hash()
             result.update(transaction)

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -11,6 +11,7 @@ from sentry.models.release import Release
 from sentry.spans.consumers.process_segments import message as message_module
 from sentry.spans.consumers.process_segments.message import _verify_compatibility, process_segment
 from sentry.spans.consumers.process_segments.shim import build_shim_event_data
+from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.issue_detection.experiments import exclude_experimental_detectors
@@ -28,7 +29,7 @@ class TestSpansTask(TestCase):
             is_segment=True,
             attributes={
                 "sentry.browser.name": {"value": "Google Chrome"},
-                "sentry.transaction": {
+                "sentry.segment.name": {
                     "value": "/api/0/organizations/{organization_id_or_slug}/n-plus-one/"
                 },
                 "sentry.transaction.method": {"value": "GET"},
@@ -97,7 +98,7 @@ class TestSpansTask(TestCase):
         child_attrs = child_span["attributes"] or {}
         segment_data = segment_span["attributes"] or {}
 
-        assert child_attrs["sentry.transaction"] == segment_data["sentry.transaction"]
+        assert child_attrs["sentry.segment.name"] == segment_data["sentry.segment.name"]
         assert child_attrs["sentry.transaction.method"] == segment_data["sentry.transaction.method"]
         assert child_attrs["sentry.transaction.op"] == segment_data["sentry.transaction.op"]
         assert child_attrs["sentry.user"] == segment_data["sentry.user"]
@@ -285,7 +286,11 @@ class TestSpansTask(TestCase):
 
     def test_segment_name_propagation(self) -> None:
         child_span, segment_span = self.generate_basic_spans()
-        segment_span["name"] = "my segment name"
+        assert (
+            attribute_value(segment_span, "sentry.segment.name")
+            == "/api/0/organizations/{organization_id_or_slug}/n-plus-one/"
+        )
+        assert attribute_value(child_span, "sentry.segment.name") is None
 
         processed_spans = process_segment([child_span, segment_span])
 
@@ -293,18 +298,17 @@ class TestSpansTask(TestCase):
         child_span, segment_span = processed_spans
         segment_attributes = segment_span["attributes"] or {}
         assert segment_attributes["sentry.segment.name"] == {
-            "type": "string",
-            "value": "my segment name",
+            "value": "/api/0/organizations/{organization_id_or_slug}/n-plus-one/",
         }
         child_attributes = child_span["attributes"] or {}
         assert child_attributes["sentry.segment.name"] == {
-            "type": "string",
-            "value": "my segment name",
+            "value": "/api/0/organizations/{organization_id_or_slug}/n-plus-one/",
         }
 
     def test_segment_name_propagation_when_name_missing(self) -> None:
         child_span, segment_span = self.generate_basic_spans()
         del segment_span["name"]
+        del segment_span["attributes"]["sentry.segment.name"]
 
         processed_spans = process_segment([child_span, segment_span])
 

--- a/tests/sentry/spans/grouping/test_strategy.py
+++ b/tests/sentry/spans/grouping/test_strategy.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 
 import pytest
+from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry.spans.grouping.strategy.base import (
     Span,
@@ -614,7 +615,7 @@ def test_standalone_spans_compat() -> None:
         SpanBuilder()
         .with_span_id("a" * 16)
         .segment()
-        .with_data({"sentry.transaction": "transaction name"})
+        .with_data({ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME: "transaction name"})
         .build_v2()
     ]
 


### PR DESCRIPTION
In our Sentry Conventions repo, `sentry.transaction` is [marked as deprecated](https://github.com/getsentry/sentry-conventions/blob/bd6c27bae0694d4b6fe6c943ad89aca4fb1204a0/model/attributes/sentry/sentry__transaction.json#L11-L15) in favor of `sentry.segment.name` for the new span schema. The latter should always be there, via one of three routes (either in Relay or an SDK):

- For transaction-derived spans, it's pulled from `event.transaction` and added onto the spans [during normalization](https://github.com/getsentry/relay/blob/4622f74bba43211328e271150e446f13eba2530e/relay-event-normalization/src/normalize/span/tag_extraction.rs#L65).

- For OTel spans, it's [copied from the span's `name`](https://github.com/getsentry/relay/blob/4622f74bba43211328e271150e446f13eba2530e/relay-spans/src/otel_to_sentry_v2.rs#L133-L135) in `otel_to_sentry_span`.

- For newstyle spans which come from SDKs, it should be there because it's put there by the SDK itself.

(In the case of the two Relay functions, careful readers will note that what's being set is `segment_name`, not `segment.name`. That conversion happens during serialization because of the [metastructure annotation](https://github.com/getsentry/relay/blob/4622f74bba43211328e271150e446f13eba2530e/relay-event-schema/src/protocol/span.rs#L783) on the `segment_name` field in the`SpanData` struct.)

In my work switching issue detectors to be span-buffer-compatible, I came across a few spots where we're still using the old attribute name. This PR updates them to use the new name.

h/t Claude for his help with the research here