### PR TITLE
ref(api): document remaining UNKNOWN endpoints, drain publish-status allowlist

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -1,7 +1,8 @@
 from pathlib import PurePath, PureWindowsPath
-from typing import Any
+from typing import Any, TypedDict
 from urllib.parse import urlparse
 
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,6 +11,14 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.integrations.base import IntegrationFeatures
 from sentry.integrations.manager import default_manager as integrations
 from sentry.integrations.services.integration import RpcIntegration, integration_service
@@ -24,9 +33,22 @@ from sentry.models.project import Project
 from sentry.models.repository import Repository
 
 
+class RepoPathParsingResponse(TypedDict):
+    integrationId: int
+    repositoryId: int
+    provider: str
+    stackRoot: str
+    sourceRoot: str
+    defaultBranch: str
+
+
 class PathMappingSerializer(CamelSnakeSerializer[dict[str, str]]):
-    stack_path = serializers.CharField()
-    source_url = serializers.URLField()
+    stack_path = serializers.CharField(
+        help_text="A file path as it appears in a stack trace frame."
+    )
+    source_url = serializers.URLField(
+        help_text="The URL of the same file in the connected source code repository."
+    )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -100,20 +122,33 @@ class ProjectRepoPathParsingEndpointLoosePermission(ProjectPermission):
     }
 
 
+@extend_schema(tags=["Integrations"])
 @cell_silo_endpoint
 class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectRepoPathParsingEndpointLoosePermission,)
-    """
-    Returns the parameters associated with the RepositoryProjectPathConfig
-    we would create based on a particular stack trace and source code URL.
-    Does validation to make sure we have an integration and repo
-    depending on the source code URL
-    """
 
+    @extend_schema(
+        operation_id="Parse a Repository Path Mapping",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        request=PathMappingSerializer,
+        responses={
+            200: inline_sentry_response_serializer("RepoPathParsing", RepoPathParsingResponse),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def post(self, request: Request, project: Project) -> Response:
+        """
+        Derive the code-mapping parameters (stack root, source root, default branch) that
+        Sentry would create for a given stack trace frame and source code URL.
+
+        Validates that a matching integration and repository exist for the provided URL.
+        """
         serializer = PathMappingSerializer(
             context={"organization_id": project.organization_id},
             data=request.data,

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -34,6 +34,8 @@ from sentry.models.repository import Repository
 
 
 class RepoPathParsingResponse(TypedDict):
+    # NOTE: API convention is to return identifiers as strings, but this endpoint has
+    # always returned these as integers. Typed to match the existing behavior.
     integrationId: int
     repositoryId: int
     provider: str

--- a/src/sentry/api/endpoints/project_servicehook_stats.py
+++ b/src/sentry/api/endpoints/project_servicehook_stats.py
@@ -1,3 +1,6 @@
+from typing import TypedDict
+
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -6,19 +9,74 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import StatsMixin, cell_silo_endpoint
 from sentry.api.bases.servicehook import ServiceHookEndpoint
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.project import Project
 from sentry.sentry_apps.models.servicehook import ServiceHook
 from sentry.tsdb.base import TSDBModel
 
 
+class ServiceHookStatsResponse(TypedDict):
+    ts: int
+    total: int
+
+
+@extend_schema(tags=["Integration"])
 @cell_silo_endpoint
 class ProjectServiceHookStatsEndpoint(ServiceHookEndpoint, StatsMixin):
     owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        operation_id="Retrieve a Service Hook's Stats",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            OpenApiParameter(
+                name="hook_id",
+                location="path",
+                required=True,
+                type=str,
+                description="The GUID of the service hook.",
+            ),
+            OpenApiParameter(
+                name="since",
+                location="query",
+                required=False,
+                type=float,
+                description="A UNIX timestamp that represents the start of the time series range, inclusive.",
+            ),
+            OpenApiParameter(
+                name="until",
+                location="query",
+                required=False,
+                type=float,
+                description="A UNIX timestamp that represents the end of the time series range, inclusive.",
+            ),
+            OpenApiParameter(
+                name="resolution",
+                location="query",
+                required=False,
+                type=str,
+                description="The time series resolution, e.g. `1h`, `1d`.",
+            ),
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListServiceHookStats", list[ServiceHookStatsResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, project: Project, hook: ServiceHook, **kwargs) -> Response:
+        """
+        Return the number of times a service hook has fired over a time series range.
+        """
         stat_args = self._parse_args(request)
 
         stats: dict[int, dict[str, int]] = {}

--- a/src/sentry/api/endpoints/project_servicehooks.py
+++ b/src/sentry/api/endpoints/project_servicehooks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,39 +11,57 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.sentry_apps.api.parsers.servicehook import ServiceHookValidator
-from sentry.sentry_apps.api.serializers.servicehook import ServiceHookSerializer
+from sentry.sentry_apps.api.serializers.servicehook import (
+    ServiceHookSerializer,
+    ServiceHookSerializerResponse,
+)
 from sentry.sentry_apps.models.servicehook import ServiceHook
 from sentry.sentry_apps.services.hook import hook_service
 
 
+@extend_schema(tags=["Integration"])
 @cell_silo_endpoint
 class ProjectServiceHooksEndpoint(ProjectEndpoint):
     owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
     def has_feature(self, request: Request, project):
         return features.has("projects:servicehooks", project=project, actor=request.user)
 
+    @extend_schema(
+        operation_id="List a Project's Service Hooks",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListServiceHooks", list[ServiceHookSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, project) -> Response:
         """
-        List a Project's Service Hooks
-        ``````````````````````````````
-
         Return a list of service hooks bound to a project.
 
-        This endpoint requires the 'servicehooks' feature to
-        be enabled for your project.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          client keys belong to.
-        :pparam string project_id_or_slug: the id or slug of the project the client keys
-                                     belong to.
-        :auth: required
+        This endpoint requires the `servicehooks` feature to be enabled for your project.
         """
         if not self.has_feature(request, project):
             return self.respond(
@@ -69,28 +88,28 @@ class ProjectServiceHooksEndpoint(ProjectEndpoint):
             on_results=lambda x: serialize(x, request.user, ServiceHookSerializer()),
         )
 
+    @extend_schema(
+        operation_id="Register a New Service Hook",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        request=ServiceHookValidator,
+        responses={
+            201: inline_sentry_response_serializer("ServiceHook", ServiceHookSerializerResponse),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def post(self, request: Request, project) -> Response:
         """
-        Register a new Service Hook
-        ```````````````````````````
-
         Register a new service hook on a project.
 
         Events include:
 
-        - event.alert: An alert is generated for an event (via rules).
-        - event.created: A new event has been processed.
+        - `event.alert`: An alert is generated for an event (via rules).
+        - `event.created`: A new event has been processed.
 
-        This endpoint requires the 'servicehooks' feature to
-        be enabled for your project.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          client keys belong to.
-        :pparam string project_id_or_slug: the id or slug of the project the client keys
-                                     belong to.
-        :param string url: the url for the webhook
-        :param array[string] events: the events to subscribe to
-        :auth: required
+        This endpoint requires the `servicehooks` feature to be enabled for your project.
         """
         if not request.user.is_authenticated:
             return self.respond(status=401)

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -9,18 +10,36 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environment_id
 from sentry.api.serializers import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NO_CONTENT,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import PROTECTED_TAG_KEYS
 from sentry.models.environment import Environment
 from sentry.ratelimits.config import RateLimitConfig
+from sentry.tagstore.types import TagKeySerializerResponse
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
+_TAG_KEY_PARAM = OpenApiParameter(
+    name="key",
+    location="path",
+    required=True,
+    type=str,
+    description="The tag key to look up.",
+)
 
+
+@extend_schema(tags=["Projects"])
 @cell_silo_endpoint
 class ProjectTagKeyDetailsEndpoint(ProjectEndpoint):
     owner = ApiOwner.UNOWNED
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     enforce_rate_limit = True
@@ -39,7 +58,20 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint):
         }
     )
 
+    @extend_schema(
+        operation_id="Retrieve a Tag Key",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG, _TAG_KEY_PARAM],
+        responses={
+            200: inline_sentry_response_serializer("TagKeyResponse", TagKeySerializerResponse),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, project, key) -> Response:
+        """
+        Return details about a tag key, including the number of unique and total values.
+        """
         lookup_key = tagstore.backend.prefix_reserved_key(key)
 
         try:
@@ -60,12 +92,19 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint):
 
         return Response(serialize(tagkey, request.user))
 
+    @extend_schema(
+        operation_id="Delete a Tag Key",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG, _TAG_KEY_PARAM],
+        responses={
+            204: RESPONSE_NO_CONTENT,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def delete(self, request: Request, project, key) -> Response:
         """
-        Remove all occurrences of the given tag key.
-
-            {method} {path}
-
+        Remove all occurrences of the given tag key and its values.
         """
         if key in PROTECTED_TAG_KEYS:
             return Response(status=403)

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -1,4 +1,4 @@
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -11,17 +11,21 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environment_id
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
-from sentry.apidocs.parameters import CursorQueryParam
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.environment import Environment
 from sentry.ratelimits.config import RateLimitConfig
+from sentry.tagstore.types import TagValueSerializerResponse
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
+@extend_schema(tags=["Projects"])
 @cell_silo_endpoint
 class ProjectTagKeyValuesEndpoint(ProjectEndpoint):
     owner = ApiOwner.UNOWNED
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     enforce_rate_limit = True
@@ -37,22 +41,39 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint):
 
     @extend_schema(
         operation_id="List a Tag's Values",
-        parameters=[CursorQueryParam],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            OpenApiParameter(
+                name="key",
+                location="path",
+                required=True,
+                type=str,
+                description="The tag key to look up.",
+            ),
+            OpenApiParameter(
+                name="query",
+                location="query",
+                required=False,
+                type=str,
+                description='Perform a "contains" match on the tag values.',
+            ),
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListTagValuesResponse", list[TagValueSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
     )
     def get(self, request: Request, project, key) -> Response:
         """
-        List a Tag's Values
-        ```````````````````
-
-        Return a list of values associated with this key.  The `query`
-        parameter can be used to to perform a "contains" match on
-        values.
-        When paginated can return at most 1000 values.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization.
-        :pparam string project_id_or_slug: the id or slug of the project.
-        :pparam string key: the tag key to look up.
-        :auth: required
+        Return a list of values associated with this tag key. The `query` parameter
+        can be used to perform a "contains" match on values. Paginated, returning at
+        most 1000 values.
         """
         lookup_key = tagstore.backend.prefix_reserved_key(key)
         tenant_ids = {"organization_id": project.organization_id}

--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -1,5 +1,7 @@
 import datetime
+from typing import NotRequired, TypedDict
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -10,18 +12,69 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.environments import get_environment_id
 from sentry.api.utils import clamp_date_range, default_start_end_dates
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import DS_DENYLIST, PROTECTED_TAG_KEYS
 from sentry.models.environment import Environment
 
 
+class ProjectTagKeyResponse(TypedDict):
+    key: str
+    name: str
+    canDelete: bool
+    # Only included when `includeValuesSeen` is not disabled.
+    uniqueValues: NotRequired[int]
+
+
+@extend_schema(tags=["Projects"])
 @cell_silo_endpoint
 class ProjectTagsEndpoint(ProjectEndpoint):
     owner = ApiOwner.UNOWNED
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        operation_id="List a Project's Tag Keys",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            OpenApiParameter(
+                name="includeValuesSeen",
+                location="query",
+                required=False,
+                type=str,
+                description="Set to `0` to omit the `uniqueValues` count for each tag key.",
+            ),
+            OpenApiParameter(
+                name="onlySamplingTags",
+                location="query",
+                required=False,
+                type=str,
+                description="Set to `1` to only return tag keys relevant to dynamic sampling.",
+            ),
+            OpenApiParameter(
+                name="useFlagsBackend",
+                location="query",
+                required=False,
+                type=str,
+                description="Set to `1` to query feature flags instead of tags.",
+            ),
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListProjectTagKeys", list[ProjectTagKeyResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, project) -> Response:
+        """
+        Return a list of the tag keys that have been seen within a project.
+        """
         try:
             environment_id = get_environment_id(request, project.organization_id)
         except Environment.DoesNotExist:

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -1,9 +1,10 @@
 import calendar
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from django.utils import timezone
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -12,6 +13,15 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationPermission
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NO_CONTENT,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.promptsactivity import PromptsActivity
@@ -20,11 +30,22 @@ from sentry.utils.prompts import prompt_config
 VALID_STATUSES = frozenset(("snoozed", "dismissed", "visible"))
 
 
+class PromptsActivityResponse(TypedDict):
+    # Maps each requested feature name to its stored prompt data (or null).
+    features: dict[str, Any]
+    # Only present when a single feature is requested: the stored data for that feature.
+    data: NotRequired[dict[str, Any] | None]
+
+
 # Endpoint to retrieve multiple PromptsActivity at once
 class PromptsActivitySerializer(serializers.Serializer):
-    feature = serializers.CharField(required=True)
+    feature = serializers.CharField(
+        required=True, help_text="The name of the feature prompt to update."
+    )
     status = serializers.ChoiceField(
-        choices=list(zip(VALID_STATUSES, VALID_STATUSES)), required=True
+        choices=list(zip(VALID_STATUSES, VALID_STATUSES)),
+        required=True,
+        help_text="The new prompt status: `snoozed`, `dismissed`, or `visible`.",
     )
 
     def validate_feature(self, value):
@@ -42,6 +63,7 @@ class PromptsActivityPermission(OrganizationPermission):
     }
 
 
+@extend_schema(tags=["Organizations"])
 @cell_silo_endpoint
 class PromptsActivityEndpoint(OrganizationEndpoint):
     publish_status = {
@@ -50,9 +72,40 @@ class PromptsActivityEndpoint(OrganizationEndpoint):
     }
     permission_classes = (PromptsActivityPermission,)
 
+    @extend_schema(
+        operation_id="Retrieve Prompt Statuses",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OpenApiParameter(
+                name="feature",
+                location="query",
+                required=True,
+                type=str,
+                many=True,
+                description="One or more feature prompt names to look up.",
+            ),
+            OpenApiParameter(
+                name="project_id",
+                location="query",
+                required=False,
+                type=str,
+                description="The project the prompt is scoped to, when the feature requires it.",
+            ),
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "PromptsActivityResponse", PromptsActivityResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, organization: Organization, **kwargs) -> Response:
-        """Return feature prompt status if dismissed or in snoozed period"""
-
+        """
+        Return whether feature prompts have been dismissed or are currently snoozed.
+        """
         if not request.user.is_authenticated:
             return Response(status=400)
 
@@ -93,7 +146,22 @@ class PromptsActivityEndpoint(OrganizationEndpoint):
         else:
             return Response({"features": featuredata})
 
+    @extend_schema(
+        operation_id="Update a Prompt Status",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
+        request=PromptsActivitySerializer,
+        responses={
+            201: RESPONSE_NO_CONTENT,
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def put(self, request: Request, organization: Organization, **kwargs) -> Response:
+        """
+        Snooze, dismiss, or restore a feature prompt for the current user.
+        """
         serializer = PromptsActivitySerializer(data=request.data)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/user_organizations.py
+++ b/src/sentry/api/endpoints/user_organizations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from django.db.models import Q
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -8,6 +9,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.organization import OrganizationSummarySerializerResponse
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import CursorQueryParam
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.users.api.bases.user import RegionSiloUserEndpoint
 from sentry.users.services.user import RpcUser
@@ -15,13 +20,45 @@ from sentry.users.services.user import RpcUser
 
 # TODO(cells): Non-routable by Synapse (no org slug in URL). Fix by moving to
 # @control_silo_endpoint and querying OrganizationMemberMapping + OrganizationMapping.
+@extend_schema(tags=["Users"])
 @cell_silo_endpoint
 class UserOrganizationsEndpoint(RegionSiloUserEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        operation_id="List a User's Organizations",
+        parameters=[
+            OpenApiParameter(
+                name="user_id",
+                location="path",
+                required=True,
+                type=str,
+                description="The ID of the user, or `me` for the current user.",
+            ),
+            OpenApiParameter(
+                name="query",
+                location="query",
+                required=False,
+                type=str,
+                description="Limit results to organizations whose name or slug contains this value.",
+            ),
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListUserOrganizations", list[OrganizationSummarySerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, user: RpcUser) -> Response:
+        """
+        Return a list of organizations that the given user is a member of.
+        """
         queryset = Organization.objects.get_for_user_ids({user.id})
 
         query = request.GET.get("query")

--- a/src/sentry/api/serializers/models/eventuser.py
+++ b/src/sentry/api/serializers/models/eventuser.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import TypedDict
 
 from sentry.api.serializers import Serializer, register
@@ -15,7 +16,8 @@ class EventUserSerializerResponse(TypedDict):
     ipAddress: str
     avatarUrl: str
     hash: str
-    dateCreated: None
+    # Legacy field, always null; typed nullable so it resolves in the OpenAPI schema.
+    dateCreated: datetime | None
 
 
 @register(EventUser)

--- a/src/sentry/api/serializers/models/release_file.py
+++ b/src/sentry/api/serializers/models/release_file.py
@@ -1,8 +1,20 @@
 from base64 import urlsafe_b64decode, urlsafe_b64encode
+from datetime import datetime
+from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.models.distribution import Distribution
 from sentry.models.releasefile import ReleaseFile
+
+
+class ReleaseFileSerializerResponse(TypedDict):
+    id: str
+    name: str
+    dist: str | None
+    headers: dict[str, Any]
+    size: int
+    sha1: str
+    dateCreated: datetime
 
 
 def encode_release_file_id(obj):
@@ -35,7 +47,7 @@ def decode_release_file_id(id: str):
 
 @register(ReleaseFile)
 class ReleaseFileSerializer(Serializer):
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs) -> ReleaseFileSerializerResponse:
         dist_name = None
         if obj.dist_id:
             dist_name = Distribution.objects.get(pk=obj.dist_id).name

--- a/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
+++ b/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
@@ -5,17 +5,12 @@ DO NOT ADD ANY NEW APIS
 """
 
 API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
-    "/api/0/organizations/{organization_id_or_slug}/invite-requests/": {"GET", "POST"},
     "/api/0/organizations/{organization_id_or_slug}/releases/{version}/assemble/": {"POST"},
     "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/": {"GET", "POST"},
     "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/{file_id}/": {
         "DELETE",
         "GET",
         "PUT",
-    },
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/": {"GET", "POST"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/{hook_id}/stats/": {
-        "GET"
     },
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/completion/": {"GET"},
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/stats/": {
@@ -30,9 +25,4 @@ API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
         "GET",
         "PUT",
     },
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/stats/": {"GET"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/tags/": {"GET"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/transfer/": {"POST"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/repo-path-parsing/": {"POST"},
-    "/api/0/users/{user_id}/organizations/": {"GET"},
 }

--- a/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
+++ b/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
@@ -5,24 +5,10 @@ DO NOT ADD ANY NEW APIS
 """
 
 API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
-    "/api/0/organizations/{organization_id_or_slug}/releases/{version}/assemble/": {"POST"},
-    "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/": {"GET", "POST"},
-    "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/{file_id}/": {
-        "DELETE",
-        "GET",
-        "PUT",
-    },
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/completion/": {"GET"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/stats/": {
-        "GET"
-    },
+    # Multipart file-upload POSTs — pending a dedicated approach to documenting
+    # multipart/form-data request bodies. The GET on each path is documented + PRIVATE.
+    "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/": {"POST"},
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/": {
-        "GET",
-        "POST",
-    },
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/{file_id}/": {
-        "DELETE",
-        "GET",
-        "PUT",
+        "POST"
     },
 }

--- a/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
+++ b/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
@@ -5,10 +5,6 @@ DO NOT ADD ANY NEW APIS
 """
 
 API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
-    "/api/0/organizations/{organization_id_or_slug}/integrations/{integration_id}/serverless-functions/": {
-        "GET",
-        "POST",
-    },
     "/api/0/organizations/{organization_id_or_slug}/invite-requests/": {"GET", "POST"},
     "/api/0/organizations/{organization_id_or_slug}/releases/{version}/assemble/": {"POST"},
     "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/": {"GET", "POST"},
@@ -17,7 +13,6 @@ API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
         "GET",
         "PUT",
     },
-    "/api/0/organizations/{organization_id_or_slug}/sentry-app-installations/": {"GET"},
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/": {"GET", "POST"},
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/{hook_id}/stats/": {
         "GET"
@@ -40,9 +35,4 @@ API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/transfer/": {"POST"},
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/repo-path-parsing/": {"POST"},
     "/api/0/users/{user_id}/organizations/": {"GET"},
-    "/api/0/sentry-apps/{sentry_app_id_or_slug}/features/": {"GET"},
-    "/api/0/sentry-apps/{sentry_app_id_or_slug}/stats/": {"GET"},
-    "/api/0/sentry-app-installations/{uuid}/": {"DELETE", "GET", "PUT"},
-    "/api/0/sentry-app-installations/{uuid}/external-issues/": {"POST"},
-    "/api/0/sentry-app-installations/{uuid}/external-issues/{external_issue_id}/": {"DELETE"},
 }

--- a/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
+++ b/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
@@ -23,9 +23,6 @@ API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
         "GET"
     },
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/completion/": {"GET"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/repositories/": {
-        "GET"
-    },
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/stats/": {
         "GET"
     },
@@ -40,10 +37,7 @@ API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
     },
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/stats/": {"GET"},
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/tags/": {"GET"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/tags/{key}/": {"DELETE", "GET"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/tags/{key}/values/": {"GET"},
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/transfer/": {"POST"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/users/": {"GET"},
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/repo-path-parsing/": {"POST"},
     "/api/0/users/{user_id}/organizations/": {"GET"},
     "/api/0/sentry-apps/{sentry_app_id_or_slug}/features/": {"GET"},

--- a/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
+++ b/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
@@ -4,11 +4,4 @@ The goal is to eventually find owners for all and shrink this list.
 DO NOT ADD ANY NEW APIS
 """
 
-API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
-    # Multipart file-upload POSTs — pending a dedicated approach to documenting
-    # multipart/form-data request bodies. The GET on each path is documented + PRIVATE.
-    "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/": {"POST"},
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/": {
-        "POST"
-    },
-}
+API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY: dict[str, set[str]] = {}

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -231,6 +231,13 @@ class ReleaseParams:
         type=str,
         description="The version identifier of the release",
     )
+    FILE_ID = OpenApiParameter(
+        name="file_id",
+        location="path",
+        required=True,
+        type=str,
+        description="The ID of the release file.",
+    )
     QUERY = OpenApiParameter(
         name="query",
         location="query",
@@ -597,6 +604,13 @@ class SentryAppParams:
         many=False,
         type=str,
         description="The ID or slug of the custom integration.",
+    )
+    INSTALLATION_UUID = OpenApiParameter(
+        name="uuid",
+        location="path",
+        required=True,
+        type=str,
+        description="The UUID of the Sentry App installation.",
     )
 
 

--- a/src/sentry/core/endpoints/organization_member_requests_invite_index.py
+++ b/src/sentry/core/endpoints/organization_member_requests_invite_index.py
@@ -1,5 +1,6 @@
 from django.db import router, transaction
 from django.db.models import Q
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -10,6 +11,18 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_member import OrganizationMemberWithTeamsSerializer
+from sentry.api.serializers.models.organization_member.response import (
+    OrganizationMemberResponse,
+    OrganizationMemberWithTeamsResponse,
+)
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.core.endpoints.organization_member_index import OrganizationMemberRequestSerializer
 from sentry.core.endpoints.organization_member_utils import save_team_assignments
 from sentry.hybridcloud.models.outbox import outbox_context
@@ -26,15 +39,31 @@ class InviteRequestPermissions(OrganizationPermission):
     }
 
 
+@extend_schema(tags=["Organizations"])
 @cell_silo_endpoint
 class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (InviteRequestPermissions,)
 
+    @extend_schema(
+        operation_id="List an Organization's Invite Requests",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, CursorQueryParam],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListInviteRequests", list[OrganizationMemberWithTeamsResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, organization: Organization) -> Response:
+        """
+        Return a list of pending invite and join requests for an organization.
+        """
         queryset = OrganizationMember.objects.filter(
             Q(user_id__isnull=True),
             Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
@@ -54,21 +83,22 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
             paginator_cls=OffsetPaginator,
         )
 
+    @extend_schema(
+        operation_id="Create an Invite Request",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
+        request=OrganizationMemberRequestSerializer,
+        responses={
+            201: inline_sentry_response_serializer("InviteRequest", OrganizationMemberResponse),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def post(self, request: Request, organization: Organization) -> Response:
         """
-        Add a invite request to Organization
-        ````````````````````````````````````
-
-        Creates an invite request given an email and suggested role / teams.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the member will belong to
-        :param string email: the email address to invite
-        :param string role: the suggested role of the new member
-        :param string orgRole: the suggested org-role of the new member
-        :param array teams: the teams which the member should belong to.
-        :param array teamRoles: the teams and team-roles assigned to the member
-
-        :auth: required
+        Create an invite request for an organization given an email and suggested
+        role / teams.
         """
         serializer = OrganizationMemberRequestSerializer(
             data=request.data,

--- a/src/sentry/core/endpoints/project_stats.py
+++ b/src/sentry/core/endpoints/project_stats.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -8,6 +9,9 @@ from sentry.api.base import StatsMixin, cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environment_id
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.models.environment import Environment
 from sentry.ratelimits.config import RateLimitConfig
@@ -15,10 +19,11 @@ from sentry.tsdb.base import TSDBModel
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
+@extend_schema(tags=["Projects"])
 @cell_silo_endpoint
 class ProjectStatsEndpoint(ProjectEndpoint, StatsMixin):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     rate_limits = RateLimitConfig(
@@ -31,31 +36,56 @@ class ProjectStatsEndpoint(ProjectEndpoint, StatsMixin):
         },
     )
 
+    @extend_schema(
+        operation_id="Retrieve Event Counts for a Project",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            OpenApiParameter(
+                name="stat",
+                location="query",
+                required=False,
+                type=str,
+                enum=["received", "rejected", "blacklisted", "generated"],
+                description="The name of the stat to query. Defaults to `received`.",
+            ),
+            OpenApiParameter(
+                name="since",
+                location="query",
+                required=False,
+                type=float,
+                description="A UNIX timestamp (in seconds) that sets the start of the query range.",
+            ),
+            OpenApiParameter(
+                name="until",
+                location="query",
+                required=False,
+                type=float,
+                description="A UNIX timestamp (in seconds) that sets the end of the query range.",
+            ),
+            OpenApiParameter(
+                name="resolution",
+                location="query",
+                required=False,
+                type=str,
+                enum=["10s", "1h", "1d"],
+                description="An explicit time series resolution.",
+            ),
+        ],
+        responses={
+            200: inline_sentry_response_serializer("ProjectStats", list[tuple[int, int]]),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, project) -> Response:
         """
-        Retrieve Event Counts for a Project
-        ```````````````````````````````````
+        Return a set of points representing a normalized timestamp and the number of
+        events seen in the period.
 
-        .. caution::
-           This endpoint may change in the future without notice.
-
-        Return a set of points representing a normalized timestamp and the
-        number of events seen in the period.
-
-        Query ranges are limited to Sentry's configured time-series
-        resolutions.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization.
-        :pparam string project_id_or_slug: the id or slug of the project.
-        :qparam string stat: the name of the stat to query (``"received"``,
-                             ``"rejected"``, ``"blacklisted"``, ``generated``)
-        :qparam timestamp since: a timestamp to set the start of the query
-                                 in seconds since UNIX epoch.
-        :qparam timestamp until: a timestamp to set the end of the query
-                                 in seconds since UNIX epoch.
-        :qparam string resolution: an explicit resolution to search
-                                   for (one of ``10s``, ``1h``, and ``1d``)
-        :auth: required
+        Query ranges are limited to Sentry's configured time-series resolutions.
+        This endpoint may change in the future without notice.
         """
         stat = request.GET.get("stat", "received")
         query_kwargs = {}

--- a/src/sentry/core/endpoints/project_transfer.py
+++ b/src/sentry/core/endpoints/project_transfer.py
@@ -4,7 +4,8 @@ from urllib.parse import urlencode
 from uuid import uuid4
 
 from django.utils import timezone
-from rest_framework import status
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -13,6 +14,14 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.decorators import sudo_required
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NO_CONTENT,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organizationmember import OrganizationMember
 from sentry.ratelimits.config import RateLimitConfig
@@ -26,14 +35,23 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 SALT = "sentry-project-transfer"
 
 
+class ProjectTransferSerializer(serializers.Serializer):
+    email = serializers.EmailField(
+        required=True,
+        help_text="The email of the organization owner to transfer the project to. "
+        "Must be an owner of a different organization.",
+    )
+
+
 class RelaxedProjectPermission(ProjectPermission):
     scope_map = {"POST": ["org:admin"]}
 
 
+@extend_schema(tags=["Projects"])
 @cell_silo_endpoint
 class ProjectTransferEndpoint(ProjectEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (RelaxedProjectPermission,)
 
@@ -52,19 +70,25 @@ class ProjectTransferEndpoint(ProjectEndpoint):
             },
         )
 
+    @extend_schema(
+        operation_id="Transfer a Project",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        request=ProjectTransferSerializer,
+        responses={
+            204: RESPONSE_NO_CONTENT,
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     @sudo_required
     def post(self, request: Request, project) -> Response:
         """
-        Transfer a Project
-        ````````````````
+        Schedule a project for transfer to a new organization.
 
-        Schedules a project for transfer to a new organization.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          project belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to delete.
-        :param string email: email of new owner. must be an organization owner
-        :auth: required
+        An email is sent to the target organization owner with a link to accept the
+        transfer.
         """
         if project.is_internal_project():
             return Response(

--- a/src/sentry/core/endpoints/project_users.py
+++ b/src/sentry/core/endpoints/project_users.py
@@ -1,25 +1,30 @@
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
 from sentry.analytics.events.eventuser_endpoint_request import EventUserEndpointRequest
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectAndStaffPermission, ProjectEndpoint
 from sentry.api.paginator import CallbackPaginator
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.eventuser import EventUserSerializer
-from sentry.apidocs.parameters import CursorQueryParam
+from sentry.api.serializers.models.eventuser import EventUserSerializer, EventUserSerializerResponse
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.eventuser import EventUser
 
 
+@extend_schema(tags=["Projects"])
 @cell_silo_endpoint
 class ProjectUsersEndpoint(ProjectEndpoint):
+    owner = ApiOwner.UNOWNED
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     rate_limits = RateLimitConfig(
         limit_overrides={
@@ -32,23 +37,34 @@ class ProjectUsersEndpoint(ProjectEndpoint):
 
     @extend_schema(
         operation_id="List a Project's Users",
-        parameters=[CursorQueryParam],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            OpenApiParameter(
+                name="query",
+                location="query",
+                required=False,
+                type=str,
+                description=(
+                    "Limit results to users matching the given query. Prefixes should be used "
+                    "to suggest the field to match on: `id`, `email`, `username`, `ip`. "
+                    "For example, `query=email:foo@example.com`."
+                ),
+            ),
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListProjectUsersResponse", list[EventUserSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
     )
     def get(self, request: Request, project) -> Response:
         """
-        List a Project's Users
-        ``````````````````````
-
         Return a list of users seen within this project.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization.
-        :pparam string project_id_or_slug: the id or slug of the project.
-        :pparam string key: the tag key to look up.
-        :auth: required
-        :qparam string query: Limit results to users matching the given query.
-                              Prefixes should be used to suggest the field to
-                              match on: ``id``, ``email``, ``username``, ``ip``.
-                              For example, ``query=email:foo@example.com``
         """
         analytics.record(
             EventUserEndpointRequest(

--- a/src/sentry/integrations/api/endpoints/organization_integration_serverless_functions.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_serverless_functions.py
@@ -1,5 +1,6 @@
-from typing import Any
+from typing import Any, TypedDict
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -8,6 +9,14 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.integrations.api.bases.organization_integrations import (
     CellOrganizationIntegrationBaseEndpoint,
 )
@@ -17,20 +26,53 @@ from sentry.shared_integrations.exceptions import IntegrationError
 
 ACTIONS = ["enable", "disable", "updateVersion"]
 
+_INTEGRATION_ID_PARAM = OpenApiParameter(
+    name="integration_id",
+    location="path",
+    required=True,
+    type=int,
+    description="The ID of the organization's integration.",
+)
+
+
+class ServerlessFunctionResponse(TypedDict):
+    name: str
+    runtime: str
+    # The installed Sentry layer version, or -1 when the function is not instrumented.
+    version: int
+    outOfDate: bool
+    enabled: bool
+
 
 class ServerlessActionSerializer(CamelSnakeSerializer):
-    action = serializers.ChoiceField(ACTIONS)
-    target = serializers.CharField()
+    action = serializers.ChoiceField(
+        ACTIONS, help_text="The action to perform on the serverless function."
+    )
+    target = serializers.CharField(help_text="The identifier of the serverless function to act on.")
 
 
+@extend_schema(tags=["Integrations"])
 @cell_silo_endpoint
 class OrganizationIntegrationServerlessFunctionsEndpoint(CellOrganizationIntegrationBaseEndpoint):
     owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        operation_id="List an Integration's Serverless Functions",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, _INTEGRATION_ID_PARAM],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListServerlessFunctions", list[ServerlessFunctionResponse]
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(
         self,
         request: Request,
@@ -39,7 +81,7 @@ class OrganizationIntegrationServerlessFunctionsEndpoint(CellOrganizationIntegra
         **kwds: Any,
     ) -> Response:
         """
-        Get the list of repository project path configs in an integration
+        Return the serverless functions discovered for an organization's integration.
         """
         integration = self.get_integration(organization.id, integration_id)
 
@@ -55,6 +97,20 @@ class OrganizationIntegrationServerlessFunctionsEndpoint(CellOrganizationIntegra
 
         return self.respond(serverless_functions)
 
+    @extend_schema(
+        operation_id="Update an Integration's Serverless Function",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, _INTEGRATION_ID_PARAM],
+        request=ServerlessActionSerializer,
+        responses={
+            200: inline_sentry_response_serializer(
+                "ServerlessFunction", ServerlessFunctionResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def post(
         self,
         request: Request,
@@ -62,6 +118,10 @@ class OrganizationIntegrationServerlessFunctionsEndpoint(CellOrganizationIntegra
         integration_id: int,
         **kwds: Any,
     ) -> Response:
+        """
+        Enable, disable, or update the Sentry layer version of a serverless function in
+        an organization's integration.
+        """
         integration = self.get_integration(organization.id, integration_id)
         install = integration.get_installation(organization_id=organization.id)
 

--- a/src/sentry/integrations/api/serializers/models/integration_feature.py
+++ b/src/sentry/integrations/api/serializers/models/integration_feature.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 
@@ -7,6 +7,14 @@ from sentry.api.serializers import Serializer, register
 from sentry.integrations.models.integration_feature import IntegrationFeature
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
+
+
+class IntegrationFeatureResponse(TypedDict):
+    featureId: int
+    # feature gating work done in getsentry expects the format 'featureGate'
+    featureGate: str
+    # Only present when the feature is serialized with a target.
+    description: NotRequired[str | None]
 
 
 @register(IntegrationFeature)
@@ -33,8 +41,8 @@ class IntegrationFeatureSerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         has_target: bool = True,
         **kwargs,
-    ):
-        data = {
+    ) -> IntegrationFeatureResponse:
+        data: IntegrationFeatureResponse = {
             "featureId": obj.feature,
             # feature gating work done in getsentry expects the format 'featureGate'
             "featureGate": obj.feature_str(),

--- a/src/sentry/releases/endpoints/organization_release_assemble.py
+++ b/src/sentry/releases/endpoints/organization_release_assemble.py
@@ -1,12 +1,25 @@
+from typing import NotRequired, TypedDict
+
 import jsonschema
 import orjson
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.release import Release
 from sentry.tasks.assemble import (
     AssembleTask,
@@ -17,20 +30,52 @@ from sentry.tasks.assemble import (
 from sentry.utils import metrics
 
 
+class OrganizationReleaseAssembleSerializer(serializers.Serializer):
+    checksum = serializers.RegexField(
+        r"^[0-9a-f]{40}$",
+        required=True,
+        help_text="The SHA1 checksum of the assembled artifact bundle.",
+    )
+    chunks = serializers.ListField(
+        child=serializers.RegexField(r"^[0-9a-f]{40}$"),
+        required=True,
+        help_text="The SHA1 checksums of the chunks the bundle is assembled from.",
+    )
+
+
+class _ReleaseAssembleResponse(TypedDict):
+    state: str
+    detail: NotRequired[str | None]
+    missingChunks: list[str]
+
+
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        operation_id="Assemble a Release Artifact Bundle",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReleaseParams.VERSION],
+        request=OrganizationReleaseAssembleSerializer,
+        responses={
+            200: inline_sentry_response_serializer(
+                "ReleaseAssembleResponse", _ReleaseAssembleResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def post(self, request: Request, organization, version) -> Response:
         """
-        Handle an artifact bundle and merge it into the release
-        ```````````````````````````````````````````````````````
-
-        :auth: required
+        Assemble an artifact bundle from previously uploaded chunks and merge it into the
+        release. Returns the current assembly state.
         """
-
         try:
             release = Release.objects.get(organization_id=organization.id, version=version)
         except Release.DoesNotExist:

--- a/src/sentry/releases/endpoints/organization_release_assemble.py
+++ b/src/sentry/releases/endpoints/organization_release_assemble.py
@@ -43,7 +43,7 @@ class OrganizationReleaseAssembleSerializer(serializers.Serializer):
     )
 
 
-class _ReleaseAssembleResponse(TypedDict):
+class ReleaseAssembleResponse(TypedDict):
     state: str
     detail: NotRequired[str | None]
     missingChunks: list[str]
@@ -63,7 +63,7 @@ class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
         request=OrganizationReleaseAssembleSerializer,
         responses={
             200: inline_sentry_response_serializer(
-                "ReleaseAssembleResponse", _ReleaseAssembleResponse
+                "ReleaseAssembleResponse", ReleaseAssembleResponse
             ),
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,

--- a/src/sentry/releases/endpoints/organization_release_file_details.py
+++ b/src/sentry/releases/endpoints/organization_release_file_details.py
@@ -24,14 +24,6 @@ from sentry.releases.endpoints.project_release_file_details import (
     ReleaseFileSerializer,
 )
 
-_FILE_ID_PARAM = OpenApiParameter(
-    name="file_id",
-    location="path",
-    required=True,
-    type=str,
-    description="The ID of the release file.",
-)
-
 
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
@@ -50,7 +42,7 @@ class OrganizationReleaseFileDetailsEndpoint(
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             ReleaseParams.VERSION,
-            _FILE_ID_PARAM,
+            ReleaseParams.FILE_ID,
             OpenApiParameter(
                 name="download",
                 location="query",
@@ -90,7 +82,7 @@ class OrganizationReleaseFileDetailsEndpoint(
 
     @extend_schema(
         operation_id="Update an Organization Release's File",
-        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReleaseParams.VERSION, _FILE_ID_PARAM],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReleaseParams.VERSION, ReleaseParams.FILE_ID],
         request=ReleaseFileSerializer,
         responses={
             200: inline_sentry_response_serializer(
@@ -121,7 +113,7 @@ class OrganizationReleaseFileDetailsEndpoint(
 
     @extend_schema(
         operation_id="Delete an Organization Release's File",
-        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReleaseParams.VERSION, _FILE_ID_PARAM],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReleaseParams.VERSION, ReleaseParams.FILE_ID],
         responses={
             204: RESPONSE_NO_CONTENT,
             401: RESPONSE_UNAUTHORIZED,

--- a/src/sentry/releases/endpoints/organization_release_file_details.py
+++ b/src/sentry/releases/endpoints/organization_release_file_details.py
@@ -1,44 +1,77 @@
-from rest_framework import serializers
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers.models.release_file import ReleaseFileSerializerResponse
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NO_CONTENT,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.models.release import Release
-from sentry.releases.endpoints.project_release_file_details import ReleaseFileDetailsMixin
+from sentry.releases.endpoints.project_release_file_details import (
+    ReleaseFileDetailsMixin,
+    ReleaseFileSerializer,
+)
+
+_FILE_ID_PARAM = OpenApiParameter(
+    name="file_id",
+    location="path",
+    required=True,
+    type=str,
+    description="The ID of the release file.",
+)
 
 
-class ReleaseFileSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=200, required=True)
-
-
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleaseFileDetailsEndpoint(
     OrganizationReleasesBaseEndpoint, ReleaseFileDetailsMixin
 ):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        operation_id="Retrieve an Organization Release's File",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+            _FILE_ID_PARAM,
+            OpenApiParameter(
+                name="download",
+                location="query",
+                required=False,
+                type=str,
+                description="If set, download the file contents instead of returning metadata.",
+            ),
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ReleaseFileResponse", ReleaseFileSerializerResponse
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, organization, version, file_id) -> Response:
         """
-        Retrieve an Organization Release's File
-        ```````````````````````````````````````
-
-        Return details on an individual file within a release.  This does
-        not actually return the contents of the file, just the associated
-        metadata.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string version: the version identifier of the release.
-        :pparam string file_id: the ID of the file to retrieve.
-        :auth: required
+        Return metadata for an individual file within a release. Does not return the file
+        contents unless `download` is set.
         """
         try:
             release = Release.objects.get(organization_id=organization.id, version=version)
@@ -55,21 +88,24 @@ class OrganizationReleaseFileDetailsEndpoint(
             check_permission_fn=lambda: request.access.has_scope("project:write"),
         )
 
+    @extend_schema(
+        operation_id="Update an Organization Release's File",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReleaseParams.VERSION, _FILE_ID_PARAM],
+        request=ReleaseFileSerializer,
+        responses={
+            200: inline_sentry_response_serializer(
+                "ReleaseFileResponse", ReleaseFileSerializerResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def put(self, request: Request, organization: Organization, version, file_id) -> Response:
         """
-        Update an Organization Release's File
-        `````````````````````````````````````
-
-        Update metadata of an existing file.  Currently only the name of
-        the file can be changed.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string version: the version identifier of the release.
-        :pparam string file_id: the ID of the file to update.
-        :param string name: the new name of the file.
-        :param string dist: the name of the dist.
-        :auth: required
+        Update metadata of an existing release file. Currently only the name of the file
+        can be changed.
         """
         try:
             release = Release.objects.get(organization_id=organization.id, version=version)
@@ -83,20 +119,20 @@ class OrganizationReleaseFileDetailsEndpoint(
 
         return self.update_releasefile(request, release, file_id)
 
+    @extend_schema(
+        operation_id="Delete an Organization Release's File",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReleaseParams.VERSION, _FILE_ID_PARAM],
+        responses={
+            204: RESPONSE_NO_CONTENT,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def delete(self, request: Request, organization, version, file_id) -> Response:
         """
-        Delete an Organization Release's File
-        `````````````````````````````````````
-
-        Permanently remove a file from a release.
-
-        This will also remove the physical file from storage.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string version: the version identifier of the release.
-        :pparam string file_id: the ID of the file to delete.
-        :auth: required
+        Permanently remove a file from a release. Also removes the physical file from
+        storage.
         """
         try:
             release = Release.objects.get(organization_id=organization.id, version=version)

--- a/src/sentry/releases/endpoints/organization_release_files.py
+++ b/src/sentry/releases/endpoints/organization_release_files.py
@@ -10,12 +10,21 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers.models.release_file import ReleaseFileSerializerResponse
-from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_CONFLICT,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.release import Release
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.releases.endpoints.project_release_files import ReleaseFilesMixin
+from sentry.releases.endpoints.project_release_files import (
+    ReleaseFilesMixin,
+    ReleaseFileUploadSerializer,
+)
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 _FILE_QUERY_PARAM = OpenApiParameter(
@@ -42,8 +51,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
-        # Multipart upload — documented separately.
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
     rate_limits = RateLimitConfig(
@@ -93,35 +101,27 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
 
         return self.get_releasefiles(request, release, organization.id)
 
+    @extend_schema(
+        operation_id="Upload a New Organization Release File",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReleaseParams.VERSION],
+        request={"multipart/form-data": ReleaseFileUploadSerializer},
+        responses={
+            201: inline_sentry_response_serializer(
+                "ReleaseFileResponse", ReleaseFileSerializerResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+            409: RESPONSE_CONFLICT,
+        },
+    )
     def post(self, request: Request, organization, version) -> Response:
         """
-        Upload a New Organization Release File
-        ``````````````````````````````````````
-
         Upload a new file for the given release.
 
-        Unlike other API requests, files must be uploaded using the
-        traditional multipart/form-data content-type.
-
-        Requests to this endpoint should use the region-specific domain
-        eg. `us.sentry.io` or `de.sentry.io`
-
-        The optional 'name' attribute should reflect the absolute path
-        that this file will be referenced as. For example, in the case of
-        JavaScript you might specify the full web URI.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string version: the version identifier of the release.
-        :param string name: the name (full path) of the file.
-        :param file file: the multipart encoded file.
-        :param string dist: the name of the dist.
-        :param string header: this parameter can be supplied multiple times
-                              to attach headers to the file.  Each header
-                              is a string in the format ``key:value``.  For
-                              instance it can be used to define a content
-                              type.
-        :auth: required
+        Files must be uploaded using the `multipart/form-data` content type, against the
+        region-specific domain (e.g. `us.sentry.io` or `de.sentry.io`).
         """
         try:
             release = Release.objects.get(organization_id=organization.id, version=version)

--- a/src/sentry/releases/endpoints/organization_release_files.py
+++ b/src/sentry/releases/endpoints/organization_release_files.py
@@ -1,24 +1,48 @@
 import logging
 
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.apidocs.parameters import CursorQueryParam
+from sentry.api.serializers.models.release_file import ReleaseFileSerializerResponse
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.release import Release
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.releases.endpoints.project_release_files import ReleaseFilesMixin
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
+_FILE_QUERY_PARAM = OpenApiParameter(
+    name="query",
+    location="query",
+    required=False,
+    type=str,
+    many=True,
+    description="If set, only files with these partial names will be returned.",
+)
+_FILE_CHECKSUM_PARAM = OpenApiParameter(
+    name="checksum",
+    location="query",
+    required=False,
+    type=str,
+    many=True,
+    description="If set, only files with these exact checksums will be returned.",
+)
 
+
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseFilesMixin):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        # Multipart upload — documented separately.
         "POST": ApiPublishStatus.UNKNOWN,
     }
 
@@ -39,21 +63,25 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
 
     @extend_schema(
         operation_id="List an Organization Release's Files",
-        parameters=[CursorQueryParam],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+            _FILE_QUERY_PARAM,
+            _FILE_CHECKSUM_PARAM,
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListReleaseFiles", list[ReleaseFileSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
     )
     def get(self, request: Request, organization, version) -> Response:
         """
-        List an Organization Release's Files
-        ````````````````````````````````````
-
         Retrieve a list of files for a given release.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string version: the version identifier of the release.
-        :qparam string query: If set, only files with these partial names will be returned.
-        :qparam string checksum: If set, only files with these exact checksums will be returned.
-        :auth: required
         """
         try:
             release = Release.objects.get(organization_id=organization.id, version=version)

--- a/src/sentry/releases/endpoints/project_release_file_details.py
+++ b/src/sentry/releases/endpoints/project_release_file_details.py
@@ -2,18 +2,32 @@ import posixpath
 from zipfile import ZipFile
 
 from django.http.response import FileResponse
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.endpoints.debug_files import has_download_permission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.release_file import decode_release_file_id
+from sentry.api.serializers.models.release_file import (
+    ReleaseFileSerializerResponse,
+    decode_release_file_id,
+)
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NO_CONTENT,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.debug_files.release_files import maybe_renew_releasefiles
 from sentry.models.distribution import Distribution
 from sentry.models.release import Release
@@ -23,9 +37,19 @@ from sentry.releases.endpoints.project_release_files import pseudo_releasefile
 #: Cannot update release artifacts in release archives
 INVALID_UPDATE_MESSAGE = "Can only update release files with integer IDs"
 
+_FILE_ID_PARAM = OpenApiParameter(
+    name="file_id",
+    location="path",
+    required=True,
+    type=str,
+    description="The ID of the release file.",
+)
+
 
 class ReleaseFileSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=200, required=True)
+    name = serializers.CharField(
+        max_length=200, required=True, help_text="The new name (full path) of the file."
+    )
 
 
 def _entry_from_index(release: Release, dist: Distribution | None, url: str) -> ReleaseFile:
@@ -201,31 +225,45 @@ class ReleaseFileDetailsMixin:
         return Response(status=204)
 
 
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 
+    @extend_schema(
+        operation_id="Retrieve a Project Release's File",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+            _FILE_ID_PARAM,
+            OpenApiParameter(
+                name="download",
+                location="query",
+                required=False,
+                type=str,
+                description="If set, download the file contents instead of returning metadata.",
+            ),
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ReleaseFileResponse", ReleaseFileSerializerResponse
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, project, version, file_id) -> Response:
         """
-        Retrieve a Project Release's File
-        `````````````````````````````````
-
-        Return details on an individual file within a release.  This does
-        not actually return the contents of the file, just the associated
-        metadata.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to retrieve the
-                                     file of.
-        :pparam string version: the version identifier of the release.
-        :pparam string file_id: the ID of the file to retrieve.
-        :auth: required
+        Return metadata for an individual file within a release. Does not return the file
+        contents unless `download` is set.
         """
         try:
             release = Release.objects.get(
@@ -241,24 +279,30 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
             check_permission_fn=lambda: has_download_permission(request, project),
         )
 
+    @extend_schema(
+        operation_id="Update a Project Release's File",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+            _FILE_ID_PARAM,
+        ],
+        request=ReleaseFileSerializer,
+        responses={
+            200: inline_sentry_response_serializer(
+                "ReleaseFileResponse", ReleaseFileSerializerResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def put(self, request: Request, project, version, file_id) -> Response:
         """
-        Update a File
-        `````````````
-
-        Update metadata of an existing file.  Currently only the name of
-        the file can be changed.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to update the
-                                     file of.
-        :pparam string version: the version identifier of the release.
-        :pparam string file_id: the ID of the file to update.
-        :param string name: the new name of the file.
-        :auth: required
+        Update metadata of an existing release file. Currently only the name of the file
+        can be changed.
         """
-
         try:
             release = Release.objects.get(
                 organization_id=project.organization_id, projects=project, version=version
@@ -268,23 +312,25 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
 
         return self.update_releasefile(request, release, file_id)
 
+    @extend_schema(
+        operation_id="Delete a Project Release's File",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+            _FILE_ID_PARAM,
+        ],
+        responses={
+            204: RESPONSE_NO_CONTENT,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def delete(self, request: Request, project, version, file_id) -> Response:
         """
-        Delete a File
-        `````````````
-
-        Permanently remove a file from a release.
-
-        This will also remove the physical file from storage, except if it is
-        stored as part of an artifact bundle.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to delete the
-                                     file of.
-        :pparam string version: the version identifier of the release.
-        :pparam string file_id: the ID of the file to delete.
-        :auth: required
+        Permanently remove a file from a release. Also removes the physical file from
+        storage, unless it is stored as part of an artifact bundle.
         """
         try:
             release = Release.objects.get(

--- a/src/sentry/releases/endpoints/project_release_file_details.py
+++ b/src/sentry/releases/endpoints/project_release_file_details.py
@@ -37,14 +37,6 @@ from sentry.releases.endpoints.project_release_files import pseudo_releasefile
 #: Cannot update release artifacts in release archives
 INVALID_UPDATE_MESSAGE = "Can only update release files with integer IDs"
 
-_FILE_ID_PARAM = OpenApiParameter(
-    name="file_id",
-    location="path",
-    required=True,
-    type=str,
-    description="The ID of the release file.",
-)
-
 
 class ReleaseFileSerializer(serializers.Serializer):
     name = serializers.CharField(
@@ -242,7 +234,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ReleaseParams.VERSION,
-            _FILE_ID_PARAM,
+            ReleaseParams.FILE_ID,
             OpenApiParameter(
                 name="download",
                 location="query",
@@ -285,7 +277,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ReleaseParams.VERSION,
-            _FILE_ID_PARAM,
+            ReleaseParams.FILE_ID,
         ],
         request=ReleaseFileSerializer,
         responses={
@@ -318,7 +310,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ReleaseParams.VERSION,
-            _FILE_ID_PARAM,
+            ReleaseParams.FILE_ID,
         ],
         responses={
             204: RESPONSE_NO_CONTENT,

--- a/src/sentry/releases/endpoints/project_release_files.py
+++ b/src/sentry/releases/endpoints/project_release_files.py
@@ -7,17 +7,21 @@ from django.db import IntegrityError, router
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.utils.functional import cached_property
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import BaseEndpointMixin, cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import ChainPaginator
 from sentry.api.serializers import serialize
-from sentry.apidocs.parameters import CursorQueryParam
+from sentry.api.serializers.models.release_file import ReleaseFileSerializerResponse
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import MAX_RELEASE_FILES_OFFSET
 from sentry.debug_files.release_files import maybe_renew_releasefiles
 from sentry.models.distribution import Distribution
@@ -231,10 +235,13 @@ def pseudo_releasefile(url, info, dist):
     )
 
 
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        # Multipart upload — documented separately.
         "POST": ApiPublishStatus.UNKNOWN,
     }
     permission_classes = (ProjectReleasePermission,)
@@ -244,23 +251,40 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
 
     @extend_schema(
         operation_id="List a Project Release's Files",
-        parameters=[CursorQueryParam],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+            OpenApiParameter(
+                name="query",
+                location="query",
+                required=False,
+                type=str,
+                many=True,
+                description="If set, only files with these partial names will be returned.",
+            ),
+            OpenApiParameter(
+                name="checksum",
+                location="query",
+                required=False,
+                type=str,
+                many=True,
+                description="If set, only files with these exact checksums will be returned.",
+            ),
+            CursorQueryParam,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListReleaseFiles", list[ReleaseFileSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
     )
     def get(self, request: Request, project, version) -> Response:
         """
-        List a Project Release's Files
-        ``````````````````````````````
-
         Retrieve a list of files for a given release.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to list the
-                                     release files of.
-        :pparam string version: the version identifier of the release.
-        :qparam string query: If set, only files with these partial names will be returned.
-        :qparam string checksum: If set, only files with these exact checksums will be returned.
-        :auth: required
         """
         try:
             release = Release.objects.get(

--- a/src/sentry/releases/endpoints/project_release_files.py
+++ b/src/sentry/releases/endpoints/project_release_files.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.utils.functional import cached_property
 from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -19,7 +20,13 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import ChainPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.release_file import ReleaseFileSerializerResponse
-from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_CONFLICT,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import MAX_RELEASE_FILES_OFFSET
@@ -37,6 +44,37 @@ _filename_re = re.compile(r"[\n\t\r\f\v\\]")
 
 
 logger = logging.getLogger(__name__)
+
+
+class ReleaseFileUploadSerializer(serializers.Serializer):
+    """Documents the multipart/form-data body of the release file upload endpoints.
+
+    The endpoints read the upload directly off ``request.data``; this serializer
+    exists to describe the request body in the OpenAPI schema.
+    """
+
+    file = serializers.FileField(
+        help_text="The multipart-encoded file contents to upload.",
+    )
+    name = serializers.CharField(
+        required=False,
+        help_text=(
+            "The name (full path) the file will be referenced as, e.g. the full web "
+            "URI of a JavaScript file. Defaults to the uploaded file's name."
+        ),
+    )
+    dist = serializers.CharField(
+        required=False,
+        help_text="The name of the distribution to associate the file with.",
+    )
+    header = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text=(
+            'Headers to attach to the file, each formatted as a `"key:value"` string '
+            "(for example, to define a content type). May be supplied multiple times."
+        ),
+    )
 
 
 def load_dist(results):
@@ -241,8 +279,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
-        # Multipart upload — documented separately.
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
     rate_limits = RateLimitConfig(
@@ -295,37 +332,31 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
 
         return self.get_releasefiles(request, release, project.organization_id)
 
+    @extend_schema(
+        operation_id="Upload a New Project Release File",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+        ],
+        request={"multipart/form-data": ReleaseFileUploadSerializer},
+        responses={
+            201: inline_sentry_response_serializer(
+                "ReleaseFileResponse", ReleaseFileSerializerResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+            409: RESPONSE_CONFLICT,
+        },
+    )
     def post(self, request: Request, project, version) -> Response:
         """
-        Upload a New Project Release File
-        `````````````````````````````````
-
         Upload a new file for the given release.
 
-        Unlike other API requests, files must be uploaded using the
-        traditional multipart/form-data content-type.
-
-        Requests to this endpoint should use the region-specific domain
-        eg. `us.sentry.io` or `de.sentry.io`
-
-        The optional 'name' attribute should reflect the absolute path
-        that this file will be referenced as. For example, in the case of
-        JavaScript you might specify the full web URI.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to change the
-                                     release of.
-        :pparam string version: the version identifier of the release.
-        :param string name: the name (full path) of the file.
-        :param string dist: the name of the dist.
-        :param file file: the multipart encoded file.
-        :param string header: this parameter can be supplied multiple times
-                              to attach headers to the file.  Each header
-                              is a string in the format ``key:value``.  For
-                              instance it can be used to define a content
-                              type.
-        :auth: required
+        Files must be uploaded using the `multipart/form-data` content type, against the
+        region-specific domain (e.g. `us.sentry.io` or `de.sentry.io`).
         """
         try:
             release = Release.objects.get(

--- a/src/sentry/releases/endpoints/project_release_repositories.py
+++ b/src/sentry/releases/endpoints/project_release_repositories.py
@@ -1,37 +1,51 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.repository import RepositorySerializerResponse
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
 
 
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseRepositories(ProjectEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     permission_classes = (ProjectReleasePermission,)
 
+    @extend_schema(
+        operation_id="Retrieve a Project Release's Repositories",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListProjectReleaseRepositoriesResponse", list[RepositorySerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, project, version) -> Response:
         """
-        Retrieve Project Repositories from a Release
-        ````````````````````````````
-
-        This endpoint is used in the commits and changed files tab of the release details page
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to retrieve the
-                                     release of.
-        :pparam string version: the version identifier of the release.
-        :auth: required
+        Return the repositories that have commits associated with a given release.
         """
 
         try:

--- a/src/sentry/releases/endpoints/project_release_setup.py
+++ b/src/sentry/releases/endpoints/project_release_setup.py
@@ -1,10 +1,17 @@
+from typing import TypedDict
+
 from django.core.cache import cache
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.deploy import Deploy
 from sentry.models.group import Group
 from sentry.models.releasecommit import ReleaseCommit
@@ -13,22 +20,38 @@ from sentry.models.repository import Repository
 from sentry.utils.hashlib import hash_values
 
 
+class ReleaseSetupStepResponse(TypedDict):
+    # One of: tag, repo, commit, deploy.
+    step: str
+    complete: bool
+
+
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 
+    @extend_schema(
+        operation_id="Retrieve a Project's Release Setup Progress",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListReleaseSetupSteps", list[ReleaseSetupStepResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, project) -> Response:
         """
-        Get list with release setup progress for a project
-        1. tag an error
-        2. link a repo
-        3. associate commits
-        4. tell sentry about a deploy
+        Return the release-setup onboarding progress for a project: whether the project
+        has tagged an error, linked a repo, associated commits, and reported a deploy.
         """
-
         tag_key = "onboard_tag:1:%s" % (project.id)
         repo_key = "onboard_repo:1:%s" % (project.organization_id)
         commit_key = "onboard_commit:1:%s" % hash_values([project.organization_id, project.id])

--- a/src/sentry/releases/endpoints/project_release_stats.py
+++ b/src/sentry/releases/endpoints/project_release_stats.py
@@ -1,17 +1,44 @@
 from datetime import datetime
+from typing import Any, TypedDict
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import release_health
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventsError, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams, ReleaseParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.release import Release
 from sentry.release_health.base import is_overview_stat
 from sentry.utils.dates import get_rollup_from_request
+
+
+class ReleaseStatsUserBreakdown(TypedDict):
+    date: datetime
+    totalUsers: int
+    crashFreeUsers: float | None
+    totalSessions: int
+    crashFreeSessions: float | None
+
+
+class ProjectReleaseStatsResponse(TypedDict):
+    # Time series of (timestamp, counts) entries; counts vary by `type`.
+    stats: list[tuple[int, dict[str, Any]]]
+    # Aggregate counts across the whole range.
+    statTotals: dict[str, Any]
+    usersBreakdown: list[ReleaseStatsUserBreakdown]
 
 
 def upsert_missing_release(project, version) -> datetime | None:
@@ -33,26 +60,44 @@ def upsert_missing_release(project, version) -> datetime | None:
             return None
 
 
+@extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseStatsEndpoint(ProjectEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 
+    @extend_schema(
+        operation_id="Retrieve a Project Release's Health Stats",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            ReleaseParams.VERSION,
+            OpenApiParameter(
+                name="type",
+                location="query",
+                required=False,
+                type=str,
+                enum=["sessions", "users"],
+                description="The kind of health stat to return. Defaults to `sessions`.",
+            ),
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ProjectReleaseStats", ProjectReleaseStatsResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, project, version) -> Response:
         """
-        Get a Project Release's Stats
-        `````````````````````````````
-
-        Returns the stats of a given release under a project.
-
-        :pparam string organization_id_or_slug: the id or slug of the organization the
-                                          release belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to list the
-                                     release files of.
-        :pparam string version: the version identifier of the release.
-        :auth: required
+        Return crash-free session/user health stats and a per-day breakdown for a release
+        within a project.
         """
         stats_type = request.GET.get("type") or "sessions"
         if not is_overview_stat(stats_type):

--- a/src/sentry/sentry_apps/api/endpoints/installation_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_details.py
@@ -1,5 +1,6 @@
 import sentry_sdk
 from django.db import router, transaction
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from requests import RequestException
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,11 +11,20 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.serializers import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NO_CONTENT,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import SentryAppInstallationStatus
 from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 from sentry.sentry_apps.api.bases.sentryapps import SentryAppInstallationBaseEndpoint
 from sentry.sentry_apps.api.parsers.sentry_app_installation import SentryAppInstallationParser
 from sentry.sentry_apps.api.serializers.sentry_app_installation import (
+    SentryAppInstallationResult,
     SentryAppInstallationSerializer,
 )
 from sentry.sentry_apps.installations import (
@@ -25,18 +35,42 @@ from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallat
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.sentry_apps.webhooks import WebhookTimeoutError
 
+_INSTALLATION_UUID_PARAM = OpenApiParameter(
+    name="uuid",
+    location="path",
+    required=True,
+    type=str,
+    description="The UUID of the Sentry App installation.",
+)
 
+
+@extend_schema(tags=["Integration"])
 @control_silo_endpoint
 class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
     owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
     allow_disabled_sentry_app_for_methods = {"DELETE"}
 
+    @extend_schema(
+        operation_id="Retrieve a Sentry App Installation",
+        parameters=[_INSTALLATION_UUID_PARAM],
+        responses={
+            200: inline_sentry_response_serializer(
+                "SentryAppInstallation", SentryAppInstallationResult
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, installation) -> Response:
+        """
+        Return details about a single custom integration (Sentry App) installation.
+        """
         return Response(
             serialize(
                 objects=SentryAppInstallation.objects.get(id=installation.id),
@@ -45,7 +79,20 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
             )
         )
 
+    @extend_schema(
+        operation_id="Uninstall a Sentry App",
+        parameters=[_INSTALLATION_UUID_PARAM],
+        responses={
+            204: RESPONSE_NO_CONTENT,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def delete(self, request: Request, installation) -> Response:
+        """
+        Uninstall a custom integration (Sentry App) from an organization.
+        """
         sentry_app_installation = SentryAppInstallation.objects.get(id=installation.id)
         db = router.db_for_write(SentryAppInstallation)
 
@@ -86,7 +133,25 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
             )
         return Response(status=204)
 
+    @extend_schema(
+        operation_id="Update a Sentry App Installation",
+        parameters=[_INSTALLATION_UUID_PARAM],
+        request=SentryAppInstallationParser,
+        responses={
+            200: inline_sentry_response_serializer(
+                "SentryAppInstallation", SentryAppInstallationResult
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def put(self, request: Request, installation) -> Response:
+        """
+        Update a custom integration (Sentry App) installation, for example to mark a
+        pending installation as installed.
+        """
         serializer = SentryAppInstallationParser(installation, data=request.data, partial=True)
 
         if serializer.is_valid():

--- a/src/sentry/sentry_apps/api/endpoints/installation_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_details.py
@@ -1,6 +1,6 @@
 import sentry_sdk
 from django.db import router, transaction
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from requests import RequestException
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,6 +18,7 @@ from sentry.apidocs.constants import (
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
 )
+from sentry.apidocs.parameters import SentryAppParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import SentryAppInstallationStatus
 from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
@@ -35,14 +36,6 @@ from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallat
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.sentry_apps.webhooks import WebhookTimeoutError
 
-_INSTALLATION_UUID_PARAM = OpenApiParameter(
-    name="uuid",
-    location="path",
-    required=True,
-    type=str,
-    description="The UUID of the Sentry App installation.",
-)
-
 
 @extend_schema(tags=["Integration"])
 @control_silo_endpoint
@@ -57,7 +50,7 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
 
     @extend_schema(
         operation_id="Retrieve a Sentry App Installation",
-        parameters=[_INSTALLATION_UUID_PARAM],
+        parameters=[SentryAppParams.INSTALLATION_UUID],
         responses={
             200: inline_sentry_response_serializer(
                 "SentryAppInstallation", SentryAppInstallationResult
@@ -81,7 +74,7 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
 
     @extend_schema(
         operation_id="Uninstall a Sentry App",
-        parameters=[_INSTALLATION_UUID_PARAM],
+        parameters=[SentryAppParams.INSTALLATION_UUID],
         responses={
             204: RESPONSE_NO_CONTENT,
             401: RESPONSE_UNAUTHORIZED,
@@ -135,7 +128,7 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
 
     @extend_schema(
         operation_id="Update a Sentry App Installation",
-        parameters=[_INSTALLATION_UUID_PARAM],
+        parameters=[SentryAppParams.INSTALLATION_UUID],
         request=SentryAppInstallationParser,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/sentry_apps/api/endpoints/installation_external_issue_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_issue_details.py
@@ -11,19 +11,13 @@ from sentry.apidocs.constants import (
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
 )
+from sentry.apidocs.parameters import SentryAppParams
 from sentry.sentry_apps.api.bases.sentryapps import (
     SentryAppInstallationExternalIssueBaseEndpoint as ExternalIssueBaseEndpoint,
 )
 from sentry.sentry_apps.services.cell import sentry_app_cell_service
 from sentry.sentry_apps.utils.errors import SentryAppError
 
-_INSTALLATION_UUID_PARAM = OpenApiParameter(
-    name="uuid",
-    location="path",
-    required=True,
-    type=str,
-    description="The UUID of the Sentry App installation.",
-)
 _EXTERNAL_ISSUE_ID_PARAM = OpenApiParameter(
     name="external_issue_id",
     location="path",
@@ -43,7 +37,7 @@ class SentryAppInstallationExternalIssueDetailsEndpoint(ExternalIssueBaseEndpoin
 
     @extend_schema(
         operation_id="Delete an External Issue",
-        parameters=[_INSTALLATION_UUID_PARAM, _EXTERNAL_ISSUE_ID_PARAM],
+        parameters=[SentryAppParams.INSTALLATION_UUID, _EXTERNAL_ISSUE_ID_PARAM],
         responses={
             204: RESPONSE_NO_CONTENT,
             401: RESPONSE_UNAUTHORIZED,

--- a/src/sentry/sentry_apps/api/endpoints/installation_external_issue_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_issue_details.py
@@ -1,22 +1,61 @@
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
+from sentry.apidocs.constants import (
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NO_CONTENT,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
 from sentry.sentry_apps.api.bases.sentryapps import (
     SentryAppInstallationExternalIssueBaseEndpoint as ExternalIssueBaseEndpoint,
 )
 from sentry.sentry_apps.services.cell import sentry_app_cell_service
 from sentry.sentry_apps.utils.errors import SentryAppError
 
+_INSTALLATION_UUID_PARAM = OpenApiParameter(
+    name="uuid",
+    location="path",
+    required=True,
+    type=str,
+    description="The UUID of the Sentry App installation.",
+)
+_EXTERNAL_ISSUE_ID_PARAM = OpenApiParameter(
+    name="external_issue_id",
+    location="path",
+    required=True,
+    type=int,
+    description="The ID of the external issue link to remove.",
+)
 
+
+@extend_schema(tags=["Integration"])
 @control_silo_endpoint
 class SentryAppInstallationExternalIssueDetailsEndpoint(ExternalIssueBaseEndpoint):
+    owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        operation_id="Delete an External Issue",
+        parameters=[_INSTALLATION_UUID_PARAM, _EXTERNAL_ISSUE_ID_PARAM],
+        responses={
+            204: RESPONSE_NO_CONTENT,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def delete(self, request: Request, installation, external_issue_id) -> Response:
+        """
+        Remove the link between a Sentry issue and an external resource created through a
+        custom integration (Sentry App) installation.
+        """
         try:
             external_issue_id = int(external_issue_id)
         except (ValueError, TypeError):

--- a/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -6,6 +7,13 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.serializers import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.sentry_apps.api.bases.sentryapps import (
     SentryAppInstallationExternalIssueBaseEndpoint as ExternalIssueBaseEndpoint,
 )
@@ -13,23 +21,57 @@ from sentry.sentry_apps.api.parsers.sentry_app import URLField
 from sentry.sentry_apps.api.serializers.platform_external_issue import (
     PlatformExternalIssueSerializer as ResponsePlatformExternalIssueSerializer,
 )
+from sentry.sentry_apps.api.serializers.platform_external_issue import (
+    PlatformExternalIssueSerializerResponse,
+)
 from sentry.sentry_apps.services.cell import sentry_app_cell_service
+
+_INSTALLATION_UUID_PARAM = OpenApiParameter(
+    name="uuid",
+    location="path",
+    required=True,
+    type=str,
+    description="The UUID of the Sentry App installation.",
+)
 
 
 class PlatformExternalIssueSerializer(serializers.Serializer):
-    webUrl = URLField()
-    project = serializers.CharField()
-    identifier = serializers.CharField()
+    webUrl = URLField(help_text="The URL of the external resource the issue is linked to.")
+    project = serializers.CharField(
+        help_text="The display name of the project the external issue belongs to."
+    )
+    identifier = serializers.CharField(
+        help_text="The identifier of the external issue, displayed in the Sentry UI."
+    )
 
 
+@extend_schema(tags=["Integration"])
 @control_silo_endpoint
 class SentryAppInstallationExternalIssuesEndpoint(ExternalIssueBaseEndpoint):
     owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        operation_id="Create an External Issue",
+        parameters=[_INSTALLATION_UUID_PARAM],
+        request=PlatformExternalIssueSerializer,
+        responses={
+            200: inline_sentry_response_serializer(
+                "PlatformExternalIssueResponse", PlatformExternalIssueSerializerResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def post(self, request: Request, installation) -> Response:
+        """
+        Link a Sentry issue to a resource in an external service through a custom
+        integration (Sentry App) installation.
+        """
         data = request.data
 
         serializer = PlatformExternalIssueSerializer(data=request.data)

--- a/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
@@ -1,4 +1,4 @@
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,6 +13,7 @@ from sentry.apidocs.constants import (
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
 )
+from sentry.apidocs.parameters import SentryAppParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.sentry_apps.api.bases.sentryapps import (
     SentryAppInstallationExternalIssueBaseEndpoint as ExternalIssueBaseEndpoint,
@@ -25,14 +26,6 @@ from sentry.sentry_apps.api.serializers.platform_external_issue import (
     PlatformExternalIssueSerializerResponse,
 )
 from sentry.sentry_apps.services.cell import sentry_app_cell_service
-
-_INSTALLATION_UUID_PARAM = OpenApiParameter(
-    name="uuid",
-    location="path",
-    required=True,
-    type=str,
-    description="The UUID of the Sentry App installation.",
-)
 
 
 class PlatformExternalIssueSerializer(serializers.Serializer):
@@ -55,7 +48,7 @@ class SentryAppInstallationExternalIssuesEndpoint(ExternalIssueBaseEndpoint):
 
     @extend_schema(
         operation_id="Create an External Issue",
-        parameters=[_INSTALLATION_UUID_PARAM],
+        parameters=[SentryAppParams.INSTALLATION_UUID],
         request=PlatformExternalIssueSerializer,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_features.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_features.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -6,21 +7,41 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import SentryAppParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.integrations.api.serializers.models.integration_feature import (
+    IntegrationFeatureResponse,
     IntegrationFeatureSerializer,
 )
 from sentry.integrations.models.integration_feature import IntegrationFeature, IntegrationTypes
 from sentry.sentry_apps.api.bases.sentryapps import SentryAppBaseEndpoint
 
 
+@extend_schema(tags=["Integration"])
 @control_silo_endpoint
 class SentryAppFeaturesEndpoint(SentryAppBaseEndpoint):
     owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        operation_id="List a Custom Integration's Features",
+        parameters=[SentryAppParams.SENTRY_APP_ID_OR_SLUG],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListSentryAppFeatures", list[IntegrationFeatureResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, sentry_app) -> Response:
+        """
+        Return the list of features that a custom integration (Sentry App) declares.
+        """
         features = IntegrationFeature.objects.filter(
             target_id=sentry_app.id, target_type=IntegrationTypes.SENTRY_APP.value
         )

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_installations.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_installations.py
@@ -10,7 +10,9 @@ from sentry.api.base import control_silo_endpoint
 from sentry.api.fields.sentry_slug import SentrySerializerSlugField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.apidocs.parameters import CursorQueryParam
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.superuser import superuser_has_permission
 from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH, SentryAppStatus
 from sentry.features.exceptions import FeatureNotRegistered
@@ -18,6 +20,7 @@ from sentry.integrations.models.integration_feature import IntegrationFeature, I
 from sentry.models.organization import Organization
 from sentry.sentry_apps.api.bases.sentryapps import SentryAppInstallationsBaseEndpoint
 from sentry.sentry_apps.api.serializers.sentry_app_installation import (
+    SentryAppInstallationResult,
     SentryAppInstallationSerializer,
 )
 from sentry.sentry_apps.installations import SentryAppInstallationCreator
@@ -31,19 +34,31 @@ class SentryAppInstallationsSerializer(serializers.Serializer):
     slug = SentrySerializerSlugField(required=True, max_length=SENTRY_APP_SLUG_MAX_LENGTH)
 
 
+@extend_schema(tags=["Integration"])
 @control_silo_endpoint
 class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
     owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,
     }
 
     @extend_schema(
         operation_id="List an Organization's Sentry App Installations",
-        parameters=[CursorQueryParam],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, CursorQueryParam],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListSentryAppInstallations", list[SentryAppInstallationResult]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
     )
     def get(self, request: Request, organization: Organization) -> Response:
+        """
+        Return a list of an organization's installations of custom integrations (Sentry Apps).
+        """
         queryset = SentryAppInstallation.objects.filter(organization_id=organization.id)
 
         return self.paginate(

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_stats_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_stats_details.py
@@ -1,27 +1,75 @@
+from typing import TypedDict
+
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tsdb
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import StatsMixin, control_silo_endpoint
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import SentryAppParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.sentry_apps.api.bases.sentryapps import SentryAppBaseEndpoint, SentryAppStatsPermission
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 
 
+class SentryAppStatsResponse(TypedDict):
+    totalInstalls: int
+    totalUninstalls: int
+    # Each entry is a (timestamp, count) pair bucketed by the chosen resolution.
+    installStats: list[tuple[int, int]]
+    uninstallStats: list[tuple[int, int]]
+
+
+@extend_schema(tags=["Integration"])
 @control_silo_endpoint
 class SentryAppStatsEndpoint(SentryAppBaseEndpoint, StatsMixin):
+    owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SentryAppStatsPermission,)
 
+    @extend_schema(
+        operation_id="Retrieve a Sentry App's Install/Uninstall Stats",
+        parameters=[
+            SentryAppParams.SENTRY_APP_ID_OR_SLUG,
+            OpenApiParameter(
+                name="since",
+                location="query",
+                required=False,
+                type=float,
+                description="A UNIX timestamp that represents the start of the time series range, inclusive.",
+            ),
+            OpenApiParameter(
+                name="until",
+                location="query",
+                required=False,
+                type=float,
+                description="A UNIX timestamp that represents the end of the time series range, inclusive.",
+            ),
+            OpenApiParameter(
+                name="resolution",
+                location="query",
+                required=False,
+                type=str,
+                description="The resolution of the time series buckets, e.g. `1h`, `1d`. Defaults to an optimal resolution for the requested range.",
+            ),
+        ],
+        responses={
+            200: inline_sentry_response_serializer("SentryAppStats", SentryAppStatsResponse),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, sentry_app) -> Response:
         """
-        :qparam float since
-        :qparam float until
-        :qparam resolution - optional
+        Return the number of installations and uninstallations of a custom integration
+        (Sentry App) over a time series range.
         """
-
         query_args = self._parse_args(request)
 
         installations = SentryAppInstallation.with_deleted.filter(

--- a/src/sentry/sentry_apps/api/parsers/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app_installation.py
@@ -5,7 +5,13 @@ from sentry.constants import SentryAppInstallationStatus
 
 
 class SentryAppInstallationParser(Serializer):
-    status = serializers.CharField()
+    status = serializers.CharField(
+        help_text=(
+            f"The new status of the installation. The only accepted value is "
+            f"`{SentryAppInstallationStatus.INSTALLED_STR}`, which marks a pending "
+            f"installation as installed."
+        )
+    )
 
     def validate_status(self, new_status):
         # can only set status to installed

--- a/src/sentry/sentry_apps/api/parsers/servicehook.py
+++ b/src/sentry/sentry_apps/api/parsers/servicehook.py
@@ -4,10 +4,21 @@ from sentry.sentry_apps.models.servicehook import SERVICE_HOOK_EVENTS
 
 
 class ServiceHookValidator(serializers.Serializer):
-    url = serializers.URLField(required=True)
-    events = serializers.ListField(child=serializers.CharField(max_length=255), required=False)
-    version = serializers.ChoiceField(choices=((0, "0"),), required=False, default=0)
-    isActive = serializers.BooleanField(required=False, default=True)
+    url = serializers.URLField(required=True, help_text="The URL that events will be sent to.")
+    events = serializers.ListField(
+        child=serializers.CharField(max_length=255),
+        required=False,
+        help_text="The list of events to subscribe to, e.g. `event.alert`, `event.created`.",
+    )
+    version = serializers.ChoiceField(
+        choices=((0, "0"),),
+        required=False,
+        default=0,
+        help_text="The version of the service hook payload format.",
+    )
+    isActive = serializers.BooleanField(
+        required=False, default=True, help_text="Whether the service hook is active."
+    )
 
     def validate_events(self, value):
         if value:

--- a/src/sentry/sentry_apps/api/serializers/servicehook.py
+++ b/src/sentry/sentry_apps/api/serializers/servicehook.py
@@ -1,10 +1,22 @@
+from datetime import datetime
+from typing import TypedDict
+
 from sentry.api.serializers import Serializer, register
 from sentry.sentry_apps.models.servicehook import ServiceHook
 
 
+class ServiceHookSerializerResponse(TypedDict):
+    id: str
+    url: str
+    secret: str
+    status: str
+    events: list[str]
+    dateCreated: datetime
+
+
 @register(ServiceHook)
 class ServiceHookSerializer(Serializer):
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs) -> ServiceHookSerializerResponse:
         return {
             "id": obj.guid,
             "url": obj.url,


### PR DESCRIPTION
Resolve every remaining `UNKNOWN` API `publish_status` by moving ~30 endpoints to `PRIVATE` with full `@extend_schema` documentation, and drain the publish-status allowlist to empty. Every routed endpoint method now has an explicit, non-`UNKNOWN` publish status.

These endpoints stay `PRIVATE` for now — the documentation is added "flip-ready", so each can be promoted to `PUBLIC` by changing a single enum value. Each cluster was validated by temporarily flipping it to `PUBLIC` and confirming the schema builds clean under `--fail-on-warn`.

**Allowlist drained to zero**

`API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY` is now empty:

```python
API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY: dict[str, set[str]] = {}
```

With no remaining escape-hatch entries, a follow-up can delete the allowlist module + its branch in the build gate, and then remove the `UNKNOWN` value from `ApiPublishStatus` entirely.

**Typed responses for raw-dict endpoints**

Endpoints that previously returned untyped dicts now have response `TypedDict`s so their contracts are explicit: `IntegrationFeatureResponse`, `SentryAppStatsResponse`, `ServerlessFunctionResponse`, `ProjectTagKeyResponse`, `ServiceHookSerializerResponse`, `ServiceHookStatsResponse`, `RepoPathParsingResponse`, `PromptsActivityResponse`, `ReleaseFileSerializerResponse`, `ReleaseAssembleResponse`, plus the release setup/stats responses. Fixed one latent bug along the way: `EventUserSerializerResponse.dateCreated` was typed as bare `None` (unresolvable in the schema) and is now `datetime | None`.

**Multipart upload request bodies**

The two release file upload `POST`s are documented with a shared `ReleaseFileUploadSerializer` declared via `request={"multipart/form-data": ...}`, which emits a proper `multipart/form-data` body (file as `format: binary`) and bypasses the JSON-only parser whitelist.

**Reviewer note:** the release `files`/`file-details` paths are also served by the legacy hand-authored docs in `api-docs/paths/releases/` (merged via `APPEND_PATHS`), which still shadow `@extend_schema` in the emitted public schema. The annotations here are the source of truth for internal tooling; migrating those paths off the legacy docs is a separate follow-up.

Follows #116650