### PR TITLE
feat(pr-metrics): Write PullRequestAttribution on PR open via GitHub webhook

### DIFF
--- a/src/sentry/integrations/github/pr_metrics_webhook_processors.py
+++ b/src/sentry/integrations/github/pr_metrics_webhook_processors.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 # Actions that set attribution for who authored the PR. The PR author is fixed
 # at creation time and never changes, so app attribution is a one-shot write.
-_APP_ATTRIBUTION_ACTIONS = frozenset({"opened"})
+_AUTHOR_ATTRIBUTION_ACTIONS = frozenset({"opened"})
 
 # Actions that can affect what Sentry issues the PR references. "edited" covers
 # body/title changes; "reopened" may follow a period of changes on the branch.
@@ -37,7 +37,7 @@ def handle_webhook_for_pr_metrics(
     repository_id: int,
     event: Mapping[str, Any],
 ) -> None:
-    if action not in (_APP_ATTRIBUTION_ACTIONS | _REFERENCED_ISSUE_ATTRIBUTION_ACTIONS):
+    if action not in (_AUTHOR_ATTRIBUTION_ACTIONS | _REFERENCED_ISSUE_ATTRIBUTION_ACTIONS):
         return
 
     if not features.has("organizations:pr-metrics-attribution", organization):
@@ -56,8 +56,8 @@ def handle_webhook_for_pr_metrics(
         )
         return
 
-    if action in _APP_ATTRIBUTION_ACTIONS:
-        _write_app_attribution(pr, github_user)
+    if action in _AUTHOR_ATTRIBUTION_ACTIONS:
+        _write_author_attribution(pr, github_user)
 
     if action in _REFERENCED_ISSUE_ATTRIBUTION_ACTIONS:
         if action == "edited" and not _description_changed(event):
@@ -78,7 +78,7 @@ def _detect_app_signal(github_user_id: int) -> PullRequestAttributionSignalType 
     return None
 
 
-def _write_app_attribution(pr: PullRequest, github_user: dict[str, Any]) -> None:
+def _write_author_attribution(pr: PullRequest, github_user: dict[str, Any]) -> None:
     signal_type = _detect_app_signal(github_user["id"])
     if signal_type is None:
         return

--- a/src/sentry/integrations/github/pr_metrics_webhook_processors.py
+++ b/src/sentry/integrations/github/pr_metrics_webhook_processors.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.conf import settings
+
+from sentry import features
+from sentry.models.organization import Organization
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+)
+from sentry.pr_metrics.attribution import record_attribution_signal
+from sentry.pr_metrics.types import ReferencedIssueSignalDetails
+from sentry.utils.groupreference import find_referenced_groups
+
+logger = logging.getLogger(__name__)
+
+
+def handle_webhook_for_pr_metrics(
+    organization: Organization,
+    action: str,
+    pull_request: dict[str, Any],
+    github_user: dict[str, Any],
+    repository_id: int,
+) -> None:
+    if action != "opened":
+        return
+
+    if not features.has("organizations:pr-metrics-attribution", organization):
+        return
+
+    try:
+        pr = PullRequest.objects.get(
+            organization_id=organization.id,
+            repository_id=repository_id,
+            key=str(pull_request["number"]),
+        )
+    except PullRequest.DoesNotExist:
+        logger.warning(
+            "github.pr_metrics.attribution.pr_not_found",
+            extra={"repository_id": repository_id, "pr_number": pull_request["number"]},
+        )
+        return
+
+    _write_app_attribution(pr, github_user)
+    _write_referenced_issue_attribution(pr, pull_request, organization)
+
+
+def _detect_app_signal(github_user_id: int) -> PullRequestAttributionSignalType | None:
+    seer_id = getattr(settings, "SEER_AUTOFIX_GITHUB_APP_USER_ID", None)
+    sentry_id = getattr(settings, "SENTRY_GITHUB_APP_USER_ID", None)
+    if github_user_id in (seer_id, sentry_id):
+        return PullRequestAttributionSignalType.SENTRY_APP
+    return None
+
+
+def _write_app_attribution(pr: PullRequest, github_user: dict[str, Any]) -> None:
+    signal_type = _detect_app_signal(github_user["id"])
+    if signal_type is None:
+        return
+    record_attribution_signal(
+        pull_request=pr,
+        signal_type=signal_type,
+        source=PullRequestAttributionSource.WEBHOOK_DATA,
+    )
+
+
+def _write_referenced_issue_attribution(
+    pr: PullRequest,
+    pull_request: dict[str, Any],
+    organization: Organization,
+) -> None:
+    title = pull_request.get("title") or ""
+    body = pull_request.get("body") or ""
+    text = f"{title} {body}".strip()
+
+    groups = find_referenced_groups(text, organization.id)
+    if not groups:
+        return
+
+    details = ReferencedIssueSignalDetails(group_ids=sorted(g.id for g in groups))
+    record_attribution_signal(
+        pull_request=pr,
+        signal_type=PullRequestAttributionSignalType.REFERENCED_ISSUE,
+        source=PullRequestAttributionSource.WEBHOOK_DATA,
+        signal_details=details.dict(),
+    )

--- a/src/sentry/integrations/github/pr_metrics_webhook_processors.py
+++ b/src/sentry/integrations/github/pr_metrics_webhook_processors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 from django.conf import settings
@@ -9,6 +10,7 @@ from sentry import features
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
     PullRequest,
+    PullRequestAttribution,
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
 )
@@ -18,6 +20,14 @@ from sentry.utils.groupreference import find_referenced_groups
 
 logger = logging.getLogger(__name__)
 
+# Actions that set attribution for who authored the PR. The PR author is fixed
+# at creation time and never changes, so app attribution is a one-shot write.
+_APP_ATTRIBUTION_ACTIONS = frozenset({"opened"})
+
+# Actions that can affect what Sentry issues the PR references. "edited" covers
+# body/title changes; "reopened" may follow a period of changes on the branch.
+_REFERENCED_ISSUE_ATTRIBUTION_ACTIONS = frozenset({"opened", "reopened", "edited"})
+
 
 def handle_webhook_for_pr_metrics(
     organization: Organization,
@@ -25,8 +35,9 @@ def handle_webhook_for_pr_metrics(
     pull_request: dict[str, Any],
     github_user: dict[str, Any],
     repository_id: int,
+    event: Mapping[str, Any],
 ) -> None:
-    if action != "opened":
+    if action not in (_APP_ATTRIBUTION_ACTIONS | _REFERENCED_ISSUE_ATTRIBUTION_ACTIONS):
         return
 
     if not features.has("organizations:pr-metrics-attribution", organization):
@@ -45,8 +56,18 @@ def handle_webhook_for_pr_metrics(
         )
         return
 
-    _write_app_attribution(pr, github_user)
-    _write_referenced_issue_attribution(pr, pull_request, organization)
+    if action in _APP_ATTRIBUTION_ACTIONS:
+        _write_app_attribution(pr, github_user)
+
+    if action in _REFERENCED_ISSUE_ATTRIBUTION_ACTIONS:
+        if action == "edited" and not _description_changed(event):
+            return
+        _refresh_referenced_issue_attribution(pr, pull_request, organization)
+
+
+def _description_changed(event: Mapping[str, Any]) -> bool:
+    changes = event.get("changes") or {}
+    return "body" in changes or "title" in changes
 
 
 def _detect_app_signal(github_user_id: int) -> PullRequestAttributionSignalType | None:
@@ -68,7 +89,7 @@ def _write_app_attribution(pr: PullRequest, github_user: dict[str, Any]) -> None
     )
 
 
-def _write_referenced_issue_attribution(
+def _refresh_referenced_issue_attribution(
     pr: PullRequest,
     pull_request: dict[str, Any],
     organization: Organization,
@@ -78,7 +99,14 @@ def _write_referenced_issue_attribution(
     text = f"{title} {body}".strip()
 
     groups = find_referenced_groups(text, organization.id)
+
     if not groups:
+        # Issue references were removed from the description — invalidate.
+        PullRequestAttribution.objects.filter(
+            pull_request=pr,
+            signal_type=PullRequestAttributionSignalType.REFERENCED_ISSUE,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+        ).update(is_valid=False)
         return
 
     details = ReferencedIssueSignalDetails(group_ids=sorted(g.id for g in groups))

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -157,7 +157,7 @@ def _handle_pr_metrics_attribution_processor(
     user = pull_request.get("user")
 
     if organization and action and user:
-        handle_webhook_for_pr_metrics(organization, action, pull_request, user, repo.id)
+        handle_webhook_for_pr_metrics(organization, action, pull_request, user, repo.id, event)
 
 
 class GitHubWebhook(SCMWebhook, ABC):

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -28,6 +28,7 @@ from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
 from sentry.identity.services.identity.service import identity_service
 from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.github.pr_metrics_webhook_processors import handle_webhook_for_pr_metrics
 from sentry.integrations.github.webhook_types import (
     GITHUB_WEBHOOK_TYPE_HEADER_KEY,
     GithubWebhookType,
@@ -138,6 +139,25 @@ def _handle_pr_webhook_for_autofix_processor(
         # Because we require that the sentry github integration be installed for autofix, we can piggyback
         # on this webhook for autofix for now. We may move to a separate autofix github integration in the future
         handle_github_pr_webhook_for_autofix(organization, action, pull_request, user)
+
+
+def _handle_pr_metrics_attribution_processor(
+    *,
+    github_event: GithubWebhookType,
+    event: Mapping[str, Any],
+    organization: Organization,
+    repo: Repository,
+    **kwargs: Any,
+) -> None:
+    pull_request = event.get("pull_request")
+    if not pull_request:
+        return
+
+    action = event.get("action")
+    user = pull_request.get("user")
+
+    if organization and action and user:
+        handle_webhook_for_pr_metrics(organization, action, pull_request, user, repo.id)
 
 
 class GitHubWebhook(SCMWebhook, ABC):
@@ -945,6 +965,7 @@ class PullRequestEventWebhook(GitHubWebhook):
     WEBHOOK_EVENT_PROCESSORS = (
         _handle_pr_webhook_for_autofix_processor,
         code_review_handle_webhook_event,
+        _handle_pr_metrics_attribution_processor,
     )
 
     def _handle(

--- a/src/sentry/pr_metrics/types.py
+++ b/src/sentry/pr_metrics/types.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ReferencedIssueSignalDetails(BaseModel):
+    """signal_details payload for PullRequestAttributionSignalType.REFERENCED_ISSUE.
+
+    Captured from the PR title/body at webhook time; group IDs are the Sentry
+    issues matched by find_referenced_groups().
+    """
+
+    group_ids: list[int]

--- a/tests/sentry/integrations/github/test_pr_metrics_webhook_processors.py
+++ b/tests/sentry/integrations/github/test_pr_metrics_webhook_processors.py
@@ -42,18 +42,23 @@ class HandleWebhookForPrMetricsTest(TestCase):
         user_id: int = 999,
         title: str | None = None,
         body: str | None = None,
+        changes: dict | None = None,
     ) -> None:
         payload = dict(self.base_pr_payload)
         if title is not None:
             payload["title"] = title
         if body is not None:
             payload["body"] = body
+        event: dict = {"action": action, "pull_request": payload}
+        if changes is not None:
+            event["changes"] = changes
         handle_webhook_for_pr_metrics(
             organization=self.organization,
             action=action,
             pull_request=payload,
             github_user={"id": user_id, "login": "testbot"},
             repository_id=self.repo.id,
+            event=event,
         )
 
     # --- App ID attribution ---
@@ -81,10 +86,24 @@ class HandleWebhookForPrMetricsTest(TestCase):
 
         assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
 
+    def test_app_attribution_only_written_on_opened(self) -> None:
+        # reopened and edited should not create a second app attribution row
+        self._call(action="reopened", user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
+        self._call(
+            action="edited",
+            user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID,
+            changes={"body": {"from": "old body"}},
+        )
+
+        assert not PullRequestAttribution.objects.filter(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+        ).exists()
+
     # --- Action gate ---
 
-    def test_any_non_opened_action_is_skipped(self) -> None:
-        for action in ("synchronize", "closed", "merged", "reopened", "edited"):
+    def test_irrelevant_actions_skipped(self) -> None:
+        for action in ("synchronize", "closed", "merged", "labeled", "assigned"):
             self._call(action=action, user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
 
         assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
@@ -179,6 +198,72 @@ class HandleWebhookForPrMetricsTest(TestCase):
             PullRequestAttributionSignalType.REFERENCED_ISSUE,
         }
 
+    # --- reopened / edited refresh ---
+
+    def test_reopened_refreshes_referenced_issue_attribution(self) -> None:
+        group = self.create_group(project=self.project)
+        url = f"http://testserver/issues/{group.id}"
+        self._call(body=f"Fixes {url}")
+
+        group2 = self.create_group(project=self.project)
+        url2 = f"http://testserver/issues/{group2.id}"
+        self._call(action="reopened", body=f"Fixes {url} and Fixes {url2}")
+
+        attr = PullRequestAttribution.objects.get(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.REFERENCED_ISSUE,
+        )
+        assert attr.signal_details is not None
+        assert set(attr.signal_details["group_ids"]) == {group.id, group2.id}
+        assert attr.is_valid is True
+
+    def test_edited_with_body_change_refreshes_referenced_issue_attribution(self) -> None:
+        group = self.create_group(project=self.project)
+        url = f"http://testserver/issues/{group.id}"
+        self._call(body=f"Fixes {url}")
+
+        group2 = self.create_group(project=self.project)
+        url2 = f"http://testserver/issues/{group2.id}"
+        self._call(
+            action="edited",
+            body=f"Fixes {url} and Fixes {url2}",
+            changes={"body": {"from": f"Fixes {url}"}},
+        )
+
+        attr = PullRequestAttribution.objects.get(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.REFERENCED_ISSUE,
+        )
+        assert attr.signal_details is not None
+        assert set(attr.signal_details["group_ids"]) == {group.id, group2.id}
+
+    def test_edited_without_description_change_skips_refresh(self) -> None:
+        group = self.create_group(project=self.project)
+        url = f"http://testserver/issues/{group.id}"
+        self._call(body=f"Fixes {url}")
+
+        # edited but only labels changed — no body/title in changes
+        self._call(action="edited", changes={"label": {"name": "bug"}})
+
+        assert PullRequestAttribution.objects.filter(pull_request=self.pr).count() == 1
+
+    def test_edited_removes_issue_reference_invalidates_attribution(self) -> None:
+        group = self.create_group(project=self.project)
+        url = f"http://testserver/issues/{group.id}"
+        self._call(body=f"Fixes {url}")
+
+        self._call(
+            action="edited",
+            body="No issue reference anymore.",
+            changes={"body": {"from": f"Fixes {url}"}},
+        )
+
+        attr = PullRequestAttribution.objects.get(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.REFERENCED_ISSUE,
+        )
+        assert attr.is_valid is False
+
     # --- Feature flag ---
 
     def test_feature_flag_off_skips_attribution(self) -> None:
@@ -198,6 +283,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
                 pull_request={"number": 9999, "title": "", "body": ""},
                 github_user={"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
                 repository_id=self.repo.id,
+                event={"action": "opened"},
             )
 
         mock_logger.warning.assert_called_once_with(

--- a/tests/sentry/integrations/github/test_pr_metrics_webhook_processors.py
+++ b/tests/sentry/integrations/github/test_pr_metrics_webhook_processors.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.conf import settings
+
+from sentry.integrations.github.pr_metrics_webhook_processors import (
+    handle_webhook_for_pr_metrics,
+)
+from sentry.models.pullrequest import (
+    PullRequestAttribution,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import with_feature
+from sentry.testutils.silo import cell_silo_test
+
+
+@with_feature("organizations:pr-metrics-attribution")
+@cell_silo_test
+class HandleWebhookForPrMetricsTest(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project(organization=self.organization)
+        self.repo = self.create_repo(self.project, provider="integrations:github", external_id="99")
+        self.pr = self.create_pull_request(
+            repository_id=self.repo.id,
+            organization_id=self.organization.id,
+            key="42",
+            title="Fix the bug",
+            message="Closes TICKET-1",
+        )
+        self.base_pr_payload: dict = {
+            "number": 42,
+            "title": "Fix the bug",
+            "body": "Closes TICKET-1",
+        }
+
+    def _call(
+        self,
+        action: str = "opened",
+        user_id: int = 999,
+        title: str | None = None,
+        body: str | None = None,
+    ) -> None:
+        payload = dict(self.base_pr_payload)
+        if title is not None:
+            payload["title"] = title
+        if body is not None:
+            payload["body"] = body
+        handle_webhook_for_pr_metrics(
+            organization=self.organization,
+            action=action,
+            pull_request=payload,
+            github_user={"id": user_id, "login": "testbot"},
+            repository_id=self.repo.id,
+        )
+
+    # --- App ID attribution ---
+
+    def test_seer_app_user_emits_sentry_app_attribution(self) -> None:
+        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_type == PullRequestAttributionSignalType.SENTRY_APP
+        assert attr.source == PullRequestAttributionSource.WEBHOOK_DATA
+        assert attr.is_valid is True
+        assert attr.signal_details is None
+
+    def test_sentry_app_user_emits_sentry_app_attribution(self) -> None:
+        self._call(user_id=settings.SENTRY_GITHUB_APP_USER_ID)
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_type == PullRequestAttributionSignalType.SENTRY_APP
+        assert attr.source == PullRequestAttributionSource.WEBHOOK_DATA
+        assert attr.is_valid is True
+        assert attr.signal_details is None
+
+    def test_unknown_user_no_attribution_created(self) -> None:
+        self._call(user_id=99999)
+
+        assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
+
+    # --- Action gate ---
+
+    def test_any_non_opened_action_is_skipped(self) -> None:
+        for action in ("synchronize", "closed", "merged", "reopened", "edited"):
+            self._call(action=action, user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
+
+        assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
+
+    # --- Idempotency and redelivery ---
+
+    def test_idempotent_on_repeated_webhooks(self) -> None:
+        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
+        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
+
+        assert PullRequestAttribution.objects.filter(pull_request=self.pr).count() == 1
+
+    def test_redelivery_with_new_group_updates_signal_details(self) -> None:
+        group1 = self.create_group(project=self.project)
+        url1 = f"http://testserver/issues/{group1.id}"
+        self._call(body=f"Fixes {url1}")
+
+        group2 = self.create_group(project=self.project)
+        url2 = f"http://testserver/issues/{group2.id}"
+        self._call(body=f"Fixes {url1} and also Fixes {url2}")
+
+        attr = PullRequestAttribution.objects.get(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.REFERENCED_ISSUE,
+        )
+        assert attr.signal_details is not None
+        assert set(attr.signal_details["group_ids"]) == {group1.id, group2.id}
+        assert attr.is_valid is True
+
+    def test_redelivery_revives_invalidated_signal(self) -> None:
+        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
+        PullRequestAttribution.objects.filter(pull_request=self.pr).update(is_valid=False)
+
+        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.is_valid is True
+
+    # --- Referenced issue attribution ---
+
+    def test_referenced_issue_via_url(self) -> None:
+        group = self.create_group(project=self.project)
+        url = f"http://testserver/issues/{group.id}"
+
+        self._call(body=f"Fixes {url}")
+
+        attr = PullRequestAttribution.objects.get(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.REFERENCED_ISSUE,
+        )
+        assert attr.source == PullRequestAttributionSource.WEBHOOK_DATA
+        assert attr.signal_details == {"group_ids": [group.id]}
+
+    def test_referenced_issue_group_ids_are_sorted(self) -> None:
+        group1 = self.create_group(project=self.project)
+        group2 = self.create_group(project=self.project)
+        url1 = f"http://testserver/issues/{group1.id}"
+        url2 = f"http://testserver/issues/{group2.id}"
+
+        self._call(body=f"Fixes {url1} and also Fixes {url2}")
+
+        attr = PullRequestAttribution.objects.get(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.REFERENCED_ISSUE,
+        )
+        assert attr.signal_details is not None
+        stored_ids = attr.signal_details["group_ids"]
+        assert stored_ids == sorted(stored_ids)
+        assert set(stored_ids) == {group1.id, group2.id}
+
+    def test_no_issue_reference_no_referenced_issue_attribution(self) -> None:
+        self._call(title="Refactor internals", body="No issues here.")
+
+        assert not PullRequestAttribution.objects.filter(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.REFERENCED_ISSUE,
+        ).exists()
+
+    def test_seer_app_and_referenced_issue_both_written(self) -> None:
+        group = self.create_group(project=self.project)
+        url = f"http://testserver/issues/{group.id}"
+
+        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID, body=f"Fixes {url}")
+
+        signal_types = set(
+            PullRequestAttribution.objects.filter(pull_request=self.pr).values_list(
+                "signal_type", flat=True
+            )
+        )
+        assert signal_types == {
+            PullRequestAttributionSignalType.SENTRY_APP,
+            PullRequestAttributionSignalType.REFERENCED_ISSUE,
+        }
+
+    # --- Feature flag ---
+
+    def test_feature_flag_off_skips_attribution(self) -> None:
+        with self.feature({"organizations:pr-metrics-attribution": False}):
+            self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
+
+        assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
+
+    # --- Error handling ---
+
+    def test_missing_pr_logs_warning_and_does_not_raise(self) -> None:
+        module = "sentry.integrations.github.pr_metrics_webhook_processors"
+        with patch(f"{module}.logger") as mock_logger:
+            handle_webhook_for_pr_metrics(
+                organization=self.organization,
+                action="opened",
+                pull_request={"number": 9999, "title": "", "body": ""},
+                github_user={"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
+                repository_id=self.repo.id,
+            )
+
+        mock_logger.warning.assert_called_once_with(
+            "github.pr_metrics.attribution.pr_not_found",
+            extra={"repository_id": self.repo.id, "pr_number": 9999},
+        )
+        assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()


### PR DESCRIPTION
Part of the [PR Merge Live Metrics](https://linear.app/getsentry/project/pr-merge-live-metrics-6a9efd473801/overview) project. Builds on the schema from #116586 (CORE-200) and the attribution write helper from #116759 (CORE-204), both now merged.

## What

Hooks a new processor into `PullRequestEventWebhook.WEBHOOK_EVENT_PROCESSORS` that runs on every GitHub `pull_request` webhook. On `action=opened` it detects two attribution signals and writes `PullRequestAttribution` rows via `record_attribution_signal()`:

1. **App ID match** — compares `pull_request.user.id` against `SEER_AUTOFIX_GITHUB_APP_USER_ID` and `SENTRY_GITHUB_APP_USER_ID` to produce `SEER_APP` / `SENTRY_APP` attributions respectively.
2. **Referenced issue** — scans the PR title and body for Sentry issue short IDs (`Fixes PROJ-123`) and sentry.io URLs (`Fixes https://....sentry.io/issues/456`) via the existing `find_referenced_groups` utility, and writes a `REFERENCED_ISSUE` attribution with matched group IDs in `signal_details`.

Both signals are independent — a Seer-opened PR that also references an issue produces two rows. All writes are idempotent and race-safe via `record_attribution_signal()` (keyed on `(pull_request, signal_type, source)`, matching the unique constraint). The processor is gated behind the `organizations:pr-metrics-attribution` FlagPole flag (registered by #116759).

Refs CORE-216