### PR TITLE
feat(api): migrate RelayUsageSerializer to Serializer[T]

### DIFF
--- a/src/sentry/api/endpoints/organization_relay_usage.py
+++ b/src/sentry/api/endpoints/organization_relay_usage.py
@@ -7,7 +7,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.relayusage import OrganizationRelayResponse
+from sentry.api.serializers.models.relayusage import OrganizationRelayResponse, RelayUsageSerializer
 from sentry.apidocs.constants import RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -37,7 +37,9 @@ class OrganizationRelayUsage(OrganizationEndpoint):
         },
         examples=OrganizationExamples.LIST_RELAYS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[OrganizationRelayResponse]]:
         """
         Return a list of trusted relays bound to an organization.
         """
@@ -50,4 +52,4 @@ class OrganizationRelayUsage(OrganizationEndpoint):
         keys = [val.get("public_key") for val in trusted_relays]
         relay_history = list(RelayUsage.objects.filter(public_key__in=keys).order_by("-last_seen"))
 
-        return Response(serialize(relay_history, request.user))
+        return Response(serialize(relay_history, request.user, serializer=RelayUsageSerializer()))

--- a/src/sentry/api/serializers/models/relayusage.py
+++ b/src/sentry/api/serializers/models/relayusage.py
@@ -13,8 +13,8 @@ class OrganizationRelayResponse(TypedDict):
 
 
 @register(RelayUsage)
-class RelayUsageSerializer(Serializer):
-    def serialize(self, obj, attrs, user, **kwargs):
+class RelayUsageSerializer(Serializer[OrganizationRelayResponse]):
+    def serialize(self, obj, attrs, user, **kwargs) -> OrganizationRelayResponse:
         return {
             "relayId": obj.relay_id,
             "version": obj.version,


### PR DESCRIPTION
Subscript `RelayUsageSerializer` with `OrganizationRelayResponse`, annotate its `serialize()` return, and tighten `organization_relay_usage.py` to `Response[list[OrganizationRelayResponse]]`. Pass the serializer explicitly at the call site so mypy picks the typed `serialize(...)` overload instead of the `Any` fallback.

Same pattern as #116743 (Tag(Key|Value)Serializer). No cast.