### PR TITLE
feat(seer): Add seer-use-agent-sandbox feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -293,6 +293,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-disable-coding-setting", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GitLab as a supported SCM provider for Seer
     manager.add("organizations:seer-gitlab-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Run Seer agents inside the sandbox execution environment
+    manager.add("organizations:seer-use-agent-sandbox", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Disable select orgs from ingesting mobile replay events.
     # Enable double-read from EAP for session health data validation
     manager.add("organizations:session-health-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -416,6 +416,13 @@ class SeerAgentClient:
         ):
             agent_run_options["enable_frontend_code_search"] = True
 
+        if features.has(
+            "organizations:seer-use-agent-sandbox",
+            self.organization,
+            actor=self.user,
+        ):
+            agent_run_options["use_agent_sandbox"] = True
+
         if features.has("organizations:seer-run-mirror-explorer", self.organization):
             user_id = (
                 self.user.id
@@ -570,6 +577,13 @@ class SeerAgentClient:
             actor=self.user,
         ):
             agent_run_options["enable_frontend_code_search"] = True
+
+        if features.has(
+            "organizations:seer-use-agent-sandbox",
+            self.organization,
+            actor=self.user,
+        ):
+            agent_run_options["use_agent_sandbox"] = True
 
         response = make_agent_chat_request(chat_body, viewer_context=self.viewer_context)
 


### PR DESCRIPTION
Adds the org-level `organizations:seer-use-agent-sandbox` temporary FlagPole flag and wires it into the Seer agent client.

When the flag is enabled for an org, the `use_agent_sandbox` agent run option is set on Seer agent requests (both `start_run` and `continue_run` in `SeerAgentClient`), telling Seer to run the agent inside the sandbox execution environment.