### PR TITLE
feat(post-process): Add overridable SIEM security logging hook

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1578,6 +1578,24 @@ def kick_off_lightweight_rca_cluster(job: PostProcessJob) -> None:
     trigger_lightweight_rca_cluster_task.delay(group.id)
 
 
+def _noop_siem_security_log_hook(job: PostProcessJob) -> None:
+    pass
+
+
+# No-op in sentry; getsentry overrides via set_siem_security_log_hook. Resolved
+# at call time so the override needs no changes to the pipelines below.
+_siem_security_log_hook: Callable[[PostProcessJob], None] = _noop_siem_security_log_hook
+
+
+def set_siem_security_log_hook(hook: Callable[[PostProcessJob], None]) -> None:
+    global _siem_security_log_hook
+    _siem_security_log_hook = hook
+
+
+def process_siem_security_logging(job: PostProcessJob) -> None:
+    _siem_security_log_hook(job)
+
+
 GROUP_CATEGORY_POST_PROCESS_PIPELINE: dict[
     GroupCategory, list[Callable[[PostProcessJob], None]]
 ] = {
@@ -1606,6 +1624,7 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE: dict[
         check_if_flags_sent,
         process_processing_errors_eap,
         process_processing_issue_detection,
+        process_siem_security_logging,
     ],
     GroupCategory.FEEDBACK: [
         feedback_filter_decorator(process_snoozes),

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -168,7 +168,8 @@ class SiemSecurityLoggingTest(TestCase):
         )
 
     def test_noop(self) -> None:
-        assert process_siem_security_logging({}) is None
+        # Default hook is a no-op: the call must complete without touching the job.
+        process_siem_security_logging({})
 
     def test_hook_swap_takes_effect(self) -> None:
         original = post_process_module._siem_security_log_hook

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -58,14 +58,18 @@ from sentry.services.eventstore.models import Event
 from sentry.services.eventstore.processing import event_processing_store
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
+from sentry.tasks import post_process as post_process_module
 from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import (
+    GROUP_CATEGORY_POST_PROCESS_PIPELINE,
     HIGHER_ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT,
     ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT,
     feedback_filter_decorator,
     locks,
     post_process_group,
+    process_siem_security_logging,
     run_post_process_job,
+    set_siem_security_log_hook,
 )
 from sentry.testutils.cases import BaseTestCase, PerformanceIssueTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers import with_feature
@@ -154,6 +158,28 @@ class ProcessWorkflowsKwargsMatcher:
             return False
 
         return True
+
+
+class SiemSecurityLoggingTest(TestCase):
+    def test_registered_in_error_pipeline(self) -> None:
+        assert (
+            process_siem_security_logging
+            in GROUP_CATEGORY_POST_PROCESS_PIPELINE[GroupCategory.ERROR]
+        )
+
+    def test_noop(self) -> None:
+        assert process_siem_security_logging({}) is None
+
+    def test_hook_swap_takes_effect(self) -> None:
+        original = post_process_module._siem_security_log_hook
+        calls = []
+        try:
+            set_siem_security_log_hook(lambda job: calls.append(job))
+            process_siem_security_logging({})
+        finally:
+            set_siem_security_log_hook(original)
+
+        assert calls == [{}]
 
 
 class BasePostProcessGroupMixin(BaseTestCase, metaclass=abc.ABCMeta):


### PR DESCRIPTION
Adds a no-op post-process pipeline step, `process_siem_security_logging`, to the ERROR pipeline. It is backed by a swappable module-level hook (`_siem_security_log_hook`) that defaults to a no-op and is installed by getsentry via the new `set_siem_security_log_hook` setter.

getsentry needs to emit structured, SIEM-ingestible security logs from error post-processing, but that logic is getsentry-specific and shouldn't live in sentry. This gives getsentry a clean seam to plug into without forking the pipeline.

The hook is resolved at call time through the stable `process_siem_security_logging` wrapper, so the override takes effect without mutating the pipeline lists. An earlier approach swapped the entry directly in `GROUP_CATEGORY_POST_PROCESS_PIPELINE` from getsentry's `AppConfig.ready()`, but that meant iterating/mutating the pipeline in place, was order-sensitive, and tripped mypy's `method-assign` check; the setter is a single typed call and order-independent.

This is a no-op on its own — sentry behavior is unchanged until getsentry installs its hook (separate PR, lands after this one).