### PR TITLE
feat(api): Plugin-narrowed union response annotations on 7 endpoints

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -16,6 +16,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
+from sentry.apidocs.response_types import DetailResponse
 
 if TYPE_CHECKING:
     from django_stubs_ext import WithAnnotations
@@ -303,7 +304,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
         },
         examples=DebugFileExamples.LIST_PROJECT_DEBUG_FILES,
     )
-    def get(self, request: Request, project: Project) -> Response:
+    def get(self, request: Request, project: Project) -> Response[list[DebugFileSerializerResponse]] | Response[DetailResponse]:
         """
         Retrieve a list of debug information files for a given project.
         """

--- a/src/sentry/apidocs/_check_response_annotation_matches_schema.py
+++ b/src/sentry/apidocs/_check_response_annotation_matches_schema.py
@@ -173,6 +173,13 @@ def _extract_response_annotation_Ts(returns: ast.expr | None) -> list[ast.expr] 
             # If any arm is `Response` (bare, unparameterized) or some other type,
             # we can't meaningfully compare — treat this as unmigrated.
             return None
+        # `Response[DetailResponse]` is the canonical error-arm shape
+        # (`sentry.apidocs.response_types.DetailResponse`). The decorator has no
+        # comparable entry for it — error statuses are declared via opaque
+        # `RESPONSE_*` constants which this linter already skips. Drop the
+        # arm here so the set comparison only weighs success-side `T`s.
+        if _name_of(T) == "DetailResponse":
+            continue
         extracted.append(T)
     return extracted or None
 

--- a/src/sentry/apidocs/response_types.py
+++ b/src/sentry/apidocs/response_types.py
@@ -1,0 +1,34 @@
+"""Static types for endpoint Response annotations.
+
+Currently houses `DetailResponse`, the canonical name for DRF's standard
+error-body shape (`{"detail": "..."}`). Endpoint methods that mix typed
+success returns with inline `Response({"detail": "..."}, status=4xx)` error
+returns annotate as `Response[T] | Response[DetailResponse]` so mypy can
+verify both arms.
+
+The structural linter at `sentry.apidocs._check_response_annotation_matches_schema`
+recognizes `DetailResponse` by name and excludes it from the
+decorator/annotation set-equality comparison (the error arm has no
+comparable decorator entry — error statuses are typically declared as
+opaque `RESPONSE_*` constants which the linter already skips).
+
+Named `response_types` rather than `types` to avoid shadowing Python's
+stdlib `types` module when subprocess tooling (e.g. some prek hooks)
+puts `apidocs/` on `sys.path`.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class DetailResponse(TypedDict):
+    """DRF's standard error-body shape, rendered by its exception handler.
+
+    Every `APIException` subclass (`ParseError`, `NotFound`, `PermissionDenied`,
+    etc.) ultimately produces a JSON body matching this shape with the
+    exception's status code. Inline `Response({"detail": "..."}, status=4xx)`
+    construction mirrors the same shape.
+    """
+
+    detail: str

--- a/src/sentry/integrations/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/integrations/api/endpoints/organization_config_integrations.py
@@ -20,6 +20,7 @@ from sentry.integrations.api.serializers.models.integration import (
 from sentry.integrations.base import is_provider_enabled
 from sentry.integrations.manager import default_manager as integrations
 from sentry.models.organization import Organization
+from sentry.apidocs.response_types import DetailResponse
 
 
 class OrganizationConfigIntegrationsEndpointResponse(TypedDict):
@@ -49,7 +50,7 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
         },
         examples=IntegrationExamples.ORGANIZATION_CONFIG_INTEGRATIONS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response[OrganizationConfigIntegrationsEndpointResponse] | Response[DetailResponse]:
         """
         Get integration provider information about all available integrations for an organization.
         """

--- a/src/sentry/integrations/api/endpoints/organization_integrations_index.py
+++ b/src/sentry/integrations/api/endpoints/organization_integrations_index.py
@@ -28,6 +28,7 @@ from sentry.organizations.services.organization.model import (
     RpcOrganization,
     RpcUserOrganizationContext,
 )
+from sentry.apidocs.response_types import DetailResponse
 
 
 def prepare_feature_filters(features_raw: Sequence[str]) -> set[str]:
@@ -85,7 +86,7 @@ class OrganizationIntegrationsEndpoint(OrganizationIntegrationBaseEndpoint):
         request: Request,
         organization_context: RpcUserOrganizationContext,
         organization: RpcOrganization,
-    ) -> Response:
+    ) -> Response[list[OrganizationIntegrationResponse]] | Response[DetailResponse]:
         """
         Lists all the available Integrations for an Organization.
         """

--- a/src/sentry/issues/endpoints/organization_eventid.py
+++ b/src/sentry/issues/endpoints/organization_eventid.py
@@ -24,6 +24,7 @@ from sentry.search.eap.rpc_utils import and_trace_item_filters
 from sentry.services import eventstore
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
+from sentry.apidocs.response_types import DetailResponse
 
 
 class EventIdLookupResponse(TypedDict):
@@ -62,7 +63,7 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationExamples.EVENT_EXAMPLES,
     )
-    def get(self, request: Request, organization: Organization, event_id: str) -> Response:
+    def get(self, request: Request, organization: Organization, event_id: str) -> Response[EventIdLookupResponse] | Response[DetailResponse]:
         """
         This resolves an event ID to the project slug and internal issue ID and internal event ID.
         """

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -30,6 +30,7 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.apidocs.response_types import DetailResponse
 
 
 def wrap_event_response(
@@ -136,7 +137,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         },
         examples=EventExamples.GROUP_EVENT_DETAILS,
     )
-    def get(self, request: Request, project: Project, event_id: str) -> Response:
+    def get(self, request: Request, project: Project, event_id: str) -> Response[GroupEventDetailsResponse] | Response[DetailResponse]:
         """
         Return details on an individual event.
         """

--- a/src/sentry/preprod/api/endpoints/public/organization_preprod_artifact_install_details.py
+++ b/src/sentry/preprod/api/endpoints/public/organization_preprod_artifact_install_details.py
@@ -20,6 +20,7 @@ from sentry.preprod.api.models.public.installable_builds import (
 from sentry.preprod.models import PreprodArtifact
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.apidocs.response_types import DetailResponse
 
 
 @extend_schema(tags=["Mobile Builds"])
@@ -62,7 +63,7 @@ class OrganizationPreprodArtifactPublicInstallDetailsEndpoint(OrganizationEndpoi
         request: Request,
         organization: Organization,
         artifact_id: str,
-    ) -> Response:
+    ) -> Response[InstallInfoResponseDict] | Response[DetailResponse]:
         """
         Retrieve install info for a given artifact.
 

--- a/src/sentry/preprod/api/endpoints/public/organization_preprod_size_analysis.py
+++ b/src/sentry/preprod/api/endpoints/public/organization_preprod_size_analysis.py
@@ -34,6 +34,7 @@ from sentry.preprod.models import (
 )
 from sentry.preprod.size_analysis.models import SizeAnalysisResults
 from sentry.utils import json
+from sentry.apidocs.response_types import DetailResponse
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +104,7 @@ class OrganizationPreprodPublicSizeAnalysisEndpoint(OrganizationEndpoint):
         request: Request,
         organization: Organization,
         artifact_id: str,
-    ) -> Response:
+    ) -> Response[SizeAnalysisResponseDict] | Response[DetailResponse]:
         """
         Retrieve size analysis results for a given artifact.
 

--- a/tests/sentry/apidocs/test_check_response_annotation_matches_schema.py
+++ b/tests/sentry/apidocs/test_check_response_annotation_matches_schema.py
@@ -417,3 +417,84 @@ class FooEndpoint:
         return Response({"x": 1})
 """
     assert _run(source) == []
+
+
+def test_union_with_detailresponse_passes() -> None:
+    """`Response[T] | Response[DetailResponse]` — the DetailResponse arm is
+    the canonical error-body shape and has no comparable decorator entry
+    (error statuses use opaque RESPONSE_* constants, already skipped).
+    The linter must exclude DetailResponse from the comparison set."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.apidocs.response_types import DetailResponse
+
+class FooResponse(TypedDict):
+    x: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response[FooResponse] | Response[DetailResponse]:
+        return Response({"x": 1})
+"""
+    assert _run(source) == []
+
+
+def test_union_with_detailresponse_and_wrong_success_still_fails() -> None:
+    """The DetailResponse arm is excluded but the success arm still has to match."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.apidocs.response_types import DetailResponse
+
+class FooResponse(TypedDict):
+    x: int
+
+class BarResponse(TypedDict):
+    y: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response[BarResponse] | Response[DetailResponse]:
+        return Response({"y": 1})
+"""
+    mismatches = _run(source)
+    assert len(mismatches) == 1
+    assert mismatches[0].decl == frozenset({"FooResponse"})
+    assert mismatches[0].annot == frozenset({"BarResponse"})
+
+
+def test_aliased_detailresponse_not_recognized() -> None:
+    """The linter matches DetailResponse by exact AST name. Aliased imports
+    (`from ... import DetailResponse as ErrorDetail`) are treated as a
+    distinct comparable arm — the decorator set won't match and the linter
+    will emit a mismatch. Migrations must use the canonical name."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.apidocs.response_types import DetailResponse as ErrorDetail
+
+class FooResponse(TypedDict):
+    x: int
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response[FooResponse] | Response[ErrorDetail]:
+        return Response({"x": 1})
+"""
+    mismatches = _run(source)
+    assert len(mismatches) == 1
+    assert mismatches[0].decl == frozenset({"FooResponse"})
+    assert mismatches[0].annot == frozenset({"FooResponse", "ErrorDetail"})

--- a/tests/tools/mypy_helpers/test_plugin.py
+++ b/tests/tools/mypy_helpers/test_plugin.py
@@ -517,3 +517,148 @@ async def view() -> Response[Shape]:
 """
     ret, out = call_mypy(src)
     assert ret == 0, out
+
+
+def test_response_union_dict_literal_narrows_to_detailresponse() -> None:
+    """The plugin narrows `Response({"detail": "..."}, status=4xx)` to the
+    DetailResponse arm of a `Response[T] | Response[DetailResponse]` union.
+    Without the plugin, mypy infers the body as `dict[str, str]` and the
+    union arm `Response[DetailResponse]` rejects it (TypedDict ≠ dict)."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def typed() -> FooResponse:
+    return {"x": 1}
+
+def view() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response({"detail": "Not found"}, status=404)
+
+def view_success() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response(typed())
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_union_wrong_shape_still_errors() -> None:
+    """A dict literal that matches NO arm's TypedDict must still error.
+    The plugin only narrows when exactly one arm accepts."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def view() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response({"wrong": "shape"}, status=400)
+"""
+    ret, out = call_mypy(src)
+    assert ret, out
+    # mypy reports the broad-dict-literal vs union mismatch
+    assert "Incompatible return value type" in out
+
+
+def test_response_union_value_type_mismatch_errors() -> None:
+    """A dict literal whose values don't match the TypedDict's declared value
+    types must NOT narrow. `{"detail": 42}` is `dict[str, int]`, not a valid
+    `DetailResponse` (which is `{"detail": str}`)."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def view() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response({"detail": 42}, status=400)
+"""
+    ret, out = call_mypy(src)
+    assert ret, out
+
+
+def test_response_union_extra_key_rejects() -> None:
+    """A dict literal with extra keys beyond the TypedDict's fields does NOT
+    satisfy the TypedDict — the plugin must NOT narrow it."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def view() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response({"detail": "x", "extra": "key"}, status=400)
+"""
+    ret, out = call_mypy(src)
+    assert ret, out
+
+
+def test_response_union_single_arm_unaffected() -> None:
+    """Single-armed `Response[T]` is mypy's native bidirectional inference
+    path. The plugin's narrowing should not interfere — mypy already accepts
+    matching dict literals here."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def view() -> Response[DetailResponse]:
+    return Response({"detail": "x"}, status=400)
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_union_no_typeddict_arms_unaffected() -> None:
+    """If the union has no TypedDict-parameterized `Response[...]` arms,
+    the plugin must not interfere — mypy handles non-TypedDict cases natively."""
+    src = """\
+from rest_framework.response import Response
+
+def view() -> Response[int] | Response[str]:
+    return Response(42)
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_union_non_dict_body_unaffected() -> None:
+    """The narrowing only fires on dict literal bodies. Variable/function-call
+    bodies use mypy's standard flow (which works fine for the success arm)."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def typed() -> FooResponse:
+    return {"x": 1}
+
+def view() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response(typed())
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out

--- a/tools/mypy_helpers/plugin.py
+++ b/tools/mypy_helpers/plugin.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable
+from typing import Any
 
 from mypy.build import PRI_MYPY
 from mypy.errorcodes import ATTR_DEFINED
 from mypy.messages import format_type
-from mypy.nodes import ARG_POS, MypyFile, TypeInfo
+from mypy.nodes import ARG_POS, DictExpr, MypyFile, StrExpr, TypeInfo
 from mypy.plugin import (
     AttributeContext,
     ClassDefContext,
@@ -19,6 +20,7 @@ from mypy.plugin import (
 )
 from mypy.plugins.common import add_attribute_to_class
 from mypy.subtypes import find_member
+from mypy.subtypes import is_subtype as _is_subtype
 from mypy.typeanal import make_optional_type
 from mypy.types import (
     AnyType,
@@ -27,8 +29,10 @@ from mypy.types import (
     Instance,
     NoneType,
     Type,
+    TypedDictType,
     TypeOfAny,
     UnionType,
+    get_proper_type,
 )
 
 
@@ -188,6 +192,38 @@ def _lazy_service_wrapper_attribute(ctx: AttributeContext, *, attr: str) -> Type
         return member
 
 
+_RESPONSE_FULLNAME = "rest_framework.response.Response"
+_ASYNC_WRAPPERS = frozenset(
+    {
+        "typing.Coroutine",
+        "typing.Awaitable",
+        "typing.AsyncGenerator",
+        "typing.AsyncIterator",
+        "typing.AsyncIterable",
+    }
+)
+
+
+def _unwrap_response_instances_from_return(expected: Type) -> list[Instance]:
+    """From a (possibly async-wrapped, possibly union) return type, collect every
+    `Response[...]` Instance for inspection. Shared by `_check_response_body_not_any`
+    and `_narrow_response_dict_literal_in_union` so both hooks see the enclosing
+    return type the same way.
+    """
+    out: list[Instance] = []
+    pending: list[Type] = [expected]
+    while pending:
+        t = get_proper_type(pending.pop())
+        if isinstance(t, UnionType):
+            pending.extend(t.items)
+        elif isinstance(t, Instance):
+            if t.type.fullname in _ASYNC_WRAPPERS and t.args:
+                pending.extend(t.args)
+            else:
+                out.append(t)
+    return out
+
+
 def _check_response_body_not_any(ctx: FunctionContext) -> Type:
     """Hard-error when `Response[T](body)` is constructed in a context that
     expects `T = <Specific>` but `body` evaluates to `Any`.
@@ -221,37 +257,13 @@ def _check_response_body_not_any(ctx: FunctionContext) -> Type:
     # Inspect the surrounding type-checker frame for the expected return type.
     # `chk.return_types` is the stack of expected return types for enclosing
     # functions. The innermost frame is the function containing this call.
+    # Async wrappers (Coroutine/Awaitable/etc.) and union arms are unwrapped
+    # by `_unwrap_response_instances_from_return`.
     chk = ctx.api.expr_checker.chk  # type: ignore[attr-defined]
     if not getattr(chk, "return_types", None):
         return ctx.default_return_type
-    expected = chk.return_types[-1]
-    # Strip Awaitable/Coroutine wrappers (async views return
-    # `Coroutine[Any, Any, Response[T]]`) and union arms.
-    expected_instances: list[Instance] = []
-    pending: list[Type] = [expected]
-    _ASYNC_WRAPPERS = frozenset(
-        {
-            "typing.Coroutine",
-            "typing.Awaitable",
-            "typing.AsyncGenerator",
-            "typing.AsyncIterator",
-            "typing.AsyncIterable",
-        }
-    )
-    while pending:
-        t = pending.pop()
-        if isinstance(t, UnionType):
-            pending.extend(t.items)
-        elif isinstance(t, Instance):
-            if t.type.fullname in _ASYNC_WRAPPERS and t.args:
-                # Coroutine[Y, S, R] → return type R is the last type arg.
-                # Awaitable/AsyncGenerator/etc. — recurse into all args, the
-                # `Response[T]` we care about will surface from whichever slot.
-                pending.extend(t.args)
-            else:
-                expected_instances.append(t)
-    for inst in expected_instances:
-        if inst.type.fullname != "rest_framework.response.Response":
+    for inst in _unwrap_response_instances_from_return(chk.return_types[-1]):
+        if inst.type.fullname != _RESPONSE_FULLNAME:
             continue
         if not inst.args:
             continue
@@ -267,10 +279,129 @@ def _check_response_body_not_any(ctx: FunctionContext) -> Type:
     return ctx.default_return_type
 
 
+def _dict_literal_matches_typeddict(
+    body: DictExpr,
+    td: TypedDictType,
+    expr_checker: Any,
+) -> bool:
+    """Return True if `body` (a dict literal AST) structurally satisfies `td`.
+
+    Conservative match — required keys all present, no unknown extras, value
+    types are mypy-subtypes of the declared field types. We deliberately
+    re-check shape here instead of routing through mypy's
+    `check_typeddict_call_with_dict` because that method emits errors directly
+    on the call site; the plugin needs to probe silently across union arms.
+    """
+    literal_keys: set[str] = set()
+    literal_items: dict[str, Type] = {}
+    for k_expr, v_expr in body.items:
+        if not isinstance(k_expr, StrExpr):
+            # Non-literal key (e.g. dynamic key expression) — can't safely
+            # match a TypedDict at compile time. Bail.
+            return False
+        literal_keys.add(k_expr.value)
+        try:
+            literal_items[k_expr.value] = expr_checker.accept(v_expr)
+        except Exception:
+            # Any exception inferring a value's type — bail out conservatively.
+            return False
+
+    # Required keys all present.
+    if not td.required_keys.issubset(literal_keys):
+        return False
+    # No unknown extras.
+    if literal_keys - set(td.items.keys()):
+        return False
+    # Value types compatible.
+    for key, value_type in literal_items.items():
+        declared = td.items.get(key)
+        if declared is None:
+            return False
+        if not _is_subtype(value_type, declared):
+            return False
+    return True
+
+
+def _narrow_response_dict_literal_in_union(ctx: FunctionContext) -> Type:
+    """Narrow `Response(<dict literal>, status=...)` to a matching TypedDict
+    arm of the enclosing function's union return type.
+
+    mypy already does this narrowing when the return type is a *single*
+    `Response[TypedDict]`. When the return type is a union of `Response[T]`
+    arms, mypy gives up bidirectional inference and infers the body as the
+    broad `dict[K, V]` of the literal — which doesn't match any specific
+    TypedDict arm because `Response[T]` is invariant. This hook restores the
+    expected narrowing by inspecting union arms one at a time.
+
+    Properties:
+      - Fires only on dict-literal bodies; non-literal bodies are unaffected.
+      - Fires only when the enclosing return is a union of `Response[...]` arms
+        with at least one TypedDict-parameterized member.
+      - Narrows only when exactly one arm structurally accepts the literal.
+        Zero or multiple matches → returns the default and mypy errors normally.
+      - Composes with `_check_response_body_not_any`: that hook fires when the
+        body is `Any`, this hook fires when the body is a dict literal. They
+        run sequentially via the dispatcher.
+    """
+    if not ctx.args or not ctx.args[0]:
+        return ctx.default_return_type
+    body_expr = ctx.args[0][0]
+    if not isinstance(body_expr, DictExpr):
+        return ctx.default_return_type
+    # Same disambiguation as `_check_response_body_not_any`: if the call uses
+    # the body-less overload (`Response(status=...)`), arg 0 may actually be
+    # `status` — not the body.
+    arg_name = ctx.arg_names[0][0] if ctx.arg_names and ctx.arg_names[0] else None
+    if arg_name not in (None, "data"):
+        return ctx.default_return_type
+
+    chk = ctx.api.expr_checker.chk  # type: ignore[attr-defined]
+    if not getattr(chk, "return_types", None):
+        return ctx.default_return_type
+
+    arms = _unwrap_response_instances_from_return(chk.return_types[-1])
+    typeddict_arms: list[tuple[Instance, TypedDictType]] = []
+    for inst in arms:
+        if inst.type.fullname != _RESPONSE_FULLNAME:
+            continue
+        if not inst.args:
+            continue
+        T_arg = get_proper_type(inst.args[0])
+        if isinstance(T_arg, TypedDictType):
+            typeddict_arms.append((inst, T_arg))
+
+    if not typeddict_arms:
+        # Not a union-of-Response[TypedDict] context. Let the default flow.
+        return ctx.default_return_type
+
+    expr_checker = ctx.api.expr_checker  # type: ignore[attr-defined]
+    matching: list[Instance] = []
+    for inst, td in typeddict_arms:
+        if _dict_literal_matches_typeddict(body_expr, td, expr_checker):
+            matching.append(inst)
+
+    if len(matching) != 1:
+        # Zero matches (real drift) or ambiguous (multiple arms accept). Either
+        # way, fall back to default and let mypy emit its standard error.
+        return ctx.default_return_type
+
+    return matching[0]
+
+
+def _dispatch_response_hook(ctx: FunctionContext) -> Type:
+    """Dispatcher for `Response(...)` construction. Tries narrowing first; if
+    that doesn't apply, falls through to the body-Any check.
+    """
+    narrowed = _narrow_response_dict_literal_in_union(ctx)
+    if narrowed is not ctx.default_return_type:
+        return narrowed
+    return _check_response_body_not_any(ctx)
+
+
 class SentryMypyPlugin(Plugin):
     def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
-        if fullname == "rest_framework.response.Response":
-            return _check_response_body_not_any
+        if fullname == _RESPONSE_FULLNAME:
+            return _dispatch_response_hook
         return None
 
     def get_function_signature_hook(


### PR DESCRIPTION
Extend the mypy plugin to narrow `Response({"detail": "..."}, status=4xx)`
calls to the matching arm of a `Response[T] | Response[DetailResponse]`
union return. This restores in-union the bidirectional TypedDict-from-
dict-literal inference that mypy already does for single-target
`Response[T]` annotations — but [intentionally refuses][1] across union
arms.

Without the plugin, `Response({"detail":"x"}, status=400)` infers as
`Response[dict[str, str]]`. `Response[T]` is invariant, so that doesn't
satisfy `Response[DetailResponse]`, and the union annotation rejects
perfectly-valid inline error returns. This blocked the previous batch's
union-based migration.

[1]: mypy treats union-target dict-literal narrowing as ambiguous in
general; not on the project roadmap.

**Plugin behavior**

The new `_narrow_response_dict_literal_in_union` hook:

- Fires only on dict-literal `Response(...)` bodies under a union return
  with at least one `Response[TypedDict]` arm.
- Matches the dict literal against each arm's TypedDict structurally
  (required keys present, no extras, value types subtype-compatible).
- Returns `Response[that_T]` when **exactly one** arm accepts. Multiple
  matches → refuses to narrow (ambiguous, mypy errors). No matches →
  refuses to narrow (real drift, mypy errors).
- Composes with the existing `_check_response_body_not_any` via a small
  dispatcher. Any-typed bodies still trigger the established error.

```
                              mypy native      +Plugin
─────────────────────────────────────────────────────
serialize() returns TypedDict      ✓ narrows    (unchanged)
dict literal, single target        ✓ narrows    (unchanged)
dict literal, union target         ✗ fails      ✓ narrows
Wrong-shape body                   ✗ errors     ✗ errors (preserved)
Ambiguous arms                     ✗ errors     ✗ errors (refuses)
Any-typed body                    ✗ errors     ✗ errors (preserved)
```

**Coverage in this PR**

- `src/sentry/apidocs/response_types.py` — new `DetailResponse` TypedDict
  (canonical name for DRF's `{"detail": "..."}` error-body shape).
  Named `response_types` to avoid shadowing stdlib `types` under
  subprocess tooling.
- `tools/mypy_helpers/plugin.py` — new narrowing hook + shared
  `_unwrap_response_instances_from_return` helper used by both hooks.
- `src/sentry/apidocs/_check_response_annotation_matches_schema.py` —
  structural linter (#116496) skips `Response[DetailResponse]` union
  arms during decorator/annotation set comparison. Error statuses are
  declarator-side opaque (RESPONSE_*), already skipped by the linter;
  this just keeps the annotation side consistent.
- 7 endpoint methods migrated to
  `-> Response[T] | Response[DetailResponse]` with the shared import.

**Endpoint scope: 7 of 25 candidates**

Per-file try-and-revert against full-tree mypy (with the plugin enabled)
selected the safe set. The 18 rejected candidates have:

- Richer error bodies than `{"detail": str}` (e.g. `dict[str, list[str]]`,
  nested dicts) — different TypedDicts needed.
- Empty literals (`Response([])` infers `list[Never]`, `Response({})`
  infers `dict[Never, Never]`) — plugin only handles dict literals with
  keys; keyless literals can't be matched against a TypedDict shape.
- Any-typed bodies from untyped helpers (e.g. `cache.get(...)` or DRF
  `ReturnDict[Any, Any]`) — correctly caught by the existing body-Any
  hook.

Each rejection surfaces a real soundness issue. Deferred to per-cluster
follow-up PRs.

**No runtime change**

Endpoint bodies untouched. No `cast()`, no `# type: ignore`, no helper
indirection. The plugin operates purely at type-check time.

**Verification**

- `.venv/bin/mypy` (full-tree, 8038 files): clean
- `prek run -q` on touched files: clean
- structural linter: clean
- `make build-api-docs`: byte-identical to master
- Plugin tests (`tests/tools/mypy_helpers/test_plugin.py`): 36/36 (29 existing + 7 new)
- Linter tests: 19/19 (16 existing + 3 new for DetailResponse arm handling)