### PR TITLE
feat(api): tighten Response annotation on 6 endpoints (no-cast subset)

### DIFF
--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -57,7 +57,9 @@ class EventAttachmentsEndpoint(ProjectEndpoint):
         },
         examples=EventAttachmentExamples.LIST_EVENT_ATTACHMENTS,
     )
-    def get(self, request: Request, project, event_id) -> Response:
+    def get(
+        self, request: Request, project, event_id
+    ) -> Response[list[EventAttachmentSerializerResponse]]:
         """
         Retrieve a list of attachments uploaded for a given event.
 

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -158,7 +158,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         },
         examples=DiscoverAndPerformanceExamples.QUERY_TIMESERIES,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response[StatsResponse]:
         """
         Retrieves explore data for a given organization as a timeseries.
 

--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -150,7 +150,9 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
         },
         examples=SourceMapDebugExamples.GET_SOURCE_MAP_DEBUG,
     )
-    def get(self, request: Request, project: Project, event_id: str) -> Response:
+    def get(
+        self, request: Request, project: Project, event_id: str
+    ) -> Response[SourceMapDebugResponse]:
         """
         Return a list of source map errors for a given event.
         """
@@ -240,11 +242,11 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
         scraping_attempt_map = get_scraping_attempt_map(event_data)
 
         # build information about individual exceptions and their stack traces
-        processed_exceptions = []
+        processed_exceptions: list[SourceMapDebugException] = []
         exception_values = get_path(event_data, "exception", "values")
         if exception_values is not None:
             for exception_value in exception_values:
-                processed_frames = []
+                processed_frames: list[SourceMapDebugFrame] = []
                 frames = get_path(exception_value, "raw_stacktrace", "frames")
                 stacktrace_frames = get_path(exception_value, "stacktrace", "frames")
                 if frames is not None:

--- a/src/sentry/api/endpoints/timeseries.py
+++ b/src/sentry/api/endpoints/timeseries.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 # Assumed ingestion delay for timeseries, this is a static number for now just to match how the frontend was doing it
 INGESTION_DELAY = 90
@@ -48,6 +48,6 @@ class StatsResponse(TypedDict):
     timeSeries: list[TimeSeries]
 
 
-EMPTY_STATS_RESPONSE: dict[str, Any] = {
+EMPTY_STATS_RESPONSE: StatsResponse = {
     "timeSeries": [],
 }

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -69,7 +69,9 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         },
         examples=DiscoverExamples.DISCOVER_SAVED_QUERIES_QUERY_RESPONSE,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[DiscoverSavedQueryResponse]]:
         """
         Retrieve a list of saved queries that are associated with the given organization.
         """
@@ -141,7 +143,10 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         # Old discover expects all queries and uses this parameter.
         if request.query_params.get("all") == "1":
             saved_queries = list(queryset.all())
-            return Response(serialize(saved_queries), status=200)
+            return Response(
+                serialize(saved_queries, serializer=DiscoverSavedQueryModelSerializer()),
+                status=200,
+            )
 
         def data_fn(offset, limit):
             return list(queryset[offset : offset + limit])

--- a/src/sentry/issues/endpoints/group_hashes.py
+++ b/src/sentry/issues/endpoints/group_hashes.py
@@ -80,7 +80,7 @@ class GroupHashesEndpoint(GroupEndpoint):
         examples=EventExamples.GROUP_HASHES,
     )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-hashes"])
-    def get(self, request: Request, group: Group) -> Response:
+    def get(self, request: Request, group: Group) -> Response[list[GroupHashesResult]]:
         """
         List the hashes that make up an issue. Each hash represents a grouping
         signature used to aggregate individual events into this issue.

--- a/src/sentry/releases/endpoints/project_releases.py
+++ b/src/sentry/releases/endpoints/project_releases.py
@@ -70,7 +70,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
         },
         examples=ReleaseExamples.LIST_PROJECT_RELEASES,
     )
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project) -> Response[list[ReleaseSerializerResponse]]:
         """
         Retrieve a list of releases for a given project.
         """


### PR DESCRIPTION
Tighten six endpoint return annotations from `-> Response` to `-> Response[T]`, where `T` is the type already named in the same method's `inline_sentry_response_serializer(...)` decorator.

Continues the Response[T] rollout from #116335 / #116433 / #116496 / #116538 / #116659. An audit found 29 endpoints today that pair a typed decorator with a bare annotation — invisible to both mypy and the structural linter. This PR ships the subset where either the body already matches structurally or a single source-typing fix (typed variable, explicit serializer instance, source retype) unblocks it, with no `cast()` calls. The remaining endpoints surface real source-typing gaps (untyped `serialize()` returns, untyped helper returns, pydantic `.dict()` boundaries) that get their own cohort PRs.

`EMPTY_STATS_RESPONSE` in `timeseries.py` was retyped from `dict[str, Any]` to `StatsResponse` so the events-timeseries endpoint's empty-projects fallback flows the correct type — the value `{"timeSeries": []}` already satisfied `StatsResponse` since `meta` is `NotRequired`.