### PR TITLE
ref(webhooks): Replace plugin page with standalone webhook settings

### DIFF
--- a/static/app/views/settings/projectPlugins/details.spec.tsx
+++ b/static/app/views/settings/projectPlugins/details.spec.tsx
@@ -26,6 +26,8 @@ describe('ProjectPluginDetails', () => {
   });
 
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/plugins/`,
       method: 'GET',
@@ -92,5 +94,63 @@ describe('ProjectPluginDetails', () => {
     await waitFor(() =>
       expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Plugin was enabled')
     );
+  });
+});
+
+describe('ProjectPluginDetails - webhook routing', () => {
+  const organization = OrganizationFixture({
+    features: ['legacy-webhook-ui'],
+  });
+  const project = ProjectFixture();
+
+  const webhookRouterConfig = {
+    location: {
+      pathname: `/settings/${organization.slug}/projects/${project.slug}/settings/plugins/webhooks/`,
+    },
+    route: '/settings/:orgId/projects/:projectId/settings/plugins/:pluginId/',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders webhook details page for pluginId=webhooks', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: ['https://example.com/hook'], enabled: true},
+    });
+
+    render(<ProjectPluginDetails />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig: webhookRouterConfig,
+    });
+
+    expect(await screen.findByText('WebHooks')).toBeInTheDocument();
+    expect(screen.getByText(/strongly recommend using an/)).toBeInTheDocument();
+  });
+
+  it('does not call plugin API for webhooks route', async () => {
+    const pluginsMock = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/plugins/`,
+      method: 'GET',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: [], enabled: false},
+    });
+
+    render(<ProjectPluginDetails />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig: webhookRouterConfig,
+    });
+
+    await screen.findByText('WebHooks');
+    expect(pluginsMock).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/settings/projectPlugins/details.spec.tsx
+++ b/static/app/views/settings/projectPlugins/details.spec.tsx
@@ -127,8 +127,7 @@ describe('ProjectPluginDetails - webhook routing', () => {
       initialRouterConfig: webhookRouterConfig,
     });
 
-    expect(await screen.findByText('WebHooks')).toBeInTheDocument();
-    expect(screen.getByText(/strongly recommend using an/)).toBeInTheDocument();
+    expect(await screen.findByText(/strongly recommend using an/)).toBeInTheDocument();
   });
 
   it('does not call plugin API for webhooks route', async () => {
@@ -150,7 +149,7 @@ describe('ProjectPluginDetails - webhook routing', () => {
       initialRouterConfig: webhookRouterConfig,
     });
 
-    await screen.findByText('WebHooks');
+    await screen.findByText(/strongly recommend using an/);
     expect(pluginsMock).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/settings/projectPlugins/details.tsx
+++ b/static/app/views/settings/projectPlugins/details.tsx
@@ -25,9 +25,21 @@ import {useParams} from 'sentry/utils/useParams';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
+import {LegacyWebhookDetails} from './legacyWebhookDetails';
 import {useTogglePluginMutation} from './useTogglePluginMutation';
 
 export default function ProjectPluginDetails() {
+  const organization = useOrganization();
+  const {pluginId} = useParams<{pluginId: string; projectId: string}>();
+
+  if (pluginId === 'webhooks' && organization.features.includes('legacy-webhook-ui')) {
+    return <LegacyWebhookDetails />;
+  }
+
+  return <PluginDetails />;
+}
+
+function PluginDetails() {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
   const {pluginId} = useParams<{pluginId: string; projectId: string}>();

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.spec.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.spec.tsx
@@ -187,7 +187,7 @@ describe('LegacyWebhookDetails', () => {
     await userEvent.click(await screen.findByRole('button', {name: 'Enable'}));
 
     await waitFor(() => expect(postMock).toHaveBeenCalled());
-    expect(indicators.addSuccessMessage).toHaveBeenCalledWith('WebHooks enabled');
+    expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Webhooks enabled');
   });
 
   it('shows disable button when enabled', async () => {

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.spec.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.spec.tsx
@@ -30,8 +30,7 @@ describe('LegacyWebhookDetails', () => {
 
     renderComponent();
 
-    expect(await screen.findByText('WebHooks')).toBeInTheDocument();
-    expect(screen.getByText(/strongly recommend using an/)).toBeInTheDocument();
+    expect(await screen.findByText(/strongly recommend using an/)).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Disable'})).toBeInTheDocument();
   });
 

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.spec.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.spec.tsx
@@ -1,0 +1,237 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as indicators from 'sentry/actionCreators/indicator';
+import {LegacyWebhookDetails} from 'sentry/views/settings/projectPlugins/legacyWebhookDetails';
+
+describe('LegacyWebhookDetails', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  function renderComponent() {
+    return render(<LegacyWebhookDetails />, {
+      organization,
+      outletContext: {project},
+    });
+  }
+
+  it('renders the full page with header and warning banner', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: ['https://example.com/hook1'], enabled: true},
+    });
+
+    renderComponent();
+
+    expect(await screen.findByText('WebHooks')).toBeInTheDocument();
+    expect(screen.getByText(/strongly recommend using an/)).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Disable'})).toBeInTheDocument();
+  });
+
+  it('renders webhook URLs in textarea', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {
+        urls: ['https://example.com/hook1', 'https://example.com/hook2'],
+        enabled: true,
+      },
+    });
+
+    renderComponent();
+
+    const textarea = await screen.findByPlaceholderText(
+      'Enter callback URLs (one per line)'
+    );
+    expect(textarea).toHaveValue('https://example.com/hook1\nhttps://example.com/hook2');
+  });
+
+  it('renders empty textarea when no URLs configured', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: [], enabled: true},
+    });
+
+    renderComponent();
+
+    const textarea = await screen.findByPlaceholderText(
+      'Enter callback URLs (one per line)'
+    );
+    expect(textarea).toHaveValue('');
+  });
+
+  it('shows loading error on fetch failure', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      statusCode: 500,
+      body: {},
+    });
+
+    renderComponent();
+
+    expect(
+      await screen.findByText('There was an error loading data.')
+    ).toBeInTheDocument();
+  });
+
+  it('saves URLs on save button click', async () => {
+    jest.spyOn(indicators, 'addSuccessMessage');
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: ['https://example.com/hook1'], enabled: true},
+    });
+
+    const saveMock = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'POST',
+      body: {
+        urls: ['https://example.com/hook1', 'https://example.com/new'],
+        enabled: true,
+      },
+    });
+
+    renderComponent();
+
+    const textarea = await screen.findByPlaceholderText(
+      'Enter callback URLs (one per line)'
+    );
+
+    await userEvent.type(textarea, '\nhttps://example.com/new');
+    await userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(indicators.addSuccessMessage).toHaveBeenCalledWith(
+      'Webhook URLs saved successfully.'
+    );
+  });
+
+  it('disables save button when no changes made', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: ['https://example.com/hook1'], enabled: true},
+    });
+
+    renderComponent();
+
+    await screen.findByPlaceholderText('Enter callback URLs (one per line)');
+    expect(screen.getByRole('button', {name: 'Save Changes'})).toBeDisabled();
+  });
+
+  it('sends test event on test button click', async () => {
+    jest.spyOn(indicators, 'addSuccessMessage');
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: ['https://example.com/hook1'], enabled: true},
+    });
+
+    const testMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/test-fire-actions/`,
+      method: 'POST',
+      body: null,
+    });
+
+    renderComponent();
+
+    await screen.findByPlaceholderText('Enter callback URLs (one per line)');
+    await userEvent.click(screen.getByRole('button', {name: 'Send Test Event'}));
+
+    await waitFor(() => expect(testMock).toHaveBeenCalled());
+    expect(indicators.addSuccessMessage).toHaveBeenCalledWith(
+      'Test event sent successfully.'
+    );
+  });
+
+  it('disables test button when webhooks are disabled', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: ['https://example.com/hook1'], enabled: false},
+    });
+
+    renderComponent();
+
+    await screen.findByPlaceholderText('Enter callback URLs (one per line)');
+    expect(screen.getByRole('button', {name: 'Send Test Event'})).toBeDisabled();
+  });
+
+  it('toggles webhook enabled state', async () => {
+    jest.spyOn(indicators, 'addSuccessMessage');
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: ['https://example.com/hook'], enabled: false},
+    });
+
+    const postMock = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'POST',
+      body: {urls: ['https://example.com/hook'], enabled: true},
+    });
+
+    renderComponent();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Enable'}));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    expect(indicators.addSuccessMessage).toHaveBeenCalledWith('WebHooks enabled');
+  });
+
+  it('shows disable button when enabled', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: ['https://example.com/hook'], enabled: true},
+    });
+
+    renderComponent();
+
+    expect(await screen.findByRole('button', {name: 'Disable'})).toBeInTheDocument();
+  });
+
+  it('shows error on save failure', async () => {
+    jest.spyOn(indicators, 'addErrorMessage');
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'GET',
+      body: {urls: ['https://example.com/hook1'], enabled: true},
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+      method: 'POST',
+      statusCode: 400,
+      body: {urls: ['Invalid URL format.']},
+    });
+
+    renderComponent();
+
+    const textarea = await screen.findByPlaceholderText(
+      'Enter callback URLs (one per line)'
+    );
+
+    await userEvent.type(textarea, '\nnot-a-url');
+    await userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+    await waitFor(() =>
+      expect(indicators.addErrorMessage).toHaveBeenCalledWith(
+        'Unable to save webhook URLs.'
+      )
+    );
+  });
+});

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
@@ -62,12 +62,18 @@ export function LegacyWebhookDetails() {
         data: {urls: data?.urls ?? [], enabled: shouldEnable},
       });
     },
-    onSuccess: (_responseData, shouldEnable) => {
-      addSuccessMessage(shouldEnable ? t('WebHooks enabled') : t('WebHooks disabled'));
-      refetch();
+    onSuccess: (responseData, shouldEnable) => {
+      addSuccessMessage(shouldEnable ? t('Webhooks enabled') : t('Webhooks disabled'));
+      setUrlsText(null);
+      queryClient.setQueryData(webhookQueryOptions.queryKey, {
+        json: responseData,
+        headers: {},
+      });
     },
-    onError: () => {
-      addErrorMessage(t('An error occurred'));
+    onError: (_error, shouldEnable) => {
+      addErrorMessage(
+        shouldEnable ? t('Could not enable webhooks.') : t('Could not disable webhooks.')
+      );
     },
   });
 
@@ -164,7 +170,7 @@ export function LegacyWebhookDetails() {
             <Button
               size="xs"
               onClick={() => testMutation.mutate()}
-              disabled={testMutation.isPending || !enabled}
+              disabled={testMutation.isPending || toggleMutation.isPending || !enabled}
               tooltipProps={
                 enabled ? undefined : {title: t('Enable webhooks to send test events')}
               }
@@ -174,6 +180,7 @@ export function LegacyWebhookDetails() {
             <Button
               size="xs"
               variant={enabled ? 'danger' : undefined}
+              disabled={toggleMutation.isPending || saveMutation.isPending}
               onClick={() => toggleMutation.mutate(!enabled)}
             >
               {enabled ? t('Disable') : t('Enable')}
@@ -188,6 +195,7 @@ export function LegacyWebhookDetails() {
               maxRows={16}
               placeholder={t('Enter callback URLs (one per line)')}
               value={displayText}
+              disabled={saveMutation.isPending || toggleMutation.isPending}
               onChange={e => setUrlsText(e.target.value)}
             />
             <Text variant="muted" size="sm">
@@ -198,7 +206,9 @@ export function LegacyWebhookDetails() {
                 size="sm"
                 variant="primary"
                 onClick={handleSave}
-                disabled={saveMutation.isPending || !hasUnsavedChanges}
+                disabled={
+                  saveMutation.isPending || toggleMutation.isPending || !hasUnsavedChanges
+                }
               >
                 {t('Save Changes')}
               </Button>

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
@@ -64,7 +64,6 @@ export function LegacyWebhookDetails() {
     },
     onSuccess: (responseData, shouldEnable) => {
       addSuccessMessage(shouldEnable ? t('Webhooks enabled') : t('Webhooks disabled'));
-      setUrlsText(null);
       queryClient.setQueryData(webhookQueryOptions.queryKey, {
         json: responseData,
         headers: {},

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
@@ -4,7 +4,9 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
 
 import {
@@ -140,18 +142,7 @@ export function LegacyWebhookDetails() {
   return (
     <div>
       <SentryDocumentTitle title="WebHooks" projectSlug={project.slug} />
-      <SettingsPageHeader
-        title="WebHooks"
-        action={
-          <Button
-            size="sm"
-            variant={enabled ? 'danger' : undefined}
-            onClick={() => toggleMutation.mutate(!enabled)}
-          >
-            {enabled ? t('Disable') : t('Enable')}
-          </Button>
-        }
-      />
+      <SettingsPageHeader title="WebHooks" />
       <Alert.Container>
         <Alert variant="warning">
           {tct(
@@ -165,7 +156,30 @@ export function LegacyWebhookDetails() {
         </Alert>
       </Alert.Container>
       <Panel>
-        <PanelHeader>{t('Webhook URLs')}</PanelHeader>
+        <PanelHeader hasButtons>
+          <Flex align="center" flex="1">
+            {t('Webhook URLs')}
+          </Flex>
+          <Grid flow="column" align="center" gap="md">
+            <Button
+              size="xs"
+              onClick={() => testMutation.mutate()}
+              disabled={testMutation.isPending || !enabled}
+              tooltipProps={
+                enabled ? undefined : {title: t('Enable webhooks to send test events')}
+              }
+            >
+              {t('Send Test Event')}
+            </Button>
+            <Button
+              size="xs"
+              variant={enabled ? 'danger' : undefined}
+              onClick={() => toggleMutation.mutate(!enabled)}
+            >
+              {enabled ? t('Disable') : t('Enable')}
+            </Button>
+          </Grid>
+        </PanelHeader>
         <PanelBody withPadding>
           <Flex direction="column" gap="md">
             <TextArea
@@ -176,17 +190,10 @@ export function LegacyWebhookDetails() {
               value={displayText}
               onChange={e => setUrlsText(e.target.value)}
             />
-            <Flex gap="md" justify="end">
-              <Button
-                size="sm"
-                onClick={() => testMutation.mutate()}
-                disabled={testMutation.isPending || !enabled}
-                tooltipProps={
-                  enabled ? undefined : {title: t('Enable webhooks to send test events')}
-                }
-              >
-                {t('Send Test Event')}
-              </Button>
+            <Text variant="muted" size="sm">
+              {t('Enter callback URLs to POST new events to (one per line).')}
+            </Text>
+            <Flex gap="md" justify="end" borderTop="primary" paddingTop="lg">
               <Button
                 size="sm"
                 variant="primary"

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
@@ -1,0 +1,204 @@
+import {useState} from 'react';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {TextArea} from '@sentry/scraps/textarea';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Panel} from 'sentry/components/panels/panel';
+import {PanelBody} from 'sentry/components/panels/panelBody';
+import {PanelHeader} from 'sentry/components/panels/panelHeader';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {t, tct} from 'sentry/locale';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
+import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
+
+interface LegacyWebhookResponse {
+  enabled: boolean;
+  urls: string[];
+}
+
+export function LegacyWebhookDetails() {
+  const organization = useOrganization();
+  const {project} = useProjectSettingsOutlet();
+  const queryClient = useQueryClient();
+
+  const webhookQueryOptions = apiOptions.as<LegacyWebhookResponse>()(
+    '/projects/$organizationIdOrSlug/$projectIdOrSlug/legacy-webhooks/',
+    {
+      path: {
+        organizationIdOrSlug: organization.slug,
+        projectIdOrSlug: project.slug,
+      },
+      staleTime: 0,
+    }
+  );
+
+  const {data, isPending, isError, refetch} = useQuery(webhookQueryOptions);
+
+  const [urlsText, setUrlsText] = useState<string | null>(null);
+  const displayText = urlsText ?? data?.urls.join('\n') ?? '';
+
+  const toggleMutation = useMutation({
+    mutationFn: (shouldEnable: boolean) => {
+      addLoadingMessage(shouldEnable ? t('Enabling…') : t('Disabling…'));
+      return fetchMutation<LegacyWebhookResponse>({
+        method: 'POST',
+        url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+        data: {urls: data?.urls ?? [], enabled: shouldEnable},
+      });
+    },
+    onSuccess: (_responseData, shouldEnable) => {
+      addSuccessMessage(shouldEnable ? t('WebHooks enabled') : t('WebHooks disabled'));
+      refetch();
+    },
+    onError: () => {
+      addErrorMessage(t('An error occurred'));
+    },
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (urls: string[]) => {
+      addLoadingMessage(t('Saving changes…'));
+      return fetchMutation<LegacyWebhookResponse>({
+        method: 'POST',
+        url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
+        data: {urls, enabled: data?.enabled ?? true},
+      });
+    },
+    onSuccess: responseData => {
+      addSuccessMessage(t('Webhook URLs saved successfully.'));
+      setUrlsText(null);
+      queryClient.setQueryData(webhookQueryOptions.queryKey, {
+        json: responseData,
+        headers: {},
+      });
+    },
+    onError: () => {
+      addErrorMessage(t('Unable to save webhook URLs.'));
+    },
+  });
+
+  const testMutation = useMutation({
+    mutationFn: () => {
+      addLoadingMessage(t('Sending test event…'));
+      return fetchMutation({
+        method: 'POST',
+        url: `/organizations/${organization.slug}/test-fire-actions/`,
+        data: {
+          actions: [
+            {
+              type: 'webhook',
+              data: {},
+              config: {target_identifier: 'webhooks'},
+            },
+          ],
+          projectSlug: project.slug,
+        },
+      });
+    },
+    onSuccess: () => {
+      addSuccessMessage(t('Test event sent successfully.'));
+    },
+    onError: () => {
+      addErrorMessage(t('Failed to send test event.'));
+    },
+  });
+
+  const handleSave = () => {
+    const urls = displayText
+      .split('\n')
+      .map(u => u.trim())
+      .filter(u => u.length > 0);
+    saveMutation.mutate(urls);
+  };
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (isError) {
+    return <LoadingError onRetry={refetch} />;
+  }
+
+  const enabled = data?.enabled ?? false;
+  const serverText = data?.urls.join('\n') ?? '';
+  const hasUnsavedChanges = displayText !== serverText;
+
+  return (
+    <div>
+      <SentryDocumentTitle title="WebHooks" projectSlug={project.slug} />
+      <SettingsPageHeader
+        title="WebHooks"
+        action={
+          <Button
+            size="sm"
+            variant={enabled ? 'danger' : undefined}
+            onClick={() => toggleMutation.mutate(!enabled)}
+          >
+            {enabled ? t('Disable') : t('Enable')}
+          </Button>
+        }
+      />
+      <Alert.Container>
+        <Alert variant="warning">
+          {tct(
+            'We strongly recommend using an [link:internal integration] instead of legacy webhooks.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/organization/integrations/integration-platform/internal-integration/" />
+              ),
+            }
+          )}
+        </Alert>
+      </Alert.Container>
+      <Panel>
+        <PanelHeader>{t('Webhook URLs')}</PanelHeader>
+        <PanelBody withPadding>
+          <Flex direction="column" gap="md">
+            <TextArea
+              autosize
+              rows={4}
+              maxRows={16}
+              placeholder={t('Enter callback URLs (one per line)')}
+              value={displayText}
+              onChange={e => setUrlsText(e.target.value)}
+            />
+            <Flex gap="md" justify="end">
+              <Button
+                size="sm"
+                onClick={() => testMutation.mutate()}
+                disabled={testMutation.isPending || !enabled}
+                tooltipProps={
+                  enabled ? undefined : {title: t('Enable webhooks to send test events')}
+                }
+              >
+                {t('Send Test Event')}
+              </Button>
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={handleSave}
+                disabled={saveMutation.isPending || !hasUnsavedChanges}
+              >
+                {t('Save Changes')}
+              </Button>
+            </Flex>
+          </Flex>
+        </PanelBody>
+      </Panel>
+    </div>
+  );
+}


### PR DESCRIPTION
- Adds new legacywebhooks component that replaces the plugindetails component
- reaches out to the test-fire-actions for the test notification and new endpoint for CRUD actions
<img width="1247" height="342" alt="image" src="https://github.com/user-attachments/assets/5e9eeae4-4dac-4fab-aad8-d28d56ad40f3" />
