### PR TITLE
perf(monitors): Batch issue stream detector fetches on Monitors list

### DIFF
--- a/static/app/views/detectors/components/detectorListConnectedAutomations.spec.tsx
+++ b/static/app/views/detectors/components/detectorListConnectedAutomations.spec.tsx
@@ -1,9 +1,10 @@
 import {AutomationFixture} from 'sentry-fixture/automations';
 import {IssueStreamDetectorFixture} from 'sentry-fixture/detectors';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DetectorListConnectedAutomations} from 'sentry/views/detectors/components/detectorListConnectedAutomations';
+import {IssueStreamDetectorContextProvider} from 'sentry/views/detectors/components/detectorListTable/issueStreamDetectorContext';
 
 describe('DetectorListConnectedAutomations', () => {
   beforeEach(() => {
@@ -90,6 +91,46 @@ describe('DetectorListConnectedAutomations', () => {
     expect(projectAlert.closest('a')).toHaveAttribute(
       'href',
       '/organizations/org-slug/monitors/alerts/2/'
+    );
+  });
+
+  it('uses batch context instead of per-row request when provider is present', async () => {
+    const batchDetectorsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: [
+        IssueStreamDetectorFixture({projectId: '1', workflowIds: ['2']}),
+        IssueStreamDetectorFixture({id: '5', projectId: '2', workflowIds: ['3']}),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/',
+      body: [
+        AutomationFixture({id: '1', name: 'Direct Alert'}),
+        AutomationFixture({id: '2', name: 'Project Alert'}),
+      ],
+    });
+
+    render(
+      <IssueStreamDetectorContextProvider projectIds={['1', '2']}>
+        <DetectorListConnectedAutomations automationIds={['1']} projectId="1" />
+      </IssueStreamDetectorContextProvider>
+    );
+
+    expect(await screen.findByText('2 alerts')).toBeInTheDocument();
+
+    // Only one batch request should have been made for detectors
+    await waitFor(() => {
+      expect(batchDetectorsRequest).toHaveBeenCalledTimes(1);
+    });
+    expect(batchDetectorsRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/detectors/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          project: [1, 2],
+          query: 'type:issue_stream',
+        }),
+      })
     );
   });
 });

--- a/static/app/views/detectors/components/detectorListConnectedAutomations.tsx
+++ b/static/app/views/detectors/components/detectorListConnectedAutomations.tsx
@@ -17,6 +17,7 @@ import {AutomationActionSummary} from 'sentry/views/automations/components/autom
 import {automationsApiOptions} from 'sentry/views/automations/hooks';
 import {getAutomationActions} from 'sentry/views/automations/hooks/utils';
 import {makeAutomationDetailsPathname} from 'sentry/views/automations/pathnames';
+import {useIssueStreamDetectorContext} from 'sentry/views/detectors/components/detectorListTable/issueStreamDetectorContext';
 import {useIssueStreamDetectorsForProject} from 'sentry/views/detectors/utils/useIssueStreamDetectorsForProject';
 
 type DetectorListConnectedAutomationsProps = {
@@ -84,8 +85,15 @@ export function DetectorListConnectedAutomations({
   automationIds,
   projectId,
 }: DetectorListConnectedAutomationsProps) {
-  const {data: issueStreamDetectors, isPending} =
-    useIssueStreamDetectorsForProject(projectId);
+  const batchContext = useIssueStreamDetectorContext();
+  const individualQuery = useIssueStreamDetectorsForProject(
+    batchContext ? undefined : projectId
+  );
+
+  const issueStreamDetectors = batchContext
+    ? batchContext.detectorsByProject.get(projectId)
+    : individualQuery.data;
+  const isPending = batchContext ? batchContext.isPending : individualQuery.isPending;
 
   // Combine the automation IDs from the project's issue stream detector with the directly-connected ones
   const combinedAutomationIds = useMemo(() => {

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -34,6 +34,7 @@ import {
   DetectorListRow,
   DetectorListRowSkeleton,
 } from 'sentry/views/detectors/components/detectorListTable/detectorListRow';
+import {IssueStreamDetectorContextProvider} from 'sentry/views/detectors/components/detectorListTable/issueStreamDetectorContext';
 import {DETECTOR_LIST_PAGE_LIMIT} from 'sentry/views/detectors/list/common/constants';
 import {useDetectorListSort} from 'sentry/views/detectors/list/common/useDetectorListSort';
 import {
@@ -133,6 +134,11 @@ export function DetectorListTable({
   const canDisable = useMemo(
     () => detectors.some(d => selected.has(d.id) && d.enabled),
     [detectors, selected]
+  );
+
+  const uniqueProjectIds = useMemo(
+    () => [...new Set(detectors.map(d => d.projectId))],
+    [detectors]
   );
 
   const selectedDetectors = detectors.filter(d => selected.has(d.id));
@@ -267,14 +273,16 @@ export function DetectorListTable({
             cursorOverlayAnchorOffset={10}
           />
         )}
-        {detectors.map(detector => (
-          <DetectorListRow
-            key={detector.id}
-            detector={detector}
-            selected={selected.has(detector.id)}
-            onSelect={handleSelect}
-          />
-        ))}
+        <IssueStreamDetectorContextProvider projectIds={uniqueProjectIds}>
+          {detectors.map(detector => (
+            <DetectorListRow
+              key={detector.id}
+              detector={detector}
+              selected={selected.has(detector.id)}
+              onSelect={handleSelect}
+            />
+          ))}
+        </IssueStreamDetectorContextProvider>
       </DetectorListSimpleTable>
     </TableContainer>
   );

--- a/static/app/views/detectors/components/detectorListTable/issueStreamDetectorContext.tsx
+++ b/static/app/views/detectors/components/detectorListTable/issueStreamDetectorContext.tsx
@@ -1,0 +1,63 @@
+import {createContext, useContext, useMemo} from 'react';
+import {useQuery} from '@tanstack/react-query';
+
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {detectorListApiOptions} from 'sentry/views/detectors/hooks';
+
+interface IssueStreamDetectorContextValue {
+  detectorsByProject: Map<string, Detector[]>;
+  isPending: boolean;
+}
+
+const IssueStreamDetectorContext = createContext<IssueStreamDetectorContextValue | null>(
+  null
+);
+
+export function useIssueStreamDetectorContext() {
+  return useContext(IssueStreamDetectorContext);
+}
+
+export function IssueStreamDetectorContextProvider({
+  projectIds,
+  children,
+}: {
+  children: React.ReactNode;
+  projectIds: string[];
+}) {
+  const organization = useOrganization();
+  const {data, isPending} = useQuery({
+    ...detectorListApiOptions(organization, {
+      query: 'type:issue_stream',
+      projects: projectIds.map(Number),
+      includeIssueStreamDetectors: true,
+    }),
+    staleTime: Infinity,
+    enabled: projectIds.length > 0,
+  });
+
+  const detectorsByProject = useMemo(() => {
+    const map = new Map<string, Detector[]>();
+    if (!data) {
+      return map;
+    }
+    for (const detector of data) {
+      const existing = map.get(detector.projectId);
+      if (existing) {
+        existing.push(detector);
+      } else {
+        map.set(detector.projectId, [detector]);
+      }
+    }
+    return map;
+  }, [data]);
+
+  const value = useMemo(
+    () => ({detectorsByProject, isPending}),
+    [detectorsByProject, isPending]
+  );
+
+  return (
+    <IssueStreamDetectorContext value={value}>{children}</IssueStreamDetectorContext>
+  );
+}

--- a/static/app/views/detectors/utils/useIssueStreamDetectorsForProject.tsx
+++ b/static/app/views/detectors/utils/useIssueStreamDetectorsForProject.tsx
@@ -16,5 +16,6 @@ export function useIssueStreamDetectorsForProject(projectId: string | undefined)
       includeIssueStreamDetectors: true,
     }),
     staleTime: Infinity,
+    enabled: projectId !== undefined,
   });
 }


### PR DESCRIPTION
Resolves [ISWF-2324](https://linear.app/getsentry/issue/ISWF-2324/performance-improvement-batch-fetch-requests-for-connected).

On the Monitors list page, each row individually fetched the project's issue stream detector to compute the connected alerts count. With 20 rows across different projects, this fired up to 20 separate API requests on page load.

This PR introduces an `IssueStreamDetectorContextProvider` that makes a single batch request for all visible projects and distributes results to rows via a React context provider. The logic falls back to the existing per-row hook when the component is used outside the list (e.g. on the detail page).

Also, `useIssueStreamDetectorsForProject` is fixed so that the query is skipped when `projectId` is `undefined`.