### PR TITLE
fix(events): Don't default the seer referrers

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -229,7 +229,14 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
         # Force the referrer to "api.auth-token.events" for events requests authorized through a bearer token
         if request.auth:
-            referrer = Referrer.API_AUTH_TOKEN_EVENTS.value
+            if (
+                referrer is not None
+                and is_valid_referrer(referrer)
+                and referrer.startswith("seer.")
+            ):
+                sentry_sdk.set_tag("query.from_seer", True)
+            else:
+                referrer = Referrer.API_AUTH_TOKEN_EVENTS.value
         elif referrer is None or not referrer:
             referrer = Referrer.API_ORGANIZATION_EVENTS.value
         elif not is_valid_referrer(referrer):


### PR DESCRIPTION
- Currently we default bearer token requests to AUTH_TOKEN so api users don't spam us with incorrect refererrs, but we don't want to do this for seer so adding a special case for them