### PR TITLE
feat(ingest): match messages in custom inbound filter

### DIFF
--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -300,11 +300,19 @@ _healthcheck_filter = _FilterSpec(
 )
 
 
-def _error_message_condition(values: Sequence[tuple[str | None, str | None]]) -> RuleCondition:
+def _error_message_condition(
+    values: Sequence[tuple[str | None, str | None]],
+    match_logentry: bool = False,
+) -> RuleCondition:
     """
     Condition that expresses error message matching for an inbound filter.
+
+    When ``match_logentry`` is set, type-less patterns (``(None, message)``) also match
+    the event's ``logentry.formatted`` message, so events captured via ``capture_message``
+    (which carry no exception interface) are covered in addition to exceptions.
     """
     conditions = []
+    message_conditions: list[RuleCondition] = []
 
     for ty, value in values:
         ty_and_value: list[RuleCondition] = []
@@ -324,7 +332,14 @@ def _error_message_condition(values: Sequence[tuple[str | None, str | None]]) ->
                 }
             )
 
-    return cast(
+        # A logentry message has no exception type, so only type-less patterns can match
+        # it. Glob the formatted message string directly.
+        if match_logentry and ty is None and value is not None:
+            message_conditions.append(
+                {"op": "glob", "name": "event.logentry.formatted", "value": [value]}
+            )
+
+    exception_condition = cast(
         RuleCondition,
         {
             "op": "any",
@@ -333,6 +348,17 @@ def _error_message_condition(values: Sequence[tuple[str | None, str | None]]) ->
                 "op": "or",
                 "inner": conditions,
             },
+        },
+    )
+
+    if not message_conditions:
+        return exception_condition
+
+    return cast(
+        RuleCondition,
+        {
+            "op": "or",
+            "inner": [exception_condition, *message_conditions],
         },
     )
 
@@ -365,7 +391,7 @@ def _custom_error_filter() -> RuleCondition | None:
     # values are configured. Return None so it is omitted from the Relay config entirely.
     if not values:
         return None
-    return _error_message_condition(values)
+    return _error_message_condition(values, match_logentry=True)
 
 
 def _hydration_error_filter() -> RuleCondition:

--- a/tests/sentry/ingest/test_inbound_filters.py
+++ b/tests/sentry/ingest/test_inbound_filters.py
@@ -2,7 +2,12 @@ import pytest
 from django.test import override_settings
 from sentry_relay.processing import is_glob_match
 
-from sentry.ingest.inbound_filters import _custom_error_filter, get_generic_filters
+from sentry.ingest.inbound_filters import (
+    _chunk_load_error_filter,
+    _custom_error_filter,
+    _error_message_condition,
+    get_generic_filters,
+)
 from sentry.models.project import Project
 from sentry.testutils.pytest.fixtures import django_db_all
 
@@ -27,6 +32,19 @@ def exception_matches_filters(
     return False
 
 
+def message_matches_filters(
+    message: str,
+    patterns: list[tuple[str | None, str | None]],
+) -> bool:
+    """Matching rules for logentry messages: only type-less patterns apply."""
+    for type_pattern, message_pattern in patterns:
+        if type_pattern is not None or message_pattern is None:
+            continue
+        if is_glob_match(message, message_pattern):
+            return True
+    return False
+
+
 def test_custom_error_filter_empty() -> None:
     # With no custom values configured, the filter is a no-op and must be omitted from
     # the Relay config entirely rather than emitting an empty condition.
@@ -39,6 +57,49 @@ def test_custom_error_filter_empty() -> None:
 
 def test_custom_error_filter_builds_one_rule_per_pattern() -> None:
     with override_settings(SENTRY_INBOUND_FILTER_CUSTOM_VALUES=CUSTOM_PATTERNS):
+        condition = _custom_error_filter()
+
+    # The custom filter matches exceptions AND messages: the exception branch iterates
+    # over event.exception.values, while type-less patterns also glob the logentry message.
+    assert condition == {
+        "op": "or",
+        "inner": [
+            {
+                "op": "any",
+                "name": "event.exception.values",
+                "inner": {
+                    "op": "or",
+                    "inner": [
+                        {
+                            "op": "and",
+                            "inner": [
+                                {"op": "glob", "name": "ty", "value": ["MyError"]},
+                                {
+                                    "op": "glob",
+                                    "name": "value",
+                                    "value": ["Something went wrong *"],
+                                },
+                            ],
+                        },
+                        {"op": "glob", "name": "value", "value": ["*known flaky test*"]},
+                    ],
+                },
+            },
+            {
+                "op": "glob",
+                "name": "event.logentry.formatted",
+                "value": ["*known flaky test*"],
+            },
+        ],
+    }
+
+
+def test_custom_error_filter_exception_only_patterns_omit_logentry_branch() -> None:
+    # Without any type-less pattern there is nothing that can match a message, so the
+    # filter collapses back to the plain exception condition.
+    with override_settings(
+        SENTRY_INBOUND_FILTER_CUSTOM_VALUES=[("MyError", "Something went wrong *")]
+    ):
         condition = _custom_error_filter()
 
     assert condition == {
@@ -54,8 +115,30 @@ def test_custom_error_filter_builds_one_rule_per_pattern() -> None:
                         {"op": "glob", "name": "value", "value": ["Something went wrong *"]},
                     ],
                 },
-                {"op": "glob", "name": "value", "value": ["*known flaky test*"]},
             ],
+        },
+    }
+
+
+def test_chunk_load_filter_unchanged_by_logentry_matching() -> None:
+    # Built-in filters must not gain message matching: they keep the exception-only shape.
+    condition = _chunk_load_error_filter()
+
+    # An "any" top level (rather than the "or" wrapper) means there is no logentry branch.
+    assert condition["op"] == "any"
+    assert "event.logentry.formatted" not in repr(condition)
+
+
+def test_error_message_condition_logentry_disabled_by_default() -> None:
+    # The logentry branch is opt-in; the default keeps the historical exception-only shape.
+    condition = _error_message_condition([(None, "*known flaky test*")])
+
+    assert condition == {
+        "op": "any",
+        "name": "event.exception.values",
+        "inner": {
+            "op": "or",
+            "inner": [{"op": "glob", "name": "value", "value": ["*known flaky test*"]}],
         },
     }
 
@@ -103,3 +186,22 @@ def test_custom_error_filter_matches_concrete_messages(
         _custom_error_filter()
 
     assert exception_matches_filters(exc_type, exc_message, CUSTOM_PATTERNS) is expected
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        # Type-less pattern matches a plain message (capture_message) event.
+        ("This is a known flaky test timeout", True),
+        ("Something else entirely", False),
+        # Patterns that carry an exception type cannot match a type-less message.
+        ("Something went wrong in checkout", False),
+    ],
+)
+def test_custom_error_filter_matches_concrete_messages_via_logentry(
+    message: str, expected: bool
+) -> None:
+    with override_settings(SENTRY_INBOUND_FILTER_CUSTOM_VALUES=CUSTOM_PATTERNS):
+        _custom_error_filter()
+
+    assert message_matches_filters(message, CUSTOM_PATTERNS) is expected


### PR DESCRIPTION
Extend the custom-error generic inbound filter to also match `capture_message` events, not just exceptions.

The condition built by `_error_message_condition` only ever inspected `event.exception.values`, globbing each exception's type and message. Message events (`capture_message`) carry no exception interface — their text lands at `event.logentry.formatted` after normalization — so they slipped past the filter entirely.

This adds an opt-in `match_logentry` flag to `_error_message_condition`. When set, type-less patterns `(None, message)` additionally glob `event.logentry.formatted`, and the result is wrapped in a top-level `or` of the exception branch and the message branches. `_custom_error_filter` enables it; the built-in `chunk-load-error` and `react-hydration-errors` filters keep the default (`match_logentry=False`), so their generated Relay config is byte-for-byte unchanged.

A logentry message has no exception type, so only type-less patterns can match a message — patterns that carry a type stay exception-only. When no type-less pattern is configured, the condition collapses back to the original exception-only shape (no empty `or` wrapper).

Note: tests assert the generated `RuleCondition` structure and simulate glob matching locally; they do not exercise real Relay evaluation of `event.logentry.formatted`. That field is the canonical normalized message path used elsewhere in Sentry (grouping, json pruning), so the name is correct, but full end-to-end confirmation would require sending a message event through Relay with the filter configured.