### PR TITLE
ref(detectors): Remove unnessary parameters and interfaces

### DIFF
--- a/src/sentry/issue_detection/README.md
+++ b/src/sentry/issue_detection/README.md
@@ -18,9 +18,8 @@ Performance Issues are built on top of the [Issue Platform](https://develop.sent
     - If the system option is a boolean, it will only run the detector if set to `True`.
     - If the system option is a number (0.0 < `x` < 1.0), it will run the detector `100 * x`% of the time.
   - After this check, the detectors are run on the event, see `run_detector_on_data()` in [performance_detection.py](./performance_detection.py)
-  - After recording metrics about the results, two checks are run, dropping the `PerformanceProblem`s if either return `False`:
-    - `PerformanceDetector.is_creation_allowed_for_organization()` - Pre-GA, check a feature flag; post-GA, just return `True`
-    - `PerformanceDetector.is_creation_allowed_for_project()` - Usually checking project's detector settings
+  - After recording metrics about the results, a check is run, dropping the `PerformanceProblem`s if it returns `False`:
+    - `PerformanceDetector.is_creation_allowed()` - Usually checking project's detector settings
 - We store the list of `PerformanceProblem`s from `_detect_performance_problems` on `job["performance_problems"]`
 - Then we run `_send_occurrence_to_platform` which reads `job["performance_problems"]`
   - It will map each `PerformanceProblem` into an `IssueOccurrence`
@@ -59,8 +58,7 @@ There are quite a few places which need to be updated when adding a new performa
 - [ ] Setup for the `PerformanceDetector` subclass
   - [ ] Update the `type` and `settings_key` attributes with the new `DetectorType`
   - [ ] (Optional) Implement `is_event_eligible()` to allow early exits.
-  - [ ] Implement `is_creation_allowed_for_organization()` to check a feature flag.
-  - [ ] Implement `is_creation_allowed_for_project()` to check a creation flag.
+  - [ ] Implement `is_creation_allowed()` to check a creation flag.
 - [ ] Write some business logic!
   - [ ] Implement `visit_span()` and `on_complete()`, adding any identified `PerformanceProblem`s to `self.stored_problems` as you go.
   - [ ] Leverage the [Writing Detectors docs](https://develop.sentry.dev/backend/issue-platform/writing-detectors/) which can help guide your detector's design.

--- a/src/sentry/issue_detection/base.py
+++ b/src/sentry/issue_detection/base.py
@@ -9,7 +9,6 @@ from typing import Any, ClassVar
 from sentry import options
 from sentry.issue_detection.detectors.utils import get_span_duration
 from sentry.issue_detection.performance_problem import PerformanceProblem
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 
 from .types import Span
@@ -62,13 +61,11 @@ class PerformanceDetector(ABC):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
         self.settings = settings
         self._event = event
         self.stored_problems: dict[str, PerformanceProblem] = {}
-        self.organization = organization
         self.detector_id = detector_id
 
     def find_span_prefix(self, settings: dict[str, Any], span_op: str) -> str | bool:

--- a/src/sentry/issue_detection/base.py
+++ b/src/sentry/issue_detection/base.py
@@ -128,19 +128,10 @@ class PerformanceDetector(ABC):
         except options.UnknownOption:
             return False
 
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
+    def is_creation_allowed(self) -> bool:
         """
         After running the detector, this method determines whether the found problems should be
-        passed to the issue platform for a given organization.
-
-        See `_detect_performance_problems` in `performance_detection.py` for more context.
-        """
-        return False
-
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
-        """
-        After running the detector, this method determines whether the found problems should be
-        passed to the issue platform for a given project.
+        passed to the issue platform.
 
         See `_detect_performance_problems` in `performance_detection.py` for more context.
         """

--- a/src/sentry/issue_detection/detectors/consecutive_db_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_db_detector.py
@@ -257,10 +257,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
     def on_complete(self) -> None:
         self._validate_and_store_performance_problem()
 
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return True
-
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]
 
     @classmethod

--- a/src/sentry/issue_detection/detectors/consecutive_db_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_db_detector.py
@@ -18,7 +18,6 @@ from sentry.issue_detection.detectors.utils import (
 )
 from sentry.issues.grouptype import PerformanceConsecutiveDBQueriesGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.utils.event_frames import get_sdk_name
 
@@ -62,10 +61,9 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.consecutive_db_spans: list[Span] = []
         self.independent_db_spans: list[Span] = []

--- a/src/sentry/issue_detection/detectors/consecutive_http_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_http_detector.py
@@ -208,8 +208,5 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
     def on_complete(self) -> None:
         self._validate_and_store_performance_problem()
 
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return True
-
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]

--- a/src/sentry/issue_detection/detectors/consecutive_http_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_http_detector.py
@@ -18,7 +18,6 @@ from sentry.issue_detection.detectors.utils import (
 )
 from sentry.issues.grouptype import PerformanceConsecutiveHTTPQueriesGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.utils.event import is_event_from_browser_javascript_sdk
 from sentry.utils.safe import get_path
@@ -35,10 +34,9 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.consecutive_http_spans: list[Span] = []
         self.lcp = None

--- a/src/sentry/issue_detection/detectors/http_overhead_detector.py
+++ b/src/sentry/issue_detection/detectors/http_overhead_detector.py
@@ -16,7 +16,6 @@ from sentry.issue_detection.detectors.utils import (
 from sentry.issues.grouptype import PerformanceHTTPOverheadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 
 from ..performance_problem import PerformanceProblem
 from ..types import Span
@@ -194,8 +193,5 @@ class HTTPOverheadDetector(PerformanceDetector):
         for location in self.location_to_indicators:
             self._store_performance_problem(location)
 
-    def is_creation_allowed_for_organization(self, organization: Organization | None) -> bool:
-        return True
-
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]

--- a/src/sentry/issue_detection/detectors/http_overhead_detector.py
+++ b/src/sentry/issue_detection/detectors/http_overhead_detector.py
@@ -15,7 +15,6 @@ from sentry.issue_detection.detectors.utils import (
 )
 from sentry.issues.grouptype import PerformanceHTTPOverheadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 
 from ..performance_problem import PerformanceProblem
 from ..types import Span
@@ -54,10 +53,9 @@ class HTTPOverheadDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.location_to_indicators: dict[str, list[list[ProblemIndicator]]] = defaultdict(list)
 

--- a/src/sentry/issue_detection/detectors/io_main_thread_detector.py
+++ b/src/sentry/issue_detection/detectors/io_main_thread_detector.py
@@ -15,7 +15,6 @@ from sentry.issues.grouptype import (
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.models.debugfile import ProjectDebugFile
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 
 from ..base import DetectorType, PerformanceDetector
@@ -42,10 +41,9 @@ class BaseIOMainThreadDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.mapper: ProguardMapper | None = None
         self.parent_to_blocked_span: dict[str, list[Span]] = defaultdict(list)
@@ -216,10 +214,9 @@ class DBMainThreadDetector(BaseIOMainThreadDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.mapper = None
         self.parent_to_blocked_span = defaultdict(list)

--- a/src/sentry/issue_detection/detectors/io_main_thread_detector.py
+++ b/src/sentry/issue_detection/detectors/io_main_thread_detector.py
@@ -110,7 +110,7 @@ class BaseIOMainThreadDetector(PerformanceDetector):
                     ],
                 )
 
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]
 
 
@@ -201,9 +201,6 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
         # doing is True since the value can be any type
         return data.get("blocked_main_thread", False) is True
 
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return True
-
 
 class DBMainThreadDetector(BaseIOMainThreadDetector):
     """
@@ -244,6 +241,3 @@ class DBMainThreadDetector(BaseIOMainThreadDetector):
             return False
         # doing is True since the value can be any type
         return data.get("blocked_main_thread", False) is True
-
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return True

--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -7,7 +7,6 @@ from typing import Any
 from sentry.issues.grouptype import PerformanceLargeHTTPPayloadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 
 from ..base import DetectorType, PerformanceDetector
 from ..detectors.utils import (
@@ -141,8 +140,5 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         hashed_url_paths = fingerprint_http_spans([span])
         return f"1-{PerformanceLargeHTTPPayloadGroupType.type_id}-{hashed_url_paths}"
 
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return True
-
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]

--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from sentry.issues.grouptype import PerformanceLargeHTTPPayloadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 
 from ..base import DetectorType, PerformanceDetector
 from ..detectors.utils import (
@@ -31,10 +30,9 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.consecutive_http_spans: list[Span] = []
         self.filtered_paths = [

--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -19,7 +19,6 @@ from sentry.issues.grouptype import (
     PerformanceNPlusOneGroupType,
 )
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 from sentry.utils import metrics
 
 
@@ -395,10 +394,9 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.state: MNPlusOneState = SearchingForMNPlusOne(
             settings=self.settings,

--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -20,7 +20,6 @@ from sentry.issues.grouptype import (
 )
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 from sentry.utils import metrics
 
 
@@ -407,10 +406,7 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
             parent_map={},
         )
 
-    def is_creation_allowed_for_organization(self, organization: Organization | None) -> bool:
-        return True
-
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]
 
     def visit_span(self, span: Span) -> None:

--- a/src/sentry/issue_detection/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_api_calls_detector.py
@@ -74,10 +74,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
             self._maybe_store_problem()
             self.spans = [span]
 
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return True
-
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]
 
     @classmethod

--- a/src/sentry/issue_detection/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_api_calls_detector.py
@@ -22,7 +22,6 @@ from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issue_detection.types import Span
 from sentry.issues.grouptype import PerformanceNPlusOneAPICallsGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.utils.safe import get_path
 
@@ -46,10 +45,9 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         # TODO: Only store the span IDs and timestamps instead of entire span objects
         self.spans: list[Span] = []

--- a/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
@@ -14,7 +14,6 @@ from sentry.issue_detection.types import Span
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 from sentry.utils import metrics
 from sentry.utils.safe import get_path
 
@@ -73,7 +72,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
         if root_span:
             self.potential_parents[root_span.get("span_id")] = root_span
 
-    def is_creation_allowed_for_project(self, project: Project | None) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]
 
     def visit_span(self, span: Span) -> None:

--- a/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
@@ -73,9 +73,6 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
         if root_span:
             self.potential_parents[root_span.get("span_id")] = root_span
 
-    def is_creation_allowed_for_organization(self, organization: Organization | None) -> bool:
-        return True
-
     def is_creation_allowed_for_project(self, project: Project | None) -> bool:
         return self.settings["detection_enabled"]
 

--- a/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
@@ -13,7 +13,6 @@ from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issue_detection.types import Span
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 from sentry.utils import metrics
 from sentry.utils.safe import get_path
 
@@ -59,10 +58,9 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.potential_parents = {}
         self.previous_span: Span | None = None

--- a/src/sentry/issue_detection/detectors/query_injection_detector.py
+++ b/src/sentry/issue_detection/detectors/query_injection_detector.py
@@ -10,7 +10,6 @@ from sentry.issue_detection.types import Span
 from sentry.issues.grouptype import QueryInjectionVulnerabilityGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 from sentry.utils import json
 
 MAX_EVIDENCE_VALUE_LENGTH = 10_000
@@ -121,7 +120,7 @@ class QueryInjectionDetector(PerformanceDetector):
             ],
         )
 
-    def is_creation_allowed_for_project(self, project: Project | None) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]
 
     def _is_span_eligible(self, span: Span) -> bool:

--- a/src/sentry/issue_detection/detectors/query_injection_detector.py
+++ b/src/sentry/issue_detection/detectors/query_injection_detector.py
@@ -121,9 +121,6 @@ class QueryInjectionDetector(PerformanceDetector):
             ],
         )
 
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return True
-
     def is_creation_allowed_for_project(self, project: Project | None) -> bool:
         return self.settings["detection_enabled"]
 

--- a/src/sentry/issue_detection/detectors/query_injection_detector.py
+++ b/src/sentry/issue_detection/detectors/query_injection_detector.py
@@ -9,7 +9,6 @@ from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issue_detection.types import Span
 from sentry.issues.grouptype import QueryInjectionVulnerabilityGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 from sentry.utils import json
 
 MAX_EVIDENCE_VALUE_LENGTH = 10_000
@@ -25,10 +24,9 @@ class QueryInjectionDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.stored_problems = {}
         self.potential_unsafe_inputs: list[tuple[str, dict[str, Any]]] = []

--- a/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from sentry.issues.grouptype import PerformanceRenderBlockingAssetSpanGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 
 from ..base import DetectorType, PerformanceDetector
 from ..detectors.utils import (
@@ -29,10 +28,9 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.transaction_start = timedelta(seconds=self.event().get("start_timestamp", 0))
         self.fcp = None

--- a/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
@@ -7,7 +7,6 @@ from typing import Any
 from sentry.issues.grouptype import PerformanceRenderBlockingAssetSpanGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 
 from ..base import DetectorType, PerformanceDetector
 from ..detectors.utils import (
@@ -52,10 +51,7 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
                 self.fcp = fcp
                 self.fcp_value = fcp_value
 
-    def is_creation_allowed_for_organization(self, organization: Organization | None) -> bool:
-        return True
-
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]
 
     def visit_span(self, span: Span) -> None:

--- a/src/sentry/issue_detection/detectors/slow_db_query_detector.py
+++ b/src/sentry/issue_detection/detectors/slow_db_query_detector.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 
 from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 
 from ..base import DetectorType, PerformanceDetector
@@ -101,9 +100,6 @@ class SlowDBQueryDetector(PerformanceDetector):
                     )
                 ],
             )
-
-    def is_creation_allowed_for_organization(self, organization: Organization | None) -> bool:
-        return True
 
     def is_creation_allowed_for_project(self, project: Project | None) -> bool:
         return self.settings["detection_enabled"]

--- a/src/sentry/issue_detection/detectors/slow_db_query_detector.py
+++ b/src/sentry/issue_detection/detectors/slow_db_query_detector.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 
 from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.project import Project
 
 from ..base import DetectorType, PerformanceDetector
 from ..detectors.utils import (
@@ -101,7 +100,7 @@ class SlowDBQueryDetector(PerformanceDetector):
                 ],
             )
 
-    def is_creation_allowed_for_project(self, project: Project | None) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]
 
     def _is_span_eligible(self, span: Span) -> bool:

--- a/src/sentry/issue_detection/detectors/sql_injection_detector.py
+++ b/src/sentry/issue_detection/detectors/sql_injection_detector.py
@@ -11,7 +11,6 @@ from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issue_detection.types import Span
 from sentry.issues.grouptype import QueryInjectionVulnerabilityGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 
 MAX_EVIDENCE_VALUE_LENGTH = 10_000
@@ -80,10 +79,9 @@ class SQLInjectionDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.stored_problems = {}
         self.request_parameters: list[Sequence[Any]] = []

--- a/src/sentry/issue_detection/detectors/sql_injection_detector.py
+++ b/src/sentry/issue_detection/detectors/sql_injection_detector.py
@@ -213,7 +213,7 @@ class SQLInjectionDetector(PerformanceDetector):
             ],
         )
 
-    def is_creation_allowed_for_project(self, project: Project | None) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]
 
     def _is_span_eligible(self, span: Span) -> bool:

--- a/src/sentry/issue_detection/detectors/sql_injection_detector.py
+++ b/src/sentry/issue_detection/detectors/sql_injection_detector.py
@@ -213,9 +213,6 @@ class SQLInjectionDetector(PerformanceDetector):
             ],
         )
 
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return True
-
     def is_creation_allowed_for_project(self, project: Project | None) -> bool:
         return self.settings["detection_enabled"]
 

--- a/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
@@ -144,10 +144,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
         resource_span = fingerprint_resource_span(span)
         return f"1-{PerformanceUncompressedAssetsGroupType.type_id}-{resource_span}"
 
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return True
-
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
+    def is_creation_allowed(self) -> bool:
         return self.settings["detection_enabled"]
 
     @classmethod

--- a/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from sentry.issues.grouptype import PerformanceUncompressedAssetsGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 
 from ..base import DetectorType, PerformanceDetector
@@ -37,10 +36,9 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
         self,
         settings: dict[str, Any],
         event: dict[str, Any],
-        organization: Organization | None = None,
         detector_id: int | None = None,
     ) -> None:
-        super().__init__(settings, event, organization, detector_id)
+        super().__init__(settings, event, detector_id)
 
         self.any_compression = False
 

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -750,7 +750,7 @@ def _detect_performance_problems(
 
     with sentry_sdk.start_span(op="initialize", name="PerformanceDetector"):
         detectors: list[PerformanceDetector] = [
-            detector_class(detection_settings[detector_class.settings_key], data, organization)
+            detector_class(detection_settings[detector_class.settings_key], data)
             for detector_class in DETECTOR_CLASSES
             if detector_class.is_detection_allowed_for_system()
         ]

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -776,12 +776,7 @@ def _detect_performance_problems(
     problems: list[PerformanceProblem] = []
     with sentry_sdk.start_span(op="performance_detection", name="is_creation_allowed"):
         for detector in detectors:
-            if all(
-                [
-                    detector.is_creation_allowed_for_organization(organization),
-                    detector.is_creation_allowed_for_project(project),
-                ]
-            ):
+            if detector.is_creation_allowed():
                 problems.extend(detector.stored_problems.values())
             else:
                 continue
@@ -964,12 +959,7 @@ def report_metrics_for_detectors(
 
         op_tags = {
             "is_standalone_spans": standalone,
-            "is_creation_allowed": all(
-                [
-                    detector.is_creation_allowed_for_organization(organization),
-                    detector.is_creation_allowed_for_project(project),
-                ]
-            ),
+            "is_creation_allowed": detector.is_creation_allowed(),
         }
         for problem in detected_problems.values():
             op = problem.op

--- a/tests/sentry/issue_detection/test_consecutive_db_detector.py
+++ b/tests/sentry/issue_detection/test_consecutive_db_detector.py
@@ -253,7 +253,7 @@ class ConsecutiveDbDetectorTest(TestCase):
             settings[ConsecutiveDBSpanDetector.settings_key], event
         )
 
-        assert detector.is_creation_allowed_for_project(project)
+        assert detector.is_creation_allowed()
 
         ProjectOption.objects.set_value(
             project=project,
@@ -266,7 +266,7 @@ class ConsecutiveDbDetectorTest(TestCase):
             settings[ConsecutiveDBSpanDetector.settings_key], event
         )
 
-        assert not detector.is_creation_allowed_for_project(project)
+        assert not detector.is_creation_allowed()
 
     def test_detects_consecutive_db_does_not_detect_php(self) -> None:
         event = self.create_issue_event()

--- a/tests/sentry/issue_detection/test_consecutive_http_detector.py
+++ b/tests/sentry/issue_detection/test_consecutive_http_detector.py
@@ -372,7 +372,7 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
             settings[ConsecutiveHTTPSpanDetector.settings_key], event
         )
 
-        assert detector.is_creation_allowed_for_project(project)
+        assert detector.is_creation_allowed()
 
         ProjectOption.objects.set_value(
             project=project,
@@ -385,7 +385,7 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
             settings[ConsecutiveHTTPSpanDetector.settings_key], event
         )
 
-        assert not detector.is_creation_allowed_for_project(project)
+        assert not detector.is_creation_allowed()
 
     def test_ignores_non_http_operations(self) -> None:
         span_duration = 2000

--- a/tests/sentry/issue_detection/test_db_main_thread_detector.py
+++ b/tests/sentry/issue_detection/test_db_main_thread_detector.py
@@ -57,7 +57,7 @@ class DBMainThreadDetectorTest(TestCase):
         settings = get_detection_settings(project)
         detector = DBMainThreadDetector(settings[DBMainThreadDetector.settings_key], event)
 
-        assert detector.is_creation_allowed_for_project(project)
+        assert detector.is_creation_allowed()
 
         ProjectOption.objects.set_value(
             project=project,
@@ -68,7 +68,7 @@ class DBMainThreadDetectorTest(TestCase):
         settings = get_detection_settings(project)
         detector = DBMainThreadDetector(settings[DBMainThreadDetector.settings_key], event)
 
-        assert not detector.is_creation_allowed_for_project(project)
+        assert not detector.is_creation_allowed()
 
     def test_does_not_detect_db_main_thread(self) -> None:
         event = get_event("db-on-main-thread/db-on-main-thread")

--- a/tests/sentry/issue_detection/test_file_io_on_main_thread_detector.py
+++ b/tests/sentry/issue_detection/test_file_io_on_main_thread_detector.py
@@ -60,7 +60,7 @@ class FileIOMainThreadDetectorTest(TestCase):
         settings = get_detection_settings(project)
         detector = FileIOMainThreadDetector(settings[FileIOMainThreadDetector.settings_key], event)
 
-        assert detector.is_creation_allowed_for_project(project)
+        assert detector.is_creation_allowed()
 
         ProjectOption.objects.set_value(
             project=project,
@@ -71,7 +71,7 @@ class FileIOMainThreadDetectorTest(TestCase):
         settings = get_detection_settings(project)
         detector = FileIOMainThreadDetector(settings[FileIOMainThreadDetector.settings_key], event)
 
-        assert not detector.is_creation_allowed_for_project(project)
+        assert not detector.is_creation_allowed()
 
     def test_detects_file_io_main_thread(self) -> None:
         event = get_event("file-io-on-main-thread/file-io-on-main-thread")

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -87,7 +87,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
             settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
         )
 
-        assert detector.is_creation_allowed_for_project(project)
+        assert detector.is_creation_allowed()
 
         ProjectOption.objects.set_value(
             project=project,
@@ -100,7 +100,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
             settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
         )
 
-        assert not detector.is_creation_allowed_for_project(project)
+        assert not detector.is_creation_allowed()
 
     def test_does_not_issue_if_url_is_not_an_http_span(self) -> None:
         spans = [

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -83,9 +83,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         event["project_id"] = project.id
 
         settings = get_detection_settings(project)
-        detector = LargeHTTPPayloadDetector(
-            settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
-        )
+        detector = LargeHTTPPayloadDetector(settings[LargeHTTPPayloadDetector.settings_key], event)
 
         assert detector.is_creation_allowed()
 
@@ -96,9 +94,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         )
 
         settings = get_detection_settings(project)
-        detector = LargeHTTPPayloadDetector(
-            settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
-        )
+        detector = LargeHTTPPayloadDetector(settings[LargeHTTPPayloadDetector.settings_key], event)
 
         assert not detector.is_creation_allowed()
 
@@ -330,9 +326,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
 
-        detector = LargeHTTPPayloadDetector(
-            settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
-        )
+        detector = LargeHTTPPayloadDetector(settings[LargeHTTPPayloadDetector.settings_key], event)
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 0
 
@@ -359,9 +353,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
 
-        detector = LargeHTTPPayloadDetector(
-            settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
-        )
+        detector = LargeHTTPPayloadDetector(settings[LargeHTTPPayloadDetector.settings_key], event)
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 1
 
@@ -380,8 +372,6 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
 
-        detector = LargeHTTPPayloadDetector(
-            settings[LargeHTTPPayloadDetector.settings_key], event, self.organization
-        )
+        detector = LargeHTTPPayloadDetector(settings[LargeHTTPPayloadDetector.settings_key], event)
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 0

--- a/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
@@ -222,7 +222,7 @@ class MNPlusOneDBDetectorTest(TestCase):
         settings = get_detection_settings(project)
         detector = self.detector(settings[self.detector.settings_key], event)
 
-        assert detector.is_creation_allowed_for_project(project)
+        assert detector.is_creation_allowed()
 
         ProjectOption.objects.set_value(
             project=project,
@@ -233,7 +233,7 @@ class MNPlusOneDBDetectorTest(TestCase):
         settings = get_detection_settings(project)
         detector = self.detector(settings[self.detector.settings_key], event)
 
-        assert not detector.is_creation_allowed_for_project(project)
+        assert not detector.is_creation_allowed()
 
     def test_respects_n_plus_one_db_duration_threshold(self) -> None:
         project = self.create_project()

--- a/tests/sentry/issue_detection/test_n_plus_one_db_span_detector.py
+++ b/tests/sentry/issue_detection/test_n_plus_one_db_span_detector.py
@@ -407,7 +407,7 @@ class NPlusOneDbSettingTest(TestCase):
         settings = get_detection_settings(project)
         detector = NPlusOneDBSpanDetector(settings[NPlusOneDBSpanDetector.settings_key], event)
 
-        assert detector.is_creation_allowed_for_project(project)
+        assert detector.is_creation_allowed()
 
         ProjectOption.objects.set_value(
             project=project,
@@ -418,4 +418,4 @@ class NPlusOneDbSettingTest(TestCase):
         settings = get_detection_settings(project)
         detector = NPlusOneDBSpanDetector(settings[NPlusOneDBSpanDetector.settings_key], event)
 
-        assert not detector.is_creation_allowed_for_project(project)
+        assert not detector.is_creation_allowed()

--- a/tests/sentry/issue_detection/test_performance_detection.py
+++ b/tests/sentry/issue_detection/test_performance_detection.py
@@ -382,29 +382,11 @@ class PerformanceDetectionTest(TestCase):
             assert_n_plus_one_db_problem(perf_problems)
 
     @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
-    def test_respects_organization_creation_permissions(self) -> None:
+    def test_respects_creation_permissions(self) -> None:
         n_plus_one_event = get_event("n-plus-one-db/n-plus-one-in-django-index-view")
         sdk_span_mock = Mock()
 
-        with patch.object(
-            NPlusOneDBSpanDetector, "is_creation_allowed_for_organization", return_value=False
-        ):
-            perf_problems = _detect_performance_problems(
-                n_plus_one_event, sdk_span_mock, self.project
-            )
-            assert perf_problems == []
-
-        perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock, self.project)
-        assert_n_plus_one_db_problem(perf_problems)
-
-    @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
-    def test_respects_project_creation_permissions(self) -> None:
-        n_plus_one_event = get_event("n-plus-one-db/n-plus-one-in-django-index-view")
-        sdk_span_mock = Mock()
-
-        with patch.object(
-            NPlusOneDBSpanDetector, "is_creation_allowed_for_project", return_value=False
-        ):
+        with patch.object(NPlusOneDBSpanDetector, "is_creation_allowed", return_value=False):
             perf_problems = _detect_performance_problems(
                 n_plus_one_event, sdk_span_mock, self.project
             )

--- a/tests/sentry/issue_detection/test_render_blocking_asset_detector.py
+++ b/tests/sentry/issue_detection/test_render_blocking_asset_detector.py
@@ -100,7 +100,7 @@ class RenderBlockingAssetDetectorTest(TestCase):
             settings[RenderBlockingAssetSpanDetector.settings_key], event
         )
 
-        assert detector.is_creation_allowed_for_project(project)
+        assert detector.is_creation_allowed()
 
         ProjectOption.objects.set_value(
             project=project,
@@ -113,7 +113,7 @@ class RenderBlockingAssetDetectorTest(TestCase):
             settings[RenderBlockingAssetSpanDetector.settings_key], event
         )
 
-        assert not detector.is_creation_allowed_for_project(project)
+        assert not detector.is_creation_allowed()
 
     def test_does_not_detect_if_resource_overlaps_fcp(self) -> None:
         event = _valid_render_blocking_asset_event("https://example.com/a.js")

--- a/tests/sentry/issue_detection/test_slow_db_span_detector.py
+++ b/tests/sentry/issue_detection/test_slow_db_span_detector.py
@@ -143,7 +143,7 @@ class SlowDBQueryDetectorTest(TestCase):
         settings = get_detection_settings(project)
         detector = SlowDBQueryDetector(settings[SlowDBQueryDetector.settings_key], slow_span_event)
 
-        assert detector.is_creation_allowed_for_project(project)
+        assert detector.is_creation_allowed()
 
         ProjectOption.objects.set_value(
             project=project,
@@ -154,4 +154,4 @@ class SlowDBQueryDetectorTest(TestCase):
         settings = get_detection_settings(project)
         detector = SlowDBQueryDetector(settings[SlowDBQueryDetector.settings_key], slow_span_event)
 
-        assert not detector.is_creation_allowed_for_project(project)
+        assert not detector.is_creation_allowed()

--- a/tests/sentry/issue_detection/test_uncompressed_asset_detector.py
+++ b/tests/sentry/issue_detection/test_uncompressed_asset_detector.py
@@ -430,7 +430,7 @@ class UncompressedAssetsDetectorTest(TestCase):
             settings[UncompressedAssetSpanDetector.settings_key], event
         )
 
-        assert detector.is_creation_allowed_for_project(project)
+        assert detector.is_creation_allowed()
 
         ProjectOption.objects.set_value(
             project=project,
@@ -443,4 +443,4 @@ class UncompressedAssetsDetectorTest(TestCase):
             settings[UncompressedAssetSpanDetector.settings_key], event
         )
 
-        assert not detector.is_creation_allowed_for_project(project)
+        assert not detector.is_creation_allowed()


### PR DESCRIPTION
Removes `is_creation_allowed_for_organization` and `is_creation_allowed_for_project`. Adds a new `is_creation_allowed` method which accepts no arguments. This removes the unnecessary dependency on organization and project model instances.