### PR TITLE
feat(preprod): Add async resumable snapshot archive download endpoint

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -919,6 +919,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.notifications.utils.tasks",
     "sentry.preprod.size_analysis.tasks",
     "sentry.preprod.snapshots.tasks",
+    "sentry.preprod.snapshots.zip_tasks",
     "sentry.preprod.tasks",
     "sentry.preprod.vcs.pr_comments.snapshot_tasks",
     "sentry.preprod.vcs.pr_comments.tasks",

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -56,6 +56,7 @@ ENDPOINT_TIMEOUT_OVERRIDE = {
     "sentry-api-0-organization-preprod-artifact-size-analysis-download": 90.0,
     "sentry-api-0-organization-objectstore": 90.0,
     "sentry-api-0-organization-preprod-snapshots-download": 90.0,
+    "sentry-api-0-organization-preprod-snapshots-archive": 90.0,
 }
 
 # stream 0.5 MB at a time

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -57,6 +57,7 @@ ENDPOINT_TIMEOUT_OVERRIDE = {
     "sentry-api-0-organization-preprod-artifact-size-analysis-download": 90.0,
     "sentry-api-0-organization-objectstore": 90.0,
     "sentry-api-0-organization-preprod-snapshots-download": 90.0,
+    "sentry-api-0-organization-preprod-snapshots-archive": 90.0,
 }
 
 # stream 0.5 MB at a time

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -149,14 +149,25 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                     file_id=None,
                     progress=0,
                 )
-                build_snapshot_images_zip.apply_async(
-                    kwargs={
-                        "org_id": artifact.project.organization_id,
-                        "project_id": artifact.project_id,
-                        "artifact_id": artifact.id,
-                        "build_token": enqueued_at,
-                    }
-                )
+                try:
+                    build_snapshot_images_zip.apply_async(
+                        kwargs={
+                            "org_id": artifact.project.organization_id,
+                            "project_id": artifact.project_id,
+                            "artifact_id": artifact.id,
+                            "build_token": enqueued_at,
+                        }
+                    )
+                except Exception:
+                    # Enqueue failed (e.g. broker unavailable). Don't leave an
+                    # orphaned "building" state that blocks retries until the
+                    # staleness window; mark failed so the client can retry.
+                    logger.exception(
+                        "preprod_snapshot_zip.enqueue_failed",
+                        extra={"preprod_artifact_id": artifact.id},
+                    )
+                    set_zip_state(metrics, status="failed")
+                    return "failed"
                 return "building"
         except UnableToAcquireLock:
             # Another request holds the lock to start a build; report the latest

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -49,15 +49,6 @@ def _is_building_fresh(state: ZipState | None) -> bool:
     return datetime.now(timezone.utc) - datetime.fromisoformat(enqueued_at) < BUILD_STALE_AFTER
 
 
-def _stream_full(file_obj: File) -> Iterator[bytes]:
-    with file_obj.getfile() as fp:
-        while True:
-            chunk = fp.read(DOWNLOAD_CHUNK_SIZE)
-            if not chunk:
-                break
-            yield chunk
-
-
 def _stream_range(file_obj: File, start: int, end: int) -> Iterator[bytes]:
     remaining = end - start + 1
     with file_obj.getfile() as fp:
@@ -184,7 +175,9 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
             except (ValueError, IndexError):
                 return HttpResponse(status=400)
         else:
-            response = StreamingHttpResponse(_stream_full(file_obj), content_type="application/zip")
+            response = StreamingHttpResponse(
+                _stream_range(file_obj, 0, file_size - 1), content_type="application/zip"
+            )
             response["Content-Length"] = file_size
 
         response["Accept-Ranges"] = "bytes"

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -101,9 +101,10 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
 
     def _ready_file(self, metrics: PreprodSnapshotMetrics) -> File | None:
         state = get_zip_state(metrics)
-        if not state or state.get("status") != "ready" or not state.get("file_id"):
+        file_id = state.get("file_id") if state else None
+        if not state or state.get("status") != "ready" or not file_id:
             return None
-        return File.objects.filter(id=state["file_id"]).first()
+        return File.objects.filter(id=file_id).first()
 
     def _ensure_build(
         self, artifact: PreprodArtifact, metrics: PreprodSnapshotMetrics, retry: bool

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -264,11 +264,19 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
             status = self._ensure_build(artifact, metrics, retry)
             payload: dict[str, object] = {"status": status}
             if status == "building":
-                # _ensure_build may return early without refreshing, so re-read to
-                # avoid reporting a stale progress percent from before this request.
+                # _ensure_build may decide "building" from the metrics row loaded
+                # in _resolve, which a concurrent build could have since flipped
+                # to "ready" or "failed". Re-read and reconcile so we never report
+                # building (plus stale progress) for a settled row, which would
+                # keep clients polling past a finished or failed build.
                 metrics.refresh_from_db()
                 state = get_zip_state(metrics)
-                payload["progress"] = state.get("progress") if state else None
+                if self._ready_file(metrics) is not None:
+                    payload["status"] = "ready"
+                elif state and state.get("status") == "failed":
+                    payload["status"] = "failed"
+                else:
+                    payload["progress"] = state.get("progress") if state else None
         except PreprodSnapshotMetrics.DoesNotExist:
             # The artifact was deleted between _resolve and re-reading state.
             return Response({"detail": "Snapshot not found"}, status=404)

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -134,17 +134,20 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                     return "ready"
                 if _is_building_fresh(get_zip_state(metrics)):
                     return "building"
+                enqueued_at = datetime.now(timezone.utc).isoformat()
                 set_zip_state(
                     metrics,
                     status="building",
-                    enqueued_at=datetime.now(timezone.utc).isoformat(),
+                    enqueued_at=enqueued_at,
                     file_id=None,
+                    progress=0,
                 )
                 build_snapshot_images_zip.apply_async(
                     kwargs={
                         "org_id": artifact.project.organization_id,
                         "project_id": artifact.project_id,
                         "artifact_id": artifact.id,
+                        "build_token": enqueued_at,
                     }
                 )
                 return "building"

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -160,10 +160,11 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                 return "building"
         except UnableToAcquireLock:
             # Another request holds the lock to start a build; report the latest
-            # committed status rather than assuming "building".
+            # settled status (which re-verifies a ready File still exists) rather
+            # than the raw stored status, falling back to "building" since a build
+            # is in the process of starting.
             metrics.refresh_from_db()
-            state = get_zip_state(metrics)
-            return state.get("status", "building") if state else "building"
+            return _settled_status() or "building"
 
     def _download(
         self, request: Request, artifact: PreprodArtifact, file_obj: File

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -105,13 +105,29 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
             return None
         return File.objects.filter(id=state["file_id"]).first()
 
-    def _ensure_build(self, artifact: PreprodArtifact, metrics: PreprodSnapshotMetrics) -> str:
-        """Return the current status, enqueuing a build if needed. Idempotent."""
-        if self._ready_file(metrics) is not None:
-            return "ready"
+    def _ensure_build(
+        self, artifact: PreprodArtifact, metrics: PreprodSnapshotMetrics, retry: bool
+    ) -> str:
+        """Return the current status, enqueuing a build if needed. Idempotent.
 
-        if _is_building_fresh(get_zip_state(metrics)):
-            return "building"
+        A ``failed`` build is reported as-is so the client can stop polling and
+        surface an error; a fresh build is only re-enqueued when ``retry`` is set
+        (an explicit user request), never automatically on a failed state.
+        """
+
+        def _settled_status() -> str | None:
+            if self._ready_file(metrics) is not None:
+                return "ready"
+            state = get_zip_state(metrics)
+            if _is_building_fresh(state):
+                return "building"
+            if not retry and state and state.get("status") == "failed":
+                return "failed"
+            return None
+
+        settled = _settled_status()
+        if settled is not None:
+            return settled
 
         lock = locks.get(
             f"preprod-snapshot-zip:{artifact.id}",
@@ -121,10 +137,9 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
         try:
             with lock.acquire():
                 metrics.refresh_from_db()
-                if self._ready_file(metrics) is not None:
-                    return "ready"
-                if _is_building_fresh(get_zip_state(metrics)):
-                    return "building"
+                settled = _settled_status()
+                if settled is not None:
+                    return settled
                 enqueued_at = datetime.now(timezone.utc).isoformat()
                 set_zip_state(
                     metrics,
@@ -143,7 +158,11 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                 )
                 return "building"
         except UnableToAcquireLock:
-            return "building"
+            # Another request holds the lock to start a build; report the latest
+            # committed status rather than assuming "building".
+            metrics.refresh_from_db()
+            state = get_zip_state(metrics)
+            return state.get("status", "building") if state else "building"
 
     def _download(
         self, request: Request, artifact: PreprodArtifact, file_obj: File
@@ -222,9 +241,13 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                 return Response({"detail": "Download not ready"}, status=409)
             return self._download(request, artifact, file_obj)
 
-        status = self._ensure_build(artifact, metrics)
+        retry = request.GET.get("retry") is not None
+        status = self._ensure_build(artifact, metrics, retry)
         payload: dict[str, object] = {"status": status}
         if status == "building":
+            # _ensure_build may return early without refreshing, so re-read to
+            # avoid reporting a stale progress percent from before this request.
+            metrics.refresh_from_db()
             state = get_zip_state(metrics)
             payload["progress"] = state.get("progress") if state else None
         return Response(payload)

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -205,6 +205,11 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
         response["Content-Disposition"] = f'attachment; filename="{filename}"'
         if etag:
             response["ETag"] = etag
+        # Superuser/cross-org downloads traverse the control-silo nginx path,
+        # which buffers the response to a temp file capped at 1GB
+        # (proxy_max_temp_file_size default) and truncates anything larger.
+        # Disable nginx buffering so the zip streams straight to the client.
+        response["X-Accel-Buffering"] = "no"
         return response
 
     def head(

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -244,12 +244,16 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
             return self._download(request, artifact, file_obj)
 
         retry = request.GET.get("retry") is not None
-        status = self._ensure_build(artifact, metrics, retry)
-        payload: dict[str, object] = {"status": status}
-        if status == "building":
-            # _ensure_build may return early without refreshing, so re-read to
-            # avoid reporting a stale progress percent from before this request.
-            metrics.refresh_from_db()
-            state = get_zip_state(metrics)
-            payload["progress"] = state.get("progress") if state else None
+        try:
+            status = self._ensure_build(artifact, metrics, retry)
+            payload: dict[str, object] = {"status": status}
+            if status == "building":
+                # _ensure_build may return early without refreshing, so re-read to
+                # avoid reporting a stale progress percent from before this request.
+                metrics.refresh_from_db()
+                state = get_zip_state(metrics)
+                payload["progress"] = state.get("progress") if state else None
+        except PreprodSnapshotMetrics.DoesNotExist:
+            # The artifact was deleted between _resolve and re-reading state.
+            return Response({"detail": "Snapshot not found"}, status=404)
         return Response(payload)

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+
+from django.conf import settings
+from django.http import HttpResponse, StreamingHttpResponse
+from django.http.response import HttpResponseBase
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
+from sentry.auth.staff import is_active_staff
+from sentry.locks import locks
+from sentry.models.files.file import File
+from sentry.models.organization import Organization
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+from sentry.preprod.snapshots.zip_builder import ZipState, get_zip_state, set_zip_state
+from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
+from sentry.replays.lib.http import MalformedRangeHeader, UnsatisfiableRange, parse_range_header
+from sentry.utils.locking import UnableToAcquireLock
+
+logger = logging.getLogger(__name__)
+
+BUILD_STALE_AFTER = timedelta(minutes=20)
+DOWNLOAD_CHUNK_SIZE = 8192
+
+
+class OrganizationPreprodSnapshotArchivePermission(OrganizationReleasePermission):
+    scope_map = {
+        **OrganizationReleasePermission.scope_map,
+        "HEAD": OrganizationReleasePermission.scope_map["GET"],
+    }
+
+
+def _is_building_fresh(state: ZipState | None) -> bool:
+    if not state or state.get("status") != "building":
+        return False
+    enqueued_at = state.get("enqueued_at")
+    if not enqueued_at:
+        return False
+    return datetime.now(timezone.utc) - datetime.fromisoformat(enqueued_at) < BUILD_STALE_AFTER
+
+
+def _stream_full(file_obj: File) -> Iterator[bytes]:
+    with file_obj.getfile() as fp:
+        while True:
+            chunk = fp.read(DOWNLOAD_CHUNK_SIZE)
+            if not chunk:
+                break
+            yield chunk
+
+
+def _stream_range(file_obj: File, start: int, end: int) -> Iterator[bytes]:
+    remaining = end - start + 1
+    with file_obj.getfile() as fp:
+        fp.seek(start)
+        while remaining > 0:
+            chunk = fp.read(min(DOWNLOAD_CHUNK_SIZE, remaining))
+            if not chunk:
+                break
+            remaining -= len(chunk)
+            yield chunk
+
+
+@extend_schema(tags=["Snapshots"])
+@cell_silo_endpoint
+class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+        "HEAD": ApiPublishStatus.PRIVATE,
+    }
+    permission_classes = (OrganizationPreprodSnapshotArchivePermission,)
+
+    def _resolve(
+        self, request: Request, organization: Organization, snapshot_id: str
+    ) -> tuple[PreprodArtifact, PreprodSnapshotMetrics] | Response:
+        if not settings.IS_DEV and not features.has(
+            "organizations:preprod-snapshots", organization, actor=request.user
+        ):
+            return Response({"detail": "Feature not enabled"}, status=403)
+
+        try:
+            artifact = PreprodArtifact.objects.select_related("project").get(
+                id=snapshot_id, project__organization_id=organization.id
+            )
+        except (PreprodArtifact.DoesNotExist, ValueError):
+            return Response({"detail": "Snapshot not found"}, status=404)
+
+        if not is_active_staff(request) and not request.access.has_project_access(artifact.project):
+            return Response({"detail": "Snapshot not found"}, status=404)
+
+        try:
+            metrics = artifact.preprodsnapshotmetrics
+        except PreprodSnapshotMetrics.DoesNotExist:
+            return Response({"detail": "Snapshot metrics not found"}, status=404)
+
+        if not (metrics.extras or {}).get("manifest_key"):
+            return Response({"detail": "Manifest key not found"}, status=404)
+
+        return artifact, metrics
+
+    def _ready_file(self, metrics: PreprodSnapshotMetrics) -> File | None:
+        state = get_zip_state(metrics)
+        if not state or state.get("status") != "ready" or not state.get("file_id"):
+            return None
+        return File.objects.filter(id=state["file_id"]).first()
+
+    def _ensure_build(self, artifact: PreprodArtifact, metrics: PreprodSnapshotMetrics) -> str:
+        """Return the current status, enqueuing a build if needed. Idempotent."""
+        if self._ready_file(metrics) is not None:
+            return "ready"
+
+        if _is_building_fresh(get_zip_state(metrics)):
+            return "building"
+
+        lock = locks.get(
+            f"preprod-snapshot-zip:{artifact.id}",
+            duration=30,
+            name="build_snapshot_images_zip",
+        )
+        try:
+            with lock.acquire():
+                metrics.refresh_from_db()
+                if self._ready_file(metrics) is not None:
+                    return "ready"
+                if _is_building_fresh(get_zip_state(metrics)):
+                    return "building"
+                set_zip_state(
+                    metrics,
+                    status="building",
+                    enqueued_at=datetime.now(timezone.utc).isoformat(),
+                    file_id=None,
+                )
+                build_snapshot_images_zip.apply_async(
+                    kwargs={
+                        "org_id": artifact.project.organization_id,
+                        "project_id": artifact.project_id,
+                        "artifact_id": artifact.id,
+                    }
+                )
+                return "building"
+        except UnableToAcquireLock:
+            return "building"
+
+    def _download(
+        self, request: Request, artifact: PreprodArtifact, file_obj: File
+    ) -> HttpResponseBase:
+        file_size = file_obj.size or 0
+        filename = f"snapshot_images_{artifact.id}.zip"
+        etag = f'"{file_obj.checksum}"' if file_obj.checksum else None
+
+        range_header = request.META.get("HTTP_RANGE")
+        if range_header:
+            try:
+                ranges = parse_range_header(range_header)
+                if not ranges:
+                    return HttpResponse(status=400)
+                if len(ranges) > 1:
+                    raise MalformedRangeHeader("Too many ranges specified.")
+                if file_size == 0:
+                    return HttpResponse(status=416)
+                start, end = ranges[0].make_range(file_size - 1)
+                response: HttpResponseBase = StreamingHttpResponse(
+                    _stream_range(file_obj, start, end),
+                    content_type="application/zip",
+                    status=206,
+                )
+                response["Content-Length"] = end - start + 1
+                response["Content-Range"] = f"bytes {start}-{end}/{file_size}"
+            except (MalformedRangeHeader, UnsatisfiableRange):
+                return HttpResponse(status=416)
+            except (ValueError, IndexError):
+                return HttpResponse(status=400)
+        else:
+            response = StreamingHttpResponse(_stream_full(file_obj), content_type="application/zip")
+            response["Content-Length"] = file_size
+
+        response["Accept-Ranges"] = "bytes"
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        if etag:
+            response["ETag"] = etag
+        return response
+
+    def head(
+        self, request: Request, organization: Organization, snapshot_id: str
+    ) -> HttpResponseBase:
+        resolved = self._resolve(request, organization, snapshot_id)
+        if isinstance(resolved, Response):
+            return resolved
+        _artifact, metrics = resolved
+
+        file_obj = self._ready_file(metrics)
+        if file_obj is None:
+            return Response({"detail": "Download not ready"}, status=409)
+
+        response = HttpResponse(content_type="application/zip")
+        response["Content-Length"] = file_obj.size or 0
+        response["Accept-Ranges"] = "bytes"
+        response["Content-Disposition"] = (
+            f'attachment; filename="snapshot_images_{snapshot_id}.zip"'
+        )
+        if file_obj.checksum:
+            response["ETag"] = f'"{file_obj.checksum}"'
+        return response
+
+    def get(
+        self, request: Request, organization: Organization, snapshot_id: str
+    ) -> HttpResponseBase:
+        resolved = self._resolve(request, organization, snapshot_id)
+        if isinstance(resolved, Response):
+            return resolved
+        artifact, metrics = resolved
+
+        if request.GET.get("download") is not None:
+            file_obj = self._ready_file(metrics)
+            if file_obj is None:
+                return Response({"detail": "Download not ready"}, status=409)
+            return self._download(request, artifact, file_obj)
+
+        status = self._ensure_build(artifact, metrics)
+        payload: dict[str, object] = {"status": status}
+        if status == "building":
+            state = get_zip_state(metrics)
+            payload["progress"] = state.get("progress") if state else None
+        return Response(payload)

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -61,6 +61,9 @@ from .snapshots.preprod_artifact_snapshot import (
     OrganizationPreprodSnapshotEndpoint,
     ProjectPreprodSnapshotEndpoint,
 )
+from .snapshots.preprod_artifact_snapshot_archive import (
+    OrganizationPreprodSnapshotArchiveEndpoint,
+)
 from .snapshots.preprod_artifact_snapshot_download import (
     OrganizationPreprodSnapshotDownloadEndpoint,
 )
@@ -220,6 +223,11 @@ preprod_organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/snapshots/(?P<snapshot_id>[^/]+)/download/$",
         OrganizationPreprodSnapshotDownloadEndpoint.as_view(),
         name="sentry-api-0-organization-preprod-snapshots-download",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/snapshots/(?P<snapshot_id>[^/]+)/archive/$",
+        OrganizationPreprodSnapshotArchiveEndpoint.as_view(),
+        name="sentry-api-0-organization-preprod-snapshots-archive",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/snapshots/(?P<snapshot_id>[^/]+)/images/(?P<image_identifier>.+)/$",

--- a/src/sentry/preprod/snapshots/zip_builder.py
+++ b/src/sentry/preprod/snapshots/zip_builder.py
@@ -34,14 +34,6 @@ class SnapshotZipBuildError(Exception):
     pass
 
 
-def _build_hash_to_filenames(manifest: SnapshotManifest) -> dict[str, list[str]]:
-    result: dict[str, list[str]] = defaultdict(list)
-    for filename, meta in manifest.images.items():
-        if not is_unsafe_path(filename):
-            result[meta.content_hash].append(filename)
-    return result
-
-
 def build_snapshot_zip(
     manifest: SnapshotManifest,
     session: Session,
@@ -60,7 +52,10 @@ def build_snapshot_zip(
     an integer percent (0-100), only when that percent advances, so a caller
     can persist build progress without one write per image.
     """
-    hash_to_filenames = _build_hash_to_filenames(manifest)
+    hash_to_filenames: dict[str, list[str]] = defaultdict(list)
+    for filename, meta in manifest.images.items():
+        if not is_unsafe_path(filename):
+            hash_to_filenames[meta.content_hash].append(filename)
     unique_hashes = list(hash_to_filenames.keys())
     total = len(unique_hashes)
     completed = 0

--- a/src/sentry/preprod/snapshots/zip_builder.py
+++ b/src/sentry/preprod/snapshots/zip_builder.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+import zipfile
+from collections import defaultdict
+from collections.abc import Callable
+from concurrent.futures import as_completed
+from typing import IO, TypedDict, Unpack, cast
+
+from objectstore_client import Session
+
+from sentry.preprod.snapshots.manifest import SnapshotManifest
+from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
+from sentry.utils.zip import is_unsafe_path
+
+logger = logging.getLogger(__name__)
+
+FETCH_MAX_WORKERS = 16
+
+ZIP_EXTRAS_KEY = "images_zip"
+
+
+class ZipState(TypedDict, total=False):
+    status: str
+    enqueued_at: str
+    file_id: int | None
+    size: int
+    built_at: str
+    progress: int
+
+
+class SnapshotZipBuildError(Exception):
+    pass
+
+
+def _build_hash_to_filenames(manifest: SnapshotManifest) -> dict[str, list[str]]:
+    result: dict[str, list[str]] = defaultdict(list)
+    for filename, meta in manifest.images.items():
+        if not is_unsafe_path(filename):
+            result[meta.content_hash].append(filename)
+    return result
+
+
+def build_snapshot_zip(
+    manifest: SnapshotManifest,
+    session: Session,
+    key_prefix: str,
+    out: IO[bytes],
+    artifact_id: int,
+    progress_callback: Callable[[int], None] | None = None,
+) -> None:
+    """Build a ZIP_STORED archive of all snapshot images into ``out``.
+
+    Images sharing a content hash are fetched once and written under each
+    original filename. Raises SnapshotZipBuildError if any image fails to
+    fetch, so callers never persist a silently-incomplete archive.
+
+    If ``progress_callback`` is given it is invoked from the main thread with
+    an integer percent (0-100), only when that percent advances, so a caller
+    can persist build progress without one write per image.
+    """
+    hash_to_filenames = _build_hash_to_filenames(manifest)
+    unique_hashes = list(hash_to_filenames.keys())
+    total = len(unique_hashes)
+    completed = 0
+    last_pct = -1
+
+    def fetch_image(image_hash: str) -> tuple[str, bytes | None]:
+        try:
+            data = session.get(f"{key_prefix}/{image_hash}").payload.read()
+            return (image_hash, data)
+        except Exception:
+            logger.exception(
+                "preprod_snapshot_zip.image_fetch_failed",
+                extra={"preprod_artifact_id": artifact_id, "image_hash": image_hash},
+            )
+            return (image_hash, None)
+
+    zf = zipfile.ZipFile(out, "w", zipfile.ZIP_STORED)
+    executor = ContextPropagatingThreadPoolExecutor(max_workers=FETCH_MAX_WORKERS)
+    try:
+        futures = [executor.submit(fetch_image, h) for h in unique_hashes]
+        for future in as_completed(futures):
+            image_hash, data = future.result()
+            if data is None:
+                raise SnapshotZipBuildError(
+                    f"failed to fetch image {image_hash} for artifact {artifact_id}"
+                )
+            for filename in hash_to_filenames[image_hash]:
+                zf.writestr(filename, data)
+            completed += 1
+            if progress_callback is not None:
+                pct = completed * 100 // total
+                if pct != last_pct:
+                    last_pct = pct
+                    progress_callback(pct)
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+        zf.close()
+
+
+def get_zip_state(metrics: PreprodSnapshotMetrics) -> ZipState | None:
+    return (metrics.extras or {}).get(ZIP_EXTRAS_KEY)
+
+
+def set_zip_state(metrics: PreprodSnapshotMetrics, **fields: Unpack[ZipState]) -> ZipState:
+    extras = dict(metrics.extras or {})
+    state = dict(extras.get(ZIP_EXTRAS_KEY) or {})
+    state.update(fields)
+    extras[ZIP_EXTRAS_KEY] = state
+    metrics.update(extras=extras)
+    return cast(ZipState, state)

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from tempfile import NamedTemporaryFile
+
+import orjson
+from taskbroker_client.retry import Retry
+
+from sentry.models.files.file import File
+from sentry.objectstore import get_preprod_session
+from sentry.preprod.snapshots.manifest import SnapshotManifest
+from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+from sentry.preprod.snapshots.zip_builder import build_snapshot_zip, get_zip_state, set_zip_state
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import preprod_tasks
+
+logger = logging.getLogger(__name__)
+
+ZIP_FILE_TYPE = "preprod_snapshot_images.zip"
+
+
+@instrumented_task(
+    name="sentry.preprod.tasks.build_snapshot_images_zip",
+    namespace=preprod_tasks,
+    retry=Retry(times=2),
+    silo_mode=SiloMode.CELL,
+    processing_deadline_duration=900,
+)
+def build_snapshot_images_zip(org_id: int, project_id: int, artifact_id: int) -> None:
+    try:
+        snapshot_metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact_id=artifact_id)
+    except PreprodSnapshotMetrics.DoesNotExist:
+        return
+
+    manifest_key = (snapshot_metrics.extras or {}).get("manifest_key")
+    if not manifest_key:
+        set_zip_state(snapshot_metrics, status="failed")
+        return
+
+    session = get_preprod_session(org_id, project_id)
+
+    file_obj: File | None = None
+    try:
+        manifest_data = orjson.loads(session.get(manifest_key).payload.read())
+        manifest = SnapshotManifest(**manifest_data)
+        key_prefix = f"{org_id}/{project_id}"
+
+        def _on_progress(pct: int) -> None:
+            # Refresh so progress merges into the latest extras blob rather than
+            # clobbering concurrent writes to other keys with a stale copy.
+            snapshot_metrics.refresh_from_db()
+            set_zip_state(snapshot_metrics, progress=pct)
+
+        with NamedTemporaryFile() as tmp:
+            build_snapshot_zip(
+                manifest,
+                session,
+                key_prefix,
+                tmp,
+                artifact_id=artifact_id,
+                progress_callback=_on_progress,
+            )
+            tmp.flush()
+            tmp.seek(0)
+            file_obj = File.objects.create(
+                name=f"snapshot_images_{artifact_id}.zip",
+                type=ZIP_FILE_TYPE,
+                headers={"Content-Type": "application/zip"},
+            )
+            file_obj.putfile(tmp)
+    except Exception:
+        logger.exception(
+            "preprod_snapshot_zip.build_failed",
+            extra={"preprod_artifact_id": artifact_id},
+        )
+        if file_obj is not None:
+            file_obj.delete()
+        snapshot_metrics.refresh_from_db()
+        set_zip_state(snapshot_metrics, status="failed")
+        return
+
+    assert file_obj is not None
+    snapshot_metrics.refresh_from_db()
+    old = get_zip_state(snapshot_metrics) or {}
+    set_zip_state(
+        snapshot_metrics,
+        status="ready",
+        file_id=file_obj.id,
+        size=file_obj.size,
+        built_at=datetime.now(timezone.utc).isoformat(),
+    )
+    old_file_id = old.get("file_id")
+    if old_file_id and old_file_id != file_obj.id:
+        old_file = File.objects.filter(id=old_file_id).first()
+        if old_file is not None:
+            old_file.delete()

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -40,8 +40,12 @@ def build_snapshot_images_zip(
         # Each enqueue stamps a fresh ``enqueued_at`` token. After the staleness
         # re-enqueue an older worker can still finish; if the stored token no
         # longer matches ours, a newer build owns the state and we must not touch
-        # it (otherwise we'd clobber its progress/result or delete its File).
-        snapshot_metrics.refresh_from_db()
+        # it (otherwise we'd clobber its progress/result or delete its File). A
+        # deleted metrics row (artifact removed mid-build) also counts as superseded.
+        try:
+            snapshot_metrics.refresh_from_db()
+        except PreprodSnapshotMetrics.DoesNotExist:
+            return True
         return (get_zip_state(snapshot_metrics) or {}).get("enqueued_at") != build_token
 
     manifest_key = (snapshot_metrics.extras or {}).get("manifest_key")
@@ -95,7 +99,13 @@ def build_snapshot_images_zip(
         return
 
     assert file_obj is not None
-    snapshot_metrics.refresh_from_db()
+    try:
+        snapshot_metrics.refresh_from_db()
+    except PreprodSnapshotMetrics.DoesNotExist:
+        # The artifact (and its metrics row) was deleted while the ZIP was
+        # building; discard the now-orphaned archive.
+        file_obj.delete()
+        return
     old = get_zip_state(snapshot_metrics) or {}
     if old.get("enqueued_at") != build_token:
         # A newer build superseded us; discard our archive and leave its state intact.

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -28,15 +28,26 @@ ZIP_FILE_TYPE = "preprod_snapshot_images.zip"
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=900,
 )
-def build_snapshot_images_zip(org_id: int, project_id: int, artifact_id: int) -> None:
+def build_snapshot_images_zip(
+    org_id: int, project_id: int, artifact_id: int, build_token: str
+) -> None:
     try:
         snapshot_metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact_id=artifact_id)
     except PreprodSnapshotMetrics.DoesNotExist:
         return
 
+    def _superseded() -> bool:
+        # Each enqueue stamps a fresh ``enqueued_at`` token. After the staleness
+        # re-enqueue an older worker can still finish; if the stored token no
+        # longer matches ours, a newer build owns the state and we must not touch
+        # it (otherwise we'd clobber its progress/result or delete its File).
+        snapshot_metrics.refresh_from_db()
+        return (get_zip_state(snapshot_metrics) or {}).get("enqueued_at") != build_token
+
     manifest_key = (snapshot_metrics.extras or {}).get("manifest_key")
     if not manifest_key:
-        set_zip_state(snapshot_metrics, status="failed")
+        if not _superseded():
+            set_zip_state(snapshot_metrics, status="failed")
         return
 
     session = get_preprod_session(org_id, project_id)
@@ -51,6 +62,8 @@ def build_snapshot_images_zip(org_id: int, project_id: int, artifact_id: int) ->
             # Refresh so progress merges into the latest extras blob rather than
             # clobbering concurrent writes to other keys with a stale copy.
             snapshot_metrics.refresh_from_db()
+            if (get_zip_state(snapshot_metrics) or {}).get("enqueued_at") != build_token:
+                return
             set_zip_state(snapshot_metrics, progress=pct)
 
         with NamedTemporaryFile() as tmp:
@@ -77,13 +90,17 @@ def build_snapshot_images_zip(org_id: int, project_id: int, artifact_id: int) ->
         )
         if file_obj is not None:
             file_obj.delete()
-        snapshot_metrics.refresh_from_db()
-        set_zip_state(snapshot_metrics, status="failed")
+        if not _superseded():
+            set_zip_state(snapshot_metrics, status="failed")
         return
 
     assert file_obj is not None
     snapshot_metrics.refresh_from_db()
     old = get_zip_state(snapshot_metrics) or {}
+    if old.get("enqueued_at") != build_token:
+        # A newer build superseded us; discard our archive and leave its state intact.
+        file_obj.delete()
+        return
     set_zip_state(
         snapshot_metrics,
         status="ready",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -479,6 +479,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/preprodartifacts/$headArtifactId/private-install-details/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/size-analysis/compare/$headArtifactId/$baseArtifactId/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/'
+  | '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/archive/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/download/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/images/$imageIdentifier/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/recompare/'

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -154,6 +154,19 @@ class SnapshotDownloadStatusTest(APITestCase):
         assert response.data["status"] == "building"
 
     @patch(ENQUEUE_TARGET)
+    def test_status_marks_failed_when_enqueue_fails(self, mock_task):
+        mock_task.apply_async.side_effect = Exception("broker down")
+        artifact = self._artifact()
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["status"] == "failed"
+        metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact)
+        assert metrics.extras is not None
+        state = metrics.extras["images_zip"]
+        assert state["status"] == "failed"
+
+    @patch(ENQUEUE_TARGET)
     def test_status_returns_404_when_metrics_deleted_mid_request(self, mock_task):
         artifact = self._artifact()
         with (

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -45,7 +45,9 @@ class SnapshotDownloadStatusTest(APITestCase):
             response = self.client.get(self._url(artifact.id))
         assert response.status_code == 200
         assert response.data["status"] == "building"
-        state = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact).extras["images_zip"]
+        extras = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact).extras
+        assert extras is not None
+        state = extras["images_zip"]
         mock_task.apply_async.assert_called_once_with(
             kwargs={
                 "org_id": self.org.id,
@@ -126,7 +128,6 @@ class SnapshotDownloadStatusTest(APITestCase):
             response = self.client.get(self._url(artifact.id) + "?retry=true")
         assert response.status_code == 200
         assert response.data["status"] == "building"
-        mock_task.apply_async.assert_called_once()
         mock_task.apply_async.assert_called_once()
 
 

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -153,6 +153,20 @@ class SnapshotDownloadStatusTest(APITestCase):
         assert response.status_code == 200
         assert response.data["status"] == "building"
 
+    @patch(ENQUEUE_TARGET)
+    def test_status_returns_404_when_metrics_deleted_mid_request(self, mock_task):
+        artifact = self._artifact()
+        with (
+            patch.object(
+                PreprodSnapshotMetrics,
+                "refresh_from_db",
+                side_effect=PreprodSnapshotMetrics.DoesNotExist,
+            ),
+            self.feature("organizations:preprod-snapshots"),
+        ):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 404
+
 
 class SnapshotDownloadBytesTest(APITestCase):
     def setUp(self):

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -45,22 +45,24 @@ class SnapshotDownloadStatusTest(APITestCase):
             response = self.client.get(self._url(artifact.id))
         assert response.status_code == 200
         assert response.data["status"] == "building"
+        state = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact).extras["images_zip"]
         mock_task.apply_async.assert_called_once_with(
             kwargs={
                 "org_id": self.org.id,
                 "project_id": self.project.id,
                 "artifact_id": artifact.id,
+                "build_token": state["enqueued_at"],
             }
         )
 
     @patch(ENQUEUE_TARGET)
-    def test_status_returns_null_progress_on_fresh_enqueue(self, mock_task):
+    def test_status_resets_progress_on_fresh_enqueue(self, mock_task):
         artifact = self._artifact()
         with self.feature("organizations:preprod-snapshots"):
             response = self.client.get(self._url(artifact.id))
         assert response.status_code == 200
         assert response.data["status"] == "building"
-        assert response.data["progress"] is None
+        assert response.data["progress"] == 0
 
     @patch(ENQUEUE_TARGET)
     def test_status_surfaces_build_progress(self, mock_task):

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -218,6 +218,8 @@ class SnapshotDownloadBytesTest(APITestCase):
         assert response["Accept-Ranges"] == "bytes"
         assert response["ETag"] == f'"{f.checksum}"'
         assert "attachment" in response["Content-Disposition"]
+        # nginx buffering disabled so >1GB control-silo downloads aren't truncated
+        assert response["X-Accel-Buffering"] == "no"
 
     def test_bounded_range(self):
         artifact, _ = self._ready_artifact()
@@ -229,6 +231,7 @@ class SnapshotDownloadBytesTest(APITestCase):
         assert self._read(response) == self.content[5:15]
         assert response["Content-Length"] == "10"
         assert response["Content-Range"] == f"bytes 5-14/{len(self.content)}"
+        assert response["X-Accel-Buffering"] == "no"
 
     def test_suffix_range(self):
         artifact, _ = self._ready_artifact()

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.urls import reverse
+
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+from sentry.testutils.cases import APITestCase
+
+ENQUEUE_TARGET = (
+    "sentry.preprod.api.endpoints.snapshots."
+    "preprod_artifact_snapshot_archive.build_snapshot_images_zip"
+)
+
+
+class SnapshotDownloadStatusTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+
+    def _artifact(self, extras=None):
+        artifact = self.create_preprod_artifact(
+            project=self.project, state=PreprodArtifact.ArtifactState.PROCESSED
+        )
+        PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=artifact,
+            image_count=1,
+            extras={"manifest_key": "k", **(extras or {})},
+        )
+        return artifact
+
+    def _url(self, snapshot_id):
+        return reverse(
+            "sentry-api-0-organization-preprod-snapshots-archive",
+            args=[self.org.slug, snapshot_id],
+        )
+
+    @patch(ENQUEUE_TARGET)
+    def test_status_enqueues_build_when_absent(self, mock_task):
+        artifact = self._artifact()
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["status"] == "building"
+        mock_task.apply_async.assert_called_once_with(
+            kwargs={
+                "org_id": self.org.id,
+                "project_id": self.project.id,
+                "artifact_id": artifact.id,
+            }
+        )
+
+    @patch(ENQUEUE_TARGET)
+    def test_status_returns_null_progress_on_fresh_enqueue(self, mock_task):
+        artifact = self._artifact()
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["status"] == "building"
+        assert response.data["progress"] is None
+
+    @patch(ENQUEUE_TARGET)
+    def test_status_surfaces_build_progress(self, mock_task):
+        from datetime import datetime, timezone
+
+        enqueued_at = datetime.now(timezone.utc).isoformat()
+        artifact = self._artifact(
+            extras={
+                "images_zip": {
+                    "status": "building",
+                    "enqueued_at": enqueued_at,
+                    "progress": 42,
+                }
+            }
+        )
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["status"] == "building"
+        assert response.data["progress"] == 42
+        mock_task.apply_async.assert_not_called()
+
+    @patch(ENQUEUE_TARGET)
+    def test_status_reports_ready_without_reenqueue(self, mock_task):
+        f = self.create_file(name="z.zip", type="preprod_snapshot_images.zip")
+        from io import BytesIO
+
+        f.putfile(BytesIO(b"zipbytes"))
+        artifact = self._artifact(
+            extras={"images_zip": {"status": "ready", "file_id": f.id, "size": f.size}}
+        )
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["status"] == "ready"
+        mock_task.apply_async.assert_not_called()
+
+    @patch(ENQUEUE_TARGET)
+    def test_status_reenqueues_when_ready_but_file_missing(self, mock_task):
+        artifact = self._artifact(
+            extras={"images_zip": {"status": "ready", "file_id": 999999, "size": 5}}
+        )
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["status"] == "building"
+        mock_task.apply_async.assert_called_once()
+
+
+class SnapshotDownloadBytesTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+        self.content = b"0123456789" * 100  # 1000 bytes
+
+    def _ready_artifact(self):
+        from io import BytesIO
+
+        f = self.create_file(
+            name="snapshot_images.zip",
+            type="preprod_snapshot_images.zip",
+            headers={"Content-Type": "application/zip"},
+        )
+        f.putfile(BytesIO(self.content))
+        artifact = self.create_preprod_artifact(
+            project=self.project, state=PreprodArtifact.ArtifactState.PROCESSED
+        )
+        PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=artifact,
+            image_count=1,
+            extras={
+                "manifest_key": "k",
+                "images_zip": {"status": "ready", "file_id": f.id, "size": f.size},
+            },
+        )
+        return artifact, f
+
+    def _url(self, snapshot_id, download=False):
+        url = reverse(
+            "sentry-api-0-organization-preprod-snapshots-archive",
+            args=[self.org.slug, snapshot_id],
+        )
+        return f"{url}?download=true" if download else url
+
+    def _read(self, response):
+        return b"".join(response.streaming_content)
+
+    def test_full_download(self):
+        artifact, f = self._ready_artifact()
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(self._url(artifact.id, download=True))
+        assert response.status_code == 200
+        assert self._read(response) == self.content
+        assert response["Content-Length"] == str(len(self.content))
+        assert response["Accept-Ranges"] == "bytes"
+        assert response["ETag"] == f'"{f.checksum}"'
+        assert "attachment" in response["Content-Disposition"]
+
+    def test_bounded_range(self):
+        artifact, _ = self._ready_artifact()
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._url(artifact.id, download=True), HTTP_RANGE="bytes=5-14"
+            )
+        assert response.status_code == 206
+        assert self._read(response) == self.content[5:15]
+        assert response["Content-Length"] == "10"
+        assert response["Content-Range"] == f"bytes 5-14/{len(self.content)}"
+
+    def test_suffix_range(self):
+        artifact, _ = self._ready_artifact()
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._url(artifact.id, download=True), HTTP_RANGE="bytes=-10"
+            )
+        assert response.status_code == 206
+        assert self._read(response) == self.content[-10:]
+        assert response["Content-Range"] == f"bytes 990-999/{len(self.content)}"
+
+    def test_unbounded_range(self):
+        artifact, _ = self._ready_artifact()
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._url(artifact.id, download=True), HTTP_RANGE="bytes=990-"
+            )
+        assert response.status_code == 206
+        assert self._read(response) == self.content[990:]
+        assert response["Content-Range"] == f"bytes 990-999/{len(self.content)}"
+
+    def test_invalid_range_416(self):
+        artifact, _ = self._ready_artifact()
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._url(artifact.id, download=True), HTTP_RANGE="bytes=5000-6000"
+            )
+        assert response.status_code == 416
+
+    def test_download_not_ready_409(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project, state=PreprodArtifact.ArtifactState.PROCESSED
+        )
+        PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=artifact, image_count=1, extras={"manifest_key": "k"}
+        )
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(self._url(artifact.id, download=True))
+        assert response.status_code == 409
+
+    def test_head_advertises_accept_ranges(self):
+        artifact, f = self._ready_artifact()
+        url = reverse(
+            "sentry-api-0-organization-preprod-snapshots-archive",
+            args=[self.org.slug, artifact.id],
+        )
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.head(url)
+        assert response.status_code == 200
+        assert response["Content-Length"] == str(len(self.content))
+        assert response["Accept-Ranges"] == "bytes"
+        assert response["Content-Type"] == "application/zip"
+        assert response["ETag"] == f'"{f.checksum}"'
+
+    def test_head_not_ready_409(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project, state=PreprodArtifact.ArtifactState.PROCESSED
+        )
+        PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=artifact, image_count=1, extras={"manifest_key": "k"}
+        )
+        url = reverse(
+            "sentry-api-0-organization-preprod-snapshots-archive",
+            args=[self.org.slug, artifact.id],
+        )
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.head(url)
+        assert response.status_code == 409

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -109,6 +109,24 @@ class SnapshotDownloadStatusTest(APITestCase):
             response = self.client.get(self._url(artifact.id))
         assert response.status_code == 200
         assert response.data["status"] == "building"
+
+    @patch(ENQUEUE_TARGET)
+    def test_status_reports_failed_without_reenqueue(self, mock_task):
+        artifact = self._artifact(extras={"images_zip": {"status": "failed"}})
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["status"] == "failed"
+        mock_task.apply_async.assert_not_called()
+
+    @patch(ENQUEUE_TARGET)
+    def test_status_retry_reenqueues_failed_build(self, mock_task):
+        artifact = self._artifact(extras={"images_zip": {"status": "failed"}})
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(self._url(artifact.id) + "?retry=true")
+        assert response.status_code == 200
+        assert response.data["status"] == "building"
+        mock_task.apply_async.assert_called_once()
         mock_task.apply_async.assert_called_once()
 
 

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -130,6 +130,29 @@ class SnapshotDownloadStatusTest(APITestCase):
         assert response.data["status"] == "building"
         mock_task.apply_async.assert_called_once()
 
+    @patch(ENQUEUE_TARGET)
+    def test_status_lock_contention_does_not_report_stale_ready(self, mock_task):
+        from unittest.mock import MagicMock
+
+        from sentry.utils.locking import UnableToAcquireLock
+
+        artifact = self._artifact(
+            extras={"images_zip": {"status": "ready", "file_id": 999999, "size": 5}}
+        )
+        lock = MagicMock()
+        lock.acquire.side_effect = UnableToAcquireLock
+        with (
+            patch(
+                "sentry.preprod.api.endpoints.snapshots."
+                "preprod_artifact_snapshot_archive.locks.get",
+                return_value=lock,
+            ),
+            self.feature("organizations:preprod-snapshots"),
+        ):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["status"] == "building"
+
 
 class SnapshotDownloadBytesTest(APITestCase):
     def setUp(self):

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from datetime import datetime, timezone
+from io import BytesIO
+from unittest.mock import MagicMock, patch
 
 from django.urls import reverse
 
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.testutils.cases import APITestCase
+from sentry.utils.locking import UnableToAcquireLock
 
 ENQUEUE_TARGET = (
     "sentry.preprod.api.endpoints.snapshots."
@@ -14,7 +17,7 @@ ENQUEUE_TARGET = (
 )
 
 
-class SnapshotDownloadStatusTest(APITestCase):
+class BaseSnapshotArchiveTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
@@ -32,12 +35,15 @@ class SnapshotDownloadStatusTest(APITestCase):
         )
         return artifact
 
-    def _url(self, snapshot_id):
-        return reverse(
+    def _url(self, snapshot_id, download=False):
+        url = reverse(
             "sentry-api-0-organization-preprod-snapshots-archive",
             args=[self.org.slug, snapshot_id],
         )
+        return f"{url}?download=true" if download else url
 
+
+class SnapshotDownloadStatusTest(BaseSnapshotArchiveTest):
     @patch(ENQUEUE_TARGET)
     def test_status_enqueues_build_when_absent(self, mock_task):
         artifact = self._artifact()
@@ -68,8 +74,6 @@ class SnapshotDownloadStatusTest(APITestCase):
 
     @patch(ENQUEUE_TARGET)
     def test_status_surfaces_build_progress(self, mock_task):
-        from datetime import datetime, timezone
-
         enqueued_at = datetime.now(timezone.utc).isoformat()
         artifact = self._artifact(
             extras={
@@ -90,8 +94,6 @@ class SnapshotDownloadStatusTest(APITestCase):
     @patch(ENQUEUE_TARGET)
     def test_status_reports_ready_without_reenqueue(self, mock_task):
         f = self.create_file(name="z.zip", type="preprod_snapshot_images.zip")
-        from io import BytesIO
-
         f.putfile(BytesIO(b"zipbytes"))
         artifact = self._artifact(
             extras={"images_zip": {"status": "ready", "file_id": f.id, "size": f.size}}
@@ -132,10 +134,6 @@ class SnapshotDownloadStatusTest(APITestCase):
 
     @patch(ENQUEUE_TARGET)
     def test_status_lock_contention_does_not_report_stale_ready(self, mock_task):
-        from unittest.mock import MagicMock
-
-        from sentry.utils.locking import UnableToAcquireLock
-
         artifact = self._artifact(
             extras={"images_zip": {"status": "ready", "file_id": 999999, "size": 5}}
         )
@@ -180,43 +178,92 @@ class SnapshotDownloadStatusTest(APITestCase):
             response = self.client.get(self._url(artifact.id))
         assert response.status_code == 404
 
+    @patch(ENQUEUE_TARGET)
+    def test_status_reconciles_to_ready_when_build_finishes_mid_request(self, mock_task):
+        f = self.create_file(name="z.zip", type="preprod_snapshot_images.zip")
+        f.putfile(BytesIO(b"zipbytes"))
+        enqueued_at = datetime.now(timezone.utc).isoformat()
+        artifact = self._artifact(
+            extras={
+                "images_zip": {
+                    "status": "building",
+                    "enqueued_at": enqueued_at,
+                    "progress": 10,
+                }
+            }
+        )
 
-class SnapshotDownloadBytesTest(APITestCase):
+        original_refresh = PreprodSnapshotMetrics.refresh_from_db
+
+        def finish_build(self_metrics, *args, **kwargs):
+            PreprodSnapshotMetrics.objects.filter(pk=self_metrics.pk).update(
+                extras={
+                    "manifest_key": "k",
+                    "images_zip": {"status": "ready", "file_id": f.id, "size": f.size},
+                }
+            )
+            original_refresh(self_metrics, *args, **kwargs)
+
+        with (
+            patch.object(
+                PreprodSnapshotMetrics, "refresh_from_db", autospec=True, side_effect=finish_build
+            ),
+            self.feature("organizations:preprod-snapshots"),
+        ):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["status"] == "ready"
+        mock_task.apply_async.assert_not_called()
+
+    @patch(ENQUEUE_TARGET)
+    def test_status_reconciles_to_failed_when_build_fails_mid_request(self, mock_task):
+        enqueued_at = datetime.now(timezone.utc).isoformat()
+        artifact = self._artifact(
+            extras={
+                "images_zip": {
+                    "status": "building",
+                    "enqueued_at": enqueued_at,
+                    "progress": 10,
+                }
+            }
+        )
+
+        original_refresh = PreprodSnapshotMetrics.refresh_from_db
+
+        def fail_build(self_metrics, *args, **kwargs):
+            PreprodSnapshotMetrics.objects.filter(pk=self_metrics.pk).update(
+                extras={"manifest_key": "k", "images_zip": {"status": "failed"}}
+            )
+            original_refresh(self_metrics, *args, **kwargs)
+
+        with (
+            patch.object(
+                PreprodSnapshotMetrics, "refresh_from_db", autospec=True, side_effect=fail_build
+            ),
+            self.feature("organizations:preprod-snapshots"),
+        ):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["status"] == "failed"
+        assert "progress" not in response.data
+
+
+class SnapshotDownloadBytesTest(BaseSnapshotArchiveTest):
     def setUp(self):
         super().setUp()
-        self.login_as(user=self.user)
-        self.org = self.create_organization(owner=self.user)
-        self.project = self.create_project(organization=self.org)
         self.content = b"0123456789" * 100  # 1000 bytes
 
     def _ready_artifact(self):
-        from io import BytesIO
-
         f = self.create_file(
             name="snapshot_images.zip",
             type="preprod_snapshot_images.zip",
             headers={"Content-Type": "application/zip"},
         )
         f.putfile(BytesIO(self.content))
-        artifact = self.create_preprod_artifact(
-            project=self.project, state=PreprodArtifact.ArtifactState.PROCESSED
-        )
-        PreprodSnapshotMetrics.objects.create(
-            preprod_artifact=artifact,
-            image_count=1,
-            extras={
-                "manifest_key": "k",
-                "images_zip": {"status": "ready", "file_id": f.id, "size": f.size},
-            },
+        artifact = self._artifact(
+            extras={"images_zip": {"status": "ready", "file_id": f.id, "size": f.size}}
         )
         return artifact, f
-
-    def _url(self, snapshot_id, download=False):
-        url = reverse(
-            "sentry-api-0-organization-preprod-snapshots-archive",
-            args=[self.org.slug, snapshot_id],
-        )
-        return f"{url}?download=true" if download else url
 
     def _read(self, response):
         return b"".join(response.streaming_content)
@@ -275,24 +322,15 @@ class SnapshotDownloadBytesTest(APITestCase):
         assert response.status_code == 416
 
     def test_download_not_ready_409(self):
-        artifact = self.create_preprod_artifact(
-            project=self.project, state=PreprodArtifact.ArtifactState.PROCESSED
-        )
-        PreprodSnapshotMetrics.objects.create(
-            preprod_artifact=artifact, image_count=1, extras={"manifest_key": "k"}
-        )
+        artifact = self._artifact()
         with self.feature("organizations:preprod-snapshots"):
             response = self.client.get(self._url(artifact.id, download=True))
         assert response.status_code == 409
 
     def test_head_advertises_accept_ranges(self):
         artifact, f = self._ready_artifact()
-        url = reverse(
-            "sentry-api-0-organization-preprod-snapshots-archive",
-            args=[self.org.slug, artifact.id],
-        )
         with self.feature("organizations:preprod-snapshots"):
-            response = self.client.head(url)
+            response = self.client.head(self._url(artifact.id))
         assert response.status_code == 200
         assert response["Content-Length"] == str(len(self.content))
         assert response["Accept-Ranges"] == "bytes"
@@ -300,16 +338,7 @@ class SnapshotDownloadBytesTest(APITestCase):
         assert response["ETag"] == f'"{f.checksum}"'
 
     def test_head_not_ready_409(self):
-        artifact = self.create_preprod_artifact(
-            project=self.project, state=PreprodArtifact.ArtifactState.PROCESSED
-        )
-        PreprodSnapshotMetrics.objects.create(
-            preprod_artifact=artifact, image_count=1, extras={"manifest_key": "k"}
-        )
-        url = reverse(
-            "sentry-api-0-organization-preprod-snapshots-archive",
-            args=[self.org.slug, artifact.id],
-        )
+        artifact = self._artifact()
         with self.feature("organizations:preprod-snapshots"):
-            response = self.client.head(url)
+            response = self.client.head(self._url(artifact.id))
         assert response.status_code == 409

--- a/tests/sentry/preprod/snapshots/test_zip_builder.py
+++ b/tests/sentry/preprod/snapshots/test_zip_builder.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import zipfile
+from io import BytesIO
+from unittest.mock import MagicMock
+
+import pytest
+
+from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
+from sentry.preprod.snapshots.zip_builder import (
+    SnapshotZipBuildError,
+    build_snapshot_zip,
+    get_zip_state,
+    set_zip_state,
+)
+from sentry.testutils.cases import TestCase
+
+
+def _meta(content_hash: str) -> ImageMetadata:
+    return ImageMetadata(content_hash=content_hash, width=10, height=10)
+
+
+def _session(data_by_key: dict[str, bytes]) -> MagicMock:
+    def _get(key):
+        result = MagicMock()
+        if key in data_by_key:
+            result.payload.read.return_value = data_by_key[key]
+        else:
+            raise Exception(f"missing key: {key}")
+        return result
+
+    session = MagicMock()
+    session.get.side_effect = _get
+    return session
+
+
+def test_build_snapshot_zip_writes_all_images_and_dedupes() -> None:
+    manifest = SnapshotManifest(
+        images={
+            "a.png": _meta("hash_a"),
+            "b.png": _meta("hash_b"),
+            "c.png": _meta("hash_a"),  # shares hash_a -> dedup fetch, two filenames
+        }
+    )
+    key_prefix = "1/2"
+    session = _session({"1/2/hash_a": b"AAA", "1/2/hash_b": b"BBB"})
+
+    out = BytesIO()
+    build_snapshot_zip(manifest, session, key_prefix, out, artifact_id=99)
+
+    out.seek(0)
+    with zipfile.ZipFile(out) as zf:
+        assert sorted(zf.namelist()) == ["a.png", "b.png", "c.png"]
+        assert zf.read("a.png") == b"AAA"
+        assert zf.read("c.png") == b"AAA"
+        assert zf.read("b.png") == b"BBB"
+    # hash_a fetched once despite two filenames
+    assert session.get.call_count == 2
+
+
+def test_build_snapshot_zip_reports_monotonic_progress() -> None:
+    images = {f"img_{i}.png": _meta(f"hash_{i}") for i in range(4)}
+    manifest = SnapshotManifest(images=images)
+    session = _session({f"1/2/hash_{i}": b"X" for i in range(4)})
+
+    seen: list[int] = []
+    build_snapshot_zip(
+        manifest, session, "1/2", BytesIO(), artifact_id=99, progress_callback=seen.append
+    )
+
+    # one callback per unique image, advancing to 100, never decreasing
+    assert seen == sorted(seen)
+    assert seen[-1] == 100
+    assert len(seen) == 4
+
+
+def test_build_snapshot_zip_progress_dedupes_repeated_percent() -> None:
+    # 200 unique images -> integer percent repeats; callback must fire only on change
+    images = {f"img_{i}.png": _meta(f"hash_{i}") for i in range(200)}
+    manifest = SnapshotManifest(images=images)
+    session = _session({f"1/2/hash_{i}": b"X" for i in range(200)})
+
+    seen: list[int] = []
+    build_snapshot_zip(
+        manifest, session, "1/2", BytesIO(), artifact_id=99, progress_callback=seen.append
+    )
+
+    assert seen == sorted(set(seen))
+    assert seen[-1] == 100
+    # deduped to one call per integer percent (0..100), not one per image
+    assert len(seen) == 101
+
+
+def test_build_snapshot_zip_empty_manifest() -> None:
+    manifest = SnapshotManifest(images={})
+    session = _session({})
+
+    out = BytesIO()
+    build_snapshot_zip(manifest, session, "1/2", out, artifact_id=99)
+
+    out.seek(0)
+    with zipfile.ZipFile(out) as zf:
+        assert zf.namelist() == []
+    assert session.get.call_count == 0
+
+
+def test_build_snapshot_zip_raises_on_fetch_failure() -> None:
+    manifest = SnapshotManifest(images={"a.png": _meta("hash_a")})
+    session = _session({})  # every get raises
+
+    with pytest.raises(SnapshotZipBuildError):
+        build_snapshot_zip(manifest, session, "1/2", BytesIO(), artifact_id=99)
+
+
+class ZipStateTest(TestCase):
+    def _metrics(self, extras=None):
+        from sentry.preprod.models import PreprodArtifact
+        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+
+        project = self.create_project()
+        artifact = PreprodArtifact.objects.create(
+            project=project, state=PreprodArtifact.ArtifactState.PROCESSED
+        )
+        return PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=artifact, image_count=0, extras=extras
+        )
+
+    def test_get_zip_state_none_when_absent(self) -> None:
+        assert get_zip_state(self._metrics()) is None
+        assert get_zip_state(self._metrics(extras={"manifest_key": "k"})) is None
+
+    def test_set_zip_state_merges_without_clobbering(self) -> None:
+        metrics = self._metrics(extras={"manifest_key": "k"})
+        set_zip_state(metrics, status="building", enqueued_at="2026-06-03T00:00:00Z")
+        metrics.refresh_from_db()
+        assert metrics.extras["manifest_key"] == "k"
+        assert metrics.extras["images_zip"]["status"] == "building"
+        state = get_zip_state(metrics)
+        assert state is not None
+        assert state["status"] == "building"
+
+
+from unittest.mock import patch
+
+import orjson
+
+from sentry.models.files.file import File
+
+BUILD_TASK_SESSION = "sentry.preprod.snapshots.zip_tasks.get_preprod_session"
+
+
+class BuildSnapshotImagesZipTaskTest(TestCase):
+    def _setup(self, images):
+        from sentry.preprod.models import PreprodArtifact
+        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+
+        org = self.organization
+        project = self.create_project(organization=org)
+        artifact = PreprodArtifact.objects.create(
+            project=project, state=PreprodArtifact.ArtifactState.PROCESSED
+        )
+        manifest_key = f"{org.id}/{project.id}/{artifact.id}/manifest.json"
+        PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=artifact,
+            image_count=len(images),
+            extras={"manifest_key": manifest_key, "images_zip": {"status": "building"}},
+        )
+        manifest_json = orjson.dumps({"images": images})
+        return org, project, artifact, manifest_key, manifest_json
+
+    def _session(self, data_by_key):
+        from unittest.mock import MagicMock
+
+        def _get(key):
+            result = MagicMock()
+            result.payload.read.return_value = data_by_key[key]
+            return result
+
+        session = MagicMock()
+        session.get.side_effect = _get
+        return session
+
+    @patch(BUILD_TASK_SESSION)
+    def test_builds_zip_and_marks_ready(self, mock_get_session):
+        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+        from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
+
+        images = {"a.png": {"content_hash": "h1", "width": 1, "height": 1}}
+        org, project, artifact, manifest_key, manifest_json = self._setup(images)
+        mock_get_session.return_value = self._session(
+            {manifest_key: manifest_json, f"{org.id}/{project.id}/h1": b"AAA"}
+        )
+
+        build_snapshot_images_zip(org_id=org.id, project_id=project.id, artifact_id=artifact.id)
+
+        metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact)
+        state = get_zip_state(metrics)
+        assert state is not None
+        assert state["status"] == "ready"
+        assert state["file_id"] is not None
+        assert state["progress"] == 100
+        file_obj = File.objects.get(id=state["file_id"])
+        import zipfile
+
+        with file_obj.getfile() as fp, zipfile.ZipFile(fp) as zf:
+            assert zf.read("a.png") == b"AAA"
+        assert state["size"] == file_obj.size
+
+    @patch(BUILD_TASK_SESSION)
+    def test_marks_failed_on_fetch_error(self, mock_get_session):
+        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+        from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
+
+        images = {"a.png": {"content_hash": "h1", "width": 1, "height": 1}}
+        org, project, artifact, manifest_key, manifest_json = self._setup(images)
+        # manifest present but image missing -> builder raises
+        mock_get_session.return_value = self._session({manifest_key: manifest_json})
+
+        build_snapshot_images_zip(org_id=org.id, project_id=project.id, artifact_id=artifact.id)
+
+        metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact)
+        state = get_zip_state(metrics)
+        assert state is not None
+        assert state["status"] == "failed"
+
+    @patch(BUILD_TASK_SESSION)
+    def test_cleans_up_file_when_putfile_fails(self, mock_get_session):
+        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+        from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
+
+        images = {"a.png": {"content_hash": "h1", "width": 1, "height": 1}}
+        org, project, artifact, manifest_key, manifest_json = self._setup(images)
+        mock_get_session.return_value = self._session(
+            {manifest_key: manifest_json, f"{org.id}/{project.id}/h1": b"AAA"}
+        )
+
+        with patch.object(File, "putfile", side_effect=Exception("boom")):
+            build_snapshot_images_zip(org_id=org.id, project_id=project.id, artifact_id=artifact.id)
+
+        metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact)
+        state = get_zip_state(metrics)
+        assert state is not None
+        assert state["status"] == "failed"
+        assert not File.objects.filter(name=f"snapshot_images_{artifact.id}.zip").exists()
+
+    @patch(BUILD_TASK_SESSION)
+    def test_rebuild_schedules_blob_cleanup_for_old_file(self, mock_get_session):
+        from io import BytesIO
+
+        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+        from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
+
+        old_file = File.objects.create(name="old.zip", type="preprod_snapshot_images.zip")
+        old_file.putfile(BytesIO(b"OLD-ZIP-CONTENT"))
+        old_blob_ids = list(old_file.blobs.values_list("id", flat=True))
+        assert old_blob_ids
+
+        images = {"a.png": {"content_hash": "h1", "width": 1, "height": 1}}
+        org, project, artifact, manifest_key, manifest_json = self._setup(images)
+        metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact)
+        set_zip_state(metrics, status="ready", file_id=old_file.id)
+
+        mock_get_session.return_value = self._session(
+            {manifest_key: manifest_json, f"{org.id}/{project.id}/h1": b"AAA"}
+        )
+
+        with (
+            patch(
+                "sentry.tasks.files.delete_unreferenced_blobs_region.apply_async"
+            ) as mock_blob_cleanup,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            build_snapshot_images_zip(org_id=org.id, project_id=project.id, artifact_id=artifact.id)
+
+        assert not File.objects.filter(id=old_file.id).exists()
+        state = get_zip_state(PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact))
+        assert state is not None
+        assert state["status"] == "ready"
+        assert state["file_id"] != old_file.id
+        mock_blob_cleanup.assert_called_once()
+        assert mock_blob_cleanup.call_args.kwargs["kwargs"]["blob_ids"] == old_blob_ids

--- a/tests/sentry/preprod/snapshots/test_zip_builder.py
+++ b/tests/sentry/preprod/snapshots/test_zip_builder.py
@@ -272,6 +272,22 @@ class BuildSnapshotImagesZipTaskTest(TestCase):
         assert not File.objects.filter(name=f"snapshot_images_{artifact.id}.zip").exists()
 
     @patch(BUILD_TASK_SESSION)
+    def test_cleans_up_file_when_metrics_deleted_mid_build(self, mock_get_session):
+        project, artifact, manifest_key = self._setup()
+        # empty manifest -> no progress callbacks, so the only refresh_from_db is
+        # the post-build one we patch to simulate the metrics row being deleted.
+        mock_get_session.return_value = _session({manifest_key: orjson.dumps({"images": {}})})
+
+        with patch.object(
+            PreprodSnapshotMetrics,
+            "refresh_from_db",
+            side_effect=PreprodSnapshotMetrics.DoesNotExist,
+        ):
+            self._run(project, artifact)
+
+        assert not File.objects.filter(name=f"snapshot_images_{artifact.id}.zip").exists()
+
+    @patch(BUILD_TASK_SESSION)
     def test_stale_build_does_not_mark_failed_when_superseded(self, mock_get_session):
         project, artifact, manifest_key = self._setup(
             zip_state={"status": "ready", "file_id": 999, "enqueued_at": "newer-token"}

--- a/tests/sentry/preprod/snapshots/test_zip_builder.py
+++ b/tests/sentry/preprod/snapshots/test_zip_builder.py
@@ -2,18 +2,26 @@ from __future__ import annotations
 
 import zipfile
 from io import BytesIO
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import orjson
 import pytest
 
+from sentry.models.files.file import File
+from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
+from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.preprod.snapshots.zip_builder import (
     SnapshotZipBuildError,
     build_snapshot_zip,
     get_zip_state,
     set_zip_state,
 )
+from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
 from sentry.testutils.cases import TestCase
+
+BUILD_TASK_SESSION = "sentry.preprod.snapshots.zip_tasks.get_preprod_session"
+BUILD_TOKEN = "2026-06-03T00:00:00+00:00"
 
 
 def _meta(content_hash: str) -> ImageMetadata:
@@ -114,12 +122,8 @@ def test_build_snapshot_zip_raises_on_fetch_failure() -> None:
 
 class ZipStateTest(TestCase):
     def _metrics(self, extras=None):
-        from sentry.preprod.models import PreprodArtifact
-        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
-
-        project = self.create_project()
-        artifact = PreprodArtifact.objects.create(
-            project=project, state=PreprodArtifact.ArtifactState.PROCESSED
+        artifact = self.create_preprod_artifact(
+            project=self.create_project(), state=PreprodArtifact.ArtifactState.PROCESSED
         )
         return PreprodSnapshotMetrics.objects.create(
             preprod_artifact=artifact, image_count=0, extras=extras
@@ -134,135 +138,105 @@ class ZipStateTest(TestCase):
         set_zip_state(metrics, status="building", enqueued_at="2026-06-03T00:00:00Z")
         metrics.refresh_from_db()
         assert metrics.extras["manifest_key"] == "k"
-        assert metrics.extras["images_zip"]["status"] == "building"
         state = get_zip_state(metrics)
         assert state is not None
         assert state["status"] == "building"
 
 
-from unittest.mock import patch
-
-import orjson
-
-from sentry.models.files.file import File
-
-BUILD_TASK_SESSION = "sentry.preprod.snapshots.zip_tasks.get_preprod_session"
-
-
 class BuildSnapshotImagesZipTaskTest(TestCase):
-    def _setup(self, images):
-        from sentry.preprod.models import PreprodArtifact
-        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+    IMAGES = {"a.png": {"content_hash": "h1", "width": 1, "height": 1}}
 
-        org = self.organization
-        project = self.create_project(organization=org)
-        artifact = PreprodArtifact.objects.create(
+    def _setup(self, zip_state=None):
+        project = self.create_project(organization=self.organization)
+        artifact = self.create_preprod_artifact(
             project=project, state=PreprodArtifact.ArtifactState.PROCESSED
         )
-        manifest_key = f"{org.id}/{project.id}/{artifact.id}/manifest.json"
+        manifest_key = f"{self.organization.id}/{project.id}/{artifact.id}/manifest.json"
         PreprodSnapshotMetrics.objects.create(
             preprod_artifact=artifact,
-            image_count=len(images),
-            extras={"manifest_key": manifest_key, "images_zip": {"status": "building"}},
+            image_count=len(self.IMAGES),
+            extras={
+                "manifest_key": manifest_key,
+                "images_zip": {
+                    "status": "building",
+                    "enqueued_at": BUILD_TOKEN,
+                    **(zip_state or {}),
+                },
+            },
         )
-        manifest_json = orjson.dumps({"images": images})
-        return org, project, artifact, manifest_key, manifest_json
+        return project, artifact, manifest_key
 
-    def _session(self, data_by_key):
-        from unittest.mock import MagicMock
+    def _ok_session(self, project, manifest_key) -> MagicMock:
+        return _session(
+            {
+                manifest_key: orjson.dumps({"images": self.IMAGES}),
+                f"{self.organization.id}/{project.id}/h1": b"AAA",
+            }
+        )
 
-        def _get(key):
-            result = MagicMock()
-            result.payload.read.return_value = data_by_key[key]
-            return result
+    def _state(self, artifact):
+        return get_zip_state(PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact))
 
-        session = MagicMock()
-        session.get.side_effect = _get
-        return session
+    def _run(self, project, artifact, build_token=BUILD_TOKEN):
+        build_snapshot_images_zip(
+            org_id=self.organization.id,
+            project_id=project.id,
+            artifact_id=artifact.id,
+            build_token=build_token,
+        )
 
     @patch(BUILD_TASK_SESSION)
     def test_builds_zip_and_marks_ready(self, mock_get_session):
-        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
-        from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
+        project, artifact, manifest_key = self._setup()
+        mock_get_session.return_value = self._ok_session(project, manifest_key)
 
-        images = {"a.png": {"content_hash": "h1", "width": 1, "height": 1}}
-        org, project, artifact, manifest_key, manifest_json = self._setup(images)
-        mock_get_session.return_value = self._session(
-            {manifest_key: manifest_json, f"{org.id}/{project.id}/h1": b"AAA"}
-        )
+        self._run(project, artifact)
 
-        build_snapshot_images_zip(org_id=org.id, project_id=project.id, artifact_id=artifact.id)
-
-        metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact)
-        state = get_zip_state(metrics)
+        state = self._state(artifact)
         assert state is not None
         assert state["status"] == "ready"
-        assert state["file_id"] is not None
         assert state["progress"] == 100
         file_obj = File.objects.get(id=state["file_id"])
-        import zipfile
-
         with file_obj.getfile() as fp, zipfile.ZipFile(fp) as zf:
             assert zf.read("a.png") == b"AAA"
         assert state["size"] == file_obj.size
 
     @patch(BUILD_TASK_SESSION)
     def test_marks_failed_on_fetch_error(self, mock_get_session):
-        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
-        from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
-
-        images = {"a.png": {"content_hash": "h1", "width": 1, "height": 1}}
-        org, project, artifact, manifest_key, manifest_json = self._setup(images)
+        project, artifact, manifest_key = self._setup()
         # manifest present but image missing -> builder raises
-        mock_get_session.return_value = self._session({manifest_key: manifest_json})
+        mock_get_session.return_value = _session(
+            {manifest_key: orjson.dumps({"images": self.IMAGES})}
+        )
 
-        build_snapshot_images_zip(org_id=org.id, project_id=project.id, artifact_id=artifact.id)
+        self._run(project, artifact)
 
-        metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact)
-        state = get_zip_state(metrics)
-        assert state is not None
-        assert state["status"] == "failed"
+        state = self._state(artifact)
+        assert state is not None and state["status"] == "failed"
 
     @patch(BUILD_TASK_SESSION)
     def test_cleans_up_file_when_putfile_fails(self, mock_get_session):
-        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
-        from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
-
-        images = {"a.png": {"content_hash": "h1", "width": 1, "height": 1}}
-        org, project, artifact, manifest_key, manifest_json = self._setup(images)
-        mock_get_session.return_value = self._session(
-            {manifest_key: manifest_json, f"{org.id}/{project.id}/h1": b"AAA"}
-        )
+        project, artifact, manifest_key = self._setup()
+        mock_get_session.return_value = self._ok_session(project, manifest_key)
 
         with patch.object(File, "putfile", side_effect=Exception("boom")):
-            build_snapshot_images_zip(org_id=org.id, project_id=project.id, artifact_id=artifact.id)
+            self._run(project, artifact)
 
-        metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact)
-        state = get_zip_state(metrics)
-        assert state is not None
-        assert state["status"] == "failed"
+        state = self._state(artifact)
+        assert state is not None and state["status"] == "failed"
         assert not File.objects.filter(name=f"snapshot_images_{artifact.id}.zip").exists()
 
     @patch(BUILD_TASK_SESSION)
     def test_rebuild_schedules_blob_cleanup_for_old_file(self, mock_get_session):
-        from io import BytesIO
-
-        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
-        from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
-
         old_file = File.objects.create(name="old.zip", type="preprod_snapshot_images.zip")
         old_file.putfile(BytesIO(b"OLD-ZIP-CONTENT"))
         old_blob_ids = list(old_file.blobs.values_list("id", flat=True))
         assert old_blob_ids
 
-        images = {"a.png": {"content_hash": "h1", "width": 1, "height": 1}}
-        org, project, artifact, manifest_key, manifest_json = self._setup(images)
-        metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact)
-        set_zip_state(metrics, status="ready", file_id=old_file.id)
-
-        mock_get_session.return_value = self._session(
-            {manifest_key: manifest_json, f"{org.id}/{project.id}/h1": b"AAA"}
+        project, artifact, manifest_key = self._setup(
+            zip_state={"status": "ready", "file_id": old_file.id}
         )
+        mock_get_session.return_value = self._ok_session(project, manifest_key)
 
         with (
             patch(
@@ -270,12 +244,45 @@ class BuildSnapshotImagesZipTaskTest(TestCase):
             ) as mock_blob_cleanup,
             self.captureOnCommitCallbacks(execute=True),
         ):
-            build_snapshot_images_zip(org_id=org.id, project_id=project.id, artifact_id=artifact.id)
+            self._run(project, artifact)
 
         assert not File.objects.filter(id=old_file.id).exists()
-        state = get_zip_state(PreprodSnapshotMetrics.objects.get(preprod_artifact=artifact))
-        assert state is not None
-        assert state["status"] == "ready"
+        state = self._state(artifact)
+        assert state is not None and state["status"] == "ready"
         assert state["file_id"] != old_file.id
         mock_blob_cleanup.assert_called_once()
         assert mock_blob_cleanup.call_args.kwargs["kwargs"]["blob_ids"] == old_blob_ids
+
+    @patch(BUILD_TASK_SESSION)
+    def test_stale_build_does_not_clobber_newer_state(self, mock_get_session):
+        newer_file = File.objects.create(name="newer.zip", type="preprod_snapshot_images.zip")
+        newer_file.putfile(BytesIO(b"NEWER"))
+        project, artifact, manifest_key = self._setup(
+            zip_state={"status": "ready", "file_id": newer_file.id, "enqueued_at": "newer-token"}
+        )
+        mock_get_session.return_value = self._ok_session(project, manifest_key)
+
+        self._run(project, artifact, build_token=BUILD_TOKEN)
+
+        state = self._state(artifact)
+        assert state is not None
+        assert state["status"] == "ready"
+        assert state["file_id"] == newer_file.id
+        assert File.objects.filter(id=newer_file.id).exists()
+        assert not File.objects.filter(name=f"snapshot_images_{artifact.id}.zip").exists()
+
+    @patch(BUILD_TASK_SESSION)
+    def test_stale_build_does_not_mark_failed_when_superseded(self, mock_get_session):
+        project, artifact, manifest_key = self._setup(
+            zip_state={"status": "ready", "file_id": 999, "enqueued_at": "newer-token"}
+        )
+        # image missing -> build raises, but our token is stale so state is untouched
+        mock_get_session.return_value = _session(
+            {manifest_key: orjson.dumps({"images": self.IMAGES})}
+        )
+
+        self._run(project, artifact, build_token=BUILD_TOKEN)
+
+        state = self._state(artifact)
+        assert state is not None
+        assert state["status"] == "ready"


### PR DESCRIPTION
Adds an additive endpoint for downloading a snapshot's images as a resumable ZIP. The existing `/snapshots/<id>/download/` streaming endpoint is left untouched, so this merges with zero frontend risk — the frontend migrates in a separate PR and the old endpoint is removed in a later cleanup.

## Why

Large snapshot-image ZIP downloads fail partway through and can't resume. The on-the-fly streaming response sends no `Content-Length` and no `Accept-Ranges`, so any mid-download connection drop is a permanent failure. Logs for a failing download confirmed the server is healthy (it pushed 2.35 GB in ~11s before the client disconnected) — the missing resume support is the problem, not the backend.

## What

New `OrganizationPreprodSnapshotArchiveEndpoint` at `.../snapshots/<id>/archive/`:

- **Async build.** A background task (`build_snapshot_images_zip`) assembles the ZIP once into a temp file on disk (memory-safe for multi-GB) and stores it as a `File`. Build state lives in `PreprodSnapshotMetrics.extras["images_zip"]` (`building`/`ready`/`failed`) — no new model. Any image-fetch failure fails the whole build instead of persisting a partial archive.
- **Status vs. bytes** (the `data_export` pattern): `GET .../archive/` returns `{status}` and idempotently enqueues the build (lock-guarded, with a 20-minute staleness re-enqueue); `?download=true` serves the stored `File` with full HTTP Range support (`206`, `Content-Range`, `Accept-Ranges`, `Content-Length`, `ETag`); `HEAD` advertises the same headers. With `Accept-Ranges` + a strong validator the browser resumes after a dropped connection instead of failing.
- Each enqueue is stamped with a build token, so a stale worker that finishes after the staleness re-enqueue can't clobber a newer build's state or delete its `File`.

Behind the existing `organizations:preprod-snapshots` flag.

## Follow-ups (not in this PR)

- Frontend PR points the "Download Images" action at the new endpoint (poll-then-download).
- Cleanup PR removes the old `/download/` endpoint once the frontend ships.
