### PR TITLE
ref(cell): Changes netloc checks to match cells by hostname instead

### DIFF
--- a/src/sentry/feedback/endpoints/error_page_embed.py
+++ b/src/sentry/feedback/endpoints/error_page_embed.py
@@ -97,9 +97,13 @@ class ErrorEmbedResolver(CellRequestResolver):
         except Exception:
             return None
 
-        host = parsed.netloc
-        app_host = urlparse(options.get("system.url-prefix")).netloc
-        if not host.endswith(app_host):
+        # Match against hostname, ignoring port and key, since these seem
+        # irrelevant to routing decisions.
+        host = parsed.hostname
+        if not host:
+            return None
+        app_host = urlparse(options.get("system.url-prefix")).hostname
+        if not app_host or not host.endswith(app_host):
             # Don't further parse URLs that aren't for us.
             return None
 

--- a/tests/sentry/feedback/endpoints/test_error_page_embed.py
+++ b/tests/sentry/feedback/endpoints/test_error_page_embed.py
@@ -1,14 +1,22 @@
 import logging
+from collections.abc import Callable
 from unittest import mock
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, urlencode, urlparse
 from uuid import uuid4
 
 import pytest
-from django.test import override_settings
+from django.conf import settings
+from django.http import HttpResponse, HttpResponseBase
+from django.test import RequestFactory, override_settings
 from django.urls import reverse
+from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import options
+from sentry.feedback.endpoints.error_page_embed import ErrorEmbedResolver
 from sentry.models.environment import Environment
+from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey
 from sentry.models.userreport import UserReport
 from sentry.silo.base import SiloLimit, SiloMode
@@ -19,7 +27,7 @@ from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
-from sentry.types.cell import get_local_locality
+from sentry.types.cell import Cell, RegionCategory, get_cell_by_name, get_local_locality
 from sentry.utils import json
 
 
@@ -288,7 +296,7 @@ def _get_incr_calls(mock_metrics: mock.MagicMock) -> set[tuple[str, tuple[tuple[
 
 
 @control_silo_test(cells=[ApiGatewayTestCase.CELL])
-class ErrorEmbedControlResolverTest(ApiGatewayTestCase):
+class ErrorEmbedCellProxyTest(ApiGatewayTestCase):
     def _create_project_key_with_mapping(self) -> ProjectKey:
         with outbox_runner():
             project_key = self.create_project_key(self.project)
@@ -355,3 +363,84 @@ class ErrorEmbedControlResolverTest(ApiGatewayTestCase):
         resp_json = json.loads(close_streaming_response(resp))
         assert resp_json["proxy"] is True
         assert resp_json["name"] == expected_name
+
+
+SECONDARY_CELL = Cell(
+    name="eu",
+    snowflake_id=2,
+    address="http://eu.internal.sentry.io",
+    category=RegionCategory.MULTI_TENANT,
+)
+
+
+@control_silo_test(cells=[ApiGatewayTestCase.CELL, SECONDARY_CELL])
+class ErrorEmbedCellResolverTest(ApiGatewayTestCase):
+    def create_project_data(self, cell_name: str) -> tuple[Organization, Project, ProjectKey]:
+        organization = self.create_organization(cell=cell_name)
+        project = self.create_project(organization=organization)
+        project_key = self.create_project_key(project)
+        return organization, project, project_key
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.primary_organization, self.primary_project, self.primary_key = (
+            self.create_project_data(ApiGatewayTestCase.CELL.name)
+        )
+        self.secondary_organization, self.secondary_project, self.secondary_key = (
+            self.create_project_data(SECONDARY_CELL.name)
+        )
+
+    @property
+    def app_host(self) -> str:
+        return urlparse(options.get("system.url-prefix")).netloc
+
+    def _cell_dsn(self, project_key: ProjectKey, cell: Cell, port: int | None = None) -> str:
+        """Build a cell-style ingest DSN (``o{org_id}.ingest.{cell}.{app_host}``)."""
+        org_id = project_key.project.organization_id
+        host = f"o{org_id}.ingest.{cell.name}.{self.app_host}"
+        if port is not None:
+            host = f"{host}:{port}"
+        return f"https://{project_key.public_key}@{host}/{project_key.project_id}"
+
+    def _resolve(self, dsn: str | None) -> Cell | None:
+        params = {"dsn": dsn} if dsn is not None else {}
+        request = Request(RequestFactory().get("/api/embed/error-page/", params))
+        view_func: Callable[..., HttpResponseBase] = mock.Mock(return_value=HttpResponse())
+        return ErrorEmbedResolver().resolve(request, view_func, {})
+
+    def test_resolver_selects_correct_cell(self) -> None:
+        primary_dsn = self._cell_dsn(self.primary_key, ApiGatewayTestCase.CELL)
+        assert self._resolve(primary_dsn) == ApiGatewayTestCase.CELL
+
+        secondary_dsn = self._cell_dsn(self.secondary_key, SECONDARY_CELL)
+        assert self._resolve(secondary_dsn) == SECONDARY_CELL
+
+    def test_resolver_returns_none_for_unroutable_requests(self) -> None:
+        # No dsn supplied at all.
+        assert self._resolve(None) is None
+
+        # A dsn with no usable host.
+        assert self._resolve("lolnope") is None
+
+        # A dsn for a host that isn't ours.
+        foreign_dsn = f"https://{self.primary_key.public_key}@o1.ingest.us.example.com/1"
+        assert self._resolve(foreign_dsn) is None
+
+        # A valid host shape but an unknown cell segment.
+        unknown_cell_dsn = f"https://{self.primary_key.public_key}@o1.ingest.zz.{self.app_host}/1"
+        assert self._resolve(unknown_cell_dsn) is None
+
+    def test_resolver_ignores_port_when_extracting_host(self) -> None:
+        dsn = self._cell_dsn(self.primary_key, ApiGatewayTestCase.CELL, port=9000)
+        assert self._resolve(dsn) == ApiGatewayTestCase.CELL
+
+    def test_resolver_falls_back_to_monolith_region(self) -> None:
+        monolith_cell = get_cell_by_name(settings.SENTRY_MONOLITH_REGION)
+
+        # Bare app host with no cell/ingest segments.
+        bare_dsn = f"https://{self.primary_key.public_key}@{self.app_host}/1"
+        assert self._resolve(bare_dsn) == monolith_cell
+
+        # Older ingest host that omits the cell segment.
+        no_cell_dsn = f"https://{self.primary_key.public_key}@o1.ingest.{self.app_host}/1"
+        assert self._resolve(no_cell_dsn) == monolith_cell


### PR DESCRIPTION
Changes `netloc` checks in error page embed to be done using `hostname` instead, which ignores ports appended to the request.
