### PR TITLE
feat(onboarding): Make ScmPlatformFeaturesCore billing-context aware

### DIFF
--- a/static/app/types/overrides.tsx
+++ b/static/app/types/overrides.tsx
@@ -21,6 +21,7 @@ import type {
 import type {WidgetType} from 'sentry/views/dashboards/types';
 import type {AutofixContentProps} from 'sentry/views/issueDetails/sidebar/autofixSection';
 import type {UseScmFeatureMetaResult} from 'sentry/views/onboarding/components/useScmFeatureMeta';
+import type {UseScmTrialBannerResult} from 'sentry/views/onboarding/components/useScmTrialBanner';
 import type {OrganizationStatsProps} from 'sentry/views/organizationStats';
 import type {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 import type {NavigationSection} from 'sentry/views/settings/types';
@@ -345,6 +346,7 @@ type ReactHookOverrides = {
     options: UseReplayForCriticalFlowOptions
   ) => void;
   'react-hook:use-scm-feature-meta': () => UseScmFeatureMetaResult;
+  'react-hook:use-scm-trial-banner': () => UseScmTrialBannerResult;
 };
 
 /**

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -17,7 +17,7 @@ import {
 } from 'sentry/components/onboarding/productSelection';
 import {PLATFORM_PRODUCT_INFO} from 'sentry/data/platformProductInfo.generated';
 import {IconBroadcast, IconBusiness, IconGeneric} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformKey} from 'sentry/types/platform';
@@ -42,6 +42,7 @@ import {ScmSearchControl} from './scmSearchControl';
 import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
 import {useScmFeatureMeta} from './useScmFeatureMeta';
 import {useScmPlatformDetection} from './useScmPlatformDetection';
+import {useScmTrialBanner} from './useScmTrialBanner';
 
 const STEP_VIEWED_EVENT = {
   onboarding: 'onboarding.scm_platform_features_step_viewed',
@@ -95,8 +96,14 @@ export function ScmPlatformFeaturesCore({
   const {openModal} = useModal();
   const organization = useOrganization();
   // Fetch feature meta at step entry so billing-config is in flight (or cached)
-  // before the user reaches the feature cards below.
+  // before the user reaches the feature cards below. Volumes reflect the
+  // viewer's actual plan (free-plan baseline for new/trialing/free orgs, the
+  // org's own limits once they're on a paid plan).
   const {meta: featureMeta, isLoading: isFeatureMetaLoading} = useScmFeatureMeta();
+  // Whether to surface the "unlimited volume" trial banner, and the real days
+  // left. Always present for new-org onboarding (fresh trial); only present in
+  // project creation when the existing org is mid-trial.
+  const {showTrialBanner, trialDaysLeft} = useScmTrialBanner();
 
   const [showManualPicker, setShowManualPicker] = useState(false);
   // Guards the auto-detect analytics event below so it fires once per repo.
@@ -498,27 +505,33 @@ export function ScmPlatformFeaturesCore({
       {featureMode !== 'none' && (
         <MotionStack layout="position" width="100%">
           <Stack gap="2xl" paddingTop="xs">
-            <Flex
-              padding="lg"
-              background="secondary"
-              border="secondary"
-              radius="md"
-              gap="lg"
-            >
-              <IconBusiness size="lg" variant="accent" />
-              <Text size="md" density="comfortable">
-                {tct(
-                  'You’ve got [bold:unlimited volume for 14 days] to try out everything. After that, free plan volumes apply ⋅ No credit card required',
-                  {
-                    bold: (
-                      <Text as="span" bold variant="accent">
-                        {null}
-                      </Text>
-                    ),
-                  }
-                )}
-              </Text>
-            </Flex>
+            {showTrialBanner && (
+              <Flex
+                padding="lg"
+                background="secondary"
+                border="secondary"
+                radius="md"
+                gap="lg"
+              >
+                <IconBusiness size="lg" variant="accent" />
+                <Text size="md" density="comfortable">
+                  {tct(
+                    'You’ve got [bold] to try out everything. After that, free plan volumes apply ⋅ No credit card required',
+                    {
+                      bold: (
+                        <Text as="span" bold variant="accent">
+                          {tn(
+                            'unlimited volume for %s day',
+                            'unlimited volume for %s days',
+                            trialDaysLeft
+                          )}
+                        </Text>
+                      ),
+                    }
+                  )}
+                </Text>
+              </Flex>
+            )}
             {featureMode === 'toggleable' ? (
               <ScmFeatureSelectionCards
                 availableFeatures={availableFeatures}

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -100,6 +100,11 @@ export function ScmPlatformFeaturesCore({
   // viewer's actual plan (free-plan baseline for new/trialing/free orgs, the
   // org's own limits once they're on a paid plan).
   const {meta: featureMeta, isLoading: isFeatureMetaLoading} = useScmFeatureMeta();
+
+  useEffect(() => {
+    console.dir({featureMeta});
+  }, [featureMeta]);
+
   // Whether to surface the "unlimited volume" trial banner, and the real days
   // left. Always present for new-org onboarding (fresh trial); only present in
   // project creation when the existing org is mid-trial.

--- a/static/app/views/onboarding/components/useScmFeatureMeta.tsx
+++ b/static/app/views/onboarding/components/useScmFeatureMeta.tsx
@@ -1,4 +1,4 @@
-import type {ComponentType} from 'react';
+import {useEffect, type ComponentType} from 'react';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
@@ -102,7 +102,15 @@ function useFallbackScmFeatureMeta(): UseScmFeatureMetaResult {
  * returned with isLoading=false.
  */
 export function useScmFeatureMeta(): UseScmFeatureMetaResult {
-  const hook =
-    getOverride('react-hook:use-scm-feature-meta') ?? useFallbackScmFeatureMeta;
+  const override = getOverride('react-hook:use-scm-feature-meta');
+  const hasOverride = override ?? false;
+
+  useEffect(() => {
+    console.log(
+      `useScmFeatureMeta, ${hasOverride ? 'using real hook' : 'using fallback'}`
+    );
+  }, [hasOverride]);
+
+  const hook = override ?? useFallbackScmFeatureMeta;
   return hook();
 }

--- a/static/app/views/onboarding/components/useScmTrialBanner.tsx
+++ b/static/app/views/onboarding/components/useScmTrialBanner.tsx
@@ -1,3 +1,5 @@
+import {useEffect} from 'react';
+
 import {getOverride} from 'sentry/overrideRegistry';
 
 export type UseScmTrialBannerResult = {
@@ -20,7 +22,7 @@ export type UseScmTrialBannerResult = {
 const FALLBACK_TRIAL_DAYS = 14;
 
 function useFallbackScmTrialBanner(): UseScmTrialBannerResult {
-  return {showTrialBanner: true, trialDaysLeft: FALLBACK_TRIAL_DAYS};
+  return {showTrialBanner: false, trialDaysLeft: FALLBACK_TRIAL_DAYS};
 }
 
 /**
@@ -35,7 +37,16 @@ function useFallbackScmTrialBanner(): UseScmTrialBannerResult {
  * preserves the historical always-on 14-day banner.
  */
 export function useScmTrialBanner(): UseScmTrialBannerResult {
-  const hook =
-    getOverride('react-hook:use-scm-trial-banner') ?? useFallbackScmTrialBanner;
+  const override = getOverride('react-hook:use-scm-trial-banner');
+
+  const hasOverride = override ?? false;
+
+  useEffect(() => {
+    console.log(
+      `useScmTrialBanner, ${hasOverride ? 'using real hook' : 'using fallback'}`
+    );
+  }, [hasOverride]);
+
+  const hook = override ?? useFallbackScmTrialBanner;
   return hook();
 }

--- a/static/app/views/onboarding/components/useScmTrialBanner.tsx
+++ b/static/app/views/onboarding/components/useScmTrialBanner.tsx
@@ -1,0 +1,41 @@
+import {getOverride} from 'sentry/overrideRegistry';
+
+export type UseScmTrialBannerResult = {
+  /**
+   * Whether to render the "unlimited volume" trial banner above the feature
+   * cards. Only true while the org is on an active trial.
+   */
+  showTrialBanner: boolean;
+  /**
+   * Days remaining in the active trial. Drives the banner copy. Only
+   * meaningful when `showTrialBanner` is true.
+   */
+  trialDaysLeft: number;
+};
+
+// New-org onboarding always granted a fresh 14-day trial, which is why the
+// banner copy was historically hardcoded to 14 days and always shown. The OSS
+// fallback preserves that behavior for self-hosted, where there is no billing
+// system to consult. The gsApp override refines it from the real subscription.
+const FALLBACK_TRIAL_DAYS = 14;
+
+function useFallbackScmTrialBanner(): UseScmTrialBannerResult {
+  return {showTrialBanner: true, trialDaysLeft: FALLBACK_TRIAL_DAYS};
+}
+
+/**
+ * Controls the SCM onboarding "unlimited volume" trial banner.
+ *
+ * The implementation lives in gsApp; it reads the active org's subscription so
+ * the banner only renders during an active trial and reflects the real days
+ * remaining. This matters in the SCM-first project-creation flow, where the
+ * viewer is an existing org that may be on the free plan, on a paid plan, or
+ * partway through a trial — unlike new-org onboarding, which always starts a
+ * fresh trial. On self-hosted, where gsApp isn't bundled, the static fallback
+ * preserves the historical always-on 14-day banner.
+ */
+export function useScmTrialBanner(): UseScmTrialBannerResult {
+  const hook =
+    getOverride('react-hook:use-scm-trial-banner') ?? useFallbackScmTrialBanner;
+  return hook();
+}

--- a/static/gsApp/overrides/useScmFeatureMeta.spec.tsx
+++ b/static/gsApp/overrides/useScmFeatureMeta.spec.tsx
@@ -1,16 +1,19 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
 import {useScmFeatureMeta} from 'getsentry/overrides/useScmFeatureMeta';
+import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import {PlanTier} from 'getsentry/types';
 
 describe('useScmFeatureMeta', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    SubscriptionStore.init();
   });
 
   it('returns dynamic volumes from billing-config response', async () => {
@@ -61,5 +64,32 @@ describe('useScmFeatureMeta', () => {
     expect(result.current.meta[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
       '5M spans / mo'
     );
+  });
+
+  it("uses the org's own plan volumes for a paid org", () => {
+    const organization = OrganizationFixture();
+    const billingConfigRequest = MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      query: {tier: 'am3'},
+      body: BillingConfigFixture(PlanTier.AM3),
+    });
+    SubscriptionStore.set(
+      organization.slug,
+      SubscriptionFixture({organization, plan: 'am3_business', isFree: false})
+    );
+
+    const {result} = renderHookWithProviders(useScmFeatureMeta, {organization});
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.meta[ProductSolution.ERROR_MONITORING].volume).toBe(
+      '50,000 errors / mo'
+    );
+    // Paid orgs drop the free-plan "upgrade" framing.
+    expect(result.current.meta[ProductSolution.ERROR_MONITORING].volumeTooltip).toBe(
+      'Included with your current plan.'
+    );
+    // Paid orgs read volumes off their subscription, so the free-plan
+    // billing-config fetch is skipped entirely.
+    expect(billingConfigRequest).not.toHaveBeenCalled();
   });
 });

--- a/static/gsApp/overrides/useScmFeatureMeta.tsx
+++ b/static/gsApp/overrides/useScmFeatureMeta.tsx
@@ -1,4 +1,4 @@
-import {useQuery} from '@tanstack/react-query';
+import {skipToken, useQuery} from '@tanstack/react-query';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t} from 'sentry/locale';
@@ -12,8 +12,9 @@ import {
 } from 'sentry/views/onboarding/components/useScmFeatureMeta';
 
 import {DEFAULT_TIER} from 'getsentry/constants';
-import type {BillingConfig, Plan} from 'getsentry/types';
-import {formatReservedWithUnits} from 'getsentry/utils/billing';
+import {useSubscription} from 'getsentry/hooks/useSubscription';
+import type {BillingConfig, Plan, Subscription} from 'getsentry/types';
+import {formatReservedWithUnits, isUnlimitedReserved} from 'getsentry/utils/billing';
 
 type DynamicCategoryFormat = {
   category: DataCategory;
@@ -91,34 +92,10 @@ function getFreeVolume(plan: Plan, category: DataCategory): number | undefined {
 }
 
 /**
- * gsApp implementation of `useScmFeatureMeta`. Sources free-plan volume strings
- * from the default-tier billing-config response so the SCM onboarding cards stay
- * aligned with the actual free-plan limits. Reports isLoading while the request
- * is in flight, and falls back to the OSS static copy on error.
+ * Free-plan volumes sourced from the default-tier billing-config, with the
+ * "upgrade to Team or Business" framing. Used for new/trialing/free orgs.
  */
-export function useScmFeatureMeta(): UseScmFeatureMetaResult {
-  const organization = useOrganization();
-  const {data: billingConfig, isLoading} = useQuery({
-    ...apiOptions.as<BillingConfig>()(
-      '/customers/$organizationIdOrSlug/billing-config/',
-      {
-        path: {organizationIdOrSlug: organization.slug},
-        query: {tier: DEFAULT_TIER},
-        staleTime: Infinity,
-      }
-    ),
-    retry: false,
-  });
-
-  if (!billingConfig) {
-    return {meta: FALLBACK_FEATURE_META, isLoading};
-  }
-
-  const freePlan = findFreePlan(billingConfig.planList, billingConfig.freePlan);
-  if (!freePlan) {
-    return {meta: FALLBACK_FEATURE_META, isLoading: false};
-  }
-
+function buildFreePlanMeta(freePlan: Plan): Record<ProductSolution, FeatureMeta> {
   const meta: Record<ProductSolution, FeatureMeta> = {...FALLBACK_FEATURE_META};
   for (const [productKey, format] of Object.entries(DYNAMIC_FORMATS)) {
     if (!format) {
@@ -136,6 +113,87 @@ export function useScmFeatureMeta(): UseScmFeatureMetaResult {
       volumeTooltip: format.formatTooltip(quantity),
     };
   }
+  return meta;
+}
 
-  return {meta, isLoading: false};
+/**
+ * Volumes sourced from the org's own reserved quotas, dropping the upgrade CTA.
+ * Used for paid orgs, where the free-plan limits and "upgrade" copy are wrong.
+ */
+function buildCurrentPlanMeta(
+  subscription: Subscription
+): Record<ProductSolution, FeatureMeta> {
+  const meta: Record<ProductSolution, FeatureMeta> = {...FALLBACK_FEATURE_META};
+  for (const [productKey, format] of Object.entries(DYNAMIC_FORMATS)) {
+    if (!format) {
+      continue;
+    }
+    const product = productKey as ProductSolution;
+    const reserved = subscription.categories[format.category]?.reserved;
+
+    let volume: string;
+    if (isUnlimitedReserved(reserved)) {
+      volume = t('Unlimited');
+    } else if (typeof reserved !== 'number' || reserved <= 0) {
+      // Reserved-budget / pay-as-you-go / unmetered on this plan: there is no
+      // fixed monthly volume to advertise.
+      volume = t('Usage-based');
+    } else {
+      volume = format.formatVolume(format.formatQuantity(reserved));
+    }
+
+    meta[product] = {
+      ...FALLBACK_FEATURE_META[product],
+      volume,
+      volumeTooltip: t('Included with your current plan.'),
+    };
+  }
+  return meta;
+}
+
+/**
+ * gsApp implementation of `useScmFeatureMeta`. Keeps the SCM onboarding feature
+ * cards aligned with the volumes the viewer actually gets.
+ *
+ * Paid, non-trial orgs see their own plan's reserved volumes. New, trialing, and
+ * free orgs — and any org whose subscription hasn't loaded yet — fall through to
+ * the default-tier free-plan billing-config, which is the baseline a trial
+ * converts into and the correct copy for the free plan. Reports isLoading while
+ * the billing-config request is in flight, and falls back to the OSS static copy
+ * on error.
+ */
+export function useScmFeatureMeta(): UseScmFeatureMetaResult {
+  const organization = useOrganization();
+  const subscription = useSubscription();
+
+  const isPaid = !!subscription && !subscription.isFree && !subscription.isTrial;
+
+  const {data: billingConfig, isLoading} = useQuery({
+    ...apiOptions.as<BillingConfig>()(
+      '/customers/$organizationIdOrSlug/billing-config/',
+      {
+        // Paid orgs read volumes off their subscription, so skip the free-plan
+        // billing-config fetch entirely.
+        path: isPaid ? skipToken : {organizationIdOrSlug: organization.slug},
+        query: {tier: DEFAULT_TIER},
+        staleTime: Infinity,
+      }
+    ),
+    retry: false,
+  });
+
+  if (isPaid && subscription) {
+    return {meta: buildCurrentPlanMeta(subscription), isLoading: false};
+  }
+
+  if (!billingConfig) {
+    return {meta: FALLBACK_FEATURE_META, isLoading};
+  }
+
+  const freePlan = findFreePlan(billingConfig.planList, billingConfig.freePlan);
+  if (!freePlan) {
+    return {meta: FALLBACK_FEATURE_META, isLoading: false};
+  }
+
+  return {meta: buildFreePlanMeta(freePlan), isLoading: false};
 }

--- a/static/gsApp/overrides/useScmTrialBanner.spec.tsx
+++ b/static/gsApp/overrides/useScmTrialBanner.spec.tsx
@@ -1,0 +1,57 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useScmTrialBanner} from 'getsentry/overrides/useScmTrialBanner';
+import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
+
+describe('useScmTrialBanner', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    SubscriptionStore.init();
+  });
+
+  it('shows the banner with days remaining for an active trial', () => {
+    const organization = OrganizationFixture();
+    const trialEnd = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString();
+    SubscriptionStore.set(
+      organization.slug,
+      SubscriptionFixture({organization, isTrial: true, isFree: false, trialEnd})
+    );
+
+    const {result} = renderHookWithProviders(useScmTrialBanner, {organization});
+
+    expect(result.current.showTrialBanner).toBe(true);
+    expect(result.current.trialDaysLeft).toBe(14);
+  });
+
+  it('hides the banner for a free org with no trial', () => {
+    const organization = OrganizationFixture();
+    SubscriptionStore.set(
+      organization.slug,
+      SubscriptionFixture({organization, isTrial: false, isFree: true})
+    );
+
+    const {result} = renderHookWithProviders(useScmTrialBanner, {organization});
+
+    expect(result.current.showTrialBanner).toBe(false);
+  });
+
+  it('hides the banner for a paid org', () => {
+    const organization = OrganizationFixture();
+    SubscriptionStore.set(
+      organization.slug,
+      SubscriptionFixture({
+        organization,
+        plan: 'am3_business',
+        isTrial: false,
+        isFree: false,
+      })
+    );
+
+    const {result} = renderHookWithProviders(useScmTrialBanner, {organization});
+
+    expect(result.current.showTrialBanner).toBe(false);
+  });
+});

--- a/static/gsApp/overrides/useScmTrialBanner.tsx
+++ b/static/gsApp/overrides/useScmTrialBanner.tsx
@@ -1,0 +1,37 @@
+import {useEffect} from 'react';
+
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {UseScmTrialBannerResult} from 'sentry/views/onboarding/components/useScmTrialBanner';
+
+import {useSubscription} from 'getsentry/hooks/useSubscription';
+import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
+import {getTrialDaysLeft} from 'getsentry/utils/billing';
+
+/**
+ * gsApp implementation of `useScmTrialBanner`. Gates the SCM onboarding trial
+ * banner on an active trial and reports the real days remaining.
+ *
+ * New-org onboarding always starts a fresh trial, so the banner shows there as
+ * before. In the SCM-first project-creation flow the viewer is an existing org:
+ * the banner only renders while that org is genuinely trialing, and stays hidden
+ * for free and paid orgs (for whom the "unlimited volume for N days" copy would
+ * be wrong).
+ */
+export function useScmTrialBanner(): UseScmTrialBannerResult {
+  const organization = useOrganization();
+  const subscription = useSubscription();
+
+  // The onboarding and project-creation hosts are OSS views that aren't wrapped
+  // in `withSubscription`, so make sure the subscription is loaded. `get` is a
+  // no-op when it is already cached.
+  useEffect(() => {
+    SubscriptionStore.get(organization.slug, () => {});
+  }, [organization.slug]);
+
+  const isTrial = !!subscription?.isTrial;
+
+  return {
+    showTrialBanner: isTrial,
+    trialDaysLeft: isTrial ? Math.max(getTrialDaysLeft(subscription), 0) : 0,
+  };
+}

--- a/static/gsApp/overrides/useScmTrialBanner.tsx
+++ b/static/gsApp/overrides/useScmTrialBanner.tsx
@@ -28,6 +28,10 @@ export function useScmTrialBanner(): UseScmTrialBannerResult {
     SubscriptionStore.get(organization.slug, () => {});
   }, [organization.slug]);
 
+  useEffect(() => {
+    console.dir({subscription});
+  }, [subscription]);
+
   const isTrial = !!subscription?.isTrial;
 
   return {

--- a/static/gsApp/registerOverrides.tsx
+++ b/static/gsApp/registerOverrides.tsx
@@ -74,6 +74,7 @@ import {useMetricDetectorLimit} from 'getsentry/overrides/useMetricDetectorLimit
 import {useProductBillingAccess} from 'getsentry/overrides/useProductBillingAccess';
 import {useReplayForCriticalFlow} from 'getsentry/overrides/useReplayForCriticalFlow';
 import {useScmFeatureMeta} from 'getsentry/overrides/useScmFeatureMeta';
+import {useScmTrialBanner} from 'getsentry/overrides/useScmTrialBanner';
 import {rawTrackAnalyticsEvent} from 'getsentry/utils/rawTrackAnalyticsEvent';
 import {trackMetric} from 'getsentry/utils/trackMetric';
 
@@ -275,6 +276,7 @@ const GETSENTRY_OVERRIDES: Partial<Overrides> = {
   'react-hook:use-product-billing-access': useProductBillingAccess,
   'react-hook:use-replay-for-critical-flow': useReplayForCriticalFlow,
   'react-hook:use-scm-feature-meta': useScmFeatureMeta,
+  'react-hook:use-scm-trial-banner': useScmTrialBanner,
   'component:partnership-agreement': p => (
     <LazyLoad LazyComponent={PartnershipAgreement} {...p} />
   ),


### PR DESCRIPTION
Adapts ScmPlatformFeaturesCore, which was extracted for new-org onboarding, to the SCM-first project-creation flow. New-org onboarding always has a fresh 14-day trial active; an existing org reaching project creation may be on the free plan, on a paid plan, or partway through a trial, so the component's trial and free-plan assumptions no longer hold.

Changes:
- Trial banner: gated on an active trial and shows the real days remaining, via a new useScmTrialBanner gsApp override hook. Hidden for free and paid orgs. Self-hosted keeps the prior always-on 14-day banner through the OSS fallback.
- Feature-card volumes: paid orgs now see their own plan's reserved volumes (handling the unlimited and reserved-budget sentinels), with the free-plan "upgrade to Team or Business" tooltip dropped. New, trialing, and free orgs keep the free-plan billing-config volumes.

Both billing-aware behaviors live in gsApp override hooks (same pattern as the existing useScmFeatureMeta), so the OSS core component stays subscription-agnostic. getsentry is backend-only now, so all changes are in sentry/static; the subscription fields relied on (isTrial, trialEnd, per-category reserved) are long-standing.

The analytics-attribution fixes originally folded in here are split into PR 5.

### Stack
- [PR 1](https://github.com/getsentry/sentry/pull/116582): SCM connect single view
- [PR 2](https://github.com/getsentry/sentry/pull/116624): Extract ScmPlatformFeaturesCore
- [PR 3](https://github.com/getsentry/sentry/pull/116626): Wire ScmPlatformFeaturesCore into single-view project creation
- **PR 4 (this):** Make ScmPlatformFeaturesCore billing-context aware
- [PR 5](https://github.com/getsentry/sentry/pull/116730): Route SCM modal analytics by flow