### PR TITLE
feat(seer): Persist PR judge summaries in upsert_pr_metrics_summary RPC

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -54,6 +54,7 @@ from sentry.integrations.services.repository import repository_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
+from sentry.models.pullrequest import PullRequest, PullRequestMetrics, PullRequestVerdict
 from sentry.models.repository import Repository
 from sentry.replays.usecases.summarize import rpc_get_replay_summary_logs
 from sentry.search.eap.resolver import SearchResolver
@@ -636,6 +637,20 @@ def send_seer_webhook(*, event_name: str, organization_id: int, payload: dict) -
     return {"success": True}
 
 
+# Counter keys accepted in a judge summary, each mapped onto the matching
+# integer field of PullRequestMetrics. Anything else in the payload is ignored
+# so the contract can grow without breaking older Sentry deploys.
+_PR_METRICS_COUNTER_FIELDS = (
+    "additions",
+    "deletions",
+    "files_changed",
+    "commits_count",
+    "comments_count",
+    "participants_count",
+    "reviews_count",
+)
+
+
 def upsert_pr_metrics_summary(
     *,
     organization_id: int,
@@ -644,7 +659,6 @@ def upsert_pr_metrics_summary(
     event_id: str,
     verdict: str,
     counters: dict,
-    refined_attribution_signals: list[dict] | None = None,
 ) -> dict:
     """Accept (in Sentry, from Seer) a PR judge summary at close/merge time.
 
@@ -652,33 +666,52 @@ def upsert_pr_metrics_summary(
     fetch and posts them back here so Sentry's canonical PR row stays the source
     of truth for product queries.
 
-    This is currently a validate-and-acknowledge stub (CORE-201): it pins the
-    signed-RPC contract so Seer can integrate before the storage exists.
+    The write is idempotent: PullRequestMetrics is one-to-one with PullRequest,
+    so a webhook/event redelivery (same ``event_id``) updates the existing row
+    rather than inserting a duplicate.
 
     Args:
         organization_id: The owning organization.
         repository_id: Sentry's internal Repository id (also pins the provider).
         pr_number: The external SCM pull-request number.
-        event_id: Idempotency key, stable across webhook redeliveries.
-        verdict: The judge verdict (e.g. "merged_unchanged").
-        counters: Comment/commit/timing counters computed at judge time.
-        refined_attribution_signals: Any newly-derived attribution signals.
+        event_id: The originating Seer event id, used for log correlation.
+        verdict: The judge verdict; one of ``PullRequestVerdict``.
+        counters: Per-PR counters computed at judge time (see
+            ``_PR_METRICS_COUNTER_FIELDS`` plus the ``is_assigned`` flag).
 
     Returns:
-        dict: ``{"success": True}`` once accepted, else ``{"success": False, "error": ...}``.
+        dict: ``{"success": True}`` once persisted, else ``{"success": False, "error": ...}``.
     """
-    if not verdict:
-        return {"success": False, "error": "verdict must be a non-empty string"}
+    if verdict not in PullRequestVerdict.values:
+        return {
+            "success": False,
+            "error": f"verdict must be one of {sorted(PullRequestVerdict.values)}",
+        }
 
     # Scope the repository to the organization to prevent cross-org reference.
     if repository_service.get_repository(organization_id=organization_id, id=repository_id) is None:
         return {"success": False, "error": "Repository not found"}
 
-    # TODO(CORE-201): persist once CORE-200's models land. Upsert
-    # PullRequestMetrics keyed on event_id (idempotent across webhook
-    # redeliveries), insert any newly-derived PullRequestAttribution rows from
-    # refined_attribution_signals, and recompute PullRequest.attribution.
-    # Full write lands in M1/M3 (CW-1436).
+    # Counters arrive from Seer (a trust boundary) and land in
+    # BoundedPositiveIntegerField columns, so clamp out negatives defensively.
+    metric_values: dict[str, Any] = {
+        field: max(0, int(counters.get(field) or 0)) for field in _PR_METRICS_COUNTER_FIELDS
+    }
+    metric_values["is_assigned"] = bool(counters.get("is_assigned", False))
+
+    # The judge summary can arrive before Sentry has seen the SCM "opened"
+    # webhook, so find-or-create the canonical PR row (a shell with null
+    # lifecycle fields the webhook backfills later).
+    pull_request, _ = PullRequest.objects.get_or_create(
+        organization_id=organization_id,
+        repository_id=repository_id,
+        key=str(pr_number),
+    )
+    PullRequestMetrics.objects.update_or_create(
+        pull_request=pull_request,
+        defaults={"verdict": verdict, **metric_values},
+    )
+
     logger.info(
         "seer.pr_metrics.upsert_pr_metrics_summary",
         extra={

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -50,6 +50,7 @@ from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException, RpcR
 from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
 from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.services.repository import repository_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
@@ -635,6 +636,115 @@ def send_seer_webhook(*, event_name: str, organization_id: int, payload: dict) -
     return {"success": True}
 
 
+def register_pr_attribution(
+    *,
+    organization_id: int,
+    repository_id: int,
+    pr_number: str,
+    signal_type: str,
+    run_id: int | None = None,
+    signal_details: dict | None = None,
+) -> dict:
+    """Accept (in Sentry, from Seer/Sentry-MCP) an attribution signal pushed for a PR.
+
+    Seer calls this when it learns a PR is attributable to a Sentry feature
+    (e.g. a delegated coding-agent run) — possibly before Sentry's SCM webhook
+    has fired. This is the cheap push path of the PR-metrics attribution flow.
+
+    This is currently a validate-and-acknowledge stub (CORE-201): it pins the
+    signed-RPC contract so Seer can integrate before the storage exists.
+
+    Args:
+        organization_id: The owning organization.
+        repository_id: Sentry's internal Repository id (also pins the provider).
+        pr_number: The external SCM pull-request number.
+        signal_type: The attribution source (e.g. "seer_delegated:cursor").
+        run_id: The Seer run id that produced the PR, if known.
+        signal_details: Optional extra context to persist on the signal.
+
+    Returns:
+        dict: ``{"success": True}`` once accepted, else ``{"success": False, "error": ...}``.
+    """
+    if not signal_type:
+        return {"success": False, "error": "signal_type must be a non-empty string"}
+
+    # Scope the repository to the organization to prevent cross-org reference.
+    if repository_service.get_repository(organization_id=organization_id, id=repository_id) is None:
+        return {"success": False, "error": "Repository not found"}
+
+    # TODO(CORE-201): persist once CORE-200's models land. Upsert a shell
+    # PullRequest row for the race where Seer learns the PR id before the SCM
+    # `opened` webhook, insert a PullRequestAttribution row, and recompute
+    # PullRequest.attribution. Full handling lands in M2 (CORE-204).
+    logger.info(
+        "seer.pr_metrics.register_pr_attribution",
+        extra={
+            "organization_id": organization_id,
+            "repository_id": repository_id,
+            "pr_number": pr_number,
+            "signal_type": signal_type,
+            "run_id": run_id,
+        },
+    )
+    return {"success": True}
+
+
+def upsert_pr_metrics_summary(
+    *,
+    organization_id: int,
+    repository_id: int,
+    pr_number: str,
+    event_id: str,
+    verdict: str,
+    counters: dict,
+    refined_attribution_signals: list[dict] | None = None,
+) -> dict:
+    """Accept (in Sentry, from Seer) a PR judge summary at close/merge time.
+
+    Seer computes the verdict + counters during its single close/merge SCM
+    fetch and posts them back here so Sentry's canonical PR row stays the source
+    of truth for product queries.
+
+    This is currently a validate-and-acknowledge stub (CORE-201): it pins the
+    signed-RPC contract so Seer can integrate before the storage exists.
+
+    Args:
+        organization_id: The owning organization.
+        repository_id: Sentry's internal Repository id (also pins the provider).
+        pr_number: The external SCM pull-request number.
+        event_id: Idempotency key, stable across webhook redeliveries.
+        verdict: The judge verdict (e.g. "merged_unchanged").
+        counters: Comment/commit/timing counters computed at judge time.
+        refined_attribution_signals: Any newly-derived attribution signals.
+
+    Returns:
+        dict: ``{"success": True}`` once accepted, else ``{"success": False, "error": ...}``.
+    """
+    if not verdict:
+        return {"success": False, "error": "verdict must be a non-empty string"}
+
+    # Scope the repository to the organization to prevent cross-org reference.
+    if repository_service.get_repository(organization_id=organization_id, id=repository_id) is None:
+        return {"success": False, "error": "Repository not found"}
+
+    # TODO(CORE-201): persist once CORE-200's models land. Upsert
+    # PullRequestMetrics keyed on event_id (idempotent across webhook
+    # redeliveries), insert any newly-derived PullRequestAttribution rows from
+    # refined_attribution_signals, and recompute PullRequest.attribution.
+    # Full write lands in M1/M3 (CW-1436).
+    logger.info(
+        "seer.pr_metrics.upsert_pr_metrics_summary",
+        extra={
+            "organization_id": organization_id,
+            "repository_id": repository_id,
+            "pr_number": pr_number,
+            "event_id": event_id,
+            "verdict": verdict,
+        },
+    )
+    return {"success": True}
+
+
 def trigger_coding_agent_launch(
     *,
     organization_id: int,
@@ -1025,6 +1135,10 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     #
     # Issue Detection
     "create_issue_occurrence": create_issue_occurrence,
+    #
+    # PR Merge Live Metrics
+    "register_pr_attribution": register_pr_attribution,
+    "upsert_pr_metrics_summary": upsert_pr_metrics_summary,
 }
 
 

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -636,59 +636,6 @@ def send_seer_webhook(*, event_name: str, organization_id: int, payload: dict) -
     return {"success": True}
 
 
-def register_pr_attribution(
-    *,
-    organization_id: int,
-    repository_id: int,
-    pr_number: str,
-    signal_type: str,
-    run_id: int | None = None,
-    signal_details: dict | None = None,
-) -> dict:
-    """Accept (in Sentry, from Seer/Sentry-MCP) an attribution signal pushed for a PR.
-
-    Seer calls this when it learns a PR is attributable to a Sentry feature
-    (e.g. a delegated coding-agent run) — possibly before Sentry's SCM webhook
-    has fired. This is the cheap push path of the PR-metrics attribution flow.
-
-    This is currently a validate-and-acknowledge stub (CORE-201): it pins the
-    signed-RPC contract so Seer can integrate before the storage exists.
-
-    Args:
-        organization_id: The owning organization.
-        repository_id: Sentry's internal Repository id (also pins the provider).
-        pr_number: The external SCM pull-request number.
-        signal_type: The attribution source (e.g. "seer_delegated:cursor").
-        run_id: The Seer run id that produced the PR, if known.
-        signal_details: Optional extra context to persist on the signal.
-
-    Returns:
-        dict: ``{"success": True}`` once accepted, else ``{"success": False, "error": ...}``.
-    """
-    if not signal_type:
-        return {"success": False, "error": "signal_type must be a non-empty string"}
-
-    # Scope the repository to the organization to prevent cross-org reference.
-    if repository_service.get_repository(organization_id=organization_id, id=repository_id) is None:
-        return {"success": False, "error": "Repository not found"}
-
-    # TODO(CORE-201): persist once CORE-200's models land. Upsert a shell
-    # PullRequest row for the race where Seer learns the PR id before the SCM
-    # `opened` webhook, insert a PullRequestAttribution row, and recompute
-    # PullRequest.attribution. Full handling lands in M2 (CORE-204).
-    logger.info(
-        "seer.pr_metrics.register_pr_attribution",
-        extra={
-            "organization_id": organization_id,
-            "repository_id": repository_id,
-            "pr_number": pr_number,
-            "signal_type": signal_type,
-            "run_id": run_id,
-        },
-    )
-    return {"success": True}
-
-
 def upsert_pr_metrics_summary(
     *,
     organization_id: int,
@@ -1137,7 +1084,6 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "create_issue_occurrence": create_issue_occurrence,
     #
     # PR Merge Live Metrics
-    "register_pr_attribution": register_pr_attribution,
     "upsert_pr_metrics_summary": upsert_pr_metrics_summary,
 }
 

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -44,6 +44,7 @@ from sentry.api.base import Endpoint, internal_cell_silo_endpoint
 from sentry.api.endpoints.project_trace_item_details import convert_rpc_attribute_to_json
 from sentry.api.utils import get_date_range_from_params
 from sentry.constants import ObjectStatus
+from sentry.db.models import BoundedPositiveIntegerField
 from sentry.exceptions import InvalidSearchQuery
 from sentry.features.base import OrganizationFeature
 from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException, RpcResolutionException
@@ -638,16 +639,15 @@ def send_seer_webhook(*, event_name: str, organization_id: int, payload: dict) -
 
 
 # Counter keys accepted in a judge summary, each mapped onto the matching
-# integer field of PullRequestMetrics. Anything else in the payload is ignored
-# so the contract can grow without breaking older Sentry deploys.
-_PR_METRICS_COUNTER_FIELDS = (
-    "additions",
-    "deletions",
-    "files_changed",
-    "commits_count",
-    "comments_count",
-    "participants_count",
-    "reviews_count",
+# integer field of PullRequestMetrics. Derived from the model so a new counter
+# column extends the contract automatically; the counters are exactly the
+# BoundedPositiveIntegerField columns (is_assigned is a bool handled separately,
+# and the pk/FK/timestamps are other field types). Anything else in the payload
+# is ignored so the contract can grow without breaking older Sentry deploys.
+_PR_METRICS_COUNTER_FIELDS = tuple(
+    field.name
+    for field in PullRequestMetrics._meta.get_fields()
+    if isinstance(field, BoundedPositiveIntegerField) and not field.primary_key
 )
 
 

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -16,6 +16,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.project import Project
 from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
+from sentry.models.pullrequest import PullRequest, PullRequestMetrics
 from sentry.models.repository import Repository
 from sentry.seer.agent.tools import get_trace_item_attributes
 from sentry.seer.autofix.coding_agent import IntegrationNotFound
@@ -1776,7 +1777,7 @@ class TestTriggerCodingAgentLaunchClearsHandoff(APITestCase):
 
 @override_settings(SEER_RPC_SHARED_SECRET=["a-long-value-that-is-hard-to-guess"])
 class TestPrMetricsRpc(APITestCase):
-    """Stub upsert_pr_metrics_summary handler (CORE-201)."""
+    """upsert_pr_metrics_summary handler (CORE-201)."""
 
     def setUp(self) -> None:
         super().setUp()
@@ -1798,10 +1799,81 @@ class TestPrMetricsRpc(APITestCase):
             repository_id=self.repository.id,
             pr_number="123",
             event_id="123:merged:abc123",
-            verdict="merged_unchanged",
-            counters={"comments": 0},
+            verdict="merged_with_iteration",
+            counters={
+                "additions": 10,
+                "deletions": 4,
+                "files_changed": 3,
+                "commits_count": 2,
+                "comments_count": 5,
+                "participants_count": 2,
+                "reviews_count": 1,
+                "is_assigned": True,
+            },
         )
         assert result == {"success": True}
+
+        pull_request = PullRequest.objects.get(
+            organization_id=self.organization.id,
+            repository_id=self.repository.id,
+            key="123",
+        )
+        metrics = PullRequestMetrics.objects.get(pull_request=pull_request)
+        assert metrics.verdict == "merged_with_iteration"
+        assert metrics.additions == 10
+        assert metrics.deletions == 4
+        assert metrics.files_changed == 3
+        assert metrics.commits_count == 2
+        assert metrics.comments_count == 5
+        assert metrics.participants_count == 2
+        assert metrics.reviews_count == 1
+        assert metrics.is_assigned is True
+
+    def test_upsert_pr_metrics_summary_defaults_missing_counters(self) -> None:
+        result = upsert_pr_metrics_summary(
+            organization_id=self.organization.id,
+            repository_id=self.repository.id,
+            pr_number="7",
+            event_id="evt",
+            verdict="closed_unmerged",
+            counters={},
+        )
+        assert result == {"success": True}
+
+        metrics = PullRequestMetrics.objects.get(pull_request__key="7")
+        assert metrics.additions == 0
+        assert metrics.commits_count == 0
+        assert metrics.is_assigned is False
+
+    def test_upsert_pr_metrics_summary_clamps_negative_counters(self) -> None:
+        # Counters cross a trust boundary into BoundedPositiveIntegerField columns.
+        result = upsert_pr_metrics_summary(
+            organization_id=self.organization.id,
+            repository_id=self.repository.id,
+            pr_number="9",
+            event_id="evt",
+            verdict="closed_unmerged",
+            counters={"additions": -5},
+        )
+        assert result == {"success": True}
+        assert PullRequestMetrics.objects.get(pull_request__key="9").additions == 0
+
+    def test_upsert_pr_metrics_summary_is_idempotent(self) -> None:
+        for verdict, additions in (("merged_unchanged", 1), ("merged_with_iteration", 8)):
+            result = upsert_pr_metrics_summary(
+                organization_id=self.organization.id,
+                repository_id=self.repository.id,
+                pr_number="42",
+                event_id="42:merged:abc",
+                verdict=verdict,
+                counters={"additions": additions},
+            )
+            assert result == {"success": True}
+
+        assert PullRequest.objects.filter(repository_id=self.repository.id, key="42").count() == 1
+        metrics = PullRequestMetrics.objects.get(pull_request__key="42")
+        assert metrics.verdict == "merged_with_iteration"
+        assert metrics.additions == 8
 
     def test_upsert_pr_metrics_summary_empty_verdict(self) -> None:
         result = upsert_pr_metrics_summary(
@@ -1813,6 +1885,19 @@ class TestPrMetricsRpc(APITestCase):
             counters={},
         )
         assert result["success"] is False
+        assert not PullRequestMetrics.objects.exists()
+
+    def test_upsert_pr_metrics_summary_invalid_verdict(self) -> None:
+        result = upsert_pr_metrics_summary(
+            organization_id=self.organization.id,
+            repository_id=self.repository.id,
+            pr_number="123",
+            event_id="evt",
+            verdict="bogus",
+            counters={},
+        )
+        assert result["success"] is False
+        assert not PullRequest.objects.filter(key="123").exists()
 
     def test_upsert_pr_metrics_summary_repository_not_found(self) -> None:
         result = upsert_pr_metrics_summary(
@@ -1838,6 +1923,7 @@ class TestPrMetricsRpc(APITestCase):
             counters={},
         )
         assert result == {"success": False, "error": "Repository not found"}
+        assert not PullRequestMetrics.objects.exists()
 
     def test_upsert_pr_metrics_summary_registered_on_internal_rpc(self) -> None:
         path = self._get_path("upsert_pr_metrics_summary")
@@ -1848,7 +1934,7 @@ class TestPrMetricsRpc(APITestCase):
                 "pr_number": "123",
                 "event_id": "123:merged:abc123",
                 "verdict": "merged_unchanged",
-                "counters": {"comments": 2},
+                "counters": {"comments_count": 2},
             },
             "meta": {},
         }
@@ -1857,3 +1943,4 @@ class TestPrMetricsRpc(APITestCase):
         )
         assert response.status_code == 200
         assert response.data == {"success": True}
+        assert PullRequestMetrics.objects.filter(pull_request__key="123").exists()

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -29,7 +29,9 @@ from sentry.seer.endpoints.seer_rpc import (
     get_project_preferences,
     get_repo_installation_id,
     has_repo_code_mappings,
+    register_pr_attribution,
     trigger_coding_agent_launch,
+    upsert_pr_metrics_summary,
     validate_repo,
 )
 from sentry.sentry_apps.metrics import SentryAppEventType
@@ -1771,3 +1773,153 @@ class TestTriggerCodingAgentLaunchClearsHandoff(APITestCase):
 
         assert result == {"success": False, "error_code": "integration_not_found"}
         assert other_project.get_option("sentry:seer_automation_handoff_point") == "root_cause"
+
+
+@override_settings(SEER_RPC_SHARED_SECRET=["a-long-value-that-is-hard-to-guess"])
+class TestPrMetricsRpc(APITestCase):
+    """Stub register_pr_attribution / upsert_pr_metrics_summary handlers (CORE-201)."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        project = self.create_project(organization=self.organization)
+        self.repository = self.create_repo(project=project, name="getsentry/sentry")
+
+    @staticmethod
+    def _get_path(method_name: str) -> str:
+        return reverse("sentry-api-0-seer-rpc-service", kwargs={"method_name": method_name})
+
+    def _auth_header(self, path: str, data: dict) -> str:
+        body = orjson.dumps(data).decode()
+        return f"rpcsignature {generate_request_signature(path, body.encode())}"
+
+    def test_register_pr_attribution_success(self) -> None:
+        result = register_pr_attribution(
+            organization_id=self.organization.id,
+            repository_id=self.repository.id,
+            pr_number="123",
+            signal_type="seer_delegated:cursor",
+            run_id=42,
+        )
+        assert result == {"success": True}
+
+    def test_register_pr_attribution_empty_signal_type(self) -> None:
+        result = register_pr_attribution(
+            organization_id=self.organization.id,
+            repository_id=self.repository.id,
+            pr_number="123",
+            signal_type="",
+        )
+        assert result["success"] is False
+
+    def test_register_pr_attribution_repository_not_found(self) -> None:
+        result = register_pr_attribution(
+            organization_id=self.organization.id,
+            repository_id=self.repository.id + 1000,
+            pr_number="123",
+            signal_type="seer_app",
+        )
+        assert result == {"success": False, "error": "Repository not found"}
+
+    def test_register_pr_attribution_repository_outside_org(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_repo = self.create_repo(project=other_project, name="getsentry/other")
+        result = register_pr_attribution(
+            organization_id=self.organization.id,
+            repository_id=other_repo.id,
+            pr_number="123",
+            signal_type="seer_app",
+        )
+        assert result == {"success": False, "error": "Repository not found"}
+
+    def test_register_pr_attribution_missing_required_arg_raises(self) -> None:
+        with pytest.raises(TypeError):
+            register_pr_attribution(
+                organization_id=self.organization.id,
+                repository_id=self.repository.id,
+                pr_number="123",
+            )
+
+    def test_register_pr_attribution_registered_on_internal_rpc(self) -> None:
+        path = self._get_path("register_pr_attribution")
+        data: dict[str, Any] = {
+            "args": {
+                "organization_id": self.organization.id,
+                "repository_id": self.repository.id,
+                "pr_number": "123",
+                "signal_type": "seer_app",
+            },
+            "meta": {},
+        }
+        response = self.client.post(
+            path, data=data, HTTP_AUTHORIZATION=self._auth_header(path, data)
+        )
+        assert response.status_code == 200
+        assert response.data == {"success": True}
+
+    def test_upsert_pr_metrics_summary_success(self) -> None:
+        result = upsert_pr_metrics_summary(
+            organization_id=self.organization.id,
+            repository_id=self.repository.id,
+            pr_number="123",
+            event_id="123:merged:abc123",
+            verdict="merged_unchanged",
+            counters={"comments": 0},
+        )
+        assert result == {"success": True}
+
+    def test_upsert_pr_metrics_summary_empty_verdict(self) -> None:
+        result = upsert_pr_metrics_summary(
+            organization_id=self.organization.id,
+            repository_id=self.repository.id,
+            pr_number="123",
+            event_id="evt",
+            verdict="",
+            counters={},
+        )
+        assert result["success"] is False
+
+    def test_upsert_pr_metrics_summary_repository_not_found(self) -> None:
+        result = upsert_pr_metrics_summary(
+            organization_id=self.organization.id,
+            repository_id=self.repository.id + 1000,
+            pr_number="123",
+            event_id="evt",
+            verdict="closed_unmerged",
+            counters={},
+        )
+        assert result == {"success": False, "error": "Repository not found"}
+
+    def test_upsert_pr_metrics_summary_repository_outside_org(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_repo = self.create_repo(project=other_project, name="getsentry/other2")
+        result = upsert_pr_metrics_summary(
+            organization_id=self.organization.id,
+            repository_id=other_repo.id,
+            pr_number="123",
+            event_id="evt",
+            verdict="closed_unmerged",
+            counters={},
+        )
+        assert result == {"success": False, "error": "Repository not found"}
+
+    def test_upsert_pr_metrics_summary_registered_on_internal_rpc(self) -> None:
+        path = self._get_path("upsert_pr_metrics_summary")
+        data: dict[str, Any] = {
+            "args": {
+                "organization_id": self.organization.id,
+                "repository_id": self.repository.id,
+                "pr_number": "123",
+                "event_id": "123:merged:abc123",
+                "verdict": "merged_unchanged",
+                "counters": {"comments": 2},
+            },
+            "meta": {},
+        }
+        response = self.client.post(
+            path, data=data, HTTP_AUTHORIZATION=self._auth_header(path, data)
+        )
+        assert response.status_code == 200
+        assert response.data == {"success": True}

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -29,7 +29,6 @@ from sentry.seer.endpoints.seer_rpc import (
     get_project_preferences,
     get_repo_installation_id,
     has_repo_code_mappings,
-    register_pr_attribution,
     trigger_coding_agent_launch,
     upsert_pr_metrics_summary,
     validate_repo,
@@ -1777,7 +1776,7 @@ class TestTriggerCodingAgentLaunchClearsHandoff(APITestCase):
 
 @override_settings(SEER_RPC_SHARED_SECRET=["a-long-value-that-is-hard-to-guess"])
 class TestPrMetricsRpc(APITestCase):
-    """Stub register_pr_attribution / upsert_pr_metrics_summary handlers (CORE-201)."""
+    """Stub upsert_pr_metrics_summary handler (CORE-201)."""
 
     def setUp(self) -> None:
         super().setUp()
@@ -1792,71 +1791,6 @@ class TestPrMetricsRpc(APITestCase):
     def _auth_header(self, path: str, data: dict) -> str:
         body = orjson.dumps(data).decode()
         return f"rpcsignature {generate_request_signature(path, body.encode())}"
-
-    def test_register_pr_attribution_success(self) -> None:
-        result = register_pr_attribution(
-            organization_id=self.organization.id,
-            repository_id=self.repository.id,
-            pr_number="123",
-            signal_type="seer_delegated:cursor",
-            run_id=42,
-        )
-        assert result == {"success": True}
-
-    def test_register_pr_attribution_empty_signal_type(self) -> None:
-        result = register_pr_attribution(
-            organization_id=self.organization.id,
-            repository_id=self.repository.id,
-            pr_number="123",
-            signal_type="",
-        )
-        assert result["success"] is False
-
-    def test_register_pr_attribution_repository_not_found(self) -> None:
-        result = register_pr_attribution(
-            organization_id=self.organization.id,
-            repository_id=self.repository.id + 1000,
-            pr_number="123",
-            signal_type="seer_app",
-        )
-        assert result == {"success": False, "error": "Repository not found"}
-
-    def test_register_pr_attribution_repository_outside_org(self) -> None:
-        other_org = self.create_organization()
-        other_project = self.create_project(organization=other_org)
-        other_repo = self.create_repo(project=other_project, name="getsentry/other")
-        result = register_pr_attribution(
-            organization_id=self.organization.id,
-            repository_id=other_repo.id,
-            pr_number="123",
-            signal_type="seer_app",
-        )
-        assert result == {"success": False, "error": "Repository not found"}
-
-    def test_register_pr_attribution_missing_required_arg_raises(self) -> None:
-        with pytest.raises(TypeError):
-            register_pr_attribution(
-                organization_id=self.organization.id,
-                repository_id=self.repository.id,
-                pr_number="123",
-            )
-
-    def test_register_pr_attribution_registered_on_internal_rpc(self) -> None:
-        path = self._get_path("register_pr_attribution")
-        data: dict[str, Any] = {
-            "args": {
-                "organization_id": self.organization.id,
-                "repository_id": self.repository.id,
-                "pr_number": "123",
-                "signal_type": "seer_app",
-            },
-            "meta": {},
-        }
-        response = self.client.post(
-            path, data=data, HTTP_AUTHORIZATION=self._auth_header(path, data)
-        )
-        assert response.status_code == 200
-        assert response.data == {"success": True}
 
     def test_upsert_pr_metrics_summary_success(self) -> None:
         result = upsert_pr_metrics_summary(


### PR DESCRIPTION
Adds the inbound `upsert_pr_metrics_summary` handler to the seer-rpc surface (next to `send_seer_webhook`): Seer's judge-summary callback at PR close/merge, so Sentry's canonical PR row stays the source of truth for product queries. Part of the **PR Merge Live Metrics** project.

Now that CORE-200's models have landed, this is a real write rather than a validate-and-acknowledge stub.

## What this adds

- `upsert_pr_metrics_summary(organization_id, repository_id, pr_number, event_id, verdict, counters)` — registered under the "PR Merge Live Metrics" section in `seer_method_registry`.

## Behavior

- Validates `verdict` against `PullRequestVerdict` up front (actionable error instead of a downstream DB/choices failure).
- Resolves the repository **scoped to the organization** via `repository_service.get_repository(...)` (IDOR-safe — returns "Repository not found" on mismatch or missing).
- Find-or-creates the canonical `PullRequest` row, then `update_or_create`s the one-to-one `PullRequestMetrics` with the verdict and counters. The summary can arrive before the SCM `opened` webhook, so the PR row may be a shell (null lifecycle fields) that the webhook backfills later.
- **Idempotent**: the one-to-one constraint means a redelivered `event_id` updates the existing metrics row instead of inserting a duplicate.
- Counters cross a trust boundary into `BoundedPositiveIntegerField` columns, so unknown keys are ignored (forward-compatible contract) and negatives are clamped to zero.

## Out of scope

Attribution is handled separately: Seer-created PRs are attributed from the existing `seer.pr_created` event on its own path, so the judge-time `refined_attribution_signals` argument is dropped from this contract.

Refs CORE-201
