### PR TITLE
fix(api): correct OpenAPI spec type gaps in issue_id and query params

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -154,6 +154,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             VisibilityParams.QUERY,
             VisibilityParams.SORT,
             VisibilityParams.DATASET,
+            VisibilityParams.ALLOW_AGGREGATE_CONDITIONS,
             CursorQueryParam,
         ],
         responses={
@@ -242,7 +243,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         elif not is_valid_referrer(referrer):
             referrer = Referrer.API_ORGANIZATION_EVENTS.value
 
-        use_aggregate_conditions = request.GET.get("allowAggregateConditions", "1") == "1"
+        use_aggregate_conditions = request.GET.get("allowAggregateConditions", "1") in ("1", "true")
 
         max_string_length: int | None = None
         truncate_str = request.GET.get("truncate")

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -6,6 +6,7 @@ from drf_spectacular.utils import OpenApiParameter
 from rest_framework import serializers
 
 from sentry import constants
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.sessions import STATS_PERIODS
 
 # NOTE: Please add new params by path vs query, then in alphabetical order
@@ -320,7 +321,7 @@ class IssueParams:
         name="issue_id",
         location="path",
         required=True,
-        type=int,
+        type=str,
         description="The ID of the issue you'd like to query.",
     )
 
@@ -627,6 +628,13 @@ class SentryAppStatusParams:
 
 
 class VisibilityParams:
+    ALLOW_AGGREGATE_CONDITIONS = OpenApiParameter(
+        name="allowAggregateConditions",
+        location="query",
+        required=False,
+        type=OpenApiTypes.BOOL,
+        description="If false, aggregate conditions in the query string are disallowed. Defaults to true.",
+    )
     QUERY = OpenApiParameter(
         name="query",
         location="query",
@@ -998,6 +1006,28 @@ class ReplayParams:
         required=True,
         type=OpenApiTypes.INT,
         description="""The ID of the replay deletion job you'd like to retrieve.""",
+    )
+
+    DATA_SOURCE = OpenApiParameter(
+        name="data_source",
+        location="query",
+        required=False,
+        type=OpenApiTypes.STR,
+        enum=[
+            Dataset.Discover.value,
+            Dataset.Events.value,
+            Dataset.Transactions.value,
+            Dataset.IssuePlatform.value,
+        ],
+        description="The data source to query replays from. Defaults to 'discover'.",
+    )
+
+    RETURN_IDS = OpenApiParameter(
+        name="returnIds",
+        location="query",
+        required=False,
+        type=OpenApiTypes.BOOL,
+        description="If true, return issue IDs rather than counts.",
     )
 
 

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -24,7 +24,7 @@ from sentry.api.serializers.models.organization import (
 )
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.user_examples import UserExamples
-from sentry.apidocs.parameters import CursorQueryParam, OrganizationParams
+from sentry.apidocs.parameters import CursorQueryParam, OrganizationParams, VisibilityParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
@@ -131,6 +131,7 @@ class OrganizationIndexEndpoint(Endpoint):
             CursorQueryParam,
             OrganizationParams.QUERY,
             OrganizationParams.SORT_BY,
+            VisibilityParams.PER_PAGE,
         ],
         request=None,
         responses={

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -14,7 +14,12 @@ from sentry.api.bases import NoProjects
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
 from sentry.apidocs.examples.replay_examples import ReplayExamples
-from sentry.apidocs.parameters import GlobalParams, OrganizationParams, VisibilityParams
+from sentry.apidocs.parameters import (
+    GlobalParams,
+    OrganizationParams,
+    ReplayParams,
+    VisibilityParams,
+)
 from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidSearchQuery
@@ -75,6 +80,8 @@ class OrganizationReplayCountEndpoint(OrganizationEventsEndpointBase):
             GlobalParams.STATS_PERIOD,
             OrganizationParams.PROJECT_ID_OR_SLUG,
             VisibilityParams.QUERY,
+            ReplayParams.DATA_SOURCE,
+            ReplayParams.RETURN_IDS,
         ],
         responses={
             200: inline_sentry_response_serializer("ReplayCounts", dict[int, int]),


### PR DESCRIPTION
<!-- Describe your PR here. -->

`IssueParams.ISSUE_ID` was declared as `type=int` in the OpenAPI spec, but the Django URL pattern captures it as a string, `GroupEndpoint.convert_args()` receives it as `str`, and the frontend, CLI, and MCP all treat issue IDs as strings. Only the spec was wrong. Changing it to `type=str` fixes the `issueId as unknown as number` casts in the [MCP migration](https://github.com/getsentry/sentry-mcp/pull/931).

Three undocumented query params that endpoints already accept are also added to the spec:
- `per_page` on List Your Organizations (handled by the paginator base class)
- `data_source` and `returnIds` on Replay Count (read by `ReplayCountQueryParamsValidator`)
- `allowAggregateConditions` on Organization Events (read via `request.GET`)

The `allowAggregateConditions` implementation is also fixed to accept `"true"` alongside `"1"`, so callers following the `BOOL` spec declaration get the expected behavior. The existing `"1"`/`"0"` convention still works. No frontend breakage — `useSpansQuery.tsx` serializes this as `'1'`/`'0'` and that behavior is unchanged.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.