### PR TITLE
feat(api): backfill Serializer[T] across 61 serializers

### DIFF
--- a/src/sentry/api/endpoints/organization_sampling_project_rates.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_rates.py
@@ -23,7 +23,7 @@ from sentry.models.project import Project
 OPTION_KEY = "sentry:target_sample_rate"
 
 
-class GetSerializer(Serializer):
+class GetSerializer(Serializer[Mapping[str, Any]]):
     """Serializer for OrganizationSamplingProjectRatesEndpoint.get"""
 
     def get_attrs(self, item_list, user, **kwargs) -> MutableMapping[Any, Any]:

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -305,6 +305,7 @@ class ControlSiloOrganizationSerializerResponse(TypedDict):
     name: str
 
 
+@register(RpcOrganizationSummary)
 class ControlSiloOrganizationSerializer(Serializer[ControlSiloOrganizationSerializerResponse]):
     def serialize(
         self,
@@ -340,6 +341,7 @@ class ControlSiloOrganizationMappingSerializerResponse(TypedDict):
     hasAuthProvider: bool
 
 
+@register(OrganizationMapping)
 class ControlSiloOrganizationMappingSerializer(
     Serializer[ControlSiloOrganizationMappingSerializerResponse]
 ):

--- a/src/sentry/api/serializers/models/release_file.py
+++ b/src/sentry/api/serializers/models/release_file.py
@@ -46,7 +46,7 @@ def decode_release_file_id(id: str):
 
 
 @register(ReleaseFile)
-class ReleaseFileSerializer(Serializer):
+class ReleaseFileSerializer(Serializer[ReleaseFileSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> ReleaseFileSerializerResponse:
         dist_name = None
         if obj.dist_id:

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -118,7 +118,7 @@ class RuleSerializerResponse(RuleSerializerResponseOptional):
 
 
 @register(Rule)
-class RuleSerializer(Serializer):
+class RuleSerializer(Serializer[RuleSerializerResponse]):
     def __init__(
         self,
         expand: list[str] | None = None,

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -383,7 +383,7 @@ def get_team_memberships(team_ids: list[int]) -> list[TeamMembership]:
     return list(members.values())
 
 
-class TeamSCIMSerializer(Serializer):
+class TeamSCIMSerializer(Serializer[OrganizationTeamSCIMSerializerResponse]):
     def __init__(
         self,
         expand: Sequence[str] | None = None,

--- a/src/sentry/auth_v2/utils/session.py
+++ b/src/sentry/auth_v2/utils/session.py
@@ -25,7 +25,7 @@ class SessionSerializerResponse(TypedDict, total=False):
     sessionOrgs: list[str] | None
 
 
-class SessionSerializer(Serializer):
+class SessionSerializer(Serializer[SessionSerializerResponse]):
     """
     These are the keys available when calling request.session.keys()
     https://docs.djangoproject.com/en/5.2/topics/http/sessions/#django.contrib.sessions.backends.base.SessionBase

--- a/src/sentry/core/endpoints/organization_member_team_details.py
+++ b/src/sentry/core/endpoints/organization_member_team_details.py
@@ -61,7 +61,7 @@ class OrganizationMemberTeamSerializer(serializers.Serializer[dict[str, Any]]):
     )
 
 
-class OrganizationMemberTeamDetailsSerializer(Serializer):
+class OrganizationMemberTeamDetailsSerializer(Serializer[OrganizationMemberTeamSerializerResponse]):
     def serialize(
         self, obj: OrganizationMemberTeam, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
     ) -> OrganizationMemberTeamSerializerResponse:

--- a/src/sentry/core/endpoints/team_members.py
+++ b/src/sentry/core/endpoints/team_members.py
@@ -28,7 +28,7 @@ class OrganizationMemberOnTeamResponse(OrganizationMemberResponse):
 
 
 @register(OrganizationMemberTeam)
-class DetailedOrganizationMemberTeamSerializer(Serializer):
+class DetailedOrganizationMemberTeamSerializer(Serializer[OrganizationMemberOnTeamResponse]):
     def __init__(self, *args, **kwargs):
         self.team = kwargs.pop("team", None)
         super().__init__(*args, **kwargs)

--- a/src/sentry/flags/endpoints/logs.py
+++ b/src/sentry/flags/endpoints/logs.py
@@ -38,7 +38,7 @@ class FlagAuditLogModelSerializerResponse(TypedDict):
 
 
 @register(FlagAuditLogModel)
-class FlagAuditLogModelSerializer(Serializer):
+class FlagAuditLogModelSerializer(Serializer[FlagAuditLogModelSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> FlagAuditLogModelSerializerResponse:
         return {
             "id": obj.id,

--- a/src/sentry/flags/endpoints/secrets.py
+++ b/src/sentry/flags/endpoints/secrets.py
@@ -29,7 +29,7 @@ class FlagWebhookSigningSecretResponse(TypedDict):
 
 
 @register(FlagWebHookSigningSecretModel)
-class FlagWebhookSigningSecretSerializer(Serializer):
+class FlagWebhookSigningSecretSerializer(Serializer[FlagWebhookSigningSecretResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> FlagWebhookSigningSecretResponse:
         return {
             "createdAt": obj.date_added.isoformat(),

--- a/src/sentry/incidents/endpoints/serializers/query_subscription.py
+++ b/src/sentry/incidents/endpoints/serializers/query_subscription.py
@@ -12,7 +12,7 @@ from sentry.users.services.user import RpcUser
 
 
 @register(SnubaQuery)
-class SnubaQuerySerializer(Serializer):
+class SnubaQuerySerializer(Serializer[dict[str, Any]]):
     def get_attrs(
         self, item_list: Sequence[SnubaQuery], user: User | RpcUser | AnonymousUser, **kwargs: Any
     ) -> MutableMapping[SnubaQuery, dict[str, Any]]:
@@ -43,7 +43,7 @@ class SnubaQuerySerializer(Serializer):
 
 
 @register(QuerySubscription)
-class QuerySubscriptionSerializer(Serializer):
+class QuerySubscriptionSerializer(Serializer[dict[str, Any]]):
     def get_attrs(
         self,
         item_list: Sequence[QuerySubscription],

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
@@ -19,7 +19,7 @@ from sentry.users.services.user.model import RpcUser
 from sentry.workflow_engine.models import Action, ActionAlertRuleTriggerAction
 
 
-class WorkflowEngineActionSerializer(Serializer):
+class WorkflowEngineActionSerializer(Serializer[dict[str, Any]]):
     def get_attrs(
         self, item_list: Sequence[Action], user: User | RpcUser | AnonymousUser, **kwargs: Any
     ) -> dict[Action, dict[str, Any]]:

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_combined.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_combined.py
@@ -19,7 +19,7 @@ from sentry.users.services.user import RpcUser
 from sentry.workflow_engine.models import Detector, Workflow
 
 
-class WorkflowEngineCombinedRuleSerializer(Serializer):
+class WorkflowEngineCombinedRuleSerializer(Serializer[MutableMapping[Any, Any]]):
     """
     Serializer for combined rules endpoint when using workflow engine.
     Dispatches to appropriate serializers based on object type.

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
@@ -29,7 +29,7 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
-class WorkflowEngineDataConditionSerializer(Serializer):
+class WorkflowEngineDataConditionSerializer(Serializer[dict[str, Any]]):
     def get_attrs(
         self,
         item_list: Sequence[DataCondition],

--- a/src/sentry/integrations/api/serializers/models/data_forwarder.py
+++ b/src/sentry/integrations/api/serializers/models/data_forwarder.py
@@ -46,7 +46,7 @@ class DataForwarderResponse(TypedDict):
 
 
 @register(DataForwarder)
-class DataForwarderSerializer(Serializer):
+class DataForwarderSerializer(Serializer[DataForwarderResponse]):
     def get_attrs(
         self,
         item_list: Sequence[DataForwarder],
@@ -101,7 +101,7 @@ class DataForwarderSerializer(Serializer):
 
 
 @register(DataForwarderProject)
-class DataForwarderProjectSerializer(Serializer):
+class DataForwarderProjectSerializer(Serializer[DataForwarderProjectResponse]):
     def serialize(
         self,
         obj: DataForwarderProject,

--- a/src/sentry/integrations/api/serializers/models/doc_integration.py
+++ b/src/sentry/integrations/api/serializers/models/doc_integration.py
@@ -12,7 +12,7 @@ from sentry.users.services.user import RpcUser
 
 
 @register(DocIntegration)
-class DocIntegrationSerializer(Serializer):
+class DocIntegrationSerializer(Serializer[Any]):
     def get_attrs(
         self,
         item_list: Sequence[DocIntegration],

--- a/src/sentry/integrations/api/serializers/models/doc_integration_avatar.py
+++ b/src/sentry/integrations/api/serializers/models/doc_integration_avatar.py
@@ -6,7 +6,7 @@ from sentry.integrations.models.doc_integration_avatar import DocIntegrationAvat
 
 
 @register(DocIntegrationAvatar)
-class DocIntegrationAvatarSerializer(Serializer):
+class DocIntegrationAvatarSerializer(Serializer[MutableMapping[str, Any]]):
     def serialize(
         self, obj: DocIntegrationAvatar, attrs, user, **kwargs
     ) -> MutableMapping[str, Any]:

--- a/src/sentry/integrations/api/serializers/models/external_issue.py
+++ b/src/sentry/integrations/api/serializers/models/external_issue.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from django.contrib.auth.models import AnonymousUser
 
+from sentry.api.serializers import register
 from sentry.api.serializers.base import Serializer
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration.service import integration_service
@@ -14,6 +15,7 @@ from sentry.users.services.user.model import RpcUser
 
 # Serializer for External Issues Model
 # Maps an external issue to to additional integration information such as key or name
+@register(ExternalIssue)
 class ExternalIssueSerializer(Serializer):
     def get_attrs(
         self,

--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -212,7 +212,7 @@ class IntegrationProviderResponse(TypedDict):
     setupDialog: dict[str, Any]
 
 
-class IntegrationProviderSerializer(Serializer):
+class IntegrationProviderSerializer(Serializer[IntegrationProviderResponse]):
     def serialize(
         self,
         obj: IntegrationProvider,

--- a/src/sentry/integrations/api/serializers/models/integration_feature.py
+++ b/src/sentry/integrations/api/serializers/models/integration_feature.py
@@ -18,7 +18,7 @@ class IntegrationFeatureResponse(TypedDict):
 
 
 @register(IntegrationFeature)
-class IntegrationFeatureSerializer(Serializer):
+class IntegrationFeatureSerializer(Serializer[IntegrationFeatureResponse]):
     def get_attrs(
         self,
         item_list: Sequence[IntegrationFeature],

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -36,7 +36,7 @@ class MonitorEnvBrokenDetectionSerializerResponse(TypedDict):
 
 
 @register(MonitorEnvBrokenDetection)
-class MonitorEnvBrokenDetectionSerializer(Serializer):
+class MonitorEnvBrokenDetectionSerializer(Serializer[MonitorEnvBrokenDetectionSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> MonitorEnvBrokenDetectionSerializerResponse:
         return {
             "userNotifiedTimestamp": obj.user_notified_timestamp,
@@ -51,7 +51,7 @@ class MonitorIncidentSerializerResponse(TypedDict):
 
 
 @register(MonitorIncident)
-class MonitorIncidentSerializer(Serializer):
+class MonitorIncidentSerializer(Serializer[MonitorIncidentSerializerResponse]):
     def get_attrs(
         self, item_list: Sequence[Any], user: Any, **kwargs: Any
     ) -> MutableMapping[Any, Any]:
@@ -87,7 +87,7 @@ class MonitorEnvironmentSerializerResponse(TypedDict):
 
 
 @register(MonitorEnvironment)
-class MonitorEnvironmentSerializer(Serializer):
+class MonitorEnvironmentSerializer(Serializer[MonitorEnvironmentSerializerResponse]):
     def get_attrs(
         self, item_list: Sequence[Any], user: Any, **kwargs: Any
     ) -> MutableMapping[Any, Any]:
@@ -195,7 +195,7 @@ class MonitorBulkEditResponse:
 
 
 @register(Monitor)
-class MonitorSerializer(Serializer):
+class MonitorSerializer(Serializer[MonitorSerializerResponse]):
     def __init__(self, environments=None, expand=None):
         self.environments = environments
         self.expand = expand
@@ -341,7 +341,7 @@ class MonitorCheckInSerializerResponse(MonitorCheckInSerializerResponseOptional)
 
 
 @register(MonitorCheckIn)
-class MonitorCheckInSerializer(Serializer):
+class MonitorCheckInSerializer(Serializer[MonitorCheckInSerializerResponse]):
     def __init__(self, start=None, end=None, expand=None, organization_id=None, project_id=None):
         self.start = start  # timestamp of the beginning of the specified date range
         self.end = end  # timestamp of the end of the specified date range
@@ -424,7 +424,7 @@ class MonitorCheckInSerializer(Serializer):
 
 
 @register(CheckinProcessingError)
-class CheckinProcessingErrorSerializer(Serializer):
+class CheckinProcessingErrorSerializer(Serializer[CheckinProcessingErrorData]):
     def serialize(
         self, obj: CheckinProcessingError, attrs, user, **kwargs
     ) -> CheckinProcessingErrorData:

--- a/src/sentry/notifications/api/serializers/notification_action_response.py
+++ b/src/sentry/notifications/api/serializers/notification_action_response.py
@@ -15,7 +15,7 @@ from sentry.utils.serializers import manytoone_to_dict
 
 
 @register(NotificationAction)
-class OutgoingNotificationActionSerializer(Serializer):
+class OutgoingNotificationActionSerializer(Serializer[dict[str, Any]]):
     """
     Model serializer for outgoing NotificationAction API payloads
     """

--- a/src/sentry/notifications/serializers.py
+++ b/src/sentry/notifications/serializers.py
@@ -8,7 +8,7 @@ from sentry.notifications.models.notificationsettingoption import NotificationSe
 from sentry.notifications.models.notificationsettingprovider import NotificationSettingProvider
 
 
-class NotificationSettingsBaseSerializer(Serializer):
+class NotificationSettingsBaseSerializer(Serializer[Mapping[str, str | None]]):
     def serialize(
         self,
         obj: Any,

--- a/src/sentry/relocation/api/serializers/relocation.py
+++ b/src/sentry/relocation/api/serializers/relocation.py
@@ -42,7 +42,7 @@ def get_all_imported_ids_of_model(chunks: QuerySet[BaseImportChunk]) -> list[int
 
 
 @register(Relocation)
-class RelocationSerializer(Serializer):
+class RelocationSerializer(Serializer[Mapping[str, Any]]):
     def serialize(
         self,
         obj: Relocation,

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -31,7 +31,7 @@ class RuleGroupHistoryResponse(TypedDict):
     eventId: str | None
 
 
-class RuleGroupHistorySerializer(Serializer):
+class RuleGroupHistorySerializer(Serializer[RuleGroupHistoryResponse]):
     def get_attrs(
         self, item_list: Sequence[RuleGroupHistory], user: Any, **kwargs: Any
     ) -> MutableMapping[Any, Any]:

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -26,7 +26,7 @@ class TimeSeriesValueResponse(TypedDict):
     count: int
 
 
-class TimeSeriesValueSerializer(Serializer):
+class TimeSeriesValueSerializer(Serializer[TimeSeriesValueResponse]):
     def serialize(
         self, obj: TimeSeriesValue, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
     ) -> TimeSeriesValueResponse:

--- a/src/sentry/sentry_apps/api/serializers/platform_external_issue.py
+++ b/src/sentry/sentry_apps/api/serializers/platform_external_issue.py
@@ -19,7 +19,7 @@ class PlatformExternalIssueSerializerResponse(TypedDict):
 
 
 @register(PlatformExternalIssue)
-class PlatformExternalIssueSerializer(Serializer):
+class PlatformExternalIssueSerializer(Serializer[PlatformExternalIssueSerializerResponse]):
     def serialize(
         self,
         obj: PlatformExternalIssue | RpcPlatformExternalIssue,

--- a/src/sentry/sentry_apps/api/serializers/request.py
+++ b/src/sentry/sentry_apps/api/serializers/request.py
@@ -13,7 +13,7 @@ from sentry.services import eventstore
 from sentry.utils.sentry_apps.webhooks import TIMEOUT_STATUS_CODE
 
 
-class RequestSerializer(Serializer):
+class RequestSerializer(Serializer[Mapping[str, Any]]):
     def __init__(self, sentry_app: SentryApp) -> None:
         self.sentry_app = sentry_app
 

--- a/src/sentry/sentry_apps/api/serializers/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app_installation.py
@@ -34,7 +34,7 @@ class SentryAppInstallationResult(TypedDict):
 
 
 @register(SentryAppInstallation)
-class SentryAppInstallationSerializer(Serializer):
+class SentryAppInstallationSerializer(Serializer[SentryAppInstallationResult]):
     def get_attrs(
         self,
         item_list: Sequence[SentryAppInstallation],

--- a/src/sentry/sentry_apps/api/serializers/sentry_app_webhook_request.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app_webhook_request.py
@@ -41,7 +41,7 @@ class SentryAppWebhookRequestSerializerResponse(TypedDict):
     response_body: NotRequired[str | None]
 
 
-class SentryAppWebhookRequestSerializer(Serializer):
+class SentryAppWebhookRequestSerializer(Serializer[SentryAppWebhookRequestSerializerResponse]):
     def __init__(self, sentry_app: SentryApp) -> None:
         self.sentry_app = sentry_app
 

--- a/src/sentry/sentry_apps/api/serializers/servicehook.py
+++ b/src/sentry/sentry_apps/api/serializers/servicehook.py
@@ -15,7 +15,7 @@ class ServiceHookSerializerResponse(TypedDict):
 
 
 @register(ServiceHook)
-class ServiceHookSerializer(Serializer):
+class ServiceHookSerializer(Serializer[ServiceHookSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> ServiceHookSerializerResponse:
         return {
             "id": obj.guid,

--- a/src/sentry/uptime/endpoints/serializers.py
+++ b/src/sentry/uptime/endpoints/serializers.py
@@ -41,7 +41,7 @@ class UptimeSubscriptionSerializerResponse(TypedDict):
 
 
 @register(UptimeSubscription)
-class UptimeSubscriptionSerializer(Serializer):
+class UptimeSubscriptionSerializer(Serializer[dict[str, Any]]):
     @override
     def serialize(self, obj: UptimeSubscription, attrs, user, **kwargs) -> dict[str, Any]:
         return {
@@ -70,7 +70,7 @@ class UptimeDetectorSerializerResponse(UptimeSubscriptionSerializerResponse):
     downtimeThreshold: int
 
 
-class UptimeDetectorSerializer(Serializer):
+class UptimeDetectorSerializer(Serializer[UptimeDetectorSerializerResponse]):
     def get_attrs(
         self, item_list: Sequence[Detector], user: Any, **kwargs: Any
     ) -> MutableMapping[Any, Any]:
@@ -170,7 +170,7 @@ class EapCheckEntrySerializerResponse(TypedDict):
 
 
 @register(EapCheckEntry)
-class EapCheckEntrySerializer(Serializer):
+class EapCheckEntrySerializer(Serializer[EapCheckEntrySerializerResponse]):
     def serialize(
         self, obj: EapCheckEntry, attrs, user, **kwargs
     ) -> EapCheckEntrySerializerResponse:
@@ -211,7 +211,7 @@ class UptimeSummarySerializerResponse(TypedDict):
 
 
 @register(UptimeSummary)
-class UptimeSummarySerializer(Serializer):
+class UptimeSummarySerializer(Serializer[UptimeSummarySerializerResponse]):
     @override
     def serialize(
         self, obj: UptimeSummary, attrs: Any, user: Any, **kwargs: Any

--- a/src/sentry/users/api/serializers/identity.py
+++ b/src/sentry/users/api/serializers/identity.py
@@ -18,7 +18,7 @@ class IdentitySerializerResponse(TypedDict):
 
 
 @register(Identity)
-class IdentitySerializer(Serializer):
+class IdentitySerializer(Serializer[IdentitySerializerResponse]):
     def serialize(
         self,
         obj: Identity,

--- a/src/sentry/users/api/serializers/identityprovider.py
+++ b/src/sentry/users/api/serializers/identityprovider.py
@@ -16,7 +16,7 @@ class IdentityProviderSerializerResponse(TypedDict):
 
 
 @register(IdentityProvider)
-class IdentityProviderSerializer(Serializer):
+class IdentityProviderSerializer(Serializer[IdentityProviderSerializerResponse]):
     def serialize(
         self,
         obj: IdentityProvider,

--- a/src/sentry/users/api/serializers/user_identity_config.py
+++ b/src/sentry/users/api/serializers/user_identity_config.py
@@ -154,7 +154,7 @@ class UserIdentityConfigSerializerResponse(TypedDict):
 
 
 @register(UserIdentityConfig)
-class UserIdentityConfigSerializer(Serializer):
+class UserIdentityConfigSerializer(Serializer[UserIdentityConfigSerializerResponse]):
     def get_attrs(
         self,
         item_list: Sequence[UserIdentityConfig],

--- a/src/sentry/users/api/serializers/useremail.py
+++ b/src/sentry/users/api/serializers/useremail.py
@@ -16,7 +16,7 @@ class UserEmailSerializerResponse(TypedDict):
 
 
 @register(UserEmail)
-class UserEmailSerializer(Serializer):
+class UserEmailSerializer(Serializer[UserEmailSerializerResponse]):
     def serialize(
         self,
         obj: UserEmail,

--- a/src/sentry/users/api/serializers/userip.py
+++ b/src/sentry/users/api/serializers/userip.py
@@ -20,7 +20,7 @@ class UserIPSerializerResponse(TypedDict):
 
 
 @register(UserIP)
-class UserIPSerializer(Serializer):
+class UserIPSerializer(Serializer[UserIPSerializerResponse]):
     def serialize(
         self,
         obj: UserIP,

--- a/src/sentry/users/api/serializers/userrole.py
+++ b/src/sentry/users/api/serializers/userrole.py
@@ -19,7 +19,7 @@ class UserRoleSerializerResponse(TypedDict):
 
 
 @register(UserRole)
-class UserRoleSerializer(Serializer):
+class UserRoleSerializer(Serializer[UserRoleSerializerResponse]):
     def serialize(
         self,
         obj: UserRole,

--- a/src/sentry/workflow_engine/endpoints/serializers/action_handler_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/action_handler_serializer.py
@@ -27,7 +27,7 @@ class ActionHandlerSerializerResponse(TypedDict):
 
 
 @register(ActionHandler)
-class ActionHandlerSerializer(Serializer):
+class ActionHandlerSerializer(Serializer[ActionHandlerSerializerResponse]):
     def transform_title(self, title: str) -> str:
         if title in PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS:
             return f"(Legacy) {title}"

--- a/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
@@ -16,7 +16,7 @@ class ActionSerializerResponse(TypedDict):
 
 
 @register(Action)
-class ActionSerializer(Serializer):
+class ActionSerializer(Serializer[ActionSerializerResponse]):
     def serialize(self, obj: Action, *args: Any, **kwargs: Any) -> ActionSerializerResponse:
         # Get the action handler and config transformer if available
         action_handler = action_handler_registry.get(obj.type)

--- a/src/sentry/workflow_engine/endpoints/serializers/alertrule_detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/alertrule_detector_serializer.py
@@ -12,7 +12,7 @@ class AlertRuleDetectorSerializerResponse(TypedDict):
 
 
 @register(AlertRuleDetector)
-class AlertRuleDetectorSerializer(Serializer):
+class AlertRuleDetectorSerializer(Serializer[AlertRuleDetectorSerializerResponse]):
     def serialize(
         self, obj: AlertRuleDetector, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> AlertRuleDetectorSerializerResponse:

--- a/src/sentry/workflow_engine/endpoints/serializers/alertrule_workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/alertrule_workflow_serializer.py
@@ -12,7 +12,7 @@ class ActionHandlerSerializerResponse(TypedDict):
 
 
 @register(AlertRuleWorkflow)
-class AlertRuleWorkflowSerializer(Serializer):
+class AlertRuleWorkflowSerializer(Serializer[ActionHandlerSerializerResponse]):
     def serialize(
         self, obj: AlertRuleWorkflow, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> ActionHandlerSerializerResponse:

--- a/src/sentry/workflow_engine/endpoints/serializers/data_condition_group_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/data_condition_group_serializer.py
@@ -11,7 +11,7 @@ from sentry.workflow_engine.models import (
 
 
 @register(DataConditionGroup)
-class DataConditionGroupSerializer(Serializer):
+class DataConditionGroupSerializer(Serializer[dict[str, Any]]):
     def get_attrs(
         self, item_list: Sequence[DataConditionGroup], user: Any, **kwargs: Any
     ) -> MutableMapping[DataConditionGroup, dict[str, Any]]:

--- a/src/sentry/workflow_engine/endpoints/serializers/data_condition_handler_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/data_condition_handler_serializer.py
@@ -13,7 +13,7 @@ class DataConditionHandlerResponse(TypedDict):
 
 
 @register(DataConditionHandler)
-class DataConditionHandlerSerializer(Serializer):
+class DataConditionHandlerSerializer(Serializer[DataConditionHandlerResponse]):
     def serialize(
         self,
         obj: DataConditionHandler[Any],

--- a/src/sentry/workflow_engine/endpoints/serializers/data_condition_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/data_condition_serializer.py
@@ -6,7 +6,7 @@ from sentry.workflow_engine.models import DataCondition
 
 
 @register(DataCondition)
-class DataConditionSerializer(Serializer):
+class DataConditionSerializer(Serializer[dict[str, Any]]):
     def serialize(self, obj: DataCondition, *args: Any, **kwargs: Any) -> dict[str, Any]:
         comparison = obj.comparison
         if isinstance(comparison, dict):

--- a/src/sentry/workflow_engine/endpoints/serializers/data_source_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/data_source_serializer.py
@@ -8,7 +8,7 @@ from sentry.workflow_engine.types import DataSourceTypeHandler
 
 
 @register(DataSource)
-class DataSourceSerializer(Serializer):
+class DataSourceSerializer(Serializer[dict[str, Any]]):
     def get_attrs(
         self, item_list: Sequence[DataSource], user: Any, **kwargs: Any
     ) -> MutableMapping[DataSource, dict[str, Any]]:

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -49,7 +49,7 @@ class DetectorSerializerResponse(DetectorSerializerResponseOptional):
 
 
 @register(Detector)
-class DetectorSerializer(Serializer):
+class DetectorSerializer(Serializer[DetectorSerializerResponse]):
     def get_attrs(
         self, item_list: Sequence[Detector], user: Any, **kwargs: Any
     ) -> MutableMapping[Detector, dict[str, Any]]:

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -27,7 +27,7 @@ class GroupOpenPeriodResponse(TypedDict):
 
 
 @register(GroupOpenPeriodActivity)
-class GroupOpenPeriodActivitySerializer(Serializer):
+class GroupOpenPeriodActivitySerializer(Serializer[GroupOpenPeriodActivityResponse]):
     def serialize(
         self, obj: GroupOpenPeriodActivity, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> GroupOpenPeriodActivityResponse:
@@ -41,7 +41,7 @@ class GroupOpenPeriodActivitySerializer(Serializer):
 
 
 @register(GroupOpenPeriod)
-class GroupOpenPeriodSerializer(Serializer):
+class GroupOpenPeriodSerializer(Serializer[GroupOpenPeriodResponse]):
     def get_attrs(self, item_list: Any, user: Any, **kwargs: Any) -> Any:
         query_start = kwargs.get("query_start")
         query_end = kwargs.get("query_end")

--- a/src/sentry/workflow_engine/endpoints/serializers/incident_groupopenperiod_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/incident_groupopenperiod_serializer.py
@@ -13,7 +13,7 @@ class IncidentGroupOpenPeriodSerializerResponse(TypedDict):
 
 
 @register(IncidentGroupOpenPeriod)
-class IncidentGroupOpenPeriodSerializer(Serializer):
+class IncidentGroupOpenPeriodSerializer(Serializer[IncidentGroupOpenPeriodSerializerResponse]):
     def serialize(
         self, obj: IncidentGroupOpenPeriod, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> IncidentGroupOpenPeriodSerializerResponse:

--- a/src/sentry/workflow_engine/endpoints/serializers/timeseries_value_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/timeseries_value_serializer.py
@@ -15,7 +15,7 @@ class TimeSeriesValueResponse(TypedDict):
     count: int
 
 
-class TimeSeriesValueSerializer(Serializer):
+class TimeSeriesValueSerializer(Serializer[TimeSeriesValueResponse]):
     def serialize(
         self, obj: TimeSeriesValue, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
     ) -> TimeSeriesValueResponse:

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
@@ -63,7 +63,7 @@ def convert_results(results: Sequence[_Result]) -> Sequence[WorkflowGroupHistory
     ]
 
 
-class WorkflowGroupHistorySerializer(Serializer):
+class WorkflowGroupHistorySerializer(Serializer[WorkflowFireHistoryResponse]):
     def get_attrs(
         self, item_list: Sequence[WorkflowGroupHistory], user: Any, **kwargs: Any
     ) -> MutableMapping[Any, Any]:

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
@@ -57,7 +57,7 @@ class WorkflowSerializerResponse(TypedDict):
 
 
 @register(Workflow)
-class WorkflowSerializer(Serializer):
+class WorkflowSerializer(Serializer[WorkflowSerializerResponse]):
     def get_attrs(
         self, item_list: Sequence[Workflow], user: Any, **kwargs: Any
     ) -> MutableMapping[Workflow, dict[str, Any]]:


### PR DESCRIPTION
Adds `Serializer[T]` subscripts where the class already had a typed `serialize() -> T` return but the base was unparameterized (61 sites), plus three `@register(Model)` decorators on Sentry output serializers that lacked one.

Lays the groundwork for a mypy-plugin extension that auto-resolves `serialize(obj, user)` calls without `serializer=` kwarg ceremony by reading these existing annotations as a static binding table. Without the plugin, the changes still help: mypy now picks the typed overload at every endpoint that passes `serializer=Foo()` explicitly.

Mechanical codemod. The original sweep had two classes of bug, both reverted: (a) several promotions surfaced pre-existing cross-file type drift (Event/Authenticator/Incident/OrganizationMember/User/Actor/UserReport/SentryAppAvatar/Dashboard) — real bugs deserving separate follow-up PRs; (b) the AST-level base-class check couldn't distinguish `sentry.api.serializers.Serializer` from `rest_framework.serializers.Serializer` without import resolution, so a number of `@register(Model)` decorators were added to DRF input serializers — those would have clobbered the model-output registry binding at runtime.