### PR TITLE
fix(performance): Hide sample transaction button without event:write

### DIFF
--- a/static/app/views/performance/onboarding.spec.tsx
+++ b/static/app/views/performance/onboarding.spec.tsx
@@ -34,6 +34,31 @@ describe('Performance Onboarding View > Unsupported Banner', () => {
   });
 });
 
+describe('Performance Onboarding View > Sample Transaction Button', () => {
+  // The default OrganizationFixture access does not include event scopes.
+  const organization = OrganizationFixture();
+
+  it('shows the sample transaction button when the user has event:write access', () => {
+    const project = ProjectFixture({
+      platform: 'java',
+      access: ['project:read', 'event:write'],
+    });
+    render(<LegacyOnboarding organization={organization} project={project} />);
+
+    expect(screen.getByTestId('create-sample-transaction-btn')).toBeInTheDocument();
+  });
+
+  it('hides the sample transaction button when the user lacks event:write access', () => {
+    const project = ProjectFixture({
+      platform: 'java',
+      access: ['project:read'],
+    });
+    render(<LegacyOnboarding organization={organization} project={project} />);
+
+    expect(screen.queryByTestId('create-sample-transaction-btn')).not.toBeInTheDocument();
+  });
+});
+
 describe('Testing new onboarding ui', () => {
   const organization = OrganizationFixture();
 
@@ -59,6 +84,7 @@ describe('Testing new onboarding ui', () => {
   it('Renders updated ui', async () => {
     const projectMock = ProjectFixture({
       platform: 'javascript-react',
+      access: ['project:read', 'event:write'],
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -20,6 +20,7 @@ import {
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import type {Client} from 'sentry/api';
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import {UnsupportedAlert} from 'sentry/components/alerts/unsupportedAlert';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -158,6 +159,18 @@ function SampleButton({
 }: SampleButtonProps) {
   const location = useLocation();
   const navigate = useNavigate();
+
+  // Creating a sample transaction POSTs to an endpoint that requires the
+  // event:write (or event:admin) scope. Members without that scope get a 403,
+  // so hide the button entirely rather than letting them click into a failure.
+  const hasEventWriteAccess =
+    hasEveryAccess(['event:write'], {organization, project}) ||
+    hasEveryAccess(['event:admin'], {organization, project});
+
+  if (!hasEventWriteAccess) {
+    return null;
+  }
+
   return (
     <Button
       data-test-id="create-sample-transaction-btn"


### PR DESCRIPTION
## Summary

The performance onboarding empty state rendered a **"View Sample Transaction" / "Take me to an example"** button (`SampleButton`) for every user. 

The endpoint it calls — `POST /projects/{org}/{project}/create-sample-transaction/` — requires the `event:write` (or `event:admin`) scope via `ProjectEventPermission`. Members without that scope got a **403 Forbidden**. 

This gates `SampleButton` on `event:write`/`event:admin` access. 

The check lives inside the shared `SampleButton` component, so it covers both render sites (`LegacyOnboarding` and the EAP `Onboarding`).


Fixes JAVASCRIPT-33CY
Refs DAIN-1003