### PR TITLE
fix(workflow_engine): Skip deescalating condition for groups without open periods

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/issue_priority_deescalating_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_priority_deescalating_handler.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from sentry.models.group import GroupStatus
-from sentry.models.groupopenperiod import get_latest_open_period
+from sentry.models.groupopenperiod import get_latest_open_period, should_create_open_periods
 from sentry.workflow_engine.models.data_condition import Condition, DataConditionEvaluationException
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
@@ -15,6 +15,9 @@ class IssuePriorityDeescalatingConditionHandler(DataConditionHandler[WorkflowEve
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         group = event_data.group
+
+        if not should_create_open_periods(group.type):
+            return False
 
         # we will fire actions on de-escalation if the priority seen is >= the threshold
         # priority specified in the comparison

--- a/src/sentry/workflow_engine/handlers/condition/issue_priority_deescalating_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_priority_deescalating_handler.py
@@ -16,6 +16,7 @@ class IssuePriorityDeescalatingConditionHandler(DataConditionHandler[WorkflowEve
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         group = event_data.group
 
+        # This condition only works for issue types that create open periods (which excludes errors).
         if not should_create_open_periods(group.type):
             return False
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_deescalating_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_deescalating_handler.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 from sentry.incidents.grouptype import MetricIssue
-from sentry.models.group import GroupStatus
+from sentry.models.group import DEFAULT_TYPE_ID, GroupStatus
 from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.testutils.helpers.options import override_options
 from sentry.types.group import PriorityLevel
 from sentry.users.services.user.service import user_service
 from sentry.workflow_engine.migration_helpers.alert_rule import (
@@ -8,7 +11,7 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     migrate_metric_data_conditions,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
+from sentry.workflow_engine.types import ConditionError, DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -96,3 +99,26 @@ class TestIssuePriorityGreaterOrEqualCondition(ConditionTestCase):
 
         self.group.update(status=GroupStatus.RESOLVED)
         self.assert_passes(self.deescalating_dc_critical, self.event_data)
+
+    @override_options(
+        {"workflow_engine.group.type_id.open_periods_type_denylist": [DEFAULT_TYPE_ID]}
+    )
+    def test_error_group_does_not_pass(self) -> None:
+        error_group, _, error_group_event = self.create_group_event()
+        error_event_data = WorkflowEventData(event=error_group_event, group=error_group_event.group)
+        self.assert_does_not_pass(self.deescalating_dc_warning, error_event_data)
+
+    @override_options(
+        {"workflow_engine.group.type_id.open_periods_type_denylist": [DEFAULT_TYPE_ID]}
+    )
+    @patch("sentry.workflow_engine.models.data_condition.logger")
+    def test_error_group_does_not_log(self, mock_logger) -> None:
+        error_group, _, error_group_event = self.create_group_event()
+        error_event_data = WorkflowEventData(event=error_group_event, group=error_group_event.group)
+        self.deescalating_dc_warning.evaluate_value(error_event_data)
+        mock_logger.info.assert_not_called()
+
+    def test_missing_open_period_for_supported_type(self) -> None:
+        GroupOpenPeriod.objects.filter(group=self.group).delete()
+        result = self.deescalating_dc_warning.evaluate_value(self.event_data)
+        assert isinstance(result, ConditionError)

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_deescalating_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_deescalating_handler.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.group import DEFAULT_TYPE_ID, GroupStatus
@@ -112,7 +112,7 @@ class TestIssuePriorityGreaterOrEqualCondition(ConditionTestCase):
         {"workflow_engine.group.type_id.open_periods_type_denylist": [DEFAULT_TYPE_ID]}
     )
     @patch("sentry.workflow_engine.models.data_condition.logger")
-    def test_error_group_does_not_log(self, mock_logger) -> None:
+    def test_error_group_does_not_log(self, mock_logger: MagicMock) -> None:
         error_group, _, error_group_event = self.create_group_event()
         error_event_data = WorkflowEventData(event=error_group_event, group=error_group_event.group)
         self.deescalating_dc_warning.evaluate_value(error_event_data)


### PR DESCRIPTION
Ref ISWF-2785

The deescalating condition handler was raising a `DataConditionEvaluationException` when evaluating groups that don't have open periods (which only includes error issues). This is a known behavior, so no need to raise an exception.

This adds an early return of `False` for issue types that don't create open periods (checked via `should_create_open_periods`).

We should also follow up with some better documentation of this condition so users aren't confused (although I doubt many users care about this working for error issues since it happens so infrequently compared to metric issues).