### PR TITLE
ci: Replace custom JEST_TEST_BALANCER env var with --testResultsProcessor

### DIFF
--- a/.github/workflows/jest-balance.yml
+++ b/.github/workflows/jest-balance.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_PR_REF: ${{ github.event.pull_request.head.ref || github.ref }}
-        run: JEST_TEST_BALANCER=1 pnpm run test-ci
+        run: pnpm run test-ci --testResultsProcessor ./tests/js/test-balancer/index.js
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -32,7 +32,6 @@ const swcConfig: SwcOptions = {
 
 const {
   CI,
-  JEST_TEST_BALANCER,
   CI_NODE_TOTAL,
   CI_NODE_INDEX,
   GITHUB_PR_SHA,
@@ -55,12 +54,6 @@ const optionalTags: {
   merge_base: MERGE_BASE || '',
   merge_base_strategy: MERGE_BASE_STRATEGY || 'full',
 };
-
-if (!!JEST_TEST_BALANCER && !CI) {
-  throw new Error(
-    '[Operation only allowed in CI]: Jest test balancer should never be ran manually as you risk skewing the numbers - please trigger the automated github workflow at https://github.com/getsentry/sentry/actions/workflows/jest-balance.yml'
-  );
-}
 
 let JEST_TESTS: string[] | undefined;
 
@@ -342,9 +335,6 @@ const config: Config.InitialOptions = {
   moduleFileExtensions: ['js', 'ts', 'jsx', 'tsx', 'pegjs'],
   globals: {},
 
-  testResultsProcessor: JEST_TEST_BALANCER
-    ? '<rootDir>/tests/js/test-balancer/index.js'
-    : undefined,
   reporters: ['default'],
   /**
    * jest.clearAllMocks() automatically called before each test


### PR DESCRIPTION
It seemed like the env-var was really only used to restrict this command `pnpm run test-ci` from being run locally with `tests/js/test-balancer/index.js` involved.

Before `jest-balance.json` was committed to the repo, so preventing people from updating and committing it by accident was a good idea.
But, we don't need that anymore because we run the balancer in CI and the output is automatically captured and stashed in a github artifact for other CI runs to use. So it's actually a benefit to run things locally as we can test that the output `jest-balance.json` contains reasonable data inside.

