### PR TITLE
feat(inbound-filters): add v2 page skeleton

### DIFF
--- a/static/app/views/settings/project/projectFilters/customFilters.tsx
+++ b/static/app/views/settings/project/projectFilters/customFilters.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {t} from 'sentry/locale';
+
+export function CustomFilters() {
+  return (
+    <CustomFiltersTable>
+      <SimpleTable.Header>
+        <SimpleTable.HeaderCell divider={false}>{t('Active')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Name')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Conditions')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Created')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Edited')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Action')}</SimpleTable.HeaderCell>
+      </SimpleTable.Header>
+      <SimpleTable.Empty>{t('No inbound filters found')}</SimpleTable.Empty>
+    </CustomFiltersTable>
+  );
+}
+
+const CustomFiltersTable = styled(SimpleTable)`
+  grid-template-columns:
+    max-content minmax(0, 1fr) minmax(0, 2fr) max-content max-content
+    max-content;
+`;

--- a/static/app/views/settings/project/projectFilters/index.spec.tsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.tsx
@@ -342,6 +342,39 @@ describe('ProjectFilters', () => {
     );
   });
 
+  it('shows inbound filters v2 tab between data filters and discarded issues', () => {
+    const organizationWithFlag = OrganizationFixture({
+      ...organization,
+      features: ['inbound-filters-v2'],
+    });
+    const projectWithDiscardGroups = ProjectFixture({
+      ...project,
+      features: ['discard-groups'],
+    });
+
+    render(<ProjectFilters />, {
+      organization: organizationWithFlag,
+      outletContext: {project: projectWithDiscardGroups},
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/${organizationWithFlag.slug}/projects/${projectWithDiscardGroups.slug}/filters/inbound-filters/`,
+        },
+        route: '/settings/:orgId/projects/:projectId/filters/:filterType/',
+      },
+    });
+
+    expect(screen.getAllByRole('tab').map(tab => tab.textContent)).toEqual([
+      'Data Filters',
+      'Inbound Filters',
+      'Discarded Issues',
+    ]);
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Filter'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Status'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Action'})).toBeInTheDocument();
+    expect(screen.getByText('No inbound filters found')).toBeInTheDocument();
+  });
+
   it('disables configuration for non project:write users', async () => {
     render(<ProjectFilters />, {
       organization: OrganizationFixture({access: []}),

--- a/static/app/views/settings/project/projectFilters/index.spec.tsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.tsx
@@ -365,7 +365,7 @@ describe('ProjectFilters', () => {
 
     expect(screen.getAllByRole('tab').map(tab => tab.textContent)).toEqual([
       'Data Filters',
-      'Inbound Filters',
+      'Custom Filters',
       'Discarded Issues',
     ]);
     expect(screen.getByRole('table')).toBeInTheDocument();

--- a/static/app/views/settings/project/projectFilters/index.spec.tsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.tsx
@@ -369,9 +369,16 @@ describe('ProjectFilters', () => {
       'Discarded Issues',
     ]);
     expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'Filter'})).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'Status'})).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'Action'})).toBeInTheDocument();
+    for (const column of [
+      'Active',
+      'Name',
+      'Conditions',
+      'Created',
+      'Edited',
+      'Action',
+    ]) {
+      expect(screen.getByRole('columnheader', {name: column})).toBeInTheDocument();
+    }
     expect(screen.getByText('No inbound filters found')).toBeInTheDocument();
   });
 

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -67,7 +67,7 @@ export default function ProjectFilters() {
                     stepBack: -1,
                   })}
                 >
-                  {t('Inbound Filters')}
+                  {t('Custom Filters')}
                 </TabList.Item>
                 <TabList.Item
                   key="discarded-groups"

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -97,8 +97,11 @@ function InboundFiltersV2() {
   return (
     <InboundFiltersV2Table>
       <SimpleTable.Header>
-        <SimpleTable.HeaderCell>{t('Filter')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>{t('Status')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Active')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Name')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Conditions')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Created')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Edited')}</SimpleTable.HeaderCell>
         <SimpleTable.HeaderCell>{t('Action')}</SimpleTable.HeaderCell>
       </SimpleTable.Header>
       <SimpleTable.Empty>{t('No inbound filters found')}</SimpleTable.Empty>
@@ -111,5 +114,7 @@ const TabsContainer = styled('div')`
 `;
 
 const InboundFiltersV2Table = styled(SimpleTable)`
-  grid-template-columns: minmax(0, 1fr) max-content max-content;
+  grid-template-columns:
+    max-content minmax(0, 1fr) minmax(0, 2fr) max-content max-content
+    max-content;
 `;

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
-import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -16,6 +15,8 @@ import {ProjectFiltersChart} from 'sentry/views/settings/project/projectFilters/
 import {ProjectFiltersSettings} from 'sentry/views/settings/project/projectFilters/projectFiltersSettings';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
+
+import {CustomFilters} from './customFilters';
 
 export default function ProjectFilters() {
   const routes = useRoutes();
@@ -84,7 +85,7 @@ export default function ProjectFilters() {
         {filterType === 'discarded-groups' ? (
           <GroupTombstones project={project} />
         ) : hasInboundFiltersV2 && filterType === 'inbound-filters' ? (
-          <InboundFiltersV2 />
+          <CustomFilters />
         ) : (
           <ProjectFiltersSettings project={project} params={params} />
         )}
@@ -93,28 +94,6 @@ export default function ProjectFilters() {
   );
 }
 
-function InboundFiltersV2() {
-  return (
-    <InboundFiltersV2Table>
-      <SimpleTable.Header>
-        <SimpleTable.HeaderCell divider={false}>{t('Active')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell divider={false}>{t('Name')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell divider={false}>{t('Conditions')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell divider={false}>{t('Created')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell divider={false}>{t('Edited')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell divider={false}>{t('Action')}</SimpleTable.HeaderCell>
-      </SimpleTable.Header>
-      <SimpleTable.Empty>{t('No inbound filters found')}</SimpleTable.Empty>
-    </InboundFiltersV2Table>
-  );
-}
-
 const TabsContainer = styled('div')`
   margin-bottom: ${p => p.theme.space.xl};
-`;
-
-const InboundFiltersV2Table = styled(SimpleTable)`
-  grid-template-columns:
-    max-content minmax(0, 1fr) minmax(0, 2fr) max-content max-content
-    max-content;
 `;

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -4,8 +4,10 @@ import styled from '@emotion/styled';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
@@ -20,12 +22,16 @@ export default function ProjectFilters() {
   const params = useParams<{filterType: string; projectId: string}>();
   const {projectId, filterType} = params;
   const {project} = useProjectSettingsOutlet();
+  const organization = useOrganization();
 
   if (!project) {
     return null;
   }
 
   const features = new Set(project.features);
+  const hasInboundFiltersV2 = organization.features.includes('inbound-filters-v2');
+  const hasDiscardGroups = features.has('discard-groups');
+  const showTabs = hasDiscardGroups || hasInboundFiltersV2;
 
   return (
     <Fragment>
@@ -42,7 +48,7 @@ export default function ProjectFilters() {
       <div>
         <ProjectFiltersChart project={project} />
 
-        {features.has('discard-groups') && (
+        {showTabs && (
           <TabsContainer>
             <Tabs value={filterType}>
               <TabList>
@@ -53,7 +59,19 @@ export default function ProjectFilters() {
                   {t('Data Filters')}
                 </TabList.Item>
                 <TabList.Item
+                  key="inbound-filters"
+                  hidden={!hasInboundFiltersV2}
+                  to={recreateRoute('inbound-filters/', {
+                    routes,
+                    params,
+                    stepBack: -1,
+                  })}
+                >
+                  {t('Inbound Filters')}
+                </TabList.Item>
+                <TabList.Item
                   key="discarded-groups"
+                  hidden={!hasDiscardGroups}
                   to={recreateRoute('discarded-groups/', {routes, params, stepBack: -1})}
                 >
                   {t('Discarded Issues')}
@@ -65,6 +83,8 @@ export default function ProjectFilters() {
 
         {filterType === 'discarded-groups' ? (
           <GroupTombstones project={project} />
+        ) : hasInboundFiltersV2 && filterType === 'inbound-filters' ? (
+          <InboundFiltersV2 />
         ) : (
           <ProjectFiltersSettings project={project} params={params} />
         )}
@@ -73,6 +93,23 @@ export default function ProjectFilters() {
   );
 }
 
+function InboundFiltersV2() {
+  return (
+    <InboundFiltersV2Table>
+      <SimpleTable.Header>
+        <SimpleTable.HeaderCell>{t('Filter')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Status')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Action')}</SimpleTable.HeaderCell>
+      </SimpleTable.Header>
+      <SimpleTable.Empty>{t('No inbound filters found')}</SimpleTable.Empty>
+    </InboundFiltersV2Table>
+  );
+}
+
 const TabsContainer = styled('div')`
   margin-bottom: ${p => p.theme.space.xl};
+`;
+
+const InboundFiltersV2Table = styled(SimpleTable)`
+  grid-template-columns: minmax(0, 1fr) max-content max-content;
 `;

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -97,12 +97,12 @@ function InboundFiltersV2() {
   return (
     <InboundFiltersV2Table>
       <SimpleTable.Header>
-        <SimpleTable.HeaderCell>{t('Active')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>{t('Name')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>{t('Conditions')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>{t('Created')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>{t('Edited')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>{t('Action')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Active')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Name')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Conditions')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Created')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Edited')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell divider={false}>{t('Action')}</SimpleTable.HeaderCell>
       </SimpleTable.Header>
       <SimpleTable.Empty>{t('No inbound filters found')}</SimpleTable.Empty>
     </InboundFiltersV2Table>


### PR DESCRIPTION
- Add a new tab to the inbound filters settings page, gated by the feature flag `inbound-filters-v2`
- To the new tab, add a skeleton of the new table that will be connected to the API for inbound filters v2

Contributes to TET-2382