### PR TITLE
fix(dynamic-sampling): use full project totals for transaction balancing

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -22,9 +22,8 @@ from sentry.dynamic_sampling.models.transactions_rebalancing import (
     TransactionsRebalancingModel,
 )
 from sentry.dynamic_sampling.per_org.configuration import BaseDynamicSamplingConfiguration
-from sentry.dynamic_sampling.per_org.queries import ProjectVolume
+from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts, ProjectVolume
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
-from sentry.dynamic_sampling.tasks.boost_low_volume_transactions import ProjectTransactions
 from sentry.dynamic_sampling.tasks.common import sample_rate_to_float
 from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
     generate_boost_low_volume_projects_cache_key,
@@ -119,14 +118,19 @@ def compare_rebalanced_projects_with_cache(
 
 def run_transaction_balancing(
     config: BaseDynamicSamplingConfiguration,
-    transaction_volumes: list[ProjectTransactions],
+    project_volumes: list[ProjectVolume],
+    transaction_volumes: list[ProjectTransactionCounts],
 ) -> dict[int, tuple[list[RebalancedItem], float]]:
     intensity = options.get("dynamic-sampling.prioritise_transactions.rebalance_intensity")
     min_implicit_factor = config.min_implicit_factor
     sample_rates = config.get_project_sample_rates()
     result: dict[int, tuple[list[RebalancedItem], float]] = {}
+    project_volume_by_id = {
+        project_volume.project_id: project_volume for project_volume in project_volumes
+    }
     for project_data in transaction_volumes:
-        project_id = project_data["project_id"]
+        project_id = project_data.project_id
+        project_volume = project_volume_by_id[project_data.project_id]
         sample_rate = sample_rates.get(project_id)
         if sample_rate is None:
             sentry_sdk.capture_message(
@@ -138,11 +142,11 @@ def run_transaction_balancing(
             TransactionsRebalancingInput(
                 classes=[
                     RebalancedItem(id=transaction_name, count=count)
-                    for transaction_name, count in project_data["transaction_counts"]
+                    for transaction_name, count in project_data.transaction_counts
                 ],
                 sample_rate=sample_rate,
-                total_num_classes=project_data.get("total_num_classes"),
-                total=project_data.get("total_num_transactions"),
+                total_num_classes=project_volume.num_distinct_transactions,
+                total=project_volume.total,
                 intensity=intensity,
             )
         )
@@ -150,7 +154,7 @@ def run_transaction_balancing(
             named_rates=named_rates,
             implicit_rate=implicit_rate,
             base_sample_rate=sample_rate,
-            total=project_data.get("total_num_transactions"),
+            total=project_volume.total,
             min_implicit_factor=min_implicit_factor,
             intensity=intensity,
         )

--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -130,7 +130,13 @@ def run_transaction_balancing(
     }
     for project_data in transaction_volumes:
         project_id = project_data.project_id
-        project_volume = project_volume_by_id[project_data.project_id]
+        project_volume = project_volume_by_id.get(project_id)
+        if project_volume is None:
+            sentry_sdk.capture_message(
+                "Project volume not found when trying to adjust the sample rates of "
+                "its transactions"
+            )
+            continue
         sample_rate = sample_rates.get(project_id)
         if sample_rate is None:
             sentry_sdk.capture_message(

--- a/src/sentry/dynamic_sampling/per_org/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/queries.py
@@ -38,6 +38,7 @@ class DynamicSamplingQueryFields(StrEnum):
     DSC_TRANSACTION = "sentry.dsc.transaction"
     COUNT = "count()"
     COUNT_SAMPLE = "count_sample()"
+    COUNT_UNIQUE_TRANSACTIONS = "count_unique(sentry.dsc.transaction)"
 
 
 @dataclass(order=True)
@@ -46,6 +47,11 @@ class ProjectVolume:
     total: int
     keep: int
     drop: int
+    # Number of distinct transaction names seen in the project over the window.
+    # Counts the *whole* project, including names that fall outside the
+    # max_transactions limit of get_eap_transaction_volumes — required for the
+    # transaction rebalancing model to size the implicit (long-tail) bucket.
+    num_distinct_transactions: int = 0
 
 
 @dataclass
@@ -154,6 +160,7 @@ def get_eap_project_volumes(
                 DynamicSamplingQueryFields.DSC_PROJECT_ID,
                 DynamicSamplingQueryFields.COUNT,
                 DynamicSamplingQueryFields.COUNT_SAMPLE,
+                DynamicSamplingQueryFields.COUNT_UNIQUE_TRANSACTIONS,
             ],
             "orderby": [DynamicSamplingQueryFields.DSC_PROJECT_ID],
             "referrer": Referrer.DYNAMIC_SAMPLING_PER_ORG_GET_EAP_PROJECT_VOLUMES.value,
@@ -166,6 +173,9 @@ def get_eap_project_volumes(
     ):
         total = _get_aggregate_int(row, DynamicSamplingQueryFields.COUNT)
         keep = _get_aggregate_int(row, DynamicSamplingQueryFields.COUNT_SAMPLE)
+        num_distinct_transactions = _get_aggregate_int(
+            row, DynamicSamplingQueryFields.COUNT_UNIQUE_TRANSACTIONS
+        )
         dsc_project_id = row.get(DynamicSamplingQueryFields.DSC_PROJECT_ID)
         if dsc_project_id is None:
             continue
@@ -176,6 +186,7 @@ def get_eap_project_volumes(
                 total=total,
                 keep=keep,
                 drop=max(total - keep, 0),
+                num_distinct_transactions=num_distinct_transactions,
             )
         )
 
@@ -187,6 +198,7 @@ def get_eap_transaction_volumes(
     time_interval: timedelta = timedelta(hours=1),
     order_by_volume: Literal["asc", "desc"] = "asc",
     max_transactions: int = 100,
+    project_volumes: list[ProjectVolume] | None = None,
 ) -> list[ProjectTransactions]:
     end_time = datetime.now(UTC)
     start_time = end_time - time_interval
@@ -237,19 +249,31 @@ def get_eap_transaction_volumes(
             continue
 
         project_id = _get_aggregate_int(row, DynamicSamplingQueryFields.DSC_PROJECT_ID)
-        project_volumes = volumes_by_project[project_id]
+        accumulator = volumes_by_project[project_id]
 
-        project_volumes.transaction_counts.append((str(transaction), total))
-        project_volumes.total_num_transactions += total
-        project_volumes.num_classes += 1
+        accumulator.transaction_counts.append((str(transaction), total))
+        accumulator.total_num_transactions += total
+        accumulator.num_classes += 1
 
+    # When project_volumes is supplied, prefer its full-project totals over the
+    # sum-of-listed accumulated above. The transaction-balancing model needs
+    # the full implicit-pool volume and class count to size the long-tail budget.
+    project_totals_by_id = {pv.project_id: pv for pv in (project_volumes or [])}
     return [
         {
             "org_id": config.organization.id,
             "project_id": project_id,
-            "transaction_counts": project_volumes.transaction_counts,
-            "total_num_transactions": project_volumes.total_num_transactions,
-            "total_num_classes": project_volumes.num_classes,
+            "transaction_counts": accumulator.transaction_counts,
+            "total_num_transactions": (
+                project_totals_by_id[project_id].total
+                if project_id in project_totals_by_id
+                else accumulator.total_num_transactions
+            ),
+            "total_num_classes": (
+                project_totals_by_id[project_id].num_distinct_transactions
+                if project_id in project_totals_by_id
+                else accumulator.num_classes
+            ),
         }
-        for project_id, project_volumes in sorted(volumes_by_project.items())
+        for project_id, accumulator in sorted(volumes_by_project.items())
     ]

--- a/src/sentry/dynamic_sampling/per_org/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/queries.py
@@ -10,7 +10,6 @@ from typing import Any, Literal, Protocol
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
 
 from sentry.dynamic_sampling.rules.utils import ProjectId
-from sentry.dynamic_sampling.tasks.boost_low_volume_transactions import ProjectTransactions
 from sentry.dynamic_sampling.tasks.common import (
     ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
     OrganizationDataVolume,
@@ -47,11 +46,14 @@ class ProjectVolume:
     total: int
     keep: int
     drop: int
-    # Number of distinct transaction names seen in the project over the window.
-    # Counts the *whole* project, including names that fall outside the
-    # max_transactions limit of get_eap_transaction_volumes — required for the
-    # transaction rebalancing model to size the implicit (long-tail) bucket.
     num_distinct_transactions: int = 0
+
+
+@dataclass(order=True)
+class ProjectTransactionCounts:
+    project_id: int
+    org_id: int
+    transaction_counts: list[tuple[str, float]]
 
 
 @dataclass
@@ -198,8 +200,7 @@ def get_eap_transaction_volumes(
     time_interval: timedelta = timedelta(hours=1),
     order_by_volume: Literal["asc", "desc"] = "asc",
     max_transactions: int = 100,
-    project_volumes: list[ProjectVolume] | None = None,
-) -> list[ProjectTransactions]:
+) -> list[ProjectTransactionCounts]:
     end_time = datetime.now(UTC)
     start_time = end_time - time_interval
     volumes_by_project: defaultdict[int, ProjectTransactionVolumesAccumulator] = defaultdict(
@@ -255,25 +256,11 @@ def get_eap_transaction_volumes(
         accumulator.total_num_transactions += total
         accumulator.num_classes += 1
 
-    # When project_volumes is supplied, prefer its full-project totals over the
-    # sum-of-listed accumulated above. The transaction-balancing model needs
-    # the full implicit-pool volume and class count to size the long-tail budget.
-    project_totals_by_id = {pv.project_id: pv for pv in (project_volumes or [])}
     return [
-        {
-            "org_id": config.organization.id,
-            "project_id": project_id,
-            "transaction_counts": accumulator.transaction_counts,
-            "total_num_transactions": (
-                project_totals_by_id[project_id].total
-                if project_id in project_totals_by_id
-                else accumulator.total_num_transactions
-            ),
-            "total_num_classes": (
-                project_totals_by_id[project_id].num_distinct_transactions
-                if project_id in project_totals_by_id
-                else accumulator.num_classes
-            ),
-        }
+        ProjectTransactionCounts(
+            project_id=project_id,
+            org_id=config.organization.id,
+            transaction_counts=accumulator.transaction_counts,
+        )
         for project_id, accumulator in sorted(volumes_by_project.items())
     ]

--- a/src/sentry/dynamic_sampling/per_org/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/queries.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Iterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Any, Literal, Protocol
@@ -54,13 +54,6 @@ class ProjectTransactionCounts:
     project_id: int
     org_id: int
     transaction_counts: list[tuple[str, float]]
-
-
-@dataclass
-class ProjectTransactionVolumesAccumulator:
-    transaction_counts: list[tuple[str, float]] = field(default_factory=list)
-    total_num_transactions: float = 0
-    num_classes: int = 0
 
 
 def _get_aggregate_int(row: Mapping[str, Any], column: str) -> int:
@@ -203,9 +196,7 @@ def get_eap_transaction_volumes(
 ) -> list[ProjectTransactionCounts]:
     end_time = datetime.now(UTC)
     start_time = end_time - time_interval
-    volumes_by_project: defaultdict[int, ProjectTransactionVolumesAccumulator] = defaultdict(
-        ProjectTransactionVolumesAccumulator
-    )
+    transaction_counts_by_project: defaultdict[int, list[tuple[str, float]]] = defaultdict(list)
 
     count_order = (
         DynamicSamplingQueryFields.COUNT
@@ -250,17 +241,14 @@ def get_eap_transaction_volumes(
             continue
 
         project_id = _get_aggregate_int(row, DynamicSamplingQueryFields.DSC_PROJECT_ID)
-        accumulator = volumes_by_project[project_id]
-
-        accumulator.transaction_counts.append((str(transaction), total))
-        accumulator.total_num_transactions += total
-        accumulator.num_classes += 1
+        transaction_counts = transaction_counts_by_project[project_id]
+        transaction_counts.append((str(transaction), total))
 
     return [
         ProjectTransactionCounts(
             project_id=project_id,
             org_id=config.organization.id,
-            transaction_counts=accumulator.transaction_counts,
+            transaction_counts=transaction_counts,
         )
-        for project_id, accumulator in sorted(volumes_by_project.items())
+        for project_id, transaction_counts in sorted(transaction_counts_by_project.items())
     ]

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -120,16 +120,21 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
     if org_volume_5m is None:
         return DynamicSamplingStatus.NO_ORG_VOLUME
 
+    # Always fetch project volumes — transaction balancing needs the full
+    # per-project totals (volume + distinct transaction count) to size the
+    # implicit/long-tail bucket, even in project-mode where project rebalancing
+    # itself is skipped.
+    project_volumes = get_eap_project_volumes(config)
+    if not project_volumes:
+        return DynamicSamplingStatus.NO_PROJECT_VOLUMES
+
     if config.should_balance_projects:
-        project_volumes = get_eap_project_volumes(config)
-        if not project_volumes:
-            return DynamicSamplingStatus.NO_PROJECT_VOLUMES
         rebalanced_projects = run_project_balancing(config, project_volumes)
         config.set_rebalanced_project_sample_rates(rebalanced_projects)
         cached_sample_rates = get_cached_rebalanced_project_sample_rates(config.organization.id)
         compare_rebalanced_projects_with_cache(config, rebalanced_projects, cached_sample_rates)
 
-    transaction_volumes = get_eap_transaction_volumes(config)
+    transaction_volumes = get_eap_transaction_volumes(config, project_volumes=project_volumes)
     if not transaction_volumes:
         return DynamicSamplingStatus.NO_TRANSACTION_VOLUMES
 

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -120,10 +120,6 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
     if org_volume_5m is None:
         return DynamicSamplingStatus.NO_ORG_VOLUME
 
-    # Always fetch project volumes — transaction balancing needs the full
-    # per-project totals (volume + distinct transaction count) to size the
-    # implicit/long-tail bucket, even in project-mode where project rebalancing
-    # itself is skipped.
     project_volumes = get_eap_project_volumes(config)
     if not project_volumes:
         return DynamicSamplingStatus.NO_PROJECT_VOLUMES
@@ -134,11 +130,13 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
         cached_sample_rates = get_cached_rebalanced_project_sample_rates(config.organization.id)
         compare_rebalanced_projects_with_cache(config, rebalanced_projects, cached_sample_rates)
 
-    transaction_volumes = get_eap_transaction_volumes(config, project_volumes=project_volumes)
+    transaction_volumes = get_eap_transaction_volumes(config)
     if not transaction_volumes:
         return DynamicSamplingStatus.NO_TRANSACTION_VOLUMES
 
-    rebalanced_transactions = run_transaction_balancing(config, transaction_volumes)
+    rebalanced_transactions = run_transaction_balancing(
+        config, project_volumes, transaction_volumes
+    )
     cached_transaction_sample_rates = get_cached_rebalanced_transaction_sample_rates(
         org_id=config.organization.id, project_ids=rebalanced_transactions.keys()
     )

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -16,9 +16,8 @@ from sentry.dynamic_sampling.per_org.calculations import (
     run_project_balancing,
     run_transaction_balancing,
 )
-from sentry.dynamic_sampling.per_org.queries import ProjectVolume
+from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts, ProjectVolume
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
-from sentry.dynamic_sampling.tasks.boost_low_volume_transactions import ProjectTransactions
 from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
     generate_boost_low_volume_projects_cache_key,
 )
@@ -137,14 +136,12 @@ def _project_transactions(
     org_id: int,
     project_id: int,
     transaction_counts: list[tuple[str, float]],
-) -> ProjectTransactions:
-    return {
-        "org_id": org_id,
-        "project_id": project_id,
-        "transaction_counts": transaction_counts,
-        "total_num_transactions": sum(count for _, count in transaction_counts),
-        "total_num_classes": len(transaction_counts),
-    }
+) -> ProjectTransactionCounts:
+    return ProjectTransactionCounts(
+        org_id=org_id,
+        project_id=project_id,
+        transaction_counts=transaction_counts,
+    )
 
 
 class TransactionBalancingCalculationsTest(TestCase):
@@ -167,6 +164,7 @@ class TransactionBalancingCalculationsTest(TestCase):
         ) as model_run:
             run_transaction_balancing(
                 config,
+                [_project_volume(project_a.id), _project_volume(project_b.id)],
                 [
                     _project_transactions(org.id, project_a.id, [("/a", 1.0)]),
                     _project_transactions(org.id, project_b.id, [("/b", 1.0)]),
@@ -192,6 +190,7 @@ class TransactionBalancingCalculationsTest(TestCase):
         ) as model_run:
             result = run_transaction_balancing(
                 config,
+                [_project_volume(project_a.id), _project_volume(project_b.id)],
                 [
                     _project_transactions(org.id, project_a.id, [("/a", 1.0)]),
                     _project_transactions(org.id, project_b.id, [("/b", 1.0)]),
@@ -304,17 +303,19 @@ class TransactionBalancingCalculationsTest(TestCase):
         assert extras[1]["is_equal"] is False
 
 
-def _branch3_transactions(org_id: int, project_id: int) -> ProjectTransactions:
-    """Construct an input that drives TransactionsRebalancingModel into branch 3
-    (explicit pool too small to absorb its budget share), producing an implicit
-    rate below the base sample rate."""
-    return {
-        "org_id": org_id,
-        "project_id": project_id,
-        "transaction_counts": [("tiny", 5.0)],
-        "total_num_transactions": 1000.0,
-        "total_num_classes": 10,
-    }
+def _branch3_project_volume(project_id: int) -> ProjectVolume:
+    """The full-project totals that drive TransactionsRebalancingModel into
+    branch 3 (explicit pool too small to absorb its budget share), producing an
+    implicit rate below the base sample rate."""
+    return ProjectVolume(
+        project_id=project_id, total=1000, keep=0, drop=0, num_distinct_transactions=10
+    )
+
+
+def _branch3_transactions(org_id: int, project_id: int) -> ProjectTransactionCounts:
+    return ProjectTransactionCounts(
+        org_id=org_id, project_id=project_id, transaction_counts=[("tiny", 5.0)]
+    )
 
 
 class TransactionBalancingImplicitFactorFloorTest(TestCase):
@@ -329,7 +330,11 @@ class TransactionBalancingImplicitFactorFloorTest(TestCase):
         config.min_implicit_factor = 0.0
         config.get_project_sample_rates.return_value = {project.id: 0.1}
 
-        result = run_transaction_balancing(config, [_branch3_transactions(org.id, project.id)])
+        result = run_transaction_balancing(
+            config,
+            [_branch3_project_volume(project.id)],
+            [_branch3_transactions(org.id, project.id)],
+        )
 
         _, implicit_rate = result[project.id]
         # Branch 3: implicit_rate = (100 - 5) / 995 ≈ 0.0955 — below base of 0.10.
@@ -343,7 +348,11 @@ class TransactionBalancingImplicitFactorFloorTest(TestCase):
         config.min_implicit_factor = 1.0
         config.get_project_sample_rates.return_value = {project.id: 0.1}
 
-        result = run_transaction_balancing(config, [_branch3_transactions(org.id, project.id)])
+        result = run_transaction_balancing(
+            config,
+            [_branch3_project_volume(project.id)],
+            [_branch3_transactions(org.id, project.id)],
+        )
 
         named_rates, implicit_rate = result[project.id]
         assert implicit_rate == pytest.approx(0.1)
@@ -365,7 +374,11 @@ class TransactionBalancingImplicitFactorFloorTest(TestCase):
         config.min_implicit_factor = 2.0
         config.get_project_sample_rates.return_value = {project.id: 0.1}
 
-        result = run_transaction_balancing(config, [_branch3_transactions(org.id, project.id)])
+        result = run_transaction_balancing(
+            config,
+            [_branch3_project_volume(project.id)],
+            [_branch3_transactions(org.id, project.id)],
+        )
 
         _, implicit_rate = result[project.id]
         assert implicit_rate == pytest.approx(0.2)
@@ -381,7 +394,11 @@ class TransactionBalancingImplicitFactorFloorTest(TestCase):
         config.min_implicit_factor = 20.0
         config.get_project_sample_rates.return_value = {project.id: 0.1}
 
-        result = run_transaction_balancing(config, [_branch3_transactions(org.id, project.id)])
+        result = run_transaction_balancing(
+            config,
+            [_branch3_project_volume(project.id)],
+            [_branch3_transactions(org.id, project.id)],
+        )
 
         named_rates, implicit_rate = result[project.id]
         assert implicit_rate == pytest.approx(2.0)
@@ -397,15 +414,14 @@ class TransactionBalancingImplicitFactorFloorTest(TestCase):
 
         # Branch 2 scenario: small long tail relative to its share → implicit_rate=1.0,
         # which is already well above any factor floor we'd set.
-        project_data: ProjectTransactions = {
-            "org_id": org.id,
-            "project_id": project.id,
-            "transaction_counts": [("heavy", 1000.0)],
-            "total_num_transactions": 1010.0,
-            "total_num_classes": 11,
-        }
+        project_volume = ProjectVolume(
+            project_id=project.id, total=1010, keep=0, drop=0, num_distinct_transactions=11
+        )
+        project_transactions = ProjectTransactionCounts(
+            org_id=org.id, project_id=project.id, transaction_counts=[("heavy", 1000.0)]
+        )
 
-        result = run_transaction_balancing(config, [project_data])
+        result = run_transaction_balancing(config, [project_volume], [project_transactions])
 
         _, implicit_rate = result[project.id]
         assert implicit_rate == 1.0

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -201,6 +201,33 @@ class TransactionBalancingCalculationsTest(TestCase):
         assert sample_rates == [0.5]
         assert set(result.keys()) == {project_a.id}
 
+    def test_run_transaction_balancing_skips_projects_without_project_volume(self) -> None:
+        org = self.create_organization()
+        project_a = self.create_project(organization=org)
+        project_b = self.create_project(organization=org)
+        config = Mock()
+        config.organization = org
+        config.min_implicit_factor = 0.0
+        config.get_project_sample_rates.return_value = {project_a.id: 0.5, project_b.id: 0.5}
+
+        with patch(
+            "sentry.dynamic_sampling.per_org.calculations.TransactionsRebalancingModel.run",
+            side_effect=lambda model_input: ([], model_input.sample_rate),
+        ) as model_run:
+            # project_b has transactions but no matching ProjectVolume — it must be
+            # skipped instead of raising a KeyError that aborts the whole org's run.
+            result = run_transaction_balancing(
+                config,
+                [_project_volume(project_a.id)],
+                [
+                    _project_transactions(org.id, project_a.id, [("/a", 1.0)]),
+                    _project_transactions(org.id, project_b.id, [("/b", 1.0)]),
+                ],
+            )
+
+        assert model_run.call_count == 1
+        assert set(result.keys()) == {project_a.id}
+
     def test_get_cached_rebalanced_transaction_sample_rates(self) -> None:
         org = self.create_organization()
         project_hit = self.create_project(organization=org)

--- a/tests/sentry/dynamic_sampling/per_org/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_queries.py
@@ -177,11 +177,13 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
                     "sentry.dsc.project_id": project.id,
                     "count()": 2,
                     "count_sample()": 2,
+                    "count_unique(sentry.dsc.transaction)": 7,
                 },
                 {
                     "sentry.dsc.project_id": other_project.id,
                     "count()": 1,
                     "count_sample()": 1,
+                    "count_unique(sentry.dsc.transaction)": 1,
                 },
             ],
         ) as run_table_query:
@@ -190,8 +192,12 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
             )
 
         assert sorted(project_volumes) == [
-            ProjectVolume(project_id=project.id, total=2, keep=2, drop=0),
-            ProjectVolume(project_id=other_project.id, total=1, keep=1, drop=0),
+            ProjectVolume(
+                project_id=project.id, total=2, keep=2, drop=0, num_distinct_transactions=7
+            ),
+            ProjectVolume(
+                project_id=other_project.id, total=1, keep=1, drop=0, num_distinct_transactions=1
+            ),
         ]
         run_table_query.assert_called_once()
         query = run_table_query.call_args.args[0]
@@ -204,6 +210,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
             DynamicSamplingQueryFields.DSC_PROJECT_ID,
             DynamicSamplingQueryFields.COUNT,
             DynamicSamplingQueryFields.COUNT_SAMPLE,
+            DynamicSamplingQueryFields.COUNT_UNIQUE_TRANSACTIONS,
         ]
         assert query["orderby"] == [DynamicSamplingQueryFields.DSC_PROJECT_ID]
         assert query["referrer"] == Referrer.DYNAMIC_SAMPLING_PER_ORG_GET_EAP_PROJECT_VOLUMES.value
@@ -438,6 +445,66 @@ class EAPTransactionVolumesTest(TestCase, SnubaTestCase, SpanTestCase):
         volumes = get_eap_transaction_volumes(self.get_config(organization))
 
         assert volumes == []
+
+    def test_get_eap_transaction_volumes_uses_project_volumes_totals(self) -> None:
+        organization = self.create_organization()
+        project = self.create_project(organization=organization)
+        timestamp = before_now(minutes=15)
+
+        # Two stored transactions account for 2 events, but the project's true
+        # totals — passed in as project_volumes — claim 100 events across 50
+        # distinct transactions. The function should prefer those totals.
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "is_segment": True,
+                        "data": {
+                            "dsc.transaction": "checkout",
+                            "dsc.project_id": str(project.id),
+                        },
+                    },
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp,
+                ),
+                self.create_span(
+                    {
+                        "is_segment": True,
+                        "data": {
+                            "dsc.transaction": "product",
+                            "dsc.project_id": str(project.id),
+                        },
+                    },
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp,
+                ),
+            ]
+        )
+
+        volumes = get_eap_transaction_volumes(
+            self.get_config(organization),
+            project_volumes=[
+                ProjectVolume(
+                    project_id=project.id,
+                    total=100,
+                    keep=50,
+                    drop=50,
+                    num_distinct_transactions=50,
+                )
+            ],
+        )
+
+        assert volumes == [
+            {
+                "org_id": organization.id,
+                "project_id": project.id,
+                "transaction_counts": [("checkout", 1), ("product", 1)],
+                "total_num_transactions": 100,
+                "total_num_classes": 50,
+            }
+        ]
 
     def test_get_eap_transaction_volumes_attributes_to_originating_project(self) -> None:
         organization = self.create_organization()

--- a/tests/sentry/dynamic_sampling/per_org/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_queries.py
@@ -12,6 +12,7 @@ from sentry.dynamic_sampling.per_org.configuration import (
 from sentry.dynamic_sampling.per_org.queries import (
     DynamicSamplingQueryFields,
     DynamicSamplingQueryFilters,
+    ProjectTransactionCounts,
     ProjectVolume,
     get_eap_organization_volume,
     get_eap_project_volumes,
@@ -423,20 +424,16 @@ class EAPTransactionVolumesTest(TestCase, SnubaTestCase, SpanTestCase):
         )
 
         assert volumes == [
-            {
-                "org_id": organization.id,
-                "project_id": project.id,
-                "transaction_counts": [("checkout", 3), ("product", 1)],
-                "total_num_transactions": 4,
-                "total_num_classes": 2,
-            },
-            {
-                "org_id": organization.id,
-                "project_id": other_project.id,
-                "transaction_counts": [("checkout", 1)],
-                "total_num_transactions": 1,
-                "total_num_classes": 1,
-            },
+            ProjectTransactionCounts(
+                org_id=organization.id,
+                project_id=project.id,
+                transaction_counts=[("checkout", 3), ("product", 1)],
+            ),
+            ProjectTransactionCounts(
+                org_id=organization.id,
+                project_id=other_project.id,
+                transaction_counts=[("checkout", 1)],
+            ),
         ]
 
     def test_get_eap_transaction_volumes_without_projects(self) -> None:
@@ -445,66 +442,6 @@ class EAPTransactionVolumesTest(TestCase, SnubaTestCase, SpanTestCase):
         volumes = get_eap_transaction_volumes(self.get_config(organization))
 
         assert volumes == []
-
-    def test_get_eap_transaction_volumes_uses_project_volumes_totals(self) -> None:
-        organization = self.create_organization()
-        project = self.create_project(organization=organization)
-        timestamp = before_now(minutes=15)
-
-        # Two stored transactions account for 2 events, but the project's true
-        # totals — passed in as project_volumes — claim 100 events across 50
-        # distinct transactions. The function should prefer those totals.
-        self.store_spans(
-            [
-                self.create_span(
-                    {
-                        "is_segment": True,
-                        "data": {
-                            "dsc.transaction": "checkout",
-                            "dsc.project_id": str(project.id),
-                        },
-                    },
-                    organization=organization,
-                    project=project,
-                    start_ts=timestamp,
-                ),
-                self.create_span(
-                    {
-                        "is_segment": True,
-                        "data": {
-                            "dsc.transaction": "product",
-                            "dsc.project_id": str(project.id),
-                        },
-                    },
-                    organization=organization,
-                    project=project,
-                    start_ts=timestamp,
-                ),
-            ]
-        )
-
-        volumes = get_eap_transaction_volumes(
-            self.get_config(organization),
-            project_volumes=[
-                ProjectVolume(
-                    project_id=project.id,
-                    total=100,
-                    keep=50,
-                    drop=50,
-                    num_distinct_transactions=50,
-                )
-            ],
-        )
-
-        assert volumes == [
-            {
-                "org_id": organization.id,
-                "project_id": project.id,
-                "transaction_counts": [("checkout", 1), ("product", 1)],
-                "total_num_transactions": 100,
-                "total_num_classes": 50,
-            }
-        ]
 
     def test_get_eap_transaction_volumes_attributes_to_originating_project(self) -> None:
         organization = self.create_organization()
@@ -534,13 +471,11 @@ class EAPTransactionVolumesTest(TestCase, SnubaTestCase, SpanTestCase):
         volumes = get_eap_transaction_volumes(self.get_config(organization))
 
         assert volumes == [
-            {
-                "org_id": organization.id,
-                "project_id": originating_project.id,
-                "transaction_counts": [("checkout", 1)],
-                "total_num_transactions": 1,
-                "total_num_classes": 1,
-            }
+            ProjectTransactionCounts(
+                org_id=organization.id,
+                project_id=originating_project.id,
+                transaction_counts=[("checkout", 1)],
+            )
         ]
 
     def test_get_eap_transaction_volumes_with_max_transactions_caps_total_rows(self) -> None:
@@ -587,18 +522,14 @@ class EAPTransactionVolumesTest(TestCase, SnubaTestCase, SpanTestCase):
         # Top 2 rows globally: project/alpha (3) and other_project/beta (2);
         # project/gamma is excluded by the cap.
         assert volumes == [
-            {
-                "org_id": organization.id,
-                "project_id": project.id,
-                "transaction_counts": [("alpha", 3)],
-                "total_num_transactions": 3,
-                "total_num_classes": 1,
-            },
-            {
-                "org_id": organization.id,
-                "project_id": other_project.id,
-                "transaction_counts": [("beta", 2)],
-                "total_num_transactions": 2,
-                "total_num_classes": 1,
-            },
+            ProjectTransactionCounts(
+                org_id=organization.id,
+                project_id=project.id,
+                transaction_counts=[("alpha", 3)],
+            ),
+            ProjectTransactionCounts(
+                org_id=organization.id,
+                project_id=other_project.id,
+                transaction_counts=[("beta", 2)],
+            ),
         ]

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -319,6 +319,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
         project.update_option("sentry:target_sample_rate", 0.2)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
+        project_volumes = [_project_volume(project.id)]
 
         with (
             self.feature("organizations:dynamic-sampling-custom"),
@@ -331,7 +332,11 @@ class SchedulePerOrgCalculationsTest(TestCase):
             ) as get_volume,
             patch(
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
+                return_value=project_volumes,
             ) as get_project_volumes,
+            patch(
+                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
+            ) as project_balancing,
             patch(
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
                 return_value=[
@@ -354,8 +359,12 @@ class SchedulePerOrgCalculationsTest(TestCase):
         assert result is None
         get_blended_sample_rate.assert_not_called()
         _assert_called_once_with_config(get_volume, org.id)
-        get_project_volumes.assert_not_called()
+        # Project volumes are fetched even in project mode (transaction balancing
+        # needs full per-project totals) but project balancing itself is skipped.
+        _assert_called_once_with_config(get_project_volumes, org.id)
+        project_balancing.assert_not_called()
         transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
+        assert get_transaction_volumes.call_args.kwargs == {"project_volumes": project_volumes}
         transaction_balancing.assert_called_once_with(
             transaction_config, get_transaction_volumes.return_value
         )

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.configuration import BaseDynamicSamplingConfiguration
-from sentry.dynamic_sampling.per_org.queries import ProjectVolume
+from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts, ProjectVolume
 from sentry.dynamic_sampling.per_org.scheduler import (
     BUCKET_COUNT,
     BUCKET_CURSOR_KEY,
@@ -195,13 +195,11 @@ class SchedulePerOrgCalculationsTest(TestCase):
             patch(
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
                 return_value=[
-                    {
-                        "org_id": org.id,
-                        "project_id": project.id,
-                        "transaction_counts": [("checkout", 1.0)],
-                        "total_num_transactions": 1.0,
-                        "total_num_classes": 1,
-                    }
+                    ProjectTransactionCounts(
+                        org_id=org.id,
+                        project_id=project.id,
+                        transaction_counts=[("checkout", 1.0)],
+                    )
                 ],
             ) as get_transaction_volumes,
             patch(
@@ -222,7 +220,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         )
         transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
         transaction_balancing.assert_called_once_with(
-            transaction_config, get_transaction_volumes.return_value
+            transaction_config, project_volumes, get_transaction_volumes.return_value
         )
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
@@ -340,13 +338,11 @@ class SchedulePerOrgCalculationsTest(TestCase):
             patch(
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
                 return_value=[
-                    {
-                        "org_id": org.id,
-                        "project_id": project.id,
-                        "transaction_counts": [("checkout", 1.0)],
-                        "total_num_transactions": 1.0,
-                        "total_num_classes": 1,
-                    }
+                    ProjectTransactionCounts(
+                        org_id=org.id,
+                        project_id=project.id,
+                        transaction_counts=[("checkout", 1.0)],
+                    )
                 ],
             ) as get_transaction_volumes,
             patch(
@@ -364,9 +360,8 @@ class SchedulePerOrgCalculationsTest(TestCase):
         _assert_called_once_with_config(get_project_volumes, org.id)
         project_balancing.assert_not_called()
         transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
-        assert get_transaction_volumes.call_args.kwargs == {"project_volumes": project_volumes}
         transaction_balancing.assert_called_once_with(
-            transaction_config, get_transaction_volumes.return_value
+            transaction_config, project_volumes, get_transaction_volumes.return_value
         )
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
@@ -406,13 +401,11 @@ class SchedulePerOrgCalculationsTest(TestCase):
             patch(
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
                 return_value=[
-                    {
-                        "org_id": org.id,
-                        "project_id": project.id,
-                        "transaction_counts": [("checkout", 1.0)],
-                        "total_num_transactions": 1.0,
-                        "total_num_classes": 1,
-                    }
+                    ProjectTransactionCounts(
+                        org_id=org.id,
+                        project_id=project.id,
+                        transaction_counts=[("checkout", 1.0)],
+                    )
                 ],
             ) as get_transaction_volumes,
             patch(
@@ -433,7 +426,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         )
         transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
         transaction_balancing.assert_called_once_with(
-            transaction_config, get_transaction_volumes.return_value
+            transaction_config, project_volumes, get_transaction_volumes.return_value
         )
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
@@ -497,13 +490,11 @@ class SchedulePerOrgCalculationsTest(TestCase):
             patch(
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
                 return_value=[
-                    {
-                        "org_id": org.id,
-                        "project_id": project.id,
-                        "transaction_counts": [("checkout", 1.0)],
-                        "total_num_transactions": 1.0,
-                        "total_num_classes": 1,
-                    }
+                    ProjectTransactionCounts(
+                        org_id=org.id,
+                        project_id=project.id,
+                        transaction_counts=[("checkout", 1.0)],
+                    )
                 ],
             ) as get_transaction_volumes,
             patch(
@@ -524,7 +515,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         )
         transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
         transaction_balancing.assert_called_once_with(
-            transaction_config, get_transaction_volumes.return_value
+            transaction_config, project_volumes, get_transaction_volumes.return_value
         )
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})


### PR DESCRIPTION
The per-org EAP transaction-volumes query only returns the top-N listed names, so `total_num_transactions` and `total_num_classes` were the sum of the listed transactions only. `TransactionsRebalancingModel` saw no implicit (long-tail) pool and always landed in branch 1, producing rates that don't match the legacy task's output.

This adds `count_unique(sentry.dsc.transaction)` to `get_eap_project_volumes` and threads the resulting `ProjectVolume` list into `get_eap_transaction_volumes` so it overrides the listed-sum totals with the full per-project totals.

Contributes to TET-2404