### PR TITLE
feat(issues): Register mcp.official-client-ids option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -658,6 +658,17 @@ register("slack-staging.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_
 register("slack-staging.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("slack-staging.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
+# OAuth client_ids of the official Sentry MCP apps, used by the issue action log to attribute
+# actions to the MCP (vs. arbitrary OAuth apps). client_id is unique/server-assigned, so matching
+# on it is deterministic and not spoofable (unlike name). Empty by default — the trusted set is
+# configured explicitly via options-automator (the public stdio client_id + the hosted remote one).
+register(
+    "mcp.official-client-ids",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Issue Summary Auto-trigger rate (max number of autofix runs auto-triggered per project per hour)
 register(
     "seer.max_num_autofix_autotriggered_per_hour",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -659,9 +659,7 @@ register("slack-staging.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_
 register("slack-staging.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
 # OAuth client_ids of the official Sentry MCP apps, used by the issue action log to attribute
-# actions to the MCP (vs. arbitrary OAuth apps). client_id is unique/server-assigned, so matching
-# on it is deterministic and not spoofable (unlike name). Empty by default — the trusted set is
-# configured explicitly via options-automator (the public stdio client_id + the hosted remote one).
+# actions to the MCP (vs. arbitrary OAuth apps).
 register(
     "mcp.official-client-ids",
     type=Sequence,


### PR DESCRIPTION
Registers `mcp.official-client-ids`, the allowlist of official Sentry MCP OAuth `client_id`s. The issue action log uses it to attribute actions to the MCP by matching the token's `application_id` against apps resolved from this list.