### PR TITLE
fix(api): document missing query params on Teams, Projects, and Project Issues endpoints

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -206,6 +206,14 @@ Valid fields include:
 """,
     )
 
+    PROJECT_QUERY = OpenApiParameter(
+        name="query",
+        location="query",
+        required=False,
+        type=str,
+        description="Filter projects by name or slug.",
+    )
+
     EXTERNAL_USER_ID = OpenApiParameter(
         name="external_user_id",
         location="path",
@@ -944,6 +952,13 @@ keys if not specified.
 
 
 class TeamParams:
+    QUERY = OpenApiParameter(
+        name="query",
+        location="query",
+        required=False,
+        type=str,
+        description="Filter teams by name or slug.",
+    )
     DETAILED = OpenApiParameter(
         name="detailed",
         location="query",

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -38,7 +38,12 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.examples.project_examples import ProjectExamples
-from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
+from sentry.apidocs.parameters import (
+    CursorQueryParam,
+    GlobalParams,
+    OrganizationParams,
+    VisibilityParams,
+)
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.core.endpoints.team_projects import (
@@ -110,7 +115,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="List an Organization's Projects",
-        parameters=[GlobalParams.ORG_ID_OR_SLUG, CursorQueryParam],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, CursorQueryParam, VisibilityParams.PER_PAGE, OrganizationParams.QUERY],
         request=None,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -115,7 +115,12 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="List an Organization's Projects",
-        parameters=[GlobalParams.ORG_ID_OR_SLUG, CursorQueryParam, VisibilityParams.PER_PAGE, OrganizationParams.PROJECT_QUERY],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            CursorQueryParam,
+            VisibilityParams.PER_PAGE,
+            OrganizationParams.PROJECT_QUERY,
+        ],
         request=None,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -115,7 +115,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="List an Organization's Projects",
-        parameters=[GlobalParams.ORG_ID_OR_SLUG, CursorQueryParam, VisibilityParams.PER_PAGE, OrganizationParams.QUERY],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, CursorQueryParam, VisibilityParams.PER_PAGE, OrganizationParams.PROJECT_QUERY],
         request=None,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/core/endpoints/organization_teams.py
+++ b/src/sentry/core/endpoints/organization_teams.py
@@ -19,7 +19,6 @@ from sentry.apidocs.examples.team_examples import TeamExamples
 from sentry.apidocs.parameters import (
     CursorQueryParam,
     GlobalParams,
-    OrganizationParams,
     TeamParams,
     VisibilityParams,
 )
@@ -92,7 +91,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
             TeamParams.DETAILED,
             CursorQueryParam,
             VisibilityParams.PER_PAGE,
-            OrganizationParams.QUERY,
+            TeamParams.QUERY,
         ],
         request=None,
         responses={

--- a/src/sentry/core/endpoints/organization_teams.py
+++ b/src/sentry/core/endpoints/organization_teams.py
@@ -16,7 +16,13 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamSerializer, TeamSerializerResponse
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.team_examples import TeamExamples
-from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, TeamParams
+from sentry.apidocs.parameters import (
+    CursorQueryParam,
+    GlobalParams,
+    OrganizationParams,
+    TeamParams,
+    VisibilityParams,
+)
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.db.models.fields.slug import DEFAULT_SLUG_MAX_LENGTH
 from sentry.integrations.models.external_actor import ExternalActor
@@ -85,6 +91,8 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
             GlobalParams.ORG_ID_OR_SLUG,
             TeamParams.DETAILED,
             CursorQueryParam,
+            VisibilityParams.PER_PAGE,
+            OrganizationParams.QUERY,
         ],
         request=None,
         responses={

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -2,6 +2,7 @@ import functools
 import logging
 
 import sentry_sdk
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -22,6 +23,13 @@ from sentry.api.helpers.group_index import (
 from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group_stream import StreamGroupSerializer
+from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
+from sentry.apidocs.parameters import (
+    CursorQueryParam,
+    GlobalParams,
+    IssueParams,
+    VisibilityParams,
+)
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.environment import Environment
 from sentry.models.group import QUERY_STATUS_LOOKUP, Group, GroupStatus
@@ -60,6 +68,24 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         }
     )
 
+    @extend_schema(
+        operation_id="List a Project's Issues",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            GlobalParams.ENVIRONMENT,
+            GlobalParams.STATS_PERIOD,
+            CursorQueryParam,
+            VisibilityParams.PER_PAGE,
+            IssueParams.DEFAULT_QUERY,
+            IssueParams.GROUP_INDEX_COLLAPSE,
+            IssueParams.SHORT_ID_LOOKUP,
+        ],
+        responses={
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+        },
+    )
     @track_slo_response("workflow")
     def get(self, request: Request, project: Project) -> Response:
         """


### PR DESCRIPTION
<!-- Describe your PR here. -->

Follow-up to #116782. Three endpoints accepted query params in code but didn't declare them in `@extend_schema`, causing `as Parameters<>` type casts in the MCP SDK migration ([getsentry/sentry-mcp#931](https://github.com/getsentry/sentry-mcp/pull/931)). Adding them removes those casts once the spec flows into a new `@sentry/api` release.

- **List Teams** — added `per_page` and `query` (filters by team name/slug)
- **List Projects** — added `per_page` and `query` (filters by project name/slug)
- **List Project Issues** — added full `@extend_schema` decorator with `per_page`, `collapse`, `query`, `shortIdLookup`, `environment`, `statsPeriod`. The endpoint was already in the spec via the legacy allowlist but had no parameter documentation.

No runtime behavior changes — these are documentation-only additions to `@extend_schema`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.