### PR TITLE
feat(issue-sort): Skip zero-weighted factors in recommended sort

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -831,13 +831,13 @@ def _recommended_aggregation(
     if not terms:
         # No weighted factors: emit a constant-0 aggregate (a bare "0.0" isn't a
         # valid Snuba aggregation expression).
-        score = "multiply(0, count())"
+        score_expr = "multiply(0, count())"
     else:
-        score = terms[0]
+        score_expr = terms[0]
         for term in terms[1:]:
-            score = f"plus({score}, {term})"
+            score_expr = f"plus({score_expr}, {term})"
 
-    return [score, ""]
+    return [score_expr, ""]
 
 
 def recommended_aggregation(

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -805,10 +805,9 @@ def _recommended_aggregation(
     # Group type boost: additive signal per issue type
     group_type_boosts = options.get("snuba.search.recommended.group-type-boost")
 
-    # Only emit terms for factors with a non-zero weight. A zero weight would
-    # multiply the factor out to 0 anyway, so there's no point making ClickHouse
-    # compute it (some factors, e.g. user impact's uniq(tags[sentry:user]), are
-    # expensive to evaluate).
+    # Skip zero-weighted factors: their term is always 0, so computing them in
+    # ClickHouse is wasted work -- especially expensive aggregates like user
+    # impact's uniq(tags[sentry:user]).
     terms = [
         f"multiply({weight}, {factor})"
         for weight, factor in (
@@ -829,8 +828,8 @@ def _recommended_aggregation(
         terms.append(f"multiIf({', '.join(conditions)}, 0.0)")
 
     if not terms:
-        # No weighted factors: emit a constant-0 aggregate (a bare "0.0" isn't a
-        # valid Snuba aggregation expression).
+        # Snuba rejects a bare "0.0" as an aggregation, so wrap the constant in an
+        # aggregate function to get a 0 score for every group.
         score_expr = "multiply(0, count())"
     else:
         score_expr = terms[0]

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -804,27 +804,40 @@ def _recommended_aggregation(
 
     # Group type boost: additive signal per issue type
     group_type_boosts = options.get("snuba.search.recommended.group-type-boost")
+
+    # Only emit terms for factors with a non-zero weight. A zero weight would
+    # multiply the factor out to 0 anyway, so there's no point making ClickHouse
+    # compute it (some factors, e.g. user impact's uniq(tags[sentry:user]), are
+    # expensive to evaluate).
+    terms = [
+        f"multiply({weight}, {factor})"
+        for weight, factor in (
+            (recency_weight, recency),
+            (spike_weight, spike),
+            (severity_weight, severity),
+            (user_impact_weight, user_impact),
+            (event_volume_weight, event_volume),
+        )
+        if weight
+    ]
+
     if group_type_boosts:
         type_expr = f"any({type_column})" if type_column else "1"
         conditions = []
         for type_id, boost in group_type_boosts.items():
             conditions.append(f"equals({type_expr}, {type_id}), {boost}")
-        type_boost = f"multiIf({', '.join(conditions)}, 0.0)"
-    else:
-        type_boost = "0.0"
+        terms.append(f"multiIf({', '.join(conditions)}, 0.0)")
 
-    return [
-        (
-            f"plus(plus(plus(plus(plus("
-            f"multiply({recency_weight}, {recency}), "
-            f"multiply({spike_weight}, {spike})), "
-            f"multiply({severity_weight}, {severity})), "
-            f"multiply({user_impact_weight}, {user_impact})), "
-            f"multiply({event_volume_weight}, {event_volume})), "
-            f"{type_boost})"
-        ),
-        "",
-    ]
+    if not terms:
+        # No weighted factors: emit a constant-0 aggregate (a bare "0.0" isn't a
+        # valid Snuba aggregation expression).
+        score = "multiply(0, count())"
+    else:
+        score = terms[0]
+        for term in terms[1:]:
+            score = f"plus({score}, {term})"
+
+    return [score, ""]
 
 
 def recommended_aggregation(

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -820,6 +820,13 @@ def _recommended_aggregation(
         if weight
     ]
 
+    if not terms:
+        # The score must be an aggregate expression. Every factor term above is an
+        # aggregate, but if all are dropped the only remaining term may be the boost
+        # below, which can be a bare constant. Seed a constant-0 aggregate so the
+        # expression Snuba receives always contains one.
+        terms.append("multiply(0, count())")
+
     if group_type_boosts:
         type_expr = f"any({type_column})" if type_column else "1"
         conditions = []
@@ -827,14 +834,9 @@ def _recommended_aggregation(
             conditions.append(f"equals({type_expr}, {type_id}), {boost}")
         terms.append(f"multiIf({', '.join(conditions)}, 0.0)")
 
-    if not terms:
-        # Snuba rejects a bare "0.0" as an aggregation, so wrap the constant in an
-        # aggregate function to get a 0 score for every group.
-        score_expr = "multiply(0, count())"
-    else:
-        score_expr = terms[0]
-        for term in terms[1:]:
-            score_expr = f"plus({score_expr}, {term})"
+    score_expr = terms[0]
+    for term in terms[1:]:
+        score_expr = f"plus({score_expr}, {term})"
 
     return [score_expr, ""]
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -4149,3 +4149,78 @@ class EventsRecommendedSortTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin)
 
         scores = {gid: score for gid, score in results}
         assert scores[profile_group.id] > scores[error_group.id]
+
+    def _recommended_scores(self, group_ids: list[int]) -> dict[int, float]:
+        results = self.backend._get_query_executor().snuba_search(
+            start=None,
+            end=None,
+            project_ids=[self.project.id],
+            environment_ids=[],
+            sort_field="recommended",
+            organization=self.organization,
+            group_ids=group_ids,
+            limit=150,
+            referrer=Referrer.TESTING_TEST,
+        )[0]
+        return {gid: score for gid, score in results}
+
+    def test_recommended_zero_weight_factor_excluded(self) -> None:
+        # A zeroed factor is dropped from the aggregation, so only the remaining
+        # weighted factors count. Severity (which favors the fatal group) is zeroed,
+        # so the higher-volume info group must still win on event volume alone.
+        ts = before_now(hours=1).isoformat()
+        for i in range(5):
+            self.store_event(
+                data={
+                    "fingerprint": ["high-vol"],
+                    "event_id": f"{'a' * 31}{i}",
+                    "message": "high-vol",
+                    "level": "info",
+                    "timestamp": ts,
+                },
+                project_id=self.project.id,
+            )
+        self.store_event(
+            data={
+                "fingerprint": ["low-vol"],
+                "event_id": "b" * 32,
+                "message": "low-vol",
+                "level": "fatal",
+                "timestamp": ts,
+            },
+            project_id=self.project.id,
+        )
+        high = Group.objects.get(project=self.project, message="high-vol")
+        low = Group.objects.get(project=self.project, message="low-vol")
+
+        weights = {
+            f"snuba.search.recommended.{k}-weight": 0.0
+            for k in ("recency", "spike", "severity", "user-impact")
+        }
+        weights["snuba.search.recommended.event-volume-weight"] = 0.2
+        weights["snuba.search.recommended.group-type-boost"] = {}
+        with self.options(weights):
+            scores = self._recommended_scores([high.id, low.id])
+
+        assert scores[high.id] > scores[low.id]
+
+    def test_recommended_all_weights_zero(self) -> None:
+        # No weighted factors and no boost: the query must still succeed, scoring 0.
+        event = self.store_event(
+            data={
+                "fingerprint": ["zero"],
+                "event_id": "a" * 32,
+                "level": "error",
+                "timestamp": before_now(hours=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        weights = {
+            f"snuba.search.recommended.{k}-weight": 0.0
+            for k in ("recency", "spike", "severity", "user-impact", "event-volume")
+        }
+        weights["snuba.search.recommended.group-type-boost"] = {}
+        with self.options(weights):
+            scores = self._recommended_scores([event.group.id])
+
+        assert scores[event.group.id] == 0

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -4165,9 +4165,6 @@ class EventsRecommendedSortTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin)
         return {gid: score for gid, score in results}
 
     def test_recommended_zero_weight_factor_excluded(self) -> None:
-        # A zeroed factor is dropped from the aggregation, so only the remaining
-        # weighted factors count. Severity (which favors the fatal group) is zeroed,
-        # so the higher-volume info group must still win on event volume alone.
         ts = before_now(hours=1).isoformat()
         for i in range(5):
             self.store_event(
@@ -4203,24 +4200,3 @@ class EventsRecommendedSortTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin)
             scores = self._recommended_scores([high.id, low.id])
 
         assert scores[high.id] > scores[low.id]
-
-    def test_recommended_all_weights_zero(self) -> None:
-        # No weighted factors and no boost: the query must still succeed, scoring 0.
-        event = self.store_event(
-            data={
-                "fingerprint": ["zero"],
-                "event_id": "a" * 32,
-                "level": "error",
-                "timestamp": before_now(hours=1).isoformat(),
-            },
-            project_id=self.project.id,
-        )
-        weights = {
-            f"snuba.search.recommended.{k}-weight": 0.0
-            for k in ("recency", "spike", "severity", "user-impact", "event-volume")
-        }
-        weights["snuba.search.recommended.group-type-boost"] = {}
-        with self.options(weights):
-            scores = self._recommended_scores([event.group.id])
-
-        assert scores[event.group.id] == 0

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -4190,13 +4190,15 @@ class EventsRecommendedSortTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin)
         high = Group.objects.get(project=self.project, message="high-vol")
         low = Group.objects.get(project=self.project, message="low-vol")
 
-        weights = {
-            f"snuba.search.recommended.{k}-weight": 0.0
-            for k in ("recency", "spike", "severity", "user-impact")
+        options = {
+            "snuba.search.recommended.recency-weight": 0.0,
+            "snuba.search.recommended.spike-weight": 0.0,
+            "snuba.search.recommended.severity-weight": 0.0,
+            "snuba.search.recommended.user-impact-weight": 0.0,
+            "snuba.search.recommended.event-volume-weight": 0.2,
+            "snuba.search.recommended.group-type-boost": {},
         }
-        weights["snuba.search.recommended.event-volume-weight"] = 0.2
-        weights["snuba.search.recommended.group-type-boost"] = {}
-        with self.options(weights):
+        with self.options(options):
             scores = self._recommended_scores([high.id, low.id])
 
         assert scores[high.id] > scores[low.id]

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -4202,3 +4202,29 @@ class EventsRecommendedSortTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin)
             scores = self._recommended_scores([high.id, low.id])
 
         assert scores[high.id] > scores[low.id]
+
+    def test_recommended_all_factors_zero_with_boost(self) -> None:
+        # All factor weights are dropped, leaving only the group type boost. The
+        # boost can be a non-aggregate expression, so the query must still be a
+        # valid aggregation and succeed.
+        event = self.store_event(
+            data={
+                "fingerprint": ["boost-only"],
+                "event_id": "a" * 32,
+                "level": "error",
+                "timestamp": before_now(hours=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        options = {
+            "snuba.search.recommended.recency-weight": 0.0,
+            "snuba.search.recommended.spike-weight": 0.0,
+            "snuba.search.recommended.severity-weight": 0.0,
+            "snuba.search.recommended.user-impact-weight": 0.0,
+            "snuba.search.recommended.event-volume-weight": 0.0,
+            "snuba.search.recommended.group-type-boost": {1: 0.5},
+        }
+        with self.options(options):
+            scores = self._recommended_scores([event.group.id])
+
+        assert event.group.id in scores


### PR DESCRIPTION
The recommended sort score is a weighted sum of factors (recency, spike, severity, user impact, event volume) computed in ClickHouse, where each factor's weight comes from a `snuba.search.recommended.*-weight` option. Previously every factor was always emitted into the aggregation and then multiplied by its weight — so a factor with a weight of `0` was still fully computed in ClickHouse only to be zeroed out.

This changes `_recommended_aggregation` to only emit terms for factors whose weight is non-zero, so ClickHouse never computes a factor that can't affect the final score. When every weight is `0` (and no group-type boost is configured), the aggregation falls back to a constant-zero expression (`multiply(0, count())`), since a bare `0.0` isn't a valid Snuba aggregation expression.

For the default configuration (all weights non-zero), the generated SQL is identical to before, so existing behavior and the existing recommended-sort tests are unaffected.