### PR TITLE
test(replays): Read live location in nuqs test adapter

### DIFF
--- a/tests/js/sentry-test/nuqsTestingAdapter.tsx
+++ b/tests/js/sentry-test/nuqsTestingAdapter.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, type ReactElement, type ReactNode} from 'react';
+import {useCallback, useMemo, useRef, type ReactElement, type ReactNode} from 'react';
 import {
   unstable_createAdapterProvider as createAdapterProvider,
   renderQueryString,
@@ -47,6 +47,12 @@ export function SentryNuqsTestingAdapter({
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const navigate = useNavigate();
 
+      // nuqs flushes updates on a deferred tick, so read location through a ref
+      // to compose onto the live URL instead of a stale render snapshot.
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const locationRef = useRef(location);
+      locationRef.current = location;
+
       // Get search params from the current location
       const searchParams = new URLSearchParams(location.search || '');
 
@@ -64,8 +70,8 @@ export function SentryNuqsTestingAdapter({
         // Navigate to the new location using Sentry's navigate
         // We need to construct the full path with the search string
         const newPath = queryString
-          ? `${location.pathname}${queryString}`
-          : location.pathname;
+          ? `${locationRef.current.pathname}${queryString}`
+          : locationRef.current.pathname;
 
         // The navigate function from TestRouter already wraps this in act()
         navigate(newPath, {replace: options.history === 'replace'});
@@ -73,7 +79,7 @@ export function SentryNuqsTestingAdapter({
 
       const getSearchParamsSnapshot = () => {
         // Always read from the current location
-        return new URLSearchParams(location.search || '');
+        return new URLSearchParams(locationRef.current.search || '');
       };
 
       return {


### PR DESCRIPTION
The nuqs testing adapter (`tests/js/sentry-test/nuqsTestingAdapter.tsx`) captured `location` from `useLocation()` inside its `updateUrl` and `getSearchParamsSnapshot` closures. Because nuqs flushes updates on a deferred tick (always at least `setTimeout(0)`), two setter calls fired back-to-back composed onto a **stale** render snapshot — so the second update dropped query params set by the first.

This surfaced after the `useFiltersInLocationQuery` migration to nuqs `useQueryStates` (#116768). The old code merged manually (`{...query, ...updatedQuery}`) and always preserved prior params; the new code delegates preservation to nuqs reading the live URL. `useErrorFilters.spec` then failed because calling `setSearchTerm` after a project filter dropped `f_e_project`.

This reads `location` through a ref that's updated every render, so the deferred flush composes onto the live URL — matching the real react-router v6 adapter, which reads `window.location`/`history` fresh at flush time. It's a test-harness correction: production was never affected, since the production adapter already reads live location and composes sequential setters correctly.

Considered making the adapter read `window.location` directly like production, but Sentry's TestRouter is in-memory, so a latest-ref over `useLocation` is the correct source.