### PR TITLE
feat(sentry-apps): Log external response code and body on issue-link failures

### DIFF
--- a/src/sentry/sentry_apps/external_requests/issue_link_requester.py
+++ b/src/sentry/sentry_apps/external_requests/issue_link_requester.py
@@ -30,6 +30,9 @@ FAILURE_REASON_BASE = f"{SentryAppEventType.EXTERNAL_ISSUE_LINKED}.{{}}"
 BAD_RESPONSE_HALT_REASON = FAILURE_REASON_BASE.format(
     SentryAppExternalRequestHaltReason.BAD_RESPONSE
 )
+# External response bodies can be large and may contain sensitive data, so we
+# only log a truncated copy to internal logs (never surfaced to the client).
+MAX_LOGGED_RESPONSE_BODY = 1024
 
 
 class IssueRequestActionType(StrEnum):
@@ -116,9 +119,21 @@ class IssueLinkRequester:
                 )
             except RequestException as e:
                 extras["error_message"] = str(e)
+
+                # Forward the status code and body the external service actually
+                # returned so we can tell why these requests fail. Kept in the
+                # internal halt log only — not added to the client-facing
+                # message or the integrator webhook_context, since the body is
+                # unbounded and may contain sensitive data.
+                log_extras = {**extras}
+                response = getattr(e, "response", None)
+                if response is not None:
+                    log_extras["external_status_code"] = response.status_code
+                    log_extras["external_response_body"] = response.text[:MAX_LOGGED_RESPONSE_BODY]
+
                 lifecycle.record_halt(
                     halt_reason=e,
-                    extra={"halt_reason": BAD_RESPONSE_HALT_REASON, **extras},
+                    extra={"halt_reason": BAD_RESPONSE_HALT_REASON, **log_extras},
                 )
 
                 raise SentryAppIntegratorError(

--- a/tests/sentry/sentry_apps/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/sentry_apps/external_requests/test_issue_link_requester.py
@@ -5,6 +5,7 @@ import responses
 from requests import HTTPError
 
 from sentry.integrations.types import EventLifecycleOutcome
+from sentry.integrations.utils.metrics import EventLifecycle
 from sentry.sentry_apps.external_requests.issue_link_requester import (
     FAILURE_REASON_BASE,
     IssueLinkRequester,
@@ -216,6 +217,48 @@ class TestIssueLinkRequester(TestCase):
         assert_count_of_metric(
             mock_record=mock_record, outcome=EventLifecycleOutcome.HALTED, outcome_count=2
         )
+
+    @responses.activate
+    def test_request_failure_records_external_response_diagnostics(self) -> None:
+        # A 4xx body that stands in for sensitive data the integrator returned.
+        external_body = "token=super-secret-do-not-leak"
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issue",
+            body=external_body,
+            status=400,
+        )
+
+        captured: dict[str, object] = {}
+        original_record_halt = EventLifecycle.record_halt
+
+        def spy(self: EventLifecycle, *args: object, **kwargs: object) -> None:
+            captured["extra"] = kwargs.get("extra")
+            return original_record_halt(self, *args, **kwargs)
+
+        with patch.object(EventLifecycle, "record_halt", autospec=True, side_effect=spy):
+            with pytest.raises(SentryAppIntegratorError) as exception_info:
+                IssueLinkRequester(
+                    install=self.install,
+                    group=self.group,
+                    uri="/link-issue",
+                    fields={},
+                    user=self.rpc_user,
+                    action=IssueRequestActionType("create"),
+                ).run()
+
+        # The external status code and (truncated) body are forwarded to the
+        # internal halt log so we can see why these requests fail.
+        halt_extra = captured["extra"]
+        assert isinstance(halt_extra, dict)
+        assert halt_extra["external_status_code"] == 400
+        assert halt_extra["external_response_body"] == external_body
+
+        # ...but they must never reach the client-facing message or the
+        # integrator webhook_context.
+        assert external_body not in exception_info.value.message
+        assert "external_response_body" not in exception_info.value.webhook_context
+        assert "external_status_code" not in exception_info.value.webhook_context
 
     @responses.activate
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")


### PR DESCRIPTION
Forward the status code and a truncated response body that an external Sentry App returns into the existing halt log for `IssueLinkRequester`, so we can see *why* issue-link requests to integrators fail.

## Background

After migrating the Sentry App schema form (`sentryAppExternalForm.new.tsx`), a wave of `InternalServerError: POST /sentry-app-installations/{uuid}/external-issue-actions/ 500` errors appeared in Sentry, spread across many orgs/installations.

These 500s are not new. The previous form only showed a toast on submit failure; the migrated form reports every submit failure via `Sentry.captureException`, so pre-existing backend failures are now visible. On the backend, `IssueLinkRequester.run()` already raises `SentryAppIntegratorError(status_code=500)` whenever an external app returns a non-2xx (`RequestException`), an unparseable body, or a schema-invalid response — and every case collapses into a single `bad_response` halt reason. We currently can't tell whether the integrator returned a 4xx, a 5xx, or whether the connection itself failed.

## What this does

In the `RequestException` branch, when the external service returned a response, record its `external_status_code` and a truncated `external_response_body` in the `lifecycle.record_halt` extras.

These diagnostics live in the internal SLO/halt log only. They are deliberately **not** added to the client-facing error message or the integrator `webhook_context`, because the body is unbounded and may contain sensitive data. (`get_public_dict()`/`to_public_dict()` only surface `message` + `public_context` to the client, so the body never reaches end users.)

## What this does not do

No status code or response-contract change — the request still fails with 500 exactly as before. This is purely added observability, so it carries no test churn for the endpoint/RPC layers.

This is the more conservative counterpart to #116467, which surfaced the same data but put the raw external body into the client-facing error message and flipped 500→502 (breaking the RPC/endpoint tests).

## Review notes

Please confirm the body cap (`MAX_LOGGED_RESPONSE_BODY = 1024`) and that keeping the body strictly in the internal halt log (not `webhook_context`) is the right boundary.