### PR TITLE
feat(broadcasts): Add organization targeting to broadcast admin UI

### DIFF
--- a/static/gsAdmin/components/createBroadcastModal.tsx
+++ b/static/gsAdmin/components/createBroadcastModal.tsx
@@ -62,6 +62,12 @@ export function CreateBroadcastModal({
         category: data.category || undefined,
         mediaUrl: data.mediaUrl || undefined,
         region: data.region || undefined,
+        organizations: data.organizations
+          ? String(data.organizations)
+              .split(',')
+              .map(s => Number(s.trim()))
+              .filter(n => n > 0)
+          : undefined,
       };
 
       updateBroadcast(newData);

--- a/static/gsAdmin/schemas/broadcasts.tsx
+++ b/static/gsAdmin/schemas/broadcasts.tsx
@@ -39,6 +39,14 @@ export function getBroadcastSchema(): Field[] {
       placeholder: 'e.g. https://blog.sentry.io/2021/01/01/shiny-new-feature',
     },
     {
+      name: 'organizations',
+      type: 'string',
+      required: false,
+      label: 'Organization IDs',
+      placeholder: 'e.g. 123, 456, 789 (leave empty to broadcast to all users)',
+      help: 'Comma-separated list of organization IDs to restrict this broadcast to. If left empty, the broadcast will be shown to all users.',
+    },
+    {
       name: 'mediaUrl',
       type: 'string',
       required: false,

--- a/static/gsAdmin/views/broadcastDetails.spec.tsx
+++ b/static/gsAdmin/views/broadcastDetails.spec.tsx
@@ -26,6 +26,7 @@ describe('Broadcast Details', () => {
       platform: ['bun', 'capacitor'],
       product: ['errors', 'spans'],
       createdBy: 'admin@sentry.io',
+      organizations: [123, 456],
       earlyAdopter: true,
     };
 
@@ -59,6 +60,9 @@ describe('Broadcast Details', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher('Created By:admin@sentry.io'))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher('Organization IDs:123, 456'))
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher('Early Adopter:Yes'))

--- a/static/gsAdmin/views/broadcastDetails.tsx
+++ b/static/gsAdmin/views/broadcastDetails.tsx
@@ -127,6 +127,9 @@ export function BroadcastDetails() {
       <DetailLabel title="Link">
         <ExternalLink href={data.link}>{data.link}</ExternalLink>
       </DetailLabel>
+      <DetailLabel title="Organization IDs">
+        {data.organizations?.length ? data.organizations.join(', ') : '-'}
+      </DetailLabel>
       <DetailLabel title="Media URL">{data.mediaUrl ?? '-'}</DetailLabel>
       <DetailLabel title="Category">
         {formatData(data.category, CATEGORYCHOICES)}
@@ -166,6 +169,12 @@ export function BroadcastDetails() {
           }
           payload[key] = value;
         }
+        if (typeof formData.organizations === 'string') {
+          payload.organizations = formData.organizations
+            .split(',')
+            .map((s: string) => Number(s.trim()))
+            .filter((n: number) => n > 0);
+        }
         return payload;
       }}
       onSubmitSuccess={() => {
@@ -194,8 +203,9 @@ export function BroadcastDetails() {
         roles: data.roles ?? [],
         plans: data.plans ?? [],
         trialStatus: data.trialStatus ?? undefined,
+        organizations: data.organizations?.length ? data.organizations.join(', ') : '',
         earlyAdopter: Boolean(data.earlyAdopter),
-        region: data.region ?? [],
+        region: data.region ?? undefined,
         platform: data.platform ?? [],
         product: data.product ?? [],
       }}
@@ -226,6 +236,13 @@ export function BroadcastDetails() {
         maxLength={256}
       />
       <TextField {...fieldProps} name="link" label="Link" required />
+      <TextField
+        {...fieldProps}
+        name="organizations"
+        label="Organization IDs"
+        help="Comma-separated list of organization IDs to restrict this broadcast to. If left empty, the broadcast will be shown to all users."
+        placeholder="e.g. 123, 456, 789 (leave empty to broadcast to all users)"
+      />
       <TextField
         {...fieldProps}
         name="mediaUrl"
@@ -266,7 +283,6 @@ export function BroadcastDetails() {
         {...fieldProps}
         name="region"
         label="Region"
-        multiple
         options={toOptions(REGIONCHOICES)}
       />
       <SelectField


### PR DESCRIPTION
Add an Organization IDs field to the broadcast create and edit forms that accepts a comma-separated list of org IDs, restricting the broadcast to those organizations. Pairs with the backend support added in getsentry#20507.

Also fixes region edit field which incorrectly used multi-select despite the model being a single CharField.
