### PR TITLE
fix(logs): Fix dead drains docs links after docs reorg

### DIFF
--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -65,11 +65,11 @@ type OnboardingProps = {
 const LOG_DRAIN_PLATFORM_DOCS: Record<string, {name: string; url: string}> = {
   'node-cloudflare-pages': {
     name: 'Cloudflare',
-    url: 'https://docs.sentry.io/product/drains/integration/cloudflare/',
+    url: 'https://docs.sentry.io/product/drains/cloudflare/',
   },
   'node-cloudflare-workers': {
     name: 'Cloudflare',
-    url: 'https://docs.sentry.io/product/drains/integration/cloudflare/',
+    url: 'https://docs.sentry.io/product/drains/cloudflare/',
   },
 };
 
@@ -91,7 +91,7 @@ function LogDrainsLink({project}: {project: Project}) {
                   <ExternalLink href={platformDoc.url}>{platformDoc.name}</ExternalLink>
                 ),
                 otlpLink: (
-                  <ExternalLink href="https://docs.sentry.io/product/drains/integration/opentelemetry-collector/" />
+                  <ExternalLink href="https://docs.sentry.io/concepts/otlp/forwarding/pipelines/collector/" />
                 ),
               }
             )
@@ -100,10 +100,10 @@ function LogDrainsLink({project}: {project: Project}) {
               {
                 link: <ExternalLink href="https://docs.sentry.io/product/drains/" />,
                 vercelLink: (
-                  <ExternalLink href="https://docs.sentry.io/product/drains/integration/vercel/" />
+                  <ExternalLink href="https://docs.sentry.io/product/drains/vercel/" />
                 ),
                 otlpLink: (
-                  <ExternalLink href="https://docs.sentry.io/product/drains/integration/opentelemetry-collector/" />
+                  <ExternalLink href="https://docs.sentry.io/concepts/otlp/forwarding/pipelines/collector/" />
                 ),
               }
             )}

--- a/static/app/views/settings/project/projectKeys/credentials/vercel.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/vercel.tsx
@@ -25,7 +25,7 @@ export function VercelTab({
         label={t('Vercel Log Drain Endpoint')}
         help={tct('Use this endpoint to configure Vercel Log Drains. [link:Learn more]', {
           link: (
-            <ExternalLink href="https://docs.sentry.io/product/drains/integration/vercel/#log-drains" />
+            <ExternalLink href="https://docs.sentry.io/product/drains/vercel/#manual-log-drain-setup" />
           ),
         })}
         inline={false}
@@ -56,7 +56,7 @@ export function VercelTab({
               'Set this URL as your Vercel Trace Drain Endpoint (OTLP format). [link:Learn more]',
               {
                 link: (
-                  <ExternalLink href="https://docs.sentry.io/product/drains/integration/vercel/#trace-drains" />
+                  <ExternalLink href="https://docs.sentry.io/product/drains/vercel/#manual-trace-drain-setup" />
                 ),
               }
             )}


### PR DESCRIPTION
## Summary

Several in-app "Learn more" links pointing at the Vercel/Cloudflare/OTLP drains docs are now **404ing**. The sentry-docs `/product/drains/integration/` subfolder was flattened and the OTLP Collector page was relocated to `/concepts/otlp/forwarding/pipelines/collector/` in [sentry-docs#16297](https://github.com/getsentry/sentry-docs/pull/16297) (Feb 11, 2026), but no redirects were added, so these links break.

This came out of ramp-up on [CW-1434 — Fix incorrect Vercel Drains docs page](https://linear.app/getsentry/issue/CW-1434/fix-incorrect-vercel-drains-docs-page).

## Changes

| Location | Before | After |
| --- | --- | --- |
| `credentials/vercel.tsx` (log drain) | `/product/drains/integration/vercel/#log-drains` | `/product/drains/vercel/#manual-log-drain-setup` |
| `credentials/vercel.tsx` (trace drain) | `/product/drains/integration/vercel/#trace-drains` | `/product/drains/vercel/#manual-trace-drain-setup` |
| `logsOnboarding.tsx` (Cloudflare) | `/product/drains/integration/cloudflare/` | `/product/drains/cloudflare/` |
| `logsOnboarding.tsx` (Vercel) | `/product/drains/integration/vercel/` | `/product/drains/vercel/` |
| `logsOnboarding.tsx` (OTLP Collector) | `/product/drains/integration/opentelemetry-collector/` | `/concepts/otlp/forwarding/pipelines/collector/` |

Anchors were also updated — the new Vercel page uses `#manual-log-drain-setup` / `#manual-trace-drain-setup` headings.

A companion sentry-docs PR adds redirects so old bookmarks/external links don't 404 either.

## Notes

- Frontend-only; no backend changes.