### PR TITLE
feat(report): add metrics for weekly report pipeline observability

### DIFF
--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -32,6 +32,7 @@ class OrganizationReportContextFactory:
         self.duration = duration
         self.organization = organization
 
+    @metrics.wraps("weekly_report.create_context.user_project_ownership")
     def _append_user_project_ownership(self, ctx: OrganizationReportContext) -> None:
         """Find the projects associated with each user.
         Populates context.project_ownership which is { user_id: set<project_id> }
@@ -45,6 +46,7 @@ class OrganizationReportContextFactory:
                 if user_id is not None:
                     ctx.project_ownership.setdefault(user_id, set()).add(project_id)
 
+    @metrics.wraps("weekly_report.create_context.project_event_counts")
     def _append_project_event_counts(self, ctx: OrganizationReportContext) -> None:
         with sentry_sdk.start_span(op="weekly_reports.project_event_counts_for_organization"):
             event_counts = project_event_counts_for_organization(
@@ -95,6 +97,7 @@ class OrganizationReportContextFactory:
                             project_ctx.error_count_by_day.get(timestamp, 0) + total
                         )
 
+    @metrics.wraps("weekly_report.create_context.issue_substatus_summaries")
     def _append_organization_project_issue_substatus_summaries(
         self, ctx: OrganizationReportContext
     ) -> None:
@@ -103,6 +106,7 @@ class OrganizationReportContextFactory:
         ):
             organization_project_issue_substatus_summaries(ctx)
 
+    @metrics.wraps("weekly_report.create_context.project_key_errors")
     def _append_project_key_errors(self, ctx: OrganizationReportContext) -> None:
         with sentry_sdk.start_span(op="weekly_reports.project_passes"):
             organization = ctx.organization
@@ -152,10 +156,12 @@ class OrganizationReportContextFactory:
                         project.id
                     ].key_performance_issues = key_performance_issues
 
+    @metrics.wraps("weekly_report.create_context.hydrate_key_error_groups")
     def _hydrate_key_error_groups(self, ctx: OrganizationReportContext) -> None:
         with sentry_sdk.start_span(op="weekly_reports.fetch_key_error_groups"):
             fetch_key_error_groups(ctx)
 
+    @metrics.wraps("weekly_report.create_context.hydrate_key_performance_issues")
     def _hydrate_key_performance_issue_groups(self, ctx: OrganizationReportContext) -> None:
         with sentry_sdk.start_span(op="weekly_reports.fetch_key_performance_issue_groups"):
             fetch_key_performance_issue_groups(ctx)
@@ -169,17 +175,11 @@ class OrganizationReportContextFactory:
         )
 
         with metrics.timer("weekly_report.create_context.duration"):
-            with metrics.timer("weekly_report.create_context.user_project_ownership"):
-                self._append_user_project_ownership(ctx)
-            with metrics.timer("weekly_report.create_context.project_event_counts"):
-                self._append_project_event_counts(ctx)
-            with metrics.timer("weekly_report.create_context.issue_substatus_summaries"):
-                self._append_organization_project_issue_substatus_summaries(ctx)
-            with metrics.timer("weekly_report.create_context.project_key_errors"):
-                self._append_project_key_errors(ctx)
-            with metrics.timer("weekly_report.create_context.hydrate_key_error_groups"):
-                self._hydrate_key_error_groups(ctx)
-            with metrics.timer("weekly_report.create_context.hydrate_key_performance_issues"):
-                self._hydrate_key_performance_issue_groups(ctx)
+            self._append_user_project_ownership(ctx)
+            self._append_project_event_counts(ctx)
+            self._append_organization_project_issue_substatus_summaries(ctx)
+            self._append_project_key_errors(ctx)
+            self._hydrate_key_error_groups(ctx)
+            self._hydrate_key_performance_issue_groups(ctx)
 
         return ctx

--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -17,6 +17,7 @@ from sentry.tasks.summaries.utils import (
     project_key_transactions_last_week,
     project_key_transactions_this_week,
 )
+from sentry.utils import metrics
 from sentry.utils.outcomes import Outcome
 from sentry.utils.snuba import parse_snuba_datetime
 
@@ -161,10 +162,24 @@ class OrganizationReportContextFactory:
 
     def create_context(self) -> OrganizationReportContext:
         ctx = OrganizationReportContext(self.timestamp, self.duration, self.organization)
-        self._append_user_project_ownership(ctx)
-        self._append_project_event_counts(ctx)
-        self._append_organization_project_issue_substatus_summaries(ctx)
-        self._append_project_key_errors(ctx)
-        self._hydrate_key_error_groups(ctx)
-        self._hydrate_key_performance_issue_groups(ctx)
+
+        metrics.distribution(
+            "weekly_report.create_context.project_count",
+            len(ctx.projects_context_map),
+        )
+
+        with metrics.timer("weekly_report.create_context.duration"):
+            with metrics.timer("weekly_report.create_context.user_project_ownership"):
+                self._append_user_project_ownership(ctx)
+            with metrics.timer("weekly_report.create_context.project_event_counts"):
+                self._append_project_event_counts(ctx)
+            with metrics.timer("weekly_report.create_context.issue_substatus_summaries"):
+                self._append_organization_project_issue_substatus_summaries(ctx)
+            with metrics.timer("weekly_report.create_context.project_key_errors"):
+                self._append_project_key_errors(ctx)
+            with metrics.timer("weekly_report.create_context.hydrate_key_error_groups"):
+                self._hydrate_key_error_groups(ctx)
+            with metrics.timer("weekly_report.create_context.hydrate_key_performance_issues"):
+                self._hydrate_key_performance_issue_groups(ctx)
+
         return ctx

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -41,7 +41,7 @@ from sentry.taskworker.namespaces import reports_tasks
 from sentry.types.group import GroupSubStatus
 from sentry.users.services.user_option import user_option_service
 from sentry.users.services.user_option.service import get_option_from_list
-from sentry.utils import json, redis
+from sentry.utils import json, metrics, redis
 from sentry.utils.dates import floor_to_utc_day, to_datetime
 from sentry.utils.email import MessageBuilder
 from sentry.utils.email.sanitize import sanitize_outbound_name
@@ -154,6 +154,7 @@ def schedule_organizations(
                     batch_id,
                     dry_run=dry_run,
                 )
+                metrics.incr("weekly_report.organization.scheduled")
                 batching.set_last_processed_org_id(organization.id)
 
             batching.delete_min_org_id()
@@ -224,7 +225,8 @@ def prepare_organization_report(
             "weekly_reports.deliver_reports",
             extra={"batch_id": str(batch_id), "organization": organization_id},
         )
-        batch.deliver_reports()
+        with metrics.timer("weekly_report.deliver_reports.duration"):
+            batch.deliver_reports()
 
 
 @dataclass(frozen=True)
@@ -259,14 +261,36 @@ class OrganizationReportBatch:
                 .values_list("user_id", flat=True)
             )
             user_list = [v for v in user_list if v is not None]
+            metrics.distribution(
+                "weekly_report.deliver_reports.org_member_count",
+                len(user_list),
+            )
             user_ids = notifications_service.get_users_for_weekly_reports(
                 organization_id=self.ctx.organization.id, user_ids=user_list
             )
+            metrics.distribution(
+                "weekly_report.deliver_reports.eligible_user_count",
+                len(user_ids),
+            )
+            filtered_by_preference = len(user_list) - len(user_ids)
+            if filtered_by_preference > 0:
+                metrics.incr(
+                    "weekly_report.user.filtered",
+                    amount=filtered_by_preference,
+                    tags={"reason": "notification_preference"},
+                )
             user_template_context_by_user_id_list = []
             if user_ids:
                 user_template_context_by_user_id_list = prepare_template_context(
                     ctx=self.ctx, user_ids=user_ids
                 )
+                skipped_no_projects = len(user_ids) - len(user_template_context_by_user_id_list)
+                if skipped_no_projects > 0:
+                    metrics.incr(
+                        "weekly_report.user.filtered",
+                        amount=skipped_no_projects,
+                        tags={"reason": "no_project_access"},
+                    )
             if user_template_context_by_user_id_list:
                 for user_template in user_template_context_by_user_id_list:
                     self._send_to_user(user_template)
@@ -292,8 +316,10 @@ class OrganizationReportBatch:
                 if not dupe_check.check_for_duplicate_delivery():
                     self.send_email(template_ctx=template_context, user_id=user_id)
                     dupe_check.record_delivery()
+                    metrics.incr("weekly_report.email.sent")
                 else:
                     lifecycle.record_halt(WeeklyReportHaltReason.DUPLICATE_DELIVERY)
+                    metrics.incr("weekly_report.email.skipped", tags={"reason": "duplicate"})
 
     def send_email(self, template_ctx: Mapping[str, Any], user_id: int) -> None:
         # get user options timezone for this user, then format the timestamp according to the timezone
@@ -308,6 +334,7 @@ class OrganizationReportBatch:
             headers={"X-SMTPAPI": json.dumps({"category": "organization_weekly_report"})},
         )
         if self.dry_run:
+            metrics.incr("weekly_report.email.skipped", tags={"reason": "dry_run"})
             return
 
         if self.email_override:

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -316,7 +316,6 @@ class OrganizationReportBatch:
                 if not dupe_check.check_for_duplicate_delivery():
                     self.send_email(template_ctx=template_context, user_id=user_id)
                     dupe_check.record_delivery()
-                    metrics.incr("weekly_report.email.sent")
                 else:
                     lifecycle.record_halt(WeeklyReportHaltReason.DUPLICATE_DELIVERY)
                     metrics.incr("weekly_report.email.skipped", tags={"reason": "duplicate"})
@@ -339,6 +338,7 @@ class OrganizationReportBatch:
 
         if self.email_override:
             message.send(to=(self.email_override,))
+            metrics.incr("weekly_report.email.sent")
         else:
             try:
                 analytics.record(
@@ -365,6 +365,7 @@ class OrganizationReportBatch:
 
             message.add_users((user_id,))
             message.send_async()
+            metrics.incr("weekly_report.email.sent")
 
 
 class _DuplicateDeliveryCheck:

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -364,8 +364,11 @@ class OrganizationReportBatch:
             )
 
             message.add_users((user_id,))
-            message.send_async()
-            metrics.incr("weekly_report.email.sent")
+            if message._send_to:
+                message.send_async()
+                metrics.incr("weekly_report.email.sent")
+            else:
+                metrics.incr("weekly_report.email.skipped", tags={"reason": "no_email"})
 
 
 class _DuplicateDeliveryCheck:


### PR DESCRIPTION
Resolves [ID-1607](https://linear.app/getsentry/issue/ID-1607/add-more-metrics-for-weekly-report-pipeline-observability)

Goal: Adds metrics across the weekly report pipeline to surface where sends fail and where time is spent.

**Context creation timing**

Each of the 6 sub-steps in `OrganizationReportContextFactory.create_context` is now wrapped with `metrics.timer`, plus an overall duration metric. A `project_count` distribution captures org size to correlate with slowness.

  - `weekly_report.create_context.duration`
  - `weekly_report.create_context {user_project_ownership,project_event_counts,issue_substatus_summaries,project_key_errors,hydrate_key_error_groups,hydrate_key_performance_issues}`
  - `weekly_report.create_context.project_count`

  **Delivery funnel and email outcome counters**

Tracks where users drop out of the pipeline — from active org members, notif preference filtering, template context generation, to final email send. Each stage emits a distribution or tagged counter so the full funnel is visible in Datadog.

  - `weekly_report.deliver_reports.{org_member_count,eligible_user_count,duration}`
  - `weekly_report.user.filtered` (tags: `reason=notification_preference|no_project_access`)
  - `weekly_report.email.sent`
  - `weekly_report.email.skipped` (tags: `reason=duplicate|dry_run|no_email`)
  - `weekly_report.organization.scheduled`
