### PR TITLE
feat(preprod): Poll snapshot ZIP build status before downloading

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.spec.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.spec.tsx
@@ -1,0 +1,166 @@
+import {Fragment} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as indicatorActions from 'sentry/actionCreators/indicator';
+import Indicators from 'sentry/components/indicators';
+import {downloadFromHref} from 'sentry/utils/downloadFromHref';
+import {SnapshotHeaderActions} from 'sentry/views/preprod/snapshots/header/snapshotHeaderActions';
+import type {SnapshotDetailsApiResponse} from 'sentry/views/preprod/types/snapshotTypes';
+
+jest.mock('sentry/utils/downloadFromHref');
+
+const SNAPSHOT_ID = '42';
+
+function makeData(): SnapshotDetailsApiResponse {
+  return {
+    head_artifact_id: SNAPSHOT_ID,
+    project_id: 'project-1',
+    comparison_type: 'solo',
+    state: 'completed',
+    image_count: 0,
+    images: [],
+    vcs_info: {},
+    base_artifact_id: null,
+    added: [],
+    added_count: 0,
+    changed: [],
+    changed_count: 0,
+    removed: [],
+    removed_count: 0,
+    unchanged: [],
+    unchanged_count: 0,
+  } as SnapshotDetailsApiResponse;
+}
+
+describe('SnapshotHeaderActions download', () => {
+  const organization = OrganizationFixture();
+  const STATUS_URL = `/organizations/${organization.slug}/preprodartifacts/snapshots/${SNAPSHOT_ID}/archive/`;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+    indicatorActions.clearIndicators();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('issues each progress toast only once across repeated polls', async () => {
+    jest.useFakeTimers();
+    const loadingSpy = jest.spyOn(indicatorActions, 'addLoadingMessage');
+
+    let calls = 0;
+    MockApiClient.addMockResponse({
+      url: STATUS_URL,
+      method: 'GET',
+      body: () => {
+        calls++;
+        return {status: 'building', progress: 42};
+      },
+    });
+
+    render(
+      <SnapshotHeaderActions
+        apiUrl="/api/0/snapshot/"
+        organizationSlug={organization.slug}
+        data={makeData()}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More actions'}), {
+      advanceTimers: jest.advanceTimersByTime,
+    });
+    await userEvent.click(screen.getByText('Download Images'), {
+      advanceTimers: jest.advanceTimersByTime,
+    });
+
+    await waitFor(() => expect(calls).toBe(1));
+
+    act(() => {
+      jest.advanceTimersByTime(1_500);
+    });
+    await waitFor(() => expect(calls).toBe(2));
+
+    const progressCalls = loadingSpy.mock.calls.filter(
+      ([message]) => typeof message === 'string' && message.includes('42%')
+    );
+    expect(progressCalls).toHaveLength(1);
+  });
+
+  it('shows build progress percentage in the toast while preparing', async () => {
+    MockApiClient.addMockResponse({
+      url: STATUS_URL,
+      method: 'GET',
+      body: {status: 'building', progress: 42},
+    });
+
+    render(
+      <Fragment>
+        <Indicators />
+        <SnapshotHeaderActions
+          apiUrl="/api/0/snapshot/"
+          organizationSlug={organization.slug}
+          data={makeData()}
+        />
+      </Fragment>,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More actions'}));
+    await userEvent.click(screen.getByText('Download Images'));
+
+    expect(await screen.findByText(/Preparing snapshot images.*42%/)).toBeInTheDocument();
+    expect(downloadFromHref).not.toHaveBeenCalled();
+  });
+
+  it('polls until ready then triggers download', async () => {
+    jest.useFakeTimers();
+
+    let calls = 0;
+    MockApiClient.addMockResponse({
+      url: STATUS_URL,
+      method: 'GET',
+      body: () => {
+        calls++;
+        return {status: calls === 1 ? 'building' : 'ready'};
+      },
+    });
+
+    render(
+      <SnapshotHeaderActions
+        apiUrl="/api/0/snapshot/"
+        organizationSlug={organization.slug}
+        data={makeData()}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More actions'}), {
+      advanceTimers: jest.advanceTimersByTime,
+    });
+    await userEvent.click(screen.getByText('Download Images'), {
+      advanceTimers: jest.advanceTimersByTime,
+    });
+
+    await waitFor(() => expect(calls).toBe(1));
+    expect(downloadFromHref).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1_500);
+    });
+
+    await waitFor(() => expect(calls).toBe(2));
+    await waitFor(() => expect(downloadFromHref).toHaveBeenCalledTimes(1));
+    expect(downloadFromHref).toHaveBeenCalledWith(
+      `snapshot_images_${SNAPSHOT_ID}.zip`,
+      `/api/0/organizations/${organization.slug}/preprodartifacts/snapshots/${SNAPSHOT_ID}/archive/?download=true`
+    );
+
+    jest.useRealTimers();
+  });
+});

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.spec.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.spec.tsx
@@ -163,4 +163,40 @@ describe('SnapshotHeaderActions download', () => {
 
     jest.useRealTimers();
   });
+
+  it('re-polls on a second download click instead of reusing cached ready', async () => {
+    let phase: 'ready' | 'building' = 'ready';
+    let calls = 0;
+    MockApiClient.addMockResponse({
+      url: STATUS_URL,
+      method: 'GET',
+      body: () => {
+        calls++;
+        return phase === 'ready' ? {status: 'ready'} : {status: 'building', progress: 5};
+      },
+    });
+
+    render(
+      <SnapshotHeaderActions
+        apiUrl="/api/0/snapshot/"
+        organizationSlug={organization.slug}
+        data={makeData()}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More actions'}));
+    await userEvent.click(screen.getByText('Download Images'));
+
+    await waitFor(() => expect(downloadFromHref).toHaveBeenCalledTimes(1));
+    const firstCallCount = calls;
+
+    phase = 'building';
+
+    await userEvent.click(screen.getByRole('button', {name: 'More actions'}));
+    await userEvent.click(screen.getByText('Download Images'));
+
+    await waitFor(() => expect(calls).toBeGreaterThan(firstCallCount));
+    expect(downloadFromHref).toHaveBeenCalledTimes(1);
+  });
 });

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -238,9 +238,10 @@ export function SnapshotHeaderActions({
   }, [apiUrl, navigate]);
 
   const handleDownloadImages = useCallback(() => {
+    queryClient.removeQueries({queryKey: [downloadStatusUrl]});
     setIsPreparingDownload(true);
     showPreparingMessage(t('Preparing snapshot images… Please be patient.'));
-  }, [showPreparingMessage]);
+  }, [queryClient, downloadStatusUrl, showPreparingMessage]);
 
   return (
     <Flex align="center" gap="md">

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -8,7 +8,11 @@ import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
 import {ConfirmDelete} from 'sentry/components/confirmDelete';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -31,7 +35,9 @@ import {t} from 'sentry/locale';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {AvatarUser} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {downloadFromHref} from 'sentry/utils/downloadFromHref';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {useBreakpoints} from 'sentry/utils/useBreakpoints';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -62,6 +68,70 @@ export function SnapshotHeaderActions({
   const project = ProjectsStore.getById(data.project_id);
   const [isApproving, setIsApproving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isPreparingDownload, setIsPreparingDownload] = useState(false);
+  const preparingMessageRef = useRef<string | null>(null);
+
+  const showPreparingMessage = useCallback((message: string) => {
+    if (preparingMessageRef.current === message) {
+      return;
+    }
+    preparingMessageRef.current = message;
+    addLoadingMessage(message);
+  }, []);
+
+  const downloadStatusUrl = getApiUrl(
+    '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/archive/',
+    {
+      path: {
+        organizationIdOrSlug: organizationSlug,
+        snapshotId: String(data.head_artifact_id),
+      },
+    }
+  );
+
+  const {data: downloadStatus} = useApiQuery<{
+    status: 'building' | 'ready' | 'failed';
+    progress?: number | null;
+  }>([downloadStatusUrl], {
+    staleTime: 0,
+    enabled: isPreparingDownload,
+    refetchInterval: query => {
+      const status = query.state.data?.json?.status;
+      return status === 'building' ? 1_500 : false;
+    },
+  });
+
+  useEffect(() => {
+    if (!isPreparingDownload || !downloadStatus) {
+      return;
+    }
+    if (downloadStatus.status === 'ready') {
+      preparingMessageRef.current = null;
+      setIsPreparingDownload(false);
+      addSuccessMessage(t('Downloading snapshot images to your browser.'));
+      downloadFromHref(
+        `snapshot_images_${data.head_artifact_id}.zip`,
+        `/api/0${downloadStatusUrl}?download=true`
+      );
+    } else if (downloadStatus.status === 'failed') {
+      preparingMessageRef.current = null;
+      setIsPreparingDownload(false);
+      addErrorMessage(t('Failed to prepare snapshot images for download.'));
+    } else {
+      const pct = downloadStatus.progress;
+      showPreparingMessage(
+        typeof pct === 'number'
+          ? t('Preparing snapshot images… %s%%. Please be patient.', pct)
+          : t('Preparing snapshot images… Please be patient.')
+      );
+    }
+  }, [
+    isPreparingDownload,
+    downloadStatus,
+    downloadStatusUrl,
+    data.head_artifact_id,
+    showPreparingMessage,
+  ]);
 
   const comparisonState = data.comparison_state;
   const approvalStatus = data.approval_status;
@@ -168,10 +238,9 @@ export function SnapshotHeaderActions({
   }, [apiUrl, navigate]);
 
   const handleDownloadImages = useCallback(() => {
-    const downloadUrl = `/api/0/organizations/${organizationSlug}/preprodartifacts/snapshots/${data.head_artifact_id}/download/`;
-
-    downloadFromHref(`snapshot_images_${data.head_artifact_id}.zip`, downloadUrl);
-  }, [organizationSlug, data.head_artifact_id]);
+    setIsPreparingDownload(true);
+    showPreparingMessage(t('Preparing snapshot images… Please be patient.'));
+  }, [showPreparingMessage]);
 
   return (
     <Flex align="center" gap="md">
@@ -272,10 +341,11 @@ export function SnapshotHeaderActions({
               label: (
                 <Flex align="center" gap="sm">
                   <IconDownload size="sm" />
-                  {t('Download Images')}
+                  {isPreparingDownload ? t('Preparing…') : t('Download Images')}
                 </Flex>
               ),
               onAction: handleDownloadImages,
+              disabled: isPreparingDownload,
               textValue: t('Download Images'),
             },
             {


### PR DESCRIPTION
Points the "Download Images" action at the new async, resumable snapshot-archive endpoint (`.../snapshots/<id>/archive/`) added in getsentry/sentry#116825.

That endpoint no longer streams the ZIP synchronously. Instead, a plain `GET .../archive/` returns `{status}` and enqueues a background build, and `GET .../archive/?download=true` serves the finished, resumable file. So clicking "Download Images" now:

1. Triggers/awaits the build by polling the status endpoint every 3s while `building` (via `useApiQuery` + `refetchInterval`, matching the existing preprod polling pattern in `snapshots.tsx`).
2. Once `ready`, downloads the file via `downloadFromHref(..., '.../archive/?download=true')`.
3. Shows a "Preparing…" state on the menu item and toasts for in-progress / success / failure.

Depends on the backend PR (#116825) being deployed first (the `/archive/` endpoint must exist). The old `/download/` endpoint is untouched, so there is no deploy-ordering risk: this PR can merge whenever, and the old endpoint is removed in a later cleanup once nothing references it. Behind the existing `organizations:preprod-snapshots` flag.