### PR TITLE
feat(pr-metrics): Emit a BigQuery row on PR close/merge (no-judge path)

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -71,6 +71,7 @@ from .organization_created import *  # noqa: F401,F403
 from .organization_joined import *  # noqa: F401,F403
 from .organization_removed import *  # noqa: F401,F403
 from .plugin_enabled import *  # noqa: F401,F403
+from .pr_metrics_events import *  # noqa: F401,F403
 from .project_created import *  # noqa: F401,F403
 from .project_issue_searched import *  # noqa: F401,F403
 from .project_transferred import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from sentry import analytics
 
-if TYPE_CHECKING:
-    from sentry.models.pullrequest import PullRequestVerdict
 
-
-@analytics.eventclass("pr_metrics.row")
+@analytics.eventclass("pr_metrics.recorded")
 class PrCloseMetricsEvent(analytics.Event):
     """Analytics row emitted when a tracked PR is closed or merged.
 
@@ -22,12 +19,13 @@ class PrCloseMetricsEvent(analytics.Event):
     # The PR number as stored on ``PullRequest.key`` (e.g. "5131" on GitHub).
     pr_key: str
     close_action: Literal["closed", "merged"]
-    # Set once a judge has scored the PR; None when no judge ran.
-    verdict: PullRequestVerdict | None = None
-    head_commit_sha: str | None = None
+    # Always present on a close/merge webhook — read fail-fast so a malformed
+    # payload errors loudly instead of emitting a silent null.
+    head_commit_sha: str
+    opened_at: str
+    closed_at: str
+    # Null for a closed-but-unmerged PR (no merge commit / merge time).
     merge_commit_sha: str | None = None
-    opened_at: str | None = None
-    closed_at: str | None = None
     merged_at: str | None = None
     draft: bool = False
     # Structural counters read straight from the close/merge webhook payload (no

--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -1,0 +1,42 @@
+from sentry import analytics
+
+
+@analytics.eventclass("pr_metrics.row")
+class PrCloseMetricsEvent(analytics.Event):
+    """Analytics row emitted when a tracked PR is closed or merged.
+
+    Carries only data Sentry already holds (no SCM fetch, no PR text). The schema
+    is provisional and expected to grow.
+    """
+
+    organization_id: int
+    repository_id: int
+    pull_request_id: int
+    # The PR number as stored on ``PullRequest.key`` (e.g. "5131" on GitHub).
+    pr_key: str
+    # "closed" (unmerged) or "merged".
+    close_action: str
+    # Set once a judge has scored the PR; None when no judge ran.
+    verdict: str | None = None
+    head_commit_sha: str | None = None
+    merge_commit_sha: str | None = None
+    opened_at: str | None = None
+    closed_at: str | None = None
+    merged_at: str | None = None
+    draft: bool = False
+    # Structural counters read straight from the close/merge webhook payload (no
+    # SCM round-trip). Text is never emitted — counts and metadata only.
+    additions: int = 0
+    deletions: int = 0
+    files_changed: int = 0
+    commits_count: int = 0
+    comments_count: int = 0
+    review_comments_count: int = 0
+    is_assigned: bool = False
+    # The point-in-time attribution snapshot at emit time: a JSON-encoded list of
+    # the active (is_valid=True) attributions, each {signal_type, source,
+    # signal_details}, ordered by attribution priority (highest-confidence first).
+    attributions: str = "[]"
+
+
+analytics.register(PrCloseMetricsEvent)

--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -5,7 +5,7 @@ from typing import Literal
 from sentry import analytics
 
 
-@analytics.eventclass("pr_metrics.recorded")
+@analytics.eventclass("scm.pr.closed")
 class PrCloseMetricsEvent(analytics.Event):
     """Analytics row emitted when a tracked PR is closed or merged.
 

--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
 from sentry import analytics
+
+if TYPE_CHECKING:
+    from sentry.models.pullrequest import PullRequestVerdict
 
 
 @analytics.eventclass("pr_metrics.row")
@@ -14,10 +21,9 @@ class PrCloseMetricsEvent(analytics.Event):
     pull_request_id: int
     # The PR number as stored on ``PullRequest.key`` (e.g. "5131" on GitHub).
     pr_key: str
-    # "closed" (unmerged) or "merged".
-    close_action: str
+    close_action: Literal["closed", "merged"]
     # Set once a judge has scored the PR; None when no judge ran.
-    verdict: str | None = None
+    verdict: PullRequestVerdict | None = None
     head_commit_sha: str | None = None
     merge_commit_sha: str | None = None
     opened_at: str | None = None

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -58,6 +58,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:code-review-beta", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Record PullRequestAttribution from the seer.pr_created event (PR Merge Live Metrics rollout)
     manager.add("organizations:pr-metrics-attribution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Emit the BigQuery row on a tracked PR's close/merge (PR Merge Live Metrics rollout)
+    manager.add("organizations:pr-metrics-emit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable continuous profiling
     manager.add("organizations:continuous-profiling", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the ingestion of profile functions metrics into EAP

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -28,7 +28,6 @@ from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
 from sentry.identity.services.identity.service import identity_service
 from sentry.integrations.base import IntegrationDomain
-from sentry.integrations.github.pr_metrics_webhook_processors import handle_webhook_for_pr_metrics
 from sentry.integrations.github.webhook_types import (
     GITHUB_WEBHOOK_TYPE_HEADER_KEY,
     GithubWebhookType,
@@ -63,6 +62,8 @@ from sentry.plugins.providers.integration_repository import (
     RepoExistsError,
     get_integration_repository_provider,
 )
+from sentry.pr_metrics.webhooks import handle_attribution as pr_metrics_handle_attribution
+from sentry.pr_metrics.webhooks import handle_emission as pr_metrics_handle_emission
 from sentry.preprod.vcs.webhooks import handle_preprod_check_run_event
 from sentry.scm.private.stream_producer import produce_event_to_scm_stream
 from sentry.seer.autofix.webhooks import handle_github_pr_webhook_for_autofix
@@ -139,25 +140,6 @@ def _handle_pr_webhook_for_autofix_processor(
         # Because we require that the sentry github integration be installed for autofix, we can piggyback
         # on this webhook for autofix for now. We may move to a separate autofix github integration in the future
         handle_github_pr_webhook_for_autofix(organization, action, pull_request, user)
-
-
-def _handle_pr_metrics_attribution_processor(
-    *,
-    github_event: GithubWebhookType,
-    event: Mapping[str, Any],
-    organization: Organization,
-    repo: Repository,
-    **kwargs: Any,
-) -> None:
-    pull_request = event.get("pull_request")
-    if not pull_request:
-        return
-
-    action = event.get("action")
-    user = pull_request.get("user")
-
-    if organization and action and user:
-        handle_webhook_for_pr_metrics(organization, action, pull_request, user, repo.id, event)
 
 
 class GitHubWebhook(SCMWebhook, ABC):
@@ -965,7 +947,8 @@ class PullRequestEventWebhook(GitHubWebhook):
     WEBHOOK_EVENT_PROCESSORS = (
         _handle_pr_webhook_for_autofix_processor,
         code_review_handle_webhook_event,
-        _handle_pr_metrics_attribution_processor,
+        pr_metrics_handle_attribution,
+        pr_metrics_handle_emission,
     )
 
     def _handle(

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Final, Literal
 
 from sentry import analytics
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
@@ -21,16 +21,18 @@ logger = logging.getLogger(__name__)
 
 # GitHub fires a single ``closed`` action for both outcomes; the ``merged`` flag
 # on the payload disambiguates.
-CLOSE_ACTION_CLOSED = "closed"
-CLOSE_ACTION_MERGED = "merged"
+CLOSE_ACTION_CLOSED: Final = "closed"
+CLOSE_ACTION_MERGED: Final = "merged"
+
+CloseAction = Literal["closed", "merged"]
 
 
 def needs_judge(pull_request: PullRequest) -> bool:
     """Whether this PR's terminal event must round-trip to Seer for a judge.
 
     Currently always ``False``: the judge path isn't wired yet, so every tracked
-    close/merge is emitted immediately with no verdict. Once judges exist this
-    gates the forward-to-Seer path that emits a judge-enriched row on the result.
+    close/merge is emitted immediately. Once judges exist this gates the
+    forward-to-Seer path that emits a judge-enriched row on the result.
     """
     return False
 
@@ -57,7 +59,7 @@ def _active_attributions(pull_request: PullRequest) -> list[dict[str, Any]]:
 def build_pr_metrics_row(
     *,
     pull_request: PullRequest,
-    close_action: str,
+    close_action: CloseAction,
     payload: Mapping[str, Any],
     attributions: list[dict[str, Any]],
 ) -> PrCloseMetricsEvent:
@@ -69,8 +71,7 @@ def build_pr_metrics_row(
     the active-attribution snapshot (see ``_active_attributions``), passed in so
     the caller's tracking gate and the emitted row read the same query.
     """
-    head_commit_sha = (payload.get("head") or {}).get("sha")
-    merge_commit_sha = payload.get("merge_commit_sha") if payload.get("merged") else None
+    is_merged = bool(payload.get("merged"))
 
     return PrCloseMetricsEvent(
         organization_id=pull_request.organization_id,
@@ -78,12 +79,14 @@ def build_pr_metrics_row(
         pull_request_id=pull_request.id,
         pr_key=pull_request.key,
         close_action=close_action,
-        verdict=None,
-        head_commit_sha=head_commit_sha,
-        merge_commit_sha=merge_commit_sha,
-        opened_at=payload.get("created_at"),
-        closed_at=payload.get("closed_at"),
-        merged_at=payload.get("merged_at"),
+        # Subscript (not .get) on always-present fields: a missing key raises and
+        # the webhook loop logs it, rather than emitting a row with null lifecycle.
+        head_commit_sha=payload["head"]["sha"],
+        opened_at=payload["created_at"],
+        closed_at=payload["closed_at"],
+        # Present only on a merge; null for a closed-but-unmerged PR.
+        merge_commit_sha=payload["merge_commit_sha"] if is_merged else None,
+        merged_at=payload["merged_at"] if is_merged else None,
         draft=bool(payload.get("draft")),
         # GitHub includes these aggregate counts on the PR object in the
         # close/merge payload, so we get size/activity for free without an SCM
@@ -102,7 +105,7 @@ def build_pr_metrics_row(
 def emit_pr_metrics_row(
     *,
     pull_request: PullRequest,
-    close_action: str,
+    close_action: CloseAction,
     payload: Mapping[str, Any],
 ) -> bool:
     """Emit one BigQuery row for a tracked PR's terminal event.

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -59,12 +59,15 @@ def build_pr_metrics_row(
     pull_request: PullRequest,
     close_action: str,
     payload: Mapping[str, Any],
+    attributions: list[dict[str, Any]],
 ) -> PrCloseMetricsEvent:
     """Assemble the provisional close/merge row from stored + payload data.
 
     ``payload`` is the GitHub ``pull_request`` object from the webhook; we read
     lifecycle facts from it directly rather than from the ``PullRequest`` row,
-    which isn't updated with close/merge state on this path.
+    which isn't updated with close/merge state on this path. ``attributions`` is
+    the active-attribution snapshot (see ``_active_attributions``), passed in so
+    the caller's tracking gate and the emitted row read the same query.
     """
     head_commit_sha = (payload.get("head") or {}).get("sha")
     merge_commit_sha = payload.get("merge_commit_sha") if payload.get("merged") else None
@@ -92,7 +95,7 @@ def build_pr_metrics_row(
         comments_count=payload.get("comments") or 0,
         review_comments_count=payload.get("review_comments") or 0,
         is_assigned=bool(payload.get("assignees") or payload.get("assignee")),
-        attributions=json.dumps(_active_attributions(pull_request)),
+        attributions=json.dumps(attributions),
     )
 
 
@@ -104,22 +107,25 @@ def emit_pr_metrics_row(
 ) -> bool:
     """Emit one BigQuery row for a tracked PR's terminal event.
 
-    The tracking gate is the existence of ≥1 valid ``PullRequestAttribution`` row.
-    Untracked PRs are skipped — we don't pay to record PRs that no Sentry feature
-    can be attributed to. Returns whether a row was emitted, for callers/tests.
+    The tracking gate is ≥1 valid ``PullRequestAttribution`` row. Untracked PRs
+    are skipped — we don't pay to record PRs that no Sentry feature can be
+    attributed to. Returns whether a row was emitted, for callers/tests.
 
     This is the seam the judge path can also call once it has the canonical
     ``PullRequest`` and the close action.
     """
-    is_tracked = PullRequestAttribution.objects.filter(
-        pull_request=pull_request, is_valid=True
-    ).exists()
-    if not is_tracked:
+    # Fetch the attribution snapshot once: it both gates emission (≥1 valid row)
+    # and rides along on the emitted row, so the two can't diverge.
+    attributions = _active_attributions(pull_request)
+    if not attributions:
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "untracked"})
         return False
 
     row = build_pr_metrics_row(
-        pull_request=pull_request, close_action=close_action, payload=payload
+        pull_request=pull_request,
+        close_action=close_action,
+        payload=payload,
+        attributions=attributions,
     )
     analytics.record(row)
     metrics.incr("pr_metrics.emit.recorded", tags={"close_action": close_action})

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -1,0 +1,135 @@
+"""PR-metrics emission: on a tracked PR's close/merge, emit one analytics row.
+
+The row goes to Sentry's analytics pipeline (which lands in BigQuery in
+production). A PR is "tracked" once it has at least one valid
+``PullRequestAttribution`` row; untracked PRs are not emitted.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from sentry import analytics
+from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
+from sentry.models.pullrequest import PullRequest, PullRequestAttribution
+from sentry.pr_metrics.attribution import SIGNAL_TYPE_CONFIDENCE
+from sentry.utils import json, metrics
+
+logger = logging.getLogger(__name__)
+
+# GitHub fires a single ``closed`` action for both outcomes; the ``merged`` flag
+# on the payload disambiguates.
+CLOSE_ACTION_CLOSED = "closed"
+CLOSE_ACTION_MERGED = "merged"
+
+
+def needs_judge(pull_request: PullRequest) -> bool:
+    """Whether this PR's terminal event must round-trip to Seer for a judge.
+
+    Currently always ``False``: the judge path isn't wired yet, so every tracked
+    close/merge is emitted immediately with no verdict. Once judges exist this
+    gates the forward-to-Seer path that emits a judge-enriched row on the result.
+    """
+    return False
+
+
+def _active_attributions(pull_request: PullRequest) -> list[dict[str, Any]]:
+    """The PR's valid attribution signals, highest-confidence first.
+
+    Each entry carries the ``signal_type``, ``source``, and ``signal_details`` so
+    the consumer sees the full picture, ordered by attribution priority so the
+    primary attribution leads. Ties break on ``signal_type`` then ``source`` for
+    a deterministic order.
+    """
+    attributions = PullRequestAttribution.objects.filter(pull_request=pull_request, is_valid=True)
+    ordered = sorted(
+        attributions,
+        key=lambda a: (-SIGNAL_TYPE_CONFIDENCE.get(a.signal_type, -1), a.signal_type, a.source),
+    )
+    return [
+        {"signal_type": a.signal_type, "source": a.source, "signal_details": a.signal_details}
+        for a in ordered
+    ]
+
+
+def build_pr_metrics_row(
+    *,
+    pull_request: PullRequest,
+    close_action: str,
+    payload: Mapping[str, Any],
+) -> PrCloseMetricsEvent:
+    """Assemble the provisional close/merge row from stored + payload data.
+
+    ``payload`` is the GitHub ``pull_request`` object from the webhook; we read
+    lifecycle facts from it directly rather than from the ``PullRequest`` row,
+    which isn't updated with close/merge state on this path.
+    """
+    head_commit_sha = (payload.get("head") or {}).get("sha")
+    merge_commit_sha = payload.get("merge_commit_sha") if payload.get("merged") else None
+
+    return PrCloseMetricsEvent(
+        organization_id=pull_request.organization_id,
+        repository_id=pull_request.repository_id,
+        pull_request_id=pull_request.id,
+        pr_key=pull_request.key,
+        close_action=close_action,
+        verdict=None,
+        head_commit_sha=head_commit_sha,
+        merge_commit_sha=merge_commit_sha,
+        opened_at=payload.get("created_at"),
+        closed_at=payload.get("closed_at"),
+        merged_at=payload.get("merged_at"),
+        draft=bool(payload.get("draft")),
+        # GitHub includes these aggregate counts on the PR object in the
+        # close/merge payload, so we get size/activity for free without an SCM
+        # fetch. Default to 0 when a provider omits a field.
+        additions=payload.get("additions") or 0,
+        deletions=payload.get("deletions") or 0,
+        files_changed=payload.get("changed_files") or 0,
+        commits_count=payload.get("commits") or 0,
+        comments_count=payload.get("comments") or 0,
+        review_comments_count=payload.get("review_comments") or 0,
+        is_assigned=bool(payload.get("assignees") or payload.get("assignee")),
+        attributions=json.dumps(_active_attributions(pull_request)),
+    )
+
+
+def emit_pr_metrics_row(
+    *,
+    pull_request: PullRequest,
+    close_action: str,
+    payload: Mapping[str, Any],
+) -> bool:
+    """Emit one BigQuery row for a tracked PR's terminal event.
+
+    The tracking gate is the existence of ≥1 valid ``PullRequestAttribution`` row.
+    Untracked PRs are skipped — we don't pay to record PRs that no Sentry feature
+    can be attributed to. Returns whether a row was emitted, for callers/tests.
+
+    This is the seam the judge path can also call once it has the canonical
+    ``PullRequest`` and the close action.
+    """
+    is_tracked = PullRequestAttribution.objects.filter(
+        pull_request=pull_request, is_valid=True
+    ).exists()
+    if not is_tracked:
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "untracked"})
+        return False
+
+    row = build_pr_metrics_row(
+        pull_request=pull_request, close_action=close_action, payload=payload
+    )
+    analytics.record(row)
+    metrics.incr("pr_metrics.emit.recorded", tags={"close_action": close_action})
+    logger.info(
+        "pr_metrics.emit.recorded",
+        extra={
+            "organization_id": pull_request.organization_id,
+            "repository_id": pull_request.repository_id,
+            "pull_request_id": pull_request.id,
+            "close_action": close_action,
+        },
+    )
+    return True

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -79,7 +79,8 @@ def handle_attribution(
     if action in _REFERENCED_ISSUE_ATTRIBUTION_ACTIONS:
         if action == "edited" and not _description_changed(event):
             return
-        _refresh_referenced_issue_attribution(pr, pull_request, organization)
+        # pr is set, so the payload is present and non-null (subscript narrows it).
+        _refresh_referenced_issue_attribution(pr, event["pull_request"], organization)
 
 
 def handle_emission(
@@ -102,11 +103,12 @@ def handle_emission(
     if not features.has("organizations:pr-metrics-emit", organization):
         return
 
-    pull_request = event.get("pull_request")
-    pr = _get_pull_request(organization, repo, pull_request)
+    pr = _get_pull_request(organization, repo, event.get("pull_request"))
     if pr is None:
         return
 
+    # pr is set, so the payload is present and non-null (subscript narrows it).
+    pull_request = event["pull_request"]
     close_action = CLOSE_ACTION_MERGED if pull_request.get("merged") else CLOSE_ACTION_CLOSED
 
     if needs_judge(pr):

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -30,6 +30,7 @@ from sentry.pr_metrics.attribution import record_attribution_signal
 from sentry.pr_metrics.emit import (
     CLOSE_ACTION_CLOSED,
     CLOSE_ACTION_MERGED,
+    CloseAction,
     emit_pr_metrics_row,
     needs_judge,
 )
@@ -109,12 +110,14 @@ def handle_emission(
 
     # pr is set, so the payload is present and non-null (subscript narrows it).
     pull_request = event["pull_request"]
-    close_action = CLOSE_ACTION_MERGED if pull_request.get("merged") else CLOSE_ACTION_CLOSED
+    close_action: CloseAction = (
+        CLOSE_ACTION_MERGED if pull_request.get("merged") else CLOSE_ACTION_CLOSED
+    )
 
     if needs_judge(pr):
         # The judge path (forward to Seer, emit on the judge result) isn't wired
         # yet, so fall through to immediate emit — a judge-eligible PR still
-        # produces a verdict-less row rather than none.
+        # produces a row rather than none.
         logger.info(
             "pr_metrics.emit.judge_path_not_implemented",
             extra={"organization_id": organization.id, "pull_request_id": pr.id},

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -72,17 +72,8 @@ def handle_attribution(
     if not features.has("organizations:pr-metrics-attribution", organization):
         return
 
-    try:
-        pr = PullRequest.objects.get(
-            organization_id=organization.id,
-            repository_id=repo.id,
-            key=str(pull_request["number"]),
-        )
-    except PullRequest.DoesNotExist:
-        logger.warning(
-            "github.pr_metrics.attribution.pr_not_found",
-            extra={"repository_id": repo.id, "pr_number": pull_request["number"]},
-        )
+    pr = _get_pull_request(organization, repo, pull_request)
+    if pr is None:
         return
 
     if action in _AUTHOR_ATTRIBUTION_ACTIONS:
@@ -118,17 +109,8 @@ def handle_emission(
     if not features.has("organizations:pr-metrics-emit", organization):
         return
 
-    try:
-        pr = PullRequest.objects.get(
-            organization_id=organization.id,
-            repository_id=repo.id,
-            key=str(pull_request["number"]),
-        )
-    except PullRequest.DoesNotExist:
-        logger.warning(
-            "github.pr_metrics.emission.pr_not_found",
-            extra={"repository_id": repo.id, "pr_number": pull_request["number"]},
-        )
+    pr = _get_pull_request(organization, repo, pull_request)
+    if pr is None:
         return
 
     close_action = CLOSE_ACTION_MERGED if pull_request.get("merged") else CLOSE_ACTION_CLOSED
@@ -143,6 +125,28 @@ def handle_emission(
         )
 
     emit_pr_metrics_row(pull_request=pr, close_action=close_action, payload=pull_request)
+
+
+def _get_pull_request(
+    organization: Organization, repo: Repository, pull_request: dict[str, Any]
+) -> PullRequest | None:
+    """Resolve the canonical PullRequest row for a webhook payload, or None.
+
+    The row is upserted by ``PullRequestEventWebhook._handle`` before processors
+    run, so a miss is unexpected — log it and let the caller bail.
+    """
+    try:
+        return PullRequest.objects.get(
+            organization_id=organization.id,
+            repository_id=repo.id,
+            key=str(pull_request["number"]),
+        )
+    except PullRequest.DoesNotExist:
+        logger.warning(
+            "github.pr_metrics.pr_not_found",
+            extra={"repository_id": repo.id, "pr_number": pull_request["number"]},
+        )
+        return None
 
 
 def _description_changed(event: Mapping[str, Any]) -> bool:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -58,11 +58,8 @@ def handle_attribution(
 ) -> None:
     """Record PR attribution signals (GH-App author + referenced issues) from the payload."""
     pull_request = event.get("pull_request")
-    if not pull_request:
-        return
-
     action = event.get("action")
-    github_user = pull_request.get("user")
+    github_user = (pull_request or {}).get("user")
     if not (action and github_user):
         return
 
@@ -99,16 +96,13 @@ def handle_emission(
     GitHub fires a single ``closed`` action for both merges and plain closes; the
     ``merged`` flag disambiguates. All non-terminal actions are ignored.
     """
-    pull_request = event.get("pull_request")
-    if not pull_request:
-        return
-
     if event.get("action") != "closed":
         return
 
     if not features.has("organizations:pr-metrics-emit", organization):
         return
 
+    pull_request = event.get("pull_request")
     pr = _get_pull_request(organization, repo, pull_request)
     if pr is None:
         return
@@ -128,13 +122,16 @@ def handle_emission(
 
 
 def _get_pull_request(
-    organization: Organization, repo: Repository, pull_request: dict[str, Any]
+    organization: Organization, repo: Repository, pull_request: dict[str, Any] | None
 ) -> PullRequest | None:
     """Resolve the canonical PullRequest row for a webhook payload, or None.
 
-    The row is upserted by ``PullRequestEventWebhook._handle`` before processors
-    run, so a miss is unexpected — log it and let the caller bail.
+    Returns None when the event carries no pull_request. Otherwise the row is
+    upserted by ``PullRequestEventWebhook._handle`` before processors run, so a
+    miss is unexpected — log it and let the caller bail.
     """
+    if not pull_request:
+        return None
     try:
         return PullRequest.objects.get(
             organization_id=organization.id,

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -1,3 +1,12 @@
+"""GitHub webhook handling for the PR Merge Live Metrics pipeline.
+
+Two independent processors are registered on
+``PullRequestEventWebhook.WEBHOOK_EVENT_PROCESSORS``: ``handle_attribution`` and
+``handle_emission``. They're separate (rather than one routing function) so the
+webhook loop isolates each in its own try/except — a failure in one can't
+suppress the other — and each carries its own feature flag and action gate.
+"""
+
 from __future__ import annotations
 
 import logging
@@ -7,6 +16,8 @@ from typing import Any
 from django.conf import settings
 
 from sentry import features
+from sentry.integrations.github.webhook_types import GithubWebhookType
+from sentry.integrations.services.integration import RpcIntegration
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
     PullRequest,
@@ -14,7 +25,14 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
 )
+from sentry.models.repository import Repository
 from sentry.pr_metrics.attribution import record_attribution_signal
+from sentry.pr_metrics.emit import (
+    CLOSE_ACTION_CLOSED,
+    CLOSE_ACTION_MERGED,
+    emit_pr_metrics_row,
+    needs_judge,
+)
 from sentry.pr_metrics.types import ReferencedIssueSignalDetails
 from sentry.utils.groupreference import find_referenced_groups
 
@@ -29,14 +47,25 @@ _AUTHOR_ATTRIBUTION_ACTIONS = frozenset({"opened"})
 _REFERENCED_ISSUE_ATTRIBUTION_ACTIONS = frozenset({"opened", "reopened", "edited"})
 
 
-def handle_webhook_for_pr_metrics(
-    organization: Organization,
-    action: str,
-    pull_request: dict[str, Any],
-    github_user: dict[str, Any],
-    repository_id: int,
+def handle_attribution(
+    *,
+    github_event: GithubWebhookType,
     event: Mapping[str, Any],
+    organization: Organization,
+    repo: Repository,
+    integration: RpcIntegration | None = None,
+    **kwargs: Any,
 ) -> None:
+    """Record PR attribution signals (GH-App author + referenced issues) from the payload."""
+    pull_request = event.get("pull_request")
+    if not pull_request:
+        return
+
+    action = event.get("action")
+    github_user = pull_request.get("user")
+    if not (action and github_user):
+        return
+
     if action not in (_AUTHOR_ATTRIBUTION_ACTIONS | _REFERENCED_ISSUE_ATTRIBUTION_ACTIONS):
         return
 
@@ -46,13 +75,13 @@ def handle_webhook_for_pr_metrics(
     try:
         pr = PullRequest.objects.get(
             organization_id=organization.id,
-            repository_id=repository_id,
+            repository_id=repo.id,
             key=str(pull_request["number"]),
         )
     except PullRequest.DoesNotExist:
         logger.warning(
             "github.pr_metrics.attribution.pr_not_found",
-            extra={"repository_id": repository_id, "pr_number": pull_request["number"]},
+            extra={"repository_id": repo.id, "pr_number": pull_request["number"]},
         )
         return
 
@@ -63,6 +92,57 @@ def handle_webhook_for_pr_metrics(
         if action == "edited" and not _description_changed(event):
             return
         _refresh_referenced_issue_attribution(pr, pull_request, organization)
+
+
+def handle_emission(
+    *,
+    github_event: GithubWebhookType,
+    event: Mapping[str, Any],
+    organization: Organization,
+    repo: Repository,
+    integration: RpcIntegration | None = None,
+    **kwargs: Any,
+) -> None:
+    """Emit a metrics row on a terminal (close/merge) PR webhook for a tracked PR.
+
+    GitHub fires a single ``closed`` action for both merges and plain closes; the
+    ``merged`` flag disambiguates. All non-terminal actions are ignored.
+    """
+    pull_request = event.get("pull_request")
+    if not pull_request:
+        return
+
+    if event.get("action") != "closed":
+        return
+
+    if not features.has("organizations:pr-metrics-emit", organization):
+        return
+
+    try:
+        pr = PullRequest.objects.get(
+            organization_id=organization.id,
+            repository_id=repo.id,
+            key=str(pull_request["number"]),
+        )
+    except PullRequest.DoesNotExist:
+        logger.warning(
+            "github.pr_metrics.emission.pr_not_found",
+            extra={"repository_id": repo.id, "pr_number": pull_request["number"]},
+        )
+        return
+
+    close_action = CLOSE_ACTION_MERGED if pull_request.get("merged") else CLOSE_ACTION_CLOSED
+
+    if needs_judge(pr):
+        # The judge path (forward to Seer, emit on the judge result) isn't wired
+        # yet, so fall through to immediate emit — a judge-eligible PR still
+        # produces a verdict-less row rather than none.
+        logger.info(
+            "pr_metrics.emit.judge_path_not_implemented",
+            extra={"organization_id": organization.id, "pull_request_id": pr.id},
+        )
+
+    emit_pr_metrics_row(pull_request=pr, close_action=close_action, payload=pull_request)
 
 
 def _description_changed(event: Mapping[str, Any]) -> bool:

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -1,6 +1,8 @@
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.pullrequest import (
     PullRequestAttribution,
@@ -84,7 +86,6 @@ class PrMetricsEmissionTest(TestCase):
             attributions=[SENTRY_APP_ATTRIBUTION],
         )
         assert row.close_action == "merged"
-        assert row.verdict is None
         assert row.merge_commit_sha == MERGE_SHA
         assert row.head_commit_sha == HEAD_SHA
         assert json.loads(row.attributions) == [SENTRY_APP_ATTRIBUTION]
@@ -110,12 +111,29 @@ class PrMetricsEmissionTest(TestCase):
         row = build_pr_metrics_row(
             pull_request=self.pull_request,
             close_action="closed",
-            payload={"number": 42, "merged": False, "head": {"sha": HEAD_SHA}},
+            payload={
+                "number": 42,
+                "merged": False,
+                "head": {"sha": HEAD_SHA},
+                "created_at": "2026-06-04T09:00:00Z",
+                "closed_at": "2026-06-04T10:00:00Z",
+            },
             attributions=[],
         )
         assert row.additions == 0
         assert row.commits_count == 0
         assert row.is_assigned is False
+
+    def test_build_row_raises_when_required_lifecycle_field_missing(self) -> None:
+        # Always-present fields are read fail-fast — a malformed payload errors
+        # (and the webhook loop logs it) rather than emitting a null lifecycle.
+        with pytest.raises(KeyError):
+            build_pr_metrics_row(
+                pull_request=self.pull_request,
+                close_action="closed",
+                payload={"number": 42, "merged": False},
+                attributions=[],
+            )
 
     def test_build_row_for_close_omits_merge_commit_sha(self) -> None:
         row = build_pr_metrics_row(
@@ -170,7 +188,6 @@ class PrMetricsEmissionTest(TestCase):
                 pull_request_id=self.pull_request.id,
                 pr_key="42",
                 close_action="merged",
-                verdict=None,
                 head_commit_sha=HEAD_SHA,
                 merge_commit_sha=MERGE_SHA,
                 opened_at="2026-06-04T09:00:00Z",

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -15,6 +15,7 @@ from sentry.pr_metrics.emit import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
+from sentry.testutils.silo import cell_silo_test
 from sentry.utils import json
 
 SENTRY_APP_ATTRIBUTION = {
@@ -27,6 +28,7 @@ HEAD_SHA = "a" * 40
 MERGE_SHA = "b" * 40
 
 
+@cell_silo_test
 class PrMetricsEmissionTest(TestCase):
     def setUp(self) -> None:
         self.repo = self.create_repo(

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -1,0 +1,202 @@
+from typing import Any
+from unittest.mock import patch
+
+from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
+from sentry.models.pullrequest import (
+    PullRequestAttribution,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+)
+from sentry.pr_metrics.emit import build_pr_metrics_row, emit_pr_metrics_row, needs_judge
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
+from sentry.utils import json
+
+SENTRY_APP_ATTRIBUTION = {
+    "signal_type": "sentry_app",
+    "source": "seer_data",
+    "signal_details": None,
+}
+
+HEAD_SHA = "a" * 40
+MERGE_SHA = "b" * 40
+
+
+class PrMetricsEmissionTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+        self.pull_request = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="42"
+        )
+
+    def _payload(self, *, merged: bool) -> dict[str, Any]:
+        return {
+            "number": 42,
+            "merged": merged,
+            "created_at": "2026-06-04T09:00:00Z",
+            "closed_at": "2026-06-04T10:00:00Z",
+            "merged_at": "2026-06-04T10:00:00Z" if merged else None,
+            "merge_commit_sha": MERGE_SHA,
+            "head": {"sha": HEAD_SHA},
+            "draft": False,
+            "additions": 12,
+            "deletions": 3,
+            "changed_files": 2,
+            "commits": 4,
+            "comments": 5,
+            "review_comments": 6,
+            "assignees": [{"login": "octocat"}],
+        }
+
+    def _track(
+        self,
+        signal_type: str = PullRequestAttributionSignalType.SENTRY_APP,
+        *,
+        source: str = PullRequestAttributionSource.SEER_DATA,
+        signal_details: dict[str, Any] | None = None,
+        is_valid: bool = True,
+    ) -> None:
+        PullRequestAttribution.objects.create(
+            pull_request=self.pull_request,
+            signal_type=signal_type,
+            source=source,
+            signal_details=signal_details,
+            is_valid=is_valid,
+        )
+
+    def test_needs_judge_is_false_in_m1(self) -> None:
+        assert needs_judge(self.pull_request) is False
+
+    def test_build_row_for_merge(self) -> None:
+        self._track()
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            payload=self._payload(merged=True),
+        )
+        assert row.close_action == "merged"
+        assert row.verdict is None
+        assert row.merge_commit_sha == MERGE_SHA
+        assert row.head_commit_sha == HEAD_SHA
+        assert json.loads(row.attributions) == [SENTRY_APP_ATTRIBUTION]
+
+    def test_build_row_carries_payload_counters(self) -> None:
+        self._track()
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            payload=self._payload(merged=True),
+        )
+        assert row.opened_at == "2026-06-04T09:00:00Z"
+        assert row.draft is False
+        assert row.additions == 12
+        assert row.deletions == 3
+        assert row.files_changed == 2
+        assert row.commits_count == 4
+        assert row.comments_count == 5
+        assert row.review_comments_count == 6
+        assert row.is_assigned is True
+
+    def test_build_row_counters_default_to_zero_when_absent(self) -> None:
+        self._track()
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="closed",
+            payload={"number": 42, "merged": False, "head": {"sha": HEAD_SHA}},
+        )
+        assert row.additions == 0
+        assert row.commits_count == 0
+        assert row.is_assigned is False
+
+    def test_build_row_for_close_omits_merge_commit_sha(self) -> None:
+        self._track()
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="closed",
+            payload=self._payload(merged=False),
+        )
+        assert row.merge_commit_sha is None
+        assert row.head_commit_sha == HEAD_SHA
+
+    def test_attributions_only_includes_valid_signals(self) -> None:
+        self._track(PullRequestAttributionSignalType.SENTRY_APP)
+        self._track(
+            PullRequestAttributionSignalType.REFERENCED_ISSUE,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=False,
+        )
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            payload=self._payload(merged=True),
+        )
+        assert json.loads(row.attributions) == [SENTRY_APP_ATTRIBUTION]
+
+    def test_attributions_ordered_by_priority_with_source_and_details(self) -> None:
+        # Lower-confidence signal recorded first, but emitted second.
+        self._track(
+            PullRequestAttributionSignalType.REFERENCED_ISSUE,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            signal_details={"group_ids": [7]},
+        )
+        self._track(PullRequestAttributionSignalType.SENTRY_APP)
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            payload=self._payload(merged=True),
+        )
+        assert json.loads(row.attributions) == [
+            SENTRY_APP_ATTRIBUTION,
+            {
+                "signal_type": "referenced_issue",
+                "source": "webhook_data",
+                "signal_details": {"group_ids": [7]},
+            },
+        ]
+
+    @patch("sentry.analytics.record")
+    def test_emit_records_for_tracked_pr(self, mock_record: Any) -> None:
+        self._track()
+        emitted = emit_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            payload=self._payload(merged=True),
+        )
+        assert emitted is True
+        assert_last_analytics_event(
+            mock_record,
+            PrCloseMetricsEvent(
+                organization_id=self.organization.id,
+                repository_id=self.repo.id,
+                pull_request_id=self.pull_request.id,
+                pr_key="42",
+                close_action="merged",
+                verdict=None,
+                head_commit_sha=HEAD_SHA,
+                merge_commit_sha=MERGE_SHA,
+                opened_at="2026-06-04T09:00:00Z",
+                closed_at="2026-06-04T10:00:00Z",
+                merged_at="2026-06-04T10:00:00Z",
+                draft=False,
+                additions=12,
+                deletions=3,
+                files_changed=2,
+                commits_count=4,
+                comments_count=5,
+                review_comments_count=6,
+                is_assigned=True,
+                attributions=json.dumps([SENTRY_APP_ATTRIBUTION]),
+            ),
+        )
+
+    @patch("sentry.analytics.record")
+    def test_emit_skips_untracked_pr(self, mock_record: Any) -> None:
+        emitted = emit_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            payload=self._payload(merged=True),
+        )
+        assert emitted is False
+        assert mock_record.call_count == 0

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -7,7 +7,12 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
 )
-from sentry.pr_metrics.emit import build_pr_metrics_row, emit_pr_metrics_row, needs_judge
+from sentry.pr_metrics.emit import (
+    _active_attributions,
+    build_pr_metrics_row,
+    emit_pr_metrics_row,
+    needs_judge,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.utils import json
@@ -70,11 +75,11 @@ class PrMetricsEmissionTest(TestCase):
         assert needs_judge(self.pull_request) is False
 
     def test_build_row_for_merge(self) -> None:
-        self._track()
         row = build_pr_metrics_row(
             pull_request=self.pull_request,
             close_action="merged",
             payload=self._payload(merged=True),
+            attributions=[SENTRY_APP_ATTRIBUTION],
         )
         assert row.close_action == "merged"
         assert row.verdict is None
@@ -83,11 +88,11 @@ class PrMetricsEmissionTest(TestCase):
         assert json.loads(row.attributions) == [SENTRY_APP_ATTRIBUTION]
 
     def test_build_row_carries_payload_counters(self) -> None:
-        self._track()
         row = build_pr_metrics_row(
             pull_request=self.pull_request,
             close_action="merged",
             payload=self._payload(merged=True),
+            attributions=[],
         )
         assert row.opened_at == "2026-06-04T09:00:00Z"
         assert row.draft is False
@@ -100,54 +105,44 @@ class PrMetricsEmissionTest(TestCase):
         assert row.is_assigned is True
 
     def test_build_row_counters_default_to_zero_when_absent(self) -> None:
-        self._track()
         row = build_pr_metrics_row(
             pull_request=self.pull_request,
             close_action="closed",
             payload={"number": 42, "merged": False, "head": {"sha": HEAD_SHA}},
+            attributions=[],
         )
         assert row.additions == 0
         assert row.commits_count == 0
         assert row.is_assigned is False
 
     def test_build_row_for_close_omits_merge_commit_sha(self) -> None:
-        self._track()
         row = build_pr_metrics_row(
             pull_request=self.pull_request,
             close_action="closed",
             payload=self._payload(merged=False),
+            attributions=[],
         )
         assert row.merge_commit_sha is None
         assert row.head_commit_sha == HEAD_SHA
 
-    def test_attributions_only_includes_valid_signals(self) -> None:
+    def test_active_attributions_only_includes_valid_signals(self) -> None:
         self._track(PullRequestAttributionSignalType.SENTRY_APP)
         self._track(
             PullRequestAttributionSignalType.REFERENCED_ISSUE,
             source=PullRequestAttributionSource.WEBHOOK_DATA,
             is_valid=False,
         )
-        row = build_pr_metrics_row(
-            pull_request=self.pull_request,
-            close_action="merged",
-            payload=self._payload(merged=True),
-        )
-        assert json.loads(row.attributions) == [SENTRY_APP_ATTRIBUTION]
+        assert _active_attributions(self.pull_request) == [SENTRY_APP_ATTRIBUTION]
 
-    def test_attributions_ordered_by_priority_with_source_and_details(self) -> None:
-        # Lower-confidence signal recorded first, but emitted second.
+    def test_active_attributions_ordered_by_priority_with_source_and_details(self) -> None:
+        # Lower-confidence signal recorded first, but ordered second.
         self._track(
             PullRequestAttributionSignalType.REFERENCED_ISSUE,
             source=PullRequestAttributionSource.WEBHOOK_DATA,
             signal_details={"group_ids": [7]},
         )
         self._track(PullRequestAttributionSignalType.SENTRY_APP)
-        row = build_pr_metrics_row(
-            pull_request=self.pull_request,
-            close_action="merged",
-            payload=self._payload(merged=True),
-        )
-        assert json.loads(row.attributions) == [
+        assert _active_attributions(self.pull_request) == [
             SENTRY_APP_ATTRIBUTION,
             {
                 "signal_type": "referenced_issue",

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -384,3 +384,19 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         self._call(merged=True)
         self._call(merged=True)
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 2
+
+    @patch(f"{MODULE}.logger")
+    @patch("sentry.analytics.record")
+    def test_missing_pr_logs_warning_and_does_not_emit(self, mock_record, mock_logger) -> None:
+        # A close webhook can arrive before the PR row exists (race).
+        handle_emission(
+            github_event=GithubWebhookType.PULL_REQUEST,
+            event={"action": "closed", "pull_request": {"number": 9999, "merged": True}},
+            organization=self.organization,
+            repo=self.repo,
+        )
+        mock_logger.warning.assert_called_once_with(
+            "github.pr_metrics.pr_not_found",
+            extra={"repository_id": self.repo.id, "pr_number": 9999},
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -325,6 +325,9 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         return {
             "number": 42,
             "merged": merged,
+            "created_at": "2026-06-04T09:00:00Z",
+            "closed_at": "2026-06-04T10:00:00Z",
+            "merged_at": "2026-06-04T10:00:00Z",
             "merge_commit_sha": MERGE_SHA,
             "head": {"sha": HEAD_SHA},
         }

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 
@@ -31,7 +32,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
             title="Fix the bug",
             message="Closes TICKET-1",
         )
-        self.base_pr_payload: dict = {
+        self.base_pr_payload: dict[str, Any] = {
             "number": 42,
             "title": "Fix the bug",
             "body": "Closes TICKET-1",
@@ -43,7 +44,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
         user_id: int = 999,
         title: str | None = None,
         body: str | None = None,
-        changes: dict | None = None,
+        changes: dict[str, Any] | None = None,
     ) -> None:
         payload = dict(self.base_pr_payload)
         payload["user"] = {"id": user_id, "login": "testbot"}
@@ -51,7 +52,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
             payload["title"] = title
         if body is not None:
             payload["body"] = body
-        event: dict = {"action": action, "pull_request": payload}
+        event: dict[str, Any] = {"action": action, "pull_request": payload}
         if changes is not None:
             event["changes"] = changes
         handle_attribution(
@@ -321,7 +322,7 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
             is_valid=True,
         )
 
-    def _payload(self, *, merged: bool = True) -> dict:
+    def _payload(self, *, merged: bool = True) -> dict[str, Any]:
         return {
             "number": 42,
             "merged": merged,
@@ -341,13 +342,13 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         )
 
     @patch("sentry.analytics.record")
-    def test_emits_on_merge(self, mock_record) -> None:
+    def test_emits_on_merge(self, mock_record: MagicMock) -> None:
         self._call(merged=True)
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
         assert mock_record.call_args_list[-1].args[0].close_action == "merged"
 
     @patch("sentry.analytics.record")
-    def test_emits_on_close_unmerged(self, mock_record) -> None:
+    def test_emits_on_close_unmerged(self, mock_record: MagicMock) -> None:
         self._call(merged=False)
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
         assert mock_record.call_args_list[-1].args[0].close_action == "closed"
@@ -355,33 +356,33 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
     @patch(f"{MODULE}.needs_judge", return_value=True)
     @patch("sentry.analytics.record")
     def test_falls_back_to_immediate_emit_when_judge_needed(
-        self, mock_record, _needs_judge
+        self, mock_record: MagicMock, _needs_judge: MagicMock
     ) -> None:
         # Until the judge path is wired, a judge-needed PR still emits immediately.
         self._call(merged=True)
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
 
     @patch("sentry.analytics.record")
-    def test_ignores_non_terminal_actions(self, mock_record) -> None:
+    def test_ignores_non_terminal_actions(self, mock_record: MagicMock) -> None:
         self._call(action="opened")
         self._call(action="edited")
         self._call(action="synchronize")
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
 
     @patch("sentry.analytics.record")
-    def test_does_nothing_when_flag_off(self, mock_record) -> None:
+    def test_does_nothing_when_flag_off(self, mock_record: MagicMock) -> None:
         with self.feature({"organizations:pr-metrics-emit": False}):
             self._call(merged=True)
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
 
     @patch("sentry.analytics.record")
-    def test_skips_untracked_pr(self, mock_record) -> None:
+    def test_skips_untracked_pr(self, mock_record: MagicMock) -> None:
         PullRequestAttribution.objects.filter(pull_request=self.pull_request).delete()
         self._call(merged=True)
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
 
     @patch("sentry.analytics.record")
-    def test_redelivery_emits_each_time(self, mock_record) -> None:
+    def test_redelivery_emits_each_time(self, mock_record: MagicMock) -> None:
         # Emission is stateless — it does not dedupe webhook redeliveries; that
         # guard lives at the terminal-event/PR-status check, not here.
         self._call(merged=True)
@@ -390,7 +391,9 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
 
     @patch(f"{MODULE}.logger")
     @patch("sentry.analytics.record")
-    def test_missing_pr_logs_warning_and_does_not_emit(self, mock_record, mock_logger) -> None:
+    def test_missing_pr_logs_warning_and_does_not_emit(
+        self, mock_record: MagicMock, mock_logger: MagicMock
+    ) -> None:
         # A close webhook can arrive before the PR row exists (race).
         handle_emission(
             github_event=GithubWebhookType.PULL_REQUEST,

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -294,7 +294,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
             )
 
         mock_logger.warning.assert_called_once_with(
-            "github.pr_metrics.attribution.pr_not_found",
+            "github.pr_metrics.pr_not_found",
             extra={"repository_id": self.repo.id, "pr_number": 9999},
         )
         assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -4,16 +4,17 @@ from unittest.mock import patch
 
 from django.conf import settings
 
-from sentry.integrations.github.pr_metrics_webhook_processors import (
-    handle_webhook_for_pr_metrics,
-)
+from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
+from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.models.pullrequest import (
     PullRequestAttribution,
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
 )
+from sentry.pr_metrics.webhooks import handle_attribution, handle_emission
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.analytics import get_event_count
 from sentry.testutils.silo import cell_silo_test
 
 
@@ -45,6 +46,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
         changes: dict | None = None,
     ) -> None:
         payload = dict(self.base_pr_payload)
+        payload["user"] = {"id": user_id, "login": "testbot"}
         if title is not None:
             payload["title"] = title
         if body is not None:
@@ -52,13 +54,11 @@ class HandleWebhookForPrMetricsTest(TestCase):
         event: dict = {"action": action, "pull_request": payload}
         if changes is not None:
             event["changes"] = changes
-        handle_webhook_for_pr_metrics(
-            organization=self.organization,
-            action=action,
-            pull_request=payload,
-            github_user={"id": user_id, "login": "testbot"},
-            repository_id=self.repo.id,
+        handle_attribution(
+            github_event=GithubWebhookType.PULL_REQUEST,
             event=event,
+            organization=self.organization,
+            repo=self.repo,
         )
 
     # --- App ID attribution ---
@@ -275,15 +275,22 @@ class HandleWebhookForPrMetricsTest(TestCase):
     # --- Error handling ---
 
     def test_missing_pr_logs_warning_and_does_not_raise(self) -> None:
-        module = "sentry.integrations.github.pr_metrics_webhook_processors"
+        module = "sentry.pr_metrics.webhooks"
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "number": 9999,
+                "title": "",
+                "body": "",
+                "user": {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
+            },
+        }
         with patch(f"{module}.logger") as mock_logger:
-            handle_webhook_for_pr_metrics(
+            handle_attribution(
+                github_event=GithubWebhookType.PULL_REQUEST,
+                event=event,
                 organization=self.organization,
-                action="opened",
-                pull_request={"number": 9999, "title": "", "body": ""},
-                github_user={"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
-                repository_id=self.repo.id,
-                event={"action": "opened"},
+                repo=self.repo,
             )
 
         mock_logger.warning.assert_called_once_with(
@@ -291,3 +298,89 @@ class HandleWebhookForPrMetricsTest(TestCase):
             extra={"repository_id": self.repo.id, "pr_number": 9999},
         )
         assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
+
+
+MODULE = "sentry.pr_metrics.webhooks"
+HEAD_SHA = "a" * 40
+MERGE_SHA = "b" * 40
+
+
+@with_feature("organizations:pr-metrics-emit")
+@cell_silo_test
+class HandleWebhookForPrMetricsEmissionTest(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project(organization=self.organization)
+        self.repo = self.create_repo(self.project, provider="integrations:github", external_id="99")
+        self.pull_request = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="42"
+        )
+        PullRequestAttribution.objects.create(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+            is_valid=True,
+        )
+
+    def _payload(self, *, merged: bool = True) -> dict:
+        return {
+            "number": 42,
+            "merged": merged,
+            "merge_commit_sha": MERGE_SHA,
+            "head": {"sha": HEAD_SHA},
+        }
+
+    def _call(self, *, action: str = "closed", merged: bool = True) -> None:
+        handle_emission(
+            github_event=GithubWebhookType.PULL_REQUEST,
+            event={"action": action, "pull_request": self._payload(merged=merged)},
+            organization=self.organization,
+            repo=self.repo,
+        )
+
+    @patch("sentry.analytics.record")
+    def test_emits_on_merge(self, mock_record) -> None:
+        self._call(merged=True)
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        assert mock_record.call_args_list[-1].args[0].close_action == "merged"
+
+    @patch("sentry.analytics.record")
+    def test_emits_on_close_unmerged(self, mock_record) -> None:
+        self._call(merged=False)
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        assert mock_record.call_args_list[-1].args[0].close_action == "closed"
+
+    @patch(f"{MODULE}.needs_judge", return_value=True)
+    @patch("sentry.analytics.record")
+    def test_falls_back_to_immediate_emit_when_judge_needed(
+        self, mock_record, _needs_judge
+    ) -> None:
+        # Until the judge path is wired, a judge-needed PR still emits immediately.
+        self._call(merged=True)
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+
+    @patch("sentry.analytics.record")
+    def test_ignores_non_terminal_actions(self, mock_record) -> None:
+        self._call(action="opened")
+        self._call(action="edited")
+        self._call(action="synchronize")
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
+
+    @patch("sentry.analytics.record")
+    def test_does_nothing_when_flag_off(self, mock_record) -> None:
+        with self.feature({"organizations:pr-metrics-emit": False}):
+            self._call(merged=True)
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
+
+    @patch("sentry.analytics.record")
+    def test_skips_untracked_pr(self, mock_record) -> None:
+        PullRequestAttribution.objects.filter(pull_request=self.pull_request).delete()
+        self._call(merged=True)
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
+
+    @patch("sentry.analytics.record")
+    def test_redelivery_emits_each_time(self, mock_record) -> None:
+        # Emission is stateless — it does not dedupe webhook redeliveries; that
+        # guard lives at the terminal-event/PR-status check, not here.
+        self._call(merged=True)
+        self._call(merged=True)
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 2


### PR DESCRIPTION
Part of the [PR Merge Live Metrics](https://linear.app/getsentry/project/pr-merge-live-metrics-6a9efd473801/overview) project. Builds on the schema (#116586, CORE-200), the `seer.pr_created` attribution path (#116759, CORE-204), and the webhook attribution processor (#116834, CORE-216).

## What

On a tracked PR's **close/merge**, Sentry now emits a provisional `pr_metrics.row` analytics event directly — no Seer judge, no round-trip. This is the "easy path" of the judge-gated emission design (the judge path is CORE-217). A PR is **tracked** once it has ≥1 valid `PullRequestAttribution` row (`is_valid=true`); untracked PRs emit nothing.

The row carries only what Sentry already holds — no SCM fetch, no PR text:

- lifecycle: `close_action`, `head_commit_sha`, `merge_commit_sha`, `opened_at` / `closed_at` / `merged_at`, `draft`
- payload-derived counters: `additions`, `deletions`, `files_changed`, `commits_count`, `comments_count`, `review_comments_count`, `is_assigned`
- `attributions`: the point-in-time snapshot of valid attribution signals (`{signal_type, source, signal_details}`), ordered by attribution priority (highest-confidence first)
- `verdict`: `None` for now (verdicts arrive with judges)

Emission is gated by the new `organizations:pr-metrics-emit` FlagPole flag, and is **stateless** — it does not dedupe webhook redeliveries (a DB-side, pre-fork guard keyed on the terminal event is CORE-227; the judge round-trip is CORE-217).

Transport is `sentry.analytics` → the existing analytics → BigQuery pipeline. The schema is intentionally provisional/additive; the consumable schema is finalized in M5 (CORE-223).

## Architecture

Consolidates all pr_metrics GitHub webhook handling into `src/sentry/pr_metrics/webhooks.py`, following the code_review pattern. Two **independent** processors are registered on `PullRequestEventWebhook.WEBHOOK_EVENT_PROCESSORS`:

- `handle_attribution` — GH-App-author + referenced-issue signals (relocated from `integrations/github/pr_metrics_webhook_processors.py`, no behavior change)
- `handle_emission` — the close/merge metrics row

They're separate rather than one routing function so the webhook loop isolates each in its own `try/except` (a failure in one can't suppress the other), and each carries its own feature flag and action gate. Domain logic lives in `pr_metrics/attribution.py` and `pr_metrics/emit.py`; `pr_metrics/webhooks.py` is the GitHub entry point.

> [!NOTE]
> This relocates the CORE-216 attribution webhook handler (a pure move, logic unchanged) from `integrations/github/` into `pr_metrics/`.

Refs CORE-221