### PR TITLE
fix(api): document project param on replay count endpoint

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -73,6 +73,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsEndpointBase):
             GlobalParams.START,
             GlobalParams.END,
             GlobalParams.STATS_PERIOD,
+            OrganizationParams.PROJECT,
             OrganizationParams.PROJECT_ID_OR_SLUG,
             VisibilityParams.QUERY,
         ],


### PR DESCRIPTION
<!-- Describe your PR here. -->

The replay count endpoint (`GET /organizations/{org}/replay-count/`) already accepts and processes a `project` query parameter — it's handled by `OrganizationEventsEndpointBase.get_snuba_params()`, which reads `project` from the request independently of the endpoint's own `ReplayCountQueryParamsValidator`. But it wasn't declared in `@extend_schema`, so it was invisible to the OpenAPI spec and the generated `@sentry/api` SDK.

This matters because `project=-1` is the sentinel for "all accessible projects". Without it, the API narrows the query to only projects the caller is a **member** of, which can silently miss replays for issues in projects the caller has access to but isn't a member of. Clients that need org-wide scope (like the MCP server) were forced to pass this parameter via an `as unknown as` cast because it wasn't in the SDK types.

Adding `OrganizationParams.PROJECT` documents the existing behavior. No runtime change.

Related: getsentry/sentry-mcp#931

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.