### PR TITLE
fix(preprod): Reap stuck PROCESSING snapshot comparisons

### DIFF
--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -26,6 +26,7 @@ from sentry.preprod.models import (
     PreprodArtifactSizeComparison,
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
+    PreprodSnapshotComparison,
 )
 from sentry.preprod.quotas import (
     has_installable_quota,
@@ -835,6 +836,7 @@ def detect_expired_preprod_artifacts() -> None:
     - PreprodArtifacts that have been processing for more than 30 minutes
     - PreprodArtifactSizeMetrics that have been in progress for more than 30 minutes
     - PreprodArtifactSizeComparisons that have been in progress for more than 30 minutes
+    - PreprodSnapshotComparisons that have been in progress for more than 30 minutes
     """
     current_time = timezone.now()
     timeout_threshold = current_time - datetime.timedelta(minutes=30)
@@ -956,15 +958,44 @@ def detect_expired_preprod_artifacts() -> None:
         )
         expired_size_comparisons_count = 0
 
+    # Find expired PreprodSnapshotComparisons (those in PROCESSING state for more than 30 minutes)
+    # Note: ignore snapshot comparisons in a pending state
+    expired_snapshot_comparisons = PreprodSnapshotComparison.objects.filter(
+        state=PreprodSnapshotComparison.State.PROCESSING, date_updated__lte=timeout_threshold
+    )
+
+    try:
+        with transaction.atomic(router.db_for_write(PreprodSnapshotComparison)):
+            expired_snapshot_comparisons_count = expired_snapshot_comparisons.update(
+                state=PreprodSnapshotComparison.State.FAILED,
+                error_code=PreprodSnapshotComparison.ErrorCode.TIMEOUT,
+                error_message="Snapshot comparison processing timed out after 30 minutes",
+            )
+
+            if expired_snapshot_comparisons_count > 0:
+                logger.info(
+                    "preprod.tasks.detect_expired_preprod_artifacts.batch_updated_expired_snapshot_comparisons_as_failed",
+                    extra={
+                        "expired_snapshot_comparisons_count": expired_snapshot_comparisons_count,
+                    },
+                )
+    except Exception:
+        logger.exception(
+            "preprod.tasks.detect_expired_preprod_artifacts.failed_to_batch_update_expired_snapshot_comparisons",
+        )
+        expired_snapshot_comparisons_count = 0
+
     logger.info(
         "preprod.tasks.detect_expired_preprod_artifacts.completed",
         extra={
             "expired_artifacts_count": expired_artifacts_count,
             "expired_size_metrics_count": expired_size_metrics_count,
             "expired_size_comparisons_count": expired_size_comparisons_count,
+            "expired_snapshot_comparisons_count": expired_snapshot_comparisons_count,
             "total_expired_count": expired_artifacts_count
             + expired_size_metrics_count
-            + expired_size_comparisons_count,
+            + expired_size_comparisons_count
+            + expired_snapshot_comparisons_count,
         },
     )
 

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -17,6 +17,7 @@ from sentry.preprod.models import (
     PreprodArtifactSizeComparison,
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
+    PreprodSnapshotComparison,
 )
 from sentry.preprod.tasks import (
     assemble_preprod_artifact,
@@ -1132,6 +1133,80 @@ class DetectExpiredPreprodArtifactsTest(TestCase):
             expired_size_comparison.error_message
             and "30 minutes" in expired_size_comparison.error_message
         )
+
+    def _create_snapshot_comparison(self, state: int) -> PreprodSnapshotComparison:
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        head_metrics = self.create_preprod_snapshot_metrics(head_artifact)
+        base_metrics = self.create_preprod_snapshot_metrics(base_artifact)
+        return self.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=state,
+        )
+
+    def test_detect_expired_preprod_artifacts_expires_stuck_snapshot_comparison(self) -> None:
+        """A snapshot comparison stuck in PROCESSING for >30 minutes is marked FAILED"""
+        old_time = timezone.now() - timedelta(minutes=35)
+
+        comparison = self._create_snapshot_comparison(
+            state=PreprodSnapshotComparison.State.PROCESSING
+        )
+        PreprodSnapshotComparison.objects.filter(id=comparison.id).update(date_updated=old_time)
+
+        detect_expired_preprod_artifacts()
+
+        comparison.refresh_from_db()
+        assert comparison.state == PreprodSnapshotComparison.State.FAILED
+        assert comparison.error_code == PreprodSnapshotComparison.ErrorCode.TIMEOUT
+        assert comparison.error_message and "30 minutes" in comparison.error_message
+
+    def test_detect_expired_preprod_artifacts_ignores_recent_snapshot_comparison(self) -> None:
+        """A snapshot comparison that started PROCESSING recently is left alone"""
+        comparison = self._create_snapshot_comparison(
+            state=PreprodSnapshotComparison.State.PROCESSING
+        )
+
+        detect_expired_preprod_artifacts()
+
+        comparison.refresh_from_db()
+        assert comparison.state == PreprodSnapshotComparison.State.PROCESSING
+
+    def test_detect_expired_preprod_artifacts_ignores_stale_non_processing_snapshot_comparison(
+        self,
+    ) -> None:
+        """An old snapshot comparison that is not PROCESSING is left alone"""
+        old_time = timezone.now() - timedelta(minutes=35)
+
+        comparison = self._create_snapshot_comparison(state=PreprodSnapshotComparison.State.SUCCESS)
+        PreprodSnapshotComparison.objects.filter(id=comparison.id).update(date_updated=old_time)
+
+        detect_expired_preprod_artifacts()
+
+        comparison.refresh_from_db()
+        assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
+        assert comparison.error_code is None
+
+    def test_detect_expired_preprod_artifacts_ignores_stale_pending_snapshot_comparison(
+        self,
+    ) -> None:
+        """An old snapshot comparison still in PENDING is left alone"""
+        old_time = timezone.now() - timedelta(minutes=35)
+
+        comparison = self._create_snapshot_comparison(state=PreprodSnapshotComparison.State.PENDING)
+        PreprodSnapshotComparison.objects.filter(id=comparison.id).update(date_updated=old_time)
+
+        detect_expired_preprod_artifacts()
+
+        comparison.refresh_from_db()
+        assert comparison.state == PreprodSnapshotComparison.State.PENDING
+        assert comparison.error_code is None
 
     def test_detect_expired_preprod_artifacts_captures_sentry_message(self) -> None:
         """Test that Sentry messages are captured for each expired artifact"""


### PR DESCRIPTION
Extend the hourly `detect_expired_preprod_artifacts` reaper to also mark `PreprodSnapshotComparison` rows stuck in `PROCESSING` for more than 30 minutes as `FAILED` + `TIMEOUT`, mirroring the existing `PreprodArtifactSizeComparison` handling.

When a `compare_snapshots` task is hard-killed mid-run — SIGKILL after a deploy/worker SIGTERM, or OOM — the `except BaseException` cleanup that would set the row to `FAILED` never runs, so the row is left stuck in `PROCESSING`. The task's retry guard only re-runs `PENDING`/`FAILED` rows, and the task is only enqueued on a build upload or a staff recompare — never on page load/poll. So a stuck comparison is skipped forever (`skipping, comparison not in retryable state (state=1)`) and spins indefinitely for the customer.

Marking it `FAILED` makes the row retryable again on the next upload or recompare, and turns the perpetual spinner into an honest failed state. This matches how the sibling `PreprodArtifactSizeComparison` PROCESSING rows are already recovered.

This is fix #3 of a two-PR Graphite stack. The follow-up PR (#1) parallelizes the odiff comparison phase so large comparisons finish well within the deadline — that's the durable fix for the underlying slowness; this PR stops affected comparisons from getting permanently wedged in the meantime.