### PR TITLE
Remove the deduplicate workflow API for the time being

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_deduplicate_workflows.py
+++ b/src/sentry/workflow_engine/endpoints/organization_deduplicate_workflows.py
@@ -196,6 +196,13 @@ def deduplicate_workflows(organization: Organization) -> None:
 
 @cell_silo_endpoint
 class OrganizationDeduplicateWorkflowsEndpoint(OrganizationEndpoint):
+    """
+    TODO, there are issues with running this script for a few reasons right now;
+    - Breaks the legacy APIs due to missing connections on AlertRuleWorkflow tables
+    - Needs to fix the DetectorWorkflow mappings, it's not currently working as expected
+    - Need to have a `dry-run` version of this, so we can return the impacted workflows before executing
+    """
+
     permission_classes = (OrganizationDeduplicateWorkflowsPermission,)
     publish_status = {
         "PUT": ApiPublishStatus.PRIVATE,

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -1,9 +1,5 @@
 from django.urls import re_path
 
-from sentry.workflow_engine.endpoints.organization_deduplicate_workflows import (
-    OrganizationDeduplicateWorkflowsEndpoint,
-)
-
 from .organization_alertrule_detector_index import OrganizationAlertRuleDetectorIndexEndpoint
 from .organization_alertrule_workflow_index import OrganizationAlertRuleWorkflowIndexEndpoint
 from .organization_available_action_index import OrganizationAvailableActionIndexEndpoint
@@ -54,11 +50,6 @@ organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/detectors/count/$",
         OrganizationDetectorCountEndpoint.as_view(),
         name="sentry-api-0-organization-detector-count",
-    ),
-    re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/workflows/deduplicate/$",
-        OrganizationDeduplicateWorkflowsEndpoint.as_view(),
-        name="sentry-api-0-organization-deduplicate-workflows",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/workflows/(?P<workflow_id>\d+)/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -596,7 +596,6 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/workflows/$workflowId/'
   | '/organizations/$organizationIdOrSlug/workflows/$workflowId/group-history/'
   | '/organizations/$organizationIdOrSlug/workflows/$workflowId/stats/'
-  | '/organizations/$organizationIdOrSlug/workflows/deduplicate/'
   | '/projects/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/alert-rule-task/$taskUuid/'

--- a/tests/sentry/workflow_engine/endpoints/test_organization_deduplicate_workflows.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_deduplicate_workflows.py
@@ -2,6 +2,8 @@ from copy import deepcopy
 from random import randint
 from typing import Any, TypedDict, Unpack
 
+import pytest
+
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.organization import Organization
 from sentry.rules import MatchType
@@ -164,6 +166,7 @@ DUPLICATE_WORKFLOW_CONFIGS: list[MockWorkflowConfig] = [
 
 
 @cell_silo_test
+@pytest.mark.skip("The endpoint is currently disabled")
 class OrganizationDeduplicateWorkflowsTest(APITestCase):
     endpoint = "sentry-api-0-organization-deduplicate-workflows"
     method = "put"


### PR DESCRIPTION
# Description
This endpoint has some issues (see the comment in code), and the feature has been de-prioritized for the time being. This PR will remove the registration for the endpoint to ensure no one invokes it until everything has been addressed.