### PR TITLE
fix(low-value-spans): Use project platform for snippets

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
@@ -43,5 +43,4 @@ describe('LowValueSpanIssueDetails', () => {
     expect(screen.queryByText('Diagnosis')).not.toBeInTheDocument();
     expect(screen.queryByText('Impact')).not.toBeInTheDocument();
   });
-
 });

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.spec.tsx
@@ -43,4 +43,5 @@ describe('LowValueSpanIssueDetails', () => {
     expect(screen.queryByText('Diagnosis')).not.toBeInTheDocument();
     expect(screen.queryByText('Impact')).not.toBeInTheDocument();
   });
+
 });

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.tsx
@@ -13,7 +13,10 @@ interface LowValueSpanIssueDetailsProps {
   project: Project;
 }
 
-export function LowValueSpanIssueDetails({event, project}: LowValueSpanIssueDetailsProps) {
+export function LowValueSpanIssueDetails({
+  event,
+  project,
+}: LowValueSpanIssueDetailsProps) {
   const evidenceData = getLowValueSpanEvidenceData(event.occurrence?.evidenceData);
 
   return (

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanIssueDetails.tsx
@@ -13,14 +13,17 @@ interface LowValueSpanIssueDetailsProps {
   project: Project;
 }
 
-export function LowValueSpanIssueDetails({event}: LowValueSpanIssueDetailsProps) {
+export function LowValueSpanIssueDetails({event, project}: LowValueSpanIssueDetailsProps) {
   const evidenceData = getLowValueSpanEvidenceData(event.occurrence?.evidenceData);
 
   return (
     <div>
       <ProblemSection evidenceData={evidenceData} />
       <SectionDivider orientation="horizontal" />
-      <TroubleshootingSection evidenceData={evidenceData} />
+      <TroubleshootingSection
+        evidenceData={evidenceData}
+        projectPlatform={project.platform}
+      />
     </div>
   );
 }

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.spec.tsx
@@ -10,7 +10,6 @@ const evidenceData: LowValueSpanEvidenceData = {
   extrapolatedCount: 60_000,
   avgDurationMs: 0.4,
   estimatedCostUsd: 12.34,
-  sdkName: 'sentry.javascript.nextjs',
   spanOrigin: 'auto',
 };
 
@@ -26,7 +25,6 @@ describe('LowValueSpanIssues ProblemSection', () => {
     expect(screen.getByText('Estimated cost')).toBeInTheDocument();
     expect(screen.getByText('$12.34')).toBeInTheDocument();
     expect(screen.getByText('<1ms')).toBeInTheDocument();
-    expect(screen.queryByText('sentry.javascript.nextjs')).not.toBeInTheDocument();
   });
 
   it('falls back to the sampled span count when extrapolated count is unavailable', () => {

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
@@ -10,18 +10,21 @@ const baseEvidenceData: LowValueSpanEvidenceData = {
   extrapolatedCount: 60_000,
   avgDurationMs: 0.4,
   estimatedCostUsd: 12.34,
-  sdkName: 'sentry.javascript.nextjs',
   spanOrigin: 'auto',
 };
 
 describe('LowValueSpanIssues TroubleshootingSection', () => {
   it('renders automatic instrumentation guidance for auto spans', () => {
-    render(<TroubleshootingSection evidenceData={baseEvidenceData} />);
+    render(
+      <TroubleshootingSection
+        evidenceData={baseEvidenceData}
+        projectPlatform="javascript-nextjs"
+      />
+    );
 
     expect(screen.getByText('Troubleshooting')).toBeInTheDocument();
     expect(screen.getByText('ignoreSpans')).toBeInTheDocument();
     expect(screen.queryByText('function - compute_checksum')).not.toBeInTheDocument();
-    expect(screen.queryByText('sentry.javascript.nextjs')).not.toBeInTheDocument();
     expect(screen.queryByText('1. Find the custom span')).not.toBeInTheDocument();
     expect(screen.queryByText('2. Remove or replace the span')).not.toBeInTheDocument();
   });
@@ -33,6 +36,7 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
           ...baseEvidenceData,
           spanOrigin: 'manual',
         }}
+        projectPlatform="javascript-nextjs"
       />
     );
 
@@ -40,13 +44,17 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
     expect(screen.getByText('2. Remove or replace the span')).toBeInTheDocument();
     expect(screen.getByText(/delete the custom span line/)).toBeInTheDocument();
     expect(screen.getAllByText('function - compute_checksum').length).toBeGreaterThan(0);
-    expect(screen.queryByText('sentry.javascript.nextjs')).not.toBeInTheDocument();
     expect(screen.queryByText('ignoreSpans')).not.toBeInTheDocument();
     expect(screen.queryByText('before_send_transaction')).not.toBeInTheDocument();
   });
 
   it('recommends JavaScript span filtering and mentions beforeSendSpan', () => {
-    render(<TroubleshootingSection evidenceData={baseEvidenceData} />);
+    render(
+      <TroubleshootingSection
+        evidenceData={baseEvidenceData}
+        projectPlatform="javascript-nextjs"
+      />
+    );
 
     expect(screen.getByText('ignoreSpans')).toBeInTheDocument();
     expect(screen.getByText('beforeSendSpan')).toBeInTheDocument();
@@ -54,13 +62,11 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
     expect(screen.getByText(/name: "compute_checksum"/)).toBeInTheDocument();
   });
 
-  it('recommends before_send_transaction for Python SDKs', () => {
+  it('recommends before_send_transaction for Python project platforms', () => {
     render(
       <TroubleshootingSection
-        evidenceData={{
-          ...baseEvidenceData,
-          sdkName: 'sentry.python',
-        }}
+        evidenceData={baseEvidenceData}
+        projectPlatform="python-django"
       />
     );
 
@@ -69,18 +75,40 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
     expect(screen.getByText(/span.get\("op"\) == "function"/)).toBeInTheDocument();
   });
 
-  it('renders generic guidance when the SDK is unavailable', () => {
+  it('uses a JavaScript project platform for JavaScript snippets', () => {
     render(
       <TroubleshootingSection
-        evidenceData={{
-          ...baseEvidenceData,
-          sdkName: null,
-        }}
+        evidenceData={baseEvidenceData}
+        projectPlatform="javascript-nextjs"
       />
     );
 
+    expect(screen.getByText('ignoreSpans')).toBeInTheDocument();
+    expect(screen.getByText(/op: "function"/)).toBeInTheDocument();
+    expect(screen.queryByText(/Add an exact-match span filter/)).not.toBeInTheDocument();
+  });
+
+  it('uses a Python project platform for Python snippets', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={baseEvidenceData}
+        projectPlatform="python-django"
+      />
+    );
+
+    expect(screen.getByText('before_send_transaction')).toBeInTheDocument();
+    expect(screen.getByText(/span.get\("op"\) == "function"/)).toBeInTheDocument();
+    expect(screen.queryByText(/Add an exact-match span filter/)).not.toBeInTheDocument();
+  });
+
+  it('renders generic guidance when the project platform is unavailable', () => {
+    render(
+      <TroubleshootingSection evidenceData={baseEvidenceData} projectPlatform={null} />
+    );
+
     expect(screen.getByText(/Add an exact-match span filter/)).toBeInTheDocument();
-    expect(screen.queryByText(/beforeSendTransaction/)).not.toBeInTheDocument();
+    expect(screen.queryByText('ignoreSpans')).not.toBeInTheDocument();
+    expect(screen.queryByText('before_send_transaction')).not.toBeInTheDocument();
   });
 
   it('treats missing span origin as automatic instrumentation', () => {
@@ -90,6 +118,7 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
           ...baseEvidenceData,
           spanOrigin: null,
         }}
+        projectPlatform="javascript-nextjs"
       />
     );
 

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
@@ -5,6 +5,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 import {ExternalLink} from 'sentry/components/links/externalLink';
 import {IconDocs} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import type {PlatformKey} from 'sentry/types/project';
 
 import {SpanCode} from './spanCode';
 import type {LowValueSpanEvidenceData} from './types';
@@ -13,20 +14,23 @@ import {
   getPythonSpanFilterSnippet,
   getSpanFilteringDocsUrl,
   getSpanLabel,
-  isJavaScriptSdk,
-  isPythonSdk,
+  isJavaScriptProjectPlatform,
+  isPythonProjectPlatform,
 } from './utils';
 
 interface TroubleshootingSectionProps {
   evidenceData: LowValueSpanEvidenceData;
+  projectPlatform?: PlatformKey | null;
 }
 
 function AutomaticInstrumentationFix({
   evidenceData,
+  projectPlatform,
 }: {
   evidenceData: LowValueSpanEvidenceData;
+  projectPlatform?: PlatformKey | null;
 }) {
-  if (isPythonSdk(evidenceData)) {
+  if (isPythonProjectPlatform(projectPlatform)) {
     return (
       <Stack gap="md">
         <Text>
@@ -42,7 +46,7 @@ function AutomaticInstrumentationFix({
     );
   }
 
-  if (isJavaScriptSdk(evidenceData)) {
+  if (isJavaScriptProjectPlatform(projectPlatform)) {
     return (
       <Stack gap="md">
         <Text>
@@ -101,8 +105,10 @@ function ManualInstrumentationFix({
 
 function AutomaticInstrumentationTroubleshooting({
   evidenceData,
+  projectPlatform,
 }: {
   evidenceData: LowValueSpanEvidenceData;
+  projectPlatform?: PlatformKey | null;
 }) {
   return (
     <Stack gap="md">
@@ -111,10 +117,13 @@ function AutomaticInstrumentationTroubleshooting({
           'This appears to come from SDK automatic instrumentation. Filter the exact operation and description before the span is sent.'
         )}
       </Text>
-      <AutomaticInstrumentationFix evidenceData={evidenceData} />
+      <AutomaticInstrumentationFix
+        evidenceData={evidenceData}
+        projectPlatform={projectPlatform}
+      />
       <Flex align="center" gap="xs">
         <IconDocs size="xs" />
-        <ExternalLink href={getSpanFilteringDocsUrl(evidenceData)}>
+        <ExternalLink href={getSpanFilteringDocsUrl(projectPlatform)}>
           {t('Read the SDK filtering docs')}
         </ExternalLink>
       </Flex>
@@ -122,7 +131,10 @@ function AutomaticInstrumentationTroubleshooting({
   );
 }
 
-export function TroubleshootingSection({evidenceData}: TroubleshootingSectionProps) {
+export function TroubleshootingSection({
+  evidenceData,
+  projectPlatform,
+}: TroubleshootingSectionProps) {
   const isManualInstrumentation = evidenceData.spanOrigin === 'manual';
 
   return (
@@ -131,7 +143,10 @@ export function TroubleshootingSection({evidenceData}: TroubleshootingSectionPro
       {isManualInstrumentation ? (
         <ManualInstrumentationFix evidenceData={evidenceData} />
       ) : (
-        <AutomaticInstrumentationTroubleshooting evidenceData={evidenceData} />
+        <AutomaticInstrumentationTroubleshooting
+          evidenceData={evidenceData}
+          projectPlatform={projectPlatform}
+        />
       )}
     </Stack>
   );

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/types.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/types.ts
@@ -7,7 +7,6 @@ export interface LowValueSpanEvidenceData {
   estimatedCostUsd: number | null;
   extrapolatedCount: number | null;
   op: string | null;
-  sdkName: string | null;
   spanOrigin: string | null;
 }
 
@@ -20,7 +19,6 @@ type LowValueSpanEvidencePayload = Partial<{
   estimatedCostUsd: unknown;
   extrapolatedCount: unknown;
   op: unknown;
-  sdkName: unknown;
   spanOrigin: unknown;
   valueScore: unknown;
 }>;
@@ -45,7 +43,6 @@ export function getLowValueSpanEvidenceData(
     extrapolatedCount: getNumberValue(data?.extrapolatedCount),
     avgDurationMs: getNumberValue(data?.avgDurationMs),
     estimatedCostUsd: getNumberValue(data?.estimatedCostUsd),
-    sdkName: getStringValue(data?.sdkName),
     spanOrigin: getStringValue(data?.spanOrigin),
   };
 }

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import type {PlatformKey} from 'sentry/types/project';
 
 import type {LowValueSpanEvidenceData} from './types';
 
@@ -7,6 +8,16 @@ const JAVASCRIPT_SPAN_FILTERING_DOCS_URL =
 const PYTHON_SPAN_FILTERING_DOCS_URL =
   'https://docs.sentry.io/platforms/python/configuration/filtering/#filtering-transaction-events';
 const GENERIC_SPAN_FILTERING_DOCS_URL = 'https://docs.sentry.io/product/explore/traces/';
+const JAVASCRIPT_PROJECT_PLATFORMS = new Set<PlatformKey>([
+  'bun',
+  'capacitor',
+  'cordova',
+  'deno',
+  'electron',
+  'ionic',
+  'react',
+  'react-native',
+]);
 
 export function getSpanLabel(evidenceData: LowValueSpanEvidenceData): string {
   const {op, description} = evidenceData;
@@ -52,29 +63,33 @@ export function formatEstimatedCostUsd(estimatedCostUsd: number | null): string 
   });
 }
 
-export function isPythonSdk(evidenceData: LowValueSpanEvidenceData): boolean {
-  const sdkName = evidenceData.sdkName?.toLowerCase() ?? '';
+export function isPythonProjectPlatform(projectPlatform?: PlatformKey | null): boolean {
+  if (projectPlatform === null || projectPlatform === undefined) {
+    return false;
+  }
 
-  return sdkName.includes('python');
+  return projectPlatform.startsWith('python');
 }
 
-export function isJavaScriptSdk(evidenceData: LowValueSpanEvidenceData): boolean {
-  const sdkName = evidenceData.sdkName?.toLowerCase() ?? '';
+export function isJavaScriptProjectPlatform(
+  projectPlatform?: PlatformKey | null
+): boolean {
+  if (projectPlatform === null || projectPlatform === undefined) {
+    return false;
+  }
 
   return (
-    sdkName.includes('javascript') ||
-    sdkName.includes('node') ||
-    sdkName.includes('browser') ||
-    sdkName.includes('nextjs') ||
-    sdkName.includes('react')
+    projectPlatform.startsWith('javascript') ||
+    projectPlatform.startsWith('node') ||
+    JAVASCRIPT_PROJECT_PLATFORMS.has(projectPlatform)
   );
 }
 
-export function getSpanFilteringDocsUrl(evidenceData: LowValueSpanEvidenceData): string {
-  if (isPythonSdk(evidenceData)) {
+export function getSpanFilteringDocsUrl(projectPlatform?: PlatformKey | null): string {
+  if (isPythonProjectPlatform(projectPlatform)) {
     return PYTHON_SPAN_FILTERING_DOCS_URL;
   }
-  if (isJavaScriptSdk(evidenceData)) {
+  if (isJavaScriptProjectPlatform(projectPlatform)) {
     return JAVASCRIPT_SPAN_FILTERING_DOCS_URL;
   }
   return GENERIC_SPAN_FILTERING_DOCS_URL;


### PR DESCRIPTION
Use the issue project platform to choose the low-value span filtering docs and snippets. This keeps snippet selection working when low-value evidence does not provide SDK metadata.