### PR TITLE
chore(api): mark prompts-activity as private

### DIFF
--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -45,8 +45,8 @@ class PromptsActivityPermission(OrganizationPermission):
 @cell_silo_endpoint
 class PromptsActivityEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (PromptsActivityPermission,)
 

--- a/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
+++ b/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
@@ -78,5 +78,4 @@ API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
     "/api/0/sentry-app-installations/{uuid}/": {"DELETE", "GET", "PUT"},
     "/api/0/sentry-app-installations/{uuid}/external-issues/": {"POST"},
     "/api/0/sentry-app-installations/{uuid}/external-issues/{external_issue_id}/": {"DELETE"},
-    "/api/0/organizations/{organization_id_or_slug}/prompts-activity/": {"GET", "PUT"},
 }


### PR DESCRIPTION
Mark the `prompts-activity` endpoint as private, since it's only used for sentry analytics(?)