### PR TITLE
fix(integrations): Hide the integration Settings tab when it is empty

### DIFF
--- a/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
@@ -1,6 +1,8 @@
+import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
 import {OpsgenieIntegrationFixture} from 'sentry-fixture/opsgenieIntegration';
 import {OpsgenieIntegrationProviderFixture} from 'sentry-fixture/opsgenieIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
 import {
   render,
@@ -75,5 +77,86 @@ describe('OpsgenieMigrationButton', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
 
     expect(onConfirmCall).toHaveBeenCalled();
+  });
+});
+
+describe('ConfigureIntegration settings tab', () => {
+  const org = OrganizationFixture({
+    access: ['org:integrations', 'org:write'],
+  });
+  const integrationId = '1';
+
+  function mockRequests(integration: ReturnType<typeof OrganizationIntegrationsFixture>) {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/config/integrations/`,
+      body: {
+        providers: [GitHubIntegrationProviderFixture({features: ['stacktrace-link']})],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/integrations/${integrationId}/`,
+      body: integration,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/plugins/configs/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/code-mappings/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/repos/`,
+      body: [],
+    });
+  }
+
+  function renderConfigure() {
+    return render(<ConfigureIntegration />, {
+      organization: org,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/${org.slug}/integrations/github/${integrationId}/`,
+          query: {},
+        },
+        route: '/settings/:orgId/integrations/:providerKey/:integrationId/',
+      },
+    });
+  }
+
+  const githubProvider = OrganizationIntegrationsFixture().provider;
+
+  it('hides the Settings tab when there is no settings content', async () => {
+    mockRequests(
+      OrganizationIntegrationsFixture({
+        provider: {...githubProvider, key: 'github'},
+        configOrganization: [],
+      })
+    );
+
+    renderConfigure();
+
+    expect(await screen.findByRole('tab', {name: 'Code Mappings'})).toBeInTheDocument();
+    expect(screen.queryByRole('tab', {name: 'Settings'})).not.toBeInTheDocument();
+  });
+
+  it('shows the Settings tab when there is organization config', async () => {
+    mockRequests(
+      OrganizationIntegrationsFixture({
+        provider: {...githubProvider, key: 'github'},
+        configOrganization: [
+          {
+            name: 'toggle',
+            type: 'boolean',
+            label: 'Toggle',
+          },
+        ],
+      })
+    );
+
+    renderConfigure();
+
+    expect(await screen.findByRole('tab', {name: 'Settings'})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'Code Mappings'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -52,8 +52,7 @@ import {IntegrationExternalUserMappings} from './integrationExternalUserMappings
 import {IntegrationItem} from './integrationItem';
 import {IntegrationServerlessFunctions} from './integrationServerlessFunctions';
 
-const TABS = ['settings', 'codeMappings', 'userMappings', 'teamMappings'] as const;
-type Tab = (typeof TABS)[number];
+type Tab = 'settings' | 'codeMappings' | 'userMappings' | 'teamMappings';
 
 const makeIntegrationQuery = (
   organization: Organization,
@@ -80,8 +79,6 @@ function ConfigureIntegration() {
   const api = useApi();
   const queryClient = useQueryClient();
   const organization = useOrganization();
-  const tabParam = decodeScalar(location.query.tab) as Tab | undefined;
-  const tab = tabParam && TABS.includes(tabParam) ? tabParam : 'settings';
   const {integrationId, providerKey} = useParams<{
     integrationId: string;
     providerKey: string;
@@ -166,6 +163,59 @@ function ConfigureIntegration() {
   if (!provider || !integration) {
     return null;
   }
+
+  // The Settings tab only has content when there is something to render in
+  // renderMainTab(). When empty, the tab is hidden entirely.
+  const settingsInstructions =
+    integration.dynamicDisplayInformation?.configure_integration?.instructions;
+  const hasSettingsTabContent =
+    integration.configOrganization.length > 0 ||
+    (settingsInstructions?.length ?? 0) > 0 ||
+    provider.features.includes('alert-rule') ||
+    provider.features.includes('serverless');
+
+  const hasStacktraceLinking = provider.features.includes('stacktrace-link');
+  const hasCodeOwners =
+    provider.features.includes('codeowners') &&
+    organization.features.includes('integrations-codeowners');
+  const hasUserMapping = provider.features.includes('user-mapping');
+
+  // The Settings tab is paired with stacktrace linking or user mapping; it is
+  // only shown when renderMainTab() would actually have content.
+  const settingsTabs: Array<[Tab, string]> =
+    hasSettingsTabContent && (hasStacktraceLinking || hasUserMapping)
+      ? [['settings', t('Settings')]]
+      : [];
+
+  const stackTraceLinkingTabs: Array<[Tab, string]> = hasStacktraceLinking
+    ? [['codeMappings', t('Code Mappings')]]
+    : [];
+
+  const codeOwnerTabs: Array<[Tab, string]> = hasCodeOwners
+    ? [
+        ['userMappings', t('User Mappings')],
+        ['teamMappings', t('Team Mappings')],
+      ]
+    : [];
+
+  // User mappings are mutually exclusive with stacktrace linking
+  // and code owners, so only render the main settings tab and user mappings.
+  const userMappingTabs: Array<[Tab, string]> = hasUserMapping
+    ? [['userMappings', t('User Mappings')]]
+    : [];
+
+  const allTabs = [
+    ...settingsTabs,
+    ...stackTraceLinkingTabs,
+    ...codeOwnerTabs,
+    ...userMappingTabs,
+  ];
+
+  const tabParam = decodeScalar(location.query.tab) as Tab | undefined;
+  const tab =
+    tabParam && allTabs.some(([key]) => key === tabParam)
+      ? tabParam
+      : (allTabs[0]?.[0] ?? 'settings');
 
   const onTabChange = (value: Tab) => {
     // XXX: Omit the cursor to prevent paginating the next tab's queries.
@@ -458,41 +508,6 @@ function ConfigureIntegration() {
   }
 
   function renderMainContent() {
-    const hasStacktraceLinking = provider!.features.includes('stacktrace-link');
-    const hasCodeOwners =
-      provider!.features.includes('codeowners') &&
-      organization.features.includes('integrations-codeowners');
-    const hasUserMapping = provider!.features.includes('user-mapping');
-
-    const tabs: Array<[Tab, string]> = [];
-    const stackTraceLinkingTabs: Array<[Tab, string]> = hasStacktraceLinking
-      ? [
-          ['settings', t('Settings')],
-          ['codeMappings', t('Code Mappings')],
-        ]
-      : [];
-
-    const codeOwnerTabs: Array<[Tab, string]> = hasCodeOwners
-      ? [
-          ['userMappings', t('User Mappings')],
-          ['teamMappings', t('Team Mappings')],
-        ]
-      : [];
-
-    // User mappings are mutually exclusive with stacktrace linking
-    // and code owners, so only render the main settings tab and user mappings.
-    const userMappingTabs: Array<[Tab, string]> = hasUserMapping
-      ? [
-          ['settings', t('Settings')],
-          ['userMappings', t('User Mappings')],
-        ]
-      : [];
-
-    const allTabs = tabs
-      .concat(stackTraceLinkingTabs)
-      .concat(codeOwnerTabs)
-      .concat(userMappingTabs);
-
     if (allTabs.length === 0) {
       return renderMainTab();
     }


### PR DESCRIPTION
The integration detail page renders a "Settings" tab whenever the provider supports stacktrace linking or user mapping, but the tab's content comes only from the organization config form, dynamic display instructions, and the alert-rule/serverless feature UI. Providers like Bitbucket have none of these, so since the repository list was removed from this tab in #115196 it has rendered completely blank.

This hides the Settings tab when it would have no content and falls the default tab selection back to the first available tab, so Bitbucket now opens on Code Mappings instead of an empty tab. GitHub and other providers that expose organization config still show it.

Fixed [ISWF-2693](https://linear.app/getsentry/issue/ISWF-2693/bitbucket-integration-settings-tab-renders-blank)