### PR TITLE
fix(preprod): Disable nginx buffering for snapshot image downloads

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_download.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_download.py
@@ -347,4 +347,9 @@ class OrganizationPreprodSnapshotDownloadEndpoint(OrganizationEndpoint):
         response["Content-Disposition"] = (
             f'attachment; filename="snapshot_images_{artifact.id}.zip"'
         )
+        # Superuser/cross-org downloads traverse the control-silo nginx path,
+        # which buffers the response to a temp file capped at 1GB
+        # (proxy_max_temp_file_size default) and truncates anything larger.
+        # Disable nginx buffering so the zip streams straight to the client.
+        response["X-Accel-Buffering"] = "no"
         return response


### PR DESCRIPTION
Large snapshot-image ZIP downloads were consistently truncated at ~1 GB when downloaded over the control-silo / cross-org (superuser) path — the browser surfaces this as "Check internet connection" with a Resume button. Same-org downloads succeed well past that (verified at 3.7 GB).

## Root cause

The download endpoint returns a `StreamingHttpResponse` that zips images on the fly (no `Content-Length`). The superuser/cross-org path is served by the control-silo `sentry.io` nginx vhost, where `proxy_buffering` is on and `proxy_max_temp_file_size` is left at the nginx default of **1024 MB**. nginx spools the streamed response to a temp file and severs the connection once it exceeds 1 GB.

The same-org path is served by a vhost that explicitly raises `proxy_max_temp_file_size` to `4096m` (added for debug-file downloads), which is why downloading your own org's snapshots works at multi-GB sizes and only the cross-org/superuser path hits the 1 GB wall.

## Fix

Set `X-Accel-Buffering: no` on the response. nginx honors this header to disable buffering for the response, so the zip streams straight through to the client instead of being spooled to the capped temp file — removing the 1 GB ceiling regardless of which vhost serves the request. There is existing precedent for unbuffered streaming responses at the edge (e.g. the `live.getsentry.com` SSE vhost), and nothing in the proxy config strips this header.

This needs to be verified against a real cross-org download (the truncation only reproduces behind the actual nginx control path, not locally).