### PR TITLE
feat(preprod): Collapse duplicate files within a group

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
@@ -267,4 +267,80 @@ describe('AppSizeInsightsSidebarRow', () => {
     expect(screen.getByText('~0%')).toBeInTheDocument();
     expect(screen.getByText('Potential savings 100 B')).toBeInTheDocument();
   });
+
+  const duplicateFilesInsight = (fileCount: number) =>
+    ProcessedInsightFixture({
+      files: [
+        {
+          path: 'Assets.car',
+          savings: fileCount * 10000,
+          percentage: 5,
+          data: {
+            fileType: 'duplicate_files' as const,
+            originalGroup: {
+              name: 'Assets.car',
+              total_savings: fileCount * 10000,
+              files: Array.from({length: fileCount}, (_, i) => ({
+                file_path: `dup/file-${i}.png`,
+                total_savings: 10000,
+              })),
+            },
+          },
+        },
+      ],
+    });
+
+  it('collapses duplicate files within a group beyond the visible limit', async () => {
+    render(
+      <AppSizeInsightsSidebarRow
+        {...getDefaultProps()}
+        insight={duplicateFilesInsight(18)}
+        isExpanded
+      />
+    );
+
+    // Only the first 15 files render; the rest are hidden behind a toggle.
+    expect(screen.getByText('dup/file-0.png')).toBeInTheDocument();
+    expect(screen.getByText('dup/file-14.png')).toBeInTheDocument();
+    expect(screen.queryByText('dup/file-15.png')).not.toBeInTheDocument();
+
+    // Expanding reveals the remaining files.
+    await userEvent.click(screen.getByRole('button', {name: 'Show 3 more files'}));
+
+    expect(screen.getByText('dup/file-15.png')).toBeInTheDocument();
+    expect(screen.getByText('dup/file-17.png')).toBeInTheDocument();
+
+    // Collapsing hides them again.
+    await userEvent.click(screen.getByRole('button', {name: 'Collapse'}));
+
+    expect(screen.queryByText('dup/file-15.png')).not.toBeInTheDocument();
+  });
+
+  it('shows all duplicate files without a toggle at or below the visible limit', () => {
+    render(
+      <AppSizeInsightsSidebarRow
+        {...getDefaultProps()}
+        insight={duplicateFilesInsight(15)}
+        isExpanded
+      />
+    );
+
+    expect(screen.getByText('dup/file-0.png')).toBeInTheDocument();
+    expect(screen.getByText('dup/file-14.png')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /Show \d+ more file/})
+    ).not.toBeInTheDocument();
+  });
+
+  it('uses singular copy when exactly one duplicate file is hidden', () => {
+    render(
+      <AppSizeInsightsSidebarRow
+        {...getDefaultProps()}
+        insight={duplicateFilesInsight(16)}
+        isExpanded
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Show 1 more file'})).toBeInTheDocument();
+  });
 });

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -7,6 +7,7 @@ import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {Collapsible} from 'sentry/components/collapsible';
 import {IconInfo} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconFlag} from 'sentry/icons/iconFlag';
@@ -52,6 +53,11 @@ const INSIGHTS_WITH_MORE_INFO_MODAL = [
 ];
 
 const DEFAULT_ITEMS_PER_PAGE = 20;
+
+// Show this many duplicate files within a group before collapsing the rest
+// behind a toggle, so one heavily-duplicated group can't render hundreds of
+// rows at once and push every other insight off-screen.
+const DUPLICATE_GROUP_VISIBLE_FILE_COUNT = 15;
 
 export function AppSizeInsightsSidebarRow({
   insight,
@@ -281,22 +287,36 @@ function DuplicateGroupFileRow({
         </Text>
       </Flex>
       <Flex direction="column" gap="xs" padding="xs sm">
-        {group.files.map((duplicateFile, index) => (
-          <Flex key={`${duplicateFile.file_path}-${index}`} align="center" gap="sm">
-            <Text size="xs" variant="muted" ellipsis style={{flex: 1, minWidth: 0}}>
-              {duplicateFile.file_path}
-            </Text>
-            <Text
-              size="xs"
-              variant="muted"
-              tabular
-              align="right"
-              style={{minWidth: '80px'}}
-            >
-              {formatBytesBase10(duplicateFile.total_savings)}
-            </Text>
-          </Flex>
-        ))}
+        <Collapsible
+          maxVisibleItems={DUPLICATE_GROUP_VISIBLE_FILE_COUNT}
+          expandButton={({onExpand, numberOfHiddenItems}) => (
+            <Button variant="link" size="xs" onClick={onExpand}>
+              {tn('Show %s more file', 'Show %s more files', numberOfHiddenItems)}
+            </Button>
+          )}
+          collapseButton={({onCollapse}) => (
+            <Button variant="link" size="xs" onClick={onCollapse}>
+              {t('Collapse')}
+            </Button>
+          )}
+        >
+          {group.files.map((duplicateFile, index) => (
+            <Flex key={`${duplicateFile.file_path}-${index}`} align="center" gap="sm">
+              <Text size="xs" variant="muted" ellipsis style={{flex: 1, minWidth: 0}}>
+                {duplicateFile.file_path}
+              </Text>
+              <Text
+                size="xs"
+                variant="muted"
+                tabular
+                align="right"
+                style={{minWidth: '80px'}}
+              >
+                {formatBytesBase10(duplicateFile.total_savings)}
+              </Text>
+            </Flex>
+          ))}
+        </Collapsible>
       </Flex>
     </Fragment>
   );


### PR DESCRIPTION
## What

In the App Size Insights sidebar, the **Duplicate Files** insight paginates _groups_, but each group rendered all of its files at once. A single heavily-duplicated group could push every other insight off-screen.

## How

Wrap each group's file list in `Collapsible`, showing the first 15 files with a **"Show N more files"** toggle (expands to all, with a **"Collapse"** button). Reuses the shared `Collapsible` component and follows the existing copy/styling conventions (`projectTeamAccess`, `commitAuthorBreakdown`, `releaseCard`).

## Testing

- 3 new unit tests: the expand/collapse round-trip, the ≤15 no-toggle threshold, and singular vs. plural button copy.
- Full spec passing (14/14); `lint:js` and `typecheck` clean.

## Notes for reviewers

- Frontend-only — no backend/API/migration, so this ships as a single PR.
- The cutoff lives in one constant (`DUPLICATE_GROUP_VISIBLE_FILE_COUNT = 15`), easy to tune.

Fixes EME-755
