### PR TITLE
fix(seer-activity): Use preferred detector instead of issue stream

### DIFF
--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -6,8 +6,10 @@ from sentry.models.group import Group
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.processors.detector import get_preferred_detector
 from sentry.workflow_engine.registry import workflow_activity_registry
 from sentry.workflow_engine.tasks.workflows import process_workflow_activity
+from sentry.workflow_engine.types import WorkflowEventData
 
 logger = logging.getLogger(__name__)
 
@@ -47,13 +49,16 @@ def seer_activity_handler(group: Group, activity: Activity) -> None:
     ):
         return
 
+    event_data = WorkflowEventData(event=activity, group=group)
     try:
-        detector = Detector.get_issue_stream_detector_for_project(group.project_id)
+        detector = get_preferred_detector(event_data=event_data)
     except Detector.DoesNotExist:
         logger.exception(
             "workflow_engine.seer_activity_handler.missing_detector", extra=logging_ctx
         )
         return
+    logging_ctx["detector_id"] = detector.id
+    logging_ctx["detector_type"] = detector.type
 
     process_workflow_activity.delay(
         activity_id=activity.id,

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -1,6 +1,7 @@
 from unittest import mock
 from unittest.mock import MagicMock
 
+from sentry.grouping.grouptype import ErrorGroupType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
@@ -54,7 +55,7 @@ class SeerActivityHandlerTest(TestCase):
         self.activity = self.create_group_activity(
             group=self.group, type=ActivityType.SEER_PR_CREATED.value
         )
-        self.detector = self.create_detector(type=IssueStreamGroupType.slug, project=self.project)
+        self.detector = Detector.objects.get(project=self.project, type=ErrorGroupType.slug)
 
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
@@ -100,14 +101,32 @@ class SeerActivityHandlerTest(TestCase):
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
     @mock.patch(
-        "sentry.workflow_engine.models.Detector.get_issue_stream_detector_for_project",
-        side_effect=Exception("DoesNotExist"),
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.get_preferred_detector",
+        side_effect=Detector.DoesNotExist,
     )
-    def test_skips_when_no_issue_stream_detector(
+    def test_skips_when_no_detector(
         self, mock_get_detector: MagicMock, mock_process_workflow_activity: MagicMock
     ) -> None:
-        mock_get_detector.side_effect = Detector.DoesNotExist
-
         seer_activity_handler(self.group, self.activity)
 
         mock_process_workflow_activity.delay.assert_not_called()
+
+    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_falls_back_to_issue_stream_detector(
+        self, mock_process_workflow_activity: MagicMock
+    ) -> None:
+        Detector.objects.filter(project=self.project, type=ErrorGroupType.slug).delete()
+        issue_stream_detector = Detector.objects.get(
+            project=self.project, type=IssueStreamGroupType.slug
+        )
+
+        seer_activity_handler(self.group, self.activity)
+
+        mock_process_workflow_activity.delay.assert_called_once_with(
+            activity_id=self.activity.id,
+            group_id=self.group.id,
+            detector_id=issue_stream_detector.id,
+        )

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -2,6 +2,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.incidents.grouptype import MetricIssue
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
@@ -116,7 +117,9 @@ class SeerActivityHandlerTest(TestCase):
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
     def test_uses_group_detector(self, mock_process_workflow_activity: MagicMock) -> None:
-        detector = self.create_detector(name="linked_detector", project=self.project)
+        detector = self.create_detector(
+            name="linked_detector", type=MetricIssue.slug, project=self.project
+        )
         self.create_detector_group(detector=detector, group=self.group)
 
         seer_activity_handler(self.group, self.activity)

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -115,6 +115,22 @@ class SeerActivityHandlerTest(TestCase):
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
+    def test_uses_group_detector(self, mock_process_workflow_activity: MagicMock) -> None:
+        detector = self.create_detector(name="linked_detector", project=self.project)
+        self.create_detector_group(detector=detector, group=self.group)
+
+        seer_activity_handler(self.group, self.activity)
+
+        mock_process_workflow_activity.delay.assert_called_once_with(
+            activity_id=self.activity.id,
+            group_id=self.group.id,
+            detector_id=detector.id,
+        )
+
+    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
     def test_falls_back_to_issue_stream_detector(
         self, mock_process_workflow_activity: MagicMock
     ) -> None:


### PR DESCRIPTION
Changes how the seer_activity_handler fetches a detector to use the helper instead of limiting it to the issue stream detector. Added a test to ensure the fallback works as expected.