### PR TITLE
ref(source-maps): point source map debug at the canonical endpoint

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -10,7 +10,7 @@ import {StacktraceBanners} from 'sentry/components/events/interfaces/crashConten
 import {
   prepareSourceMapDebuggerFrameInformation,
   useSourceMapDebugQuery,
-  type SourceMapDebugBlueThunderResponse,
+  type SourceMapDebugResponse,
 } from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData';
 import {renderLinksInText} from 'sentry/components/events/interfaces/crashContent/exception/utils';
 import {getStacktracePlatform} from 'sentry/components/events/interfaces/utils';
@@ -160,7 +160,7 @@ function InnerContent({
   hasChainedExceptions: boolean;
   hiddenExceptions: ExceptionRenderStateMap;
   isSampleError: boolean;
-  sourceMapDebuggerData: SourceMapDebugBlueThunderResponse | undefined;
+  sourceMapDebuggerData: SourceMapDebugResponse | undefined;
   toggleRelatedExceptions: (exceptionId: number) => void;
   values: ExceptionValue[];
   project?: Project;

--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
@@ -6,7 +6,7 @@ import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-export interface SourceMapDebugBlueThunderResponseFrame {
+export interface SourceMapDebugResponseFrame {
   debug_id_process: {
     debug_id: string | null;
     uploaded_source_file_with_correct_debug_id: boolean;
@@ -34,10 +34,10 @@ export interface SourceMapDebugBlueThunderResponseFrame {
   };
 }
 
-export interface SourceMapDebugBlueThunderResponse {
+export interface SourceMapDebugResponse {
   dist: string | null;
   exceptions: Array<{
-    frames: SourceMapDebugBlueThunderResponseFrame[];
+    frames: SourceMapDebugResponseFrame[];
   }>;
   has_debug_ids: boolean;
   has_uploaded_some_artifact_with_a_debug_id: boolean;
@@ -51,7 +51,7 @@ export interface SourceMapDebugBlueThunderResponse {
 }
 
 export type SourceMapDebugQueryResult = UseApiQueryResult<
-  SourceMapDebugBlueThunderResponse,
+  SourceMapDebugResponse,
   RequestError
 >;
 
@@ -63,10 +63,10 @@ export function useSourceMapDebugQuery(
   const organization = useOrganization({allowNull: true});
   const isSdkThatShouldShowSourceMapsDebugger =
     sdkName?.startsWith('sentry.javascript.') ?? false;
-  return useApiQuery<SourceMapDebugBlueThunderResponse>(
+  return useApiQuery<SourceMapDebugResponse>(
     [
       getApiUrl(
-        '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/source-map-debug-blue-thunder-edition/',
+        '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/source-map-debug/',
         {
           path: {
             organizationIdOrSlug: organization!.slug,
@@ -90,8 +90,8 @@ export function useSourceMapDebugQuery(
 }
 
 function getDebugIdProgress(
-  sourceMapDebuggerData: SourceMapDebugBlueThunderResponse,
-  debuggerFrame: SourceMapDebugBlueThunderResponseFrame
+  sourceMapDebuggerData: SourceMapDebugResponse,
+  debuggerFrame: SourceMapDebugResponseFrame
 ) {
   let debugIdProgress = 0;
   if (sourceMapDebuggerData.sdk_debug_id_support === 'full') {
@@ -110,8 +110,8 @@ function getDebugIdProgress(
 }
 
 function getReleaseProgress(
-  sourceMapDebuggerData: SourceMapDebugBlueThunderResponse,
-  debuggerFrame: SourceMapDebugBlueThunderResponseFrame
+  sourceMapDebuggerData: SourceMapDebugResponse,
+  debuggerFrame: SourceMapDebugResponseFrame
 ) {
   let releaseProgress = 0;
   if (sourceMapDebuggerData.release !== null) {
@@ -129,7 +129,7 @@ function getReleaseProgress(
   return {releaseProgress, releaseProgressPercent: releaseProgress / 4};
 }
 
-function getScrapingProgress(debuggerFrame: SourceMapDebugBlueThunderResponseFrame) {
+function getScrapingProgress(debuggerFrame: SourceMapDebugResponseFrame) {
   let scrapingProgress = 0;
 
   if (debuggerFrame.scraping_process?.source_file?.status === 'success') {
@@ -148,8 +148,8 @@ function getScrapingProgress(debuggerFrame: SourceMapDebugBlueThunderResponseFra
 }
 
 export function prepareSourceMapDebuggerFrameInformation(
-  sourceMapDebuggerData: SourceMapDebugBlueThunderResponse,
-  debuggerFrame: SourceMapDebugBlueThunderResponseFrame,
+  sourceMapDebuggerData: SourceMapDebugResponse,
+  debuggerFrame: SourceMapDebugResponseFrame,
   event: Event,
   projectPlatform: PlatformKey | undefined
 ): FrameSourceMapDebuggerData {

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -485,7 +485,7 @@ describe('Core StackTrace', () => {
     const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
     ProjectsStore.loadInitialData([project]);
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/events/${javascriptEvent.id}/source-map-debug-blue-thunder-edition/`,
+      url: `/projects/${organization.slug}/${project.slug}/events/${javascriptEvent.id}/source-map-debug/`,
       body: {
         dist: null,
         exceptions: [

--- a/static/app/views/issueDetails/configurationIssues/sourceMapIssues/diagnosisSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/sourceMapIssues/diagnosisSection.spec.tsx
@@ -26,7 +26,7 @@ function TestWrapper() {
 
 describe('DiagnosisSection', () => {
   const organization = OrganizationFixture();
-  const apiUrl = `/projects/${organization.slug}/${PROJECT_SLUG}/events/${EVENT_ID}/source-map-debug-blue-thunder-edition/`;
+  const apiUrl = `/projects/${organization.slug}/${PROJECT_SLUG}/events/${EVENT_ID}/source-map-debug/`;
 
   it('shows error state when the API call fails', async () => {
     MockApiClient.addMockResponse({url: apiUrl, statusCode: 500, body: {}});

--- a/static/app/views/issueDetails/configurationIssues/sourceMapIssues/diagnosisSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/sourceMapIssues/diagnosisSection.tsx
@@ -14,9 +14,7 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 
-function getDiagnosisMessage(
-  data: SourceMapDebugResponse | undefined
-): ReactNode | null {
+function getDiagnosisMessage(data: SourceMapDebugResponse | undefined): ReactNode | null {
   if (!data) {
     return (
       <Text>{t('Unable to load source map diagnostic information for this event.')}</Text>

--- a/static/app/views/issueDetails/configurationIssues/sourceMapIssues/diagnosisSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/sourceMapIssues/diagnosisSection.tsx
@@ -6,7 +6,7 @@ import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import type {
-  SourceMapDebugBlueThunderResponse,
+  SourceMapDebugResponse,
   SourceMapDebugQueryResult,
 } from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -15,7 +15,7 @@ import {IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 
 function getDiagnosisMessage(
-  data: SourceMapDebugBlueThunderResponse | undefined
+  data: SourceMapDebugResponse | undefined
 ): ReactNode | null {
   if (!data) {
     return (

--- a/tests/js/fixtures/sourceMapDebug.ts
+++ b/tests/js/fixtures/sourceMapDebug.ts
@@ -1,10 +1,10 @@
 import type {
-  SourceMapDebugBlueThunderResponse,
-  SourceMapDebugBlueThunderResponseFrame,
+  SourceMapDebugResponse,
+  SourceMapDebugResponseFrame,
 } from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData';
 
 type ReleaseProcess = NonNullable<
-  SourceMapDebugBlueThunderResponseFrame['release_process']
+  SourceMapDebugResponseFrame['release_process']
 >;
 
 export function SourceMapDebugReleaseProcessFixture(
@@ -22,8 +22,8 @@ export function SourceMapDebugReleaseProcessFixture(
 }
 
 export function SourceMapDebugFrameFixture(
-  params: Partial<SourceMapDebugBlueThunderResponseFrame> = {}
-): SourceMapDebugBlueThunderResponseFrame {
+  params: Partial<SourceMapDebugResponseFrame> = {}
+): SourceMapDebugResponseFrame {
   return {
     debug_id_process: {
       debug_id: null,
@@ -37,8 +37,8 @@ export function SourceMapDebugFrameFixture(
 }
 
 export function SourceMapDebugResponseFixture(
-  params: Partial<SourceMapDebugBlueThunderResponse> = {}
-): SourceMapDebugBlueThunderResponse {
+  params: Partial<SourceMapDebugResponse> = {}
+): SourceMapDebugResponse {
   return {
     dist: null,
     release: null,

--- a/tests/js/fixtures/sourceMapDebug.ts
+++ b/tests/js/fixtures/sourceMapDebug.ts
@@ -3,9 +3,7 @@ import type {
   SourceMapDebugResponseFrame,
 } from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData';
 
-type ReleaseProcess = NonNullable<
-  SourceMapDebugResponseFrame['release_process']
->;
+type ReleaseProcess = NonNullable<SourceMapDebugResponseFrame['release_process']>;
 
 export function SourceMapDebugReleaseProcessFixture(
   params: Partial<ReleaseProcess> = {}


### PR DESCRIPTION
Follow up of https://github.com/getsentry/sentry/pull/116649/changes. Switch the frontend usages of the source map debug endpoint from the 'blue-thunder-edition' URL to `source-map-debug`.