### PR TITLE
ci: Move the DSN for the jest project to github secrets

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -213,6 +213,8 @@ jobs:
 
       - name: jest
         env:
+          SENTRY_DSN: ${{ secrets.SENTRY_JEST_DSN }}
+
           CI_NODE_TOTAL: ${{ matrix.total }}
           CI_NODE_INDEX: ${{ matrix.index }}
 

--- a/.github/workflows/jest-balance.yml
+++ b/.github/workflows/jest-balance.yml
@@ -18,6 +18,7 @@ jobs:
         env:
           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_PR_REF: ${{ github.event.pull_request.head.ref || github.ref }}
+          SENTRY_DSN: ${{ secrets.SENTRY_JEST_DSN }}
         run: pnpm run test-ci --testResultsProcessor ./tests/js/test-balancer/index.js
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -38,6 +38,7 @@ const {
   GITHUB_PR_REF,
   GITHUB_RUN_ID,
   GITHUB_RUN_ATTEMPT,
+  SENTRY_DSN,
 } = process.env;
 
 const JEST_TEST_FILES_PATH = path.resolve(import.meta.dirname, 'jest-test-files.json');
@@ -321,10 +322,7 @@ const config: Config.InitialOptions = {
     sentryConfig: {
       init: {
         // jest project under Sentry organization (dev productivity team)
-        dsn:
-          CI && Boolean(GITHUB_PR_REF)
-            ? 'https://3fe1dce93e3a4267979ebad67f3de327@o1.ingest.us.sentry.io/4857230'
-            : false,
+        dsn: Boolean(CI) && Boolean(GITHUB_PR_REF) && SENTRY_DSN ? SENTRY_DSN : false,
         // Use production env to reduce sampling of commits on master
         environment: CI ? (IS_MASTER_BRANCH ? 'ci:master' : 'ci:pull_request') : 'local',
         tracesSampleRate: CI ? 0.75 : 0,


### PR DESCRIPTION
Some external folks are sending data into our project. its not a huge problem because we have special envs that let us filter out the random stuff. but someone could easily r-euse our envs and then we would be in trouble.

The new DSN is configured in sentry already: https://sentry.sentry.io/settings/projects/jest/keys/232ba39ed1567f1852c02e79600c3779/
The value is in github here: https://github.com/getsentry/sentry/settings/secrets/actions.

After this lands, maybe a few days later, we can disable or revoke the old key.