### PR TITLE
fix(metrics): Add group by attribute fallback

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -12,6 +12,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {useMetricGroupByFallbackAttributes} from 'sentry/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsGroupBys,
@@ -59,6 +60,7 @@ export function GroupBySelector({
   const isDisabled = disabledReason !== undefined;
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
+  const hasTraceMetricFilter = Boolean(traceMetricFilter);
 
   const {data, isLoading} = useQuery({
     ...traceItemAttributeKeysOptions({
@@ -68,32 +70,41 @@ export function GroupBySelector({
       query: skipTraceMetricFilter ? undefined : traceMetricFilter,
     }),
     select: selectTraceItemTagCollection(),
-    enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
+    enabled: skipTraceMetricFilter || hasTraceMetricFilter,
   });
+
+  const {attributes: fallbackAttributes, isLoading: isFallbackLoading} =
+    useMetricGroupByFallbackAttributes({
+      enabled: !skipTraceMetricFilter && hasTraceMetricFilter,
+      traceMetric,
+    });
 
   const visibleNumberTags = useMemo(() => {
     return Object.fromEntries(
-      Object.entries(data?.numberAttributes ?? {}).filter(
-        ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
-      )
+      Object.entries({
+        ...fallbackAttributes.numberAttributes,
+        ...data?.numberAttributes,
+      }).filter(([key]) => !HiddenTraceMetricGroupByFields.includes(key))
     );
-  }, [data?.numberAttributes]);
+  }, [data?.numberAttributes, fallbackAttributes.numberAttributes]);
 
   const visibleStringTags = useMemo(() => {
     return Object.fromEntries(
-      Object.entries(data?.stringAttributes ?? {}).filter(
-        ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
-      )
+      Object.entries({
+        ...fallbackAttributes.stringAttributes,
+        ...data?.stringAttributes,
+      }).filter(([key]) => !HiddenTraceMetricGroupByFields.includes(key))
     );
-  }, [data?.stringAttributes]);
+  }, [data?.stringAttributes, fallbackAttributes.stringAttributes]);
 
   const visibleBooleanTags = useMemo(() => {
     return Object.fromEntries(
-      Object.entries(data?.booleanAttributes ?? {}).filter(
-        ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
-      )
+      Object.entries({
+        ...fallbackAttributes.booleanAttributes,
+        ...data?.booleanAttributes,
+      }).filter(([key]) => !HiddenTraceMetricGroupByFields.includes(key))
     );
-  }, [data?.booleanAttributes]);
+  }, [data?.booleanAttributes, fallbackAttributes.booleanAttributes]);
 
   const enabledOptions = useGroupByFields({
     groupBys,
@@ -142,8 +153,13 @@ export function GroupBySelector({
       )}
       options={enabledOptions}
       value={[...groupBys]}
-      loading={isLoading}
-      disabled={isDisabled || (!skipTraceMetricFilter && !traceMetricFilter)}
+      loading={isLoading || isFallbackLoading}
+      disabled={
+        isDisabled ||
+        isLoading ||
+        isFallbackLoading ||
+        (!skipTraceMetricFilter && !hasTraceMetricFilter)
+      }
       onChange={handleChange}
       style={{width: '100%'}}
     />

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -1,11 +1,14 @@
 import {type ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {MetricToolbar} from 'sentry/views/explore/metrics/metricToolbar';
 import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {
@@ -37,8 +40,10 @@ function Wrapper({
 
 describe('MetricToolbar', () => {
   let mockAttributesRequest: jest.Mock;
+  const project = ProjectFixture({id: '1', slug: 'project-slug'});
 
   beforeEach(() => {
+    ProjectsStore.loadInitialData([project]);
     mockAttributesRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/trace-items/attributes/',
       body: [],
@@ -51,6 +56,10 @@ describe('MetricToolbar', () => {
       url: '/organizations/org-slug/recent-searches/',
       body: [],
     });
+  });
+
+  afterEach(() => {
+    ProjectsStore.reset();
   });
 
   it('renders group by selector for equation visualizations', async () => {
@@ -134,5 +143,163 @@ describe('MetricToolbar', () => {
     );
 
     expect(await screen.findByRole('button', {name: /Group by/})).toBeInTheDocument();
+  });
+
+  it('merges trace item detail attributes into group by options', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-enabled'],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [
+        {
+          attributeType: 'string',
+          key: 'endpoint.attribute',
+          name: 'endpoint.attribute',
+        },
+        {
+          attributeType: 'string',
+          key: 'shared.attribute',
+          name: 'shared.attribute',
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [
+          {
+            [TraceMetricKnownFieldKey.ID]: 'metric-id',
+            [TraceMetricKnownFieldKey.PROJECT_ID]: project.id,
+            [TraceMetricKnownFieldKey.TRACE]: 'trace-id',
+            [TraceMetricKnownFieldKey.TIMESTAMP]: '2025-04-10T14:37:55+00:00',
+          },
+        ],
+        meta: {fields: {}},
+      },
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.explore.metric-samples-table',
+        }),
+      ],
+    });
+    const mockTraceItemDetailsRequest = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/trace-items/metric-id/',
+      asyncDelay: 50,
+      body: {
+        attributes: [
+          {name: 'fallback.string', type: 'str', value: 'value'},
+          {name: 'tags[fallback.number,number]', type: 'float', value: 1.23},
+          {name: 'tags[fallback.boolean,boolean]', type: 'bool', value: true},
+          {name: 'tags[sentry.item_type,number]', type: 'float', value: 0},
+          {name: 'shared.attribute', type: 'str', value: 'duplicate'},
+        ],
+        itemId: 'metric-id',
+        meta: {},
+        timestamp: '2025-04-10T14:37:55+00:00',
+      },
+    });
+
+    render(
+      <MetricToolbar
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryLabel="A"
+      />,
+      {
+        organization,
+        additionalWrapper: ({children}: {children: ReactNode}) => (
+          <Wrapper
+            queryParams={
+              new ReadableQueryParams({
+                extrapolate: true,
+                mode: Mode.SAMPLES,
+                query: '',
+                cursor: '',
+                fields: ['id', 'timestamp'],
+                sortBys: [{field: 'timestamp', kind: 'desc'}],
+                aggregateCursor: '',
+                aggregateFields: [
+                  new VisualizeFunction('sum(value,test_metric,distribution,none)'),
+                ],
+                aggregateSortBys: [
+                  {field: 'sum(value,test_metric,distribution,none)', kind: 'desc'},
+                ],
+              })
+            }
+          >
+            {children}
+          </Wrapper>
+        ),
+      }
+    );
+
+    const groupByButton = await screen.findByRole('button', {name: /Group by/});
+
+    await waitFor(() => {
+      expect(mockTraceItemDetailsRequest).toHaveBeenCalledTimes(1);
+      expect(groupByButton).toBeDisabled();
+    });
+
+    await waitFor(() => {
+      expect(groupByButton).toBeEnabled();
+    });
+
+    await userEvent.click(groupByButton);
+
+    expect(await screen.findByText('endpoint.attribute')).toBeInTheDocument();
+    expect(screen.getByText('fallback.string')).toBeInTheDocument();
+    expect(screen.getByText('fallback.number')).toBeInTheDocument();
+    expect(screen.getByText('fallback.boolean')).toBeInTheDocument();
+    expect(screen.getAllByText('shared.attribute')).toHaveLength(1);
+    expect(screen.queryByText('tags[fallback.number,number]')).not.toBeInTheDocument();
+    expect(screen.queryByText('sentry.item_type')).not.toBeInTheDocument();
+  });
+
+  it('does not fetch trace item detail fallback for equation visualizations', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+    });
+    const mockMetricSamplesRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [], meta: {fields: {}}},
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.explore.metric-samples-table',
+        }),
+      ],
+    });
+
+    render(
+      <MetricToolbar
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryLabel="ƒ1"
+        referenceMap={{A: 'sum(value)', B: 'avg(value)'}}
+      />,
+      {
+        organization,
+        additionalWrapper: ({children}: {children: ReactNode}) => (
+          <Wrapper
+            queryParams={
+              new ReadableQueryParams({
+                extrapolate: true,
+                mode: Mode.AGGREGATE,
+                query: '',
+                cursor: '',
+                fields: ['id', 'timestamp'],
+                sortBys: [{field: 'timestamp', kind: 'desc'}],
+                aggregateCursor: '',
+                aggregateFields: [new VisualizeEquation('equation|A + B')],
+                aggregateSortBys: [{field: 'equation|A + B', kind: 'desc'}],
+              })
+            }
+          >
+            {children}
+          </Wrapper>
+        ),
+      }
+    );
+
+    expect(await screen.findByRole('button', {name: /Group by/})).toBeInTheDocument();
+    expect(mockMetricSamplesRequest).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes.tsx
@@ -45,9 +45,9 @@ export function useMetricGroupByFallbackAttributes({
     defined(firstSample?.[TraceMetricKnownFieldKey.TRACE]);
 
   const traceDetailsResult = useMetricTraceDetail({
-    metricId: String(firstSample?.[TraceMetricKnownFieldKey.ID] ?? ''),
-    projectId: String(firstSample?.[TraceMetricKnownFieldKey.PROJECT_ID] ?? ''),
-    traceId: String(firstSample?.[TraceMetricKnownFieldKey.TRACE] ?? ''),
+    metricId: firstSample?.[TraceMetricKnownFieldKey.ID] ?? '',
+    projectId: firstSample?.[TraceMetricKnownFieldKey.PROJECT_ID] ?? '',
+    traceId: firstSample?.[TraceMetricKnownFieldKey.TRACE] ?? '',
     timestamp: getTimeStampFromTableDateField(
       firstSample?.[TraceMetricKnownFieldKey.TIMESTAMP]
     ),

--- a/static/app/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes.tsx
@@ -45,9 +45,9 @@ export function useMetricGroupByFallbackAttributes({
     defined(firstSample?.[TraceMetricKnownFieldKey.TRACE]);
 
   const traceDetailsResult = useMetricTraceDetail({
-    metricId: firstSample?.[TraceMetricKnownFieldKey.ID] ?? '',
-    projectId: firstSample?.[TraceMetricKnownFieldKey.PROJECT_ID] ?? '',
-    traceId: firstSample?.[TraceMetricKnownFieldKey.TRACE] ?? '',
+    metricId: String(firstSample?.[TraceMetricKnownFieldKey.ID] ?? ''),
+    projectId: String(firstSample?.[TraceMetricKnownFieldKey.PROJECT_ID] ?? ''),
+    traceId: String(firstSample?.[TraceMetricKnownFieldKey.TRACE] ?? ''),
     timestamp: getTimeStampFromTableDateField(
       firstSample?.[TraceMetricKnownFieldKey.TIMESTAMP]
     ),

--- a/static/app/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes.tsx
@@ -1,0 +1,102 @@
+import {useMemo} from 'react';
+
+import type {TagCollection} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
+import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
+import {prettifyTagKey} from 'sentry/utils/fields';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetricSamplesTable';
+import {useMetricTraceDetail} from 'sentry/views/explore/metrics/hooks/useMetricTraceDetail';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
+import {getTraceItemTagCollection} from 'sentry/views/explore/utils/traceItemAttributeKeysOptions';
+
+interface TraceItemTagCollections {
+  booleanAttributes: TagCollection;
+  numberAttributes: TagCollection;
+  stringAttributes: TagCollection;
+}
+
+const EMPTY_TAG_COLLECTIONS: TraceItemTagCollections = {
+  booleanAttributes: {},
+  numberAttributes: {},
+  stringAttributes: {},
+};
+
+export function useMetricGroupByFallbackAttributes({
+  enabled,
+  traceMetric,
+}: {
+  enabled: boolean;
+  traceMetric: TraceMetric;
+}) {
+  const sampleResult = useMetricSamplesTable({
+    disabled: !enabled,
+    fields: [],
+    limit: 1,
+    traceMetric,
+  });
+
+  const firstSample = sampleResult.result.data?.[0];
+  const canFetchTraceDetails =
+    enabled &&
+    defined(firstSample?.[TraceMetricKnownFieldKey.ID]) &&
+    defined(firstSample?.[TraceMetricKnownFieldKey.PROJECT_ID]) &&
+    defined(firstSample?.[TraceMetricKnownFieldKey.TRACE]);
+
+  const traceDetailsResult = useMetricTraceDetail({
+    metricId: String(firstSample?.[TraceMetricKnownFieldKey.ID] ?? ''),
+    projectId: String(firstSample?.[TraceMetricKnownFieldKey.PROJECT_ID] ?? ''),
+    traceId: String(firstSample?.[TraceMetricKnownFieldKey.TRACE] ?? ''),
+    timestamp: getTimeStampFromTableDateField(
+      firstSample?.[TraceMetricKnownFieldKey.TIMESTAMP]
+    ),
+    enabled: canFetchTraceDetails,
+  });
+
+  const attributes = useMemo(() => {
+    return getTagCollectionsFromTraceItemAttributes(
+      traceDetailsResult.data?.attributes ?? []
+    );
+  }, [traceDetailsResult.data?.attributes]);
+
+  return {
+    attributes,
+    isLoading:
+      enabled &&
+      (sampleResult.result.isFetching ||
+        !sampleResult.result.isFetched ||
+        (canFetchTraceDetails && traceDetailsResult.isLoading)),
+  };
+}
+
+function getTagCollectionsFromTraceItemAttributes(
+  attributes: TraceItemResponseAttribute[]
+): TraceItemTagCollections {
+  if (attributes.length === 0) {
+    return EMPTY_TAG_COLLECTIONS;
+  }
+
+  return getTraceItemTagCollection(
+    attributes.map(attribute => ({
+      attributeSource: {source_type: 'user'},
+      attributeType: getTraceItemAttributeType(attribute),
+      key: attribute.name,
+      name: prettifyTagKey(attribute.name),
+    }))
+  );
+}
+
+function getTraceItemAttributeType(
+  attribute: TraceItemResponseAttribute
+): 'boolean' | 'number' | 'string' {
+  if (attribute.type === 'int' || attribute.type === 'float') {
+    return 'number';
+  }
+
+  if (attribute.type === 'bool') {
+    return 'boolean';
+  }
+
+  return 'string';
+}


### PR DESCRIPTION
Adding in a fallback to the metrics group by selector to pull in data from the first trace item detail.