### PR TITLE
test(spans): improve flush cleanup coverage

### DIFF
--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -11,7 +11,7 @@ from django.test import override_settings
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.spans.buffer import SpansBuffer
-from sentry.spans.buffer_types import FlushedSegment, OutputSpan, Span
+from sentry.spans.buffer_types import Span
 from sentry.spans.consumers.process.flusher import MultiProducer, SpanFlusher
 from sentry.testutils.helpers.options import override_options
 from tests.sentry.spans.test_buffer import DEFAULT_OPTIONS
@@ -33,21 +33,36 @@ def _blocking_main_for_join_test(
 
 @override_options({**DEFAULT_OPTIONS, "spans.buffer.flusher.log-flushed-segments": True})
 def test_flusher_logs_flushed_segments() -> None:
-    segment_key = f"span-buf:s:{{1:{'a' * 32}}}:{'b' * 16}".encode()
-    flushed_segment = FlushedSegment(
-        queue_key=b"span-buf:q:0",
-        spans=[OutputSpan(payload={"span_id": "b" * 16})],
-        project_id=1,
+    project_id = 999_002
+    trace_id = "9" * 32
+    span_id = "b" * 16
+    slice_id = 999_002
+    segment_key = f"span-buf:s:{{{project_id}:{trace_id}}}:{span_id}".encode()
+    queue_key = f"span-buf:q:{slice_id}-0".encode()
+    buffer = SpansBuffer(assigned_shards=[0], slice_id=slice_id)
+    buffer.process_spans(
+        [
+            Span(
+                payload=_payload(span_id),
+                trace_id=trace_id,
+                span_id=span_id,
+                parent_span_id=None,
+                segment_id=None,
+                is_segment_span=True,
+                project_id=project_id,
+                partition=0,
+            )
+        ],
+        now=0,
     )
-    buffer = mock.Mock()
-    buffer.any_shard_at_limit = False
-    buffer.flush_segments.return_value = {segment_key: flushed_segment}
     stopped = SimpleNamespace(value=0)
     current_drift = SimpleNamespace(value=0)
     backpressure_since = SimpleNamespace(value=0)
     healthy_since = SimpleNamespace(value=0)
+    produced: list[tuple[int, Any, int]] = []
 
-    def produce_to_pipe(project_id, payload, dropped):
+    def produce_to_pipe(project_id: int, payload: Any, dropped: int) -> None:
+        produced.append((project_id, payload, dropped))
         stopped.value = 1
 
     with mock.patch("sentry.spans.consumers.process.flusher.logger") as mock_logger:
@@ -65,12 +80,17 @@ def test_flusher_logs_flushed_segments() -> None:
         "spans.buffer.flushed_segment",
         extra={
             "segment_key": segment_key.decode("utf-8"),
-            "queue_key": "span-buf:q:0",
+            "queue_key": queue_key.decode("utf-8"),
             "span_count": 1,
-            "project_id": 1,
+            "project_id": project_id,
         },
     )
-    buffer.done_flush_segments.assert_called_once_with({segment_key: flushed_segment})
+    assert len(produced) == 1
+    assert produced[0][0] == project_id
+    assert produced[0][2] == 1
+    assert orjson.loads(produced[0][1].value)["spans"][0]["span_id"] == span_id
+    assert buffer.client.zscore(queue_key, segment_key) is None
+    assert not buffer.client.keys(f"*{project_id}:{trace_id}*")
 
 
 @override_options({**DEFAULT_OPTIONS, "spans.buffer.max-flush-segments": 1})

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -1677,6 +1677,9 @@ def test_flush_lock(
 
 
 def test_flush_lock_released_after_done_flush(buffer: SpansBuffer) -> None:
+    """
+    A single flusher releases the segment flush lock during cleanup.
+    """
     process_spans(
         [
             Span(
@@ -1702,6 +1705,78 @@ def test_flush_lock_released_after_done_flush(buffer: SpansBuffer) -> None:
         buffer.done_flush_segments(rv)
         assert buffer.client.exists(lock_key) == 0
 
+    assert_clean(buffer.client)
+
+
+def test_flush_lock_cleanup_releases_stale_queue_entry(buffer: SpansBuffer) -> None:
+    """
+    Two shard queues can contain the same segment.
+
+    The first flusher produces the segment and releases the lock during cleanup.
+    The second flusher then acquires the lock and removes its stale queue entry
+    without producing spans again.
+    """
+    process_spans(
+        [
+            Span(
+                payload=_payload("b" * 16),
+                trace_id="a" * 32,
+                span_id="b" * 16,
+                parent_span_id=None,
+                segment_id=None,
+                is_segment_span=True,
+                project_id=1,
+                partition=0,
+            ),
+        ],
+        buffer,
+        now=0,
+    )
+
+    process_spans(
+        [
+            Span(
+                payload=_payload("a" * 16),
+                trace_id="a" * 32,
+                span_id="a" * 16,
+                parent_span_id="b" * 16,
+                segment_id=None,
+                project_id=1,
+                partition=1,
+            ),
+        ],
+        buffer,
+        now=0,
+    )
+
+    buffer_a = SpansBuffer(assigned_shards=[0], slice_id=buffer.slice_id)
+    buffer_b = SpansBuffer(assigned_shards=[1], slice_id=buffer.slice_id)
+
+    with override_options({"spans.buffer.flusher.flush-lock-ttl": 10}):
+        rv_a = buffer_a.flush_segments(now=11)
+        rv_b = buffer_b.flush_segments(now=11)
+
+        segment_key = next(iter(rv_a))
+        queue_key_a = buffer_a.store.get_queue_key(0)
+        queue_key_b = buffer_b.store.get_queue_key(1)
+        lock_key = buffer_a.store.get_flush_lock_key(segment_key)
+
+        assert len(rv_a) == 1
+        assert rv_b == {}
+        assert buffer.client.zscore(queue_key_a, segment_key) is not None
+        assert buffer.client.zscore(queue_key_b, segment_key) is not None
+
+        buffer_a.done_flush_segments(rv_a)
+
+        assert buffer.client.zscore(queue_key_a, segment_key) is None
+        assert buffer.client.zscore(queue_key_b, segment_key) is not None
+        assert buffer.client.exists(lock_key) == 0
+
+        stale_rv = buffer_b.flush_segments(now=12)
+        assert stale_rv[segment_key].spans == []
+        buffer_b.done_flush_segments(stale_rv)
+
+    assert buffer.client.zscore(queue_key_b, segment_key) is None
     assert_clean(buffer.client)
 
 


### PR DESCRIPTION
  Refs STREAM-999

  Cover the lock-contention cleanup path where the same segment is queued in
  multiple shards. The test verifies that the first flusher releases the lock
  during cleanup, then the contending flusher removes its stale queue entry
  without producing duplicate spans.

  Also update a SpanFlusher logging test to use a real SpansBuffer so it
  validates the flush, produce, and cleanup lifecycle against Redis.