### PR TITLE
test: exercise run-on-changed eslint scoping

### DIFF
--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/fixtures/negativeCategorical.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/fixtures/negativeCategorical.tsx
@@ -10,7 +10,7 @@ export const sampleNegativeData: CategoricalSeries = {
     {category: 'Chrome', value: 150},
     {category: 'Firefox', value: -45},
     {category: 'Safari', value: -120},
-    {category: 'Edge', value: 85},
+    {category: 'Edge', value: 90},
     {category: 'Opera', value: -30},
   ],
 };


### PR DESCRIPTION
Draft to validate the scoped ESLint flow on #116718. Not for merge.

This PR's only change is a one-line tweak to a leaf fixture (`negativeCategorical.tsx`). Its transitive reverse-dependency set is just itself plus `categoricalSeriesWidgetVisualization.stories.tsx`, so the `eslint (impacted files)` CI step should run on exactly those two files rather than the full suite.

Watch the `eslint (impacted files)` step's `DEBUG=run-on-changed:*` output to confirm the changed + impacted file lists.