### PR TITLE
feat(preprod): Run snapshot odiff comparisons in parallel

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2179,6 +2179,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Preprod snapshot comparison controls
+register(
+    "preprod.snapshots.odiff-worker-count",
+    default=4,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Webhook processing controls
 register(
     "hybridcloud.webhookpayload.worker_threads",

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import logging
+import queue
 import threading
+import time
+from concurrent.futures import as_completed
 from difflib import SequenceMatcher
 from typing import NamedTuple
 
@@ -13,6 +17,7 @@ from objectstore_client.client import RequestError
 from pydantic import ValidationError
 from taskbroker_client.retry import Retry
 
+from sentry import options
 from sentry.objectstore import get_preprod_session
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.image_diff.compare import DIFF_ALGORITHM_VERSION, compare_images_batch
@@ -20,6 +25,7 @@ from sentry.preprod.snapshots.image_diff.odiff import OdiffServer
 from sentry.preprod.snapshots.manifest import (
     ComparisonManifest,
     ComparisonSummary,
+    ImageMetadata,
     SnapshotManifest,
 )
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
@@ -41,6 +47,16 @@ class _DiffCandidate(NamedTuple):
     head_hash: str
     base_hash: str
     pixel_count: int
+
+
+class _BatchResult(NamedTuple):
+    image_results: dict[str, dict[str, object]]
+    changed: int
+    unchanged: int
+    errored: int
+    fetched_bytes: int
+    fetched_count: int
+    duration_s: float
 
 
 class _ImageDiffResult(NamedTuple):
@@ -204,6 +220,164 @@ def _create_pixel_batches(
     return batches
 
 
+def _tally_statuses(results: dict[str, dict[str, object]]) -> tuple[int, int, int]:
+    changed = sum(1 for r in results.values() if r["status"] == "changed")
+    unchanged = sum(1 for r in results.values() if r["status"] == "unchanged")
+    errored = sum(1 for r in results.values() if r["status"] == "errored")
+    return changed, unchanged, errored
+
+
+def _process_batch(
+    batch: list[_DiffCandidate],
+    *,
+    server_pool: queue.Queue[OdiffServer],
+    session: Session,
+    image_key_prefix: str,
+    head_artifact_id: int,
+    base_artifact_id: int,
+    head_images: dict[str, ImageMetadata],
+    diff_threshold: float | None,
+) -> _BatchResult:
+    started = time.monotonic()
+    image_results: dict[str, dict[str, object]] = {}
+    fetched_bytes = fetched_count = 0
+
+    # OdiffServer and the objectstore Session are shared across worker threads:
+    # each server is checked out of the pool so only one thread uses it at a time,
+    # and Session.get/.put are thread-safe (stateless per request over a pooled connection).
+    server = server_pool.get()
+    try:
+        diff_pairs: list[tuple[bytes, bytes]] = []
+        batch_names: list[str] = []
+        batch_hashes: list[tuple[str, str]] = []
+
+        unique_hashes: set[str] = set()
+        for candidate in batch:
+            unique_hashes.add(candidate.head_hash)
+            unique_hashes.add(candidate.base_hash)
+
+        fetch_cache, failed_hashes = _fetch_batch_images(session, image_key_prefix, unique_hashes)
+
+        for candidate in batch:
+            if candidate.head_hash in failed_hashes or candidate.base_hash in failed_hashes:
+                logger.warning(
+                    "compare_snapshots: failed to fetch images for %s",
+                    candidate.name,
+                    extra={
+                        "head_artifact_id": head_artifact_id,
+                        "head_hash": candidate.head_hash,
+                        "base_hash": candidate.base_hash,
+                    },
+                )
+                image_results[candidate.name] = {
+                    "status": "errored",
+                    "head_hash": candidate.head_hash,
+                    "base_hash": candidate.base_hash,
+                    "reason": "image_fetch_failed",
+                }
+                continue
+            head_data = fetch_cache[candidate.head_hash]
+            base_data = fetch_cache[candidate.base_hash]
+            fetched_bytes += len(head_data) + len(base_data)
+            fetched_count += 2
+            diff_pairs.append((base_data, head_data))
+            batch_names.append(candidate.name)
+            batch_hashes.append((candidate.head_hash, candidate.base_hash))
+
+        logger.info(
+            "compare_snapshots: running batch of %d pairs (%d unique hashes fetched)",
+            len(diff_pairs),
+            len(fetch_cache),
+            extra={"head_artifact_id": head_artifact_id, "names": batch_names},
+        )
+        diff_results = compare_images_batch(diff_pairs, server=server)
+
+        for name, (head_hash, base_hash), diff_result in zip(
+            batch_names, batch_hashes, diff_results, strict=True
+        ):
+            if diff_result is None:
+                image_results[name] = {
+                    "status": "errored",
+                    "head_hash": head_hash,
+                    "base_hash": base_hash,
+                    "reason": "image_processing_failed",
+                }
+                continue
+
+            stem = _image_name_to_path_stem(name)
+            diff_mask_key = (
+                f"{image_key_prefix}/{head_artifact_id}/{base_artifact_id}/diff/{stem}.png"
+            )
+            session.put(diff_result.diff_mask_png, key=diff_mask_key, content_type="image/png")
+
+            diff_pct = (
+                diff_result.changed_pixels / diff_result.total_pixels
+                if diff_result.total_pixels > 0
+                else 0
+            )
+            effective_threshold = next(
+                t for t in (head_images[name].diff_threshold, diff_threshold, 0.0) if t is not None
+            )
+            is_changed = diff_pct > effective_threshold
+
+            diff_mask_image_id = f"{head_artifact_id}/{base_artifact_id}/diff/{stem}.png"
+            image_results[name] = {
+                "status": "changed" if is_changed else "unchanged",
+                "head_hash": head_hash,
+                "base_hash": base_hash,
+                "changed_pixels": diff_result.changed_pixels,
+                "total_pixels": diff_result.total_pixels,
+                "diff_mask_key": diff_mask_key,
+                "diff_mask_image_id": diff_mask_image_id,
+                "before_width": diff_result.before_width,
+                "before_height": diff_result.before_height,
+                "after_width": diff_result.after_width,
+                "after_height": diff_result.after_height,
+                "aligned_height": diff_result.aligned_height,
+            }
+    except Exception:
+        # Isolate a batch-level failure: leave already-processed pairs intact and
+        # mark only the unprocessed ones errored, so partial progress survives.
+        logger.exception(
+            "compare_snapshots: batch failed",
+            extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
+        )
+        for candidate in batch:
+            if candidate.name not in image_results:
+                image_results[candidate.name] = {
+                    "status": "errored",
+                    "head_hash": candidate.head_hash,
+                    "base_hash": candidate.base_hash,
+                    "reason": "batch_failed",
+                }
+    finally:
+        server_pool.put(server)
+
+    changed, unchanged, errored = _tally_statuses(image_results)
+    duration_s = time.monotonic() - started
+    # Per-batch detail kept at DEBUG to avoid flooding prod with one line per batch;
+    # the INFO "odiff phase complete" summary carries the aggregate.
+    logger.debug(
+        "compare_snapshots: batch done",
+        extra={
+            "head_artifact_id": head_artifact_id,
+            "pairs": len(batch),
+            "duration_s": round(duration_s, 3),
+            "changed": changed,
+            "errored": errored,
+        },
+    )
+    return _BatchResult(
+        image_results=image_results,
+        changed=changed,
+        unchanged=unchanged,
+        errored=errored,
+        fetched_bytes=fetched_bytes,
+        fetched_count=fetched_count,
+        duration_s=duration_s,
+    )
+
+
 class ImageFingerprint(NamedTuple):
     name: str
     status: str
@@ -332,7 +506,7 @@ def _try_auto_approve_snapshot(
     namespace=preprod_tasks,
     retry=Retry(times=3),
     silo_mode=SiloMode.CELL,
-    processing_deadline_duration=300,
+    processing_deadline_duration=600,
 )
 def compare_snapshots(
     project_id: int,
@@ -569,6 +743,8 @@ def compare_snapshots(
                 "eligible_for_diff": len(eligible),
                 "unchanged_count": unchanged_count,
                 "error_count": error_count,
+                # Time spent before odiff (manifest load + categorize + matching).
+                "duration_s": round((timezone.now() - task_start_time).total_seconds(), 3),
             },
         )
 
@@ -577,149 +753,69 @@ def compare_snapshots(
 
         batches = _create_pixel_batches(eligible, MAX_PIXELS_PER_BATCH)
 
+        worker_count = max(
+            1, min(options.get("preprod.snapshots.odiff-worker-count"), len(batches))
+        )
         logger.info(
             "compare_snapshots: starting odiff, %d batches, %d pairs",
             len(batches),
             len(eligible),
-            extra={"head_artifact_id": head_artifact_id},
+            extra={"head_artifact_id": head_artifact_id, "worker_count": worker_count},
         )
 
-        # TODO: spawn N OdiffServer workers and distribute pairs across them
-        # via a thread pool to parallelize the odiff comparison step per batch
-        with OdiffServer() as server:
-            for batch in batches:
-                diff_pairs: list[tuple[bytes, bytes]] = []
-                batch_names: list[str] = []
-                batch_hashes: list[tuple[str, str]] = []
+        odiff_phase_start = time.monotonic()
+        slowest_batch_s = 0.0
 
-                unique_hashes: set[str] = set()
-                for candidate in batch:
-                    unique_hashes.add(candidate.head_hash)
-                    unique_hashes.add(candidate.base_hash)
+        # Guarded so a comparison with nothing to diff doesn't spawn an idle odiff subprocess.
+        if batches:
+            with contextlib.ExitStack() as stack:
+                server_pool: queue.Queue[OdiffServer] = queue.Queue()
+                for _ in range(worker_count):
+                    server_pool.put(stack.enter_context(OdiffServer()))
 
-                # Fetch unique hashes in parallel; session.get() is thread-safe
-                fetch_cache, failed_hashes = _fetch_batch_images(
-                    session, image_key_prefix, unique_hashes
-                )
-
-                for candidate in batch:
-                    if candidate.head_hash in failed_hashes or candidate.base_hash in failed_hashes:
-                        logger.warning(
-                            "compare_snapshots: failed to fetch images for %s",
-                            candidate.name,
-                            extra={
-                                "head_artifact_id": head_artifact_id,
-                                "head_hash": candidate.head_hash,
-                                "base_hash": candidate.base_hash,
-                            },
+                with ContextPropagatingThreadPoolExecutor(max_workers=worker_count) as executor:
+                    futures = [
+                        executor.submit(
+                            _process_batch,
+                            batch,
+                            server_pool=server_pool,
+                            session=session,
+                            image_key_prefix=image_key_prefix,
+                            head_artifact_id=head_artifact_id,
+                            base_artifact_id=base_artifact_id,
+                            head_images=head_images,
+                            diff_threshold=diff_threshold,
                         )
-                        error_count += 1
-                        image_results[candidate.name] = {
-                            "status": "errored",
-                            "head_hash": candidate.head_hash,
-                            "base_hash": candidate.base_hash,
-                            "reason": "image_fetch_failed",
-                        }
-                        continue
-                    head_data = fetch_cache[candidate.head_hash]
-                    base_data = fetch_cache[candidate.base_hash]
-                    total_fetched_bytes += len(head_data) + len(base_data)
-                    total_fetched_count += 2
-                    diff_pairs.append((base_data, head_data))
-                    batch_names.append(candidate.name)
-                    batch_hashes.append((candidate.head_hash, candidate.base_hash))
+                        for batch in batches
+                    ]
+                    for future in as_completed(futures):
+                        result = future.result()
+                        image_results.update(result.image_results)
+                        changed_count += result.changed
+                        unchanged_count += result.unchanged
+                        error_count += result.errored
+                        total_fetched_bytes += result.fetched_bytes
+                        total_fetched_count += result.fetched_count
+                        slowest_batch_s = max(slowest_batch_s, result.duration_s)
 
-                logger.info(
-                    "compare_snapshots: running batch of %d pairs (%d unique hashes fetched)",
-                    len(diff_pairs),
-                    len(fetch_cache),
-                    extra={"head_artifact_id": head_artifact_id, "names": batch_names},
-                )
-                diff_results = compare_images_batch(diff_pairs, server=server)
-                logger.info(
-                    "compare_snapshots: batch complete, %d results",
-                    len(diff_results),
-                    extra={"head_artifact_id": head_artifact_id},
-                )
-
-                for name, (head_hash, base_hash), diff_result in zip(
-                    batch_names, batch_hashes, diff_results, strict=True
-                ):
-                    if diff_result is None:
-                        error_count += 1
-                        image_results[name] = {
-                            "status": "errored",
-                            "head_hash": head_hash,
-                            "base_hash": base_hash,
-                            "reason": "image_processing_failed",
-                        }
-                        continue
-
-                    stem = _image_name_to_path_stem(name)
-                    diff_mask_key = (
-                        f"{image_key_prefix}/{head_artifact_id}/{base_artifact_id}/diff/{stem}.png"
-                    )
-                    diff_mask_bytes = diff_result.diff_mask_png
-                    logger.info(
-                        "compare_snapshots: uploading mask for %s (%d bytes, changed_px=%d)",
-                        name,
-                        len(diff_mask_bytes),
-                        diff_result.changed_pixels,
-                        extra={
-                            "head_artifact_id": head_artifact_id,
-                            "diff_mask_key": diff_mask_key,
-                        },
-                    )
-                    session.put(diff_mask_bytes, key=diff_mask_key, content_type="image/png")
-
-                    diff_pct = (
-                        diff_result.changed_pixels / diff_result.total_pixels
-                        if diff_result.total_pixels > 0
-                        else 0
-                    )
-                    specific_image_diff_threshold = head_images[name].diff_threshold
-                    effective_threshold = (
-                        specific_image_diff_threshold
-                        if specific_image_diff_threshold is not None
-                        else diff_threshold
-                        if diff_threshold is not None
-                        else 0.0
-                    )
-                    is_changed = diff_pct > effective_threshold
-                    if is_changed:
-                        changed_count += 1
-                    else:
-                        unchanged_count += 1
-
-                    logger.debug(
-                        "compare_snapshots: %s diff_pct=%.6f threshold=%s (per_image=%s global=%s) is_changed=%s pixels=%d/%d",
-                        name,
-                        diff_pct,
-                        effective_threshold,
-                        specific_image_diff_threshold,
-                        diff_threshold,
-                        is_changed,
-                        diff_result.changed_pixels,
-                        diff_result.total_pixels,
-                        extra={"head_artifact_id": head_artifact_id},
-                    )
-
-                    diff_mask_image_id = f"{head_artifact_id}/{base_artifact_id}/diff/{stem}.png"
-
-                    image_results[name] = {
-                        "status": "changed" if is_changed else "unchanged",
-                        "head_hash": head_hash,
-                        "base_hash": base_hash,
-                        "changed_pixels": diff_result.changed_pixels,
-                        "total_pixels": diff_result.total_pixels,
-                        "diff_mask_key": diff_mask_key,
-                        "diff_mask_image_id": diff_mask_image_id,
-                        "before_width": diff_result.before_width,
-                        "before_height": diff_result.before_height,
-                        "after_width": diff_result.after_width,
-                        "after_height": diff_result.after_height,
-                        "aligned_height": diff_result.aligned_height,
-                    }
+        odiff_phase_s = time.monotonic() - odiff_phase_start
+        # Throughput reflects only the pairs odiff actually processed (eligible);
+        # hash-identical and oversized images are skipped before the phase starts.
+        odiff_pairs = len(eligible)
+        logger.info(
+            "compare_snapshots: odiff phase complete",
+            extra={
+                "head_artifact_id": head_artifact_id,
+                "base_artifact_id": base_artifact_id,
+                "worker_count": worker_count,
+                "batches": len(batches),
+                "odiff_pairs": odiff_pairs,
+                "duration_s": round(odiff_phase_s, 3),
+                "slowest_batch_s": round(slowest_batch_s, 3),
+                "pairs_per_s": round(odiff_pairs / odiff_phase_s, 2) if odiff_phase_s > 0 else 0,
+                "fetched_mb": round(total_fetched_bytes / 1_000_000, 2),
+            },
+        )
 
         for name in sorted(added):
             image_results[name] = {"status": "added", "head_hash": head_by_name[name]}

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -5,6 +5,8 @@ import logging
 import queue
 import threading
 import time
+from collections import Counter
+from collections.abc import Callable
 from concurrent.futures import as_completed
 from difflib import SequenceMatcher
 from typing import NamedTuple
@@ -40,6 +42,26 @@ logger = logging.getLogger(__name__)
 
 MAX_DIFF_PIXELS = 40_000_000
 MAX_PIXELS_PER_BATCH = 40_000_000
+
+# Concurrent batch fetches/uploads make transient objectstore 429/503s likelier. Retry once
+# (more would just amplify rate limiting); other errors (e.g. 404) fail fast.
+_RETRYABLE_OBJECTSTORE_STATUSES = frozenset({429, 503})
+_OBJECTSTORE_MAX_ATTEMPTS = 2
+_OBJECTSTORE_RETRY_DELAY_S = 0.5
+
+
+def _retry_objectstore[T](operation: Callable[[], T]) -> T:
+    for attempt in range(1, _OBJECTSTORE_MAX_ATTEMPTS + 1):
+        try:
+            return operation()
+        except RequestError as e:
+            if (
+                e.status not in _RETRYABLE_OBJECTSTORE_STATUSES
+                or attempt == _OBJECTSTORE_MAX_ATTEMPTS
+            ):
+                raise
+            time.sleep(_OBJECTSTORE_RETRY_DELAY_S)
+    raise AssertionError("unreachable")
 
 
 class _DiffCandidate(NamedTuple):
@@ -186,7 +208,9 @@ def _fetch_batch_images(
 
     def fetch(image_hash: str) -> None:
         try:
-            data = session.get(f"{key_prefix}/{image_hash}").payload.read()
+            data = _retry_objectstore(
+                lambda: session.get(f"{key_prefix}/{image_hash}").payload.read()
+            )
             with lock:
                 cache[image_hash] = data
         except Exception:
@@ -221,10 +245,8 @@ def _create_pixel_batches(
 
 
 def _tally_statuses(results: dict[str, dict[str, object]]) -> tuple[int, int, int]:
-    changed = sum(1 for r in results.values() if r["status"] == "changed")
-    unchanged = sum(1 for r in results.values() if r["status"] == "unchanged")
-    errored = sum(1 for r in results.values() if r["status"] == "errored")
-    return changed, unchanged, errored
+    counts = Counter(r["status"] for r in results.values())
+    return counts["changed"], counts["unchanged"], counts["errored"]
 
 
 def _process_batch(
@@ -308,7 +330,13 @@ def _process_batch(
             diff_mask_key = (
                 f"{image_key_prefix}/{head_artifact_id}/{base_artifact_id}/diff/{stem}.png"
             )
-            session.put(diff_result.diff_mask_png, key=diff_mask_key, content_type="image/png")
+            _retry_objectstore(
+                lambda: session.put(
+                    diff_result.diff_mask_png,
+                    key=diff_mask_key,
+                    content_type="image/png",
+                )
+            )
 
             diff_pct = (
                 diff_result.changed_pixels / diff_result.total_pixels
@@ -645,10 +673,14 @@ def compare_snapshots(
 
         try:
             head_manifest = SnapshotManifest(
-                **orjson.loads(session.get(head_manifest_key).payload.read())
+                **orjson.loads(
+                    _retry_objectstore(lambda: session.get(head_manifest_key).payload.read())
+                )
             )
             base_manifest = SnapshotManifest(
-                **orjson.loads(session.get(base_manifest_key).payload.read())
+                **orjson.loads(
+                    _retry_objectstore(lambda: session.get(base_manifest_key).payload.read())
+                )
             )
         except (orjson.JSONDecodeError, RequestError, ValidationError, TypeError):
             logger.exception(
@@ -868,10 +900,12 @@ def compare_snapshots(
         comparison_key = (
             f"{org_id}/{project_id}/{head_artifact_id}/{base_artifact_id}/comparison.json"
         )
-        session.put(
-            orjson.dumps(comparison_manifest.dict()),
-            key=comparison_key,
-            content_type="application/json",
+        _retry_objectstore(
+            lambda: session.put(
+                orjson.dumps(comparison_manifest.dict()),
+                key=comparison_key,
+                content_type="application/json",
+            )
         )
 
         comparison.state = PreprodSnapshotComparison.State.SUCCESS

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -3,13 +3,52 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import orjson
+import pytest
+from objectstore_client.client import RequestError
 
 from sentry.preprod.models import PreprodArtifact, PreprodSnapshotComparison
 from sentry.preprod.snapshots.image_diff.types import DiffResult
-from sentry.preprod.snapshots.tasks import compare_snapshots
+from sentry.preprod.snapshots.tasks import _retry_objectstore, compare_snapshots
 from sentry.testutils.cases import TestCase
 
 TASKS = "sentry.preprod.snapshots.tasks"
+
+
+class RetryObjectstoreTest(TestCase):
+    def test_retries_once_then_succeeds_on_429(self) -> None:
+        calls = []
+
+        def op() -> str:
+            calls.append(1)
+            if len(calls) < 2:
+                raise RequestError("rate limited", status=429, response="")
+            return "ok"
+
+        with patch("sentry.preprod.snapshots.tasks.time.sleep"):
+            assert _retry_objectstore(op) == "ok"
+        assert len(calls) == 2
+
+    def test_gives_up_after_one_retry(self) -> None:
+        calls = []
+
+        def op() -> str:
+            calls.append(1)
+            raise RequestError("rate limited", status=429, response="")
+
+        with patch("sentry.preprod.snapshots.tasks.time.sleep"), pytest.raises(RequestError):
+            _retry_objectstore(op)
+        assert len(calls) == 2
+
+    def test_does_not_retry_non_transient_status(self) -> None:
+        calls = []
+
+        def op() -> str:
+            calls.append(1)
+            raise RequestError("not found", status=404, response="")
+
+        with pytest.raises(RequestError):
+            _retry_objectstore(op)
+        assert len(calls) == 1
 
 
 def _manifest_bytes(images: dict[str, str]) -> bytes:
@@ -224,3 +263,27 @@ class CompareSnapshotsTest(TestCase):
         assert images["a.png"]["status"] == "changed"
         assert images["b.png"]["status"] == "errored"
         assert images["b.png"]["reason"] == "image_processing_failed"
+
+    def test_compare_snapshots_retries_rate_limited_manifest(self) -> None:
+        session = self._make_session(
+            head_images={"a.png": "h1"},
+            base_images={"a.png": "h0"},
+        )
+        underlying_get = session.get.side_effect
+        state = {"throttled": False}
+
+        def flaky_get(key: str) -> MagicMock:
+            if key == self.head_key and not state["throttled"]:
+                state["throttled"] = True
+                raise RequestError("rate limited", status=429, response="")
+            return underlying_get(key)
+
+        session.get.side_effect = flaky_get
+        with patch("sentry.preprod.snapshots.tasks.time.sleep"):
+            self._run(session, diff_results=[_diff_result(50)])
+
+        assert state["throttled"]  # the 429 was hit and retried, not fatal
+        comparison = PreprodSnapshotComparison.objects.get(
+            head_snapshot_metrics=self.head_metrics, base_snapshot_metrics=self.base_metrics
+        )
+        assert comparison.state == PreprodSnapshotComparison.State.SUCCESS

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import orjson
+
+from sentry.preprod.models import PreprodArtifact, PreprodSnapshotComparison
+from sentry.preprod.snapshots.image_diff.types import DiffResult
+from sentry.preprod.snapshots.tasks import compare_snapshots
+from sentry.testutils.cases import TestCase
+
+TASKS = "sentry.preprod.snapshots.tasks"
+
+
+def _manifest_bytes(images: dict[str, str]) -> bytes:
+    return orjson.dumps(
+        {
+            "images": {
+                name: {"content_hash": h, "width": 10, "height": 10} for name, h in images.items()
+            },
+            "selective": False,
+            "all_image_file_names": None,
+        }
+    )
+
+
+def _diff_result(changed_pixels: int) -> DiffResult:
+    return DiffResult(
+        diff_mask_png=b"\x89PNGfake",
+        changed_pixels=changed_pixels,
+        total_pixels=100,
+        aligned_height=10,
+        before_width=10,
+        before_height=10,
+        after_width=10,
+        after_height=10,
+    )
+
+
+class CompareSnapshotsTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.head_artifact = self.create_preprod_artifact(
+            project=self.project, state=PreprodArtifact.ArtifactState.PROCESSED
+        )
+        self.base_artifact = self.create_preprod_artifact(
+            project=self.project, state=PreprodArtifact.ArtifactState.PROCESSED
+        )
+        self.head_key = (
+            f"{self.organization.id}/{self.project.id}/{self.head_artifact.id}/manifest.json"
+        )
+        self.base_key = (
+            f"{self.organization.id}/{self.project.id}/{self.base_artifact.id}/manifest.json"
+        )
+        # The factory does not accept extras=; set manifest_key explicitly after creation.
+        self.head_metrics = self.create_preprod_snapshot_metrics(self.head_artifact)
+        self.head_metrics.extras = {"manifest_key": self.head_key}
+        self.head_metrics.save()
+        self.base_metrics = self.create_preprod_snapshot_metrics(self.base_artifact)
+        self.base_metrics.extras = {"manifest_key": self.base_key}
+        self.base_metrics.save()
+
+    def _make_session(self, head_images: dict[str, str], base_images: dict[str, str]) -> MagicMock:
+        manifests = {
+            self.head_key: _manifest_bytes(head_images),
+            self.base_key: _manifest_bytes(base_images),
+        }
+
+        def _get(key: str) -> MagicMock:
+            result = MagicMock()
+            if key in manifests:
+                result.payload.read.return_value = manifests[key]
+            else:  # image fetch: f"{org}/{project}/{hash}"
+                result.payload.read.return_value = b"imgbytes"
+            return result
+
+        session = MagicMock()
+        session.get.side_effect = _get
+        return session
+
+    def _run(self, session: MagicMock, diff_results: list[DiffResult | None]) -> None:
+        with (
+            patch(f"{TASKS}.get_preprod_session", return_value=session),
+            patch(f"{TASKS}.OdiffServer"),
+            patch(f"{TASKS}.compare_images_batch", return_value=diff_results),
+            patch(f"{TASKS}.update_preprod_snapshot_vcs"),
+            patch(f"{TASKS}._try_auto_approve_snapshot"),
+        ):
+            compare_snapshots(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                head_artifact_id=self.head_artifact.id,
+                base_artifact_id=self.base_artifact.id,
+            )
+
+    def test_compare_snapshots_success_serial(self) -> None:
+        session = self._make_session(
+            head_images={"a.png": "h1", "b.png": "same"},
+            base_images={"a.png": "h0", "b.png": "same"},
+        )
+        self._run(session, diff_results=[_diff_result(changed_pixels=50)])
+
+        comparison = PreprodSnapshotComparison.objects.get(
+            head_snapshot_metrics=self.head_metrics, base_snapshot_metrics=self.base_metrics
+        )
+        assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
+        assert comparison.images_changed == 1
+        assert comparison.images_unchanged == 1
+        put_keys = [c.kwargs.get("key") for c in session.put.call_args_list]
+        assert any("/diff/" in (k or "") for k in put_keys)
+        assert any(k and k.endswith("comparison.json") for k in put_keys)
+
+    def test_compare_snapshots_spawns_n_servers_for_many_batches(self) -> None:
+        session = self._make_session(
+            head_images={f"img{i}.png": f"h{i}a" for i in range(6)},
+            base_images={f"img{i}.png": f"h{i}b" for i in range(6)},
+        )
+        with (
+            patch(f"{TASKS}.get_preprod_session", return_value=session),
+            patch(f"{TASKS}.OdiffServer") as mock_server,
+            patch(
+                f"{TASKS}.compare_images_batch",
+                side_effect=lambda pairs, server=None: [_diff_result(5) for _ in pairs],
+            ),
+            patch(f"{TASKS}.update_preprod_snapshot_vcs"),
+            patch(f"{TASKS}._try_auto_approve_snapshot"),
+            patch(f"{TASKS}.MAX_PIXELS_PER_BATCH", 100),
+            self.options({"preprod.snapshots.odiff-worker-count": 3}),
+        ):
+            compare_snapshots(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                head_artifact_id=self.head_artifact.id,
+                base_artifact_id=self.base_artifact.id,
+            )
+        # 6 images at 100px each -> 1 pair per batch -> 6 batches; min(3, 6) == 3 servers
+        assert mock_server.call_count == 3
+        comparison = PreprodSnapshotComparison.objects.get(
+            head_snapshot_metrics=self.head_metrics, base_snapshot_metrics=self.base_metrics
+        )
+        assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
+        assert comparison.images_changed == 6
+
+    def test_compare_snapshots_logs_odiff_phase_summary(self) -> None:
+        session = self._make_session(
+            head_images={"a.png": "h1", "b.png": "same"},
+            base_images={"a.png": "h0", "b.png": "same"},
+        )
+        with (
+            patch(f"{TASKS}.get_preprod_session", return_value=session),
+            patch(f"{TASKS}.OdiffServer"),
+            patch(f"{TASKS}.compare_images_batch", return_value=[_diff_result(50)]),
+            patch(f"{TASKS}.update_preprod_snapshot_vcs"),
+            patch(f"{TASKS}._try_auto_approve_snapshot"),
+            patch(f"{TASKS}.logger") as mock_logger,
+        ):
+            compare_snapshots(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                head_artifact_id=self.head_artifact.id,
+                base_artifact_id=self.base_artifact.id,
+            )
+        messages = [c.args[0] for c in mock_logger.info.call_args_list]
+        assert "compare_snapshots: odiff phase complete" in messages
+
+    def test_compare_snapshots_batch_failure_is_isolated(self) -> None:
+        session = self._make_session(
+            head_images={"a.png": "h1"},
+            base_images={"a.png": "h0"},
+        )
+
+        def _put(data, key=None, content_type=None):
+            if "/diff/" in (key or ""):
+                raise RuntimeError("mask upload failed")
+            return MagicMock()
+
+        session.put.side_effect = _put
+        with (
+            patch(f"{TASKS}.get_preprod_session", return_value=session),
+            patch(f"{TASKS}.OdiffServer"),
+            patch(f"{TASKS}.compare_images_batch", return_value=[_diff_result(5)]),
+            patch(f"{TASKS}.update_preprod_snapshot_vcs"),
+            patch(f"{TASKS}._try_auto_approve_snapshot"),
+        ):
+            compare_snapshots(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                head_artifact_id=self.head_artifact.id,
+                base_artifact_id=self.base_artifact.id,
+            )
+
+        comparison = PreprodSnapshotComparison.objects.get(
+            head_snapshot_metrics=self.head_metrics, base_snapshot_metrics=self.base_metrics
+        )
+        assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
+        assert comparison.images_changed == 0
+        comparison_json = next(
+            c.args[0]
+            for c in session.put.call_args_list
+            if (c.kwargs.get("key") or "").endswith("comparison.json")
+        )
+        images = orjson.loads(comparison_json)["images"]
+        assert images["a.png"]["status"] == "errored"
+
+    def test_compare_snapshots_per_image_processing_failure(self) -> None:
+        session = self._make_session(
+            head_images={"a.png": "h1", "b.png": "h3"},
+            base_images={"a.png": "h0", "b.png": "h2"},
+        )
+        # both pairs change; odiff yields a result for a.png and None (failed) for b.png
+        self._run(session, diff_results=[_diff_result(50), None])
+
+        comparison = PreprodSnapshotComparison.objects.get(
+            head_snapshot_metrics=self.head_metrics, base_snapshot_metrics=self.base_metrics
+        )
+        assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
+        assert comparison.images_changed == 1
+        comparison_json = next(
+            c.args[0]
+            for c in session.put.call_args_list
+            if (c.kwargs.get("key") or "").endswith("comparison.json")
+        )
+        images = orjson.loads(comparison_json)["images"]
+        assert images["a.png"]["status"] == "changed"
+        assert images["b.png"]["status"] == "errored"
+        assert images["b.png"]["reason"] == "image_processing_failed"


### PR DESCRIPTION
Parallelize the preprod snapshot odiff comparison phase. The single serial `OdiffServer` is replaced with a pool of N persistent servers (tunable via the new `preprod.snapshots.odiff-worker-count` option, default 4) driven by a `ContextPropagatingThreadPoolExecutor`. The per-batch fetch → compare → upload work is extracted into `_process_batch`, which checks a server out of a `queue.Queue`, runs the batch, uploads its diff masks, and returns partial results that are merged single-threaded in the main loop.

**Why:** for large builds the comparison diffs thousands of changed image pairs one at a time against one node process, taking 3+ minutes — long enough to hit the task's 300s `processing_deadline` (`ProcessingDeadlineExceeded`) or be interrupted by a deploy SIGTERM. A real build (~6,000 changed pairs across 431 batches) was timing out this way. Spreading the batches across N servers brings it comfortably under the deadline.

**Notes for reviewers:**
- Concurrency safety: each `OdiffServer` is only ever used by one thread (checked out of the pool); the objectstore `Session` is thread-safe for `get`/`put`; each batch's `compare_images_batch` uses its own tempdir, so there are no cross-thread filename collisions. All result accumulation happens in the main thread — workers mutate no shared state.
- A mid-batch failure is isolated: already-processed pairs are preserved and only the unprocessed ones are marked `errored`, so a single bad batch doesn't fail the whole comparison.
- Memory scales with N (each worker can hold a pair's decoded/padded images), which is why N is an `FLAG_AUTOMATOR_MODIFIABLE` option — it can be dialed down in prod without a deploy. `MAX_DIFF_PIXELS` still caps any single pair.
- Adds a `compare_snapshots: odiff phase complete` summary log (duration, throughput, slowest batch, worker count) for post-deploy diagnosis, and the first end-to-end tests for `compare_snapshots` (which previously had no task-level coverage).

This is the durable follow-up to #116708 (which stopped killed comparisons from getting stuck in `PROCESSING`); together they address the timeout end-to-end.