### PR TITLE
docs: add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,3 +256,41 @@ Frontend (`static/`) and backend (`src/`, `tests/`) are **not atomically deploye
 - If your changes touch both frontend and backend, split them into **separate PRs**.
 - Land the backend PR first when the frontend depends on new API changes.
 - Pure test additions alongside `src/` changes are fine in one PR.
+
+## Cursor Cloud specific instructions
+
+Cloud VMs do not run macOS `devenv bootstrap`. Use `devenv --nocoderoot sync` (also in the VM update script) to refresh Python/Node dependencies. `devenv sync` may exit non-zero on `prek install` when `core.hooksPath` is set by the agent runtime; Python/JS deps still install — run `.venv/bin/prek run -q` directly for lint.
+
+### Docker and `devservices`
+
+- Docker must be running before `devservices up` / `devservices serve`. If `docker ps` fails with permission errors: `sudo service docker start` and ensure the user can access `/var/run/docker.sock` (e.g. `sudo chmod 666 /var/run/docker.sock` in ephemeral VMs).
+- Start backing services: `devservices up` (default mode: postgres, redis, kafka, clickhouse, snuba, relay, objectstore, spotlight).
+- First-time DB setup (after postgres is up): `sentry init --dev --no-clobber` (creates `~/.sentry/`), create DBs via `scripts/lib.sh` helpers or `docker exec postgres-postgres-1 createdb ...`, then `sentry upgrade --noinput` and `sentry createuser --superuser --email admin@sentry.io --password admin --no-input`.
+
+### Environment variables
+
+When not using `direnv allow`, export before `sentry` / `pytest` / `devservices`:
+
+```bash
+export PATH="/workspace/.venv/bin:$HOME/.local/share/sentry-devenv/bin:$PATH"
+export SENTRY_CONF="${SENTRY_CONF:-$HOME/.sentry}"
+```
+
+Use Node from devenv for frontend commands: `export PATH="/workspace/.devenv/bin/node-env/bin:$PATH"` (or rely on `devenv sync` putting it on PATH).
+
+### Dev server
+
+- `devservices serve` — webpack on **127.0.0.1:8000**, Django on **0.0.0.0:8001** (proxy via 8000). Login: `admin@sentry.io` / `admin`.
+- Frontend-only (no Docker): `pnpm run dev-ui` → https://sentry.dev.getsentry.net:7999/ (API proxied to production).
+
+### Lint / test (quick checks)
+
+See main sections above; typical cloud-agent smoke tests:
+
+```bash
+.venv/bin/prek run -q
+.venv/bin/pytest -n0 --reuse-db tests/sentry/middleware/test_health.py
+pnpm test-ci static/app/utils/slugify.spec.tsx
+```
+
+Event ingestion through to Issues requires `devservices up --mode ingest` and `devservices serve -- --ingest --workers`; default mode accepts events at Relay but may not show issues without ingest consumers.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with Docker/devservices startup, `SENTRY_CONF`, dev server ports, and smoke-test commands for cloud agents.

This was produced while validating the Sentry dev environment on a Linux cloud VM.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3dbafe0-66ec-4dd5-bc45-3f35e9027f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3dbafe0-66ec-4dd5-bc45-3f35e9027f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

