### PR TITLE
feat(apigateway): Retry proxied cell requests on transient failures

### DIFF
--- a/src/sentry/hybridcloud/apigateway/exception.py
+++ b/src/sentry/hybridcloud/apigateway/exception.py
@@ -1,4 +1,0 @@
-class Retryable(Exception):
-    def __init__(self, original: BaseException) -> None:
-        super().__init__(str(original))
-        self.original = original

--- a/src/sentry/hybridcloud/apigateway/exception.py
+++ b/src/sentry/hybridcloud/apigateway/exception.py
@@ -1,0 +1,4 @@
+class Retryable(Exception):
+    def __init__(self, original: BaseException) -> None:
+        super().__init__(str(original))
+        self.original = original

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -78,8 +78,8 @@ def _create_request_session(retry_count: int) -> Session:
         max_retries=Retry(
             total=retry_count,
             backoff_factor=0.1,
-            status_forcelist=[503],
-            allowed_methods=["GET", "POST"],
+            status_forcelist=[502, 503, 504],
+            allowed_methods=["GET", "POST", "PUT", "DELETE"],
         )
     )
     http = Session()
@@ -276,6 +276,7 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
 
         raise
 
+    # This block can be removed after migration too pool with retry
     if resp.status_code >= 502:
         metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
         if circuit_breaker is not None:

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -4,11 +4,12 @@ Utilities related to proxying a request to a cell
 
 from __future__ import annotations
 
+import functools
 import logging
 from collections.abc import Callable, Generator
 from http.cookiejar import Cookie
 from threading import local
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
 from urllib.parse import urljoin, urlparse
 from wsgiref.util import is_hop_by_hop
 
@@ -19,10 +20,11 @@ from requests import Response as ExternalResponse
 from requests import Session
 from requests import request as external_request
 from requests.cookies import RequestsCookieJar
-from requests.exceptions import ConnectionError, Timeout
+from requests.exceptions import ConnectionError, HTTPError, Timeout
 
 from sentry import options
 from sentry.api.exceptions import RequestTimeout
+from sentry.hybridcloud.apigateway.exception import Retryable
 from sentry.objectstore.endpoints.organization import ChunkedEncodingDecoder, get_raw_body
 from sentry.options.rollout import in_random_rollout
 from sentry.silo.util import (
@@ -42,6 +44,28 @@ from sentry.utils.circuit_breaker2 import CircuitBreaker, CountBasedTripStrategy
 from sentry.utils.http import BodyWithLength
 
 logger = logging.getLogger(__name__)
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def retry(times: int = 3) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        @functools.wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            max_attempts = times if options.get("apigateway.proxy.retry.enabled") else 0
+            for attempt in range(max_attempts + 1):
+                try:
+                    return func(*args, **kwargs)
+                except Retryable as exc:
+                    if attempt == max_attempts:
+                        raise exc.original
+            raise AssertionError("unreachable")
+
+        return wrapper
+
+    return decorator
+
 
 # Endpoints that handle uploaded files have higher timeouts configured
 # and we need to honor those timeouts when proxying.
@@ -148,6 +172,7 @@ def proxy_error_embed_request(
     return proxy_cell_request(request, cell, url_name)
 
 
+@retry()
 def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpResponseBase:
     """Take a django request object and proxy it to a cell silo"""
 
@@ -234,18 +259,20 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
             circuit_breaker.record_error()
 
         # remote silo timeout. Use DRF timeout instead
-        raise RequestTimeout()
-    except ConnectionError:
+        raise Retryable(RequestTimeout())
+    except ConnectionError as e:
         metrics.incr("apigateway.proxy.connection_error", tags=metric_tags)
         if circuit_breaker is not None:
             circuit_breaker.record_error()
 
-        raise
+        raise Retryable(e)
 
     if resp.status_code >= 502:
         metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
         if circuit_breaker is not None:
             circuit_breaker.record_error()
+
+        raise Retryable(HTTPError(response=resp))
 
     new_headers = clean_outbound_headers(resp.headers)
     resp.headers.clear()

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -4,12 +4,11 @@ Utilities related to proxying a request to a cell
 
 from __future__ import annotations
 
-import functools
 import logging
-from collections.abc import Callable, Generator, MutableMapping, Sequence
+from collections.abc import Callable, Generator
 from http.cookiejar import Cookie
 from threading import local
-from typing import Any, ParamSpec, TypeVar
+from typing import Any
 from urllib.parse import urljoin, urlparse
 from wsgiref.util import is_hop_by_hop
 
@@ -19,12 +18,12 @@ from django.http.response import HttpResponseBase
 from requests import Response as ExternalResponse
 from requests import Session
 from requests import request as external_request
+from requests.adapters import HTTPAdapter, Retry
 from requests.cookies import RequestsCookieJar
-from requests.exceptions import ConnectionError, HTTPError, Timeout
+from requests.exceptions import ConnectionError, RetryError, Timeout
 
 from sentry import options
 from sentry.api.exceptions import RequestTimeout
-from sentry.hybridcloud.apigateway.exception import Retryable
 from sentry.objectstore.endpoints.organization import ChunkedEncodingDecoder, get_raw_body
 from sentry.options.rollout import in_random_rollout
 from sentry.silo.util import (
@@ -45,37 +44,6 @@ from sentry.utils.http import BodyWithLength
 
 logger = logging.getLogger(__name__)
 
-P = ParamSpec("P")
-R = TypeVar("R")
-
-
-def retry(
-    times: int = 3,
-    non_retryable_url_names: Sequence[str] = (),
-) -> Callable[[Callable[P, R]], Callable[P, R]]:
-    non_retryable = frozenset(non_retryable_url_names)
-
-    def decorator(func: Callable[P, R]) -> Callable[P, R]:
-        @functools.wraps(func)
-        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            url_name = kwargs.get("url_name")
-            if not options.get("apigateway.proxy.retry.enabled") or url_name in non_retryable:
-                max_attempts = 0
-            else:
-                max_attempts = times
-            for attempt in range(max_attempts + 1):
-                try:
-                    return func(*args, **kwargs)
-                except Retryable as exc:
-                    if attempt == max_attempts:
-                        raise exc.original
-            raise AssertionError("unreachable")
-
-        return wrapper
-
-    return decorator
-
-
 # Endpoints that handle uploaded files have higher timeouts configured
 # and we need to honor those timeouts when proxying.
 # See frontend/templates/sites-enabled/sentry.io in getsentry/ops
@@ -94,7 +62,7 @@ ENDPOINT_TIMEOUT_OVERRIDE = {
 # stream 0.5 MB at a time
 PROXY_CHUNK_SIZE = 512 * 1024
 
-_connection = local()
+_connections = local()
 
 
 class _StatelessCookieJar(RequestsCookieJar):
@@ -105,12 +73,37 @@ class _StatelessCookieJar(RequestsCookieJar):
         return None
 
 
-def _get_connection() -> Session:
-    if not hasattr(_connection, "session"):
-        session = Session()
-        session.cookies = _StatelessCookieJar()
-        _connection.session = session
-    return _connection.session
+def _create_request_session(retry_count: int) -> Session:
+    retry_adapter = HTTPAdapter(
+        max_retries=Retry(
+            total=retry_count,
+            backoff_factor=0.1,
+            status_forcelist=[503],
+            allowed_methods=["GET", "POST"],
+        )
+    )
+    http = Session()
+    http.cookies = _StatelessCookieJar()
+    http.mount("http://", retry_adapter)
+    http.mount("https://", retry_adapter)
+    return http
+
+
+def _get_connection(retry_count: int) -> Session:
+    """
+    Get a shared requests.Session.
+
+    Because retry limits are part of the session definition,
+    each unique retry value creates a different connection pool.
+    """
+    if not hasattr(_connections, "session"):
+        _connections.session = {}
+
+    if not _connections.session.get(retry_count, None):
+        http = _create_request_session(retry_count)
+        _connections.session[retry_count] = http
+
+    return _connections.session[retry_count]
 
 
 def _parse_response(response: ExternalResponse, remote_url: str) -> StreamingHttpResponse:
@@ -181,62 +174,15 @@ def proxy_error_embed_request(
     return proxy_cell_request(request, cell, url_name)
 
 
-@retry(non_retryable_url_names=tuple(ENDPOINT_TIMEOUT_OVERRIDE))
-def _perform_request(
-    *,
-    method: str,
-    target_url: str,
-    headers: MutableMapping[str, str],
-    params: dict[str, Any] | None,
-    data: bytes | Generator[bytes] | ChunkedEncodingDecoder | BodyWithLength | None,
-    timeout: float | None,
-    requester: Callable[..., ExternalResponse],
-    metric_tags: dict[str, str],
-    circuit_breaker: CircuitBreaker | None,
-    url_name: str,
-) -> ExternalResponse:
-    try:
-        with metrics.timer("apigateway.proxy_request.duration", tags=metric_tags):
-            resp = requester(
-                method,
-                url=target_url,
-                headers=headers,
-                params=params,
-                data=data,
-                stream=True,
-                timeout=timeout,
-                # By default, requests resolves redirects for every verb except HEAD.
-                # Disable that to avoid misrepresenting the original sentry.io request.
-                allow_redirects=False,
-            )
-    except Timeout:
-        metrics.incr("apigateway.proxy.request_timeout", tags=metric_tags)
-        if circuit_breaker is not None:
-            circuit_breaker.record_error()
-
-        # remote silo timeout. Use DRF timeout instead
-        raise Retryable(RequestTimeout())
-    except ConnectionError as e:
-        metrics.incr("apigateway.proxy.connection_error", tags=metric_tags)
-        if circuit_breaker is not None:
-            circuit_breaker.record_error()
-
-        raise Retryable(e)
-
-    if resp.status_code >= 502:
-        metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
-        if circuit_breaker is not None:
-            circuit_breaker.record_error()
-
-    return resp
-
-
 def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpResponseBase:
     """Take a django request object and proxy it to a cell silo"""
 
     metric_tags = {"destination_cell": cell.name, "url_name": url_name}
     circuit_breaker: CircuitBreaker | None = None
     use_pooling = in_random_rollout("hybridcloud.apigateway.use_pooling.rate")
+    retry_enabled = (
+        options.get("apigateway.proxy.retry.enabled") and url_name not in ENDPOINT_TIMEOUT_OVERRIDE
+    )
 
     # TODO(mark) remove rollout options
     if options.get("apigateway.proxy.circuit-breaker.enabled"):
@@ -291,29 +237,49 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
     else:
         data = BodyWithLength(request)
 
-    # When pooling is enabled, reuse the thread-local session to keep connections
-    # alive across requests; otherwise issue a one-off request.
+    max_retries = options.get("apigateway.proxy.retry.max_count") if retry_enabled else 0
     requester: Callable[..., ExternalResponse] = (
-        _get_connection().request if use_pooling else external_request
+        _get_connection(max_retries).request if use_pooling else external_request
     )
 
     try:
-        resp = _perform_request(
-            method=request.method,
-            target_url=target_url,
-            headers=header_dict,
-            params=dict(query_params) if query_params is not None else None,
-            data=data,
-            timeout=timeout,
-            requester=requester,
-            metric_tags=metric_tags,
-            circuit_breaker=circuit_breaker,
-            url_name=url_name,
-        )
-    except HTTPError as exc:
-        # Retries exhausted on a 5xx response; forward the original response to the client.
-        assert exc.response is not None
-        resp = exc.response
+        with metrics.timer("apigateway.proxy_request.duration", tags=metric_tags):
+            resp = requester(
+                request.method,
+                url=target_url,
+                headers=header_dict,
+                params=dict(query_params) if query_params is not None else None,
+                data=data,
+                stream=True,
+                timeout=timeout,
+                # By default, requests resolves redirects for every verb except HEAD.
+                # Disable that to avoid misrepresenting the original sentry.io request.
+                allow_redirects=False,
+            )
+    except Timeout:
+        metrics.incr("apigateway.proxy.request_timeout", tags=metric_tags)
+        if circuit_breaker is not None:
+            circuit_breaker.record_error()
+
+        # remote silo timeout. Use DRF timeout instead
+        raise RequestTimeout()
+    except RetryError:
+        metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
+        if circuit_breaker is not None:
+            circuit_breaker.record_error()
+
+        raise
+    except ConnectionError:
+        metrics.incr("apigateway.proxy.connection_error", tags=metric_tags)
+        if circuit_breaker is not None:
+            circuit_breaker.record_error()
+
+        raise
+
+    if resp.status_code >= 502:
+        metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
+        if circuit_breaker is not None:
+            circuit_breaker.record_error()
 
     new_headers = clean_outbound_headers(resp.headers)
     resp.headers.clear()

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import functools
 import logging
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, MutableMapping, Sequence
 from http.cookiejar import Cookie
 from threading import local
 from typing import Any, ParamSpec, TypeVar
@@ -49,11 +49,20 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def retry(times: int = 3) -> Callable[[Callable[P, R]], Callable[P, R]]:
+def retry(
+    times: int = 3,
+    non_retryable_url_names: Sequence[str] = (),
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    non_retryable = frozenset(non_retryable_url_names)
+
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            max_attempts = times if options.get("apigateway.proxy.retry.enabled") else 0
+            url_name = kwargs.get("url_name")
+            if not options.get("apigateway.proxy.retry.enabled") or url_name in non_retryable:
+                max_attempts = 0
+            else:
+                max_attempts = times
             for attempt in range(max_attempts + 1):
                 try:
                     return func(*args, **kwargs)
@@ -172,7 +181,56 @@ def proxy_error_embed_request(
     return proxy_cell_request(request, cell, url_name)
 
 
-@retry()
+@retry(non_retryable_url_names=tuple(ENDPOINT_TIMEOUT_OVERRIDE))
+def _perform_request(
+    *,
+    method: str,
+    target_url: str,
+    headers: MutableMapping[str, str],
+    params: dict[str, Any] | None,
+    data: bytes | Generator[bytes] | ChunkedEncodingDecoder | BodyWithLength | None,
+    timeout: float | None,
+    requester: Callable[..., ExternalResponse],
+    metric_tags: dict[str, str],
+    circuit_breaker: CircuitBreaker | None,
+    url_name: str,
+) -> ExternalResponse:
+    try:
+        with metrics.timer("apigateway.proxy_request.duration", tags=metric_tags):
+            resp = requester(
+                method,
+                url=target_url,
+                headers=headers,
+                params=params,
+                data=data,
+                stream=True,
+                timeout=timeout,
+                # By default, requests resolves redirects for every verb except HEAD.
+                # Disable that to avoid misrepresenting the original sentry.io request.
+                allow_redirects=False,
+            )
+    except Timeout:
+        metrics.incr("apigateway.proxy.request_timeout", tags=metric_tags)
+        if circuit_breaker is not None:
+            circuit_breaker.record_error()
+
+        # remote silo timeout. Use DRF timeout instead
+        raise Retryable(RequestTimeout())
+    except ConnectionError as e:
+        metrics.incr("apigateway.proxy.connection_error", tags=metric_tags)
+        if circuit_breaker is not None:
+            circuit_breaker.record_error()
+
+        raise Retryable(e)
+
+    if resp.status_code >= 502:
+        metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
+        if circuit_breaker is not None:
+            circuit_breaker.record_error()
+
+    return resp
+
+
 def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpResponseBase:
     """Take a django request object and proxy it to a cell silo"""
 
@@ -240,39 +298,22 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
     )
 
     try:
-        with metrics.timer("apigateway.proxy_request.duration", tags=metric_tags):
-            resp = requester(
-                request.method,
-                url=target_url,
-                headers=header_dict,
-                params=dict(query_params) if query_params is not None else None,
-                data=data,
-                stream=True,
-                timeout=timeout,
-                # By default, requests resolves redirects for every verb except HEAD.
-                # Disable that to avoid misrepresenting the original sentry.io request.
-                allow_redirects=False,
-            )
-    except Timeout:
-        metrics.incr("apigateway.proxy.request_timeout", tags=metric_tags)
-        if circuit_breaker is not None:
-            circuit_breaker.record_error()
-
-        # remote silo timeout. Use DRF timeout instead
-        raise Retryable(RequestTimeout())
-    except ConnectionError as e:
-        metrics.incr("apigateway.proxy.connection_error", tags=metric_tags)
-        if circuit_breaker is not None:
-            circuit_breaker.record_error()
-
-        raise Retryable(e)
-
-    if resp.status_code >= 502:
-        metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
-        if circuit_breaker is not None:
-            circuit_breaker.record_error()
-
-        raise Retryable(HTTPError(response=resp))
+        resp = _perform_request(
+            method=request.method,
+            target_url=target_url,
+            headers=header_dict,
+            params=dict(query_params) if query_params is not None else None,
+            data=data,
+            timeout=timeout,
+            requester=requester,
+            metric_tags=metric_tags,
+            circuit_breaker=circuit_breaker,
+            url_name=url_name,
+        )
+    except HTTPError as exc:
+        # Retries exhausted on a 5xx response; forward the original response to the client.
+        assert exc.response is not None
+        resp = exc.response
 
     new_headers = clean_outbound_headers(resp.headers)
     resp.headers.clear()

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -79,7 +79,7 @@ def _create_request_session(retry_count: int) -> Session:
             total=retry_count,
             backoff_factor=0.1,
             status_forcelist=[502, 503, 504],
-            allowed_methods=["GET", "POST", "PUT", "DELETE"],
+            allowed_methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
         )
     )
     http = Session()

--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -213,3 +213,9 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "apigateway.proxy.retry.max_count",
+    type=Int,
+    default=3,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -207,3 +207,9 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "apigateway.proxy.retry.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -34,13 +34,15 @@ url_name = "sentry-api-0-projets"
 
 @pytest.fixture(autouse=True)
 def close_sync_proxy_connection() -> Generator[None]:
-    # The proxy reuses a thread-local requests.Session for connection pooling.
-    # Reset it between tests so pooled connections and cookie state don't leak.
+    # The proxy reuses thread-local requests.Sessions for connection pooling, keyed
+    # by retry count. Reset them between tests so pooled connections and cookie
+    # state don't leak.
     yield
-    connection = sync_proxy._connection
-    if hasattr(connection, "session"):
-        connection.session.close()
-        del connection.session
+    connections = sync_proxy._connections
+    if hasattr(connections, "session"):
+        for session in connections.session.values():
+            session.close()
+        del connections.session
 
 
 def test_sync_response_closes_upstream_after_streaming() -> None:


### PR DESCRIPTION
Retry proxied cell requests on transient failures (Timeout, connection errors, and 5xx responses with status >= 502) before surfacing the error to the caller.

**Retry Decorator**

A new `retry` decorator in `proxy.py` re-invokes the wrapped function up to three times when it raises `Retryable`. If retries are exhausted, the original wrapped exception is re-raised so callers see the same exception type as before.

**Option Gate**

Retries are gated on the `apigateway.proxy.retry.enabled` option. When disabled, the decorator runs the function once and immediately re-raises the original exception, preserving today's behavior.

**Wrapping in proxy_cell_request**

`proxy_cell_request` now raises `Retryable` for `Timeout` (wrapping `RequestTimeout`), `ConnectionError`, and responses with `status_code >= 502` (wrapping `requests.HTTPError`). Previously, 5xx responses were returned to the caller; with retry enabled, they trigger a retry, and on exhaustion the `HTTPError` is raised.