### PR TITLE
fix(replays): Clear stale filters when changing replay tabs

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -153,6 +153,34 @@ describe('useActiveReplayTab', () => {
     });
   });
 
+  it('should clear replay detail filters when changing tabs', async () => {
+    const {result, router} = renderHookWithProviders(useActiveReplayTab, {
+      initialProps: {},
+      initialRouterConfig: {
+        location: {
+          pathname: '/mock-pathname/',
+          query: {
+            query: 'click.tag:button',
+            f_c_logLevel: ['error'],
+            f_n_search: 'pokemon',
+            n_detail_row: '0',
+            n_detail_tab: 'response',
+          },
+        },
+      },
+      organization: OrganizationFixture({features: []}),
+    });
+
+    act(() => result.current.setActiveTab('network'));
+
+    await waitFor(() => {
+      expect(router.location.query).toEqual({
+        query: 'click.tag:button',
+        t_main: 'network',
+      });
+    });
+  });
+
   it('should update the tab query parameter shallowly', async () => {
     const onUrlUpdate = jest.fn<
       ReturnType<OnUrlUpdateFunction>,

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -1,8 +1,9 @@
 import {useCallback} from 'react';
-import {createParser, parseAsStringLiteral, useQueryState} from 'nuqs';
+import {createParser, parseAsStringLiteral, useQueryState, useQueryStates} from 'nuqs';
 
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import {defined} from 'sentry/utils';
+import {replayDetailFilterParsers} from 'sentry/utils/replays/hooks/useFiltersInLocationQuery';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export enum TabKey {
@@ -62,6 +63,11 @@ export function useActiveReplayTab({isVideoReplay = false}: {isVideoReplay?: boo
       .withDefault(defaultTab)
       .withOptions({clearOnDefault: false, shallow: true})
   );
+  const [, clearReplayDetailFilters] = useQueryStates(replayDetailFilterParsers, {
+    history: 'replace',
+    shallow: true,
+    throttleMs: 0,
+  });
 
   return {
     getActiveTab: useCallback(
@@ -72,9 +78,13 @@ export function useActiveReplayTab({isVideoReplay = false}: {isVideoReplay?: boo
     setActiveTab: useCallback(
       (value: string) => {
         const lower = value.toLowerCase() as TabKey;
-        setTabParam(isReplayTab({tab: lower, isVideoReplay}) ? lower : defaultTab);
+        const nextTab = isReplayTab({tab: lower, isVideoReplay}) ? lower : defaultTab;
+        if (nextTab !== tabParam) {
+          clearReplayDetailFilters(null);
+        }
+        setTabParam(nextTab);
       },
-      [setTabParam, defaultTab, isVideoReplay]
+      [clearReplayDetailFilters, setTabParam, defaultTab, isVideoReplay, tabParam]
     ),
   };
 }

--- a/static/app/utils/replays/hooks/useFiltersInLocationQuery.tsx
+++ b/static/app/utils/replays/hooks/useFiltersInLocationQuery.tsx
@@ -1,6 +1,10 @@
 import {useCallback} from 'react';
-import type {Query} from 'history';
-import {parseAsNativeArrayOf, parseAsString, useQueryStates} from 'nuqs';
+import {
+  type inferParserType,
+  parseAsNativeArrayOf,
+  parseAsString,
+  useQueryStates,
+} from 'nuqs';
 
 const parseAsStringArray = parseAsNativeArrayOf(parseAsString);
 
@@ -23,7 +27,12 @@ export const replayDetailFilterParsers = {
   n_detail_tab: parseAsString,
 };
 
-export function useFiltersInLocationQuery<Q extends Query>() {
+type ReplayDetailFilterQuery = inferParserType<typeof replayDetailFilterParsers>;
+type ReplayDetailFilterUpdate = Partial<{
+  [Key in keyof ReplayDetailFilterQuery]: ReplayDetailFilterQuery[Key] | undefined;
+}>;
+
+export function useFiltersInLocationQuery() {
   const [query, setQuery] = useQueryStates(replayDetailFilterParsers, {
     history: 'replace',
     shallow: true,
@@ -31,17 +40,59 @@ export function useFiltersInLocationQuery<Q extends Query>() {
   });
 
   const setFilter = useCallback(
-    (updatedQuery: Partial<Q>) => {
-      const nuqsQuery = Object.fromEntries(
-        Object.entries(updatedQuery).map(([key, value]) => [key, value ?? null])
-      );
-      setQuery(nuqsQuery);
+    (updatedQuery: ReplayDetailFilterUpdate) => {
+      setQuery({
+        ...('f_b_search' in updatedQuery
+          ? {f_b_search: updatedQuery.f_b_search ?? null}
+          : {}),
+        ...('f_b_type' in updatedQuery ? {f_b_type: updatedQuery.f_b_type ?? null} : {}),
+        ...('f_c_logLevel' in updatedQuery
+          ? {f_c_logLevel: updatedQuery.f_c_logLevel ?? null}
+          : {}),
+        ...('f_c_search' in updatedQuery
+          ? {f_c_search: updatedQuery.f_c_search ?? null}
+          : {}),
+        ...('f_e_level' in updatedQuery
+          ? {f_e_level: updatedQuery.f_e_level ?? null}
+          : {}),
+        ...('f_e_project' in updatedQuery
+          ? {f_e_project: updatedQuery.f_e_project ?? null}
+          : {}),
+        ...('f_e_search' in updatedQuery
+          ? {f_e_search: updatedQuery.f_e_search ?? null}
+          : {}),
+        ...('f_n_method' in updatedQuery
+          ? {f_n_method: updatedQuery.f_n_method ?? null}
+          : {}),
+        ...('f_n_search' in updatedQuery
+          ? {f_n_search: updatedQuery.f_n_search ?? null}
+          : {}),
+        ...('f_n_status' in updatedQuery
+          ? {f_n_status: updatedQuery.f_n_status ?? null}
+          : {}),
+        ...('f_n_type' in updatedQuery ? {f_n_type: updatedQuery.f_n_type ?? null} : {}),
+        ...('f_ol_search' in updatedQuery
+          ? {f_ol_search: updatedQuery.f_ol_search ?? null}
+          : {}),
+        ...('f_ol_severity' in updatedQuery
+          ? {f_ol_severity: updatedQuery.f_ol_severity ?? null}
+          : {}),
+        ...('f_t_search' in updatedQuery
+          ? {f_t_search: updatedQuery.f_t_search ?? null}
+          : {}),
+        ...('n_detail_row' in updatedQuery
+          ? {n_detail_row: updatedQuery.n_detail_row ?? null}
+          : {}),
+        ...('n_detail_tab' in updatedQuery
+          ? {n_detail_tab: updatedQuery.n_detail_tab ?? null}
+          : {}),
+      });
     },
     [setQuery]
   );
 
   return {
     setFilter,
-    query: query as Q,
+    query,
   };
 }

--- a/static/app/utils/replays/hooks/useFiltersInLocationQuery.tsx
+++ b/static/app/utils/replays/hooks/useFiltersInLocationQuery.tsx
@@ -1,22 +1,47 @@
 import {useCallback} from 'react';
 import type {Query} from 'history';
+import {parseAsNativeArrayOf, parseAsString, useQueryStates} from 'nuqs';
 
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
+const parseAsStringArray = parseAsNativeArrayOf(parseAsString);
+
+export const replayDetailFilterParsers = {
+  f_b_search: parseAsString,
+  f_b_type: parseAsStringArray,
+  f_c_logLevel: parseAsStringArray,
+  f_c_search: parseAsString,
+  f_e_level: parseAsStringArray,
+  f_e_project: parseAsStringArray,
+  f_e_search: parseAsString,
+  f_n_method: parseAsStringArray,
+  f_n_search: parseAsString,
+  f_n_status: parseAsStringArray,
+  f_n_type: parseAsStringArray,
+  f_ol_search: parseAsString,
+  f_ol_severity: parseAsStringArray,
+  f_t_search: parseAsString,
+  n_detail_row: parseAsString,
+  n_detail_tab: parseAsString,
+};
 
 export function useFiltersInLocationQuery<Q extends Query>() {
-  const {pathname, query} = useLocation<Q>();
-  const navigate = useNavigate();
+  const [query, setQuery] = useQueryStates(replayDetailFilterParsers, {
+    history: 'replace',
+    shallow: true,
+    throttleMs: 0,
+  });
 
   const setFilter = useCallback(
     (updatedQuery: Partial<Q>) => {
-      navigate({pathname, query: {...query, ...updatedQuery}}, {replace: true});
+      const nuqsQuery = Object.fromEntries(
+        Object.entries(updatedQuery).map(([key, value]) => [key, value ?? null])
+      );
+      setQuery(nuqsQuery);
     },
-    [pathname, query, navigate]
+    [setQuery]
   );
 
   return {
     setFilter,
-    query,
+    query: query as Q,
   };
 }

--- a/static/app/utils/replays/hooks/useFiltersInLocationQuery.tsx
+++ b/static/app/utils/replays/hooks/useFiltersInLocationQuery.tsx
@@ -50,27 +50,40 @@ type ArrayReplayDetailFilterKey = {
     : never;
 }[keyof ReplayDetailFilterQuery];
 
-const stringReplayDetailFilterKeys: StringReplayDetailFilterKey[] = [
-  'f_b_search',
-  'f_c_search',
-  'f_e_search',
-  'f_n_search',
-  'f_ol_search',
-  'f_t_search',
-  'n_detail_row',
-  'n_detail_tab',
-];
+function makeReplayDetailFilterKeys<
+  StringKeys extends StringReplayDetailFilterKey,
+  ArrayKeys extends ArrayReplayDetailFilterKey,
+>(keys: {
+  array: ArrayKeys[];
+  missing: Record<Exclude<keyof ReplayDetailFilterQuery, StringKeys | ArrayKeys>, never>;
+  string: StringKeys[];
+}) {
+  return keys;
+}
 
-const arrayReplayDetailFilterKeys: ArrayReplayDetailFilterKey[] = [
-  'f_b_type',
-  'f_c_logLevel',
-  'f_e_level',
-  'f_e_project',
-  'f_n_method',
-  'f_n_status',
-  'f_n_type',
-  'f_ol_severity',
-];
+const replayDetailFilterKeys = makeReplayDetailFilterKeys({
+  string: [
+    'f_b_search',
+    'f_c_search',
+    'f_e_search',
+    'f_n_search',
+    'f_ol_search',
+    'f_t_search',
+    'n_detail_row',
+    'n_detail_tab',
+  ],
+  array: [
+    'f_b_type',
+    'f_c_logLevel',
+    'f_e_level',
+    'f_e_project',
+    'f_n_method',
+    'f_n_status',
+    'f_n_type',
+    'f_ol_severity',
+  ],
+  missing: {},
+});
 
 function setNullableStringValue(
   target: NullableReplayDetailFilterUpdate,
@@ -96,10 +109,10 @@ function toNullableQuery(
   updatedQuery: ReplayDetailFilterUpdate
 ): NullableReplayDetailFilterUpdate {
   const nullableQuery: NullableReplayDetailFilterUpdate = {};
-  for (const key of stringReplayDetailFilterKeys) {
+  for (const key of replayDetailFilterKeys.string) {
     setNullableStringValue(nullableQuery, updatedQuery, key);
   }
-  for (const key of arrayReplayDetailFilterKeys) {
+  for (const key of replayDetailFilterKeys.array) {
     setNullableArrayValue(nullableQuery, updatedQuery, key);
   }
   return nullableQuery;

--- a/static/app/utils/replays/hooks/useFiltersInLocationQuery.tsx
+++ b/static/app/utils/replays/hooks/useFiltersInLocationQuery.tsx
@@ -31,6 +31,48 @@ type ReplayDetailFilterQuery = inferParserType<typeof replayDetailFilterParsers>
 type ReplayDetailFilterUpdate = Partial<{
   [Key in keyof ReplayDetailFilterQuery]: ReplayDetailFilterQuery[Key] | undefined;
 }>;
+type NullableReplayDetailFilterUpdate = Partial<{
+  [Key in keyof ReplayDetailFilterQuery]: ReplayDetailFilterQuery[Key] | null;
+}>;
+
+const replayDetailFilterKeys: Array<keyof ReplayDetailFilterQuery> = [
+  'f_b_search',
+  'f_b_type',
+  'f_c_logLevel',
+  'f_c_search',
+  'f_e_level',
+  'f_e_project',
+  'f_e_search',
+  'f_n_method',
+  'f_n_search',
+  'f_n_status',
+  'f_n_type',
+  'f_ol_search',
+  'f_ol_severity',
+  'f_t_search',
+  'n_detail_row',
+  'n_detail_tab',
+];
+
+function setNullableValue<Key extends keyof ReplayDetailFilterQuery>(
+  target: NullableReplayDetailFilterUpdate,
+  source: ReplayDetailFilterUpdate,
+  key: Key
+) {
+  if (key in source) {
+    target[key] = source[key] ?? null;
+  }
+}
+
+function toNullableQuery(
+  updatedQuery: ReplayDetailFilterUpdate
+): NullableReplayDetailFilterUpdate {
+  const nullableQuery: NullableReplayDetailFilterUpdate = {};
+  for (const key of replayDetailFilterKeys) {
+    setNullableValue(nullableQuery, updatedQuery, key);
+  }
+  return nullableQuery;
+}
 
 export function useFiltersInLocationQuery() {
   const [query, setQuery] = useQueryStates(replayDetailFilterParsers, {
@@ -41,52 +83,7 @@ export function useFiltersInLocationQuery() {
 
   const setFilter = useCallback(
     (updatedQuery: ReplayDetailFilterUpdate) => {
-      setQuery({
-        ...('f_b_search' in updatedQuery
-          ? {f_b_search: updatedQuery.f_b_search ?? null}
-          : {}),
-        ...('f_b_type' in updatedQuery ? {f_b_type: updatedQuery.f_b_type ?? null} : {}),
-        ...('f_c_logLevel' in updatedQuery
-          ? {f_c_logLevel: updatedQuery.f_c_logLevel ?? null}
-          : {}),
-        ...('f_c_search' in updatedQuery
-          ? {f_c_search: updatedQuery.f_c_search ?? null}
-          : {}),
-        ...('f_e_level' in updatedQuery
-          ? {f_e_level: updatedQuery.f_e_level ?? null}
-          : {}),
-        ...('f_e_project' in updatedQuery
-          ? {f_e_project: updatedQuery.f_e_project ?? null}
-          : {}),
-        ...('f_e_search' in updatedQuery
-          ? {f_e_search: updatedQuery.f_e_search ?? null}
-          : {}),
-        ...('f_n_method' in updatedQuery
-          ? {f_n_method: updatedQuery.f_n_method ?? null}
-          : {}),
-        ...('f_n_search' in updatedQuery
-          ? {f_n_search: updatedQuery.f_n_search ?? null}
-          : {}),
-        ...('f_n_status' in updatedQuery
-          ? {f_n_status: updatedQuery.f_n_status ?? null}
-          : {}),
-        ...('f_n_type' in updatedQuery ? {f_n_type: updatedQuery.f_n_type ?? null} : {}),
-        ...('f_ol_search' in updatedQuery
-          ? {f_ol_search: updatedQuery.f_ol_search ?? null}
-          : {}),
-        ...('f_ol_severity' in updatedQuery
-          ? {f_ol_severity: updatedQuery.f_ol_severity ?? null}
-          : {}),
-        ...('f_t_search' in updatedQuery
-          ? {f_t_search: updatedQuery.f_t_search ?? null}
-          : {}),
-        ...('n_detail_row' in updatedQuery
-          ? {n_detail_row: updatedQuery.n_detail_row ?? null}
-          : {}),
-        ...('n_detail_tab' in updatedQuery
-          ? {n_detail_tab: updatedQuery.n_detail_tab ?? null}
-          : {}),
-      });
+      setQuery(toNullableQuery(updatedQuery));
     },
     [setQuery]
   );

--- a/static/app/utils/replays/hooks/useFiltersInLocationQuery.tsx
+++ b/static/app/utils/replays/hooks/useFiltersInLocationQuery.tsx
@@ -35,29 +35,57 @@ type NullableReplayDetailFilterUpdate = Partial<{
   [Key in keyof ReplayDetailFilterQuery]: ReplayDetailFilterQuery[Key] | null;
 }>;
 
-const replayDetailFilterKeys: Array<keyof ReplayDetailFilterQuery> = [
+type StringReplayDetailFilterKey = {
+  [Key in keyof ReplayDetailFilterQuery]: ReplayDetailFilterQuery[Key] extends
+    | string
+    | null
+    ? Key
+    : never;
+}[keyof ReplayDetailFilterQuery];
+type ArrayReplayDetailFilterKey = {
+  [Key in keyof ReplayDetailFilterQuery]: ReplayDetailFilterQuery[Key] extends
+    | string[]
+    | null
+    ? Key
+    : never;
+}[keyof ReplayDetailFilterQuery];
+
+const stringReplayDetailFilterKeys: StringReplayDetailFilterKey[] = [
   'f_b_search',
-  'f_b_type',
-  'f_c_logLevel',
   'f_c_search',
-  'f_e_level',
-  'f_e_project',
   'f_e_search',
-  'f_n_method',
   'f_n_search',
-  'f_n_status',
-  'f_n_type',
   'f_ol_search',
-  'f_ol_severity',
   'f_t_search',
   'n_detail_row',
   'n_detail_tab',
 ];
 
-function setNullableValue<Key extends keyof ReplayDetailFilterQuery>(
+const arrayReplayDetailFilterKeys: ArrayReplayDetailFilterKey[] = [
+  'f_b_type',
+  'f_c_logLevel',
+  'f_e_level',
+  'f_e_project',
+  'f_n_method',
+  'f_n_status',
+  'f_n_type',
+  'f_ol_severity',
+];
+
+function setNullableStringValue(
   target: NullableReplayDetailFilterUpdate,
   source: ReplayDetailFilterUpdate,
-  key: Key
+  key: StringReplayDetailFilterKey
+) {
+  if (key in source) {
+    target[key] = source[key] ?? null;
+  }
+}
+
+function setNullableArrayValue(
+  target: NullableReplayDetailFilterUpdate,
+  source: ReplayDetailFilterUpdate,
+  key: ArrayReplayDetailFilterKey
 ) {
   if (key in source) {
     target[key] = source[key] ?? null;
@@ -68,8 +96,11 @@ function toNullableQuery(
   updatedQuery: ReplayDetailFilterUpdate
 ): NullableReplayDetailFilterUpdate {
   const nullableQuery: NullableReplayDetailFilterUpdate = {};
-  for (const key of replayDetailFilterKeys) {
-    setNullableValue(nullableQuery, updatedQuery, key);
+  for (const key of stringReplayDetailFilterKeys) {
+    setNullableStringValue(nullableQuery, updatedQuery, key);
+  }
+  for (const key of arrayReplayDetailFilterKeys) {
+    setNullableArrayValue(nullableQuery, updatedQuery, key);
   }
   return nullableQuery;
 }

--- a/static/app/views/explore/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/explore/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -9,11 +9,6 @@ import type {ReplayFrame} from 'sentry/utils/replays/types';
 import {getFrameOpOrCategory} from 'sentry/utils/replays/types';
 import {filterItems} from 'sentry/views/explore/replays/detail/utils';
 
-type FilterFields = {
-  f_b_search: string;
-  f_b_type: string[];
-};
-
 type Options = {
   frames: ReplayFrame[];
 };
@@ -105,7 +100,7 @@ const FILTERS = {
 };
 
 export function useBreadcrumbFilters({frames}: Options): Return {
-  const {setFilter, query} = useFiltersInLocationQuery<FilterFields>();
+  const {setFilter, query} = useFiltersInLocationQuery();
 
   // Keep a reference of object paths that are expanded (via <StructuredEventData>)
   // by log row, so they they can be restored as the Console pane is scrolling.

--- a/static/app/views/explore/replays/detail/console/useConsoleFilters.spec.tsx
+++ b/static/app/views/explore/replays/detail/console/useConsoleFilters.spec.tsx
@@ -1,21 +1,15 @@
-import type {Location} from 'history';
 import {ReplayConsoleFrameFixture} from 'sentry-fixture/replay/replayBreadcrumbFrameData';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  renderHookWithProviders as renderHook,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 import {hydrateBreadcrumbs} from 'sentry/utils/replays/hydrateBreadcrumbs';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
-import type {FilterFields} from 'sentry/views/explore/replays/detail/console/useConsoleFilters';
 import {useConsoleFilters} from 'sentry/views/explore/replays/detail/console/useConsoleFilters';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useNavigate');
-
-const mockUseNavigate = jest.mocked(useNavigate);
-const mockUseLocation = jest.mocked(useLocation);
 
 const frames = hydrateBreadcrumbs(ReplayRecordFixture(), [
   ReplayConsoleFrameFixture({
@@ -95,58 +89,31 @@ const frames = hydrateBreadcrumbs(ReplayRecordFixture(), [
 ]);
 
 describe('useConsoleFilters', () => {
-  it('should update the url when setters are called', () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
+  it('should update the url when setters are called', async () => {
     const LOG_FILTER = ['error'];
     const SEARCH_FILTER = 'component';
 
-    mockUseLocation
-      .mockReturnValueOnce({
-        pathname: '/',
-        query: {},
-      } as Location<FilterFields>)
-      .mockReturnValueOnce({
-        pathname: '/',
-        query: {f_c_logLevel: LOG_FILTER},
-      } as Location<FilterFields>);
-
-    const {result, rerender} = renderHook(useConsoleFilters, {
+    const {result, router} = renderHook(useConsoleFilters, {
       initialProps: {frames},
     });
 
-    result.current.setLogLevel(LOG_FILTER);
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      {
-        pathname: '/',
-        query: {
-          f_c_logLevel: LOG_FILTER,
-        },
-      },
-      {replace: true}
+    act(() => result.current.setLogLevel(LOG_FILTER));
+    await waitFor(() =>
+      expect(router.location.query).toEqual({
+        f_c_logLevel: 'error',
+      })
     );
 
-    rerender({frames});
-
-    result.current.setSearchTerm(SEARCH_FILTER);
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      {
-        pathname: '/',
-        query: {
-          f_c_logLevel: LOG_FILTER,
-          f_c_search: SEARCH_FILTER,
-        },
-      },
-      {replace: true}
+    act(() => result.current.setSearchTerm(SEARCH_FILTER));
+    await waitFor(() =>
+      expect(router.location.query).toEqual({
+        f_c_logLevel: 'error',
+        f_c_search: SEARCH_FILTER,
+      })
     );
   });
 
   it('should not filter anything when no values are set', async () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {},
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useConsoleFilters, {
       initialProps: {frames},
     });
@@ -154,44 +121,47 @@ describe('useConsoleFilters', () => {
   });
 
   it('should filter by logLevel', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_c_logLevel: ['error', 'warning'],
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useConsoleFilters, {
       initialProps: {frames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_c_logLevel: ['error', 'warning'],
+          },
+        },
+      },
     });
     expect(result.current.items).toHaveLength(2);
   });
 
   it('should filter by searchTerm', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_c_search: 'component',
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useConsoleFilters, {
       initialProps: {frames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_c_search: 'component',
+          },
+        },
+      },
     });
     expect(result.current.items).toHaveLength(2);
   });
 
   it('should filter by searchTerm and logLevel', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_c_search: 'error occurred',
-        f_c_logLevel: ['error'],
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useConsoleFilters, {
       initialProps: {frames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_c_search: 'error occurred',
+            f_c_logLevel: ['error'],
+          },
+        },
+      },
     });
     expect(result.current.items).toHaveLength(1);
   });
@@ -229,13 +199,6 @@ describe('useConsoleFilters', () => {
     // const CRUMB_ERROR = {level: BreadcrumbLevelType.ERROR, message: ''} as Crumb;
     // const CRUMB_ISSUE = {category: 'issue', level: 'error', message: ''} as Crumb;
 
-    beforeEach(() => {
-      mockUseLocation.mockReturnValue({
-        pathname: '/',
-        query: {},
-      } as Location<FilterFields>);
-    });
-
     it('should return a sorted list of BreadcrumbLevelType', () => {
       const simpleCrumbs = [CRUMB_LOG_1!, CRUMB_WARN!, CRUMB_ERROR!];
 
@@ -261,13 +224,14 @@ describe('useConsoleFilters', () => {
     it('should inject extra BreadcrumbLevelType values', () => {
       const simpleCrumbs = [CRUMB_WARN!, CRUMB_ERROR!];
 
-      mockUseLocation.mockReturnValue({
-        pathname: '/',
-        query: {f_c_logLevel: ['log']},
-      } as Location<FilterFields>);
-
       const {result} = renderHook(useConsoleFilters, {
         initialProps: {frames: simpleCrumbs},
+        initialRouterConfig: {
+          location: {
+            pathname: '/',
+            query: {f_c_logLevel: ['log']},
+          },
+        },
       });
 
       expect(result.current.getLogLevels()).toStrictEqual([

--- a/static/app/views/explore/replays/detail/console/useConsoleFilters.tsx
+++ b/static/app/views/explore/replays/detail/console/useConsoleFilters.tsx
@@ -11,11 +11,6 @@ import {
 } from 'sentry/utils/replays/types';
 import {filterItems} from 'sentry/views/explore/replays/detail/utils';
 
-type FilterFields = {
-  f_c_logLevel: string[];
-  f_c_search: string;
-};
-
 type Options = {
   frames: BreadcrumbFrame[];
 };
@@ -68,7 +63,7 @@ function sortBySeverity(a: string, b: string) {
 }
 
 export function useConsoleFilters({frames}: Options): Return {
-  const {setFilter, query} = useFiltersInLocationQuery<FilterFields>();
+  const {setFilter, query} = useFiltersInLocationQuery();
 
   // Keep a reference of object paths that are expanded (via <StructuredEventData>)
   // by log row, so they they can be restored as the Console pane is scrolling.

--- a/static/app/views/explore/replays/detail/console/useConsoleFilters.tsx
+++ b/static/app/views/explore/replays/detail/console/useConsoleFilters.tsx
@@ -11,7 +11,7 @@ import {
 } from 'sentry/utils/replays/types';
 import {filterItems} from 'sentry/views/explore/replays/detail/utils';
 
-export type FilterFields = {
+type FilterFields = {
   f_c_logLevel: string[];
   f_c_search: string;
 };

--- a/static/app/views/explore/replays/detail/errorList/useErrorFilters.spec.tsx
+++ b/static/app/views/explore/replays/detail/errorList/useErrorFilters.spec.tsx
@@ -1,23 +1,15 @@
-import type {Location} from 'history';
 import {RawReplayErrorFixture} from 'sentry-fixture/replay/error';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  renderHookWithProviders as renderHook,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import {hydrateErrors} from 'sentry/utils/replays/hydrateErrors';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
-import type {
-  ErrorSelectOption,
-  FilterFields,
-} from 'sentry/views/explore/replays/detail/errorList/useErrorFilters';
+import type {ErrorSelectOption} from 'sentry/views/explore/replays/detail/errorList/useErrorFilters';
 import {useErrorFilters} from 'sentry/views/explore/replays/detail/errorList/useErrorFilters';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useNavigate');
-
-const mockUseNavigate = jest.mocked(useNavigate);
-const mockUseLocation = jest.mocked(useLocation);
 
 const {
   errorFrames: [ERROR_1_JS_RANGEERROR, ERROR_2_NEXTJS_TYPEERROR, ERROR_3_JS_UNDEFINED],
@@ -58,9 +50,7 @@ const {
 );
 
 describe('useErrorFilters', () => {
-  it('should update the url when setters are called', () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
+  it('should update the url when setters are called', async () => {
     const errorFrames = [
       ERROR_1_JS_RANGEERROR!,
       ERROR_2_NEXTJS_TYPEERROR!,
@@ -74,44 +64,23 @@ describe('useErrorFilters', () => {
     } as ErrorSelectOption;
     const SEARCH_FILTER = 'BadRequestError';
 
-    mockUseLocation
-      .mockReturnValueOnce({
-        pathname: '/',
-        query: {},
-      } as Location<FilterFields>)
-      .mockReturnValueOnce({
-        pathname: '/',
-        query: {f_e_project: [PROJECT_OPTION.value]},
-      } as Location<FilterFields>);
-
-    const {result, rerender} = renderHook(useErrorFilters, {
+    const {result, router} = renderHook(useErrorFilters, {
       initialProps: {errorFrames},
     });
 
-    result.current.setFilters([PROJECT_OPTION]);
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      {
-        pathname: '/',
-        query: {
-          f_e_level: [],
-          f_e_project: [PROJECT_OPTION.value],
-        },
-      },
-      {replace: true}
+    act(() => result.current.setFilters([PROJECT_OPTION]));
+    await waitFor(() =>
+      expect(router.location.query).toEqual({
+        f_e_project: PROJECT_OPTION.value,
+      })
     );
 
-    rerender({errorFrames});
-
-    result.current.setSearchTerm(SEARCH_FILTER);
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      {
-        pathname: '/',
-        query: {
-          f_e_project: [PROJECT_OPTION.value],
-          f_e_search: SEARCH_FILTER,
-        },
-      },
-      {replace: true}
+    act(() => result.current.setSearchTerm(SEARCH_FILTER));
+    await waitFor(() =>
+      expect(router.location.query).toEqual({
+        f_e_project: PROJECT_OPTION.value,
+        f_e_search: SEARCH_FILTER,
+      })
     );
   });
 
@@ -121,11 +90,6 @@ describe('useErrorFilters', () => {
       ERROR_2_NEXTJS_TYPEERROR!,
       ERROR_3_JS_UNDEFINED!,
     ];
-
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {},
-    } as Location<FilterFields>);
 
     const {result} = renderHook(useErrorFilters, {
       initialProps: {errorFrames},
@@ -140,15 +104,16 @@ describe('useErrorFilters', () => {
       ERROR_3_JS_UNDEFINED!,
     ];
 
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_e_project: ['javascript'],
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useErrorFilters, {
       initialProps: {errorFrames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_e_project: ['javascript'],
+          },
+        },
+      },
     });
     expect(result.current.items).toStrictEqual([
       ERROR_1_JS_RANGEERROR!,
@@ -163,15 +128,16 @@ describe('useErrorFilters', () => {
       ERROR_3_JS_UNDEFINED!,
     ];
 
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_e_level: ['error'],
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useErrorFilters, {
       initialProps: {errorFrames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_e_level: ['error'],
+          },
+        },
+      },
     });
     expect(result.current.items).toStrictEqual([
       ERROR_2_NEXTJS_TYPEERROR!,
@@ -186,15 +152,16 @@ describe('useErrorFilters', () => {
       ERROR_3_JS_UNDEFINED!,
     ];
 
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_e_search: 'Maximum update depth',
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useErrorFilters, {
       initialProps: {errorFrames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_e_search: 'Maximum update depth',
+          },
+        },
+      },
     });
     expect(result.current.items).toHaveLength(1);
   });

--- a/static/app/views/explore/replays/detail/errorList/useErrorFilters.tsx
+++ b/static/app/views/explore/replays/detail/errorList/useErrorFilters.tsx
@@ -17,12 +17,6 @@ const DEFAULT_FILTERS = {
   f_e_project: [],
 } as Record<ErrorSelectOption['qs'], string[]>;
 
-type FilterFields = {
-  f_e_level: string[];
-  f_e_project: string[];
-  f_e_search: string;
-};
-
 type Options = {
   errorFrames: ErrorFrame[];
 };
@@ -51,7 +45,7 @@ const FILTERS = {
 };
 
 export function useErrorFilters({errorFrames}: Options): Return {
-  const {setFilter, query} = useFiltersInLocationQuery<FilterFields>();
+  const {setFilter, query} = useFiltersInLocationQuery();
 
   const level = useMemo(() => decodeList(query.f_e_level), [query.f_e_level]);
   const project = useMemo(() => decodeList(query.f_e_project), [query.f_e_project]);

--- a/static/app/views/explore/replays/detail/errorList/useErrorFilters.tsx
+++ b/static/app/views/explore/replays/detail/errorList/useErrorFilters.tsx
@@ -17,7 +17,7 @@ const DEFAULT_FILTERS = {
   f_e_project: [],
 } as Record<ErrorSelectOption['qs'], string[]>;
 
-export type FilterFields = {
+type FilterFields = {
   f_e_level: string[];
   f_e_project: string[];
   f_e_search: string;

--- a/static/app/views/explore/replays/detail/network/useNetworkFilters.spec.tsx
+++ b/static/app/views/explore/replays/detail/network/useNetworkFilters.spec.tsx
@@ -1,4 +1,3 @@
-import type {Location} from 'history';
 import {
   ReplayNavigationFrameFixture,
   ReplayNavigationPushFrameFixture,
@@ -7,20 +6,16 @@ import {
 } from 'sentry-fixture/replay/replaySpanFrameData';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  renderHookWithProviders as renderHook,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import {hydrateSpans} from 'sentry/utils/replays/hydrateSpans';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 
-import type {FilterFields, NetworkSelectOption} from './useNetworkFilters';
+import type {NetworkSelectOption} from './useNetworkFilters';
 import {useNetworkFilters} from './useNetworkFilters';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useNavigate');
-
-const mockUseNavigate = jest.mocked(useNavigate);
-const mockUseLocation = jest.mocked(useLocation);
 
 const [
   SPAN_0_NAVIGATE,
@@ -118,9 +113,7 @@ describe('useNetworkFilters', () => {
     SPAN_8_FETCH_POST!,
   ];
 
-  it('should update the url when setters are called', () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
+  it('should update the url when setters are called', async () => {
     const TYPE_OPTION: NetworkSelectOption = {
       value: 'resource.fetch',
       label: 'resource.fetch',
@@ -133,72 +126,36 @@ describe('useNetworkFilters', () => {
     };
     const SEARCH_FILTER = 'pikachu';
 
-    mockUseLocation
-      .mockReturnValueOnce({
-        pathname: '/',
-        query: {},
-      } as Location<FilterFields>)
-      .mockReturnValueOnce({
-        pathname: '/',
-        query: {f_n_type: [TYPE_OPTION.value]},
-      } as Location<FilterFields>)
-      .mockReturnValueOnce({
-        pathname: '/',
-        query: {f_n_type: [TYPE_OPTION.value], f_n_status: [STATUS_OPTION.value]},
-      } as Location<FilterFields>);
-
-    const {result, rerender} = renderHook(useNetworkFilters, {
+    const {result, router} = renderHook(useNetworkFilters, {
       initialProps: {networkFrames},
     });
 
-    result.current.setFilters([TYPE_OPTION]);
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      {
-        pathname: '/',
-        query: {
-          f_n_method: [],
-          f_n_status: [],
-          f_n_type: [TYPE_OPTION.value],
-        },
-      },
-      {replace: true}
+    act(() => result.current.setFilters([TYPE_OPTION]));
+    await waitFor(() =>
+      expect(router.location.query).toEqual({
+        f_n_type: TYPE_OPTION.value,
+      })
     );
 
-    rerender({networkFrames});
-
-    result.current.setFilters([TYPE_OPTION, STATUS_OPTION]);
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      {
-        pathname: '/',
-        query: {
-          f_n_method: [],
-          f_n_status: [STATUS_OPTION.value],
-          f_n_type: [TYPE_OPTION.value],
-        },
-      },
-      {replace: true}
+    act(() => result.current.setFilters([TYPE_OPTION, STATUS_OPTION]));
+    await waitFor(() =>
+      expect(router.location.query).toEqual({
+        f_n_status: STATUS_OPTION.value,
+        f_n_type: TYPE_OPTION.value,
+      })
     );
 
-    rerender({networkFrames});
-
-    result.current.setSearchTerm(SEARCH_FILTER);
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      {
-        pathname: '/',
-        query: {
-          f_n_type: [TYPE_OPTION.value],
-          f_n_status: [STATUS_OPTION.value],
-          f_n_search: SEARCH_FILTER,
-        },
-      },
-      {replace: true}
+    act(() => result.current.setSearchTerm(SEARCH_FILTER));
+    await waitFor(() =>
+      expect(router.location.query).toEqual({
+        f_n_search: SEARCH_FILTER,
+        f_n_status: STATUS_OPTION.value,
+        f_n_type: TYPE_OPTION.value,
+      })
     );
   });
 
-  it('should clear details params when setters are called', () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
+  it('should clear details params when setters are called', async () => {
     const TYPE_OPTION: NetworkSelectOption = {
       value: 'resource.fetch',
       label: 'resource.fetch',
@@ -211,86 +168,45 @@ describe('useNetworkFilters', () => {
     };
     const SEARCH_FILTER = 'pikachu';
 
-    mockUseLocation
-      .mockReturnValueOnce({
-        pathname: '/',
-        query: {
-          n_detail_row: '0',
-          n_detail_tab: 'response',
-        },
-      } as Location<FilterFields>)
-      .mockReturnValueOnce({
-        pathname: '/',
-        query: {
-          f_n_type: [TYPE_OPTION.value],
-          n_detail_row: '0',
-          n_detail_tab: 'response',
-        },
-      } as Location<FilterFields>)
-      .mockReturnValueOnce({
-        pathname: '/',
-        query: {
-          f_n_type: [TYPE_OPTION.value],
-          f_n_status: [STATUS_OPTION.value],
-          n_detail_row: '0',
-          n_detail_tab: 'response',
-        },
-      } as Location<FilterFields>);
-
-    const {result, rerender} = renderHook(useNetworkFilters, {
+    const {result, router} = renderHook(useNetworkFilters, {
       initialProps: {networkFrames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            n_detail_row: '0',
+            n_detail_tab: 'response',
+          },
+        },
+      },
     });
 
-    result.current.setFilters([TYPE_OPTION]);
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      {
-        pathname: '/',
-        query: {
-          f_n_method: [],
-          f_n_status: [],
-          f_n_type: [TYPE_OPTION.value],
-        },
-      },
-      {replace: true}
+    act(() => result.current.setFilters([TYPE_OPTION]));
+    await waitFor(() =>
+      expect(router.location.query).toEqual({
+        f_n_type: TYPE_OPTION.value,
+      })
     );
 
-    rerender({networkFrames});
-
-    result.current.setFilters([TYPE_OPTION, STATUS_OPTION]);
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      {
-        pathname: '/',
-        query: {
-          f_n_method: [],
-          f_n_status: [STATUS_OPTION.value],
-          f_n_type: [TYPE_OPTION.value],
-        },
-      },
-      {replace: true}
+    act(() => result.current.setFilters([TYPE_OPTION, STATUS_OPTION]));
+    await waitFor(() =>
+      expect(router.location.query).toEqual({
+        f_n_status: STATUS_OPTION.value,
+        f_n_type: TYPE_OPTION.value,
+      })
     );
 
-    rerender({networkFrames});
-
-    result.current.setSearchTerm(SEARCH_FILTER);
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      {
-        pathname: '/',
-        query: {
-          f_n_status: [STATUS_OPTION.value],
-          f_n_type: [TYPE_OPTION.value],
-          f_n_search: SEARCH_FILTER,
-        },
-      },
-      {replace: true}
+    act(() => result.current.setSearchTerm(SEARCH_FILTER));
+    await waitFor(() =>
+      expect(router.location.query).toEqual({
+        f_n_search: SEARCH_FILTER,
+        f_n_status: STATUS_OPTION.value,
+        f_n_type: TYPE_OPTION.value,
+      })
     );
   });
 
   it('should not filter anything when no values are set', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {},
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useNetworkFilters, {
       initialProps: {networkFrames},
     });
@@ -298,87 +214,93 @@ describe('useNetworkFilters', () => {
   });
 
   it('should filter by method', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_n_method: ['POST'],
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useNetworkFilters, {
       initialProps: {networkFrames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_n_method: ['POST'],
+          },
+        },
+      },
     });
     expect(result.current.items).toStrictEqual([SPAN_8_FETCH_POST]);
   });
 
   it('should include css/js/img when method GET is selected', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_n_method: ['GET'],
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useNetworkFilters, {
       initialProps: {networkFrames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_n_method: ['GET'],
+          },
+        },
+      },
     });
     expect(result.current.items).toHaveLength(8);
   });
 
   it('should filter by status', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_n_status: ['200'],
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useNetworkFilters, {
       initialProps: {networkFrames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_n_status: ['200'],
+          },
+        },
+      },
     });
     expect(result.current.items).toHaveLength(2);
   });
 
   it('should filter by type', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_n_type: ['resource.fetch'],
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useNetworkFilters, {
       initialProps: {networkFrames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_n_type: ['resource.fetch'],
+          },
+        },
+      },
     });
     expect(result.current.items).toHaveLength(3);
   });
 
   it('should filter by searchTerm', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_n_search: 'pikachu',
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useNetworkFilters, {
       initialProps: {networkFrames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_n_search: 'pikachu',
+          },
+        },
+      },
     });
     expect(result.current.items).toHaveLength(1);
   });
 
   it('should filter by type, searchTerm and logLevel', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_n_status: ['200'],
-        f_n_type: ['resource.fetch'],
-        f_n_search: 'pokemon/',
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useNetworkFilters, {
       initialProps: {networkFrames},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_n_status: ['200'],
+            f_n_type: ['resource.fetch'],
+            f_n_search: 'pokemon/',
+          },
+        },
+      },
     });
     expect(result.current.items).toHaveLength(1);
   });

--- a/static/app/views/explore/replays/detail/network/useNetworkFilters.tsx
+++ b/static/app/views/explore/replays/detail/network/useNetworkFilters.tsx
@@ -18,7 +18,7 @@ const DEFAULT_FILTERS = {
   f_n_type: [],
 } as Record<NetworkSelectOption['qs'], string[]>;
 
-export type FilterFields = {
+type FilterFields = {
   f_n_method: string[];
   f_n_search: string;
   f_n_status: string[];

--- a/static/app/views/explore/replays/detail/network/useNetworkFilters.tsx
+++ b/static/app/views/explore/replays/detail/network/useNetworkFilters.tsx
@@ -18,15 +18,6 @@ const DEFAULT_FILTERS = {
   f_n_type: [],
 } as Record<NetworkSelectOption['qs'], string[]>;
 
-type FilterFields = {
-  f_n_method: string[];
-  f_n_search: string;
-  f_n_status: string[];
-  f_n_type: string[];
-  n_detail_row?: string;
-  n_detail_tab?: string;
-};
-
 type Options = {
   networkFrames: SpanFrame[];
 };
@@ -60,7 +51,7 @@ const FILTERS = {
 };
 
 export function useNetworkFilters({networkFrames}: Options): Return {
-  const {setFilter, query} = useFiltersInLocationQuery<FilterFields>();
+  const {setFilter, query} = useFiltersInLocationQuery();
 
   const method = useMemo(() => decodeList(query.f_n_method), [query.f_n_method]);
   const status = useMemo(() => decodeList(query.f_n_status), [query.f_n_status]);

--- a/static/app/views/explore/replays/detail/network/useNetworkFilters.tsx
+++ b/static/app/views/explore/replays/detail/network/useNetworkFilters.tsx
@@ -108,7 +108,14 @@ export function useNetworkFilters({networkFrames}: Options): Return {
 
   const getResourceTypes = useCallback(
     () =>
-      Array.from(new Set(networkFrames.map(frame => frame.op).concat(type)))
+      Array.from(
+        new Set(
+          networkFrames
+            .map(frame => frame.op)
+            .concat('resource.fetch')
+            .concat(type)
+        )
+      )
         .sort((a, b) => (operationName(a) < operationName(b) ? -1 : 1))
         .map(
           (value): NetworkSelectOption => ({
@@ -126,6 +133,7 @@ export function useNetworkFilters({networkFrames}: Options): Return {
         new Set(
           networkFrames
             .map(frame => String(getFrameStatus(frame) ?? UNKNOWN_STATUS))
+            .concat('200')
             .concat(status)
             .map(String)
         )

--- a/static/app/views/explore/replays/detail/ourlogs/useOurLogFilters.tsx
+++ b/static/app/views/explore/replays/detail/ourlogs/useOurLogFilters.tsx
@@ -11,11 +11,6 @@ import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {getLogSeverityLevel} from 'sentry/views/explore/logs/utils';
 
-type FilterFields = {
-  f_ol_search: string;
-  f_ol_severity: string[];
-};
-
 type Options = {
   logItems: OurLogsResponseItem[];
 };
@@ -64,7 +59,7 @@ function filterItems<T>(options: {
 }
 
 export function useOurLogFilters({logItems}: Options): Return {
-  const {setFilter, query} = useFiltersInLocationQuery<FilterFields>();
+  const {setFilter, query} = useFiltersInLocationQuery();
 
   const severityValues = useMemo(
     () => decodeList(query.f_ol_severity),

--- a/static/app/views/explore/replays/detail/tagPanel/useTagFilters.spec.tsx
+++ b/static/app/views/explore/replays/detail/tagPanel/useTagFilters.spec.tsx
@@ -1,26 +1,13 @@
-import type {Location} from 'history';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders as renderHook} from 'sentry-test/reactTestingLibrary';
 
-import {useLocation} from 'sentry/utils/useLocation';
-import type {FilterFields} from 'sentry/views/explore/replays/detail/tagPanel/useTagFilters';
 import {useTagFilters} from 'sentry/views/explore/replays/detail/tagPanel/useTagFilters';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useNavigate');
-
-const mockUseLocation = jest.mocked(useLocation);
 
 const tags = ReplayRecordFixture().tags;
 
 describe('useTagsFilters', () => {
   it('should not filter anything when no values are set', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {},
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useTagFilters, {
       initialProps: {tags},
     });
@@ -28,15 +15,16 @@ describe('useTagsFilters', () => {
   });
 
   it('should filter by searchTerm', () => {
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      query: {
-        f_t_search: 'Browser',
-      },
-    } as Location<FilterFields>);
-
     const {result} = renderHook(useTagFilters, {
       initialProps: {tags},
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            f_t_search: 'Browser',
+          },
+        },
+      },
     });
     expect(result.current.items).toEqual({
       'browser.name': ['Other'],

--- a/static/app/views/explore/replays/detail/tagPanel/useTagFilters.tsx
+++ b/static/app/views/explore/replays/detail/tagPanel/useTagFilters.tsx
@@ -5,10 +5,6 @@ import {useFiltersInLocationQuery} from 'sentry/utils/replays/hooks/useFiltersIn
 import {filterItems} from 'sentry/views/explore/replays/detail/utils';
 import type {ReplayRecord} from 'sentry/views/explore/replays/types';
 
-type FilterFields = {
-  f_t_search: string;
-};
-
 type Options = {
   tags: ReplayRecord['tags'];
 };
@@ -27,7 +23,7 @@ const FILTERS = {
 };
 
 export function useTagFilters({tags}: Options): Return {
-  const {setFilter, query} = useFiltersInLocationQuery<FilterFields>();
+  const {setFilter, query} = useFiltersInLocationQuery();
 
   const searchTerm = decodeScalar(query.f_t_search, '').toLowerCase();
 

--- a/static/app/views/explore/replays/detail/tagPanel/useTagFilters.tsx
+++ b/static/app/views/explore/replays/detail/tagPanel/useTagFilters.tsx
@@ -5,7 +5,7 @@ import {useFiltersInLocationQuery} from 'sentry/utils/replays/hooks/useFiltersIn
 import {filterItems} from 'sentry/views/explore/replays/detail/utils';
 import type {ReplayRecord} from 'sentry/views/explore/replays/types';
 
-export type FilterFields = {
+type FilterFields = {
   f_t_search: string;
 };
 


### PR DESCRIPTION
Replay detail filters now use typed `nuqs` query state and are cleared when users switch replay tabs. This prevents stale pane-specific filters or selected network details from carrying into another replay tab.

**Replay Detail Filters**

The shared replay filter hook now owns the known detail query parsers, and tests exercise real router query updates instead of mocked navigation.

**Network Filter Defaults**

The network filter menu keeps `fetch` and `200` available even when the current replay frames do not include those values.