### PR TITLE
ci: Run ESLint only on changed files in a PR

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -39,6 +39,21 @@ mdx_typecheckable: &mdx_typecheckable
   - added|deleted|modified: 'static/app/components/core/**/*.{ts,tsx}'
   - added|deleted|modified: 'static/**/__stories__/**/*.{ts,tsx}'
 
+lintable_modified: &lintable_modified
+  - *sentry_frontend_workflow_file
+  - *sentry_frontend_snapshots_workflow_file
+  - added|modified: '**/*.{ts,tsx,js,jsx,mjs}'
+  - added|modified: 'static/**/*.{less,json,yml,md,mdx}'
+  - added|modified: '{vercel,tsconfig,biome,package}.json'
+
+lintable_rules_changed: &lintable_rules_changed
+  - *sentry_frontend_workflow_file
+  - *sentry_frontend_snapshots_workflow_file
+  - added|modified: 'package.json'
+  - added|modified: '.github/file-filters.yml'
+  - added|modified: '*.config.ts'
+  - added|modified: 'static/eslint/**/*.{ts,tsx,js,jsx,mjs}'
+
 # Trigger to apply the 'Scope: Frontend' label to PRs
 frontend_all: &frontend_all
   - *sentry_frontend_workflow_file

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,6 +29,7 @@ jobs:
       typecheckable_rules_changed: ${{ steps.changes.outputs.typecheckable_rules_changed }}
       mdx_typecheckable: ${{ steps.changes.outputs.mdx_typecheckable }}
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
+      frontend_all_files: ${{ steps.changes.outputs.frontend_all_files }}
       merge_base: ${{ steps.merge_base.outputs.merge_base }}
       merge_base_strategy: ${{ steps.merge_base.outputs.merge_base_strategy }}
     steps:
@@ -126,9 +127,15 @@ jobs:
           echo "::remove-matcher owner=masters::"
           echo "::add-matcher::.github/eslint-stylish.json"
 
-      - name: eslint
+      - name: eslint (all)
+        if: github.event_name != 'pull_request'
         id: eslint
         run: pnpm run lint:js
+
+      - name: eslint (changed)
+        if: github.event_name == 'pull_request'
+        id: eslint-changed
+        run: pnpm run lint:js ${{ needs.files-changed.outputs.frontend_all_files }}
 
   knip:
     if: needs.files-changed.outputs.frontend_all == 'true'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -28,6 +28,9 @@ jobs:
       testable_rules_changed: ${{ steps.changes.outputs.testable_rules_changed }}
       typecheckable_rules_changed: ${{ steps.changes.outputs.typecheckable_rules_changed }}
       mdx_typecheckable: ${{ steps.changes.outputs.mdx_typecheckable }}
+      lintable_modified: ${{ steps.changes.outputs.lintable_modified }}
+      lintable_modified_files: ${{ steps.changes.outputs.lintable_modified_files }}
+      lintable_rules_changed: ${{ steps.changes.outputs.lintable_rules_changed }}
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
       frontend_all_files: ${{ steps.changes.outputs.frontend_all_files }}
       merge_base: ${{ steps.merge_base.outputs.merge_base }}
@@ -127,15 +130,14 @@ jobs:
           echo "::remove-matcher owner=masters::"
           echo "::add-matcher::.github/eslint-stylish.json"
 
-      - name: eslint (all)
-        if: github.event_name != 'pull_request'
+      - name: eslint
         id: eslint
-        run: pnpm run lint:js
-
-      - name: eslint (changed)
-        if: github.event_name == 'pull_request'
-        id: eslint-changed
-        run: pnpm run lint:js ${{ needs.files-changed.outputs.frontend_all_files }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" && "${{ needs.files-changed.outputs.lintable_rules_changed }}" == "false" ]; then
+            pnpm run lint:js ${{ needs.files-changed.outputs.lintable_modified_files }}
+          else
+            pnpm run lint:js
+          fi
 
   knip:
     if: needs.files-changed.outputs.frontend_all == 'true'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -132,9 +132,12 @@ jobs:
 
       - name: eslint
         id: eslint
+        env:
+          LINTABLE_RULES_CHANGED: ${{ needs.files-changed.outputs.lintable_rules_changed }}
+          LINTABLE_MODIFIED_FILES: ${{ needs.files-changed.outputs.lintable_modified_files }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" == "pull_request" && "${{ needs.files-changed.outputs.lintable_rules_changed }}" == "false" ]; then
-            pnpm run lint:js ${{ needs.files-changed.outputs.lintable_modified_files }}
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$LINTABLE_RULES_CHANGED" == "false" ]]; then
+            pnpm run lint:js $LINTABLE_MODIFIED_FILES
           else
             pnpm run lint:js
           fi


### PR DESCRIPTION
During a PR CI run, only run ESLint against the files that were changed. 
The step will, as before, only run if some `frontend_all` files were detected in the PR. It'll pass all those filenames to eslint to work on.
The matcher for those files is: https://github.com/getsentry/sentry/blob/master/.github/file-filters.yml#L43-L48

---

The CI run for this PR proves that it works well:

```
Run pnpm run lint:js .github/workflows/frontend.yml

> sentry@0.0.0 lint:js /home/runner/work/sentry/sentry
> eslint --concurrency=3 .github/workflows/frontend.yml


/home/runner/work/sentry/sentry/.github/workflows/frontend.yml
  0:0  warning  File ignored because of a matching ignore pattern. Use "--no-ignore" to disable file ignore settings or use "--no-warn-ignored" to suppress this warning

✖ 1 problem (0 errors, 1 warning)
```

ESLint got the list of files (just the one file) and tried to run. Nothing to do this time because it's a *.yml, we're happy the triggers and file list are being passed along correctly.