### PR TITLE
feat(seer): Add award-emoji parity to GitLab merge-request webhook handler

### DIFF
--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -2,16 +2,6 @@
 Handler for GitLab merge_request webhook events.
 https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#merge-request-events
 
-Award emoji parity with the GitHub webhook forwarder
------------------------------------------------------
-
-The GitHub pull_request handler adds :eyes: to the PR description (and removes
-any stale :tada:) to signal that a Seer review run is in progress. This handler
-replicates that behaviour for GitLab merge requests via the SCM library's
-provider-agnostic reaction actions (``scm.actions.create_pull_request_reaction``
-and friends). The call is skipped for close/merge actions since those are cleanup
-events, not new review triggers.
-
 Known limitations
 -----------------
 

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -44,10 +44,17 @@ from datetime import datetime, timezone
 from typing import Any
 
 from pydantic import ValidationError
+from scm import actions as scm_actions
+from scm.types import (
+    CreatePullRequestReactionProtocol,
+    DeletePullRequestReactionProtocol,
+    GetAuthenticatedActorProtocol,
+    GetPullRequestReactionsProtocol,
+    Reaction,
+    ReactionResult,
+)
 
 from sentry import features
-from scm import actions as scm_actions
-
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
@@ -63,9 +70,11 @@ from sentry.utils import json
 from sentry.utils.redis import redis_clusters
 
 from ..metrics import (
+    CodeReviewErrorType,
     WebhookFilteredReason,
     record_webhook_enqueued,
     record_webhook_filtered,
+    record_webhook_handler_error,
     record_webhook_received,
 )
 from ..preflight import CodeReviewPreflightService
@@ -185,51 +194,91 @@ def _delete_existing_reactions_and_add_reaction(
     organization_id: int,
     repo: Repository,
     mr_iid: str,
-    reactions_to_delete: list[str],
-    reaction_to_add: str | None,
+    action_value: str,
+    reactions_to_delete: list[Reaction],
+    reaction_to_add: Reaction | None,
 ) -> None:
     """
-    Delete stale reactions on the MR description and add a fresh one.
+    Delete stale reactions on the MR and add a fresh one.
 
     Mirrors ``delete_existing_reactions_and_add_reaction`` from the GitHub webhook
     path. Uses the SCM library's provider-agnostic reaction actions so the logic
-    is identical for every supported SCM provider. Errors are logged and swallowed
-    so that a failing reaction call never blocks the Seer review task.
+    is identical for every supported SCM provider. Errors are logged, recorded as
+    a ``REACTION_FAILED`` metric, and swallowed so a failing reaction call never
+    blocks the Seer review task.
 
     ``reactions_to_delete`` and ``reaction_to_add`` use the SCM ``Reaction`` type
     values (e.g. ``"hooray"`` for :tada:, ``"eyes"`` for :eyes:); the provider
     translates them to platform-specific names (GitLab award emoji, etc.).
+
+    Unlike GitHub (where re-adding a reaction is idempotent), GitLab rejects a
+    duplicate ``award_emoji`` POST, so we only add ``reaction_to_add`` when our own
+    user has not already placed it; otherwise a re-review of an MR that already has
+    :eyes: would fail on every trigger.
     """
     try:
         scm = scm_factory.new(organization_id, repo.id, "code-review-webhook")
     except Exception:
         logger.warning("gitlab.webhook.merge_request.reaction.scm_init_failed")
+        record_webhook_handler_error(
+            GITLAB_WEBHOOK_EVENT, action_value, CodeReviewErrorType.REACTION_FAILED
+        )
         return
 
-    if reactions_to_delete:
-        try:
-            # Identify reactions placed by the current OAuth user (our integration bot)
-            # so we only remove our own reactions, not those from other users.
-            current_actor = scm_actions.get_authenticated_actor(scm)["data"]
-            current_actor_id = current_actor["id"]
-            existing = scm_actions.get_pull_request_reactions(scm, mr_iid)["data"]
-            for reaction in existing:
-                author = reaction.get("author")
-                if (
-                    author is not None
-                    and author.get("id") == current_actor_id
-                    and reaction.get("content") in reactions_to_delete
-                    and reaction.get("id")
-                ):
-                    scm_actions.delete_pull_request_reaction(scm, mr_iid, str(reaction["id"]))
-        except Exception:
-            logger.warning("gitlab.webhook.merge_request.reaction.delete_failed", exc_info=True)
+    # The SCM facade only exposes capability methods after narrowing against the
+    # relevant runtime-checkable protocols (see ``scm.facade.Facade``); a provider
+    # that does not support reactions would not satisfy these checks.
+    if not (
+        isinstance(scm, GetAuthenticatedActorProtocol)
+        and isinstance(scm, GetPullRequestReactionsProtocol)
+        and isinstance(scm, CreatePullRequestReactionProtocol)
+        and isinstance(scm, DeletePullRequestReactionProtocol)
+    ):
+        logger.warning("gitlab.webhook.merge_request.reaction.unsupported_provider")
+        record_webhook_handler_error(
+            GITLAB_WEBHOOK_EVENT, action_value, CodeReviewErrorType.REACTION_FAILED
+        )
+        return
 
-    if reaction_to_add:
+    # Reactions placed by the current OAuth user (our integration identity). We only
+    # ever touch our own reactions, and reuse this list to skip a redundant add.
+    own_reactions: list[ReactionResult] = []
+    if reactions_to_delete or reaction_to_add:
+        try:
+            current_actor_id = scm_actions.get_authenticated_actor(scm)["data"]["id"]
+            existing = scm_actions.get_pull_request_reactions(scm, mr_iid)["data"]
+            own_reactions = [
+                reaction
+                for reaction in existing
+                if (author := reaction.get("author")) is not None
+                and author["id"] == current_actor_id
+            ]
+        except Exception:
+            logger.warning("gitlab.webhook.merge_request.reaction.fetch_failed", exc_info=True)
+            record_webhook_handler_error(
+                GITLAB_WEBHOOK_EVENT, action_value, CodeReviewErrorType.REACTION_FAILED
+            )
+
+    for reaction in own_reactions:
+        if reaction.get("content") in reactions_to_delete and reaction.get("id"):
+            try:
+                scm_actions.delete_pull_request_reaction(scm, mr_iid, str(reaction["id"]))
+            except Exception:
+                logger.warning("gitlab.webhook.merge_request.reaction.delete_failed", exc_info=True)
+                record_webhook_handler_error(
+                    GITLAB_WEBHOOK_EVENT, action_value, CodeReviewErrorType.REACTION_FAILED
+                )
+
+    if reaction_to_add and not any(
+        reaction.get("content") == reaction_to_add for reaction in own_reactions
+    ):
         try:
             scm_actions.create_pull_request_reaction(scm, mr_iid, reaction_to_add)
         except Exception:
             logger.warning("gitlab.webhook.merge_request.reaction.add_failed", exc_info=True)
+            record_webhook_handler_error(
+                GITLAB_WEBHOOK_EVENT, action_value, CodeReviewErrorType.REACTION_FAILED
+            )
 
 
 def handle_merge_request_event(
@@ -347,6 +396,7 @@ def handle_merge_request_event(
                 organization_id=org.id,
                 repo=repo,
                 mr_iid=str(mr_iid),
+                action_value=action_value,
                 reactions_to_delete=["hooray"],
                 reaction_to_add="eyes",
             )

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -223,21 +223,15 @@ def _delete_existing_awards_and_add_award(
                         and award.get("id")
                         and award.get("name") in emojis_to_delete
                     ):
-                        client.delete_merge_request_award(
-                            project_id, mr_iid, str(award["id"])
-                        )
+                        client.delete_merge_request_award(project_id, mr_iid, str(award["id"]))
         except Exception:
-            logger.warning(
-                "gitlab.webhook.merge_request.award.delete_failed", exc_info=True
-            )
+            logger.warning("gitlab.webhook.merge_request.award.delete_failed", exc_info=True)
 
     if emoji_to_add:
         try:
             client.create_merge_request_award(project_id, mr_iid, emoji_to_add)
         except Exception:
-            logger.warning(
-                "gitlab.webhook.merge_request.award.add_failed", exc_info=True
-            )
+            logger.warning("gitlab.webhook.merge_request.award.add_failed", exc_info=True)
 
 
 def handle_merge_request_event(

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -2,6 +2,15 @@
 Handler for GitLab merge_request webhook events.
 https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#merge-request-events
 
+Award emoji parity with the GitHub webhook forwarder
+-----------------------------------------------------
+
+The GitHub pull_request handler adds :eyes: to the PR description (and removes
+any stale :tada:) to signal that a Seer review run is in progress. This handler
+replicates that behaviour for GitLab merge requests using the GitLab award emoji
+API (``/projects/:id/merge_requests/:mr_iid/award_emoji``). The call is skipped
+for close/merge actions since those are cleanup events, not new review triggers.
+
 Known limitations
 -----------------
 
@@ -58,6 +67,12 @@ from ..metrics import (
 from ..preflight import CodeReviewPreflightService
 from ..utils import SeerEndpoint, _common_codegen_request_payload
 from .task import process_github_webhook_event
+
+# GitLab award emoji names used by the Seer code-review flow.
+# "tada" is the GitLab equivalent of GitHub's "hooray" (:tada: 🎉).
+# "eyes" is the same on both platforms (:eyes: 👀).
+GITLAB_EMOJI_TADA = "tada"
+GITLAB_EMOJI_EYES = "eyes"
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +182,64 @@ def _resolve_review_trigger(
     return None
 
 
+def _delete_existing_awards_and_add_award(
+    *,
+    integration: RpcIntegration,
+    organization_id: int,
+    repo: Repository,
+    mr_iid: str,
+    emojis_to_delete: list[str],
+    emoji_to_add: str | None,
+) -> None:
+    """
+    Delete stale award emojis on the MR description and add a fresh one.
+
+    Mirrors ``delete_existing_reactions_and_add_reaction`` from the GitHub webhook
+    path, adapted for the GitLab award emoji API. Errors are logged and swallowed
+    so that a failing emoji call never blocks the Seer review task.
+    """
+    try:
+        client = integration.get_installation(organization_id=organization_id).get_client()
+    except Exception:
+        logger.warning("gitlab.webhook.merge_request.award.missing_installation")
+        return
+
+    project_id = str(repo.config.get("project_id", ""))
+    if not project_id:
+        logger.warning("gitlab.webhook.merge_request.award.missing_project_id")
+        return
+
+    if emojis_to_delete:
+        try:
+            # Identify awards placed by the current OAuth user (our integration bot)
+            # so we only delete our own awards, not those from other users.
+            current_user = client.get_user() or {}
+            current_user_id = current_user.get("id")
+            existing_awards = client.get_merge_request_awards(project_id, mr_iid) or []
+            if current_user_id is not None:
+                for award in existing_awards:
+                    if (
+                        award.get("user", {}).get("id") == current_user_id
+                        and award.get("id")
+                        and award.get("name") in emojis_to_delete
+                    ):
+                        client.delete_merge_request_award(
+                            project_id, mr_iid, str(award["id"])
+                        )
+        except Exception:
+            logger.warning(
+                "gitlab.webhook.merge_request.award.delete_failed", exc_info=True
+            )
+
+    if emoji_to_add:
+        try:
+            client.create_merge_request_award(project_id, mr_iid, emoji_to_add)
+        except Exception:
+            logger.warning(
+                "gitlab.webhook.merge_request.award.add_failed", exc_info=True
+            )
+
+
 def handle_merge_request_event(
     *,
     event: Mapping[str, Any],
@@ -270,6 +343,21 @@ def handle_merge_request_event(
     if _is_duplicate_delivery(seen_key):
         logger.warning("gitlab.webhook.merge_request.duplicate_delivery_skipped")
         return
+
+    # Mirror the GitHub pull_request handler: add :eyes: to the MR description to
+    # signal a Seer review run is in progress, and remove any stale :tada: left
+    # over from a previous run. Skip for close/merge since those are not new runs.
+    if action not in CLOSE_ACTIONS:
+        mr_iid = object_attributes.get("iid")
+        if mr_iid is not None:
+            _delete_existing_awards_and_add_award(
+                integration=integration,
+                organization_id=org.id,
+                repo=repo,
+                mr_iid=str(mr_iid),
+                emojis_to_delete=[GITLAB_EMOJI_TADA],
+                emoji_to_add=GITLAB_EMOJI_EYES,
+            )
 
     _schedule_task(
         action=action,

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -7,9 +7,10 @@ Award emoji parity with the GitHub webhook forwarder
 
 The GitHub pull_request handler adds :eyes: to the PR description (and removes
 any stale :tada:) to signal that a Seer review run is in progress. This handler
-replicates that behaviour for GitLab merge requests using the GitLab award emoji
-API (``/projects/:id/merge_requests/:mr_iid/award_emoji``). The call is skipped
-for close/merge actions since those are cleanup events, not new review triggers.
+replicates that behaviour for GitLab merge requests via the SCM library's
+provider-agnostic reaction actions (``scm.actions.create_pull_request_reaction``
+and friends). The call is skipped for close/merge actions since those are cleanup
+events, not new review triggers.
 
 Known limitations
 -----------------
@@ -45,11 +46,14 @@ from typing import Any
 from pydantic import ValidationError
 
 from sentry import features
+from scm import actions as scm_actions
+
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.scm import factory as scm_factory
 from sentry.seer.code_review.models import (
     SeerCodeReviewTaskRequestForPrClosed,
     SeerCodeReviewTaskRequestForPrReview,
@@ -67,12 +71,6 @@ from ..metrics import (
 from ..preflight import CodeReviewPreflightService
 from ..utils import SeerEndpoint, _common_codegen_request_payload
 from .task import process_github_webhook_event
-
-# GitLab award emoji names used by the Seer code-review flow.
-# "tada" is the GitLab equivalent of GitHub's "hooray" (:tada: 🎉).
-# "eyes" is the same on both platforms (:eyes: 👀).
-GITLAB_EMOJI_TADA = "tada"
-GITLAB_EMOJI_EYES = "eyes"
 
 logger = logging.getLogger(__name__)
 
@@ -182,56 +180,56 @@ def _resolve_review_trigger(
     return None
 
 
-def _delete_existing_awards_and_add_award(
+def _delete_existing_reactions_and_add_reaction(
     *,
-    integration: RpcIntegration,
     organization_id: int,
     repo: Repository,
     mr_iid: str,
-    emojis_to_delete: list[str],
-    emoji_to_add: str | None,
+    reactions_to_delete: list[str],
+    reaction_to_add: str | None,
 ) -> None:
     """
-    Delete stale award emojis on the MR description and add a fresh one.
+    Delete stale reactions on the MR description and add a fresh one.
 
     Mirrors ``delete_existing_reactions_and_add_reaction`` from the GitHub webhook
-    path, adapted for the GitLab award emoji API. Errors are logged and swallowed
-    so that a failing emoji call never blocks the Seer review task.
+    path. Uses the SCM library's provider-agnostic reaction actions so the logic
+    is identical for every supported SCM provider. Errors are logged and swallowed
+    so that a failing reaction call never blocks the Seer review task.
+
+    ``reactions_to_delete`` and ``reaction_to_add`` use the SCM ``Reaction`` type
+    values (e.g. ``"hooray"`` for :tada:, ``"eyes"`` for :eyes:); the provider
+    translates them to platform-specific names (GitLab award emoji, etc.).
     """
     try:
-        client = integration.get_installation(organization_id=organization_id).get_client()
+        scm = scm_factory.new(organization_id, repo.id, "code-review-webhook")
     except Exception:
-        logger.warning("gitlab.webhook.merge_request.award.missing_installation")
+        logger.warning("gitlab.webhook.merge_request.reaction.scm_init_failed")
         return
 
-    project_id = str(repo.config.get("project_id", ""))
-    if not project_id:
-        logger.warning("gitlab.webhook.merge_request.award.missing_project_id")
-        return
-
-    if emojis_to_delete:
+    if reactions_to_delete:
         try:
-            # Identify awards placed by the current OAuth user (our integration bot)
-            # so we only delete our own awards, not those from other users.
-            current_user = client.get_user() or {}
-            current_user_id = current_user.get("id")
-            existing_awards = client.get_merge_request_awards(project_id, mr_iid) or []
-            if current_user_id is not None:
-                for award in existing_awards:
-                    if (
-                        award.get("user", {}).get("id") == current_user_id
-                        and award.get("id")
-                        and award.get("name") in emojis_to_delete
-                    ):
-                        client.delete_merge_request_award(project_id, mr_iid, str(award["id"]))
+            # Identify reactions placed by the current OAuth user (our integration bot)
+            # so we only remove our own reactions, not those from other users.
+            current_actor = scm_actions.get_authenticated_actor(scm)["data"]
+            current_actor_id = current_actor["id"]
+            existing = scm_actions.get_pull_request_reactions(scm, mr_iid)["data"]
+            for reaction in existing:
+                author = reaction.get("author")
+                if (
+                    author is not None
+                    and author.get("id") == current_actor_id
+                    and reaction.get("content") in reactions_to_delete
+                    and reaction.get("id")
+                ):
+                    scm_actions.delete_pull_request_reaction(scm, mr_iid, str(reaction["id"]))
         except Exception:
-            logger.warning("gitlab.webhook.merge_request.award.delete_failed", exc_info=True)
+            logger.warning("gitlab.webhook.merge_request.reaction.delete_failed", exc_info=True)
 
-    if emoji_to_add:
+    if reaction_to_add:
         try:
-            client.create_merge_request_award(project_id, mr_iid, emoji_to_add)
+            scm_actions.create_pull_request_reaction(scm, mr_iid, reaction_to_add)
         except Exception:
-            logger.warning("gitlab.webhook.merge_request.award.add_failed", exc_info=True)
+            logger.warning("gitlab.webhook.merge_request.reaction.add_failed", exc_info=True)
 
 
 def handle_merge_request_event(
@@ -341,16 +339,16 @@ def handle_merge_request_event(
     # Mirror the GitHub pull_request handler: add :eyes: to the MR description to
     # signal a Seer review run is in progress, and remove any stale :tada: left
     # over from a previous run. Skip for close/merge since those are not new runs.
+    # Uses SCM Reaction type values: "hooray" = :tada:, "eyes" = :eyes:.
     if action not in CLOSE_ACTIONS:
         mr_iid = object_attributes.get("iid")
         if mr_iid is not None:
-            _delete_existing_awards_and_add_award(
-                integration=integration,
+            _delete_existing_reactions_and_add_reaction(
                 organization_id=org.id,
                 repo=repo,
                 mr_iid=str(mr_iid),
-                emojis_to_delete=[GITLAB_EMOJI_TADA],
-                emoji_to_add=GITLAB_EMOJI_EYES,
+                reactions_to_delete=["hooray"],
+                reaction_to_add="eyes",
             )
 
     _schedule_task(

--- a/tests/sentry/seer/code_review/webhooks/test_merge_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_merge_request.py
@@ -803,9 +803,7 @@ class MergeRequestAwardEmojiTest(GitLabTestCase):
     @pytest.fixture(autouse=True)
     def mock_gitlab_client(self) -> Generator[None]:
         with (
-            patch(
-                "sentry.integrations.gitlab.client.GitLabApiClient.get_user"
-            ) as mock_get_user,
+            patch("sentry.integrations.gitlab.client.GitLabApiClient.get_user") as mock_get_user,
             patch(
                 "sentry.integrations.gitlab.client.GitLabApiClient.get_merge_request_awards"
             ) as mock_get_awards,

--- a/tests/sentry/seer/code_review/webhooks/test_merge_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_merge_request.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import orjson
 import pytest
@@ -11,8 +11,6 @@ from sentry.models.organizationcontributors import OrganizationContributors
 from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.seer.code_review.webhooks.merge_request import (
-    GITLAB_EMOJI_EYES,
-    GITLAB_EMOJI_TADA,
     WEBHOOK_SEEN_KEY_PREFIX,
     handle_merge_request_event,
 )
@@ -780,19 +778,23 @@ class MergeRequestEventWebhookTest(GitLabTestCase):
         assert self.mock_seer.call_count == 2
 
 
-class MergeRequestAwardEmojiTest(GitLabTestCase):
-    """Tests for the award-emoji behaviour added to the GitLab merge-request handler.
-
-    The handler should add :eyes: to the MR description for every non-close action
-    that passes all filter checks (mirrors the GitHub pull_request reaction path).
-    It must also attempt to delete any stale :tada: awards left from a previous run.
-    """
-
-    CODE_REVIEW_FEATURES = {
-        "organizations:gen-ai-features",
-        "organizations:code-review-beta",
-        "organizations:seer-code-review-gitlab",
+def _make_scm_reaction(reaction_id: int, content: str, author_id: int) -> dict:
+    """Build a minimal ReactionResult-shaped dict for test fixtures."""
+    return {
+        "id": reaction_id,
+        "content": content,
+        "author": {"id": author_id, "username": "sentry-bot"},
     }
+
+
+class MergeRequestReactionTest(GitLabTestCase):
+    """Tests for the reaction-emoji behaviour added to the GitLab merge-request handler.
+
+    The handler should add :eyes: (reaction "eyes") to the MR description for every
+    non-close action that passes all filter checks, and remove stale :tada: (reaction
+    "hooray") awards left from a previous run.  Mirrors the GitHub pull_request path.
+    Reactions are called via the SCM library's provider-agnostic actions module.
+    """
 
     @pytest.fixture(autouse=True)
     def mock_seer_request(self) -> Generator[None]:
@@ -801,25 +803,28 @@ class MergeRequestAwardEmojiTest(GitLabTestCase):
             yield
 
     @pytest.fixture(autouse=True)
-    def mock_gitlab_client(self) -> Generator[None]:
-        with (
-            patch("sentry.integrations.gitlab.client.GitLabApiClient.get_user") as mock_get_user,
-            patch(
-                "sentry.integrations.gitlab.client.GitLabApiClient.get_merge_request_awards"
-            ) as mock_get_awards,
-            patch(
-                "sentry.integrations.gitlab.client.GitLabApiClient.create_merge_request_award"
-            ) as mock_create_award,
-            patch(
-                "sentry.integrations.gitlab.client.GitLabApiClient.delete_merge_request_award"
-            ) as mock_delete_award,
+    def mock_scm(self) -> Generator[None]:
+        """Patch scm_factory.new to return a mock SCM and expose the action spies."""
+        mock_scm_instance = MagicMock()
+        # get_authenticated_actor → ActionResult[Author]
+        mock_scm_instance.get_authenticated_actor.return_value = {
+            "data": {"id": 42, "username": "sentry-bot"},
+            "type": "gitlab",
+            "raw": {},
+            "meta": {},
+        }
+        # get_pull_request_reactions → PaginatedActionResult[list[ReactionResult]]
+        mock_scm_instance.get_pull_request_reactions.return_value = {
+            "data": [],
+            "type": "gitlab",
+            "raw": {},
+            "meta": {"page_info": {}},
+        }
+        with patch(
+            "sentry.seer.code_review.webhooks.merge_request.scm_factory.new",
+            return_value=mock_scm_instance,
         ):
-            mock_get_user.return_value = {"id": 42, "username": "sentry-bot"}
-            mock_get_awards.return_value = []
-            self.mock_get_user = mock_get_user
-            self.mock_get_awards = mock_get_awards
-            self.mock_create_award = mock_create_award
-            self.mock_delete_award = mock_delete_award
+            self.mock_scm = mock_scm_instance
             yield
 
     def _setup_code_review(self, triggers: list[CodeReviewTrigger] | None = None) -> None:
@@ -864,43 +869,16 @@ class MergeRequestAwardEmojiTest(GitLabTestCase):
             "organizations:seer-code-review-gitlab",
         }
     )
-    def test_eyes_award_added_for_open_action(self) -> None:
-        """An :eyes: award must be created on the MR when action=open."""
-        self._setup_code_review()
-        event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
-
-        with self.tasks():
-            self._call_handler(event)
-
-        self.mock_create_award.assert_called_once_with(
-            "15",
-            str(event["object_attributes"]["iid"]),
-            GITLAB_EMOJI_EYES,
-        )
-
-    @with_feature(
-        {
-            "organizations:gen-ai-features",
-            "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
-        }
-    )
-    def test_stale_tada_award_deleted_before_eyes_added(self) -> None:
-        """A stale :tada: award by our bot must be deleted before :eyes: is added."""
+    def test_eyes_reaction_added_for_open_action(self) -> None:
+        """:eyes: reaction must be added to the MR when action=open."""
         self._setup_code_review()
         event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
         mr_iid = str(event["object_attributes"]["iid"])
 
-        # Seed an existing :tada: award by our bot (user id 42).
-        self.mock_get_awards.return_value = [
-            {"id": 7, "name": GITLAB_EMOJI_TADA, "user": {"id": 42}},
-        ]
-
         with self.tasks():
             self._call_handler(event)
 
-        self.mock_delete_award.assert_called_once_with("15", mr_iid, "7")
-        self.mock_create_award.assert_called_once_with("15", mr_iid, GITLAB_EMOJI_EYES)
+        self.mock_scm.create_pull_request_reaction.assert_called_once_with(mr_iid, "eyes")
 
     @with_feature(
         {
@@ -909,21 +887,51 @@ class MergeRequestAwardEmojiTest(GitLabTestCase):
             "organizations:seer-code-review-gitlab",
         }
     )
-    def test_other_users_tada_award_not_deleted(self) -> None:
-        """Awards by other users must not be touched."""
+    def test_stale_hooray_reaction_deleted_before_eyes_added(self) -> None:
+        """A stale :tada: ("hooray") reaction by our bot must be deleted before :eyes: is added."""
+        self._setup_code_review()
+        event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+        mr_iid = str(event["object_attributes"]["iid"])
+
+        # Seed an existing "hooray" reaction by our bot (author id 42).
+        self.mock_scm.get_pull_request_reactions.return_value = {
+            "data": [_make_scm_reaction(7, "hooray", 42)],
+            "type": "gitlab",
+            "raw": {},
+            "meta": {"page_info": {}},
+        }
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_scm.delete_pull_request_reaction.assert_called_once_with(mr_iid, "7")
+        self.mock_scm.create_pull_request_reaction.assert_called_once_with(mr_iid, "eyes")
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-code-review-gitlab",
+        }
+    )
+    def test_other_users_hooray_reaction_not_deleted(self) -> None:
+        """Reactions from other users must not be touched."""
         self._setup_code_review()
         event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
 
-        # A :tada: award from a different user (id 99).
-        self.mock_get_awards.return_value = [
-            {"id": 8, "name": GITLAB_EMOJI_TADA, "user": {"id": 99}},
-        ]
+        # A "hooray" reaction from a different user (id 99).
+        self.mock_scm.get_pull_request_reactions.return_value = {
+            "data": [_make_scm_reaction(8, "hooray", 99)],
+            "type": "gitlab",
+            "raw": {},
+            "meta": {"page_info": {}},
+        }
 
         with self.tasks():
             self._call_handler(event)
 
-        self.mock_delete_award.assert_not_called()
-        self.mock_create_award.assert_called_once()
+        self.mock_scm.delete_pull_request_reaction.assert_not_called()
+        self.mock_scm.create_pull_request_reaction.assert_called_once()
 
     @with_feature(
         {
@@ -932,8 +940,8 @@ class MergeRequestAwardEmojiTest(GitLabTestCase):
             "organizations:seer-code-review-gitlab",
         }
     )
-    def test_no_eyes_award_for_close_action(self) -> None:
-        """Close actions must not trigger any award emoji changes."""
+    def test_no_reaction_for_close_action(self) -> None:
+        """Close actions must not trigger any reaction changes."""
         self._setup_code_review()
         event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
         event["object_attributes"]["action"] = "close"
@@ -941,8 +949,8 @@ class MergeRequestAwardEmojiTest(GitLabTestCase):
         with self.tasks():
             self._call_handler(event)
 
-        self.mock_create_award.assert_not_called()
-        self.mock_delete_award.assert_not_called()
+        self.mock_scm.create_pull_request_reaction.assert_not_called()
+        self.mock_scm.delete_pull_request_reaction.assert_not_called()
 
     @with_feature(
         {
@@ -951,8 +959,8 @@ class MergeRequestAwardEmojiTest(GitLabTestCase):
             "organizations:seer-code-review-gitlab",
         }
     )
-    def test_no_eyes_award_for_merge_action(self) -> None:
-        """Merge actions must not trigger any award emoji changes."""
+    def test_no_reaction_for_merge_action(self) -> None:
+        """Merge actions must not trigger any reaction changes."""
         self._setup_code_review()
         event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
         event["object_attributes"]["action"] = "merge"
@@ -960,8 +968,8 @@ class MergeRequestAwardEmojiTest(GitLabTestCase):
         with self.tasks():
             self._call_handler(event)
 
-        self.mock_create_award.assert_not_called()
-        self.mock_delete_award.assert_not_called()
+        self.mock_scm.create_pull_request_reaction.assert_not_called()
+        self.mock_scm.delete_pull_request_reaction.assert_not_called()
 
     @with_feature(
         {
@@ -970,17 +978,17 @@ class MergeRequestAwardEmojiTest(GitLabTestCase):
             "organizations:seer-code-review-gitlab",
         }
     )
-    def test_award_failure_does_not_block_seer_task(self) -> None:
-        """A failing award-emoji API call must not prevent the Seer task from being scheduled."""
+    def test_reaction_failure_does_not_block_seer_task(self) -> None:
+        """A failing reaction API call must not prevent the Seer task from being scheduled."""
         self._setup_code_review()
         event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
 
-        self.mock_create_award.side_effect = Exception("gitlab api down")
+        self.mock_scm.create_pull_request_reaction.side_effect = Exception("scm api down")
 
         with self.tasks():
             self._call_handler(event)
 
-        # Seer task must still be called even though the emoji failed.
+        # Seer task must still be scheduled even though the reaction failed.
         self.mock_seer.assert_called_once()
 
     @with_feature(
@@ -990,18 +998,15 @@ class MergeRequestAwardEmojiTest(GitLabTestCase):
             "organizations:seer-code-review-gitlab",
         }
     )
-    def test_eyes_award_added_for_update_with_new_commit(self) -> None:
-        """An :eyes: award must also be added for update+commit (ON_NEW_COMMIT trigger)."""
+    def test_eyes_reaction_added_for_update_with_new_commit(self) -> None:
+        """:eyes: must also be added for update+commit (ON_NEW_COMMIT trigger)."""
         self._setup_code_review()
         event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
         event["object_attributes"]["action"] = "update"
         event["object_attributes"]["oldrev"] = "0" * 40
+        mr_iid = str(event["object_attributes"]["iid"])
 
         with self.tasks():
             self._call_handler(event)
 
-        self.mock_create_award.assert_called_once_with(
-            "15",
-            str(event["object_attributes"]["iid"]),
-            GITLAB_EMOJI_EYES,
-        )
+        self.mock_scm.create_pull_request_reaction.assert_called_once_with(mr_iid, "eyes")

--- a/tests/sentry/seer/code_review/webhooks/test_merge_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_merge_request.py
@@ -11,6 +11,8 @@ from sentry.models.organizationcontributors import OrganizationContributors
 from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.seer.code_review.webhooks.merge_request import (
+    GITLAB_EMOJI_EYES,
+    GITLAB_EMOJI_TADA,
     WEBHOOK_SEEN_KEY_PREFIX,
     handle_merge_request_event,
 )
@@ -776,3 +778,232 @@ class MergeRequestEventWebhookTest(GitLabTestCase):
             self._call_handler(second)
 
         assert self.mock_seer.call_count == 2
+
+
+class MergeRequestAwardEmojiTest(GitLabTestCase):
+    """Tests for the award-emoji behaviour added to the GitLab merge-request handler.
+
+    The handler should add :eyes: to the MR description for every non-close action
+    that passes all filter checks (mirrors the GitHub pull_request reaction path).
+    It must also attempt to delete any stale :tada: awards left from a previous run.
+    """
+
+    CODE_REVIEW_FEATURES = {
+        "organizations:gen-ai-features",
+        "organizations:code-review-beta",
+        "organizations:seer-code-review-gitlab",
+    }
+
+    @pytest.fixture(autouse=True)
+    def mock_seer_request(self) -> Generator[None]:
+        with patch("sentry.seer.code_review.webhooks.task.make_seer_request") as mock_seer:
+            self.mock_seer = mock_seer
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_gitlab_client(self) -> Generator[None]:
+        with (
+            patch(
+                "sentry.integrations.gitlab.client.GitLabApiClient.get_user"
+            ) as mock_get_user,
+            patch(
+                "sentry.integrations.gitlab.client.GitLabApiClient.get_merge_request_awards"
+            ) as mock_get_awards,
+            patch(
+                "sentry.integrations.gitlab.client.GitLabApiClient.create_merge_request_award"
+            ) as mock_create_award,
+            patch(
+                "sentry.integrations.gitlab.client.GitLabApiClient.delete_merge_request_award"
+            ) as mock_delete_award,
+        ):
+            mock_get_user.return_value = {"id": 42, "username": "sentry-bot"}
+            mock_get_awards.return_value = []
+            self.mock_get_user = mock_get_user
+            self.mock_get_awards = mock_get_awards
+            self.mock_create_award = mock_create_award
+            self.mock_delete_award = mock_delete_award
+            yield
+
+    def _setup_code_review(self, triggers: list[CodeReviewTrigger] | None = None) -> None:
+        if triggers is None:
+            triggers = [
+                CodeReviewTrigger.ON_NEW_COMMIT,
+                CodeReviewTrigger.ON_READY_FOR_REVIEW,
+            ]
+        repo = self.create_gitlab_repo(name="Cool Group / Sentry")
+        repo.config["path"] = "cool-group/sentry"
+        repo.save()
+        trigger_values = [t.value for t in triggers]
+        self.create_repository_settings(
+            repository=repo,
+            enabled_code_review=True,
+            code_review_triggers=trigger_values,
+        )
+        OrganizationContributors.objects.get_or_create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            external_identifier="51",
+            defaults={"alias": "root"},
+        )
+        self.repo = repo
+
+    def _call_handler(self, event: dict[str, Any]) -> None:
+        handle_merge_request_event(
+            event=event,
+            organization=RpcOrganization(
+                id=self.organization.id,
+                slug=self.organization.slug,
+                name=self.organization.name,
+            ),
+            repo=self.repo,
+            integration=self.integration,
+        )
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-code-review-gitlab",
+        }
+    )
+    def test_eyes_award_added_for_open_action(self) -> None:
+        """An :eyes: award must be created on the MR when action=open."""
+        self._setup_code_review()
+        event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_create_award.assert_called_once_with(
+            "15",
+            str(event["object_attributes"]["iid"]),
+            GITLAB_EMOJI_EYES,
+        )
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-code-review-gitlab",
+        }
+    )
+    def test_stale_tada_award_deleted_before_eyes_added(self) -> None:
+        """A stale :tada: award by our bot must be deleted before :eyes: is added."""
+        self._setup_code_review()
+        event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+        mr_iid = str(event["object_attributes"]["iid"])
+
+        # Seed an existing :tada: award by our bot (user id 42).
+        self.mock_get_awards.return_value = [
+            {"id": 7, "name": GITLAB_EMOJI_TADA, "user": {"id": 42}},
+        ]
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_delete_award.assert_called_once_with("15", mr_iid, "7")
+        self.mock_create_award.assert_called_once_with("15", mr_iid, GITLAB_EMOJI_EYES)
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-code-review-gitlab",
+        }
+    )
+    def test_other_users_tada_award_not_deleted(self) -> None:
+        """Awards by other users must not be touched."""
+        self._setup_code_review()
+        event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+
+        # A :tada: award from a different user (id 99).
+        self.mock_get_awards.return_value = [
+            {"id": 8, "name": GITLAB_EMOJI_TADA, "user": {"id": 99}},
+        ]
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_delete_award.assert_not_called()
+        self.mock_create_award.assert_called_once()
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-code-review-gitlab",
+        }
+    )
+    def test_no_eyes_award_for_close_action(self) -> None:
+        """Close actions must not trigger any award emoji changes."""
+        self._setup_code_review()
+        event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+        event["object_attributes"]["action"] = "close"
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_create_award.assert_not_called()
+        self.mock_delete_award.assert_not_called()
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-code-review-gitlab",
+        }
+    )
+    def test_no_eyes_award_for_merge_action(self) -> None:
+        """Merge actions must not trigger any award emoji changes."""
+        self._setup_code_review()
+        event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+        event["object_attributes"]["action"] = "merge"
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_create_award.assert_not_called()
+        self.mock_delete_award.assert_not_called()
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-code-review-gitlab",
+        }
+    )
+    def test_award_failure_does_not_block_seer_task(self) -> None:
+        """A failing award-emoji API call must not prevent the Seer task from being scheduled."""
+        self._setup_code_review()
+        event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+
+        self.mock_create_award.side_effect = Exception("gitlab api down")
+
+        with self.tasks():
+            self._call_handler(event)
+
+        # Seer task must still be called even though the emoji failed.
+        self.mock_seer.assert_called_once()
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-code-review-gitlab",
+        }
+    )
+    def test_eyes_award_added_for_update_with_new_commit(self) -> None:
+        """An :eyes: award must also be added for update+commit (ON_NEW_COMMIT trigger)."""
+        self._setup_code_review()
+        event = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+        event["object_attributes"]["action"] = "update"
+        event["object_attributes"]["oldrev"] = "0" * 40
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_create_award.assert_called_once_with(
+            "15",
+            str(event["object_attributes"]["iid"]),
+            GITLAB_EMOJI_EYES,
+        )

--- a/tests/sentry/seer/code_review/webhooks/test_merge_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_merge_request.py
@@ -38,7 +38,34 @@ def _rpc_org(org: Organization) -> RpcOrganization:
     )
 
 
-class MergeRequestEventWebhookTest(GitLabTestCase):
+class _FakeScmClient:
+    """Spec for the SCM reaction methods the handler invokes.
+
+    Used as a ``MagicMock(spec=...)`` so the mock satisfies the runtime-checkable
+    SCM capability protocols the handler guards on. A bare ``MagicMock`` does not:
+    Python's protocol ``isinstance`` check uses ``inspect.getattr_static``, which
+    bypasses ``MagicMock.__getattr__``. The real provider-backed facade exposes
+    these as concrete class attributes, so it passes the same guard in production.
+    """
+
+    def get_authenticated_actor(self) -> Any: ...
+
+    def get_pull_request_reactions(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def create_pull_request_reaction(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def delete_pull_request_reaction(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class _MergeRequestHandlerTestBase(GitLabTestCase):
+    """Shared setup for the GitLab merge-request handler tests.
+
+    ``mock_scm`` is autouse so that *every* handler test is isolated from the SCM
+    library: the handler now calls ``scm_factory.new`` for every non-close action
+    that schedules a review, and without this patch those tests would build a real
+    provider and issue (swallowed) HTTP requests to the integration's base URL.
+    """
+
     CODE_REVIEW_FEATURES = {
         "organizations:gen-ai-features",
         "organizations:code-review-beta",
@@ -49,6 +76,35 @@ class MergeRequestEventWebhookTest(GitLabTestCase):
     def mock_seer_request(self) -> Generator[None]:
         with patch("sentry.seer.code_review.webhooks.task.make_seer_request") as mock_seer:
             self.mock_seer = mock_seer
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_scm(self) -> Generator[None]:
+        """Patch scm_factory.new to return a mock SCM and expose the action spies.
+
+        Ids are strings to match the real provider contract (``ResourceId = str``);
+        ``map_author`` / ``map_reaction_result`` coerce GitLab's numeric ids to str.
+        """
+        mock_scm_instance = MagicMock(spec=_FakeScmClient)
+        # get_authenticated_actor → ActionResult[Author]
+        mock_scm_instance.get_authenticated_actor.return_value = {
+            "data": {"id": "42", "username": "sentry-bot"},
+            "type": "gitlab",
+            "raw": {},
+            "meta": {},
+        }
+        # get_pull_request_reactions → PaginatedActionResult[list[ReactionResult]]
+        mock_scm_instance.get_pull_request_reactions.return_value = {
+            "data": [],
+            "type": "gitlab",
+            "raw": {},
+            "meta": {"page_info": {}},
+        }
+        with patch(
+            "sentry.seer.code_review.webhooks.merge_request.scm_factory.new",
+            return_value=mock_scm_instance,
+        ):
+            self.mock_scm = mock_scm_instance
             yield
 
     def _setup_code_review(
@@ -93,6 +149,8 @@ class MergeRequestEventWebhookTest(GitLabTestCase):
             integration=self.integration,
         )
 
+
+class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
     @with_feature(
         {
             "organizations:gen-ai-features",
@@ -778,89 +836,27 @@ class MergeRequestEventWebhookTest(GitLabTestCase):
         assert self.mock_seer.call_count == 2
 
 
-def _make_scm_reaction(reaction_id: int, content: str, author_id: int) -> dict:
-    """Build a minimal ReactionResult-shaped dict for test fixtures."""
+def _make_scm_reaction(reaction_id: int, content: str, author_id: int) -> dict[str, Any]:
+    """Build a minimal ReactionResult-shaped dict for test fixtures.
+
+    The real SCM provider stringifies ids (``ResourceId = str``), so the fixture
+    coerces them too; the handler compares author ids by equality.
+    """
     return {
-        "id": reaction_id,
+        "id": str(reaction_id),
         "content": content,
-        "author": {"id": author_id, "username": "sentry-bot"},
+        "author": {"id": str(author_id), "username": "sentry-bot"},
     }
 
 
-class MergeRequestReactionTest(GitLabTestCase):
+class MergeRequestReactionTest(_MergeRequestHandlerTestBase):
     """Tests for the reaction-emoji behaviour added to the GitLab merge-request handler.
 
-    The handler should add :eyes: (reaction "eyes") to the MR description for every
-    non-close action that passes all filter checks, and remove stale :tada: (reaction
-    "hooray") awards left from a previous run.  Mirrors the GitHub pull_request path.
-    Reactions are called via the SCM library's provider-agnostic actions module.
+    The handler should add :eyes: (reaction "eyes") to the MR for every non-close
+    action that passes all filter checks, and remove stale :tada: (reaction "hooray")
+    awards left from a previous run.  Mirrors the GitHub pull_request path. Reactions
+    are called via the SCM library's provider-agnostic actions module.
     """
-
-    @pytest.fixture(autouse=True)
-    def mock_seer_request(self) -> Generator[None]:
-        with patch("sentry.seer.code_review.webhooks.task.make_seer_request") as mock_seer:
-            self.mock_seer = mock_seer
-            yield
-
-    @pytest.fixture(autouse=True)
-    def mock_scm(self) -> Generator[None]:
-        """Patch scm_factory.new to return a mock SCM and expose the action spies."""
-        mock_scm_instance = MagicMock()
-        # get_authenticated_actor → ActionResult[Author]
-        mock_scm_instance.get_authenticated_actor.return_value = {
-            "data": {"id": 42, "username": "sentry-bot"},
-            "type": "gitlab",
-            "raw": {},
-            "meta": {},
-        }
-        # get_pull_request_reactions → PaginatedActionResult[list[ReactionResult]]
-        mock_scm_instance.get_pull_request_reactions.return_value = {
-            "data": [],
-            "type": "gitlab",
-            "raw": {},
-            "meta": {"page_info": {}},
-        }
-        with patch(
-            "sentry.seer.code_review.webhooks.merge_request.scm_factory.new",
-            return_value=mock_scm_instance,
-        ):
-            self.mock_scm = mock_scm_instance
-            yield
-
-    def _setup_code_review(self, triggers: list[CodeReviewTrigger] | None = None) -> None:
-        if triggers is None:
-            triggers = [
-                CodeReviewTrigger.ON_NEW_COMMIT,
-                CodeReviewTrigger.ON_READY_FOR_REVIEW,
-            ]
-        repo = self.create_gitlab_repo(name="Cool Group / Sentry")
-        repo.config["path"] = "cool-group/sentry"
-        repo.save()
-        trigger_values = [t.value for t in triggers]
-        self.create_repository_settings(
-            repository=repo,
-            enabled_code_review=True,
-            code_review_triggers=trigger_values,
-        )
-        OrganizationContributors.objects.get_or_create(
-            organization_id=self.organization.id,
-            integration_id=self.integration.id,
-            external_identifier="51",
-            defaults={"alias": "root"},
-        )
-        self.repo = repo
-
-    def _call_handler(self, event: dict[str, Any]) -> None:
-        handle_merge_request_event(
-            event=event,
-            organization=RpcOrganization(
-                id=self.organization.id,
-                slug=self.organization.slug,
-                name=self.organization.name,
-            ),
-            repo=self.repo,
-            integration=self.integration,
-        )
 
     @with_feature(
         {
@@ -1010,3 +1006,143 @@ class MergeRequestReactionTest(GitLabTestCase):
             self._call_handler(event)
 
         self.mock_scm.create_pull_request_reaction.assert_called_once_with(mr_iid, "eyes")
+        # The reaction is best-effort decoration; the review must still be scheduled.
+        self.mock_seer.assert_called_once()
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_eyes_not_readded_when_already_present(self) -> None:
+        """An :eyes: our user already placed must not be re-added (GitLab rejects duplicates)."""
+        self._setup_code_review()
+        event = _make_event("open")
+        self.mock_scm.get_pull_request_reactions.return_value = {
+            "data": [_make_scm_reaction(5, "eyes", 42)],
+            "type": "gitlab",
+            "raw": {},
+            "meta": {"page_info": {}},
+        }
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_scm.create_pull_request_reaction.assert_not_called()
+        self.mock_seer.assert_called_once()
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_delete_happens_before_add(self) -> None:
+        """Stale reactions are removed before the fresh :eyes: is added."""
+        self._setup_code_review()
+        event = _make_event("open")
+        self.mock_scm.get_pull_request_reactions.return_value = {
+            "data": [_make_scm_reaction(7, "hooray", 42)],
+            "type": "gitlab",
+            "raw": {},
+            "meta": {"page_info": {}},
+        }
+
+        with self.tasks():
+            self._call_handler(event)
+
+        called = [c[0] for c in self.mock_scm.method_calls]
+        assert called.index("delete_pull_request_reaction") < called.index(
+            "create_pull_request_reaction"
+        )
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_delete_failure_does_not_block_add(self) -> None:
+        """A failed delete must not prevent the :eyes: add or the Seer task."""
+        self._setup_code_review()
+        event = _make_event("open")
+        mr_iid = str(event["object_attributes"]["iid"])
+        self.mock_scm.get_pull_request_reactions.return_value = {
+            "data": [_make_scm_reaction(7, "hooray", 42)],
+            "type": "gitlab",
+            "raw": {},
+            "meta": {"page_info": {}},
+        }
+        self.mock_scm.delete_pull_request_reaction.side_effect = Exception("scm api down")
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_scm.create_pull_request_reaction.assert_called_once_with(mr_iid, "eyes")
+        self.mock_seer.assert_called_once()
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_fetch_failure_does_not_block_add_or_seer(self) -> None:
+        """A failed reaction lookup must not prevent the :eyes: add or the Seer task."""
+        self._setup_code_review()
+        event = _make_event("open")
+        mr_iid = str(event["object_attributes"]["iid"])
+        self.mock_scm.get_pull_request_reactions.side_effect = Exception("scm api down")
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_scm.create_pull_request_reaction.assert_called_once_with(mr_iid, "eyes")
+        self.mock_seer.assert_called_once()
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_scm_init_failure_does_not_block_seer_task(self) -> None:
+        """If the SCM client cannot be built, the Seer task must still be scheduled."""
+        self._setup_code_review()
+        event = _make_event("open")
+
+        with patch(
+            "sentry.seer.code_review.webhooks.merge_request.scm_factory.new",
+            side_effect=Exception("scm init down"),
+        ):
+            with self.tasks():
+                self._call_handler(event)
+
+        self.mock_scm.create_pull_request_reaction.assert_not_called()
+        self.mock_seer.assert_called_once()
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_no_reaction_for_draft_open(self) -> None:
+        """A draft MR is filtered before scheduling, so no reaction is placed."""
+        self._setup_code_review()
+        event = _make_event("open", draft=True)
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_scm.create_pull_request_reaction.assert_not_called()
+        self.mock_scm.delete_pull_request_reaction.assert_not_called()
+        self.mock_seer.assert_not_called()
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_no_reaction_when_trigger_disabled(self) -> None:
+        """open maps to ON_READY_FOR_REVIEW; with only ON_NEW_COMMIT enabled, nothing reacts."""
+        self._setup_code_review(triggers=[CodeReviewTrigger.ON_NEW_COMMIT])
+        event = _make_event("open")
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_scm.create_pull_request_reaction.assert_not_called()
+        self.mock_seer.assert_not_called()
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_no_reaction_for_update_without_oldrev(self) -> None:
+        """An update with no new commit / un-draft is filtered before any reaction."""
+        self._setup_code_review()
+        event = _make_event("update")
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_scm.create_pull_request_reaction.assert_not_called()
+        self.mock_seer.assert_not_called()
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_no_reaction_for_duplicate_delivery(self) -> None:
+        """A duplicate delivery is deduped before the reaction code, so :eyes: is added once."""
+        self._setup_code_review()
+        event = _make_event("open")
+
+        with self.tasks():
+            self._call_handler(event)
+            self._call_handler(event)
+
+        assert self.mock_scm.create_pull_request_reaction.call_count == 1
+        assert self.mock_seer.call_count == 1


### PR DESCRIPTION
## Summary

The GitHub `pull_request` and `issue_comment` webhook forwarders both call `delete_existing_reactions_and_add_reaction` before scheduling a Seer task. This removes any stale :tada: from a previous run and adds :eyes: to signal a review is in progress.

This PR adds the equivalent behaviour to the GitLab `merge_request` handler using the [GitLab award emoji API](https://docs.gitlab.com/ee/api/award_emoji.html).

## Changes

- **`GITLAB_EMOJI_TADA`** / **`GITLAB_EMOJI_EYES`** constants — GitLab uses `"tada"` where GitHub uses `"hooray"`; `"eyes"` is the same on both platforms.
- **`_delete_existing_awards_and_add_award()`** — mirrors the GitHub helper:
  1. Fetches the current OAuth user to identify our bot's award ID (analogous to filtering by `"sentry[bot]"` login on GitHub).
  2. Deletes any stale `tada` awards placed by our bot.
  3. Adds an `eyes` award.
  All API errors are caught and logged so a failing emoji call never blocks the Seer review task.
- **`handle_merge_request_event()`** — calls the helper after the duplicate-delivery guard, skipping it for `close`/`merge` actions (cleanup events, not new review runs).

## What's not included

Per Suejung's analysis, `issue_comment` forwarding (triggering on `@sentry review` in an MR comment) is intentionally **not** added here. GitLab doesn't have an equivalent event mapping and usage on GitHub is very low. That can be addressed separately if needed.

## Tests

New `MergeRequestAwardEmojiTest` class covering:
- ✅ `open` → `:eyes:` award created
- ✅ stale `:tada:` by our bot → deleted before `:eyes:` added
- ✅ `:tada:` by *other* users → left untouched
- ✅ `close` / `merge` → no award changes
- ✅ award API failure → Seer task still scheduled (no regression)
- ✅ `update` + new commit (ON_NEW_COMMIT) → `:eyes:` added

## Verification

Syntax validated; full test run requires devenv. No venv available in this sandbox — CI will confirm.

---
Action taken on behalf of Colton Allen.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0AKG192UP3%3A1780333755.225689%22)