### PR TITLE
ci: Make jest matrix config dynamic for PR runs

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -84,7 +84,7 @@ jobs:
           fi
 
           INDEX_ARRAY=$(seq 0 $(( RUNNERS - 1 )) | jq -s .)
-          echo "jest_test_matrix=$(jq -nc --argjson index "$INDEX_ARRAY" --argjson total "$RUNNERS" '{index: $index, total: $total}')" >> $GITHUB_OUTPUT
+          echo "jest_test_matrix=$(jq -nc --argjson index "$INDEX_ARRAY" --argjson total "$RUNNERS" '{index: $index, total: [$total]}')" >> $GITHUB_OUTPUT
 
   typescript:
     if: needs.files-changed.outputs.frontend_all == 'true'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -83,9 +83,8 @@ jobs:
             RUNNERS=1
           fi
 
-          JSON_ARRAY=$(seq 0 $(( RUNNERS - 1 )) | jq -R . | jq -s .)
-          # Output the full matrix object
-          echo "jest_test_matrix=$(jq -nc --argjson indices "$JSON_ARRAY" --argjson total "$RUNNERS" '{instance: {index: $indices, total: $total}}')" >> $GITHUB_OUTPUT
+          INDEX_ARRAY=$(seq 0 $(( RUNNERS - 1 )) | jq -s .)
+          echo "jest_test_matrix=$(jq -nc --argjson index "$INDEX_ARRAY" --argjson total "$RUNNERS" '{index: $index, total: $total}')" >> $GITHUB_OUTPUT
 
   typescript:
     if: needs.files-changed.outputs.frontend_all == 'true'
@@ -208,7 +207,7 @@ jobs:
           path: |
             .cache/jest
             ~/.cache/swc
-          key: jest-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'jest.config.ts') }}-${{ matrix.instance.index }}
+          key: jest-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'jest.config.ts') }}-${{ matrix.index }}
           restore-keys: |
             jest-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'jest.config.ts') }}-
             jest-cache-${{ runner.os }}-
@@ -228,8 +227,8 @@ jobs:
 
       - name: jest
         env:
-          CI_NODE_TOTAL: ${{ matrix.instance.total }}
-          CI_NODE_INDEX: ${{ matrix.instance.index }}
+          CI_NODE_TOTAL: ${{ matrix.total }}
+          CI_NODE_INDEX: ${{ matrix.index }}
 
           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_PR_REF: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -75,9 +75,6 @@ jobs:
           echo "merge_base=${MERGE_BASE:-}" >> "$GITHUB_OUTPUT"
           echo "merge_base_strategy=${STRATEGY}" >> "$GITHUB_OUTPUT"
 
-      - name: Calculate Test Matrix
-        id: calc-test-matrix
-        run: |
           RUNNERS=8
           if [ "$STRATEGY" == "changedSince" ]; then
             RUNNERS=1
@@ -85,7 +82,7 @@ jobs:
           # Create a JSON array for indices [1, 2, ... RUNNERS]
           JSON_ARRAY=$(seq 1 $RUNNERS | jq -R . | jq -s .)
           # Output the full matrix object
-          echo "jest_test_matrix=$(jq -n --argjson indices "$JSON_ARRAY" '{index: $indices, total: [$RUNNERS]}')" >> $GITHUB_OUTPUT
+          echo "jest_test_matrix=$(jq -n --argjson indices "$JSON_ARRAY" --argjson total "$RUNNERS" '{index: $indices, total: $total}')" >> $GITHUB_OUTPUT
 
   typescript:
     if: needs.files-changed.outputs.frontend_all == 'true'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -85,7 +85,7 @@ jobs:
 
           JSON_ARRAY=$(seq 0 $(( RUNNERS - 1 )) | jq -R . | jq -s .)
           # Output the full matrix object
-          echo "jest_test_matrix=$(jq -nc --argjson indices "$JSON_ARRAY" --argjson total "$RUNNERS" '{index: $indices, total: $total}')" >> $GITHUB_OUTPUT
+          echo "jest_test_matrix=$(jq -nc --argjson indices "$JSON_ARRAY" --argjson total "$RUNNERS" '{instance: {index: $indices, total: $total}}')" >> $GITHUB_OUTPUT
 
   typescript:
     if: needs.files-changed.outputs.frontend_all == 'true'
@@ -191,8 +191,7 @@ jobs:
       # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
       fail-fast: false
-      matrix:
-        instance: ${{ fromJson(needs.files-changed.outputs.jest_test_matrix) }}
+      matrix: ${{ fromJson(needs.files-changed.outputs.jest_test_matrix) }}
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -35,6 +35,7 @@ jobs:
       frontend_all_files: ${{ steps.changes.outputs.frontend_all_files }}
       merge_base: ${{ steps.merge_base.outputs.merge_base }}
       merge_base_strategy: ${{ steps.merge_base.outputs.merge_base_strategy }}
+      jest_test_matrix: ${{ steps.calc-test-matrix.outputs.jest_test_matrix }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -73,6 +74,18 @@ jobs:
           fi
           echo "merge_base=${MERGE_BASE:-}" >> "$GITHUB_OUTPUT"
           echo "merge_base_strategy=${STRATEGY}" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate Test Matrix
+        id: calc-test-matrix
+        run: |
+          RUNNERS=8
+          if [ "$STRATEGY" == "changedSince" ]; then
+            RUNNERS=1
+          fi
+          # Create a JSON array for indices [1, 2, ... RUNNERS]
+          JSON_ARRAY=$(seq 1 $RUNNERS | jq -R . | jq -s .)
+          # Output the full matrix object
+          echo "jest_test_matrix=$(jq -n --argjson indices "$JSON_ARRAY" '{index: $indices, total: [$RUNNERS]}')" >> $GITHUB_OUTPUT
 
   typescript:
     if: needs.files-changed.outputs.frontend_all == 'true'
@@ -179,9 +192,7 @@ jobs:
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
       fail-fast: false
       matrix:
-        # XXX: When updating this, make sure you also update CI_NODE_TOTAL.
-
-        instance: [0, 1, 2, 3, 4, 5, 6, 7]
+        instance: ${{ fromJson(needs.files-changed.outputs.jest_test_matrix) }}
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -198,7 +209,7 @@ jobs:
           path: |
             .cache/jest
             ~/.cache/swc
-          key: jest-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'jest.config.ts') }}-${{ matrix.instance }}
+          key: jest-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'jest.config.ts') }}-${{ matrix.instance.index }}
           restore-keys: |
             jest-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'jest.config.ts') }}-
             jest-cache-${{ runner.os }}-
@@ -218,13 +229,12 @@ jobs:
 
       - name: jest
         env:
+          CI_NODE_TOTAL: ${{ matrix.instance.total }}
+          CI_NODE_INDEX: ${{ matrix.instance.index }}
+
           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_PR_REF: ${{ github.event.pull_request.head.ref || github.ref }}
-          # XXX: CI_NODE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
-          #      Otherwise, if there are other things in the matrix, using strategy.job-total
-          #      wouldn't be correct.
-          CI_NODE_TOTAL: 8
-          CI_NODE_INDEX: ${{ matrix.instance }}
+
           # Disable testing-library from printing out any of of the DOM to
           # stdout. No one actually looks through this in CI, they're just
           # going to run it locally.

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -35,7 +35,7 @@ jobs:
       frontend_all_files: ${{ steps.changes.outputs.frontend_all_files }}
       merge_base: ${{ steps.merge_base.outputs.merge_base }}
       merge_base_strategy: ${{ steps.merge_base.outputs.merge_base_strategy }}
-      jest_test_matrix: ${{ steps.merge_base.outputs.jest_test_matrix }}
+      jest_test_matrix: ${{ steps.jest_matrix_config.outputs.jest_test_matrix }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -76,6 +76,7 @@ jobs:
           echo "merge_base_strategy=${STRATEGY}" >> "$GITHUB_OUTPUT"
 
       - name: Jest Matrix Config
+        id: jest_matrix_config
         run: |
           RUNNERS=8
           if [ "${{ steps.merge_base.outputs.merge_base_strategy }}" == "changedSince" ]; then

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -75,12 +75,12 @@ jobs:
           echo "merge_base=${MERGE_BASE:-}" >> "$GITHUB_OUTPUT"
           echo "merge_base_strategy=${STRATEGY}" >> "$GITHUB_OUTPUT"
 
-          RUNNERS=7
+          RUNNERS=8
           if [ "$STRATEGY" == "changedSince" ]; then
-            RUNNERS=0
+            RUNNERS=1
           fi
-          # Create a JSON array for indices [0, 1, ... RUNNERS]
-          JSON_ARRAY=$(seq 0 $RUNNERS | jq -R . | jq -s .)
+          # Create a JSON array for indices [0, 1, ... RUNNERS-1]
+          JSON_ARRAY=$(seq 0 $(( RUNNERS - 1 )) | jq -R . | jq -s .)
           # Output the full matrix object
           echo "jest_test_matrix=$(jq -n --argjson indices "$JSON_ARRAY" --argjson total "$RUNNERS" '{index: $indices, total: $total}')" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -82,7 +82,7 @@ jobs:
           # Create a JSON array for indices [0, 1, ... RUNNERS-1]
           JSON_ARRAY=$(seq 0 $(( RUNNERS - 1 )) | jq -R . | jq -s .)
           # Output the full matrix object
-          echo "jest_test_matrix=$(jq -n --argjson indices "$JSON_ARRAY" --argjson total "$RUNNERS" '{index: $indices, total: $total}')" >> $GITHUB_OUTPUT
+          echo "jest_test_matrix=$(jq -nc --argjson indices "$JSON_ARRAY" --argjson total "$RUNNERS" '{index: $indices, total: $total}')" >> $GITHUB_OUTPUT
 
   typescript:
     if: needs.files-changed.outputs.frontend_all == 'true'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -35,7 +35,7 @@ jobs:
       frontend_all_files: ${{ steps.changes.outputs.frontend_all_files }}
       merge_base: ${{ steps.merge_base.outputs.merge_base }}
       merge_base_strategy: ${{ steps.merge_base.outputs.merge_base_strategy }}
-      jest_test_matrix: ${{ steps.calc-test-matrix.outputs.jest_test_matrix }}
+      jest_test_matrix: ${{ steps.merge_base.outputs.jest_test_matrix }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -75,11 +75,13 @@ jobs:
           echo "merge_base=${MERGE_BASE:-}" >> "$GITHUB_OUTPUT"
           echo "merge_base_strategy=${STRATEGY}" >> "$GITHUB_OUTPUT"
 
+      - name: Jest Matrix Config
+        run: |
           RUNNERS=8
-          if [ "$STRATEGY" == "changedSince" ]; then
+          if [ "${{ steps.merge_base.outputs.merge_base_strategy }}" == "changedSince" ]; then
             RUNNERS=1
           fi
-          # Create a JSON array for indices [0, 1, ... RUNNERS-1]
+
           JSON_ARRAY=$(seq 0 $(( RUNNERS - 1 )) | jq -R . | jq -s .)
           # Output the full matrix object
           echo "jest_test_matrix=$(jq -nc --argjson indices "$JSON_ARRAY" --argjson total "$RUNNERS" '{index: $indices, total: $total}')" >> $GITHUB_OUTPUT

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -75,12 +75,12 @@ jobs:
           echo "merge_base=${MERGE_BASE:-}" >> "$GITHUB_OUTPUT"
           echo "merge_base_strategy=${STRATEGY}" >> "$GITHUB_OUTPUT"
 
-          RUNNERS=8
+          RUNNERS=7
           if [ "$STRATEGY" == "changedSince" ]; then
-            RUNNERS=1
+            RUNNERS=0
           fi
-          # Create a JSON array for indices [1, 2, ... RUNNERS]
-          JSON_ARRAY=$(seq 1 $RUNNERS | jq -R . | jq -s .)
+          # Create a JSON array for indices [0, 1, ... RUNNERS]
+          JSON_ARRAY=$(seq 0 $RUNNERS | jq -R . | jq -s .)
           # Output the full matrix object
           echo "jest_test_matrix=$(jq -n --argjson indices "$JSON_ARRAY" --argjson total "$RUNNERS" '{index: $indices, total: $total}')" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Make the matrix config for jest dynamic: only when it's using the `changedSince` strategy, which only happens with a PR

This helps fix the problem where we have 8 runners being used when we actually intended to only run tests related to the changes at hand.

It doesn't fully improve the PR run though: there are more internal conditions like `JEST_TESTS` and `JEST_LIST_TESTS_INNER` which could load up a long list of tests, or the same list of tests in each matrix instance. What this does though it simplify the runtime env, so we're just running everything on one worker node. 
We could endup with slower test runs for PRs that codemod/change a lot of files at once, but this is something we can overcome in a followup if we move the call to `jest --listTests` from inside jest.config.ts, to frontend.yml instead.