### PR TITLE
ci: Update the span-tags we record when jest suite runs

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -47,12 +47,12 @@ const JEST_TESTS: string[] | undefined = fs.existsSync(JEST_TEST_FILES_PATH)
 const IS_MASTER_BRANCH = GITHUB_PR_REF === 'refs/heads/master';
 
 const optionalTags: {
-  tests_count: number | 'all';
+  total_tests?: number | 'all';
   node_index?: number;
   node_total?: number;
   balancer_strategy?: string;
 } = {
-  tests_count: JEST_TESTS?.length ?? 'all',
+  total_tests: undefined,
   node_index: undefined,
   node_total: undefined,
   balancer_strategy: undefined,
@@ -214,6 +214,7 @@ if (
   );
   const nodeTotal = Number(CI_NODE_TOTAL);
   const nodeIndex = Number(CI_NODE_INDEX);
+  optionalTags.total_tests = JEST_TESTS.length;
   optionalTags.node_total = nodeTotal;
   optionalTags.node_index = nodeIndex;
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -47,10 +47,15 @@ const JEST_TESTS: string[] | undefined = fs.existsSync(JEST_TEST_FILES_PATH)
 const IS_MASTER_BRANCH = GITHUB_PR_REF === 'refs/heads/master';
 
 const optionalTags: {
-  balancer?: boolean;
+  tests_count: number | 'all';
+  node_index?: number;
+  node_total?: number;
   balancer_strategy?: string;
 } = {
-  balancer: false,
+  tests_count: JEST_TESTS?.length ?? 'all',
+  node_index: undefined,
+  node_total: undefined,
+  balancer_strategy: undefined,
 };
 
 /**
@@ -209,11 +214,12 @@ if (
   );
   const nodeTotal = Number(CI_NODE_TOTAL);
   const nodeIndex = Number(CI_NODE_INDEX);
+  optionalTags.node_total = nodeTotal;
+  optionalTags.node_index = nodeIndex;
 
   if (balance) {
-    optionalTags.balancer = true;
-    optionalTags.balancer_strategy = 'by_path';
     testMatch = getTestsForGroup(nodeIndex, nodeTotal, envTestList, balance);
+    optionalTags.balancer_strategy = 'by_duration';
   } else {
     const tests = envTestList.sort((a, b) => b.localeCompare(a));
 
@@ -224,6 +230,7 @@ if (
     const chunk = size + (nodeIndex < remainder ? 1 : 0);
 
     testMatch = tests.slice(offset, offset + chunk).map(test => '<rootDir>' + test);
+    optionalTags.balancer_strategy = 'by_name';
   }
 }
 


### PR DESCRIPTION
This updates the tags that are included with the spans that we log whenever jest runs. I don't think any dashboards currently look at the tags, but they'll be nice to help slice&dice the data to see why outliers exist.

I think going forward we'll see PR runs (where branch!=master) that have different perf characteristics. This will let us see how many tests were included, how many nodes they got spread over, we'll expect to see `strategy=by_duration` in all cases too.

Follows https://github.com/getsentry/sentry/pull/116749
Follows https://github.com/getsentry/sentry/pull/116770
