### PR TITLE
feat(inbound-filters): change `*/health{/,}` to `*/health{/*,}`

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -797,7 +797,7 @@ HEALTH_CHECK_GLOBS = [
     "*healthcheck*",
     "*health-check*",
     "*heartbeat*",
-    "*/health{/,}",
+    "*/health{/*,}",
     "*/healthy{/,}",
     "*/healthz{/,}",
     "*/health_check{/,}",

--- a/tests/sentry/dynamic_sampling/rules/biases/test_ignore_health_checks_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_ignore_health_checks_bias.py
@@ -47,6 +47,8 @@ def expand_glob_for_fnmatch(pattern: str) -> list[str]:
     pattern = pattern.replace(r"\[", "[[]").replace(r"\]", "[]]")
 
     # Expand {/,} brace syntax
+    if "{/*,}" in pattern:
+        return [pattern.replace("{/*,}", "/*"), pattern.replace("{/*,}", "")]
     if "{/,}" in pattern:
         return [pattern.replace("{/,}", "/"), pattern.replace("{/,}", "")]
     return [pattern]
@@ -89,12 +91,12 @@ def matches_health_check_globs(transaction_name: str) -> bool:
         ("POST /heartbeat", "*heartbeat*"),
         ("heartbeat", "*heartbeat*"),
         ("service-heartbeat-check", "*heartbeat*"),
-        # Pattern: */health{/,}
-        ("/api/health", "*/health{/,}"),
-        ("/api/health/", "*/health{/,}"),
-        ("GET /health", "*/health{/,}"),
-        ("GET /health/", "*/health{/,}"),
-        ("/v1/health", "*/health{/,}"),
+        # Pattern: */health{/*,}
+        ("/api/health", "*/health{/*,}"),
+        ("/api/health/foo", "*/health{/*,}"),
+        ("GET /health", "*/health{/*,}"),
+        ("GET /health/", "*/health{/*,}"),
+        ("/v1/health", "*/health{/*,}"),
         # Pattern: */healthy{/,}
         ("/api/healthy", "*/healthy{/,}"),
         ("/api/healthy/", "*/healthy{/,}"),

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
@@ -161,7 +161,7 @@ config:
       - '*healthcheck*'
       - '*health-check*'
       - '*heartbeat*'
-      - '*/health{/,}'
+      - '*/health{/*,}'
       - '*/healthy{/,}'
       - '*/healthz{/,}'
       - '*/health_check{/,}'


### PR DESCRIPTION
Change the `*/health{/,}` glob pattern for inbound filters  & dynamic sampling to  `*/health{/*,}`. (Changed inspired by https://github.com/getsentry/sentry/pull/110402)

Closes: https://github.com/getsentry/sentry/issues/116558