### PR TITLE
ref(icons): import theme types from the theme types leaf

### DIFF
--- a/static/app/icons/svgIcon.tsx
+++ b/static/app/icons/svgIcon.tsx
@@ -1,6 +1,6 @@
 import {useTheme} from '@emotion/react';
 
-import type {ContentVariant, IconSize} from 'sentry/utils/theme';
+import type {ContentVariant, IconSize} from 'sentry/utils/theme/types';
 
 import {useIconDefaults} from './useIconDefaults';
 


### PR DESCRIPTION
## Summary

`icons/svgIcon` imported `ContentVariant`/`IconSize` from the `sentry/utils/theme` **barrel**, which pulls in the heavy theme module and its in-cycle `constants` dependency. Those types already live in the pure `utils/theme/types` leaf — sourcing them from there removes svgIcon (and, downstream, the 154-icon barrel) from the type-import cycle.

**Largest type-import SCC: 2189 → 2014.**

One-line change; no behavior change.

🤖 Draft for review.