### PR TITLE
feat(seer): Steer low-value span root cause analysis

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -23,6 +23,7 @@ from sentry.analytics.events.autofix_events import (
 )
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory
 from sentry.integrations.services.integration import integration_service
+from sentry.processing_errors.grouptype import LowValueSpanConfigurationType
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.autofix.artifact_schemas import (
@@ -32,6 +33,7 @@ from sentry.seer.autofix.artifact_schemas import (
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.prompts import (
     code_changes_prompt,
+    low_value_span_root_cause_prompt,
     root_cause_prompt,
     solution_prompt,
 )
@@ -147,7 +149,11 @@ def build_step_prompt(step: AutofixStep, group: Group, user_context: str | None 
         Formatted prompt string
     """
     config = STEP_CONFIGS[step]
-    prompt = config.prompt_fn(
+    prompt_fn = config.prompt_fn
+    if step == AutofixStep.ROOT_CAUSE and group.type == LowValueSpanConfigurationType.type_id:
+        prompt_fn = low_value_span_root_cause_prompt
+
+    prompt = prompt_fn(
         short_id=group.qualified_short_id or str(group.id),
         title=group.title or "Unknown error",
         culprit=group.culprit or "unknown",

--- a/src/sentry/seer/autofix/prompts.py
+++ b/src/sentry/seer/autofix/prompts.py
@@ -30,6 +30,27 @@ def root_cause_prompt(*, short_id: str, title: str, culprit: str, artifact_key: 
     )
 
 
+def low_value_span_root_cause_prompt(
+    *, short_id: str, title: str, culprit: str, artifact_key: str | None
+) -> str:
+    context = (
+        "This is the root cause: this is a low-value span issue, meaning Sentry detected a "
+        "high-volume span with low telemetry value. This is not an exception in the user's "
+        "codebase.\n\n"
+        "Use the latest occurrence evidence to identify the span by op, description, and origin. "
+        "If the span origin is manual, the manually instrumented span code should be removed. "
+        "Otherwise, the automatically created span should be filtered before sending."
+    )
+    prompt = root_cause_prompt(
+        short_id=short_id,
+        title=title,
+        culprit=culprit,
+        artifact_key=artifact_key,
+    )
+
+    return f"{context}\n\n{prompt}"
+
+
 def solution_prompt(*, short_id: str, title: str, culprit: str, artifact_key: str | None) -> str:
     return dedent(
         f"""\

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -5,6 +5,7 @@ import pytest
 from rest_framework.exceptions import PermissionDenied
 
 from sentry.constants import DataCategory
+from sentry.processing_errors.grouptype import LowValueSpanConfigurationType
 from sentry.seer.agent.client_models import (
     Artifact,
     MemoryBlock,
@@ -235,6 +236,20 @@ class TestBuildStepPrompt(TestCase):
         prompt = build_step_prompt(AutofixStep.ROOT_CAUSE, self.group)
 
         assert "unknown" in prompt
+
+    def test_low_value_span_root_cause_prompt_uses_issue_specific_context(self) -> None:
+        group = self.create_group(
+            project=self.project,
+            message="Low-value span detected",
+            type=LowValueSpanConfigurationType.type_id,
+        )
+
+        prompt = build_step_prompt(AutofixStep.ROOT_CAUSE, group)
+
+        assert prompt.startswith("This is the root cause")
+        assert "low-value span issue" in prompt
+        assert "latest occurrence evidence" in prompt
+        assert "root_cause artifact" in prompt
 
     def test_all_prompts_are_dedented(self) -> None:
         for step in AutofixStep:


### PR DESCRIPTION
Steer Autofix root cause analysis for low-value span issues so Seer treats them as Sentry created optimization guidance instead of exception-style failures. This keeps the normal Autofix step flow while giving root cause analysis enough issue-specific context to use the latest occurrence evidence correctly.

Currently the root cause analysis tries to handle this type of issue as if it is an exception in the user's codebase, not understanding it is an issue created by Sentry to notify users about optimization potential. Low-value span RCA now explains that the root cause is a high-volume span with low telemetry value.

Part of TET-2194