### PR TITLE
fix(search-query-builder): Sync external query while disabled

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -62,6 +62,7 @@ type UpdateQueryAction = {
   query: string;
   type: 'UPDATE_QUERY';
   focusOverride?: FocusOverride | null;
+  ignoreDisabled?: boolean;
   shouldCommitQuery?: boolean;
 };
 
@@ -1004,7 +1005,7 @@ export function useQueryBuilderState({
 
   const reducer: Reducer<QueryBuilderState, QueryBuilderActions> = useCallback(
     (state, action): QueryBuilderState => {
-      if (disabled) {
+      if (disabled && !(action.type === 'UPDATE_QUERY' && action.ignoreDisabled)) {
         return state;
       }
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -182,6 +182,48 @@ describe('SearchQueryBuilder', () => {
     expect(await screen.findByPlaceholderText('foo')).toBeInTheDocument();
   });
 
+  it('syncs external initial query changes while disabled', async () => {
+    function ExternalProviderSearchQueryBuilder({
+      disabled,
+      initialQuery,
+    }: {
+      disabled: boolean;
+      initialQuery: string;
+    }) {
+      return (
+        <SearchQueryBuilderProvider
+          {...defaultProps}
+          disabled={disabled}
+          initialQuery={initialQuery}
+        >
+          <SearchQueryBuilder
+            {...defaultProps}
+            disabled={disabled}
+            initialQuery={initialQuery}
+          />
+        </SearchQueryBuilderProvider>
+      );
+    }
+
+    const {rerender} = render(
+      <ExternalProviderSearchQueryBuilder disabled initialQuery="" />
+    );
+
+    rerender(
+      <ExternalProviderSearchQueryBuilder disabled initialQuery="browser.name:Firefox" />
+    );
+    rerender(
+      <ExternalProviderSearchQueryBuilder
+        disabled={false}
+        initialQuery="browser.name:Firefox"
+      />
+    );
+
+    expect(
+      await screen.findByRole('row', {name: 'browser.name:Firefox'})
+    ).toBeInTheDocument();
+  });
+
   describe('rendering search query builder', () => {
     it('does not show the size-limit prompt after the user searches filter keys', async () => {
       const manyMatchingFilterKeys = Object.fromEntries(

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -277,7 +277,7 @@ function SearchQueryBuilderUI({
 
   useOnChange({onChange});
   useLayoutEffect(() => {
-    dispatch({type: 'UPDATE_QUERY', query: initialQuery});
+    dispatch({type: 'UPDATE_QUERY', query: initialQuery, ignoreDisabled: true});
   }, [dispatch, initialQuery]);
 
   const {width: actionBarWidth} = useDimensions({elementRef: actionBarRef});


### PR DESCRIPTION
Allow the query builder to update it's state even when disabled.

Closes EXP-984