### PR TITLE
feat(api): Union response annotations with plugin narrowing + relaxed linter

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -17,6 +17,8 @@ from rest_framework.response import Response
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
 
+from sentry.apidocs.response_types import DetailResponse
+
 if TYPE_CHECKING:
     from django_stubs_ext import WithAnnotations
 
@@ -303,7 +305,9 @@ class DebugFilesEndpoint(ProjectEndpoint):
         },
         examples=DebugFileExamples.LIST_PROJECT_DEBUG_FILES,
     )
-    def get(self, request: Request, project: Project) -> Response:
+    def get(
+        self, request: Request, project: Project
+    ) -> Response[list[DebugFileSerializerResponse]] | Response[DetailResponse]:
         """
         Retrieve a list of debug information files for a given project.
         """

--- a/src/sentry/apidocs/_check_response_annotation_matches_schema.py
+++ b/src/sentry/apidocs/_check_response_annotation_matches_schema.py
@@ -67,9 +67,11 @@ class Mismatch:
     def __str__(self) -> str:
         decl = ", ".join(sorted(self.decl)) or "<none>"
         annot = ", ".join(sorted(self.annot)) or "<none>"
+        missing = ", ".join(sorted(self.decl - self.annot))
         return (
             f"{self.path}:{self.line} {self.cls}.{self.method}: "
-            f"decorator declares {{{decl}}}, annotation declares {{{annot}}}"
+            f"decorator declares {{{decl}}} but annotation declares {{{annot}}} "
+            f"(missing from annotation: {{{missing}}})"
         )
 
 
@@ -211,7 +213,15 @@ def check_file(path: Path) -> list[Mismatch]:
 
         decl_set = frozenset(_name_of(t) for t in decl_Ts)
         annot_set = frozenset(_name_of(t) for t in annot_Ts)
-        if decl_set != annot_set:
+        # Subset semantics, not strict equality: every typed T declared by
+        # `inline_sentry_response_serializer` in the decorator MUST appear in
+        # the annotation (drift caught), but the annotation MAY declare extra
+        # arms not in the decorator (e.g. local error TypedDicts not exposed
+        # in OpenAPI via opaque `RESPONSE_*` constants). This preserves
+        # API-as-today: endpoints that keep `RESPONSE_BAD_REQUEST`-style
+        # opaque error declarations can still enrich their internal
+        # annotations without changing the OpenAPI document.
+        if not decl_set.issubset(annot_set):
             mismatches.append(
                 Mismatch(
                     path=path,
@@ -244,9 +254,11 @@ def main(argv: list[str]) -> int:
         sys.stdout.write(f"{m}\n")
     if all_mismatches:
         sys.stderr.write(
-            f"\n{len(all_mismatches)} mismatch(es) — the set of `T`s declared by "
+            f"\n{len(all_mismatches)} mismatch(es) — every `T` declared by "
             "`inline_sentry_response_serializer(...)` in `@extend_schema` must "
-            "equal the set of `T`s in the `Response[T]` (or union) annotation.\n",
+            "appear in the `Response[T]` (or union) annotation. The annotation "
+            "MAY declare additional arms (e.g. local error TypedDicts) that the "
+            "decorator does not expose.\n",
         )
         return 1
     return 0

--- a/src/sentry/apidocs/response_types.py
+++ b/src/sentry/apidocs/response_types.py
@@ -1,0 +1,33 @@
+"""Shared TypedDicts for endpoint Response annotations.
+
+This module holds TypedDict shapes that recur across multiple endpoints.
+It is *not* authoritative — endpoints whose error/response shapes don't
+match anything here are expected to declare local TypedDicts in their
+own files. The structural linter at
+`sentry.apidocs._check_response_annotation_matches_schema` is name-agnostic;
+it does not special-case any TypedDict name in this module.
+
+`DetailResponse` is included because DRF's exception handler renders every
+uncaught `APIException` subclass as `{"detail": "..."}` and a non-trivial
+number of endpoints return that shape inline. Other shapes can graduate
+into this module as they emerge from real usage.
+
+The module is named `response_types` rather than `types` to avoid shadowing
+Python's stdlib `types` module under subprocess tooling (e.g. some prek hooks).
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class DetailResponse(TypedDict):
+    """DRF's standard error-body shape: `{"detail": str}`.
+
+    Use in `Response[T] | Response[DetailResponse]` annotations on endpoints
+    whose inline error returns are exactly `Response({"detail": "..."}, status=4xx)`.
+    Endpoints whose error bodies have richer or different shapes should
+    declare their own local TypedDicts instead.
+    """
+
+    detail: str

--- a/src/sentry/integrations/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/integrations/api/endpoints/organization_config_integrations.py
@@ -12,6 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST
 from sentry.apidocs.examples.integration_examples import IntegrationExamples
 from sentry.apidocs.parameters import GlobalParams, IntegrationParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.integrations.api.serializers.models.integration import (
     IntegrationProviderResponse,
@@ -49,7 +50,9 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
         },
         examples=IntegrationExamples.ORGANIZATION_CONFIG_INTEGRATIONS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[OrganizationConfigIntegrationsEndpointResponse] | Response[DetailResponse]:
         """
         Get integration provider information about all available integrations for an organization.
         """

--- a/src/sentry/integrations/api/endpoints/organization_integrations_index.py
+++ b/src/sentry/integrations/api/endpoints/organization_integrations_index.py
@@ -15,6 +15,7 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.apidocs.examples.integration_examples import IntegrationExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, IntegrationParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.integrations.api.bases.organization_integrations import (
@@ -85,7 +86,7 @@ class OrganizationIntegrationsEndpoint(OrganizationIntegrationBaseEndpoint):
         request: Request,
         organization_context: RpcUserOrganizationContext,
         organization: RpcOrganization,
-    ) -> Response:
+    ) -> Response[list[OrganizationIntegrationResponse]] | Response[DetailResponse]:
         """
         Lists all the available Integrations for an Organization.
         """

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -29,6 +29,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.event_examples import EventExamples
 from sentry.apidocs.parameters import CursorQueryParam, EventParams, GlobalParams, IssueParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.exceptions import InvalidSearchQuery
@@ -86,7 +87,9 @@ class GroupEventsEndpoint(GroupEndpoint):
         examples=EventExamples.GROUP_EVENTS_SIMPLE,
     )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-events"])
-    def get(self, request: Request, group: Group) -> Response:
+    def get(
+        self, request: Request, group: Group
+    ) -> Response[list[SimpleEventSerializerResponse]] | Response[DetailResponse]:
         """
         Return a list of error events bound to an issue
         """

--- a/src/sentry/issues/endpoints/organization_eventid.py
+++ b/src/sentry/issues/endpoints/organization_eventid.py
@@ -16,6 +16,7 @@ from sentry.api.serializers.models.event import EventSerializerResponse
 from sentry.apidocs.constants import RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
@@ -62,7 +63,9 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationExamples.EVENT_EXAMPLES,
     )
-    def get(self, request: Request, organization: Organization, event_id: str) -> Response:
+    def get(
+        self, request: Request, organization: Organization, event_id: str
+    ) -> Response[EventIdLookupResponse] | Response[DetailResponse]:
         """
         This resolves an event ID to the project slug and internal issue ID and internal event ID.
         """

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -23,6 +23,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.event_examples import EventExamples
 from sentry.apidocs.parameters import EventParams, GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
@@ -136,7 +137,9 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         },
         examples=EventExamples.GROUP_EVENT_DETAILS,
     )
-    def get(self, request: Request, project: Project, event_id: str) -> Response:
+    def get(
+        self, request: Request, project: Project, event_id: str
+    ) -> Response[GroupEventDetailsResponse] | Response[DetailResponse]:
         """
         Return details on an individual event.
         """

--- a/src/sentry/preprod/api/endpoints/public/organization_preprod_artifact_install_details.py
+++ b/src/sentry/preprod/api/endpoints/public/organization_preprod_artifact_install_details.py
@@ -11,6 +11,7 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.preprod_examples import PreprodExamples
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.preprod.api.models.public.installable_builds import (
@@ -62,7 +63,7 @@ class OrganizationPreprodArtifactPublicInstallDetailsEndpoint(OrganizationEndpoi
         request: Request,
         organization: Organization,
         artifact_id: str,
-    ) -> Response:
+    ) -> Response[InstallInfoResponseDict] | Response[DetailResponse]:
         """
         Retrieve install info for a given artifact.
 

--- a/src/sentry/preprod/api/endpoints/public/organization_preprod_size_analysis.py
+++ b/src/sentry/preprod/api/endpoints/public/organization_preprod_size_analysis.py
@@ -16,6 +16,7 @@ from sentry.api.serializers.rest_framework.base import convert_dict_key_case, sn
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.preprod_examples import PreprodExamples
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.files.file import File
 from sentry.models.organization import Organization
@@ -103,7 +104,7 @@ class OrganizationPreprodPublicSizeAnalysisEndpoint(OrganizationEndpoint):
         request: Request,
         organization: Organization,
         artifact_id: str,
-    ) -> Response:
+    ) -> Response[SizeAnalysisResponseDict] | Response[DetailResponse]:
         """
         Retrieve size analysis results for a given artifact.
 

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -15,6 +15,7 @@ from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
 from sentry.apidocs.examples.replay_examples import ReplayExamples
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams, VisibilityParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
@@ -81,7 +82,9 @@ class OrganizationReplayCountEndpoint(OrganizationEventsEndpointBase):
             403: RESPONSE_FORBIDDEN,
         },
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[dict[int, int]] | Response[DetailResponse]:
         """Return a count of replays for a list of issue or transaction IDs.
 
         The `query` parameter is required. It is a search query that includes exactly one of `issue.id`, `transaction`, or `replay_id` (string or list of strings).

--- a/tests/sentry/apidocs/test_check_response_annotation_matches_schema.py
+++ b/tests/sentry/apidocs/test_check_response_annotation_matches_schema.py
@@ -191,8 +191,12 @@ class FooEndpoint:
     assert mismatches[0].annot == frozenset({"FooResponse"})
 
 
-def test_annotation_has_extra_T_not_in_decorator_fires() -> None:
-    """If the annotation union declares a `T` that the decorator doesn't, fail."""
+def test_annotation_has_extra_T_not_in_decorator_passes() -> None:
+    """Under the subset linter, the annotation MAY declare arms the decorator
+    doesn't. These are internal-only type contracts (e.g. local error
+    TypedDicts not exposed in OpenAPI via inline_sentry_response_serializer).
+    The decorator's typed-T set still has to be a subset of the annotation's,
+    but the annotation is free to declare more."""
     source = """
 from typing import TypedDict
 from drf_spectacular.utils import extend_schema
@@ -202,20 +206,17 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 class FooResponse(TypedDict):
     x: int
 
-class GhostResponse(TypedDict):
-    y: int
+class LocalErrorBody(TypedDict):
+    error: str
 
 class FooEndpoint:
     @extend_schema(
         responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
     )
-    def get(self) -> Response[FooResponse] | Response[GhostResponse]:
+    def get(self) -> Response[FooResponse] | Response[LocalErrorBody]:
         return Response({"x": 1})
 """
-    mismatches = _run(source)
-    assert len(mismatches) == 1
-    assert mismatches[0].decl == frozenset({"FooResponse"})
-    assert mismatches[0].annot == frozenset({"FooResponse", "GhostResponse"})
+    assert _run(source) == []
 
 
 def test_multi_2xx_decorator_with_union_annotation() -> None:
@@ -416,4 +417,98 @@ class FooEndpoint:
     def get(self) -> Response[FooResponse]:
         return Response({"x": 1})
 """
+    assert _run(source) == []
+
+
+def test_decorator_opaque_RESPONSE_constants_with_annotation_error_arm_passes() -> None:
+    """API-as-today scenario: decorator declares only the 200 schema via
+    `inline_sentry_response_serializer` and uses opaque `RESPONSE_*` constants
+    for errors. Annotation declares the full union including a local error
+    TypedDict. Under subset semantics this passes — the annotation is
+    internal-only enrichment that doesn't change the published OpenAPI."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+RESPONSE_BAD_REQUEST = OpenApiResponse(description="Bad Request")
+
+class FooResponse(TypedDict):
+    x: int
+
+class FooErrorBody(TypedDict):
+    detail: str
+
+class FooEndpoint:
+    @extend_schema(
+        responses={
+            200: inline_sentry_response_serializer("Foo", FooResponse),
+            400: RESPONSE_BAD_REQUEST,
+        },
+    )
+    def get(self) -> Response[FooResponse] | Response[FooErrorBody]:
+        return Response({"x": 1})
+"""
+    assert _run(source) == []
+
+
+def test_decorator_typed_error_must_appear_in_annotation() -> None:
+    """If the decorator declares a typed error arm via
+    `inline_sentry_response_serializer`, the annotation MUST include that T.
+    Drift in this direction is still caught."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class TypedErrorBody(TypedDict):
+    detail: str
+
+class FooEndpoint:
+    @extend_schema(
+        responses={
+            200: inline_sentry_response_serializer("Foo", FooResponse),
+            400: inline_sentry_response_serializer("Err", TypedErrorBody),
+        },
+    )
+    def get(self) -> Response[FooResponse]:
+        return Response({"x": 1})
+"""
+    mismatches = _run(source)
+    assert len(mismatches) == 1
+    assert mismatches[0].decl == frozenset({"FooResponse", "TypedErrorBody"})
+    assert mismatches[0].annot == frozenset({"FooResponse"})
+
+
+def test_linter_is_name_agnostic_about_typeddicts() -> None:
+    """The linter must not special-case any TypedDict name (no DetailResponse
+    skip, no shape-based heuristics). It compares the sets of names as-is."""
+    source = """
+from typing import TypedDict
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from sentry.apidocs.utils import inline_sentry_response_serializer
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+class FooEndpoint:
+    @extend_schema(
+        responses={200: inline_sentry_response_serializer("Foo", FooResponse)},
+    )
+    def get(self) -> Response[FooResponse] | Response[DetailResponse]:
+        return Response({"x": 1})
+"""
+    # decorator set = {FooResponse}, annotation set = {FooResponse, DetailResponse}
+    # {FooResponse} ⊆ {FooResponse, DetailResponse} → passes
+    # Critically: the linter passes NOT because it special-cases DetailResponse,
+    # but because the subset rule accepts any extra annotation arm.
     assert _run(source) == []

--- a/tests/tools/mypy_helpers/test_plugin.py
+++ b/tests/tools/mypy_helpers/test_plugin.py
@@ -517,3 +517,202 @@ async def view() -> Response[Shape]:
 """
     ret, out = call_mypy(src)
     assert ret == 0, out
+
+
+def test_response_union_dict_literal_narrows_to_typeddict_arm() -> None:
+    """When the return is `Response[A] | Response[B]` (a union of TypedDicts),
+    a dict-literal body that matches exactly one arm must narrow. mypy doesn't
+    do this natively in union contexts — the plugin restores it."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def typed() -> FooResponse:
+    return {"x": 1}
+
+def view() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response({"detail": "Not found"}, status=404)
+
+def view_success() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response(typed())
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_union_dict_literal_wrong_shape_errors() -> None:
+    """Plugin only narrows when exactly one arm accepts. A dict literal that
+    matches no arm must still surface as a mypy error."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def view() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response({"wrong": "shape"}, status=400)
+"""
+    ret, out = call_mypy(src)
+    assert ret, out
+    assert "Incompatible return value type" in out
+
+
+def test_response_union_value_type_mismatch_errors() -> None:
+    """`{"detail": 42}` is dict[str, int], not a valid `DetailResponse`
+    (whose declared `detail: str`). Plugin must NOT narrow."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def view() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response({"detail": 42}, status=400)
+"""
+    ret, out = call_mypy(src)
+    assert ret, out
+
+
+def test_response_union_extra_key_rejects() -> None:
+    """A dict literal with extra keys beyond the TypedDict's fields does NOT
+    satisfy the TypedDict — plugin must NOT narrow it."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def view() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response({"detail": "x", "extra": "key"}, status=400)
+"""
+    ret, out = call_mypy(src)
+    assert ret, out
+
+
+def test_response_union_single_arm_unaffected() -> None:
+    """Single-armed `Response[T]` is mypy's native bidirectional path. Plugin
+    narrowing must not interfere."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def view() -> Response[DetailResponse]:
+    return Response({"detail": "x"}, status=400)
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_union_no_typeddict_arms_unaffected() -> None:
+    """If no union arm has a TypedDict T, plugin must not interfere."""
+    src = """\
+from rest_framework.response import Response
+
+def view() -> Response[int] | Response[str]:
+    return Response(42)
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_union_non_literal_body_unaffected() -> None:
+    """Narrowing only fires on literal bodies. Variable/function-call bodies
+    use mypy's standard flow — success arm matches via standard inference."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def typed() -> FooResponse:
+    return {"x": 1}
+
+def view() -> Response[FooResponse] | Response[DetailResponse]:
+    return Response(typed())
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_union_empty_list_narrows_to_list_arm() -> None:
+    """`Response([])` should match any `Response[list[T]]` arm — empty list
+    inhabits any element type. mypy infers `list[Never]` for `[]`, which
+    doesn't match invariant `list[T]` without plugin help."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def view() -> Response[list[FooResponse]] | Response[DetailResponse]:
+    return Response([], status=200)
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_union_empty_dict_narrows_to_dict_arm() -> None:
+    """`Response({})` should match `Response[dict[K, V]]` arms — empty dict
+    inhabits any dict. mypy infers `dict[Never, Never]` for `{}`."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class DetailResponse(TypedDict):
+    detail: str
+
+def view() -> Response[dict[int, int]] | Response[DetailResponse]:
+    return Response({}, status=200)
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_response_union_name_agnostic_local_typeddict() -> None:
+    """The plugin must narrow against ANY TypedDict arm — including locally-
+    declared ones in the same file. It is NOT hardcoded to recognize specific
+    names like `DetailResponse`."""
+    src = """\
+from typing import TypedDict
+from rest_framework.response import Response
+
+class FooResponse(TypedDict):
+    x: int
+
+class StatsPeriodErrorResponse(TypedDict):
+    error: dict[str, str]
+
+def view() -> Response[FooResponse] | Response[StatsPeriodErrorResponse]:
+    return Response({"error": {"period": "invalid"}}, status=400)
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out

--- a/tools/mypy_helpers/plugin.py
+++ b/tools/mypy_helpers/plugin.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable
+from typing import Any
 
 from mypy.build import PRI_MYPY
 from mypy.errorcodes import ATTR_DEFINED
 from mypy.messages import format_type
-from mypy.nodes import ARG_POS, MypyFile, TypeInfo
+from mypy.nodes import ARG_POS, DictExpr, ListExpr, MypyFile, StrExpr, TypeInfo
 from mypy.plugin import (
     AttributeContext,
     ClassDefContext,
@@ -19,6 +20,7 @@ from mypy.plugin import (
 )
 from mypy.plugins.common import add_attribute_to_class
 from mypy.subtypes import find_member
+from mypy.subtypes import is_subtype as _is_subtype
 from mypy.typeanal import make_optional_type
 from mypy.types import (
     AnyType,
@@ -27,8 +29,10 @@ from mypy.types import (
     Instance,
     NoneType,
     Type,
+    TypedDictType,
     TypeOfAny,
     UnionType,
+    get_proper_type,
 )
 
 
@@ -188,6 +192,166 @@ def _lazy_service_wrapper_attribute(ctx: AttributeContext, *, attr: str) -> Type
         return member
 
 
+_RESPONSE_FULLNAME = "rest_framework.response.Response"
+_ASYNC_WRAPPERS = frozenset(
+    {
+        "typing.Coroutine",
+        "typing.Awaitable",
+        "typing.AsyncGenerator",
+        "typing.AsyncIterator",
+        "typing.AsyncIterable",
+    }
+)
+
+
+def _unwrap_response_instances_from_return(expected: Type) -> list[Instance]:
+    """From a (possibly async-wrapped, possibly union) return type, collect every
+    `Response[...]` Instance for inspection. Shared by the body-Any check and
+    the dict/list-literal narrowing hook so both see the enclosing return type
+    the same way.
+    """
+    out: list[Instance] = []
+    pending: list[Type] = [expected]
+    while pending:
+        t = get_proper_type(pending.pop())
+        if isinstance(t, UnionType):
+            pending.extend(t.items)
+        elif isinstance(t, Instance):
+            if t.type.fullname in _ASYNC_WRAPPERS and t.args:
+                pending.extend(t.args)
+            else:
+                out.append(t)
+    return out
+
+
+def _dict_literal_matches_typeddict(
+    body: DictExpr,
+    td: TypedDictType,
+    expr_checker: Any,
+) -> bool:
+    """True if `body` (a non-empty dict literal) structurally satisfies `td`.
+
+    Required keys all present, no unknown extras, value types are mypy-subtypes
+    of declared field types. We re-check shape here rather than routing through
+    mypy's `check_typeddict_call_with_dict` because that method emits errors
+    directly on the call site — the plugin needs to probe silently across
+    union arms.
+    """
+    literal_keys: set[str] = set()
+    literal_items: dict[str, Type] = {}
+    for k_expr, v_expr in body.items:
+        if not isinstance(k_expr, StrExpr):
+            return False
+        literal_keys.add(k_expr.value)
+        try:
+            literal_items[k_expr.value] = expr_checker.accept(v_expr)
+        except Exception:
+            return False
+    if not td.required_keys.issubset(literal_keys):
+        return False
+    if literal_keys - set(td.items.keys()):
+        return False
+    for key, value_type in literal_items.items():
+        declared = td.items.get(key)
+        if declared is None:
+            return False
+        if not _is_subtype(value_type, declared):
+            return False
+    return True
+
+
+def _empty_dict_matches_arm(arm_T: Type) -> bool:
+    """True if `Response({})` satisfies `Response[arm_T]`.
+
+    Matches `dict[K, V]` for any K, V (empty dict inhabits any dict), and
+    TypedDicts with no required keys (e.g. `total=False` shapes).
+    """
+    arm_T = get_proper_type(arm_T)
+    if isinstance(arm_T, TypedDictType):
+        return not arm_T.required_keys
+    if isinstance(arm_T, Instance) and arm_T.type.fullname == "builtins.dict":
+        return True
+    return False
+
+
+def _empty_list_matches_arm(arm_T: Type) -> bool:
+    """True if `Response([])` satisfies `Response[arm_T]` — any `list[X]` arm.
+
+    Empty list inhabits any `list[X]` because there are no elements that
+    could violate `X`.
+    """
+    arm_T = get_proper_type(arm_T)
+    if isinstance(arm_T, Instance) and arm_T.type.fullname == "builtins.list":
+        return True
+    return False
+
+
+def _narrow_response_literal_in_union(ctx: FunctionContext) -> Type:
+    """Narrow `Response(<literal>, ...)` to a matching arm of the enclosing
+    function's union return type.
+
+    Mypy already narrows when the return type is a single `Response[X]`. When
+    the return is a union of `Response[...]` arms, mypy gives up bidirectional
+    inference and infers the body as the broad type of the literal — which
+    doesn't match any specific arm because `Response[T]` is invariant. This
+    hook restores the expected narrowing by inspecting each arm.
+
+    Handles three literal shapes:
+      - non-empty `DictExpr` → TypedDict-coercion check against TypedDict arms
+      - empty `DictExpr` `{}` → matches `dict[K, V]` arms or no-required-keys
+        TypedDict arms
+      - empty `ListExpr` `[]` → matches `list[T]` arms
+
+    Returns `Response[that_T]` when exactly one arm accepts the literal. Zero
+    or multiple matches → returns default (mypy errors). Non-literal bodies
+    are untouched. Name-agnostic: no hardcoded TypedDict names.
+    """
+    if not ctx.args or not ctx.args[0]:
+        return ctx.default_return_type
+    body_expr = ctx.args[0][0]
+    # Identify which literal we're dealing with.
+    is_empty_dict = isinstance(body_expr, DictExpr) and not body_expr.items
+    is_nonempty_dict = isinstance(body_expr, DictExpr) and bool(body_expr.items)
+    is_empty_list = isinstance(body_expr, ListExpr) and not body_expr.items
+    if not (is_empty_dict or is_nonempty_dict or is_empty_list):
+        return ctx.default_return_type
+
+    arg_name = ctx.arg_names[0][0] if ctx.arg_names and ctx.arg_names[0] else None
+    if arg_name not in (None, "data"):
+        return ctx.default_return_type
+
+    chk = ctx.api.expr_checker.chk  # type: ignore[attr-defined]
+    if not getattr(chk, "return_types", None):
+        return ctx.default_return_type
+
+    response_arms: list[Instance] = [
+        inst
+        for inst in _unwrap_response_instances_from_return(chk.return_types[-1])
+        if inst.type.fullname == _RESPONSE_FULLNAME and inst.args
+    ]
+    if not response_arms:
+        return ctx.default_return_type
+
+    expr_checker = ctx.api.expr_checker  # type: ignore[attr-defined]
+    matching: list[Instance] = []
+    for inst in response_arms:
+        T_arg = get_proper_type(inst.args[0])
+        if is_nonempty_dict and isinstance(T_arg, TypedDictType):
+            assert isinstance(body_expr, DictExpr)
+            if _dict_literal_matches_typeddict(body_expr, T_arg, expr_checker):
+                matching.append(inst)
+        elif is_empty_dict and _empty_dict_matches_arm(T_arg):
+            matching.append(inst)
+        elif is_empty_list and _empty_list_matches_arm(T_arg):
+            matching.append(inst)
+
+    if len(matching) != 1:
+        # Zero matches (real drift) or multiple (ambiguous) — fall back to
+        # default and let mypy emit its standard error.
+        return ctx.default_return_type
+    return matching[0]
+
+
 def _check_response_body_not_any(ctx: FunctionContext) -> Type:
     """Hard-error when `Response[T](body)` is constructed in a context that
     expects `T = <Specific>` but `body` evaluates to `Any`.
@@ -219,39 +383,13 @@ def _check_response_body_not_any(ctx: FunctionContext) -> Type:
         return ctx.default_return_type
 
     # Inspect the surrounding type-checker frame for the expected return type.
-    # `chk.return_types` is the stack of expected return types for enclosing
-    # functions. The innermost frame is the function containing this call.
+    # Async wrappers (Coroutine/Awaitable/etc.) and union arms are unwrapped
+    # by `_unwrap_response_instances_from_return`.
     chk = ctx.api.expr_checker.chk  # type: ignore[attr-defined]
     if not getattr(chk, "return_types", None):
         return ctx.default_return_type
-    expected = chk.return_types[-1]
-    # Strip Awaitable/Coroutine wrappers (async views return
-    # `Coroutine[Any, Any, Response[T]]`) and union arms.
-    expected_instances: list[Instance] = []
-    pending: list[Type] = [expected]
-    _ASYNC_WRAPPERS = frozenset(
-        {
-            "typing.Coroutine",
-            "typing.Awaitable",
-            "typing.AsyncGenerator",
-            "typing.AsyncIterator",
-            "typing.AsyncIterable",
-        }
-    )
-    while pending:
-        t = pending.pop()
-        if isinstance(t, UnionType):
-            pending.extend(t.items)
-        elif isinstance(t, Instance):
-            if t.type.fullname in _ASYNC_WRAPPERS and t.args:
-                # Coroutine[Y, S, R] → return type R is the last type arg.
-                # Awaitable/AsyncGenerator/etc. — recurse into all args, the
-                # `Response[T]` we care about will surface from whichever slot.
-                pending.extend(t.args)
-            else:
-                expected_instances.append(t)
-    for inst in expected_instances:
-        if inst.type.fullname != "rest_framework.response.Response":
+    for inst in _unwrap_response_instances_from_return(chk.return_types[-1]):
+        if inst.type.fullname != _RESPONSE_FULLNAME:
             continue
         if not inst.args:
             continue
@@ -267,10 +405,21 @@ def _check_response_body_not_any(ctx: FunctionContext) -> Type:
     return ctx.default_return_type
 
 
+def _dispatch_response_hook(ctx: FunctionContext) -> Type:
+    """Single Response() construction hook. Tries literal-narrowing first
+    (covers dict literals + empty literals); if that doesn't apply, falls
+    through to the body-Any check.
+    """
+    narrowed = _narrow_response_literal_in_union(ctx)
+    if narrowed is not ctx.default_return_type:
+        return narrowed
+    return _check_response_body_not_any(ctx)
+
+
 class SentryMypyPlugin(Plugin):
     def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
-        if fullname == "rest_framework.response.Response":
-            return _check_response_body_not_any
+        if fullname == _RESPONSE_FULLNAME:
+            return _dispatch_response_hook
         return None
 
     def get_function_signature_hook(


### PR DESCRIPTION
Three pieces of infrastructure that together enable typing endpoints with
mixed return shapes (success TypedDict + inline error bodies) without
business-logic changes.

**Plugin narrowing across union arms**

The mypy plugin gains a sibling hook to the body-Any check. When
`Response(<literal>, ...)` is constructed inside a function returning a
union of `Response[...]` arms, the plugin narrows the literal to one
arm structurally:

```
Non-empty dict literal       → TypedDict-coercion check per arm's T
Empty dict literal `{}`      → matches dict[K,V] or no-required-keys TypedDict
Empty list literal `[]`      → matches list[T] arms
```

Exactly one match → returns `Response[that_T]`. Zero (drift) or multiple
(ambiguous) → falls back to default. The plugin is **name-agnostic** —
no hardcoded TypedDict names. It does for unions what mypy already does
in single-target `Response[T]` contexts, which mypy intentionally
refuses to extend to unions (bidirectional TypedDict-from-literal
inference is single-target only by design).

**Linter relaxation: set-subset, not set-equality**

The structural linter (#116496) now requires the decorator's typed-T
set to be a **subset** of the annotation's typed-T set, not equal.

```
Before (set-equality):
─────────────────────
Decorator: {200: inline_sentry_response_serializer("X", T)}
Annotation: Response[T] | Response[ErrorT]
              → mismatch (annotation declares more)

After (set-subset):
───────────────────
Same input → linter passes. {T} ⊆ {T, ErrorT}.
```

This lets endpoints enrich their internal annotations (e.g. local error
TypedDicts) without forcing decorator migrations that would change the
OpenAPI document. Drift in the other direction (decorator declares T that
annotation omits) is still caught.

**`src/sentry/apidocs/response_types.py` as a shared-shapes module**

A small module that holds TypedDict shapes recurring across endpoints.
Initial contents: `DetailResponse` (DRF's standard `{"detail": str}`
shape). The module is **not** authoritative — endpoints whose error
shapes don't match anything here are expected to declare local
TypedDicts in their own files. The linter is name-agnostic, treating
shared and local TypedDicts identically.

**Migration coverage in this PR: 9 of 25 candidate endpoints**

Migrated under the new infrastructure:

```
src/sentry/api/endpoints/debug_files.py
src/sentry/issues/endpoints/organization_eventid.py
src/sentry/issues/endpoints/project_event_details.py
src/sentry/integrations/api/endpoints/organization_config_integrations.py
src/sentry/integrations/api/endpoints/organization_integrations_index.py
src/sentry/preprod/api/endpoints/public/organization_preprod_size_analysis.py
src/sentry/preprod/api/endpoints/public/organization_preprod_artifact_install_details.py
src/sentry/issues/endpoints/group_events.py            (plugin G1 — empty list)
src/sentry/replays/endpoints/organization_replay_count.py (plugin G1 — empty dict)
```

Each migrated endpoint's diff is exactly two things: add a `DetailResponse`
import, and change the return annotation from `Response` to a union.

**The other 16 candidates stay unmigrated**

They have body sources that are typed `Any` at the runtime API surface
(`serializer.errors` returns DRF `ReturnDict[Any, Any]`, pydantic
`resp.dict()` returns `dict[str, Any]`, untyped helper functions), or
inline bodies with custom nested shapes that don't match shared
TypedDicts. Migrating them requires improving the *source* — typing DRF
stubs better, typing pydantic dict() returns, etc. — not changing how
the endpoints work. They stay bare-`-> Response` until the source
typing catches up.

**No runtime changes anywhere.** No `cast()` calls. No `# type: ignore`
comments. No `return → raise` conversions. Plugin and linter operate
purely at type-check time.

**Verification**

- Full-tree mypy (8038 files): clean in src/ and tests/
- prek: clean
- Structural linter: clean
- `make build-api-docs`: byte-identical to master
- Plugin tests: 39/39 pass (29 existing + 7 union-narrowing + 3 empty-literal/name-agnostic)
- Linter tests: 19/19 pass (16 existing + 3 subset-semantic scenarios)