### PR TITLE
feat(api): migrate Tag(Key|Value)Serializer to Serializer[T]

### DIFF
--- a/src/sentry/issues/endpoints/group_tagkey_details.py
+++ b/src/sentry/issues/endpoints/group_tagkey_details.py
@@ -66,7 +66,7 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
         examples=[TagsExamples.GROUP_TAGKEY_DETAILS],
     )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-tag-key-details"])
-    def get(self, request: Request, group, key) -> Response:
+    def get(self, request: Request, group, key) -> Response[TagKeySerializerResponse]:
         """
         Returns the values and aggregate details of a given tag key related to an issue.
         """

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -11,7 +11,7 @@ from sentry.utils.services import Service
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
-    from sentry.tagstore.types import GroupTagValue
+    from sentry.tagstore.types import GroupTagKey, GroupTagValue, TagKey
 
 # Valid pattern for tag key names
 TAG_KEY_RE = re.compile(r"^[a-zA-Z0-9_\.:-]+$")
@@ -152,7 +152,7 @@ class TagStorage(Service):
         environment_id,
         key: str,
         tenant_ids=None,
-    ):
+    ) -> GroupTagKey | TagKey:
         """
         >>> get_group_tag_key(group, 3, "key1")
         """

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -804,7 +804,7 @@ class SnubaTagStorage(TagStorage):
         key,
         tenant_ids=None,
         **kwargs,
-    ):
+    ) -> GroupTagKey | TagKey:
         return self.__get_tag_key_and_top_values(
             group.project_id,
             group,

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -240,7 +240,7 @@ class _KeyCallable[T, U](Protocol):
 
 class _ValueCallable[U](Protocol):
     def __call__(
-        self, *, key: str, value: object, times_seen: int, first_seen: datetime, last_seen: datetime
+        self, *, key: str, value: str, times_seen: int, first_seen: datetime, last_seen: datetime
     ) -> U: ...
 
 

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -142,7 +142,7 @@ class TagKeySerializerResponse(TagKeySerializerResponseOptional):
 
 @register(GroupTagKey)
 @register(TagKey)
-class TagKeySerializer(Serializer):
+class TagKeySerializer(Serializer[TagKeySerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> TagKeySerializerResponse:
         from sentry import tagstore
 
@@ -175,7 +175,7 @@ class TagValueSerializerResponse(TagValueSerializerResponseOptional):
 
 @register(GroupTagValue)
 @register(TagValue)
-class TagValueSerializer(Serializer):
+class TagValueSerializer(Serializer[TagValueSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> TagValueSerializerResponse:
         from sentry import tagstore
 

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -58,7 +58,7 @@ class TagKey(TagType):
         values_seen: int | None = None,
         status: int = TagKeyStatus.ACTIVE,
         count: int | None = None,
-        top_values=None,
+        top_values: tuple[TagValue, ...] | None = None,
     ):
         self.key = key
         self.values_seen = values_seen

--- a/tests/sentry/issues/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/issues/endpoints/test_group_tagkey_values.py
@@ -189,6 +189,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
             "foo",
             tenant_ids={"organization_id": group.project.organization_id},
         )
+        assert group_tag_key.top_values is not None
         top_values = {tv.value for tv in group_tag_key.top_values}
         assert top_values == {"", "bar"}
 

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -1215,6 +1215,7 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
 
             assert gk.key == "foo"
             assert gk.values_seen == 1
+            assert gk.top_values is not None
             assert gk.top_values[0].value == "bar"
 
 


### PR DESCRIPTION
Subscript `TagKeySerializer` and `TagValueSerializer` with their already-typed response shapes, type the `get_group_tag_key` backend method's return, and tighten `group_tagkey_details.py` to `Response[TagKeySerializerResponse]`.

Round 3 of the Response[T] rollout (after #116717 / #116736). Same no-cast principle: each tightening fixes the underlying source-typing gap rather than papering over it at the call site. The endpoint calls `serialize(group_tag_key, request.user, serializer=TagKeySerializer())`; without a typed return on `get_group_tag_key`, mypy resolved `serialize()` to the `Any` fallback overload and the body-is-Any plugin fired.

Typing the backend method's return as `GroupTagKey | TagKey` (the union the Snuba implementation already concretely returns) lets mypy pick the typed `Serializer[T]` overload and flow `TagKeySerializerResponse` through end-to-end.