### PR TITLE
fix(issues): Show issue row checkbox on keyboard focus"

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -762,7 +762,7 @@ const Wrapper = styled(PanelItem)<{
   padding: ${p => p.theme.space.md} 0;
   min-height: 82px;
 
-  &:not(:has(:hover)):not(:has(input:checked)) {
+  &:not(:has(:hover)):not(:has(input:checked)):not(:focus-within) {
     ${CheckboxLabel} {
       ${p => p.theme.visuallyHidden};
     }


### PR DESCRIPTION
On the issues list we hide each row’s checkbox until you hover (or until it’s already checked). That’s fine with a mouse, but if you tab through the list you can still land on the checkbox and toggle it with Space—you just can’t see it.

This adds `:focus-within` to that hide rule in `group.tsx`, so the checkbox shows up whenever focus is anywhere in the row. 

Hover behavior stays the same.