### PR TITLE
chore(options): Cleaning up more unused options

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -106,12 +106,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "hybrid_cloud.authentication.use_api_key_replica",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "outbox_replication.sentry_apitoken.replication_version",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1164,22 +1164,10 @@ register(
 )
 
 register(
-    "seer.explorer_index.enable",
-    type=Bool,
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "seer.explorer_index.killswitch.enable",
     type=Bool,
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.explorer-index.rollout",
-    type=Float,
-    default=0.0,
-    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "seer.explorer.context-engine-rollout",
@@ -2383,14 +2371,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# When True, the circuit breaker tracks state and emits metrics but does not block requests.
-register(
-    "sentry-apps.webhook.circuit-breaker.dry-run",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Enables statistical detectors for a project
 register(
     "statistical_detectors.enable",
@@ -3137,13 +3117,6 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "workflow_engine.scheduler.use_conditional_delete",
-    type=Bool,
-    default=True,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 register(
     "workflow_engine.associate_error_detectors",
     type=Bool,


### PR DESCRIPTION
More unused option clean up to prepare for our migration to the new sentry-options. The following 5 keys have no usages in code and have PRs claiming they are unused.

`hybrid_cloud.authentication.use_api_key_replica` - has no code usages or automator value. Last known usage was removed in #57184 (almost 3 years ago)

`seer.explorer-index.rollout` and `seer.explorer_index.enable` - have values in the automator but have had no code usage since #115186, where the PR explicitly says "cleaning up rollout flags"

`sentry-apps.webhook.circuit-breaker.dry-run` - was explicitly replaced in #114820 by `*.live-run`. Confirmed with the engineer that this is no longer needed

`workflow_engine.scheduler.use_conditional_delete` - usages were removed in #100992 and #104484, has no value in the automator

A follow up for this is to remove the 3 value definitions in getsentry/sentry-options-automator (or not, the bot will pick it up and then jr will remove them lol)