### PR TITLE
ref(stats): Remove barMinHeight from usage chart bars

### DIFF
--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -372,7 +372,6 @@ function UsageChartBody({
     BarSeries({
       name: SeriesTypes.ACCEPTED,
       data: chartData.accepted,
-      barMinHeight: 1,
       stack: 'usage',
       legendHoverLink: false,
     }),
@@ -381,7 +380,6 @@ function UsageChartBody({
           BarSeries({
             name: SeriesTypes.ACCEPTED,
             data: chartData.accepted_stored,
-            barMinHeight: 1,
             barGap: '-100%',
             z: 3,
             silent: true,
@@ -401,14 +399,12 @@ function UsageChartBody({
     BarSeries({
       name: SeriesTypes.FILTERED,
       data: chartData.filtered,
-      barMinHeight: 1,
       stack: 'usage',
       legendHoverLink: false,
     }),
     BarSeries({
       name: SeriesTypes.RATE_LIMITED,
       data: chartData.rateLimited,
-      barMinHeight: 1,
       stack: 'usage',
       legendHoverLink: false,
     }),
@@ -427,7 +423,6 @@ function UsageChartBody({
     BarSeries({
       name: SeriesTypes.PROJECTED,
       data: chartData.projected,
-      barMinHeight: 1,
       stack: 'usage',
       legendHoverLink: false,
     }),


### PR DESCRIPTION
Remove `barMinHeight: 1` from the org stats usage chart bar series.

Several bar series (accepted, accepted_stored, filtered, rate-limited, and
projected) set `barMinHeight: 1`, so ECharts drew a 1px sliver even when the
underlying value was 0. The tooltip still reported the real value (0), but the
persistent tiny bar was purely cosmetic and could be misread as non-zero usage.

This behaviour is confusing users, so I am dropping it