### PR TITLE
ref(autofix): Make stopping point validation aware of billing tier

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -91,15 +91,26 @@ def extract_api_error_message(response: Any) -> str | None:
 
 
 def get_valid_automated_run_stopping_points(
-    organization: Organization,
+    organization: Organization | None = None,
+    *,
+    is_seat_based: bool | None = None,
 ) -> set[AutofixStoppingPoint]:
-    """Return the set of stopping points valid for the given organization."""
+    """Return the set of stopping points valid for an org's billing tier.
+
+    Pass is_seat_based to skip the feature-flag lookup when the caller
+    already knows the org's tier (e.g. during seat-based migration).
+    """
+    if is_seat_based is None:
+        if organization is None:
+            raise ValueError("Either organization or is_seat_based must be provided.")
+        is_seat_based = is_seer_seat_based_tier_enabled(organization)
+
     valid = {
         AutofixStoppingPoint.CODE_CHANGES,
         AutofixStoppingPoint.OPEN_PR,
         AutofixStoppingPoint.ROOT_CAUSE,
     }
-    if not is_seer_seat_based_tier_enabled(organization):
+    if not is_seat_based:
         valid.add(AutofixStoppingPoint.SOLUTION)
     return valid
 
@@ -368,13 +379,21 @@ def default_seer_project_preference(project: Project) -> SeerProjectPreference:
 
 def get_org_default_seer_automation_handoff(
     organization: Organization,
+    *,
+    is_seat_based: bool | None = None,
 ) -> tuple[str, SeerAutomationHandoffConfiguration | None]:
-    """Get the default stopping point and automation handoff for an organization."""
+    """Get the default stopping point and automation handoff for an organization.
+
+    Pass is_seat_based to skip the feature-flag lookup when the caller
+    already knows the org's tier (e.g. during seat-based migration).
+    """
     stopping_point = organization.get_option(
         "sentry:default_automated_run_stopping_point", SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
     )
     # Guard against stored stopping points that are no longer valid.
-    if stopping_point not in get_valid_automated_run_stopping_points(organization):
+    if stopping_point not in get_valid_automated_run_stopping_points(
+        organization, is_seat_based=is_seat_based
+    ):
         stopping_point = SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
 
     auto_open_prs = organization.get_option("sentry:auto_open_prs", AUTO_OPEN_PRS_DEFAULT)

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -99,6 +99,8 @@ def get_valid_automated_run_stopping_points(
         AutofixStoppingPoint.OPEN_PR,
         AutofixStoppingPoint.ROOT_CAUSE,
     }
+    if not is_seer_seat_based_tier_enabled(organization):
+        valid.add(AutofixStoppingPoint.SOLUTION)
     return valid
 
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -68,13 +68,15 @@ class AutofixStoppingPoint(StrEnum):
     OPEN_PR = "open_pr"
 
 
-SEAT_BASED_STOPPING_POINTS: set[AutofixStoppingPoint] = {
-    AutofixStoppingPoint.CODE_CHANGES,
-    AutofixStoppingPoint.OPEN_PR,
-    AutofixStoppingPoint.ROOT_CAUSE,
-}
+SEAT_BASED_STOPPING_POINTS: frozenset[AutofixStoppingPoint] = frozenset(
+    {
+        AutofixStoppingPoint.CODE_CHANGES,
+        AutofixStoppingPoint.OPEN_PR,
+        AutofixStoppingPoint.ROOT_CAUSE,
+    }
+)
 
-USAGE_BASED_STOPPING_POINTS: set[AutofixStoppingPoint] = SEAT_BASED_STOPPING_POINTS | {
+USAGE_BASED_STOPPING_POINTS: frozenset[AutofixStoppingPoint] = SEAT_BASED_STOPPING_POINTS | {
     AutofixStoppingPoint.SOLUTION,
 }
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -68,6 +68,17 @@ class AutofixStoppingPoint(StrEnum):
     OPEN_PR = "open_pr"
 
 
+SEAT_BASED_STOPPING_POINTS: set[AutofixStoppingPoint] = {
+    AutofixStoppingPoint.CODE_CHANGES,
+    AutofixStoppingPoint.OPEN_PR,
+    AutofixStoppingPoint.ROOT_CAUSE,
+}
+
+USAGE_BASED_STOPPING_POINTS: set[AutofixStoppingPoint] = SEAT_BASED_STOPPING_POINTS | {
+    AutofixStoppingPoint.SOLUTION,
+}
+
+
 def extract_api_error_message(response: Any) -> str | None:
     # Anthropic returns {"error": {"type": "...", "message": "..."}}; others
     # (OpenAI, GitHub, Stripe) use one of "error.message" or top-level "message".
@@ -91,28 +102,12 @@ def extract_api_error_message(response: Any) -> str | None:
 
 
 def get_valid_automated_run_stopping_points(
-    organization: Organization | None = None,
-    *,
-    is_seat_based: bool | None = None,
+    organization: Organization,
 ) -> set[AutofixStoppingPoint]:
-    """Return the set of stopping points valid for an org's billing tier.
-
-    Pass is_seat_based to skip the feature-flag lookup when the caller
-    already knows the org's tier (e.g. during seat-based migration).
-    """
-    if is_seat_based is None:
-        if organization is None:
-            raise ValueError("Either organization or is_seat_based must be provided.")
-        is_seat_based = is_seer_seat_based_tier_enabled(organization)
-
-    valid = {
-        AutofixStoppingPoint.CODE_CHANGES,
-        AutofixStoppingPoint.OPEN_PR,
-        AutofixStoppingPoint.ROOT_CAUSE,
-    }
-    if not is_seat_based:
-        valid.add(AutofixStoppingPoint.SOLUTION)
-    return valid
+    """Return the set of stopping points valid for an org's billing tier."""
+    if is_seer_seat_based_tier_enabled(organization):
+        return SEAT_BASED_STOPPING_POINTS
+    return USAGE_BASED_STOPPING_POINTS
 
 
 class AutofixRequest(BaseModel):
@@ -379,21 +374,13 @@ def default_seer_project_preference(project: Project) -> SeerProjectPreference:
 
 def get_org_default_seer_automation_handoff(
     organization: Organization,
-    *,
-    is_seat_based: bool | None = None,
 ) -> tuple[str, SeerAutomationHandoffConfiguration | None]:
-    """Get the default stopping point and automation handoff for an organization.
-
-    Pass is_seat_based to skip the feature-flag lookup when the caller
-    already knows the org's tier (e.g. during seat-based migration).
-    """
+    """Get the default stopping point and automation handoff for a seat-based organization."""
     stopping_point = organization.get_option(
         "sentry:default_automated_run_stopping_point", SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
     )
     # Guard against stored stopping points that are no longer valid.
-    if stopping_point not in get_valid_automated_run_stopping_points(
-        organization, is_seat_based=is_seat_based
-    ):
+    if stopping_point not in SEAT_BASED_STOPPING_POINTS:
         stopping_point = SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
 
     auto_open_prs = organization.get_option("sentry:auto_open_prs", AUTO_OPEN_PRS_DEFAULT)

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -105,7 +105,7 @@ def extract_api_error_message(response: Any) -> str | None:
 
 def get_valid_automated_run_stopping_points(
     organization: Organization,
-) -> set[AutofixStoppingPoint]:
+) -> frozenset[AutofixStoppingPoint]:
     """Return the set of stopping points valid for an org's billing tier."""
     if is_seer_seat_based_tier_enabled(organization):
         return SEAT_BASED_STOPPING_POINTS

--- a/src/sentry/seer/endpoints/project_seer_settings.py
+++ b/src/sentry/seer/endpoints/project_seer_settings.py
@@ -335,6 +335,11 @@ class _BaseProjectSettingsUpdateSerializer(CamelSnakeSerializer):
             raise serializers.ValidationError(f"{value} is not a valid integration.")
         return value
 
+    def validate_stopping_point(self, value: str) -> str:
+        if value not in get_valid_automated_run_stopping_points(self.context["organization"]):
+            raise serializers.ValidationError(f'"{value}" is not a valid choice.')
+        return value
+
     def validate(self, data):
         if "agent" in data and data["agent"] != "seer" and "integration_id" not in data:
             raise serializers.ValidationError(
@@ -364,11 +369,6 @@ class ProjectSettingsUpdateSerializer(_BaseProjectSettingsUpdateSerializer):
         choices=[AutofixAutomationTuningSettings.OFF, AutofixAutomationTuningSettings.MEDIUM],
         required=False,
     )
-
-    def validate_stopping_point(self, value: str) -> str:
-        if value not in get_valid_automated_run_stopping_points(self.context["organization"]):
-            raise serializers.ValidationError(f'"{value}" is not a valid choice.')
-        return value
 
     def validate(self, data):
         data = super().validate(data)

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -20,6 +20,7 @@ from sentry.seer.autofix.constants import (
     SeerAutomationSource,
 )
 from sentry.seer.autofix.utils import (
+    SEAT_BASED_STOPPING_POINTS,
     AutofixStoppingPoint,
     AutomationCodingAgent,
     SeerProjectSettingsUpdate,
@@ -27,7 +28,6 @@ from sentry.seer.autofix.utils import (
     get_autofix_state,
     get_org_default_seer_automation_handoff,
     get_seer_seat_based_tier_cache_key,
-    get_valid_automated_run_stopping_points,
     update_seer_project_settings,
 )
 from sentry.tasks.base import instrumented_task
@@ -242,11 +242,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
                 "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
             )
 
-    default_stopping_point, default_handoff = get_org_default_seer_automation_handoff(
-        organization, is_seat_based=True
-    )
-    valid_stopping_points = get_valid_automated_run_stopping_points(is_seat_based=True)
-
+    default_stopping_point, default_handoff = get_org_default_seer_automation_handoff(organization)
     preferences = bulk_read_preferences_from_sentry_db(organization_id, project_ids)
 
     # Determine which projects need updates
@@ -262,12 +258,12 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
 
             # Skip projects that a) already have an acceptable stopping point configured
             # AND b) already have a handoff configured or no org default handoff.
-            if existing_stopping_point in valid_stopping_points and (
+            if existing_stopping_point in SEAT_BASED_STOPPING_POINTS and (
                 existing_handoff or default_handoff is None
             ):
                 continue
 
-            if existing_stopping_point in valid_stopping_points:
+            if existing_stopping_point in SEAT_BASED_STOPPING_POINTS:
                 stopping_point = existing_stopping_point
             if existing_handoff:
                 handoff = existing_handoff

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -242,8 +242,10 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
                 "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
             )
 
-    default_stopping_point, default_handoff = get_org_default_seer_automation_handoff(organization)
-    valid_stopping_points = get_valid_automated_run_stopping_points(organization)
+    default_stopping_point, default_handoff = get_org_default_seer_automation_handoff(
+        organization, is_seat_based=True
+    )
+    valid_stopping_points = get_valid_automated_run_stopping_points(is_seat_based=True)
 
     preferences = bulk_read_preferences_from_sentry_db(organization_id, project_ids)
 

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1649,7 +1649,8 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
                 response = self.get_success_response(self.organization.slug, **data)
                 assert response.data["defaultAutomatedRunStoppingPoint"] == choice
 
-    def test_default_automated_run_stopping_point_rejects_invalid(self) -> None:
+    @patch("sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True)
+    def test_default_automated_run_stopping_point_rejects_invalid(self, mock_seat_based) -> None:
         for invalid in ("solution", "invalid_point"):
             with self.subTest(value=invalid):
                 data = {"defaultAutomatedRunStoppingPoint": invalid}


### PR DESCRIPTION
The `get_valid_automated_run_stopping_points(org)` function should account for usage-based orgs too. Currently it is only used in callsites that guarantee seat-based orgs, but it's safer and more useful for it to account for both pricing tiers. `is_seer_seat_based_tier_enabled()` is cached so I don't expect this check to cause problems even in hot paths.

I also made a constant for seat-based stopping points and a constant for usage-based stopping points. These can be used in contexts where the callsite already knows what tier it's in. For example, `get_org_default_seer_automation_handoff` and `configure_seer_for_existing_org` now use `SEAT_BASED_STOPPING_POINTS`, since a) they always operate in a seat-based context, and b) **`configure_seer_for_existing_org` is for orgs migrating from old seer to new seer and [the billing flag may not have fully propagated yet.](https://github.com/getsentry/sentry/blob/8081842937964ca138d428d768b6fe31ca7eaa51/src/sentry/tasks/seer/autofix.py#L286)**

Followup to https://github.com/getsentry/sentry/pull/116623#discussion_r3343192640