### PR TITLE
ref(auth): Make signed-URL email verification the only path

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -281,11 +281,6 @@ register(
     default="signed-url-confirmation-emails-salt",
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "user-settings.signed-url-confirmation-emails",
-    default=True,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Staff
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -283,7 +283,7 @@ register(
 )
 register(
     "user-settings.signed-url-confirmation-emails",
-    default=False,
+    default=True,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/users/api/endpoints/user_emails.py
+++ b/src/sentry/users/api/endpoints/user_emails.py
@@ -119,38 +119,21 @@ class UserEmailsEndpoint(UserEndpoint):
         result = validator.validated_data
         email = result["email"].lower().strip()
 
-        use_signed_urls = options.get("user-settings.signed-url-confirmation-emails")
         try:
-            if use_signed_urls:
-                add_email_signed(email, user)
-                logger.info(
-                    "user.email.add",
-                    extra={
-                        "user_id": user.id,
-                        "ip_address": request.META["REMOTE_ADDR"],
-                        "used_signed_url": True,
-                        "email": email,
-                    },
-                )
-                return self.respond(
-                    {"detail": _("A verification email has been sent. Please check your inbox.")},
-                    status=201,
-                )
-            else:
-                new_useremail = add_email(email, user)
-                logger.info(
-                    "user.email.add",
-                    extra={
-                        "user_id": user.id,
-                        "ip_address": request.META["REMOTE_ADDR"],
-                        "used_signed_url": False,
-                        "email": email,
-                    },
-                )
-                return self.respond(
-                    serialize(new_useremail, user=request.user, serializer=UserEmailSerializer()),
-                    status=201,
-                )
+            add_email_signed(email, user)
+            logger.info(
+                "user.email.add",
+                extra={
+                    "user_id": user.id,
+                    "ip_address": request.META["REMOTE_ADDR"],
+                    "used_signed_url": True,
+                    "email": email,
+                },
+            )
+            return self.respond(
+                {"detail": _("A verification email has been sent. Please check your inbox.")},
+                status=201,
+            )
         except DuplicateEmailError:
             return self.respond(
                 {"detail": _("That email address is already associated with your account.")},

--- a/src/sentry/users/api/endpoints/user_emails.py
+++ b/src/sentry/users/api/endpoints/user_emails.py
@@ -13,6 +13,8 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.api.bases.user import UserEndpoint
 from sentry.users.api.parsers.email import AllowedEmailField
 from sentry.users.api.serializers.useremail import UserEmailSerializer
@@ -58,32 +60,6 @@ def add_email_signed(email: str, user: User) -> None:
     user.send_signed_url_confirm_email_singular(email, signed_data)
 
 
-def add_email(email: str, user: User) -> UserEmail:
-    """
-    Adds an email to user account
-
-    Can be either primary or secondary
-    """
-
-    # Bad email
-    if email is None:
-        raise InvalidEmailError
-
-    if UserEmail.objects.filter(user=user, email__iexact=email.lower()).exists():
-        raise DuplicateEmailError
-
-    try:
-        with transaction.atomic(using=router.db_for_write(UserEmail)):
-            new_email = UserEmail.objects.create(user=user, email=email)
-    except IntegrityError:
-        raise DuplicateEmailError
-
-    new_email.set_hash()
-    new_email.save()
-    user.send_confirm_email_singular(new_email)
-    return new_email
-
-
 @control_silo_endpoint
 class UserEmailsEndpoint(UserEndpoint):
     publish_status = {
@@ -92,6 +68,15 @@ class UserEmailsEndpoint(UserEndpoint):
         "PUT": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,
     }
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.IP: RateLimit(limit=10, window=60),
+                RateLimitCategory.USER: RateLimit(limit=10, window=60),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=60),
+            },
+        }
+    )
     owner = ApiOwner.UNOWNED
 
     def get(self, request: Request, user: User) -> Response:
@@ -143,7 +128,8 @@ class UserEmailsEndpoint(UserEndpoint):
     @sudo_required
     def put(self, request: Request, user: User) -> Response:
         """
-        Update a primary email address
+        Update a primary email address.
+        The UI only offers "Set as primary" for emails that are already saved and already verified.
         """
 
         validator = EmailValidator(data=request.data)
@@ -154,28 +140,20 @@ class UserEmailsEndpoint(UserEndpoint):
         old_email = user.email.lower()
         new_email = result["email"].lower()
 
-        new_useremail = user.emails.filter(email__iexact=new_email).first()
+        # defense in depth: UserEmail must already exist and be verified
+        existing_useremail = user.emails.filter(email__iexact=new_email).first()
+        if not existing_useremail or not existing_useremail.is_verified:
+            return self.respond(
+                {
+                    "email": _(
+                        "You must add and verify an email address before marking it as primary."
+                    )
+                },
+                status=400,
+            )
 
-        # If email doesn't exist for user, attempt to add new email
-        if not new_useremail:
-            try:
-                new_useremail = add_email(new_email, user)
-            except DuplicateEmailError:
-                new_useremail = user.emails.get(email__iexact=new_email)
-            else:
-                logger.info(
-                    "user.email.add",
-                    extra={
-                        "user_id": user.id,
-                        "ip_address": request.META["REMOTE_ADDR"],
-                        "email": new_useremail.email,
-                    },
-                )
-                new_email = new_useremail.email
-
-        # Check if email is in use
-        # TODO(dcramer): this needs rate limiting to avoid abuse
-        # TODO(dcramer): this needs a lock/constraint
+        # Check if new_email is the primary email on another User.
+        # User can only see result if they have verified new_email
         if (
             User.objects.filter(Q(email__iexact=new_email) | Q(username__iexact=new_email))
             .exclude(id=user.id)
@@ -186,38 +164,45 @@ class UserEmailsEndpoint(UserEndpoint):
                 status=400,
             )
 
-        if not new_useremail.is_verified:
-            return self.respond(
-                {"email": _("You must verify your email address before marking it as primary.")},
-                status=400,
-            )
-
-        options = UserOption.objects.filter(user=user, key="mail:email")
-        for option in options:
-            if option.value != old_email:
-                continue
-            option.update(value=new_email)
-
-        has_new_username = old_email == user.username
-
         # email_unique mirrors email under a DB-level unique constraint.
         # It is normally synced by User.save(), which this update() bypasses.
         update_kwargs = {"email": new_email, "email_unique": new_email}
 
-        if has_new_username and not User.objects.filter(username__iexact=new_email).exists():
+        # if username is email, update it
+        if old_email == user.username:
             update_kwargs["username"] = new_email
 
-        # NOTE(mattrobenolt): When changing your primary email address,
-        # we explicitly want to invalidate existing lost password hashes,
-        # so that in the event of a compromised inbox, an outstanding
-        # password hash can't be used to gain access. We also feel this
-        # is a large enough of a security concern to force logging
-        # out other current sessions.
-        user.clear_lost_passwords()
-        user.refresh_session_nonce(request._request)
-        update_kwargs["session_nonce"] = user.session_nonce
+        try:
+            with transaction.atomic(using=router.db_for_write(User)):
+                user_options_using_old_email = UserOption.objects.filter(
+                    user=user, key="mail:email", value=old_email
+                )
+                for user_option in user_options_using_old_email:
+                    # do this per-instance .update() to trigger post_save logic
+                    user_option.update(value=new_email)
 
-        user.update(**update_kwargs)
+                # NOTE(mattrobenolt): When changing your primary email address,
+                # we explicitly want to invalidate existing lost password hashes,
+                # so that in the event of a compromised inbox, an outstanding
+                # password hash can't be used to gain access. We also feel this
+                # is a large enough of a security concern to force logging
+                # out other current sessions.
+                user.clear_lost_passwords()
+                user.refresh_session_nonce()
+                update_kwargs["session_nonce"] = user.session_nonce
+
+                user.update(**update_kwargs)
+        except IntegrityError:
+            # The cross-account check above is racy: email_unique and username are
+            # DB-unique, so another account can claim this email between the check
+            # and this write.
+            return self.respond(
+                {"email": _("That email address is already associated with another account.")},
+                status=400,
+            )
+
+        # only update the session if transaction above succeeds
+        request.session["_nonce"] = user.session_nonce
 
         logger.info(
             "user.email.edit",
@@ -229,7 +214,7 @@ class UserEmailsEndpoint(UserEndpoint):
         )
 
         return self.respond(
-            serialize(new_useremail, user=request.user, serializer=UserEmailSerializer()),
+            serialize(existing_useremail, user=request.user, serializer=UserEmailSerializer()),
             status=200,
         )
 

--- a/src/sentry/users/api/endpoints/user_emails.py
+++ b/src/sentry/users/api/endpoints/user_emails.py
@@ -106,15 +106,6 @@ class UserEmailsEndpoint(UserEndpoint):
 
         try:
             add_email_signed(email, user)
-            logger.info(
-                "user.email.add",
-                extra={
-                    "user_id": user.id,
-                    "ip_address": request.META["REMOTE_ADDR"],
-                    "used_signed_url": True,
-                    "email": email,
-                },
-            )
             return self.respond(
                 {"detail": _("A verification email has been sent. Please check your inbox.")},
                 status=201,

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -406,13 +406,6 @@ def confirm_signed_email(
 ) -> HttpResponseRedirect | HttpResponse:
     EMAIL_CONFIRMATION_SALT = options.get("user-settings.signed-url-confirmation-emails-salt")
 
-    use_signed_urls = options.get("user-settings.signed-url-confirmation-emails")
-    if not use_signed_urls:
-        msg = ERR_CONFIRMING_EMAIL
-        level = messages.ERROR
-        messages.add_message(request, level, msg)
-        return HttpResponseRedirect(reverse("sentry-account-settings-emails"))
-
     msg = _("Thanks for confirming your email")
     level = messages.SUCCESS
 

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -46,6 +46,8 @@ ERR_SIGNATURE_EXPIRED = _(
     "Settings to resend the verification email."
 )
 
+SUCCESS_CONFIRMING_EMAIL = _("Thanks for confirming your email")
+
 
 class InvalidRequest(Exception):
     pass
@@ -398,9 +400,6 @@ def confirm_signed_email(
 ) -> HttpResponseRedirect | HttpResponse:
     EMAIL_CONFIRMATION_SALT = options.get("user-settings.signed-url-confirmation-emails-salt")
 
-    msg = _("Thanks for confirming your email")
-    level = messages.SUCCESS
-
     try:
         data = unsign(
             signed_data, salt=EMAIL_CONFIRMATION_SALT, max_age=2 * 24 * 60 * 60
@@ -417,31 +416,23 @@ def confirm_signed_email(
             defaults={"validation_hash": "", "is_verified": True},
         )
     except SignatureExpired:
-        msg = ERR_SIGNATURE_EXPIRED
-        level = messages.ERROR
-        messages.add_message(request, level, msg)
-        return HttpResponseRedirect(reverse("sentry-account-settings-emails"))
+        msg, level = ERR_SIGNATURE_EXPIRED, messages.ERROR
     except (InvalidRequest, BadSignature):
-        msg = ERR_CONFIRMING_EMAIL
-        level = messages.ERROR
-        messages.add_message(request, level, msg)
-        return HttpResponseRedirect(reverse("sentry-account-settings-emails"))
+        msg, level = ERR_CONFIRMING_EMAIL, messages.ERROR
     except Exception:
         logger.exception("user.email.signed-confirm.error")
-        msg = ERR_CONFIRMING_EMAIL
-        level = messages.ERROR
-        messages.add_message(request, level, msg)
-        return HttpResponseRedirect(reverse("sentry-account-settings-emails"))
-
-    email_verified.send(email=email.email, sender=email)
-    logger.info(
-        "user.email.signed-confirm",
-        extra={
-            "user_id": request.user.id,
-            "ip_address": request.META["REMOTE_ADDR"],
-            "email": email.email,
-        },
-    )
+        msg, level = ERR_CONFIRMING_EMAIL, messages.ERROR
+    else:
+        email_verified.send(email=email.email, sender=email)
+        logger.info(
+            "user.email.signed-confirm",
+            extra={
+                "user_id": request.user.id,
+                "ip_address": request.META["REMOTE_ADDR"],
+                "email": email.email,
+            },
+        )
+        msg, level = SUCCESS_CONFIRMING_EMAIL, messages.SUCCESS
 
     messages.add_message(request, level, msg)
     return HttpResponseRedirect(reverse("sentry-account-settings-emails"))

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -410,7 +410,9 @@ def confirm_signed_email(
         if request.user.id != int(data["user_id"]):
             raise InvalidRequest
 
-        email, _created = UserEmail.objects.update_or_create(
+        # Verifying an existing unverified email is a separate path
+        # This path is only emails that don't exist yet
+        email, created = UserEmail.objects.get_or_create(
             user_id=request.user.id,
             email=data["email"],
             defaults={"validation_hash": "", "is_verified": True},
@@ -423,15 +425,16 @@ def confirm_signed_email(
         logger.exception("user.email.signed-confirm.error")
         msg, level = ERR_CONFIRMING_EMAIL, messages.ERROR
     else:
-        email_verified.send(email=email.email, sender=email)
-        logger.info(
-            "user.email.signed-confirm",
-            extra={
-                "user_id": request.user.id,
-                "ip_address": request.META["REMOTE_ADDR"],
-                "email": email.email,
-            },
-        )
+        if created:
+            email_verified.send(email=email.email, sender=email)
+            logger.info(
+                "user.email.signed-confirm",
+                extra={
+                    "user_id": request.user.id,
+                    "ip_address": request.META["REMOTE_ADDR"],
+                    "email": email.email,
+                },
+            )
         msg, level = SUCCESS_CONFIRMING_EMAIL, messages.SUCCESS
 
     messages.add_message(request, level, msg)

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -46,16 +46,8 @@ ERR_SIGNATURE_EXPIRED = _(
     "Settings to resend the verification email."
 )
 
-INFO_EMAIL_ALREADY_VERIFIED = _("The email you are trying to verify has already been verified.")
-
 
 class InvalidRequest(Exception):
-    pass
-
-
-class VerifiedEmailAlreadyExists(Exception):
-    """email already exists as a verified email on the account"""
-
     pass
 
 
@@ -419,19 +411,11 @@ def confirm_signed_email(
         if request.user.id != int(data["user_id"]):
             raise InvalidRequest
 
-        # check to see if the email has already been verified
-        try:
-            email = UserEmail.objects.get(user=request.user.id, email=data["email"])
-            if email.is_verified:
-                raise VerifiedEmailAlreadyExists()
-        except UserEmail.DoesNotExist:
-            # user email does not exist, so we can create it
-            pass
-    except VerifiedEmailAlreadyExists:
-        msg = INFO_EMAIL_ALREADY_VERIFIED
-        level = messages.INFO
-        messages.add_message(request, level, msg)
-        return HttpResponseRedirect(reverse("sentry-account-settings-emails"))
+        email, _created = UserEmail.objects.update_or_create(
+            user_id=request.user.id,
+            email=data["email"],
+            defaults={"validation_hash": "", "is_verified": True},
+        )
     except SignatureExpired:
         msg = ERR_SIGNATURE_EXPIRED
         level = messages.ERROR
@@ -448,15 +432,6 @@ def confirm_signed_email(
         level = messages.ERROR
         messages.add_message(request, level, msg)
         return HttpResponseRedirect(reverse("sentry-account-settings-emails"))
-
-    user = User.objects.get(id=request.user.id)
-    email = UserEmail.objects.create(
-        user=user,
-        email=data["email"],
-        validation_hash="",
-        is_verified=True,
-    )
-    email.save()
 
     email_verified.send(email=email.email, sender=email)
     logger.info(

--- a/tests/sentry/users/api/endpoints/test_user_emails.py
+++ b/tests/sentry/users/api/endpoints/test_user_emails.py
@@ -87,6 +87,53 @@ class UserEmailsTest(APITestCase):
         assert user.email != "altemail1@example.com"
         assert user.username != "altemail1@example.com"
 
+    def test_change_email_not_on_account_to_primary(self) -> None:
+        response = self.client.put(self.url, data={"email": "neveradded@example.com"})
+        assert response.status_code == 400, response.data
+
+        user = User.objects.get(id=self.user.id)
+        assert user.email == "foo@example.com"
+        assert not UserEmail.objects.filter(user=self.user, email="neveradded@example.com").exists()
+
+    def test_change_to_email_on_another_account(self) -> None:
+        shared_email = "shared@example.com"
+        # another account already owns this email as its primary
+        self.create_user(email=shared_email)
+        # current user has added and verified the same email as a secondary
+        self.create_useremail(user=self.user, email=shared_email, is_verified=True)
+
+        response = self.client.put(self.url, data={"email": shared_email})
+        assert response.status_code == 400, response.data
+        assert "another account" in str(response.data["email"])
+
+        user = User.objects.get(id=self.user.id)
+        assert user.email == "foo@example.com"
+
+    def test_change_primary_migrates_matching_user_options(self) -> None:
+        new_email = "altemail1@example.com"
+        self.create_useremail(user=self.user, email=new_email, is_verified=True)
+
+        # a per-project notification option pointing at the current primary
+        matching_option = UserOption.objects.create(
+            user=self.user, project_id=self.project.id, key="mail:email", value="foo@example.com"
+        )
+        # a per-project option pointing at a different address - must be left alone
+        other_project = self.create_project(organization=self.organization)
+        unrelated_option = UserOption.objects.create(
+            user=self.user,
+            project_id=other_project.id,
+            key="mail:email",
+            value="elsewhere@example.com",
+        )
+
+        response = self.client.put(self.url, data={"email": new_email})
+        assert response.status_code == 200, response.data
+
+        matching_option.refresh_from_db()
+        unrelated_option.refresh_from_db()
+        assert matching_option.value == new_email
+        assert unrelated_option.value == "elsewhere@example.com"
+
     def test_remove_email(self) -> None:
         UserEmail.objects.create(user=self.user, email="altemail1@example.com")
 

--- a/tests/sentry/users/api/endpoints/test_user_emails.py
+++ b/tests/sentry/users/api/endpoints/test_user_emails.py
@@ -40,11 +40,12 @@ class UserEmailsTest(APITestCase):
         response = self.client.post(self.url, data={"email": "altemail1@example.com"})
 
         assert response.status_code == 201, response.data
-        assert UserEmail.objects.filter(user=self.user, email="altemail1@example.com").exists()
+        # email is not in db yet - only saved when verified
+        assert not UserEmail.objects.filter(user=self.user, email="altemail1@example.com").exists()
 
-        # duplicate email returns 409
+        # duplicate email returns 201
         response = self.client.post(self.url, data={"email": "altemail1@example.com"})
-        assert response.status_code == 409, response.data
+        assert response.status_code == 201, response.data
 
     def test_cant_have_same_email_with_different_casing(self) -> None:
         user = self.create_user(email="FOOBAR@example.com")

--- a/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
@@ -130,11 +130,48 @@ class UserEmailsConfirmTest(APITestCase):
         assert resp.status_code == 200
         assert resp.redirect_chain == [(reverse("sentry-account-settings-emails"), 302)]
 
+        # Confirmation is idempotent: re-confirming an already-verified email
+        # succeeds rather than surfacing an error.
         messages = list(resp.context["messages"])
         assert len(messages) == 1
-        assert (
-            messages[0].message == "The email you are trying to verify has already been verified."
+        assert messages[0].message == "Thanks for confirming your email"
+
+    def test_confirm_email_existing_unverified(self) -> None:
+        from sentry import options
+
+        EMAIL_CONFIRMATION_SALT = options.get("user-settings.signed-url-confirmation-emails-salt")
+
+        self.login_as(self.user)
+
+        new_email = "newemailfromsignedurl@example.com"
+
+        # An unverified row already exists (e.g. created when the email was added).
+        UserEmail.objects.create(
+            user=self.user,
+            email=new_email,
+            is_verified=False,
         )
+
+        signed_data = sign(
+            user_id=self.user.id,
+            email=new_email,
+            salt=EMAIL_CONFIRMATION_SALT,
+        )
+
+        signed_url = reverse("sentry-account-confirm-signed-email", args=[signed_data])
+
+        resp = self.client.get(signed_url, follow=True)
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [(reverse("sentry-account-settings-emails"), 302)]
+
+        # The existing row is verified in place, not duplicated.
+        user_email = UserEmail.objects.get(user=self.user, email=new_email)
+        assert user_email.is_verified
+        assert UserEmail.objects.filter(user=self.user, email=new_email).count() == 1
+
+        messages = list(resp.context["messages"])
+        assert len(messages) == 1
+        assert messages[0].message == "Thanks for confirming your email"
 
     def test_confirm_email_expired_signature(self) -> None:
         from datetime import timedelta

--- a/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
@@ -136,43 +136,6 @@ class UserEmailsConfirmTest(APITestCase):
         assert len(messages) == 1
         assert messages[0].message == "Thanks for confirming your email"
 
-    def test_confirm_email_existing_unverified(self) -> None:
-        from sentry import options
-
-        EMAIL_CONFIRMATION_SALT = options.get("user-settings.signed-url-confirmation-emails-salt")
-
-        self.login_as(self.user)
-
-        new_email = "newemailfromsignedurl@example.com"
-
-        # An unverified row already exists (e.g. created when the email was added).
-        UserEmail.objects.create(
-            user=self.user,
-            email=new_email,
-            is_verified=False,
-        )
-
-        signed_data = sign(
-            user_id=self.user.id,
-            email=new_email,
-            salt=EMAIL_CONFIRMATION_SALT,
-        )
-
-        signed_url = reverse("sentry-account-confirm-signed-email", args=[signed_data])
-
-        resp = self.client.get(signed_url, follow=True)
-        assert resp.status_code == 200
-        assert resp.redirect_chain == [(reverse("sentry-account-settings-emails"), 302)]
-
-        # The existing row is verified in place, not duplicated.
-        user_email = UserEmail.objects.get(user=self.user, email=new_email)
-        assert user_email.is_verified
-        assert UserEmail.objects.filter(user=self.user, email=new_email).count() == 1
-
-        messages = list(resp.context["messages"])
-        assert len(messages) == 1
-        assert messages[0].message == "Thanks for confirming your email"
-
     def test_confirm_email_expired_signature(self) -> None:
         from datetime import timedelta
 

--- a/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
@@ -3,7 +3,6 @@ from unittest import mock
 from django.urls import reverse
 
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.useremail import UserEmail
 from sentry.utils.signing import sign
@@ -47,12 +46,6 @@ class UserEmailsConfirmTest(APITestCase):
         self.get_error_response(self.user.id, email="", status_code=400)
         assert send_confirm_email.call_count == 0
 
-    @override_options(
-        {
-            "user-settings.signed-url-confirmation-emails": True,
-            "user-settings.signed-url-confirmation-emails-salt": "signed-url-confirmation-emails-salt",
-        }
-    )
     def test_confirm_email_signed_url(self) -> None:
         from sentry import options
 
@@ -81,12 +74,6 @@ class UserEmailsConfirmTest(APITestCase):
         assert len(messages) == 1
         assert messages[0].message == "Thanks for confirming your email"
 
-    @override_options(
-        {
-            "user-settings.signed-url-confirmation-emails": True,
-            "user-settings.signed-url-confirmation-emails-salt": "signed-url-confirmation-emails-salt",
-        }
-    )
     def test_confirm_email_invalid_signed_url(self) -> None:
         self.login_as(self.user)
 
@@ -115,12 +102,6 @@ class UserEmailsConfirmTest(APITestCase):
             == "There was an error confirming your email. Please try again or visit your Account Settings to resend the verification email."
         )
 
-    @override_options(
-        {
-            "user-settings.signed-url-confirmation-emails": True,
-            "user-settings.signed-url-confirmation-emails-salt": "signed-url-confirmation-emails-salt",
-        }
-    )
     def test_confirm_email_already_verified(self) -> None:
         from sentry import options
 
@@ -155,12 +136,6 @@ class UserEmailsConfirmTest(APITestCase):
             messages[0].message == "The email you are trying to verify has already been verified."
         )
 
-    @override_options(
-        {
-            "user-settings.signed-url-confirmation-emails": True,
-            "user-settings.signed-url-confirmation-emails-salt": "signed-url-confirmation-emails-salt",
-        }
-    )
     def test_confirm_email_expired_signature(self) -> None:
         from datetime import timedelta
 
@@ -191,31 +166,4 @@ class UserEmailsConfirmTest(APITestCase):
         assert (
             messages[0].message
             == "The confirmation link has expired. Please visit your Account Settings to resend the verification email."
-        )
-
-    @override_options(
-        {
-            "user-settings.signed-url-confirmation-emails": False,
-            "user-settings.signed-url-confirmation-emails-salt": "signed-url-confirmation-emails-salt",
-        }
-    )
-    def test_confirm_email_signed_urls_disabled(self) -> None:
-        self.login_as(self.user)
-
-        new_email = "newemailfromsignedurl@example.com"
-        signed_data = sign(
-            user_id=self.user.id,
-            email=new_email,
-            salt="signed-url-confirmation-emails-salt",
-        )
-        resp = self.client.get(
-            reverse("sentry-account-confirm-signed-email", args=[signed_data]), follow=True
-        )
-        assert resp.status_code == 200
-
-        messages = list(resp.context["messages"])
-        assert len(messages) == 1
-        assert (
-            messages[0].message
-            == "There was an error confirming your email. Please try again or visit your Account Settings to resend the verification email."
         )


### PR DESCRIPTION
## Summary
- Default `user-settings.signed-url-confirmation-emails` to `True` and remove all option-checking branches
- Signed-URL verification is now the only code path for adding secondary emails — the legacy hash-based flow is removed
- Clean up tests that toggled the option

## Context
This option has been enabled in production since January 2025. 
Removing the dead code path so we're not maintaining two flows.

Self-hosted instances that disable the built-in SMTP server will lose the ability to add secondary emails (no way to send verification links). Companion docs update makes this dependency explicit.