### PR TITLE
fix(sentry-apps): Omit empty optional fields from issue-link submissions

### DIFF
--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.spec.tsx
@@ -161,4 +161,58 @@ describe('SentryAppExternalFormNew', () => {
       )
     );
   });
+
+  it('omits optional fields the user never filled from the submitted payload', async () => {
+    const submitUrl = `/sentry-app-installations/${sentryAppInstallation.uuid}/external-issue-actions/`;
+    const submitRequest = MockApiClient.addMockResponse({
+      method: 'POST',
+      url: submitUrl,
+      body: {},
+    });
+
+    const config: ComponentProps<typeof SentryAppExternalFormNew>['config'] = {
+      uri: '/integrations/sentry/issues/create',
+      required_fields: [{type: 'text', name: 'title', label: 'Title'}],
+      optional_fields: [
+        {
+          type: 'select',
+          name: 'priority_id',
+          label: 'Priority',
+          choices: [
+            ['p1', 'High'],
+            ['p2', 'Low'],
+          ],
+        },
+      ],
+    };
+
+    render(
+      <SentryAppExternalFormNew
+        sentryAppInstallationUuid={sentryAppInstallation.uuid}
+        appName={sentryApp.name}
+        config={config}
+        action="create"
+        element="issue-link"
+        onSubmitSuccess={jest.fn()}
+      />
+    );
+
+    await userEvent.type(screen.getByRole('textbox', {name: 'Title'}), 'It broke');
+    await userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+    // The untouched optional select must be dropped, not sent as
+    // `priority_id: null`. Matching `data` exactly asserts its absence.
+    await waitFor(() =>
+      expect(submitRequest).toHaveBeenCalledWith(
+        submitUrl,
+        expect.objectContaining({
+          data: {
+            title: 'It broke',
+            action: 'create',
+            uri: '/integrations/sentry/issues/create',
+          },
+        })
+      )
+    );
+  });
 });

--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import * as Sentry from '@sentry/react';
 import {queryOptions, useMutation, useQueryClient} from '@tanstack/react-query';
+import omitBy from 'lodash/omitBy';
 
 import {Flex} from '@sentry/scraps/layout';
 
@@ -1019,7 +1020,9 @@ export function SentryAppExternalFormNew({
         method: 'POST',
         data: {
           ...normalizedExtraFields,
-          ...values,
+          // The adapter seeds untouched fields (selects become null); the legacy
+          // FormModel sent only filled values, so reuse hasValue to drop empties.
+          ...omitBy(values, value => !hasValue(value)),
           action,
           uri: config.uri,
         },


### PR DESCRIPTION
Strip empty values from the Sentry App issue-link form payload before submit.

## Why

The migrated form's adapter seeds every field with a value, so an untouched optional `select` submits as `<field>_id: null`. The legacy `FormModel` left untouched fields `undefined`, which `JSON.stringify` dropped — so they were never sent. Some external integrations reject these unexpected `null` ids, surfacing as a 500 from `…/external-issue-actions/`. This restores the prior wire behavior.

## Fix

Filter out empty values before they hit the request body, reusing the form's existing `hasValue` helper (via `lodash/omitBy`): `...omitBy(values, value => !hasValue(value))`. This drops `null`/`undefined`/`''` while keeping meaningful values like `0`/`"0"`. Scoped to the sentry-app form, not the shared adapter, since other consumers may treat `null` as meaningful.

Regression test added; existing tests, typecheck, and lint pass.