### PR TITLE
feat(integrations): ExternalActor from login-with-github identity

### DIFF
--- a/src/sentry/identity/base.py
+++ b/src/sentry/identity/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import logging
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from sentry.identity.services.identity.model import RpcIdentity
@@ -57,6 +58,16 @@ class Provider(PipelineProvider["IdentityPipeline"], abc.ABC):
         Return the new state which should be used for an identity.
         """
         return new_data
+
+    def post_link_identity(self, identity: Mapping[str, Any], user_id: int) -> None:
+        """
+        Hook invoked after an identity is linked via the social-auth pipeline.
+
+        ``identity`` is the mapping returned by ``build_identity`` and ``user_id`` is
+        the Sentry user the identity was linked to. No-op by default; providers may
+        override to perform side effects (e.g. backfilling derived mappings). Callers
+        invoke this best-effort, so implementations must not assume they can raise.
+        """
 
     def refresh_identity(self, identity: Identity | RpcIdentity, **kwargs: Any) -> None:
         """

--- a/src/sentry/identity/base.py
+++ b/src/sentry/identity/base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import abc
 import logging
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from sentry.identity.services.identity.model import RpcIdentity
@@ -59,7 +58,7 @@ class Provider(PipelineProvider["IdentityPipeline"], abc.ABC):
         """
         return new_data
 
-    def post_link_identity(self, identity: Mapping[str, Any], user_id: int) -> None:
+    def post_link_identity(self, identity: dict[str, Any], user_id: int) -> None:
         """
         Hook invoked after an identity is linked via the social-auth pipeline.
 

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -6,7 +6,7 @@ from django.core.exceptions import PermissionDenied
 from sentry import http, options
 from sentry.constants import ObjectStatus
 from sentry.identity.oauth2 import OAuth2Provider
-from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import (
     ExternalActorSource,
     ExternalProviders,
@@ -137,15 +137,10 @@ def ensure_external_actors_for_github_identity(
         if not org_ids:
             return
 
-        # Materialize inside the try so a DB error here can't escape into the
-        # caller's login/link flow (the iteration below would otherwise run the query).
-        org_integrations = list(
-            OrganizationIntegration.objects.filter(
-                organization_id__in=org_ids,
-                status=ObjectStatus.ACTIVE,
-                integration__provider=IntegrationProviderSlug.GITHUB.value,
-                integration__status=ObjectStatus.ACTIVE,
-            ).values_list("organization_id", "integration_id")
+        org_integrations = integration_service.get_organization_integrations(
+            organization_ids=org_ids,
+            providers=[IntegrationProviderSlug.GITHUB.value],
+            status=ObjectStatus.ACTIVE,
         )
     except Exception:
         logger.exception(
@@ -155,11 +150,11 @@ def ensure_external_actors_for_github_identity(
         return
 
     external_name = f"@{github_login}"
-    for organization_id, integration_id in org_integrations:
+    for oi in org_integrations:
         try:
             organization_service.upsert_external_actor(
-                organization_id=organization_id,
-                integration_id=integration_id,
+                organization_id=oi.organization_id,
+                integration_id=oi.integration_id,
                 user_id=user_id,
                 provider=ExternalProviders.GITHUB.value,
                 external_name=external_name,
@@ -171,7 +166,7 @@ def ensure_external_actors_for_github_identity(
                 "github.identity.external_actor.create_failed",
                 extra={
                     "user_id": user_id,
-                    "organization_id": organization_id,
-                    "integration_id": integration_id,
+                    "organization_id": oi.organization_id,
+                    "integration_id": oi.integration_id,
                 },
             )

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -1,8 +1,14 @@
+import logging
+from collections.abc import Mapping
+from typing import Any
+
 from django.core.exceptions import PermissionDenied
 
 from sentry import http, options
 from sentry.identity.oauth2 import OAuth2Provider
 from sentry.integrations.types import IntegrationProviderSlug
+
+logger = logging.getLogger(__name__)
 
 
 def get_user_info(access_token):
@@ -56,3 +62,92 @@ class GitHubIdentityProvider(OAuth2Provider):
             "scopes": [],  # GitHub apps do not have user scopes
             "data": self.get_oauth_data(data),
         }
+
+    def post_link_identity(self, identity: Mapping[str, Any], user_id: int) -> None:
+        # A linked GitHub identity is an authoritative user<->GitHub mapping, so mirror
+        # it into ExternalActor for the user's GitHub-integrated orgs. Best-effort.
+        #
+        # This is github.com only by design: GitHub Enterprise has no social-login flow
+        # (GitHubEnterpriseIdentityProvider.build_identity raises), so enterprise Identity
+        # rows are created at integration-install time, not here, and remain the backfill's
+        # responsibility.
+        github_id = identity.get("id")
+        ensure_external_actors_for_github_identity(
+            user_id=user_id,
+            github_login=identity.get("login"),
+            github_id=str(github_id) if github_id is not None else None,
+        )
+
+
+def ensure_external_actors_for_github_identity(
+    *,
+    user_id: int,
+    github_login: str | None,
+    github_id: str | None,
+) -> None:
+    """
+    Reactively create GitHub ``ExternalActor`` mappings for a user who just linked their
+    github.com identity to Sentry (the social-auth login flow).
+
+    A linked GitHub identity is an authoritative user<->GitHub mapping, so we mirror it
+    into ``ExternalActor`` for every organization the user belongs to that has an active
+    GitHub integration. Discovery happens entirely in the control silo
+    (``OrganizationMemberMapping``/``OrganizationIntegration``/``Integration`` are all
+    control models); only the row write crosses into the org's cell, via a single
+    cell-resolved RPC per org.
+
+    This is best-effort: it must never raise into the linking flow, and the periodic
+    backfill remains the safety net for anything missed here.
+    """
+    from sentry.constants import ObjectStatus
+    from sentry.integrations.models.organization_integration import OrganizationIntegration
+    from sentry.integrations.types import ExternalActorSource, ExternalProviders
+    from sentry.models.organizationmembermapping import OrganizationMemberMapping
+    from sentry.organizations.services.organization import organization_service
+
+    if not github_login:
+        return
+
+    try:
+        org_ids = list(
+            OrganizationMemberMapping.objects.filter(user_id=user_id).values_list(
+                "organization_id", flat=True
+            )
+        )
+        if not org_ids:
+            return
+
+        org_integrations = OrganizationIntegration.objects.filter(
+            organization_id__in=org_ids,
+            status=ObjectStatus.ACTIVE,
+            integration__provider=IntegrationProviderSlug.GITHUB.value,
+            integration__status=ObjectStatus.ACTIVE,
+        ).values_list("organization_id", "integration_id")
+    except Exception:
+        logger.exception(
+            "github.identity.external_actor.discovery_failed",
+            extra={"user_id": user_id},
+        )
+        return
+
+    external_name = f"@{github_login.lstrip('@')}"
+    for organization_id, integration_id in org_integrations:
+        try:
+            organization_service.upsert_external_actor(
+                organization_id=organization_id,
+                integration_id=integration_id,
+                user_id=user_id,
+                provider=ExternalProviders.GITHUB.value,
+                external_name=external_name,
+                external_id=github_id,
+                source=ExternalActorSource.IDENTITY.value,
+            )
+        except Exception:
+            logger.exception(
+                "github.identity.external_actor.create_failed",
+                extra={
+                    "user_id": user_id,
+                    "organization_id": organization_id,
+                    "integration_id": integration_id,
+                },
+            )

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Mapping
 from typing import Any
 
 from django.core.exceptions import PermissionDenied
@@ -63,14 +62,14 @@ class GitHubIdentityProvider(OAuth2Provider):
             "data": self.get_oauth_data(data),
         }
 
-    def post_link_identity(self, identity: Mapping[str, Any], user_id: int) -> None:
+    def post_link_identity(self, identity: dict[str, Any], user_id: int) -> None:
         # A linked GitHub identity is an authoritative user<->GitHub mapping, so mirror
         # it into ExternalActor for the user's GitHub-integrated orgs. Best-effort.
         #
         # This is github.com only by design: GitHub Enterprise has no social-login flow
-        # (GitHubEnterpriseIdentityProvider.build_identity raises), so enterprise Identity
-        # rows are created at integration-install time, not here, and remain the backfill's
-        # responsibility.
+        # (GitHubEnterpriseIdentityProvider.build_identity raises). The only enterprise
+        # identity that ever exists is the installer's (linked at integration-install
+        # time), which isn't worth mapping, so we skip enterprise here entirely.
         github_id = identity.get("id")
         ensure_external_actors_for_github_identity(
             user_id=user_id,

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -74,6 +74,14 @@ class GitHubIdentityProvider(OAuth2Provider):
         # A linked GitHub identity is an authoritative user<->GitHub mapping, so mirror
         # it into ExternalActor for the user's GitHub-integrated orgs. Best-effort.
         #
+        # NOTE: This hook only fires for the "associate identity from account settings"
+        # flow (sentry.users.web.account_identity.AccountIdentityAssociateView ->
+        # IdentityPipeline.finish_pipeline). The primary "Sign in with GitHub" login/
+        # signup flow lives in getsentry (getsentry.web.identity, the `github_login`
+        # provider) and never reaches finish_pipeline, so it calls
+        # ensure_external_actors_for_github_identity() directly. Both paths are wired
+        # so either way of establishing a GitHub identity reacts the same way.
+        #
         # This is github.com only by design: GitHub Enterprise has no social-login flow
         # (GitHubEnterpriseIdentityProvider.build_identity raises). The only enterprise
         # identity that ever exists is the installer's (linked at integration-install
@@ -103,8 +111,19 @@ def ensure_external_actors_for_github_identity(
     control models); only the row write crosses into the org's cell, via a single
     cell-resolved RPC per org.
 
-    This is best-effort: it must never raise into the linking flow, and the periodic
-    backfill remains the safety net for anything missed here.
+    This mirrors the ``ExternalActorSource.IDENTITY`` discovery in getsentry's
+    ``backfill_github_external_actor`` job, but reactively at identity-link time rather
+    than as a periodic sweep (and cheaper: the GitHub login arrives in the OAuth payload,
+    so we skip the per-user ``/user/{id}`` lookup the backfill has to make).
+
+    Called from two places, since GitHub identities get established in two flows:
+      - getsentry's ``github_login`` login/signup views (the "Sign in with GitHub"
+        button) -- the common path; see ``getsentry.web.identity``.
+      - ``GitHubIdentityProvider.post_link_identity`` (the "associate identity from
+        account settings" flow).
+
+    This is best-effort and never raises into the caller's flow; the periodic backfill
+    remains the safety net for anything missed here.
     """
     if not github_login:
         return
@@ -118,12 +137,16 @@ def ensure_external_actors_for_github_identity(
         if not org_ids:
             return
 
-        org_integrations = OrganizationIntegration.objects.filter(
-            organization_id__in=org_ids,
-            status=ObjectStatus.ACTIVE,
-            integration__provider=IntegrationProviderSlug.GITHUB.value,
-            integration__status=ObjectStatus.ACTIVE,
-        ).values_list("organization_id", "integration_id")
+        # Materialize inside the try so a DB error here can't escape into the
+        # caller's login/link flow (the iteration below would otherwise run the query).
+        org_integrations = list(
+            OrganizationIntegration.objects.filter(
+                organization_id__in=org_ids,
+                status=ObjectStatus.ACTIVE,
+                integration__provider=IntegrationProviderSlug.GITHUB.value,
+                integration__status=ObjectStatus.ACTIVE,
+            ).values_list("organization_id", "integration_id")
+        )
     except Exception:
         logger.exception(
             "github.identity.external_actor.discovery_failed",

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -131,7 +131,7 @@ def ensure_external_actors_for_github_identity(
         )
         return
 
-    external_name = f"@{github_login.lstrip('@')}"
+    external_name = f"@{github_login}"
     for organization_id, integration_id in org_integrations:
         try:
             organization_service.upsert_external_actor(

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -4,8 +4,16 @@ from typing import Any
 from django.core.exceptions import PermissionDenied
 
 from sentry import http, options
+from sentry.constants import ObjectStatus
 from sentry.identity.oauth2 import OAuth2Provider
-from sentry.integrations.types import IntegrationProviderSlug
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.types import (
+    ExternalActorSource,
+    ExternalProviders,
+    IntegrationProviderSlug,
+)
+from sentry.models.organizationmembermapping import OrganizationMemberMapping
+from sentry.organizations.services.organization import organization_service
 
 logger = logging.getLogger(__name__)
 
@@ -98,12 +106,6 @@ def ensure_external_actors_for_github_identity(
     This is best-effort: it must never raise into the linking flow, and the periodic
     backfill remains the safety net for anything missed here.
     """
-    from sentry.constants import ObjectStatus
-    from sentry.integrations.models.organization_integration import OrganizationIntegration
-    from sentry.integrations.types import ExternalActorSource, ExternalProviders
-    from sentry.models.organizationmembermapping import OrganizationMemberMapping
-    from sentry.organizations.services.organization import organization_service
-
     if not github_login:
         return
 

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -6,7 +6,6 @@ from django.core.exceptions import PermissionDenied
 from sentry import http, options
 from sentry.constants import ObjectStatus
 from sentry.identity.oauth2 import OAuth2Provider
-from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import (
     ExternalActorSource,
     ExternalProviders,
@@ -127,6 +126,11 @@ def ensure_external_actors_for_github_identity(
     """
     if not github_login:
         return
+
+    # Imported lazily to avoid a circular import: this module is imported during
+    # identity provider registration (sentry.identity), which runs before the
+    # integration service module has finished initializing.
+    from sentry.integrations.services.integration import integration_service
 
     try:
         org_ids = list(

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 from functools import cached_property
 
@@ -24,6 +25,8 @@ from sentry.users.models.identity import Identity, IdentityProvider
 from sentry.utils import metrics
 
 from . import default_manager
+
+logger = logging.getLogger(__name__)
 
 IDENTITY_LINKED = _("Your {identity_provider} account has been associated with your Sentry account")
 
@@ -75,6 +78,16 @@ class IdentityPipeline(Pipeline[IdentityProvider, PipelineSessionStore]):
                     "data": identity.get("data", {}),
                 },
             )
+
+            # Let providers react to a freshly linked identity (e.g. backfilling
+            # derived mappings). Best-effort: never let it break the link flow.
+            try:
+                self.provider.post_link_identity(identity, self.request.user.id)
+            except Exception:
+                logger.exception(
+                    "identity.post_link_identity.failed",
+                    extra={"provider": self.provider.key},
+                )
 
             messages.add_message(
                 self.request,

--- a/src/sentry/organizations/services/organization/impl.py
+++ b/src/sentry/organizations/services/organization/impl.py
@@ -720,6 +720,32 @@ class DatabaseBackedOrganizationService(OrganizationService):
             flags=F("flags").bitand(~OrganizationMember.flags["sso:linked"]),
         ).count()
 
+    def upsert_external_actor(
+        self,
+        *,
+        organization_id: int,
+        integration_id: int,
+        user_id: int,
+        provider: int,
+        external_name: str,
+        external_id: str | None = None,
+        source: int | None = None,
+    ) -> bool:
+        from sentry.integrations.models.external_actor import ExternalActor
+
+        _, created = ExternalActor.objects.get_or_create(
+            organization_id=organization_id,
+            provider=provider,
+            external_name=external_name,
+            user_id=user_id,
+            defaults={
+                "integration_id": integration_id,
+                "external_id": external_id,
+                "source": source,
+            },
+        )
+        return created
+
     def delete_organization(
         self, *, organization_id: int, user: RpcUser
     ) -> RpcOrganizationDeleteResponse:

--- a/src/sentry/organizations/services/organization/impl.py
+++ b/src/sentry/organizations/services/organization/impl.py
@@ -18,6 +18,7 @@ from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
 from sentry.hybridcloud.rpc import OptionValue, logger
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleActivity
 from sentry.incidents.models.incident import IncidentActivity
+from sentry.integrations.models.external_actor import ExternalActor
 from sentry.models.activity import Activity
 from sentry.models.dashboard import Dashboard, DashboardFavoriteUser, DashboardRevision
 from sentry.models.groupassignee import GroupAssignee
@@ -731,8 +732,6 @@ class DatabaseBackedOrganizationService(OrganizationService):
         external_id: str | None = None,
         source: int | None = None,
     ) -> bool:
-        from sentry.integrations.models.external_actor import ExternalActor
-
         _, created = ExternalActor.objects.get_or_create(
             organization_id=organization_id,
             provider=provider,

--- a/src/sentry/organizations/services/organization/impl.py
+++ b/src/sentry/organizations/services/organization/impl.py
@@ -735,9 +735,10 @@ class DatabaseBackedOrganizationService(OrganizationService):
         _, created = ExternalActor.objects.get_or_create(
             organization_id=organization_id,
             provider=provider,
-            external_name=external_name,
+            external_name__iexact=external_name,
             user_id=user_id,
             defaults={
+                "external_name": external_name,
                 "integration_id": integration_id,
                 "external_id": external_id,
                 "source": source,

--- a/src/sentry/organizations/services/organization/service.py
+++ b/src/sentry/organizations/services/organization/service.py
@@ -581,6 +581,38 @@ class OrganizationService(RpcService):
 
     @cell_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
+    def upsert_external_actor(
+        self,
+        *,
+        organization_id: int,
+        integration_id: int,
+        user_id: int,
+        provider: int,
+        external_name: str,
+        external_id: str | None = None,
+        source: int | None = None,
+    ) -> bool:
+        """
+        Idempotently create the ExternalActor mapping linking a Sentry user to their
+        external (SCM/messaging) identity within an organization. Runs in the
+        organization's cell since ExternalActor is a cell-silo model. Returns True if a
+        new row was created.
+
+        The caller owns provider-specific formatting (e.g. the leading "@" that
+        git-family providers use on ``external_name``).
+
+        :param organization_id: The organization to create the mapping in
+        :param integration_id: The org's active integration id for this provider
+        :param user_id: The Sentry user id
+        :param provider: The ExternalProviders value (e.g. ExternalProviders.GITHUB)
+        :param external_name: The external display name (verbatim; caller normalizes)
+        :param external_id: The external unique id, if known
+        :param source: The ExternalActorSource value describing how this was derived
+        """
+        pass
+
+    @cell_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
     def delete_organization(
         self, *, organization_id: int, user: RpcUser
     ) -> RpcOrganizationDeleteResponse:

--- a/tests/sentry/integrations/github/test_identity_external_actor.py
+++ b/tests/sentry/integrations/github/test_identity_external_actor.py
@@ -13,8 +13,13 @@ from sentry.integrations.types import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import no_silo_test
 
 
+# Monolith mode: the orchestrator reads control models (OrganizationMemberMapping/
+# OrganizationIntegration) and writes the cell-silo ExternalActor via RPC, and the
+# assertions read ExternalActor back -- all of which must be locally accessible.
+@no_silo_test
 class EnsureExternalActorsForGithubIdentityTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -158,6 +163,7 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         assert not self._external_actors(user_id=self.user.id).exists()
 
 
+@no_silo_test
 class GitHubIdentityProviderPostLinkTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/integrations/github/test_identity_external_actor.py
+++ b/tests/sentry/integrations/github/test_identity_external_actor.py
@@ -1,0 +1,198 @@
+from unittest import mock
+
+from sentry.constants import ObjectStatus
+from sentry.identity.github.provider import (
+    GitHubIdentityProvider,
+    ensure_external_actors_for_github_identity,
+)
+from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.types import (
+    ExternalActorSource,
+    ExternalProviders,
+    IntegrationProviderSlug,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.outbox import outbox_runner
+
+
+class EnsureExternalActorsForGithubIdentityTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.create_user())
+        with outbox_runner():
+            self.create_member(user=self.user, organization=self.organization)
+
+    def _github_integration(self, organization=None, **kwargs):
+        return self.create_integration(
+            organization=organization or self.organization,
+            provider=IntegrationProviderSlug.GITHUB.value,
+            external_id=kwargs.pop("external_id", "github:1"),
+            **kwargs,
+        )
+
+    def _external_actors(self, **filters):
+        return ExternalActor.objects.filter(**filters)
+
+    def test_creates_external_actor_for_github_integrated_org(self):
+        integration = self._github_integration()
+
+        ensure_external_actors_for_github_identity(
+            user_id=self.user.id, github_login="octocat", github_id="583231"
+        )
+
+        actor = self._external_actors(
+            organization_id=self.organization.id, user_id=self.user.id
+        ).get()
+        assert actor.provider == ExternalProviders.GITHUB.value
+        assert actor.external_name == "@octocat"
+        assert actor.external_id == "583231"
+        assert actor.integration_id == integration.id
+        assert actor.source == ExternalActorSource.IDENTITY.value
+
+    def test_normalizes_login_with_leading_at(self):
+        self._github_integration()
+
+        ensure_external_actors_for_github_identity(
+            user_id=self.user.id, github_login="@octocat", github_id=None
+        )
+
+        actor = self._external_actors(user_id=self.user.id).get()
+        assert actor.external_name == "@octocat"
+        assert actor.external_id is None
+
+    def test_idempotent(self):
+        self._github_integration()
+
+        for _ in range(2):
+            ensure_external_actors_for_github_identity(
+                user_id=self.user.id, github_login="octocat", github_id="583231"
+            )
+
+        assert self._external_actors(user_id=self.user.id).count() == 1
+
+    def test_skips_org_without_github_integration(self):
+        # Org membership exists but no GitHub integration is installed.
+        ensure_external_actors_for_github_identity(
+            user_id=self.user.id, github_login="octocat", github_id="583231"
+        )
+
+        assert not self._external_actors(user_id=self.user.id).exists()
+
+    def test_skips_org_user_is_not_a_member_of(self):
+        other_org = self.create_organization(owner=self.create_user())
+        self._github_integration(organization=other_org)
+
+        ensure_external_actors_for_github_identity(
+            user_id=self.user.id, github_login="octocat", github_id="583231"
+        )
+
+        assert not self._external_actors(organization_id=other_org.id).exists()
+
+    def test_skips_disabled_github_integration(self):
+        self._github_integration(oi_params={"status": ObjectStatus.DISABLED})
+
+        ensure_external_actors_for_github_identity(
+            user_id=self.user.id, github_login="octocat", github_id="583231"
+        )
+
+        assert not self._external_actors(user_id=self.user.id).exists()
+
+    def test_only_maps_github_provider_integrations(self):
+        # A non-GitHub integration in the same org must not produce a mapping.
+        self.create_integration(
+            organization=self.organization,
+            provider=IntegrationProviderSlug.SLACK.value,
+            external_id="slack:1",
+        )
+
+        ensure_external_actors_for_github_identity(
+            user_id=self.user.id, github_login="octocat", github_id="583231"
+        )
+
+        assert not self._external_actors(user_id=self.user.id).exists()
+
+    def test_fans_out_across_multiple_github_orgs(self):
+        second_org = self.create_organization(owner=self.create_user())
+        with outbox_runner():
+            self.create_member(user=self.user, organization=second_org)
+        self._github_integration()
+        self._github_integration(organization=second_org, external_id="github:2")
+
+        ensure_external_actors_for_github_identity(
+            user_id=self.user.id, github_login="octocat", github_id="583231"
+        )
+
+        assert self._external_actors(user_id=self.user.id).count() == 2
+
+    def test_missing_login_is_noop(self):
+        self._github_integration()
+
+        ensure_external_actors_for_github_identity(
+            user_id=self.user.id, github_login=None, github_id="583231"
+        )
+
+        assert not self._external_actors(user_id=self.user.id).exists()
+
+    def test_user_with_no_memberships_is_noop(self):
+        loner = self.create_user()
+
+        ensure_external_actors_for_github_identity(
+            user_id=loner.id, github_login="octocat", github_id="583231"
+        )
+
+        assert not self._external_actors(user_id=loner.id).exists()
+
+    def test_rpc_failure_is_swallowed_best_effort(self):
+        self._github_integration()
+
+        with mock.patch(
+            "sentry.organizations.services.organization.organization_service.upsert_external_actor",
+            side_effect=Exception("boom"),
+        ):
+            # Must not propagate: a failed mapping never breaks the identity-link flow.
+            ensure_external_actors_for_github_identity(
+                user_id=self.user.id, github_login="octocat", github_id="583231"
+            )
+
+        assert not self._external_actors(user_id=self.user.id).exists()
+
+
+class GitHubIdentityProviderPostLinkTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.create_user())
+        with outbox_runner():
+            self.create_member(user=self.user, organization=self.organization)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider=IntegrationProviderSlug.GITHUB.value,
+            external_id="github:1",
+        )
+
+    def test_post_link_identity_creates_external_actor(self):
+        provider = GitHubIdentityProvider()
+
+        provider.post_link_identity(
+            {"type": "github", "id": 583231, "login": "octocat"}, self.user.id
+        )
+
+        actor = ExternalActor.objects.get(
+            organization_id=self.organization.id, user_id=self.user.id
+        )
+        assert actor.external_name == "@octocat"
+        assert actor.external_id == "583231"
+        assert actor.provider == ExternalProviders.GITHUB.value
+
+    def test_post_link_identity_without_github_id_sets_null_external_id(self):
+        provider = GitHubIdentityProvider()
+
+        # A payload without a numeric "id" still yields a mapping keyed on the login.
+        provider.post_link_identity({"type": "github", "login": "octocat"}, self.user.id)
+
+        actor = ExternalActor.objects.get(
+            organization_id=self.organization.id, user_id=self.user.id
+        )
+        assert actor.external_name == "@octocat"
+        assert actor.external_id is None

--- a/tests/sentry/integrations/github/test_identity_external_actor.py
+++ b/tests/sentry/integrations/github/test_identity_external_actor.py
@@ -21,12 +21,17 @@ from sentry.testutils.silo import no_silo_test
 # assertions read ExternalActor back -- all of which must be locally accessible.
 @no_silo_test
 class EnsureExternalActorsForGithubIdentityTest(TestCase):
+    github_login = "octocat"
+    github_id = "583231"
+    external_name = "@octocat"
+
     def setUp(self):
         super().setUp()
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.create_user())
         with outbox_runner():
             self.create_member(user=self.user, organization=self.organization)
+        assert not ExternalActor.objects.exists()
 
     def _github_integration(self, organization=None, **kwargs):
         return self.create_integration(
@@ -43,15 +48,15 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         integration = self._github_integration()
 
         ensure_external_actors_for_github_identity(
-            user_id=self.user.id, github_login="octocat", github_id="583231"
+            user_id=self.user.id, github_login=self.github_login, github_id=self.github_id
         )
 
         actor = self._external_actors(
             organization_id=self.organization.id, user_id=self.user.id
         ).get()
         assert actor.provider == ExternalProviders.GITHUB.value
-        assert actor.external_name == "@octocat"
-        assert actor.external_id == "583231"
+        assert actor.external_name == self.external_name
+        assert actor.external_id == self.github_id
         assert actor.integration_id == integration.id
         assert actor.source == ExternalActorSource.IDENTITY.value
 
@@ -59,11 +64,11 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         self._github_integration()
 
         ensure_external_actors_for_github_identity(
-            user_id=self.user.id, github_login="octocat", github_id=None
+            user_id=self.user.id, github_login=self.github_login, github_id=None
         )
 
         actor = self._external_actors(user_id=self.user.id).get()
-        assert actor.external_name == "@octocat"
+        assert actor.external_name == self.external_name
         assert actor.external_id is None
 
     def test_idempotent(self):
@@ -71,7 +76,7 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
 
         for _ in range(2):
             ensure_external_actors_for_github_identity(
-                user_id=self.user.id, github_login="octocat", github_id="583231"
+                user_id=self.user.id, github_login=self.github_login, github_id=self.github_id
             )
 
         assert self._external_actors(user_id=self.user.id).count() == 1
@@ -79,7 +84,7 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
     def test_skips_org_without_github_integration(self):
         # Org membership exists but no GitHub integration is installed.
         ensure_external_actors_for_github_identity(
-            user_id=self.user.id, github_login="octocat", github_id="583231"
+            user_id=self.user.id, github_login=self.github_login, github_id=self.github_id
         )
 
         assert not self._external_actors(user_id=self.user.id).exists()
@@ -89,7 +94,7 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         self._github_integration(organization=other_org)
 
         ensure_external_actors_for_github_identity(
-            user_id=self.user.id, github_login="octocat", github_id="583231"
+            user_id=self.user.id, github_login=self.github_login, github_id=self.github_id
         )
 
         assert not self._external_actors(organization_id=other_org.id).exists()
@@ -98,7 +103,7 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         self._github_integration(oi_params={"status": ObjectStatus.DISABLED})
 
         ensure_external_actors_for_github_identity(
-            user_id=self.user.id, github_login="octocat", github_id="583231"
+            user_id=self.user.id, github_login=self.github_login, github_id=self.github_id
         )
 
         assert not self._external_actors(user_id=self.user.id).exists()
@@ -112,7 +117,7 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         )
 
         ensure_external_actors_for_github_identity(
-            user_id=self.user.id, github_login="octocat", github_id="583231"
+            user_id=self.user.id, github_login=self.github_login, github_id=self.github_id
         )
 
         assert not self._external_actors(user_id=self.user.id).exists()
@@ -125,7 +130,7 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         self._github_integration(organization=second_org, external_id="github:2")
 
         ensure_external_actors_for_github_identity(
-            user_id=self.user.id, github_login="octocat", github_id="583231"
+            user_id=self.user.id, github_login=self.github_login, github_id=self.github_id
         )
 
         assert self._external_actors(user_id=self.user.id).count() == 2
@@ -134,7 +139,7 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         self._github_integration()
 
         ensure_external_actors_for_github_identity(
-            user_id=self.user.id, github_login=None, github_id="583231"
+            user_id=self.user.id, github_login=None, github_id=self.github_id
         )
 
         assert not self._external_actors(user_id=self.user.id).exists()
@@ -143,7 +148,7 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         loner = self.create_user()
 
         ensure_external_actors_for_github_identity(
-            user_id=loner.id, github_login="octocat", github_id="583231"
+            user_id=loner.id, github_login=self.github_login, github_id=self.github_id
         )
 
         assert not self._external_actors(user_id=loner.id).exists()
@@ -157,7 +162,7 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         ):
             # Must not propagate: a failed mapping never breaks the identity-link flow.
             ensure_external_actors_for_github_identity(
-                user_id=self.user.id, github_login="octocat", github_id="583231"
+                user_id=self.user.id, github_login=self.github_login, github_id=self.github_id
             )
 
         assert not self._external_actors(user_id=self.user.id).exists()

--- a/tests/sentry/integrations/github/test_identity_external_actor.py
+++ b/tests/sentry/integrations/github/test_identity_external_actor.py
@@ -50,11 +50,11 @@ class EnsureExternalActorsForGithubIdentityTest(TestCase):
         assert actor.integration_id == integration.id
         assert actor.source == ExternalActorSource.IDENTITY.value
 
-    def test_normalizes_login_with_leading_at(self):
+    def test_null_github_id_yields_null_external_id(self):
         self._github_integration()
 
         ensure_external_actors_for_github_identity(
-            user_id=self.user.id, github_login="@octocat", github_id=None
+            user_id=self.user.id, github_login="octocat", github_id=None
         )
 
         actor = self._external_actors(user_id=self.user.id).get()


### PR DESCRIPTION
Add some necessary plumbing: a `post_link_identity` hook, and `upsert_external_actor` to work over RPC.

The real work is in `ensure_external_actors_for_github_identity`, which creates `ExternalActor` rows for any orgs/integrations the user has, since we have strong signal that this user has a given GitHub username.

Note that the only time we invoke `ensure_external_actors_for_github_identity` here is in `IdentityPipeline.finish_pipeline`, which only happens when the user associates with a GitHub account in their account settings--NOT the "Login with GitHub" button. For that, we'll open a PR in https://github.com/getsentry/getsentry pinned to this commit, which will also call `ensure_external_actors_for_github_identity`.

Resolves ISWF-2757