### PR TITLE
chore(sentry apps, webhooks): Remove unused flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -412,8 +412,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-conversations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Conduit demo endpoint and UI
     manager.add("organizations:conduit-demo", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable hard timeout alarm for webhooks
-    manager.add("organizations:sentry-app-webhook-hard-timeout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     # Enables organization access to the new notification platform
     manager.add("organizations:notification-platform.internal-testing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -414,10 +414,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:conduit-demo", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable hard timeout alarm for webhooks
     manager.add("organizations:sentry-app-webhook-hard-timeout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable circuit breaker for webhook endpoint failure detection
-    manager.add("organizations:sentry-app-webhook-circuit-breaker", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Override dry-run to enable real blocking per app-owner org during rollout
-    manager.add("organizations:sentry-app-webhook-circuit-breaker-live-run", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     # Enables organization access to the new notification platform
     manager.add("organizations:notification-platform.internal-testing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -12,7 +12,7 @@ from requests import RequestException, Response
 from requests.exceptions import ChunkedEncodingError, ConnectionError, Timeout
 from rest_framework import status
 
-from sentry import features, options
+from sentry import options
 from sentry.exceptions import RestrictedIPAddress
 from sentry.http import safe_urlopen
 from sentry.integrations.utils.metrics import EventLifecycle
@@ -193,30 +193,18 @@ def _circuit_breaker_allows_request(
 def _send_webhook_request(
     url: str,
     app_platform_event: AppPlatformEvent[T],
-    organization_context: RpcUserOrganizationContext | None,
 ) -> Response:
-    if organization_context is not None and features.has(
-        "organizations:sentry-app-webhook-hard-timeout",
-        organization_context.organization,
-    ):
-        # We're using a signal based timeout here because we need to interrupt the blocking
-        # socket.connect() operation. See SENTRY-5HA6 for more context. Here we're hanging at
-        # the socket.connect() call and the timeout we set in safe_urlopen is not being respected.
-        timeout_seconds = options.get("sentry-apps.webhook.hard-timeout.sec")
-        with timeout_alarm(timeout_seconds, _handle_webhook_timeout):
-            return safe_urlopen(
-                url=url,
-                data=app_platform_event.body,
-                headers=app_platform_event.headers,
-                timeout=options.get("sentry-apps.webhook.timeout.sec"),
-            )
-
-    return safe_urlopen(
-        url=url,
-        data=app_platform_event.body,
-        headers=app_platform_event.headers,
-        timeout=options.get("sentry-apps.webhook.timeout.sec"),
-    )
+    # We're using a signal based timeout here because we need to interrupt the blocking
+    # socket.connect() operation. See SENTRY-5HA6 for more context. Here we're hanging at
+    # the socket.connect() call and the timeout we set in safe_urlopen is not being respected.
+    timeout_seconds = options.get("sentry-apps.webhook.hard-timeout.sec")
+    with timeout_alarm(timeout_seconds, _handle_webhook_timeout):
+        return safe_urlopen(
+            url=url,
+            data=app_platform_event.body,
+            headers=app_platform_event.headers,
+            timeout=options.get("sentry-apps.webhook.timeout.sec"),
+        )
 
 
 @sentry_sdk.trace(name="send_and_save_webhook_request")
@@ -276,7 +264,7 @@ def send_and_save_webhook_request(
                 return Response()
 
             with circuit_breaker_tracking(circuit_breaker):
-                response = _send_webhook_request(url, app_platform_event, owner_context)
+                response = _send_webhook_request(url, app_platform_event)
 
         except WebhookTimeoutError:
             if circuit_breaker and circuit_breaker.is_open() and owner_org is not None:

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -27,7 +27,6 @@ from sentry.notifications.platform.types import (
 )
 from sentry.organizations.services.organization.model import (
     RpcOrganization,
-    RpcUserOrganizationContext,
 )
 from sentry.organizations.services.organization.service import organization_service
 from sentry.sentry_apps.metrics import (
@@ -41,7 +40,7 @@ from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.silo.base import SiloMode
 from sentry.taskworker.timeout import timeout_alarm
-from sentry.utils import redis
+from sentry.utils import metrics, redis
 from sentry.utils.circuit_breaker2 import CircuitBreaker, RateBasedTripStrategy
 from sentry.utils.http import absolute_uri
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
@@ -96,11 +95,7 @@ def ignore_unpublished_app_errors(
 
 def _create_circuit_breaker(
     sentry_app: SentryApp | RpcSentryApp,
-    organization_context: RpcUserOrganizationContext | None,
 ) -> CircuitBreaker | None:
-    if organization_context is None:
-        return None
-
     # We don't want to make a circuit breaker in CONTROL silo as it's only used for installation webhooks which are v. low volume
     if SiloMode.get_current_mode() == SiloMode.CONTROL:
         return None
@@ -179,10 +174,16 @@ def _notify_webhook_disabled(
 
 def _circuit_breaker_allows_request(
     circuit_breaker: CircuitBreaker | None,
+    sentry_app: SentryApp | RpcSentryApp,
     lifecycle: EventLifecycle,
 ) -> bool:
     if circuit_breaker is None or circuit_breaker.should_allow_request():
         return True
+
+    metrics.incr(
+        "sentry_app.webhook.circuit_breaker.would_block",
+        tags={"slug": sentry_app.slug},
+    )
 
     lifecycle.record_halt(
         halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.CIRCUIT_BROKEN}"
@@ -259,8 +260,8 @@ def send_and_save_webhook_request(
                 include_teams=False,
             )
             owner_org = owner_context.organization if owner_context is not None else None
-            circuit_breaker = _create_circuit_breaker(sentry_app, owner_context)
-            if not _circuit_breaker_allows_request(circuit_breaker, lifecycle):
+            circuit_breaker = _create_circuit_breaker(sentry_app)
+            if not _circuit_breaker_allows_request(circuit_breaker, sentry_app, lifecycle):
                 return Response()
 
             with circuit_breaker_tracking(circuit_breaker):

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -41,7 +41,7 @@ from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.silo.base import SiloMode
 from sentry.taskworker.timeout import timeout_alarm
-from sentry.utils import metrics, redis
+from sentry.utils import redis
 from sentry.utils.circuit_breaker2 import CircuitBreaker, RateBasedTripStrategy
 from sentry.utils.http import absolute_uri
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
@@ -98,10 +98,7 @@ def _create_circuit_breaker(
     sentry_app: SentryApp | RpcSentryApp,
     organization_context: RpcUserOrganizationContext | None,
 ) -> CircuitBreaker | None:
-    if organization_context is None or not features.has(
-        "organizations:sentry-app-webhook-circuit-breaker",
-        organization_context.organization,
-    ):
+    if organization_context is None:
         return None
 
     # We don't want to make a circuit breaker in CONTROL silo as it's only used for installation webhooks which are v. low volume
@@ -156,17 +153,6 @@ def _notify_webhook_disabled(
     if not set_dedup_key(sentry_app, circuit_breaker):
         return
 
-    live_run = features.has(
-        "organizations:sentry-app-webhook-circuit-breaker-live-run",
-        owner_org,
-    )
-    if not live_run:
-        logger.info(
-            "sentry_app.webhook.circuit_breaker.would_email",
-            extra={"slug": sentry_app.slug},
-        )
-        return
-
     data = SentryAppWebhookDisabled(
         sentry_app_slug=sentry_app.slug,
         sentry_app_name=sentry_app.name,
@@ -193,27 +179,9 @@ def _notify_webhook_disabled(
 
 def _circuit_breaker_allows_request(
     circuit_breaker: CircuitBreaker | None,
-    sentry_app: SentryApp | RpcSentryApp,
-    org_id: int,
     lifecycle: EventLifecycle,
-    owner_org: RpcOrganization | None,
 ) -> bool:
     if circuit_breaker is None or circuit_breaker.should_allow_request():
-        return True
-
-    live_run = owner_org is not None and features.has(
-        "organizations:sentry-app-webhook-circuit-breaker-live-run",
-        owner_org,
-    )
-    metrics.incr(
-        "sentry_app.webhook.circuit_breaker.would_block",
-        tags={"slug": sentry_app.slug, "live_run": live_run},
-    )
-    logger.warning(
-        "sentry_app.webhook.circuit_breaker.would_block",
-        extra={"slug": sentry_app.slug, "org_id": org_id, "live_run": live_run},
-    )
-    if not live_run:
         return True
 
     lifecycle.record_halt(
@@ -304,9 +272,7 @@ def send_and_save_webhook_request(
             )
             owner_org = owner_context.organization if owner_context is not None else None
             circuit_breaker = _create_circuit_breaker(sentry_app, owner_context)
-            if not _circuit_breaker_allows_request(
-                circuit_breaker, sentry_app, org_id, lifecycle, owner_org
-            ):
+            if not _circuit_breaker_allows_request(circuit_breaker, lifecycle):
                 return Response()
 
             with circuit_breaker_tracking(circuit_breaker):

--- a/tests/acceptance/test_organization_sentry_app_detailed_view.py
+++ b/tests/acceptance/test_organization_sentry_app_detailed_view.py
@@ -1,3 +1,8 @@
+import contextlib
+from collections.abc import Callable, Generator
+from types import FrameType
+from unittest import mock
+
 from fixtures.page_objects.organization_integration_settings import (
     OrganizationSentryAppDetailViewPage,
 )
@@ -5,6 +10,16 @@ from sentry.deletions.tasks.scheduled import run_scheduled_deletions_control
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
+
+
+@contextlib.contextmanager
+def _noop_timeout_alarm(
+    seconds: float, handler: Callable[[int, FrameType | None], None]
+) -> Generator[None]:
+    # The install/uninstall webhooks fire from the live-server request thread, where
+    # SIGALRM-based timeout_alarm raises (signals only work in the main thread). We don't
+    # exercise webhook delivery here, so stub it out.
+    yield
 
 
 @no_silo_test
@@ -19,6 +34,10 @@ class OrganizationSentryAppDetailedView(AcceptanceTestCase):
             name="Super Awesome App",
         )
         self.login_as(self.user)
+
+        patcher = mock.patch("sentry.utils.sentry_apps.webhooks.timeout_alarm", _noop_timeout_alarm)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def load_page(self, slug: str) -> None:
         url = f"/settings/{self.organization.slug}/sentry-apps/{slug}/"

--- a/tests/sentry/utils/sentry_apps/test_webhook_timeout.py
+++ b/tests/sentry/utils/sentry_apps/test_webhook_timeout.py
@@ -10,7 +10,6 @@ from sentry.sentry_apps.metrics import SentryAppWebhookHaltReason
 from sentry.sentry_apps.utils.webhooks import IssueActionType, SentryAppResourceType
 from sentry.testutils.asserts import assert_halt_metric
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import cell_silo_test
 from sentry.utils.sentry_apps.webhooks import WebhookTimeoutError, send_and_save_webhook_request
@@ -30,7 +29,6 @@ class WebhookTimeoutTest(TestCase):
             organization=self.organization, slug=self.sentry_app.slug
         )
 
-    @with_feature("organizations:sentry-app-webhook-hard-timeout")
     @override_options(
         {
             "sentry-apps.webhook.hard-timeout.sec": 5.0,
@@ -60,7 +58,6 @@ class WebhookTimeoutTest(TestCase):
         assert response == mock_response
         mock_safe_urlopen.assert_called_once()
 
-    @with_feature("organizations:sentry-app-webhook-hard-timeout")
     @override_options(
         {
             "sentry-apps.webhook.hard-timeout.sec": 1.0,
@@ -92,7 +89,6 @@ class WebhookTimeoutTest(TestCase):
         with pytest.raises(WebhookTimeoutError, match="Webhook request exceeded hard timeout"):
             send_and_save_webhook_request(self.sentry_app, app_platform_event)
 
-    @with_feature("organizations:sentry-app-webhook-hard-timeout")
     @override_options(
         {
             "sentry-apps.webhook.hard-timeout.sec": 1.0,
@@ -119,7 +115,6 @@ class WebhookTimeoutTest(TestCase):
         with pytest.raises(WebhookTimeoutError):
             send_and_save_webhook_request(self.sentry_app, app_platform_event)
 
-    @with_feature("organizations:sentry-app-webhook-hard-timeout")
     @override_options(
         {
             "sentry-apps.webhook.hard-timeout.sec": 1.0,
@@ -152,7 +147,6 @@ class WebhookTimeoutTest(TestCase):
             error_msg=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.HARD_TIMEOUT}",
         )
 
-    @with_feature("organizations:sentry-app-webhook-hard-timeout")
     @override_options(
         {
             "sentry-apps.webhook.hard-timeout.sec": 5.0,
@@ -187,7 +181,6 @@ class WebhookTimeoutTest(TestCase):
         signal.signal(signal.SIGALRM, current_handler)
         assert current_handler == original_handler
 
-    @with_feature("organizations:sentry-app-webhook-hard-timeout")
     @override_options(
         {
             "sentry-apps.webhook.hard-timeout.sec": 5.0,

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -68,48 +68,9 @@ class WebhookCircuitBreakerTest(TestCase):
 
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
-    def test_no_circuit_breaker_without_feature_flag(self, mock_safe_urlopen):
-        """Without feature flag, no circuit breaker is instantiated."""
-        mock_response = Mock(spec=Response)
-        mock_response.status_code = 200
-        mock_response.headers = {}
-        mock_safe_urlopen.return_value = mock_response
-
-        response = send_and_save_webhook_request(self.sentry_app, self._make_event())
-        assert response is not None
-        assert response.status_code == 200
-
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
-    @override_options(CIRCUIT_BREAKER_OPTIONS)
-    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
-    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_without_live_run_emits_metric_but_sends_webhook(self, MockBreaker, mock_safe_urlopen):
-        """Without live-run flag, a broken circuit emits would_block but still sends."""
-        mock_breaker_instance = MockBreaker.return_value
-        mock_breaker_instance.should_allow_request.return_value = False
-
-        mock_response = Mock(spec=Response)
-        mock_response.status_code = 200
-        mock_response.headers = {}
-        mock_safe_urlopen.return_value = mock_response
-
-        response = send_and_save_webhook_request(self.sentry_app, self._make_event())
-        # In dry-run, webhook is still sent
-        assert response is not None
-        assert response.status_code == 200
-        mock_safe_urlopen.assert_called_once()
-
-    @with_feature(
-        [
-            "organizations:sentry-app-webhook-circuit-breaker",
-            "organizations:sentry-app-webhook-circuit-breaker-live-run",
-        ]
-    )
-    @override_options(CIRCUIT_BREAKER_OPTIONS)
-    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_blocking_mode_returns_empty_response(self, MockBreaker, mock_safe_urlopen):
-        """With live-run flag enabled, a broken circuit blocks the webhook."""
+        """A broken circuit blocks the webhook."""
         mock_breaker_instance = MockBreaker.return_value
         mock_breaker_instance.should_allow_request.return_value = False
 
@@ -117,7 +78,6 @@ class WebhookCircuitBreakerTest(TestCase):
         # Webhook is blocked — no HTTP call made
         mock_safe_urlopen.assert_not_called()
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
@@ -134,7 +94,6 @@ class WebhookCircuitBreakerTest(TestCase):
         mock_breaker_instance.record_error.assert_called_once()
         mock_breaker_instance.record_success.assert_not_called()
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
@@ -152,7 +111,6 @@ class WebhookCircuitBreakerTest(TestCase):
         mock_breaker_instance.record_error.assert_not_called()
         mock_breaker_instance.record_success.assert_not_called()
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
@@ -169,7 +127,6 @@ class WebhookCircuitBreakerTest(TestCase):
         send_and_save_webhook_request(self.sentry_app, self._make_event())
         mock_breaker_instance.record_success.assert_called_once()
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch.object(CircuitBreaker, "record_success")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -224,13 +181,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         mock_breaker_instance.recovery_duration = 600
         return mock_breaker_instance
 
-    @with_feature(
-        [
-            "organizations:sentry-app-webhook-circuit-breaker",
-            "organizations:sentry-app-webhook-circuit-breaker-live-run",
-            "organizations:notification-platform.internal-testing",
-        ]
-    )
+    @with_feature("organizations:notification-platform.internal-testing")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch.object(NotificationService, "notify_async")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -238,7 +189,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
     def test_timeout_with_trip_calls_notify_async(
         self, MockBreaker, mock_safe_urlopen, mock_notify_async
     ):
-        """When the breaker trips during a timeout with live-run, an email is dispatched."""
+        """When the breaker trips during a timeout, an email is dispatched."""
         self._configure_breaker(MockBreaker, is_open=True)
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
@@ -247,7 +198,6 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
         mock_notify_async.assert_called_once()
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch.object(NotificationService, "notify_async")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -264,35 +214,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
         mock_notify_async.assert_not_called()
 
-    @with_feature(
-        [
-            "organizations:sentry-app-webhook-circuit-breaker",
-            "organizations:notification-platform.internal-testing",
-        ]
-    )
-    @override_options(CIRCUIT_BREAKER_OPTIONS)
-    @patch.object(NotificationService, "notify_async")
-    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
-    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_without_live_run_does_not_dispatch_notify_async(
-        self, MockBreaker, mock_safe_urlopen, mock_notify_async
-    ):
-        """Without live-run flag, email is skipped even when the breaker trips."""
-        self._configure_breaker(MockBreaker, is_open=True)
-        mock_safe_urlopen.side_effect = WebhookTimeoutError()
-
-        with pytest.raises(WebhookTimeoutError):
-            send_and_save_webhook_request(self.sentry_app, self._make_event())
-
-        mock_notify_async.assert_not_called()
-
-    @with_feature(
-        [
-            "organizations:sentry-app-webhook-circuit-breaker",
-            "organizations:sentry-app-webhook-circuit-breaker-live-run",
-            "organizations:notification-platform.internal-testing",
-        ]
-    )
+    @with_feature("organizations:notification-platform.internal-testing")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch.object(NotificationService, "notify_async")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -313,13 +235,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         dedup_key = f"sentry-app.webhook.circuit-breaker.notified.{self.sentry_app.slug}"
         assert client.ttl(dedup_key) >= 86400
 
-    @with_feature(
-        [
-            "organizations:sentry-app-webhook-circuit-breaker",
-            "organizations:sentry-app-webhook-circuit-breaker-live-run",
-            "organizations:notification-platform.internal-testing",
-        ]
-    )
+    @with_feature("organizations:notification-platform.internal-testing")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch.object(NotificationService, "notify_async")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -339,13 +255,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         assert len(targets) == 1
         assert targets[0].resource_id == "creator@example.com"
 
-    @with_feature(
-        [
-            "organizations:sentry-app-webhook-circuit-breaker",
-            "organizations:sentry-app-webhook-circuit-breaker-live-run",
-            "organizations:notification-platform.internal-testing",
-        ]
-    )
+    @with_feature("organizations:notification-platform.internal-testing")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch.object(NotificationService, "notify_async")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -377,7 +287,6 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         assert len(targets) == 1
         assert targets[0].resource_id == "creator@example.com"
 
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch.object(NotificationService, "notify_async")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -405,13 +314,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
         mock_notify_async.assert_not_called()
 
-    @with_feature(
-        [
-            "organizations:sentry-app-webhook-circuit-breaker",
-            "organizations:sentry-app-webhook-circuit-breaker-live-run",
-            "organizations:notification-platform.internal-testing",
-        ]
-    )
+    @with_feature("organizations:notification-platform.internal-testing")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch.object(NotificationService, "notify_async")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
@@ -435,13 +338,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
         assert mock_notify_async.call_count == 2
 
-    @with_feature(
-        [
-            "organizations:sentry-app-webhook-circuit-breaker",
-            "organizations:sentry-app-webhook-circuit-breaker-live-run",
-            "organizations:notification-platform.internal-testing",
-        ]
-    )
+    @with_feature("organizations:notification-platform.internal-testing")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch.object(NotificationService, "notify_async", side_effect=RuntimeError("email boom"))


### PR DESCRIPTION
Remove the `organizations:sentry-app-webhook-circuit-breaker`, `organizations:sentry-app-webhook-circuit-breaker-live-run`, and `organizations:sentry-app-webhook-hard-timeout` flags as they're fully GA'd. 