### PR TITLE
fix(performance): Use full issue URL in trace drawer

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.spec.tsx
@@ -75,7 +75,10 @@ describe('ErrorNodeDetails', () => {
       expect(issueMock).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/issues/${group.id}/`,
         expect.objectContaining({
-          query: {collapse: 'release', expand: 'inbox'},
+          query: {
+            collapse: ['release', 'tags', 'stats'],
+            expand: ['inbox', 'owners'],
+          },
         })
       );
     });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.spec.tsx
@@ -1,7 +1,8 @@
+import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {TraceTreeNodeExtra} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
@@ -24,9 +25,15 @@ describe('ErrorNodeDetails', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('renders error details with title and ID', () => {
+  it('renders error details with title and ID', async () => {
     const organization = OrganizationFixture();
     const project = ProjectFixture({id: '1', slug: 'project_slug'});
+    const group = GroupFixture({id: '123'});
+    const issueMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/`,
+      method: 'GET',
+      body: group,
+    });
 
     act(() => ProjectsStore.loadInitialData([project]));
 
@@ -35,6 +42,7 @@ describe('ErrorNodeDetails', () => {
       title: 'TypeError: Cannot read property of undefined',
       level: 'error',
       message: 'Something went wrong',
+      issue_id: Number(group.id),
     });
 
     const extra = createMockExtra({organization});
@@ -62,5 +70,14 @@ describe('ErrorNodeDetails', () => {
     expect(
       screen.getByText(/This error is related to an ongoing issue/)
     ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(issueMock).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/issues/${group.id}/`,
+        expect.objectContaining({
+          query: {collapse: 'release', expand: 'inbox'},
+        })
+      );
+    });
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -34,7 +34,7 @@ type UseTraceIssueGroupProps = {
   organization: Organization;
 };
 
-export function useTraceIssueGroup({issueId, organization}: UseTraceIssueGroupProps) {
+function useTraceIssueGroup({issueId, organization}: UseTraceIssueGroupProps) {
   return useQuery(
     apiOptions.as<Group>()('/organizations/$organizationIdOrSlug/issues/$issueId/', {
       path: issueId ? {organizationIdOrSlug: organization.slug, issueId} : skipToken,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import {skipToken, useQuery} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
 
@@ -12,10 +12,9 @@ import {PanelItem} from 'sentry/components/panels/panelItem';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Level} from 'sentry/types/event';
-import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {RequestError} from 'sentry/utils/requestError/requestError';
+import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {getTraceIssueSeverityClassName} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
@@ -56,18 +55,14 @@ function Issue(props: IssueProps) {
     data: fetchedIssue,
     isError,
     error,
-  } = useQuery(
-    apiOptions.as<Group>()('/organizations/$organizationIdOrSlug/issues/$issueId/', {
-      path: props.issue.issue_id
-        ? {organizationIdOrSlug: props.organization.slug, issueId: props.issue.issue_id}
-        : skipToken,
-      query: {
-        collapse: 'release',
-        expand: 'inbox',
-      },
-      staleTime: 2 * 60 * 1000,
-    })
-  );
+  } = useQuery({
+    ...groupApiOptions({
+      groupId: String(props.issue.issue_id),
+      organizationSlug: props.organization.slug,
+      environments: [],
+    }),
+    staleTime: 10 * 60 * 1000,
+  });
 
   const iconClassName = getTraceIssueSeverityClassName(props.issue);
 
@@ -183,9 +178,9 @@ export function IssueList({issues, node, organization}: IssueListProps) {
   const uniqueIssues = [
     ...node.uniqueErrorIssues.sort(sortIssuesByLevel),
     ...node.uniqueOccurrenceIssues,
-  ];
+  ].filter(issue => issue.issue_id);
 
-  if (!issues.length) {
+  if (!issues.length || !uniqueIssues.length) {
     return null;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import {skipToken, useQuery} from '@tanstack/react-query';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
 
@@ -13,8 +14,8 @@ import {t} from 'sentry/locale';
 import type {Level} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {getTraceIssueSeverityClassName} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
@@ -27,6 +28,24 @@ type IssueProps = {
 };
 
 const MAX_DISPLAYED_ISSUES_COUNT = 3;
+
+type UseTraceIssueGroupProps = {
+  issueId: number;
+  organization: Organization;
+};
+
+export function useTraceIssueGroup({issueId, organization}: UseTraceIssueGroupProps) {
+  return useQuery(
+    apiOptions.as<Group>()('/organizations/$organizationIdOrSlug/issues/$issueId/', {
+      path: issueId ? {organizationIdOrSlug: organization.slug, issueId} : skipToken,
+      query: {
+        collapse: 'release',
+        expand: 'inbox',
+      },
+      staleTime: 2 * 60 * 1000,
+    })
+  );
+}
 
 const issueOrderPriority: Record<Level | 'default', number> = {
   fatal: 0,
@@ -55,21 +74,10 @@ function Issue(props: IssueProps) {
     data: fetchedIssue,
     isError,
     error,
-  } = useApiQuery<Group>(
-    [
-      getApiUrl('/issues/$issueId/', {path: {issueId: props.issue.issue_id}}),
-      {
-        query: {
-          collapse: 'release',
-          expand: 'inbox',
-        },
-      },
-    ],
-    {
-      enabled: !!props.issue.issue_id,
-      staleTime: 2 * 60 * 1000,
-    }
-  );
+  } = useTraceIssueGroup({
+    issueId: props.issue.issue_id,
+    organization: props.organization,
+  });
 
   const iconClassName = getTraceIssueSeverityClassName(props.issue);
 
@@ -92,7 +100,9 @@ function Issue(props: IssueProps) {
   ) : isError ? (
     <LoadingError
       message={
-        error.status === 404 ? t('This issue was deleted') : t('Failed to fetch issue')
+        error instanceof RequestError && error.status === 404
+          ? t('This issue was deleted')
+          : t('Failed to fetch issue')
       }
     />
   ) : null;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -29,24 +29,6 @@ type IssueProps = {
 
 const MAX_DISPLAYED_ISSUES_COUNT = 3;
 
-type UseTraceIssueGroupProps = {
-  issueId: number;
-  organization: Organization;
-};
-
-function useTraceIssueGroup({issueId, organization}: UseTraceIssueGroupProps) {
-  return useQuery(
-    apiOptions.as<Group>()('/organizations/$organizationIdOrSlug/issues/$issueId/', {
-      path: issueId ? {organizationIdOrSlug: organization.slug, issueId} : skipToken,
-      query: {
-        collapse: 'release',
-        expand: 'inbox',
-      },
-      staleTime: 2 * 60 * 1000,
-    })
-  );
-}
-
 const issueOrderPriority: Record<Level | 'default', number> = {
   fatal: 0,
   error: 1,
@@ -74,10 +56,18 @@ function Issue(props: IssueProps) {
     data: fetchedIssue,
     isError,
     error,
-  } = useTraceIssueGroup({
-    issueId: props.issue.issue_id,
-    organization: props.organization,
-  });
+  } = useQuery(
+    apiOptions.as<Group>()('/organizations/$organizationIdOrSlug/issues/$issueId/', {
+      path: props.issue.issue_id
+        ? {organizationIdOrSlug: props.organization.slug, issueId: props.issue.issue_id}
+        : skipToken,
+      query: {
+        collapse: 'release',
+        expand: 'inbox',
+      },
+      staleTime: 2 * 60 * 1000,
+    })
+  );
 
   const iconClassName = getTraceIssueSeverityClassName(props.issue);
 


### PR DESCRIPTION
The trace drawer issue cards were still fetching group data through the old top-level issue alias.

ref #116818, which removes the legacy URLs from the generated known API URL type.