### PR TITLE
fix(ourlogs): source observed timestamp from hover-prefetched trace item attributes

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -228,6 +228,9 @@ export function usePrefetchTraceItemDetailsOnHover({
   projectRef.current = project;
   const queryClient = useQueryClient();
   const [traceItemMeta, setTraceItemMeta] = useState<TraceItemDetailsMeta | undefined>();
+  const [traceItemAttributes, setTraceItemAttributes] = useState<
+    TraceItemResponseAttribute[] | undefined
+  >();
 
   const {hoverProps} = useHover({
     onHoverStart: () => {
@@ -254,6 +257,7 @@ export function usePrefetchTraceItemDetailsOnHover({
         queryClient.fetchQuery(options).then(
           response => {
             setTraceItemMeta(response?.json?.meta);
+            setTraceItemAttributes(response?.json?.attributes);
           },
           () => {}
         );
@@ -267,5 +271,5 @@ export function usePrefetchTraceItemDetailsOnHover({
     isDisabled: hoverPrefetchDisabled,
   });
 
-  return {hoverProps, traceItemMeta};
+  return {hoverProps, traceItemMeta, traceItemAttributes};
 }

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -329,19 +329,20 @@ export const LogRowContent = memo(function LogRowContent({
   const logTimestampSeconds = isRegularLogResponseItem(dataRow)
     ? getLogRowTimestampMillis(dataRow) / 1000
     : null;
-  const {hoverProps, traceItemMeta} = usePrefetchTraceItemDetailsOnHover({
-    traceItemId: rowId,
-    projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
-    traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID]),
-    traceItemType: TraceItemDataset.LOGS,
-    referrer: 'api.explore.log-item-details',
-    timestamp: logTimestampSeconds,
-    sharedHoverTimeoutRef,
-    timeout: prefetchTimeout,
-  });
+  const {hoverProps, traceItemMeta, traceItemAttributes} =
+    usePrefetchTraceItemDetailsOnHover({
+      traceItemId: rowId,
+      projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
+      traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID]),
+      traceItemType: TraceItemDataset.LOGS,
+      referrer: 'api.explore.log-item-details',
+      timestamp: logTimestampSeconds,
+      sharedHoverTimeoutRef,
+      timeout: prefetchTimeout,
+    });
   const [caseInsensitivity] = useCaseInsensitivity();
 
-  const observedTimestamp = traceItemsResult.data?.attributes?.find(
+  const observedTimestamp = traceItemAttributes?.find(
     a => a.name === 'sentry.observed_timestamp_nanos'
   );
 


### PR DESCRIPTION
#115505 referenced `traceItemsResult.data?.attributes`, but the row had been refactored to fetch trace item details on hover via `usePrefetchTraceItemDetailsOnHover`.