### PR TITLE
fix(metrics): Load fallback attributes in metric filters

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -22,7 +22,7 @@ import {
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricsTabSeerComboBox} from 'sentry/views/explore/metrics/metricsTabSeerComboBox';
-import {useMetricFallbackAttributes} from 'sentry/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes';
+import {useMetricFallbackAttributes} from 'sentry/views/explore/metrics/metricToolbar/useMetricFallbackAttributes';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsQuery,

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -22,6 +22,7 @@ import {
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricsTabSeerComboBox} from 'sentry/views/explore/metrics/metricsTabSeerComboBox';
+import {useMetricFallbackAttributes} from 'sentry/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsQuery,
@@ -82,7 +83,9 @@ export function Filter({
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
   const attributeQuery = skipTraceMetricFilter ? undefined : traceMetricFilter;
 
-  const {data: data} = useQuery({
+  const hasTraceMetricFilter = Boolean(traceMetricFilter);
+
+  const {data, isLoading} = useQuery({
     ...traceItemAttributeKeysOptions({
       organization,
       selection,
@@ -91,9 +94,15 @@ export function Filter({
       projectIds,
       environments,
     }),
-    enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
+    enabled: skipTraceMetricFilter || hasTraceMetricFilter,
     select: selectTraceItemTagCollection(),
   });
+
+  const {attributes: fallbackAttributes, isLoading: isFallbackLoading} =
+    useMetricFallbackAttributes({
+      enabled: !skipTraceMetricFilter && hasTraceMetricFilter,
+      traceMetric,
+    });
 
   const visibleNumberTags = useMemo(() => {
     const staticNumberTags = SENTRY_TRACEMETRIC_NUMBER_TAGS.reduce<TagCollection>(
@@ -106,15 +115,14 @@ export function Filter({
       {}
     );
 
-    return {
-      ...staticNumberTags,
-      ...Object.fromEntries(
-        Object.entries(data?.numberAttributes ?? {}).filter(
-          ([key]) => !HiddenTraceMetricSearchFields.includes(key)
-        )
-      ),
-    };
-  }, [data?.numberAttributes]);
+    return Object.fromEntries(
+      Object.entries({
+        ...staticNumberTags,
+        ...fallbackAttributes.numberAttributes,
+        ...data?.numberAttributes,
+      }).filter(([key]) => !HiddenTraceMetricSearchFields.includes(key))
+    );
+  }, [data?.numberAttributes, fallbackAttributes.numberAttributes]);
 
   const visibleStringTags = useMemo(() => {
     const staticStringTags = SENTRY_TRACEMETRIC_STRING_TAGS.reduce<TagCollection>(
@@ -127,15 +135,14 @@ export function Filter({
       {}
     );
 
-    return {
-      ...staticStringTags,
-      ...Object.fromEntries(
-        Object.entries(data?.stringAttributes ?? {}).filter(
-          ([key]) => !HiddenTraceMetricSearchFields.includes(key)
-        )
-      ),
-    };
-  }, [data?.stringAttributes]);
+    return Object.fromEntries(
+      Object.entries({
+        ...staticStringTags,
+        ...fallbackAttributes.stringAttributes,
+        ...data?.stringAttributes,
+      }).filter(([key]) => !HiddenTraceMetricSearchFields.includes(key))
+    );
+  }, [data?.stringAttributes, fallbackAttributes.stringAttributes]);
 
   const visibleBooleanTags = useMemo(() => {
     const staticBooleanTags = SENTRY_TRACEMETRIC_BOOLEAN_TAGS.reduce<TagCollection>(
@@ -148,15 +155,16 @@ export function Filter({
       {}
     );
 
-    return {
-      ...staticBooleanTags,
-      ...Object.fromEntries(
-        Object.entries(data?.booleanAttributes ?? {}).filter(
-          ([key]) => !HiddenTraceMetricSearchFields.includes(key)
-        )
-      ),
-    };
-  }, [data?.booleanAttributes]);
+    return Object.fromEntries(
+      Object.entries({
+        ...staticBooleanTags,
+        ...fallbackAttributes.booleanAttributes,
+        ...data?.booleanAttributes,
+      }).filter(([key]) => !HiddenTraceMetricSearchFields.includes(key))
+    );
+  }, [data?.booleanAttributes, fallbackAttributes.booleanAttributes]);
+
+  const isLoadingAttributes = isLoading || isFallbackLoading;
 
   const tracesItemSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps =
     useMemo(() => {
@@ -176,6 +184,8 @@ export function Filter({
         hiddenAttributeKeys: HiddenTraceMetricSearchFields,
         projects: projectIds,
         environments,
+        disabled:
+          isLoadingAttributes || (!skipTraceMetricFilter && !hasTraceMetricFilter),
 
         // Disable the recent searches when not using a trace metric filter or when the metric name
         // is not set because the recent searches for metrics need to be namespaced on the trace metric filter.
@@ -190,6 +200,8 @@ export function Filter({
       traceMetric.name,
       attributeQuery,
       skipTraceMetricFilter,
+      hasTraceMetricFilter,
+      isLoadingAttributes,
       projectIds,
       environments,
     ]);
@@ -204,6 +216,7 @@ export function Filter({
       // This prevents race conditions when navigating between different metrics
       key={traceMetric.name}
       {...searchQueryBuilderProviderProps}
+      disabled={tracesItemSearchQueryBuilderProps.disabled}
       enableAISearch={hasTranslateEndpoint && hasMetricsAISearch}
       aiSearchBadgeType="alpha"
     >

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -12,7 +12,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {useMetricGroupByFallbackAttributes} from 'sentry/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes';
+import {useMetricFallbackAttributes} from 'sentry/views/explore/metrics/metricToolbar/useMetricFallbackAttributes';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsGroupBys,
@@ -74,7 +74,7 @@ export function GroupBySelector({
   });
 
   const {attributes: fallbackAttributes, isLoading: isFallbackLoading} =
-    useMetricGroupByFallbackAttributes({
+    useMetricFallbackAttributes({
       enabled: !skipTraceMetricFilter && hasTraceMetricFilter,
       traceMetric,
     });

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -2,7 +2,13 @@ import {type ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
@@ -245,6 +251,119 @@ describe('MetricToolbar', () => {
     });
 
     await userEvent.click(groupByButton);
+
+    expect(await screen.findByText('endpoint.attribute')).toBeInTheDocument();
+    expect(screen.getByText('fallback.string')).toBeInTheDocument();
+    expect(screen.getByText('fallback.number')).toBeInTheDocument();
+    expect(screen.getByText('fallback.boolean')).toBeInTheDocument();
+    expect(screen.getAllByText('shared.attribute')).toHaveLength(1);
+    expect(screen.queryByText('tags[fallback.number,number]')).not.toBeInTheDocument();
+    expect(screen.queryByText('sentry.item_type')).not.toBeInTheDocument();
+  });
+
+  it('merges trace item detail attributes into query builder options on load', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-enabled'],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [
+        {
+          attributeType: 'string',
+          key: 'endpoint.attribute',
+          name: 'endpoint.attribute',
+        },
+        {
+          attributeType: 'string',
+          key: 'shared.attribute',
+          name: 'shared.attribute',
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [
+          {
+            [TraceMetricKnownFieldKey.ID]: 'metric-id',
+            [TraceMetricKnownFieldKey.PROJECT_ID]: project.id,
+            [TraceMetricKnownFieldKey.TRACE]: 'trace-id',
+            [TraceMetricKnownFieldKey.TIMESTAMP]: '2025-04-10T14:37:55+00:00',
+          },
+        ],
+        meta: {fields: {}},
+      },
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.explore.metric-samples-table',
+        }),
+      ],
+    });
+    const mockTraceItemDetailsRequest = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/trace-items/metric-id/',
+      asyncDelay: 50,
+      body: {
+        attributes: [
+          {name: 'fallback.string', type: 'str', value: 'value'},
+          {name: 'tags[fallback.number,number]', type: 'float', value: 1.23},
+          {name: 'tags[fallback.boolean,boolean]', type: 'bool', value: true},
+          {name: 'tags[sentry.item_type,number]', type: 'float', value: 0},
+          {name: 'shared.attribute', type: 'str', value: 'duplicate'},
+        ],
+        itemId: 'metric-id',
+        meta: {},
+        timestamp: '2025-04-10T14:37:55+00:00',
+      },
+    });
+
+    render(
+      <MetricToolbar
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryLabel="A"
+      />,
+      {
+        organization,
+        additionalWrapper: ({children}: {children: ReactNode}) => (
+          <Wrapper
+            queryParams={
+              new ReadableQueryParams({
+                extrapolate: true,
+                mode: Mode.SAMPLES,
+                query: '',
+                cursor: '',
+                fields: ['id', 'timestamp'],
+                sortBys: [{field: 'timestamp', kind: 'desc'}],
+                aggregateCursor: '',
+                aggregateFields: [
+                  new VisualizeFunction('sum(value,test_metric,distribution,none)'),
+                ],
+                aggregateSortBys: [
+                  {field: 'sum(value,test_metric,distribution,none)', kind: 'desc'},
+                ],
+              })
+            }
+          >
+            {children}
+          </Wrapper>
+        ),
+      }
+    );
+
+    const searchBuilder = await screen.findByTestId('search-query-builder');
+    const searchInput = within(searchBuilder).getByRole('combobox', {
+      name: 'Add a search term',
+    });
+
+    await waitFor(() => {
+      expect(mockTraceItemDetailsRequest).toHaveBeenCalled();
+      expect(searchInput).toBeDisabled();
+    });
+
+    await waitFor(() => {
+      expect(searchInput).toBeEnabled();
+    });
+
+    await userEvent.click(searchInput);
 
     expect(await screen.findByText('endpoint.attribute')).toBeInTheDocument();
     expect(screen.getByText('fallback.string')).toBeInTheDocument();

--- a/static/app/views/explore/metrics/metricToolbar/useMetricFallbackAttributes.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/useMetricFallbackAttributes.tsx
@@ -70,8 +70,6 @@ export function useMetricFallbackAttributes({
   };
 }
 
-export const useMetricGroupByFallbackAttributes = useMetricFallbackAttributes;
-
 function getTagCollectionsFromTraceItemAttributes(
   attributes: TraceItemResponseAttribute[]
 ): TraceItemTagCollections {

--- a/static/app/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/useMetricGroupByFallbackAttributes.tsx
@@ -23,7 +23,7 @@ const EMPTY_TAG_COLLECTIONS: TraceItemTagCollections = {
   stringAttributes: {},
 };
 
-export function useMetricGroupByFallbackAttributes({
+export function useMetricFallbackAttributes({
   enabled,
   traceMetric,
 }: {
@@ -69,6 +69,8 @@ export function useMetricGroupByFallbackAttributes({
         (canFetchTraceDetails && traceDetailsResult.isLoading)),
   };
 }
+
+export const useMetricGroupByFallbackAttributes = useMetricFallbackAttributes;
 
 function getTagCollectionsFromTraceItemAttributes(
   attributes: TraceItemResponseAttribute[]


### PR DESCRIPTION
Metric filters now load trace item detail fallback attributes into the query builder on initial load. This gives the filter builder the same fallback attribute coverage as metric group-by when the attribute index does not include all sample detail keys yet.