### PR TITLE
ref(issueDetails): move DetectorDetails type to a leaf module

### DIFF
--- a/static/app/views/issueDetails/context.tsx
+++ b/static/app/views/issueDetails/context.tsx
@@ -8,7 +8,7 @@ import {
   type Reducer,
 } from 'react';
 
-import type {DetectorDetails} from 'sentry/views/issueDetails/sidebar/detectorSection';
+import type {DetectorDetails} from 'sentry/views/issueDetails/sidebar/detectorDetails';
 
 export const enum SectionKey {
   /**

--- a/static/app/views/issueDetails/sidebar/detectorDetails.tsx
+++ b/static/app/views/issueDetails/sidebar/detectorDetails.tsx
@@ -1,0 +1,11 @@
+export interface DetectorDetails {
+  description?: string;
+  detectorId?: string;
+  detectorPath?: string;
+  detectorSlug?: string;
+  detectorType?:
+    | 'metric_alert'
+    | 'cron_monitor'
+    | 'uptime_monitor'
+    | 'mobile_build_monitor';
+}

--- a/static/app/views/issueDetails/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/sidebar/detectorSection.tsx
@@ -16,19 +16,8 @@ import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import {useDetectorQuery} from 'sentry/views/detectors/hooks';
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 import {useIssueDetails} from 'sentry/views/issueDetails/context';
+import type {DetectorDetails} from 'sentry/views/issueDetails/sidebar/detectorDetails';
 import {SidebarSectionTitle} from 'sentry/views/issueDetails/sidebar/sidebar';
-
-export interface DetectorDetails {
-  description?: string;
-  detectorId?: string;
-  detectorPath?: string;
-  detectorSlug?: string;
-  detectorType?:
-    | 'metric_alert'
-    | 'cron_monitor'
-    | 'uptime_monitor'
-    | 'mobile_build_monitor';
-}
 
 export function getDetectorDetails({
   event,


### PR DESCRIPTION
## Summary

`views/issueDetails/context` imported the `DetectorDetails` type from the `detectorSection` **component**, while `detectorSection` imports the issue-details context back — a 2-cycle. `DetectorDetails` is a pure interface, so moving it to a sibling leaf module (`detectorDetails`) and importing from there removes the context from the type-import cycle. Only `context.tsx` imported the type from the component, so this is a clean relocation (no shim).

**Largest type-import SCC: 2193 → 2106.**

🤖 Draft for review.