### PR TITLE
fix(components): fix copy block handler

### DIFF
--- a/static/app/components/copyToClipboardButton.tsx
+++ b/static/app/components/copyToClipboardButton.tsx
@@ -16,6 +16,7 @@ interface CopyToClipboardButtonProps extends Omit<
 export function CopyToClipboardButton({
   onCopy,
   onError,
+  onClick,
   text,
   ...props
 }: CopyToClipboardButtonProps) {
@@ -23,12 +24,12 @@ export function CopyToClipboardButton({
 
   return (
     <Button
+      {...props}
       onClick={e => {
         copy(text).then(onCopy).catch(onError);
-        props.onClick?.(e);
+        onClick?.(e);
       }}
       icon={<IconCopy variant="muted" />}
-      {...props}
     />
   );
 }


### PR DESCRIPTION
## Summary

bug report: https://sentry.slack.com/archives/C091QF41ULT/p1780535170916269

`CopyToClipboardButton` spread `{...props}` *after* its internal `onClick` and never destructured `onClick` out of `props`. As a result, any consumer that passed its own `onClick` would override the handler that actually performs the copy — clicking ran only the consumer's handler, so nothing was copied and no success toast appeared.

The fix destructures `onClick` out and spreads `{...props}` first, so the copy always runs and the consumer's `onClick` is merged in (called after the copy).

## Impact

This fixes copy for **every** `CopyToClipboardButton` consumer that passes an `onClick`. The visible symptom was the Seer Explorer message block copy button, which passes `onClick={e => e.stopPropagation()}` and was a silent no-op in production. Consumers that don't pass an `onClick` were unaffected, which is why this went unnoticed.

No consumer overrides `icon`, so moving it below the spread is safe.
