### PR TITLE
ci(cloud-agent): install uv and fix prek hooks before devenv sync

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Cloud-agent install/update script for Sentry.
+#
+# This is intended to be referenced from `.cursor/environment.json` (the
+# `install` command) and run on every cloud-agent VM boot. It is idempotent:
+# it only performs work that is missing and is safe to run repeatedly.
+#
+# It exists to work around two issues that otherwise make `devenv sync` fail
+# on Linux cloud agents:
+#
+#   1. devenv/sync.py no longer manages `uv` (getsentry/sentry#107810). It now
+#      requires `uv` to already be on PATH and hard-exits with code 1 if it is
+#      missing. On macOS `uv` is installed via the Brewfile, but Linux cloud
+#      agents have no Homebrew, so nothing installs it -> sync bails before any
+#      dependency is installed.
+#
+#   2. Cursor configures a repo-local `core.hooksPath` for its agent hooks.
+#      `prek install` (invoked by `devenv sync`) refuses to run while
+#      `core.hooksPath` is set, failing the sync. We temporarily clear it for
+#      the duration of the sync and restore it afterwards so Cursor's hooks
+#      keep working.
+
+set -euo pipefail
+
+# devenv is bootstrapped into this location by the cloud-agent base image.
+export PATH="$HOME/.local/share/sentry-devenv/bin:$PATH"
+
+# --- Fix 1: ensure `uv` is available before `devenv sync` -------------------
+if ! command -v uv >/dev/null 2>&1; then
+  echo ">>> uv not found; installing via astral.sh installer"
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+# The astral installer drops uv into ~/.local/bin.
+export PATH="$HOME/.local/bin:$PATH"
+uv --version
+
+# --- Fix 2: let `prek install` run despite Cursor's core.hooksPath ----------
+PREV_HOOKS_PATH="$(git config --local --get core.hooksPath || true)"
+restore_hooks_path() {
+  if [ -n "${PREV_HOOKS_PATH}" ]; then
+    git config --local core.hooksPath "${PREV_HOOKS_PATH}" || true
+  fi
+}
+trap restore_hooks_path EXIT
+
+if [ -n "${PREV_HOOKS_PATH}" ]; then
+  echo ">>> temporarily unsetting core.hooksPath (${PREV_HOOKS_PATH}) for prek"
+  git config --local --unset-all core.hooksPath || true
+fi
+
+# --- Run the real environment sync ------------------------------------------
+devenv --nocoderoot sync


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The Cursor cloud-agent install script runs `devenv --nocoderoot sync`, which fails immediately on Linux cloud agents:

```
devenv is no longer managing uv; please run `brew install uv`.
```

`devenv/sync.py` stopped managing `uv` in #107810. It now requires `uv` to already be on `PATH` and hard-exits with code `1` when it is missing:

```python
if not shutil.which("uv"):
    print("\n\n\ndevenv is no longer managing uv; please run `brew install uv`.\n\n\n")
    return 1
```

On macOS `uv` is installed via the `Brewfile` (`brew 'uv'`) during `devenv sync`. Linux cloud agents have no Homebrew, so nothing installs `uv` and sync bails before installing any dependency.

A second blocker surfaces once `uv` is present: Cursor sets a repo-local `core.hooksPath`, which makes `prek install` (run by `devenv sync`) refuse to run.

## What

- Add an idempotent `.cursor/install.sh` that:
  - installs `uv` via the astral.sh installer if it is missing and puts `~/.local/bin` on `PATH`;
  - temporarily clears `core.hooksPath` so `prek install` can run, restoring it afterwards;
  - runs `devenv --nocoderoot sync`.
- Add `.cursor/environment.json` wiring the cloud-agent `install` command to that script.

## Caveat for reviewers

`.cursor/environment.json` takes precedence over personal/team saved (dashboard) environments for this repo. This PR only sets `install`. If the existing dashboard environment relies on a custom `snapshot`, `start`, `terminals`, or `ports`, those must be ported into this file too — otherwise the simpler option is to leave `.cursor/environment.json` out and just point the dashboard `install` command at `bash .cursor/install.sh`.

## Testing

Verified on a Linux cloud-agent VM that installing `uv` and clearing `core.hooksPath` gets `devenv sync` past both failing gates (node, pnpm, JS deps, Python deps, prek, and fast-editable all succeed). See logs in the PR thread / agent walkthrough.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f247a549-3407-4a1b-b890-f439388926be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f247a549-3407-4a1b-b890-f439388926be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

