### PR TITLE
ref(api): remove publish-status allowlist and the UNKNOWN status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -694,7 +694,6 @@ module = [
     "sentry.api.validators.*",
     "sentry.apidocs",
     "sentry.apidocs.api_ownership_allowlist_dont_modify",
-    "sentry.apidocs.api_publish_status_allowlist_dont_modify",
     "sentry.apidocs.build",
     "sentry.apidocs.constants",
     "sentry.apidocs.extensions",

--- a/src/sentry/api/api_publish_status.py
+++ b/src/sentry/api/api_publish_status.py
@@ -6,8 +6,6 @@ class ApiPublishStatus(Enum):
     Used to track if an API is publicly documented
     """
 
-    UNKNOWN = "unknown"
-
     PUBLIC = "public"  # stable API that is visible in public documentation
     PRIVATE = "private"  # any API that will not be published at any point
     EXPERIMENTAL = "experimental"  # API in development and will be published at some point

--- a/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
+++ b/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
@@ -1,7 +1,0 @@
-"""
-This list is tracking old api endpoints that we couldn't decide publish status for.
-The goal is to eventually find owners for all and shrink this list.
-DO NOT ADD ANY NEW APIS
-"""
-
-API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY: dict[str, set[str]] = {}

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -10,9 +10,6 @@ from drf_spectacular.generators import EndpointEnumerator, SchemaGenerator
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.apidocs.api_ownership_allowlist_dont_modify import API_OWNERSHIP_ALLOWLIST_DONT_MODIFY
-from sentry.apidocs.api_publish_status_allowlist_dont_modify import (
-    API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY,
-)
 from sentry.apidocs.build import OPENAPI_TAGS
 from sentry.apidocs.utils import SentryApiBuildError
 
@@ -82,7 +79,6 @@ def __write_ownership_data(ownership_data: dict[ApiOwner, dict]):
             ApiPublishStatus.EXPERIMENTAL.value: sorted(
                 ownership_data[team][ApiPublishStatus.EXPERIMENTAL]
             ),
-            ApiPublishStatus.UNKNOWN.value: sorted(ownership_data[team][ApiPublishStatus.UNKNOWN]),
         }
         index += __get_line_count_for_team_stats(ownership_data[team])
     dir = os.path.dirname(os.path.realpath(__file__))
@@ -123,7 +119,6 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
         owner_team = callback.view_class.owner
         if owner_team not in ownership_data:
             ownership_data[owner_team] = {
-                ApiPublishStatus.UNKNOWN: set(),
                 ApiPublishStatus.PUBLIC: set(),
                 ApiPublishStatus.PRIVATE: set(),
                 ApiPublishStatus.EXPERIMENTAL: set(),
@@ -137,18 +132,11 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
                     + "If you can't find your team in ApiOwners feel free to add the associated github group. ",
                 )
 
-        # Fail if method is not included in publish_status or has unknown status
-        if (
-            method not in callback.view_class.publish_status
-            or callback.view_class.publish_status[method] is ApiPublishStatus.UNKNOWN
-        ):
-            if (
-                path not in API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY
-                or method not in API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY[path]
-            ):
-                raise SentryApiBuildError(
-                    f"All methods must have a known publish_status. Please add a valid publish status for Endpoint {callback.view_class} {method} method.",
-                )
+        # Fail if a method does not declare a publish_status
+        if method not in callback.view_class.publish_status:
+            raise SentryApiBuildError(
+                f"All methods must declare a publish_status. Please add a valid publish status for Endpoint {callback.view_class} {method} method.",
+            )
 
         if any(path.startswith(p) for p in EXCLUSION_PATH_PREFIXES):
             pass


### PR DESCRIPTION
Follow-up to #116745. Now that no endpoint carries an `UNKNOWN` publish status, this removes the escape-hatch machinery entirely.

- Deletes `api_publish_status_allowlist_dont_modify.py` and the build-gate branch that let allowlisted paths skip the publish-status check. The gate now simply requires every routed method to declare a `publish_status`.
- Removes `UNKNOWN` from `ApiPublishStatus` — it is unreachable once the allowlist is gone.
- Drops the now-always-empty `"unknown"` bucket from the generated API ownership stats.

**Build gate is now strict**

Before, a method could be `UNKNOWN` (or missing) and still pass if its path was allowlisted:

```python
if (
    method not in view.publish_status
    or view.publish_status[method] is ApiPublishStatus.UNKNOWN
):
    if path not in ALLOWLIST or method not in ALLOWLIST[path]:
        raise SentryApiBuildError(...)
```

After, every method must declare a real status:

```python
if method not in view.publish_status:
    raise SentryApiBuildError(...)
```

**Sentaur bot note**

The API ownership stats file (`api_ownership_stats_dont_modify.json`, generated at build time and published to the schema repo) will no longer contain an `"unknown"` key per team. The Sentaur Slack bot reads this file — it needs to stop expecting that key. The buckets were already empty after #116745, so no data is lost.