### PR TITLE
ref(preprod): Download snapshot images via direct browser request

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -167,32 +167,11 @@ export function SnapshotHeaderActions({
     });
   }, [apiUrl, navigate]);
 
-  const handleDownloadImages = useCallback(async () => {
+  const handleDownloadImages = useCallback(() => {
     const downloadUrl = `/api/0/organizations/${organizationSlug}/preprodartifacts/snapshots/${data.head_artifact_id}/download/`;
 
-    try {
-      const response = await fetch(downloadUrl, {credentials: 'include'});
-
-      if (!response.ok) {
-        if (response.status === 403) {
-          const detail = await response.json().catch(() => ({}));
-          handleStaffPermissionError(detail?.detail);
-        } else if (response.status === 404) {
-          addErrorMessage(t('Snapshot images not found.'));
-        } else {
-          addErrorMessage(t('Download failed (status: %s)', response.status));
-        }
-        return;
-      }
-
-      const blob = await response.blob();
-      const blobUrl = URL.createObjectURL(blob);
-      downloadFromHref(`snapshot_images_${data.head_artifact_id}.zip`, blobUrl);
-      setTimeout(() => URL.revokeObjectURL(blobUrl), 100);
-      addSuccessMessage(t('Snapshot images download started'));
-    } catch (error) {
-      addErrorMessage(t('Download failed: %s', String(error)));
-    }
+    downloadFromHref(`snapshot_images_${data.head_artifact_id}.zip`, downloadUrl);
+    addSuccessMessage(t('Snapshot images download started'));
   }, [organizationSlug, data.head_artifact_id]);
 
   return (

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -171,7 +171,6 @@ export function SnapshotHeaderActions({
     const downloadUrl = `/api/0/organizations/${organizationSlug}/preprodartifacts/snapshots/${data.head_artifact_id}/download/`;
 
     downloadFromHref(`snapshot_images_${data.head_artifact_id}.zip`, downloadUrl);
-    addSuccessMessage(t('Snapshot images download started'));
   }, [organizationSlug, data.head_artifact_id]);
 
   return (


### PR DESCRIPTION
Simplify the snapshot image download to use a direct browser navigation to the download endpoint rather than fetching the zip blob in JavaScript first.

The previous implementation called `fetch`, buffered the entire archive into a blob in memory, created an object URL, and then triggered the download. For large snapshot image archives this is wasteful and risks failing on memory. It also duplicated error handling (403 / 404 / generic) that the browser surfaces on its own when navigating to the endpoint.

By passing the download URL straight to `downloadFromHref`, the browser streams the response and handles HTTP error statuses directly, so the manual fetch/blob/cleanup and error-branching logic can be removed.

No change to the download endpoint or the success toast behavior.