### PR TITLE
ref(api): resolve UNKNOWN publish_status for release and deprecated endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -305,8 +305,8 @@ def debounce_update_release_health_data(organization, project_ids: list[int]):
 class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnalyticsMixin):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.PUBLIC,
-        "POST": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
     rate_limits = RateLimitConfig(
@@ -924,7 +924,7 @@ class OrganizationReleaseTimeseriesData(TypedDict):
 class OrganizationReleasesStatsEndpoint(OrganizationReleasesBaseEndpoint):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     @extend_schema(

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timedelta
+from typing import TypedDict
 
 import sentry_sdk
 from django.db import IntegrityError
@@ -14,6 +15,7 @@ from rest_framework.serializers import ListField
 
 from sentry import analytics, features, release_health
 from sentry.analytics.events.release_created import ReleaseCreatedEvent
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import ReleaseAnalyticsMixin, cell_silo_endpoint
 from sentry.api.bases import NoProjects
@@ -38,8 +40,17 @@ from sentry.api.serializers.rest_framework import (
     ReleaseHeadCommitSerializerDeprecated,
     ReleaseWithVersionSerializer,
 )
+from sentry.api.serializers.types import ReleaseSerializerResponse
 from sentry.api.utils import get_auth_api_token_type
-from sentry.apidocs.parameters import CursorQueryParam
+from sentry.apidocs.constants import (
+    RESPONSE_ALREADY_REPORTED,
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
@@ -288,11 +299,13 @@ def debounce_update_release_health_data(organization, project_ids: list[int]):
     cache.set_many(dict(zip(should_update.values(), [True] * len(should_update))), 60)
 
 
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnalyticsMixin):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
     }
 
     rate_limits = RateLimitConfig(
@@ -332,9 +345,25 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
 
     @extend_schema(
         operation_id="List an Organization's Releases",
-        parameters=[CursorQueryParam],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.ENVIRONMENT,
+            ReleaseParams.QUERY,
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListOrganizationReleasesResponse", list[ReleaseSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
     )
     def get(self, request: Request, organization: Organization) -> Response:
+        """
+        Return a list of releases for a given organization, sorted by most recent.
+        """
         if request.headers.get("X-Performance-Optimizations") == "enabled":
             return self.__get_new(request, organization)
         else:
@@ -698,48 +727,28 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
             **paginator_kwargs,
         )
 
+    @extend_schema(
+        operation_id="Create a New Release for an Organization",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
+        request=ReleaseSerializerWithProjects,
+        responses={
+            201: inline_sentry_response_serializer(
+                "CreateOrganizationReleaseResponse", ReleaseSerializerResponse
+            ),
+            208: RESPONSE_ALREADY_REPORTED,
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+        },
+    )
     def post(self, request: Request, organization: Organization) -> Response:
         """
-        Create a New Release for an Organization
-        ````````````````````````````````````````
-        Create a new release for the given Organization.  Releases are used by
-        Sentry to improve its error reporting abilities by correlating
-        first seen events with the release that might have introduced the
-        problem.
-        Releases are also necessary for sourcemaps and other debug features
-        that require manual upload for functioning well.
+        Create a new release for the given organization. Releases are used by Sentry to
+        improve error reporting by correlating first-seen events with the release that may
+        have introduced them, and are required for source maps and other debug features.
 
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :param string version: a version identifier for this release. Can
-                               be a version number, a commit hash etc. It cannot contain certain
-                               whitespace characters (`\\r`, `\\n`, `\\f`, `\\x0c`, `\\t`) or any
-                               slashes (`\\`, `/`). The version names `.`, `..` and `latest` are also
-                               reserved, and cannot be used.
-        :param string ref: an optional commit reference.  This is useful if
-                           a tagged version has been provided.
-        :param url url: a URL that points to the release.  This can be the
-                        path to an online interface to the sourcecode
-                        for instance.
-        :param array projects: a list of project ids or slugs that are involved in
-                               this release
-        :param datetime dateReleased: an optional date that indicates when
-                                      the release went live.  If not provided
-                                      the current time is assumed.
-        :param array commits: an optional list of commit data to be associated
-                              with the release. Commits must include parameters
-                              ``id`` (the sha of the commit), and can optionally
-                              include ``repository``, ``message``, ``patch_set``,
-                              ``author_name``, ``author_email``, and ``timestamp``.
-                              See [release without integration example](/workflow/releases/).
-        :param array refs: an optional way to indicate the start and end commits
-                           for each repository included in a release. Head commits
-                           must include parameters ``repository`` and ``commit``
-                           (the HEAD sha). They can optionally include ``previousCommit``
-                           (the sha of the HEAD of the previous release), which should
-                           be specified if this is the first time you've sent commit data.
-                           ``commit`` may contain a range in the form of ``previousCommit..commit``
-        :auth: required
+        Release versions that are the same across multiple projects within an organization
+        are treated as the same release in Sentry.
         """
         bind_organization_context(organization)
         serializer = ReleaseSerializerWithProjects(
@@ -902,19 +911,45 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
         return Response(serializer.errors, status=400)
 
 
+class OrganizationReleaseTimeseriesData(TypedDict):
+    version: str
+    date: datetime
+
+
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleasesStatsEndpoint(OrganizationReleasesBaseEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PUBLIC,
     }
 
+    @extend_schema(
+        operation_id="List an Organization's Release Timeseries Data",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.ENVIRONMENT,
+            GlobalParams.STATS_PERIOD,
+            GlobalParams.START,
+            GlobalParams.END,
+            ReleaseParams.QUERY,
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "OrganizationReleaseTimeseriesResponse",
+                list[OrganizationReleaseTimeseriesData],
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, organization: Organization) -> Response:
         """
-        List an Organization's Releases specifically for building timeseries
-        ```````````````````````````````
-        Return a list of releases for a given organization, sorted for most recent releases.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization
+        Return a minimal list of an organization's releases (version and date only),
+        sorted by most recent. Intended for building release timeseries, such as
+        plotting release markers on charts.
         """
         query = request.GET.get("query")
 

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -49,6 +49,7 @@ from sentry.apidocs.constants import (
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
 )
+from sentry.apidocs.examples.release_examples import ReleaseExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidSearchQuery
@@ -359,6 +360,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
+        examples=ReleaseExamples.LIST_ORGANIZATION_RELEASES,
     )
     def get(self, request: Request, organization: Organization) -> Response:
         """
@@ -740,6 +742,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
         },
+        examples=ReleaseExamples.CREATE_RELEASE,
     )
     def post(self, request: Request, organization: Organization) -> Response:
         """
@@ -944,6 +947,7 @@ class OrganizationReleasesStatsEndpoint(OrganizationReleasesBaseEndpoint):
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
+        examples=ReleaseExamples.LIST_RELEASE_TIMESERIES,
     )
     def get(self, request: Request, organization: Organization) -> Response:
         """

--- a/src/sentry/api/fields/user.py
+++ b/src/sentry/api/fields/user.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from sentry.users.models.user import User
@@ -9,6 +11,7 @@ from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 
 
+@extend_schema_field(field=OpenApiTypes.STR)
 class UserField(serializers.Field):
     def to_representation(self, value: RpcUser) -> str:
         return value.username

--- a/src/sentry/api/serializers/rest_framework/release.py
+++ b/src/sentry/api/serializers/rest_framework/release.py
@@ -76,7 +76,11 @@ class ReleaseSerializer(serializers.Serializer):
         help_text="An optional list of commit data to be associated.",
     )
 
-    status = serializers.CharField(required=False, allow_null=False)
+    status = serializers.CharField(
+        required=False,
+        allow_null=False,
+        help_text="The status of the release. Can be `open` or `archived`.",
+    )
 
     def validate_status(self, value):
         try:
@@ -87,9 +91,15 @@ class ReleaseSerializer(serializers.Serializer):
 
 class ReleaseWithVersionSerializer(ReleaseSerializer):
     version = serializers.CharField(
-        max_length=MAX_VERSION_LENGTH, trim_whitespace=False, required=True
+        max_length=MAX_VERSION_LENGTH,
+        trim_whitespace=False,
+        required=True,
+        help_text="A version identifier for this release. Can be a version number, a commit hash, and so on.",
     )
-    owner = UserField(required=False)
+    owner = UserField(
+        required=False,
+        help_text="The username of the user to set as the release owner.",
+    )
 
     def validate_version(self, value):
         if not Release.is_valid_version(value):

--- a/src/sentry/api/serializers/types.py
+++ b/src/sentry/api/serializers/types.py
@@ -22,6 +22,11 @@ class ReleaseSerializerResponseOptional(TypedDict, total=False):
 
 
 class ReleaseSerializerResponse(ReleaseSerializerResponseOptional):
+    # NOTE: The API design guidelines (https://develop.sentry.dev/backend/api/design/)
+    # call for resource identifiers to be returned as strings. This release `id` is a
+    # long-standing integer in the public response and is relied on by existing clients,
+    # so changing it would be breaking; left as-is intentionally. `version` is the
+    # human-friendly identifier. Do not copy this pattern into new public responses.
     id: int
     version: str
     newGroups: int

--- a/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
+++ b/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
@@ -5,24 +5,11 @@ DO NOT ADD ANY NEW APIS
 """
 
 API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
-    "/api/0/{var}/{issue_id}/stats/": {"GET"},
-    "/api/0/{var}/{issue_id}/tags/": {"GET"},
-    "/api/0/{var}/{issue_id}/integrations/{integration_id}/": {"DELETE", "GET", "POST", "PUT"},
-    "/api/0/organizations/{organization_id_or_slug}/{var}/{issue_id}/stats/": {"GET"},
-    "/api/0/organizations/{organization_id_or_slug}/{var}/{issue_id}/tags/": {"GET"},
-    "/api/0/organizations/{organization_id_or_slug}/{var}/{issue_id}/integrations/{integration_id}/": {
-        "DELETE",
-        "GET",
-        "POST",
-        "PUT",
-    },
     "/api/0/organizations/{organization_id_or_slug}/integrations/{integration_id}/serverless-functions/": {
         "GET",
         "POST",
     },
     "/api/0/organizations/{organization_id_or_slug}/invite-requests/": {"GET", "POST"},
-    "/api/0/organizations/{organization_id_or_slug}/releases/": {"GET", "POST"},
-    "/api/0/organizations/{organization_id_or_slug}/releases/stats/": {"GET"},
     "/api/0/organizations/{organization_id_or_slug}/releases/{version}/assemble/": {"POST"},
     "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/": {"GET", "POST"},
     "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/{file_id}/": {
@@ -30,26 +17,12 @@ API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
         "GET",
         "PUT",
     },
-    "/api/0/organizations/{organization_id_or_slug}/releases/{version}/commits/": {"GET"},
     "/api/0/organizations/{organization_id_or_slug}/sentry-app-installations/": {"GET"},
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/": {"GET", "POST"},
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/{hook_id}/stats/": {
         "GET"
     },
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/": {"GET", "POST"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/token/": {
-        "GET",
-        "POST",
-    },
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/completion/": {"GET"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/": {
-        "DELETE",
-        "GET",
-        "PUT",
-    },
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/commits/": {
-        "GET"
-    },
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/repositories/": {
         "GET"
     },

--- a/src/sentry/apidocs/examples/release_examples.py
+++ b/src/sentry/apidocs/examples/release_examples.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from drf_spectacular.utils import OpenApiExample
 
+from sentry.api.serializers.models.commit import CommitSerializerResponse
 from sentry.api.serializers.types import ReleaseSerializerResponse
 
 RELEASE: ReleaseSerializerResponse = {
@@ -53,11 +54,70 @@ RELEASE: ReleaseSerializerResponse = {
 }
 
 
+COMMIT: CommitSerializerResponse = {
+    "id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "message": "fix: handle empty release version",
+    "dateCreated": datetime.fromisoformat("2024-01-01T00:00:00Z"),
+    "pullRequest": None,
+    "suspectCommitType": "",
+}
+
+RELEASE_TIMESERIES = {
+    "version": "frontend@1.0.0",
+    "date": datetime.fromisoformat("2024-01-01T00:00:00Z"),
+}
+
+
 class ReleaseExamples:
     LIST_PROJECT_RELEASES = [
         OpenApiExample(
             "Return a list of releases for a project",
             value=[RELEASE],
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]
+
+    LIST_ORGANIZATION_RELEASES = [
+        OpenApiExample(
+            "Return a list of releases for an organization",
+            value=[RELEASE],
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]
+
+    RETRIEVE_RELEASE = [
+        OpenApiExample(
+            "Retrieve a release",
+            value=RELEASE,
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]
+
+    CREATE_RELEASE = [
+        OpenApiExample(
+            "Create a release",
+            value=RELEASE,
+            response_only=True,
+            status_codes=["201"],
+        )
+    ]
+
+    LIST_RELEASE_COMMITS = [
+        OpenApiExample(
+            "Return a list of commits for a release",
+            value=[COMMIT],
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]
+
+    LIST_RELEASE_TIMESERIES = [
+        OpenApiExample(
+            "Return a list of release versions and dates",
+            value=[RELEASE_TIMESERIES],
             response_only=True,
             status_codes=["200"],
         )

--- a/src/sentry/issues/endpoints/group_integration_details.py
+++ b/src/sentry/issues/endpoints/group_integration_details.py
@@ -75,10 +75,10 @@ class IntegrationIssueConfigSerializer(IntegrationSerializer):
 class GroupIntegrationDetailsEndpoint(GroupEndpoint):
     owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
-        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
+        "DELETE": ApiPublishStatus.PRIVATE,
     }
 
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])

--- a/src/sentry/issues/endpoints/group_stats.py
+++ b/src/sentry/issues/endpoints/group_stats.py
@@ -16,7 +16,7 @@ from sentry.tsdb.base import TSDBModel
 @cell_silo_endpoint
 class GroupStatsEndpoint(GroupEndpoint, StatsMixin):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-stats"])

--- a/src/sentry/issues/endpoints/group_tags.py
+++ b/src/sentry/issues/endpoints/group_tags.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 @cell_silo_endpoint
 class GroupTagsEndpoint(GroupEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     enforce_rate_limit = True

--- a/src/sentry/releases/endpoints/organization_release_commits.py
+++ b/src/sentry/releases/endpoints/organization_release_commits.py
@@ -10,6 +10,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.commit import CommitSerializerResponse
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.examples.release_examples import ReleaseExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.release import Release
@@ -39,6 +40,7 @@ class OrganizationReleaseCommitsEndpoint(OrganizationReleasesBaseEndpoint):
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
+        examples=ReleaseExamples.LIST_RELEASE_COMMITS,
     )
     def get(self, request: Request, organization, version) -> Response:
         """

--- a/src/sentry/releases/endpoints/organization_release_commits.py
+++ b/src/sentry/releases/endpoints/organization_release_commits.py
@@ -22,7 +22,7 @@ from sentry.models.releasecommit import ReleaseCommit
 class OrganizationReleaseCommitsEndpoint(OrganizationReleasesBaseEndpoint):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     @extend_schema(

--- a/src/sentry/releases/endpoints/organization_release_commits.py
+++ b/src/sentry/releases/endpoints/organization_release_commits.py
@@ -2,37 +2,47 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.apidocs.parameters import CursorQueryParam
+from sentry.api.serializers.models.commit import CommitSerializerResponse
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 
 
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleaseCommitsEndpoint(OrganizationReleasesBaseEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PUBLIC,
     }
 
     @extend_schema(
         operation_id="List an Organization Release's Commits",
-        parameters=[CursorQueryParam],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListOrganizationReleaseCommitsResponse", list[CommitSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
     )
     def get(self, request: Request, organization, version) -> Response:
         """
-        List an Organization Release's Commits
-        ``````````````````````````````````````
-
         Retrieve a list of commits for a given release.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string version: the version identifier of the release.
-        :auth: required
         """
         try:
             release = Release.objects.distinct().get(

--- a/src/sentry/releases/endpoints/project_release_commits.py
+++ b/src/sentry/releases/endpoints/project_release_commits.py
@@ -2,45 +2,51 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.apidocs.parameters import CursorQueryParam
+from sentry.api.serializers.models.commit import CommitSerializerResponse
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
 
 
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (ProjectReleasePermission,)
 
     @extend_schema(
         operation_id="List a Project Release's Commits",
-        parameters=[CursorQueryParam],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListProjectReleaseCommitsResponse", list[CommitSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
     )
     def get(self, request: Request, project, version) -> Response:
         """
-        List a Project Release's Commits
-        ````````````````````````````````
-
         Retrieve a list of commits for a given release.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to list the
-                                     release files of.
-        :pparam string version: the version identifier of the release.
-
-        :pparam string repo_name: the repository name
-
-        :auth: required
         """
 
         organization_id = project.organization_id

--- a/src/sentry/releases/endpoints/project_release_commits.py
+++ b/src/sentry/releases/endpoints/project_release_commits.py
@@ -24,7 +24,7 @@ from sentry.models.repository import Repository
 class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 

--- a/src/sentry/releases/endpoints/project_release_commits.py
+++ b/src/sentry/releases/endpoints/project_release_commits.py
@@ -10,6 +10,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.commit import CommitSerializerResponse
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.examples.release_examples import ReleaseExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
@@ -43,6 +44,7 @@ class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
+        examples=ReleaseExamples.LIST_RELEASE_COMMITS,
     )
     def get(self, request: Request, project, version) -> Response:
         """

--- a/src/sentry/releases/endpoints/project_release_details.py
+++ b/src/sentry/releases/endpoints/project_release_details.py
@@ -38,9 +38,9 @@ from sentry.utils.sdk import bind_organization_context
 class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "DELETE": ApiPublishStatus.PUBLIC,
-        "GET": ApiPublishStatus.PUBLIC,
-        "PUT": ApiPublishStatus.PUBLIC,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 

--- a/src/sentry/releases/endpoints/project_release_details.py
+++ b/src/sentry/releases/endpoints/project_release_details.py
@@ -1,9 +1,11 @@
 import sentry_sdk
+from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import options
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import ReleaseAnalyticsMixin, cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
@@ -11,6 +13,16 @@ from sentry.api.endpoints.organization_releases import get_stats_period_detail
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ReleaseSerializer
+from sentry.api.serializers.types import ReleaseSerializerResponse
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NO_CONTENT,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.activity import Activity
 from sentry.models.release import Release
 from sentry.models.releases.exceptions import UnsafeReleaseDeletion
@@ -20,28 +32,38 @@ from sentry.types.activity import ActivityType
 from sentry.utils.sdk import bind_organization_context
 
 
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (ProjectReleasePermission,)
 
+    @extend_schema(
+        operation_id="Retrieve a Project's Release",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+            ReleaseParams.SUMMARY_STATS_PERIOD,
+            ReleaseParams.HEALTH_STATS_PERIOD,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ProjectReleaseResponse", ReleaseSerializerResponse
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, project, version) -> Response:
         """
-        Retrieve a Project's Release
-        ````````````````````````````
-
         Return details on an individual release.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to retrieve the
-                                     release of.
-        :pparam string version: the version identifier of the release.
-        :auth: required
         """
         with_health = request.GET.get("health") == "1"
         summary_stats_period = request.GET.get("summaryStatsPeriod") or "14d"
@@ -72,28 +94,28 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
             )
         )
 
+    @extend_schema(
+        operation_id="Update a Project's Release",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+        ],
+        request=ReleaseSerializer,
+        responses={
+            200: inline_sentry_response_serializer(
+                "UpdateProjectReleaseResponse", ReleaseSerializerResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def put(self, request: Request, project, version) -> Response:
         """
-        Update a Project's Release
-        ``````````````````````````
-
-        Update a release.  This can change some metadata associated with
-        the release (the ref, url, and dates).
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to change the
-                                     release of.
-        :pparam string version: the version identifier of the release.
-        :param string ref: an optional commit reference.  This is useful if
-                           a tagged version has been provided.
-        :param url url: a URL that points to the release.  This can be the
-                        path to an online interface to the sourcecode
-                        for instance.
-        :param datetime dateReleased: an optional date that indicates when
-                                      the release went live.  If not provided
-                                      the current time is assumed.
-        :auth: required
+        Update a release. This can change metadata associated with the release
+        (its ref, url, dates, and status) and associate commits with it.
         """
         bind_organization_context(project.organization)
         scope = sentry_sdk.get_isolation_scope()
@@ -153,19 +175,24 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
             )
         )
 
+    @extend_schema(
+        operation_id="Delete a Project's Release",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+        ],
+        responses={
+            204: RESPONSE_NO_CONTENT,
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def delete(self, request: Request, project, version) -> Response:
         """
-        Delete a Project's Release
-        ``````````````````````````
-
         Permanently remove a release and all of its files.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to delete the
-                                     release of.
-        :pparam string version: the version identifier of the release.
-        :auth: required
         """
         try:
             release = Release.objects.get(

--- a/src/sentry/releases/endpoints/project_release_details.py
+++ b/src/sentry/releases/endpoints/project_release_details.py
@@ -21,6 +21,7 @@ from sentry.apidocs.constants import (
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
 )
+from sentry.apidocs.examples.release_examples import ReleaseExamples
 from sentry.apidocs.parameters import GlobalParams, ReleaseParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.activity import Activity
@@ -60,6 +61,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
+        examples=ReleaseExamples.RETRIEVE_RELEASE,
     )
     def get(self, request: Request, project, version) -> Response:
         """

--- a/src/sentry/releases/endpoints/project_releases.py
+++ b/src/sentry/releases/endpoints/project_releases.py
@@ -20,6 +20,8 @@ from sentry.api.serializers.rest_framework import ReleaseWithVersionSerializer
 from sentry.api.serializers.types import ReleaseSerializerResponse
 from sentry.api.utils import get_auth_api_token_type
 from sentry.apidocs.constants import (
+    RESPONSE_ALREADY_REPORTED,
+    RESPONSE_BAD_REQUEST,
     RESPONSE_FORBIDDEN,
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
@@ -44,7 +46,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (ProjectReleasePermission,)
     rate_limits = RateLimitConfig(
@@ -104,37 +106,32 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
             ),
         )
 
+    @extend_schema(
+        operation_id="Create a New Release for a Project",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+        ],
+        request=ReleaseWithVersionSerializer,
+        responses={
+            201: inline_sentry_response_serializer(
+                "CreateProjectReleaseResponse", ReleaseSerializerResponse
+            ),
+            208: RESPONSE_ALREADY_REPORTED,
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+        },
+    )
     def post(self, request: Request, project) -> Response:
         """
-        Create a New Release for a Project
-        ``````````````````````````````````
+        Create a new release and/or associate a project with a release. Releases are used by
+        Sentry to improve error reporting by correlating first-seen events with the release
+        that may have introduced them, and are required for source maps and other debug
+        features.
 
-        Create a new release and/or associate a project with a release.
-        Release versions that are the same across multiple projects
-        within an Organization will be treated as the same release in Sentry.
-
-        Releases are used by Sentry to improve its error reporting abilities
-        by correlating first seen events with the release that might have
-        introduced the problem.
-
-        Releases are also necessary for sourcemaps and other debug features
-        that require manual upload for functioning well.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to create a
-                                     release for.
-        :param string version: a version identifier for this release.  Can
-                               be a version number, a commit hash etc.
-        :param string ref: an optional commit reference.  This is useful if
-                           a tagged version has been provided.
-        :param url url: a URL that points to the release.  This can be the
-                        path to an online interface to the sourcecode
-                        for instance.
-        :param datetime dateReleased: an optional date that indicates when
-                                      the release went live.  If not provided
-                                      the current time is assumed.
-        :auth: required
+        Release versions that are the same across multiple projects within an organization
+        are treated as the same release in Sentry.
         """
         bind_organization_context(project.organization)
         serializer = ReleaseWithVersionSerializer(

--- a/src/sentry/releases/endpoints/project_releases.py
+++ b/src/sentry/releases/endpoints/project_releases.py
@@ -46,7 +46,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
-        "POST": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
     rate_limits = RateLimitConfig(

--- a/src/sentry/releases/endpoints/project_releases.py
+++ b/src/sentry/releases/endpoints/project_releases.py
@@ -122,6 +122,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
         },
+        examples=ReleaseExamples.CREATE_RELEASE,
     )
     def post(self, request: Request, project) -> Response:
         """

--- a/src/sentry/releases/endpoints/project_releases_token.py
+++ b/src/sentry/releases/endpoints/project_releases_token.py
@@ -38,8 +38,8 @@ def _get_signature(project_id, plugin_id, token):
 @cell_silo_endpoint
 class ProjectReleasesTokenEndpoint(ProjectEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (StrictProjectPermission, DisallowImpersonatedTokenCreation)
 


### PR DESCRIPTION
Resolves the `ApiPublishStatus.UNKNOWN` placeholder on 10 endpoints and removes their entries from the publish-status allowlist. First batch of an effort to drain `api_publish_status_allowlist_dont_modify.py` and eventually delete the `UNKNOWN` status. `publish_status` is docs-only, so there is no runtime, routing, or auth change here.

**All touched endpoints → `PRIVATE`**

For now these are marked `PRIVATE` (not published as public API), clearing them out of `UNKNOWN`: the release CRUD endpoints (`OrganizationReleases`, `OrganizationReleasesStats`, `OrganizationReleaseCommits`, `ProjectReleases` POST, `ProjectReleaseDetails`, `ProjectReleaseCommits`), the `@deprecated` group stats/tags/integration-details endpoints, and the project releases deploy-token endpoint.

`ProjectReleases` **GET** stays `PUBLIC` — it was already public before this branch; only the `POST` we touched flips.

**OpenAPI documentation is kept (intentionally)**

Even though these are `PRIVATE`, they keep full `@extend_schema` documentation (params, responses, descriptions, examples). We want this documentation in place and intend to start *requiring* it on private endpoints, since internal changes will be driven off the generated schema/types. The docs are dormant in the public schema today but ready.

**Shared schema/type fixes**

- Annotated `UserField` with `@extend_schema_field(OpenApiTypes.STR)` (matches `api/fields/actor.py` / `sentry_slug.py`).
- Added `help_text` to `ReleaseSerializer`'s `status`/`version`/`owner` fields.
- Added `COMMIT` and release-timeseries example fixtures to `release_examples.py`.

**Design note**

Reviewed against the [API design guidelines](https://develop.sentry.dev/backend/api/design/). One pre-existing deviation documented inline on `ReleaseSerializerResponse.id`: the release `id` is an integer rather than a string. Long-standing, codebase-wide; not introduced here.

Verified: `make build-api-docs` (`--validate --fail-on-warn`) clean, and `mypy` clean on all touched files.