### PR TITLE
feat(search): Add `release:latest` as an autocomplete option in the issue feed

### DIFF
--- a/static/app/views/issueList/issueListCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListCommandPaletteActions.tsx
@@ -127,10 +127,12 @@ function FilterActions({
         : undefined,
       statsPeriod: pageFilters.datetime.period,
     };
+    const tagKey = key === FieldKey.FIRST_RELEASE ? 'release' : key;
+
     const fetchParams = {
       api,
       orgSlug: organization.slug,
-      tagKey: key,
+      tagKey,
       search: '',
       projectIds,
       endpointParams,
@@ -142,21 +144,20 @@ function FilterActions({
       return values.map(v => v.value);
     }
 
-    if (key === FieldKey.FIRST_RELEASE) {
-      const values = await fetchTagValues({
-        ...fetchParams,
-        tagKey: 'release',
-        dataset: Dataset.ERRORS,
-      });
-      return ['latest', ...values.map(v => v.value)];
-    }
-
     const [errorsValues, platformValues] = await Promise.all([
       fetchTagValues({...fetchParams, dataset: Dataset.ERRORS}),
       fetchTagValues({...fetchParams, dataset: Dataset.ISSUE_PLATFORM}),
     ]);
 
-    return mergeAndSortTagValues(errorsValues, platformValues, 'count').map(v => v.value);
+    const values = mergeAndSortTagValues(errorsValues, platformValues, 'count').map(
+      v => v.value
+    );
+
+    if (key === FieldKey.RELEASE || key === FieldKey.FIRST_RELEASE) {
+      return ['latest', ...values];
+    }
+
+    return values;
   };
 
   const issueFields = useMemo(

--- a/static/app/views/issueList/searchBar.spec.tsx
+++ b/static/app/views/issueList/searchBar.spec.tsx
@@ -167,5 +167,37 @@ describe('IssueListSearchBar', () => {
         expect(tagValueMock).toHaveBeenCalledTimes(2);
       });
     });
+
+    it('displays "latest" as an option for the release filter', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/tags/',
+        method: 'GET',
+        body: [{key: 'release', name: 'release'}],
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/tags/release/values/',
+        method: 'GET',
+        body: [
+          {
+            name: 'v1.0.0',
+            value: 'v1.0.0',
+            count: 5,
+            firstSeen: '2021-01-01T00:00:00Z',
+            lastSeen: '2021-01-01T00:00:00Z',
+          },
+        ] as TagValue[],
+      });
+
+      render(<IssueListSearchBar {...newDefaultProps} />);
+
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      await userEvent.paste('release:', {delay: null});
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Edit value for filter: release'})
+      );
+
+      expect(await screen.findByRole('option', {name: 'latest'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'v1.0.0'})).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -158,11 +158,12 @@ export function useIssueListSearchBarDataProvider(
           : undefined,
         statsPeriod: pageFilters.datetime.period,
       };
+      const tagKey = key === FieldKey.FIRST_RELEASE ? 'release' : key;
 
       const fetchTagValuesPayload = {
         api,
         orgSlug: organization.slug,
-        tagKey: key,
+        tagKey,
         search,
         projectIds,
         endpointParams,
@@ -175,28 +176,6 @@ export function useIssueListSearchBarDataProvider(
           ...fetchTagValuesPayload,
           organization,
         });
-      }
-
-      if (key === FieldKey.FIRST_RELEASE) {
-        const includeLatest = 'latest'.startsWith(search.toLowerCase());
-        return [
-          ...(includeLatest
-            ? [
-                {
-                  count: 1,
-                  firstSeen: '2021-01-01',
-                  lastSeen: '2021-01-01',
-                  name: 'latest',
-                  value: 'latest',
-                } as TagValue,
-              ]
-            : []),
-          ...(await fetchTagValues({
-            ...fetchTagValuesPayload,
-            tagKey: 'release',
-            dataset: Dataset.ERRORS,
-          })),
-        ];
       }
 
       const [eventsDatasetValues, issuePlatformDatasetValues] = await Promise.all([

--- a/static/app/views/issueList/utils/getIssueTagValues.tsx
+++ b/static/app/views/issueList/utils/getIssueTagValues.tsx
@@ -1,6 +1,6 @@
 import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {TagValue} from 'sentry/types/group';
-import {DEVICE_CLASS_TAG_VALUES, isDeviceClass} from 'sentry/utils/fields';
+import {DEVICE_CLASS_TAG_VALUES, FieldKey, isDeviceClass} from 'sentry/utils/fields';
 
 /**
  * Returns a function that fetches tag values for a given tag key. Useful as
@@ -18,7 +18,7 @@ export function makeGetIssueTagValues(
       return DEVICE_CLASS_TAG_VALUES;
     }
     const values = await tagValueLoader(tag.key, searchQuery);
-    return values.map(({value}) => {
+    const stringValues = values.map(({value}) => {
       // Truncate results to 5000 characters to avoid exceeding the max url query length
       // The message attribute for example can be 8192 characters.
       if (typeof value === 'string' && value.length > 5000) {
@@ -26,5 +26,15 @@ export function makeGetIssueTagValues(
       }
       return value;
     });
+
+    const includeLatest =
+      (tag.key === FieldKey.RELEASE || tag.key === FieldKey.FIRST_RELEASE) &&
+      'latest'.startsWith(searchQuery.toLowerCase());
+
+    if (includeLatest) {
+      return ['latest', ...stringValues];
+    }
+
+    return stringValues;
   };
 }


### PR DESCRIPTION
Resolves [ISWF-2221](https://linear.app/getsentry/issue/ISWF-2221/add-releaselatest-to-autocomplete).

Shows `latest` as an autocomplete suggestion for both `release:` and `firstRelease:` filters in the issue feed search bar.

Cleans up the existing `firstRelease:latest` implementation by moving the `latest` injection from the `tagValueLoader` (which used fake `TagValue` objects) into `makeGetIssueTagValues` where values are already plain strings.

Fixes `firstRelease:` autocomplete to fetch from both the `ERRORS` and `ISSUE_PLATFORM` datasets (was previously ERRORS-only).