### PR TITLE
fix(txn-summary): Clean up `getEAPTotalsEventView`

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -59,7 +59,6 @@ import {EAPChartsWidget} from 'sentry/views/performance/transactionSummary/trans
 import {EAPSidebarCharts} from 'sentry/views/performance/transactionSummary/transactionOverview/eapSidebarCharts';
 import {canUseTransactionMetricsData} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {
-  EAP_WEB_VITALS,
   makeVitalGroups,
   PERCENTILE as VITAL_PERCENTILE,
 } from 'sentry/views/performance/transactionSummary/transactionVitals/constants';
@@ -151,13 +150,7 @@ function EAPSummaryContentInner({
 
   // NOTE: This is not a robust check for whether or not a transaction is a front end
   // transaction, however it will suffice for now.
-  const hasWebVitals =
-    isSummaryViewFrontendPageLoad(eventView, projects) ||
-    (totalValues !== null &&
-      EAP_WEB_VITALS.some(vital => {
-        const field = `percentile(${vital},${VITAL_PERCENTILE})`;
-        return Number.isFinite(totalValues[field]) && totalValues[field] !== 0;
-      }));
+  const hasWebVitals = isSummaryViewFrontendPageLoad(eventView, projects);
 
   const isFrontendView = isSummaryViewFrontend(eventView, projects);
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -35,7 +35,6 @@ import {
 import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {useTransactionSummaryContext} from 'sentry/views/performance/transactionSummary/transactionSummaryContext';
 import {
-  EAP_WEB_VITALS,
   makeVitalGroups,
   PERCENTILE as VITAL_PERCENTILE,
 } from 'sentry/views/performance/transactionSummary/transactionVitals/constants';
@@ -373,29 +372,14 @@ function getEAPTotalsEventView(
   _organization: Organization,
   eventView: EventView
 ): EventView {
-  const vitals = EAP_WEB_VITALS;
-
   const totalsColumns: QueryFieldValue[] = [
     {
       kind: 'function',
       function: ['p95', '', undefined, undefined],
     },
-    {
-      kind: 'function',
-      function: ['count_unique', 'user', undefined, undefined],
-    },
   ];
 
-  return eventView.withColumns([
-    ...totalsColumns,
-    ...vitals.map(
-      vital =>
-        ({
-          kind: 'function',
-          function: ['percentile', vital, VITAL_PERCENTILE.toString(), undefined],
-        }) as Column
-    ),
-  ]);
+  return eventView.withColumns(totalsColumns);
 }
 
 export default TransactionOverview;


### PR DESCRIPTION
The `percentile` function doesn't exist in EAP so this call always failed. The screen works correctly without it, so remove the call and the (also always failing) attempt to read the results. We can rely on `isSummaryViewFrontendPageLoad` and the default state of the performance score widget alone for this.

Further, the `count_unique(user)` result was never read, so remove that query too.

---

🤖: Nope.