### PR TITLE
fix(monitors): Show "no projects" component in monitors list view

### DIFF
--- a/static/app/views/detectors/detectorViewContainer.tsx
+++ b/static/app/views/detectors/detectorViewContainer.tsx
@@ -1,14 +1,19 @@
 import {Outlet} from 'react-router-dom';
 
+import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 export default function DetectorViewContainer() {
+  const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
 
   return (
     <PageFiltersContainer>
-      <Outlet />
+      <NoProjectMessage organization={organization}>
+        <Outlet />
+      </NoProjectMessage>
     </PageFiltersContainer>
   );
 }


### PR DESCRIPTION
Fixes JAVASCRIPT-3A4N

The monitors list view was missing the standard `NoProjectMessage` wrapper that most other views (discover, traces, performance, etc.) include. If an organization has no projects, creating a new detector will cause the page to crash.